### PR TITLE
MSYS2 Mingw64 compilation pt. 2

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -316,7 +316,12 @@ IF(MSVC)
 		ENDIF()
 	ENDFOREACH()
 ElSE()
-	ADD_DEFINITIONS(-fPIC -Wno-non-virtual-dtor)
+    IF(WIN32)
+        # -fPIC is not relevant on Windows and create pointless warnings
+        ADD_DEFINITIONS(-Wno-non-virtual-dtor)
+    ELSE()
+        ADD_DEFINITIONS(-fPIC -Wno-non-virtual-dtor)
+    ENDIF()
 ENDIF()
 
 INCLUDE_DIRECTORIES(${INCLUDE_DIRECTORIES} ${OCC_INCLUDE_DIR} ${OPENCOLLADA_INCLUDE_DIRS}

--- a/src/ifcconvert/ColladaSerializer.cpp
+++ b/src/ifcconvert/ColladaSerializer.cpp
@@ -223,7 +223,7 @@ void ColladaSerializer::ColladaExporter::ColladaScene::write() {
 		closeVisualScene();
 		closeLibrary();
 
-		COLLADASW::Scene scene (mSW, COLLADASW::URI ("#" + scene_id), COLLADASW::URI ("#" + scene_id));
+		COLLADASW::Scene scene (mSW, COLLADASW::URI ("#" + scene_id));
 		scene.add();		
 	}
 }

--- a/src/ifcgeomserver/IfcGeomServer.cpp
+++ b/src/ifcgeomserver/IfcGeomServer.cpp
@@ -27,9 +27,12 @@
 #include <iostream>
 #include <boost/cstdint.hpp>
 
-#if defined(_WIN32) && defined(__CYGWIN__)
+// NB: Streams are only re-opened as binary when compiled with MSVC currently.
+//     It is unclear what the correct behaviour would be compiled with e.g MinGW
+#if defined(_MSC_VER)
 #define SET_BINARY_STREAMS
 #endif
+
 #ifdef SET_BINARY_STREAMS
 #include <io.h>
 #include <fcntl.h>

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -47,48 +47,54 @@ using namespace IfcParse;
 // strtod_l() is used and a reference to the "C" locale is obtained here. The alternative is 
 // to use std::istringstream::imbue(std::locale::classic()), but there are subtleties in 
 // parsing in MSVC2010 and it appears to be much slower. 
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
+
 static _locale_t locale = (_locale_t) 0;
 void init_locale() {
 	if (locale == (_locale_t) 0) {
 		locale = _create_locale(LC_NUMERIC, "C");
 	}
 }
-//#else
-#endif
 
-#ifdef __APPLE__
-#include <xlocale.h>
-//#endif
-static locale_t locale = (locale_t) 0;
-void init_locale() {
-	if (locale == (locale_t) 0) {
-		locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t) 0);
-	}
-}
-#endif
+#else
 
-#ifdef __MINGW64__
+#if defined(__MINGW64__) || defined(__MINGW32__)
 #include <locale>
 #include <sstream>
 
 typedef void* locale_t;
-static locale_t locale = (locale_t) 0;
+static locale_t locale = (locale_t)0;
 
 void init_locale() {}
 
 double strtod_l(const char* start, char** end, locale_t loc) {
-    double d;
-    std::stringstream ss;
-    ss.imbue(std::locale::classic());
-    ss << start;
-    ss >> d;
-    size_t nread = ss.tellg();
-    *end = const_cast<char*>(start) + nread;
-    return d;
+	double d;
+	std::stringstream ss;
+	ss.imbue(std::locale::classic());
+	ss << start;
+	ss >> d;
+	size_t nread = ss.tellg();
+	*end = const_cast<char*>(start) + nread;
+	return d;
 }
+
+#else
+
+#ifdef __APPLE__
+#include <xlocale.h>
+#endif
+#include <locale.h>
+
+static locale_t locale = (locale_t)0;
+void init_locale() {
+	if (locale == (locale_t)0) {
+		locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+	}
+}
+
 #endif
 
+#endif
 
 // 
 // Opens the file, gets the filesize and reads a chunk in memory


### PR DESCRIPTION
See #78

A script to compile using MSYS2:

~~~
wget https://github.com/tpaviot/oce/releases/download/OCE-0.16.1/OCE-0.16.1-Mingw64.zip
unzip -qq OCE-0.16.1-Mingw64.zip

pacman --noconfirm -S mingw-w64-x86_64-toolchain mingw-w64-x86_64-boost mingw-w64-x86_64-opencollada-git make swig

export PATH=/mingw64/bin/:$PATH

OPENCOLLADA_INCLUDE_DIR=/mingw64/include/opencollada  \
OPENCOLLADA_LIBRARY_DIR=/mingw64/lib/opencollada      \
OCC_INCLUDE_DIR=`pwd`/OCE-0.16.1-Mingw64/include/oce/ \
OCC_LIBRARY_DIR=`pwd`/OCE-0.16.1-Mingw64/Win64/lib/   \
cmake -G "MSYS Makefiles"                             \
-D CMAKE_C_COMPILER=/mingw64/bin/gcc.exe              \
-D CMAKE_CXX_COMPILER=/mingw64/bin/g++.exe            \
-D CMAKE_MAKE_PROGRAM=/mingw64/bin/mingw32-make.exe   \
-D SWIG_DIR=/usr/bin ../github/cmake

/mingw64/bin/mingw32-make.exe -j 4
~~~

An incompatibility related to `rand_r()` that has been fixed up stream after OCE-0.16.1. Not committed to IfcOpenShell since fixed upstream:

~~~
diff --git a/src/ifcgeom/IfcGeomFunctions.cpp b/src/ifcgeom/IfcGeomFunctions.cpp
index 4bcc841..14dec67 100644
--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -93,6 +93,16 @@
 #include <ShapeFix_ShapeTolerance.hxx>
 #include <ShapeFix_Solid.hxx>

+// Taken from this commit for compatibility with OCE versions that predate this
+// https://github.com/tpaviot/oce/commit/c005215755872242142faff78b593bfb2107431e
+#if OCC_VERSION_HEX < 0x60800
+#if defined(__MINGW64__)
+#ifndef rand_r
+#define rand_r(__seed) (__seed == __seed ? rand () : rand ())
+#endif
+#endif
+#endif
+
 #include <ShapeAnalysis_Curve.hxx>
 #include <ShapeAnalysis_Surface.hxx>

~~~

Not sure if a MinGW build of IfcGeomServer works now without stdin and -out set not explicitly set to binary. A `std::basic_stream::setf()` seemed not to be available.