### PR TITLE
Performance improvement of IfcParse tokenizer

### DIFF
--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -815,7 +815,7 @@ Entity::Entity(unsigned int i, IfcFile* f) : args(0), _id(i) {
 	file = f;
 	Token datatype = f->tokens->Next();
 	if ( ! TokenFunc::isKeyword(datatype)) throw IfcException("Unexpected token while parsing entity");
-	_type = IfcSchema::Type::FromString(TokenFunc::asString(datatype));
+	_type = IfcSchema::Type::FromString(TokenFunc::asStringRef(datatype));
 	offset = datatype.startPos;
 }
 
@@ -857,7 +857,7 @@ void Entity::Load(std::vector<unsigned int>& ids, bool seek) const {
 		file->tokens->stream->Seek(offset);
 		Token datatype = file->tokens->Next();
 		if ( ! TokenFunc::isKeyword(datatype)) throw IfcException("Unexpected token while parsing entity");
-		_type = IfcSchema::Type::FromString(TokenFunc::asString(datatype));
+		_type = IfcSchema::Type::FromString(TokenFunc::asStringRef(datatype));
 	}
 	Token open = file->tokens->Next();
 	args = new ArgumentList();

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -315,7 +315,7 @@ Token IfcSpfLexer::Next() {
 	// If the cursor is at [()=,;$*] we know token consists of single char
 	if (c == '(' || c == ')' || c == '=' || c == ',' || c == ';' || c == '$' || c == '*') {
 		stream->Inc();
-		return TokenPtr(this,pos);
+		return TokenPtr(this, pos, pos+1);
 	}
 
 	int len = 0;
@@ -331,7 +331,7 @@ Token IfcSpfLexer::Next() {
 		// If a string is encountered defer processing to the IfcCharacterDecoder
 		if ( c == '\'' ) decoder->dryRun();
 	}
-	if ( len ) return TokenPtr(this,pos);
+	if ( len ) return TokenPtr(this, pos);
 	else return TokenPtr();
 }
 
@@ -362,8 +362,14 @@ std::string IfcSpfLexer::TokenString(unsigned int offset) {
 // Functions for creating Tokens from an arbitary file offset.
 // The first 4 bits are reserved for Tokens of type ()=,;$*
 //
-Token IfcParse::TokenPtr(IfcSpfLexer* tokens, unsigned int offset) { return Token(tokens,offset); }
-Token IfcParse::TokenPtr() { return Token((IfcSpfLexer*)0,0); }
+Token IfcParse::TokenPtr(IfcSpfLexer* lexer, unsigned start, unsigned end) {
+	if (end == unsigned(-1)) {
+		std::string tokenStr = lexer->TokenString(start);
+		end = start + (unsigned)tokenStr.size();
+	}
+	return Token(lexer, start, end);
+}
+Token IfcParse::TokenPtr() { return Token(); }
 
 //
 // Functions to convert Tokens to binary data

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -601,12 +601,6 @@ std::vector< std::vector<T> > read_aggregate_of_aggregate_as_vector2(const std::
 //
 // Functions for casting the ArgumentList to other types
 //
-ArgumentList::operator int() const { throw IfcException("Argument is not an integer"); }
-ArgumentList::operator bool() const { throw IfcException("Argument is not a boolean"); }
-ArgumentList::operator double() const { throw IfcException("Argument is not a number"); }
-ArgumentList::operator std::string() const { throw IfcException("Argument is not a string"); }
-ArgumentList::operator boost::dynamic_bitset<>() const { throw IfcException("Argument is not a binary"); }
-
 ArgumentList::operator std::vector<double>() const {
 	return read_aggregate_as_vector<double>(list);
 }
@@ -622,8 +616,6 @@ ArgumentList::operator std::vector<std::string>() const {
 ArgumentList::operator std::vector<boost::dynamic_bitset<> >() const {
 	return read_aggregate_as_vector<boost::dynamic_bitset<> >(list);
 }
-
-ArgumentList::operator IfcUtil::IfcBaseClass*() const { throw IfcException("Argument is not an entity instance"); }
 
 ArgumentList::operator IfcEntityList::ptr() const {
 	IfcEntityList::ptr l ( new IfcEntityList() );
@@ -732,15 +724,7 @@ TokenArgument::operator bool() const { return TokenFunc::asBool(token); }
 TokenArgument::operator double() const { return TokenFunc::asFloat(token); }
 TokenArgument::operator std::string() const { return TokenFunc::asString(token); }
 TokenArgument::operator boost::dynamic_bitset<>() const { return TokenFunc::asBinary(token); }
-TokenArgument::operator std::vector<double>() const { throw IfcException("Argument is not a list of floats"); }
-TokenArgument::operator std::vector<int>() const { throw IfcException("Argument is not a list of ints"); }
-TokenArgument::operator std::vector<std::string>() const { throw IfcException("Argument is not a list of strings"); }
-TokenArgument::operator std::vector<boost::dynamic_bitset<> >() const { throw IfcException("Argument is not a list of binaries"); }
 TokenArgument::operator IfcUtil::IfcBaseClass*() const { return token.first->file->entityById(TokenFunc::asInt(token)); }
-TokenArgument::operator IfcEntityList::ptr() const { throw IfcException("Argument is not a list of entity instances"); }
-TokenArgument::operator std::vector< std::vector<int> >() const { throw IfcException("Argument is not a list of list of ints"); }
-TokenArgument::operator std::vector< std::vector<double> >() const { throw IfcException("Argument is not a list of list of floats"); }
-TokenArgument::operator IfcEntityListList::ptr() const { throw IfcException("Argument is not a list of list of entity instances"); }
 unsigned int TokenArgument::size() const { return 1; }
 Argument* TokenArgument::operator [] (unsigned int /*i*/) const { throw IfcException("Argument is not a list of attributes"); }
 std::string TokenArgument::toString(bool upper) const { 
@@ -759,20 +743,7 @@ IfcUtil::ArgumentType EntityArgument::type() const {
 //
 // Functions for casting the EntityArgument to other types
 //
-EntityArgument::operator int() const { throw IfcException("Argument is not an integer"); }
-EntityArgument::operator bool() const { throw IfcException("Argument is not a boolean"); }
-EntityArgument::operator double() const { throw IfcException("Argument is not a number"); }
-EntityArgument::operator boost::dynamic_bitset<>() const { throw IfcException("Argument is not a binary"); }
-EntityArgument::operator std::string() const { throw IfcException("Argument is not a string"); }
-EntityArgument::operator std::vector<double>() const { throw IfcException("Argument is not a list of floats"); }
-EntityArgument::operator std::vector<int>() const { throw IfcException("Argument is not a list of ints"); }
-EntityArgument::operator std::vector<std::string>() const { throw IfcException("Argument is not a list of strings"); }
-EntityArgument::operator std::vector<boost::dynamic_bitset<> >() const { throw IfcException("Argument is not a list of binaries"); }
 EntityArgument::operator IfcUtil::IfcBaseClass*() const { return entity; }
-EntityArgument::operator IfcEntityList::ptr() const { throw IfcException("Argument is not a list of entity instances"); }
-EntityArgument::operator std::vector< std::vector<int> >() const { throw IfcException("Argument is not a list of list of ints"); }
-EntityArgument::operator std::vector< std::vector<double> >() const { throw IfcException("Argument is not a list of list of floats"); }
-EntityArgument::operator IfcEntityListList::ptr() const { throw IfcException("Argument is not a list of list of entity instances"); }
 unsigned int EntityArgument::size() const { return 1; }
 Argument* EntityArgument::operator [] (unsigned int /*i*/) const { throw IfcException("Argument is not a list of arguments"); }
 std::string EntityArgument::toString(bool upper) const { 

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -70,8 +70,8 @@ void init_locale() {
 // Opens the file, gets the filesize and reads a chunk in memory
 //
 IfcSpfStream::IfcSpfStream(const std::string& fn)
-    : stream(0)
-    , buffer(0)
+		: stream(0)
+		, buffer(0)
 {
 	eof = false;
 #ifdef _MSC_VER
@@ -104,8 +104,8 @@ IfcSpfStream::IfcSpfStream(const std::string& fn)
 }
 
 IfcSpfStream::IfcSpfStream(std::istream& f, int l)
-    : stream(0)
-    , buffer(0)
+		: stream(0)
+		, buffer(0)
 {
 	eof = false;
 	size = l;
@@ -121,8 +121,8 @@ IfcSpfStream::IfcSpfStream(std::istream& f, int l)
 }
 
 IfcSpfStream::IfcSpfStream(void* data, int l)
-    : stream(0)
-    , buffer(0)
+		: stream(0)
+		, buffer(0)
 {
 	eof = false;
 	size = l;

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -315,7 +315,7 @@ Token IfcSpfLexer::Next() {
 	// If the cursor is at [()=,;$*] we know token consists of single char
 	if (c == '(' || c == ')' || c == '=' || c == ',' || c == ';' || c == '$' || c == '*') {
 		stream->Inc();
-		return TokenPtr(c);
+		return TokenPtr(this,pos);
 	}
 
 	int len = 0;
@@ -363,7 +363,6 @@ std::string IfcSpfLexer::TokenString(unsigned int offset) {
 // The first 4 bits are reserved for Tokens of type ()=,;$*
 //
 Token IfcParse::TokenPtr(IfcSpfLexer* tokens, unsigned int offset) { return Token(tokens,offset); }
-Token IfcParse::TokenPtr(char c) { return Token((IfcSpfLexer*)0,(unsigned) c); }
 Token IfcParse::TokenPtr() { return Token((IfcSpfLexer*)0,0); }
 
 //
@@ -373,8 +372,17 @@ bool TokenFunc::startsWith(const Token& t, char c) {
 	return t.first->stream->Read(t.second) == c;
 }
 
-bool TokenFunc::isOperator(const Token& t, char op) {
-	return (!t.first) && (!op || (unsigned)op == t.second);
+bool TokenFunc::isOperator(const Token& t, char op) { //todo: separate overload for op==0 ?
+	//extract first char
+	char sym = (t.first ? t.first->stream->Read(t.second) : 0);
+	//check it for being operator
+	if (!(sym == '(' || sym == ')' || sym == '=' || sym == ',' || sym == ';' || sym == '$' || sym == '*'))
+		return false;
+	//if required, check if it is prescribed one
+	if (op != 0 && sym != op)
+		return false;
+	return true;
+	//return (!t.first) && (!op || (unsigned)op == t.second);
 }
 
 bool TokenFunc::isIdentifier(const Token& t) {

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -485,22 +485,26 @@ bool TokenFunc::isFloat(const Token& t) {
 }
 
 int TokenFunc::asInt(const Token& t) {
-	//assert(t.type == Token_INT);
+	if (t.type != Token_INT)
+		throw IfcException("Token is not an integer");
 	return t.value_int;
 }
 
 int TokenFunc::asIdentifier(const Token& t) {
-	//assert(t.type == Token_IDENTIFIER);
+	if (t.type != Token_IDENTIFIER)
+		throw IfcException("Token is not an identifier");
 	return t.value_int;
 }
 
 bool TokenFunc::asBool(const Token& t) {
-	//assert(t.type == Token_BOOL);
+	if (t.type != Token_BOOL)
+		throw IfcException("Token is not a boolean");
 	return t.value_bool;
 }
 
 double TokenFunc::asFloat(const Token& t) {
-	//assert(t.type == Token_FLOAT);
+	if (t.type != Token_FLOAT)
+		throw IfcException("Token is not a float");
 	return t.value_double;
 }
 

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -661,7 +661,7 @@ Argument* ArgumentList::operator [] (unsigned int i) const {
 
 void ArgumentList::set(unsigned int i, Argument* argument) {
 	while (size() < i) {
-		push(new TokenArgument(Token(static_cast<IfcSpfLexer*>(0), '$')));
+		push(new NullArgument());
 	}
 	if (i < size()) {
 		delete list[i];

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -139,13 +139,6 @@ namespace IfcParse {
 
 		IfcUtil::ArgumentType type() const;
 		
-		operator int() const;
-		operator bool() const;
-		operator double() const;
-		operator std::string() const;
-		operator boost::dynamic_bitset<>() const;
-		operator IfcUtil::IfcBaseClass*() const;
-
 		operator std::vector<int>() const;
 		operator std::vector<double>() const;
 		operator std::vector<std::string>() const;
@@ -184,16 +177,6 @@ namespace IfcParse {
 		operator boost::dynamic_bitset<>() const;
 		operator IfcUtil::IfcBaseClass*() const;
 
-		operator std::vector<int>() const;
-		operator std::vector<double>() const;
-		operator std::vector<std::string>() const;
-		operator std::vector<boost::dynamic_bitset<> >() const;
-		operator IfcEntityList::ptr() const;
-		
-		operator std::vector< std::vector<int> >() const;
-		operator std::vector< std::vector<double> >() const;
-		operator IfcEntityListList::ptr() const;
-
 		bool isNull() const;
 		unsigned int size() const;
 
@@ -213,22 +196,7 @@ namespace IfcParse {
 
 		IfcUtil::ArgumentType type() const;
 
-		operator int() const;
-		operator bool() const;
-		operator double() const;
-		operator std::string() const;
-		operator boost::dynamic_bitset<>() const;
 		operator IfcUtil::IfcBaseClass*() const;
-
-		operator std::vector<int>() const;
-		operator std::vector<double>() const;
-		operator std::vector<std::string>() const;
-		operator std::vector<boost::dynamic_bitset<> >() const;
-		operator IfcEntityList::ptr() const;
-
-		operator std::vector< std::vector<int> >() const;
-		operator std::vector< std::vector<double> >() const;
-		operator IfcEntityListList::ptr() const;
 
 		bool isNull() const;
 		unsigned int size() const;

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -107,7 +107,6 @@ namespace IfcParse {
 	// The first 4 bits are reserved for Tokens of type ()=,;$*
 	//
 	Token TokenPtr(IfcSpfLexer* tokens, unsigned int offset);
-	Token TokenPtr(char c);	
 	Token TokenPtr();
 
 	/// A stream of tokens to be read from a IfcSpfStream.

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -158,6 +158,19 @@ namespace IfcParse {
 		std::string toString(bool upper=false) const;
 	};
 
+
+	/// Argument being null, e.g. '$'
+	///              == ===
+	class IfcParse_EXPORT NullArgument : public Argument {
+	public:
+		NullArgument() {}
+		IfcUtil::ArgumentType type() const { return IfcUtil::Argument_NULL; }
+		bool isNull() const { return true; }
+		unsigned int size() const { return 1; }
+		Argument* operator [] (unsigned int /*i*/) const { throw IfcException("Argument is not a list of attributes"); }
+		std::string toString(bool /*upper=false*/) const { return "$"; }
+	};
+
 	/// Argument of type scalar or string, e.g.
 	/// #1=IfcVector(#2,1.0);
 	///              == ===

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -145,9 +145,12 @@ namespace IfcParse {
 	class IfcParse_EXPORT IfcSpfLexer {
 	private:
 		IfcCharacterDecoder* decoder;
+		//storage for temporary string without allocation
+		mutable std::string _tempString;
 		unsigned int skipWhitespace();
 		unsigned int skipComment();
 	public:
+		std::string &GetTempString() const { return _tempString; }
 		IfcSpfStream* stream;
 		IfcFile* file;
 		IfcSpfLexer(IfcSpfStream* s, IfcFile* f);

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -127,6 +127,8 @@ namespace IfcParse {
 		static double asFloat(const Token& t);
 		/// Returns the token as a string (without the dot or apostrophe)
 		static std::string asString(const Token& t);
+		/// Returns the token as a string in internal buffer (for optimization purposes)
+		static const std::string &asStringRef(const Token& t);
 		/// Returns the token as a string (without the dot or apostrophe)
 		static boost::dynamic_bitset<> asBinary(const Token& t);
 		/// Returns a string representation of the token (including the dot or apostrophe)
@@ -156,7 +158,7 @@ namespace IfcParse {
 		IfcSpfLexer(IfcSpfStream* s, IfcFile* f);
 		Token Next();
 		~IfcSpfLexer();
-		std::string TokenString(unsigned int offset);
+		void TokenString(unsigned int offset, std::string &result);
 	};
 
 	/// Argument of type list, e.g.

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -60,7 +60,13 @@ namespace IfcParse {
 	class IfcFile;
 	class IfcSpfLexer;
 
-	typedef std::pair<IfcSpfLexer*, unsigned> Token;
+	struct Token {
+		IfcSpfLexer* lexer; //TODO: remove it from here
+		unsigned startPos, endPos;
+
+		Token() : lexer(0), startPos(0), endPos((unsigned)-1) {}
+		Token(IfcSpfLexer* _lexer, unsigned _startPos) : lexer(_lexer), startPos(_startPos), endPos((unsigned)-1) {}
+	};
 
 	/// Provides functions to convert Tokens to binary data
 	/// Tokens are merely offsets to where they can be read in the file

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -60,12 +60,27 @@ namespace IfcParse {
 	class IfcFile;
 	class IfcSpfLexer;
 
+	enum TokenType {
+		Token_NONE,
+		Token_STRING,
+		Token_IDENTIFIER,
+		Token_OPERATOR,
+		Token_ENUMERATION,
+		Token_KEYWORD,
+		Token_INT,
+		Token_BOOL,
+		Token_FLOAT,
+		Token_BINARY
+	};
+
 	struct Token {
 		IfcSpfLexer* lexer; //TODO: remove it from here
 		unsigned startPos, endPos;
+		TokenType type;
 
-		Token() : lexer(0), startPos(0), endPos(0) {}
-		Token(IfcSpfLexer* _lexer, unsigned _startPos, unsigned _endPos) : lexer(_lexer), startPos(_startPos), endPos(_endPos) {}
+		Token() : lexer(0), startPos(0), endPos(0), type(Token_NONE) {}
+		Token(IfcSpfLexer* _lexer, unsigned _startPos, unsigned _endPos, TokenType _type)
+			: lexer(_lexer), startPos(_startPos), endPos(_endPos), type(_type) {}
 	};
 
 	/// Provides functions to convert Tokens to binary data

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -137,8 +137,9 @@ namespace IfcParse {
 	// Functions for creating Tokens from an arbitary file offset
 	// The first 4 bits are reserved for Tokens of type ()=,;$*
 	//
-	Token TokenPtr(IfcSpfLexer* tokens, unsigned start, unsigned end = unsigned(-1));
-	Token TokenPtr();
+	Token OperatorTokenPtr(IfcSpfLexer* tokens, unsigned start, unsigned end);
+	Token GeneralTokenPtr(IfcSpfLexer* tokens, unsigned start, unsigned end);
+	Token NoneTokenPtr();
 
 	/// A stream of tokens to be read from a IfcSpfStream.
 	class IfcParse_EXPORT IfcSpfLexer {

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -77,6 +77,12 @@ namespace IfcParse {
 		IfcSpfLexer* lexer; //TODO: remove it from here
 		unsigned startPos, endPos;
 		TokenType type;
+		union {
+			bool value_bool;      //types: BOOL
+			char value_char;      //types: OPERATOR
+			int value_int;        //types: INT, IDENTIFIER
+			double value_double;  //types: FLOAT
+		};
 
 		Token() : lexer(0), startPos(0), endPos(0), type(Token_NONE) {}
 		Token(IfcSpfLexer* _lexer, unsigned _startPos, unsigned _endPos, TokenType _type)
@@ -96,7 +102,9 @@ namespace IfcParse {
 		/// Returns whether the token can be interpreted as an identifier
 		static bool isIdentifier(const Token& t);
 		/// Returns whether the token can be interpreted as a syntactical operator
-		static bool isOperator(const Token& t, char op = 0);
+		static bool isOperator(const Token& t);
+		/// Returns whether the token is a given operator
+		static bool isOperator(const Token& t, char op);
 		/// Returns whether the token can be interpreted as an enumerated value
 		static bool isEnumeration(const Token& t);
 		/// Returns whether the token can be interpreted as a datatype name
@@ -111,6 +119,8 @@ namespace IfcParse {
 		static bool isBinary(const Token& t);
 		/// Returns the token interpreted as an integer
 		static int asInt(const Token& t);
+		/// Returns the token interpreted as an identifier
+		static int asIdentifier(const Token& t);
 		/// Returns the token interpreted as an boolean (.T. or .F.)
 		static bool asBool(const Token& t);
 		/// Returns the token as a floating point number

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -64,8 +64,8 @@ namespace IfcParse {
 		IfcSpfLexer* lexer; //TODO: remove it from here
 		unsigned startPos, endPos;
 
-		Token() : lexer(0), startPos(0), endPos((unsigned)-1) {}
-		Token(IfcSpfLexer* _lexer, unsigned _startPos) : lexer(_lexer), startPos(_startPos), endPos((unsigned)-1) {}
+		Token() : lexer(0), startPos(0), endPos(0) {}
+		Token(IfcSpfLexer* _lexer, unsigned _startPos, unsigned _endPos) : lexer(_lexer), startPos(_startPos), endPos(_endPos) {}
 	};
 
 	/// Provides functions to convert Tokens to binary data
@@ -112,7 +112,7 @@ namespace IfcParse {
 	// Functions for creating Tokens from an arbitary file offset
 	// The first 4 bits are reserved for Tokens of type ()=,;$*
 	//
-	Token TokenPtr(IfcSpfLexer* tokens, unsigned int offset);
+	Token TokenPtr(IfcSpfLexer* tokens, unsigned start, unsigned end = unsigned(-1));
 	Token TokenPtr();
 
 	/// A stream of tokens to be read from a IfcSpfStream.

--- a/src/ifcparse/IfcUtil.cpp
+++ b/src/ifcparse/IfcUtil.cpp
@@ -76,6 +76,24 @@ unsigned int IfcUtil::IfcBaseType::getArgumentCount() const { return 1; }
 Argument* IfcUtil::IfcBaseType::getArgument(unsigned int i) const { return entity->getArgument(i); }
 const char* IfcUtil::IfcBaseType::getArgumentName(unsigned int i) const { if (i == 0) { return "wrappedValue"; } else { throw IfcParse::IfcAttributeOutOfRangeException("Argument index out of range"); } }
 
+
+//Note: some of these methods are overloaded in derived classes
+Argument::operator int() const { throw IfcParse::IfcException("Argument is not an integer"); }
+Argument::operator bool() const { throw IfcParse::IfcException("Argument is not a boolean"); }
+Argument::operator double() const { throw IfcParse::IfcException("Argument is not a number"); }
+Argument::operator std::string() const { throw IfcParse::IfcException("Argument is not a string"); }
+Argument::operator boost::dynamic_bitset<>() const { throw IfcParse::IfcException("Argument is not a binary"); }
+Argument::operator IfcUtil::IfcBaseClass*() const { throw IfcParse::IfcException("Argument is not an entity instance"); }
+Argument::operator std::vector<double>() const { throw IfcParse::IfcException("Argument is not a list of floats"); }
+Argument::operator std::vector<int>() const { throw IfcParse::IfcException("Argument is not a list of ints"); }
+Argument::operator std::vector<std::string>() const { throw IfcParse::IfcException("Argument is not a list of strings"); }
+Argument::operator std::vector<boost::dynamic_bitset<> >() const { throw IfcParse::IfcException("Argument is not a list of binaries"); }
+Argument::operator IfcEntityList::ptr() const { throw IfcParse::IfcException("Argument is not a list of entity instances"); }
+Argument::operator std::vector< std::vector<int> >() const { throw IfcParse::IfcException("Argument is not a list of list of ints"); }
+Argument::operator std::vector< std::vector<double> >() const { throw IfcParse::IfcException("Argument is not a list of list of floats"); }
+Argument::operator IfcEntityListList::ptr() const { throw IfcParse::IfcException("Argument is not a list of list of entity instances"); }
+
+
 static const char* const argument_type_string[] = {
 	"NULL",
 	"DERIVED",

--- a/src/ifcparse/IfcUtil.h
+++ b/src/ifcparse/IfcUtil.h
@@ -291,22 +291,22 @@ namespace IfcParse {
 
 class IfcParse_EXPORT Argument {
 public:
-	virtual operator int() const = 0;
-	virtual operator bool() const = 0;
-	virtual operator double() const = 0;
-	virtual operator std::string() const = 0;
-	virtual operator boost::dynamic_bitset<>() const = 0;
-	virtual operator IfcUtil::IfcBaseClass*() const = 0;
+	virtual operator int() const;
+	virtual operator bool() const;
+	virtual operator double() const;
+	virtual operator std::string() const;
+	virtual operator boost::dynamic_bitset<>() const;
+	virtual operator IfcUtil::IfcBaseClass*() const;
 
-	virtual operator std::vector<int>() const = 0;
-	virtual operator std::vector<double>() const = 0;
-	virtual operator std::vector<std::string>() const = 0;
-	virtual operator std::vector<boost::dynamic_bitset<> >() const = 0;
-	virtual operator IfcEntityList::ptr() const = 0;
+	virtual operator std::vector<int>() const;
+	virtual operator std::vector<double>() const;
+	virtual operator std::vector<std::string>() const;
+	virtual operator std::vector<boost::dynamic_bitset<> >() const;
+	virtual operator IfcEntityList::ptr() const;
 
-	virtual operator std::vector< std::vector<int> >() const = 0;
-	virtual operator std::vector< std::vector<double> >() const = 0;
-	virtual operator IfcEntityListList::ptr() const = 0;
+	virtual operator std::vector< std::vector<int> >() const;
+	virtual operator std::vector< std::vector<double> >() const;
+	virtual operator IfcEntityListList::ptr() const;
 
 	virtual bool isNull() const = 0;
 	virtual unsigned int size() const = 0;


### PR DESCRIPTION
In my opinion, most of the performance issues in IfcParse are due to too many dynamic memory allocations.
This PR is dedicated to removing memory allocations in tokenization process, at least for numbers and operators.

As a result, opening a 47Mb file in our IfcParse-based project now takes 9.5 seconds instead of 12.5 seconds. According to MSVC profiler, samples count of IfcParse.dll has reduced from 3600 to 2600. Built with MSVC2013 x64 with additional optimizations enabled.

In the new tokenization system, most of the information for each token is determined at the moment it is created, and it is saved within the Token struct itself. In particular:
1. startPos - index of first char in token (was saved before).
2. endPos - index of the after-the-last char of token (I thought it would be useful, but it is not actually used).
3. type - operator/keyword/integer/bool/whatever.
4. value - only for some types of tokens, stored in union.
For simple tokens, their values are determined on creation without any memory allocations. This allows to avoid costly creation of std::string-s in IfcSpfLexer::TokenString function.


There are several points I would like to discuss about these changes:

(1) [According to STEP specification](http://www.steptools.com/library/standard/p21e3_dis_paris.html#clause-5-6), EOL chars may appear in any tokens. So breaking a real number into two lines is considered a correct STEP. This is rather unpleasant for tokenization, because it is not possible to parse numbers with standard libraries "in-place" (unless all EOLs are removed even before tokenization).
In order to support such weird tokens, I copy each token into a 64-byte buffer on stack, removing all EOL in process (see function RemoveTokenSeparators). This allows to avoid dynamic allocation, but limits length of any integer or real number to 63 characters. I wonder if it is really a problem and if anyone knows a way to fix it (without dynamic allocation).
For example, the following valid numbers would screw tokenization process in the PR:
- integer: 00000...[repeat 70 times]...0000078
- real: 14.1039...[write 70 digits]...23569

(2) IfcParse library lacks an assert macro.
Throwing exception is the right thing to do on ill-formatted inputs. But sometimes it is desirable to check for conditions which must be true by construction, in order to simplify debugging process. And throwing exception in a small getter function is a waste of program time and space. See functions asInt, asFloat and other for example.
