### PR TITLE
Windows batch script enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Prerequisites
 * Git
 * CMake (2.6 or newer)
 * Windows: Visual Studio 2008 or newer with C++ toolset, MinGW not supported currently
-* *nix: GCC 4.7 or newer, or Clang (any version should work, but not tested)
+* *nix: GCC 4.7 or newer, or Clang (any version)
 
 Dependencies
 -------------
@@ -52,8 +52,8 @@ Only) to deploy the headers and binaries into a single location if wanted/needed
 
 Alternatively, one can use the utility batch files to build and install the project easily from the command-line:
 
-    > build-ifcopenshell.cmd
-    > install-ifcopenshell.cmd
+    > build-ifcopenshell.bat
+    > install-ifcopenshell.bat
 
 ### Compiling on *nix
 There might be an Open CASCADE package in your operating system's software repository. If not, you will need to compile

--- a/win/build-deps.cmd
+++ b/win/build-deps.cmd
@@ -121,6 +121,10 @@ echo.
 call cecho.cmd black cyan "If you are not ready with the above, press Ctrl-C to abort!"
 
 pause
+
+:: Cache last used CMake generator for other scripts to use
+if defined GEN_SHORTHAND echo GEN_SHORTHAND=%GEN_SHORTHAND%>"%~dp0\BuildDepsCache-%TARGET_ARCH%.txt"
+
 echo.
 set START_TIME=%TIME%
 echo Build started at %START_TIME%.
@@ -265,7 +269,7 @@ set PYTHON_INSTALLER=python-%PYTHON_VERSION%%PYTHON_AMD64_POSTFIX%.msi
 :: NOTE/TODO 3.5.0 doesn't use MSI any longer, but exe: set PYTHON_INSTALLER=python-%PYTHON_VERSION%%PYTHON_AMD64_POSTFIX%.exe
 IF "%IFCOS_INSTALL_PYTHON%"=="TRUE" (
     REM Store Python versions to BuildDepsCache.txt for run-cmake.bat
-    echo PY_VER_MAJOR_MINOR=%PY_VER_MAJOR_MINOR%>"%~dp0\BuildDepsCache-%TARGET_ARCH%.txt"
+    echo PY_VER_MAJOR_MINOR=%PY_VER_MAJOR_MINOR%>>"%~dp0\BuildDepsCache-%TARGET_ARCH%.txt"
     echo PYTHONHOME=%PYTHONHOME%>>"%~dp0\BuildDepsCache-%TARGET_ARCH%.txt"
 
     cd "%DEPS_DIR%"

--- a/win/build-ifcopenshell.bat
+++ b/win/build-ifcopenshell.bat
@@ -27,12 +27,20 @@ echo.
 
 :: Enable the delayed environment variable expansion needed in VSConfig.cmd.
 setlocal EnableDelayedExpansion
-:: Read cached variables (GEN_SHORTHAND, PY_VER_MAJOR_MINOR, PYTHONHOME, and possible others) from BuildDepsCache.txt.
-:: TODO Simply make x64 to take precedence over x86, but it would be niced that the last used target arch would be used.
-if exist BuildDepsCache-x86.txt for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x86.txt) do set %%G=%%H
-if exist BuildDepsCache-x64.txt. for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x64.txt) do set %%G=%%H
+set IFCOS_PAUSE_ON_ERROR=
+
+:: Read cached variables from the most recently modified BuildDepsCache.txt.
+for /f "tokens=*" %%f in ('dir BuildDepsCache-*.txt /o:-n /t:a /b') do (
+    for /f "delims== tokens=1,2" %%G in (%%f) do set %%G=%%H
+)
+
 set GENERATOR=%1
-if (%1)==() if defined GEN_SHORTHAND (
+if (%1)==() (
+    if not defined GEN_SHORTHAND (
+        echo BuildDepsCache file does and/or GEN_SHORTHAND missing from it. Run build-deps.cmd to create it.
+        set IFCOS_PAUSE_ON_ERROR=pause
+        goto :Error
+    )
     set GENERATOR=%GEN_SHORTHAND%
     echo Generator not passed, but GEN_SHORTHAND=!GENERATOR! read from BuildDepsCache
     echo.
@@ -60,6 +68,7 @@ goto :End
 :Error
 echo.
 call %~dp0\utils\cecho.cmd 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% build failed!"
+%IFCOS_PAUSE_ON_ERROR%
 set IFCOS_SCRIPT_RET=1
 
 :End

--- a/win/build-ifcopenshell.bat
+++ b/win/build-ifcopenshell.bat
@@ -27,29 +27,39 @@ echo.
 
 :: Enable the delayed environment variable expansion needed in VSConfig.cmd.
 setlocal EnableDelayedExpansion
-call vs-cfg.cmd %1
+:: Read cached variables (GEN_SHORTHAND, PY_VER_MAJOR_MINOR, PYTHONHOME, and possible others) from BuildDepsCache.txt.
+:: TODO Simply make x64 to take precedence over x86, but it would be niced that the last used target arch would be used.
+if exist BuildDepsCache-x86.txt for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x86.txt) do set %%G=%%H
+if exist BuildDepsCache-x64.txt. for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x64.txt) do set %%G=%%H
+set GENERATOR=%1
+if (%1)==() if defined GEN_SHORTHAND (
+    set GENERATOR=%GEN_SHORTHAND%
+    echo Generator not passed, but GEN_SHORTHAND=!GENERATOR! read from BuildDepsCache
+    echo.
+)
+call vs-cfg.cmd %GENERATOR%
 IF NOT %ERRORLEVEL%==0 GOTO :Error
 call build-type-cfg.cmd %2
 IF NOT %ERRORLEVEL%==0 GOTO :Error
 
 echo.
-IF "%IFCOS_NUM_BUILD_PROCS%"=="" set IFCOS_NUM_BUILD_PROCS=%NUMBER_OF_PROCESSORS%
+if not defined IFCOS_NUM_BUILD_PROCS set IFCOS_NUM_BUILD_PROCS=%NUMBER_OF_PROCESSORS%
 call cecho.cmd 0 13 "* IFCOS_NUM_BUILD_PROCS`t= %IFCOS_NUM_BUILD_PROCS%"
 echo.
 
-call cecho.cmd 0 13 "Installing %VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME%"
-MSBuild ..\%BUILD_DIR%\INSTALL.%VCPROJ_FILE_EXT% /nologo /m:%IFCOS_NUM_BUILD_PROCS% /p:Platform=%VS_PLATFORM% ^
-    /p:Configuration=%BUILD_CFG% %3 %4 %5 %6 %7 %8 %9
+call cecho.cmd 0 13 "Building %VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME%"
+cmake --build ..\%BUILD_DIR% -- /nologo /m:%IFCOS_NUM_BUILD_PROCS% /p:Platform=%VS_PLATFORM% /p:Configuration=%BUILD_CFG% ^
+    %3 %4 %5 %6 %7 %8 %9
 IF NOT %ERRORLEVEL%==0 GOTO :Error
 
 echo.
-call cecho.cmd 0 10 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% installation finished."
+call cecho.cmd 0 10 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% build finished."
 set IFCOS_SCRIPT_RET=0
 goto :End
 
 :Error
 echo.
-call %~dp0\utils\cecho.cmd 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% installation failed!"
+call %~dp0\utils\cecho.cmd 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% build failed!"
 set IFCOS_SCRIPT_RET=1
 
 :End

--- a/win/install-ifcopenshell.bat
+++ b/win/install-ifcopenshell.bat
@@ -27,12 +27,19 @@ echo.
 
 :: Enable the delayed environment variable expansion needed in VSConfig.cmd.
 setlocal EnableDelayedExpansion
-:: Read cached variables (GEN_SHORTHAND, PY_VER_MAJOR_MINOR, PYTHONHOME, and possible others) from BuildDepsCache.txt.
-:: TODO Simply make x64 to take precedence over x86, but it would be niced that the last used target arch would be used.
-if exist BuildDepsCache-x86.txt for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x86.txt) do set %%G=%%H
-if exist BuildDepsCache-x64.txt. for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x64.txt) do set %%G=%%H
+set IFCOS_PAUSE_ON_ERROR=
+
+:: Read cached variables from the most recently modified BuildDepsCache.txt.
+for /f "tokens=*" %%f in ('dir BuildDepsCache-*.txt /o:-n /t:a /b') do (
+    for /f "delims== tokens=1,2" %%G in (%%f) do set %%G=%%H
+)
 set GENERATOR=%1
-if (%1)==() if defined GEN_SHORTHAND (
+if (%1)==() (
+    if not defined GEN_SHORTHAND (
+        echo BuildDepsCache file does and/or GEN_SHORTHAND missing from it. Run build-deps.cmd to create it.
+        set IFCOS_PAUSE_ON_ERROR=pause
+        goto :Error
+    )
     set GENERATOR=%GEN_SHORTHAND%
     echo Generator not passed, but GEN_SHORTHAND=!GENERATOR! read from BuildDepsCache
     echo.
@@ -60,6 +67,7 @@ goto :End
 :Error
 echo.
 call %~dp0\utils\cecho.cmd 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% installation failed!"
+%IFCOS_PAUSE_ON_ERROR%
 set IFCOS_SCRIPT_RET=1
 
 :End

--- a/win/install-ifcopenshell.bat
+++ b/win/install-ifcopenshell.bat
@@ -27,7 +27,17 @@ echo.
 
 :: Enable the delayed environment variable expansion needed in VSConfig.cmd.
 setlocal EnableDelayedExpansion
-call vs-cfg.cmd %1
+:: Read cached variables (GEN_SHORTHAND, PY_VER_MAJOR_MINOR, PYTHONHOME, and possible others) from BuildDepsCache.txt.
+:: TODO Simply make x64 to take precedence over x86, but it would be niced that the last used target arch would be used.
+if exist BuildDepsCache-x86.txt for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x86.txt) do set %%G=%%H
+if exist BuildDepsCache-x64.txt. for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x64.txt) do set %%G=%%H
+set GENERATOR=%1
+if (%1)==() if defined GEN_SHORTHAND (
+    set GENERATOR=%GEN_SHORTHAND%
+    echo Generator not passed, but GEN_SHORTHAND=!GENERATOR! read from BuildDepsCache
+    echo.
+)
+call vs-cfg.cmd %GENERATOR%
 IF NOT %ERRORLEVEL%==0 GOTO :Error
 call build-type-cfg.cmd %2
 IF NOT %ERRORLEVEL%==0 GOTO :Error
@@ -37,19 +47,19 @@ IF "%IFCOS_NUM_BUILD_PROCS%"=="" set IFCOS_NUM_BUILD_PROCS=%NUMBER_OF_PROCESSORS
 call cecho.cmd 0 13 "* IFCOS_NUM_BUILD_PROCS`t= %IFCOS_NUM_BUILD_PROCS%"
 echo.
 
-call cecho.cmd 0 13 "Building %VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME%"
-MSBuild ..\%BUILD_DIR%\%PROJECT_NAME%.sln /nologo /m:%IFCOS_NUM_BUILD_PROCS% /p:Platform=%VS_PLATFORM% ^
+call cecho.cmd 0 13 "Installing %VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME%"
+cmake --build ..\%BUILD_DIR% --target INSTALL -- /nologo /m:%IFCOS_NUM_BUILD_PROCS% /p:Platform=%VS_PLATFORM% ^
     /p:Configuration=%BUILD_CFG% %3 %4 %5 %6 %7 %8 %9
 IF NOT %ERRORLEVEL%==0 GOTO :Error
 
 echo.
-call cecho.cmd 0 10 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% build finished."
+call cecho.cmd 0 10 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% installation finished."
 set IFCOS_SCRIPT_RET=0
 goto :End
 
 :Error
 echo.
-call %~dp0\utils\cecho.cmd 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% build failed!"
+call %~dp0\utils\cecho.cmd 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% installation failed!"
 set IFCOS_SCRIPT_RET=1
 
 :End

--- a/win/readme.md
+++ b/win/readme.md
@@ -44,7 +44,7 @@ After this, one can build the project using the `IfcOpenShell.sln` file in the b
 if wanted. Convenience batch files `build-ifcopenshell.bat` and `install-ifcopenshell.bat` can also be used. The batch
 files expect `%1` and `%2` in same fashion as above and possible extra parameters are passed for the `MSBuild` call.
 `run-cmake.bat`, `build-ifcopenshell.bat`, and `install-ifcopenshell.bat` can also be directly invoked from Filer Explorer
-or regular Command Prompt if BuildDepsCache file exists (x64 version takes precedence). Running the scripts without extra
+or regular Command Prompt if BuildDepsCache file exists (the last modified version is used). Running the scripts without extra
 parameters reads the build options from an existing CMakeCache.txt.
 
 The project will be installed to `installed-vs<VERSION>-<ARCHITECTURE>\` folder in the project's root folder and the

--- a/win/readme.md
+++ b/win/readme.md
@@ -3,28 +3,32 @@ Windows Build Tools and Scripts
 This folder contains build tools and script for automatic building and deployment of IfcOpenShell (IFCOS)
 and its dependencies.
 
-As a general guideline, `.cmd` files are non-standalone batch files that need to be run from command
-prompt or from another batch file, and/or while the Visual Studio environment variables set, and `.bat` files are
-standalone batch files that can be run also e.g. from the File Explorer.
+As a general guideline, `.cmd` files are non-standalone batch files that need to be run from command prompt or from
+another batch file, and/or while the Visual Studio environment variables set, and `.bat` files are standalone batch
+files that can also be invoked e.g. by double-clicking in the File Explorer.
 
 Usage Instructions
 ------------------
-Execute `build-deps.cmd` to fetch, build and install the dependencies. The batch file will print
-the requirements for a successful execution. The script allows a few user-configurable build options
-which are listed in the usage instructions. Either edit the script file or set these values before
-running the script.
+Execute `build-deps.cmd` to fetch, build and install the dependencies. The batch file will print the requirements for
+a successful execution. The script allows a few user-configurable build options which are listed in the usage
+instructions. Either edit the script file or set these values before running the script.
 
-`build-deps.cmd` expects a CMake generator as `%1` and a build configuration type (`RelWithDebInfo/Release/MinSizeRel/Debug`,
-defaults to `RelWithDebInfo`) as `%2`. If the generator is not provided, the generator is deduced from the Visual Studio
-environment variables. User-friendly VS generator shorthands are supported, e.g. `vs2013-x86` or `vs2015-x64`, and these are
-converted to the appropriate CMake ones by the scripts. A build type (`Build/Rebuild/Clean`, defaults to `Build`) can be
-provided as `%3`. See `vs-cfg.cmd` if you wish to change the defaults. The batch file will create `deps\` and
-`deps-vs<VERSION>-<ARCHITECTURE>-installed\` directories to the project root. Debug and release builds of the depedencies
-can co-exist by simply running `build-deps.cmd <GENERATOR> Debug` and `build-deps.cmd <GENERATOR> <Release|RelWithDebInfo|MinSizeRel>`.
+`build-deps.cmd` expects a CMake generator as `%1` and a build configuration type (`RelWithDebInfo`, `Release`,
+`MinSizeRel`, or `Debug`, defaults to `RelWithDebInfo`) as `%2`. If the generator is not provided, the generator is
+deduced from the Visual Studio environment variables. User-friendly VS generator shorthands are supported, e.g.
+`vs2013-x86` or `vs2015-x64`, and these are converted to the appropriate CMake ones by the scripts. A build type
+(`Build`, `Rebuild`, or `Clean`, defaults to `Build`) can be provided as `%3`. See `vs-cfg.cmd` if you wish to change
+the defaults. The batch file will create `deps\` and `deps-vs<VERSION>-<ARCHITECTURE>-installed\` directories to the
+project root. Debug and release builds of the depedencies can co-exist by simply running
+```
+> build-deps.cmd <GENERATOR> Debug
+> build-deps.cmd <GENERATOR> <Release|RelWithDebInfo|MinSizeRel>
+```
 
-After the dependencies are build, execute `run-cmake.bat`. The batch file expects always a CMake generator as `%1`
-(if not provided, the same default value as above is used), and the rest of possible parameters are passed as is.
-If passing build options for the script, the generator must be always passed as the first option:
+After the dependencies are build, execute `run-cmake.bat`. The batch file expects a CMake generator as `%1` and the
+rest of possible parameters are passed as is. If a generator is not provided, the generator is read from the
+BuildDepsCache file, or tried to be deduced from the location of `cl.exe`. If passing build options for the script,
+the generator must be always passed as the first option:
 ```
 > run-cmake.bat vs2015-x64 -DUSE_IFC4=1 -DBUILD_IFCPYTHON=0
 ```
@@ -37,19 +41,18 @@ Note that building IfcOpenShell as 64-bit is recommended as many of real life IF
 easily more than 2 GBs of RAM while converting.
 
 After this, one can build the project using the `IfcOpenShell.sln` file in the build folder. Build the `INSTALL` project
-if wanted. Convenience batch files `build-ifcopenshell.bat` and `install-ifcopenshell.bat` can also be used. The batch files
-expect `%1` and `%2` in same fashion as above and possible extra parameters are passed for the `MSBuild` call. `run-cmake.bat`,
-`build-ifcopenshell.bat`, and `install-ifcopenshell.bat` can also be directly invoked from Filer Explorer or regular Command
-Prompt if BuildDepsCache file exists (x64 version takes precedence). Running the scripts without extra parameters reads the build
-options from an existing CMakeCache.txt.
+if wanted. Convenience batch files `build-ifcopenshell.bat` and `install-ifcopenshell.bat` can also be used. The batch
+files expect `%1` and `%2` in same fashion as above and possible extra parameters are passed for the `MSBuild` call.
+`run-cmake.bat`, `build-ifcopenshell.bat`, and `install-ifcopenshell.bat` can also be directly invoked from Filer Explorer
+or regular Command Prompt if BuildDepsCache file exists (x64 version takes precedence). Running the scripts without extra
+parameters reads the build options from an existing CMakeCache.txt.
 
+The project will be installed to `installed-vs<VERSION>-<ARCHITECTURE>\` folder in the project's root folder and the
+required IfcOpenShell-Python parts are deployed to the `<PYTHONHOME>\Lib\site-packages\` folder. The 3ds Max plug-in,
+`IfcMax.dli`, needs to be copied manually to the 3ds Max's `plugins` folder.
 
-The project will be installed to `installed-vs<VERSION>-<ARCHITECTURE>\` folder in the project's root folder and the required IfcOpenShell-Python
-parts are deployed to the `<PYTHONHOME>\Lib\site-packages\` folder. The 3ds Max plug-in, IfcMax.dli, needs to be copied manually
-to the 3ds Max's `plugins` folder.
-
-**Note:** All of the dependencies are build as static libraries against the static run-time allowing the developer
-to effortlessly deploy standalone IFCOS executables.
+**Note:** Currently all of the dependencies are build as static libraries against the static run-time allowing the
+developer to effortlessly deploy standalone IFCOS executables.
 
 Using an already existing Python installation
 ---------------------------------------------
@@ -61,13 +64,15 @@ Before building the dependencies, disable the script from installing Python:
 > buid-deps.cmd
 ```
 
-After bulding the dependencies, create BuildDepsCache file to `IfcOpenShell\win` which tells the used Python version and intallation directory:
+After building the dependencies, append Python version and installation directory information to the BuildDepsCache file
+in `IfcOpenShell\win`:
 ```
-> echo PY_VER_MAJOR_MINOR=35> BuildDepsCache-x64.txt
+> echo PY_VER_MAJOR_MINOR=35>> BuildDepsCache-x64.txt
 > echo PYTHONHOME=C:\Python3>> BuildDepsCache-x64.txt
 ```
 
-After this you should be able to run `run-cmake.bat` normally. If using 32-bit Python, the name of the file must be `BuildDepsCache-x86.txt`.
+After this you should be able to run `run-cmake.bat` normally. If using 32-bit Python, the name of the file must be
+`BuildDepsCache-x86.txt`.
 
 Directory Structure
 ------------------

--- a/win/readme.md
+++ b/win/readme.md
@@ -37,14 +37,19 @@ Note that building IfcOpenShell as 64-bit is recommended as many of real life IF
 easily more than 2 GBs of RAM while converting.
 
 After this, one can build the project using the `IfcOpenShell.sln` file in the build folder. Build the `INSTALL` project
-if wanted. Convenience batch files `build-ifcopenshell.cmd` and `install-ifcopenshell.cmd` can also be used. The batch files
-expect `%1` and `%2` in same fashion as above and possible extra parameters are passed for the `MSBuild` call. The project will
-be installed to `installed-vs<VERSION>-<ARCHITECTURE>\` folder in the project's root folder and the required IfcOpenShell-Python
+if wanted. Convenience batch files `build-ifcopenshell.bat` and `install-ifcopenshell.bat` can also be used. The batch files
+expect `%1` and `%2` in same fashion as above and possible extra parameters are passed for the `MSBuild` call. `run-cmake.bat`,
+`build-ifcopenshell.bat`, and `install-ifcopenshell.bat` can also be directly invoked from Filer Explorer or regular Command
+Prompt if BuildDepsCache file exists (x64 version takes precedence). Running the scripts without extra parameters reads the build
+options from an existing CMakeCache.txt.
+
+
+The project will be installed to `installed-vs<VERSION>-<ARCHITECTURE>\` folder in the project's root folder and the required IfcOpenShell-Python
 parts are deployed to the `<PYTHONHOME>\Lib\site-packages\` folder. The 3ds Max plug-in, IfcMax.dli, needs to be copied manually
 to the 3ds Max's `plugins` folder.
 
 **Note:** All of the dependencies are build as static libraries against the static run-time allowing the developer
-to effortlessly deploy standalone IFCOS binaries.
+to effortlessly deploy standalone IFCOS executables.
 
 Using an already existing Python installation
 ---------------------------------------------
@@ -76,9 +81,9 @@ Directory Structure
 |   build-all.cmd                   - Runs all of the build scripts for IFCOS and it dependencies in a row without pauses
 |   build-deps.cmd                  - Fetches and builds all needed dependencies for IFCOS
 |   BuildDepsCache-<ARCH>.txt       - Cache file created by build-deps.cmd
-|   build-ifcopenshell.cmd          - Builds IFCOS
+|   build-ifcopenshell.bat          - Builds IFCOS
 |   build-type-cfg.cmd              - Utility file used by the build scripts
-|   install-ifcopenshell.cmd        - Builds IFCOS's INSTALL project
+|   install-ifcopenshell.bat        - Builds IFCOS's INSTALL project
 |   readme.md                       - This file
 |   run-cmake.bat                   - Sets environment variables for the dependencies and runs CMake for IFCOS
 |   set-python-to-path.bat          - Utility for setting PYTHONHOME (read from BuildDepsCache-<ARCH>.txt) to PATH

--- a/win/run-cmake.bat
+++ b/win/run-cmake.bat
@@ -23,13 +23,20 @@ echo.
 set PROJECT_NAME=IfcOpenShell
 
 setlocal EnableDelayedExpansion
+set IFCOS_PAUSE_ON_ERROR=
 
-:: Read cached variables (GEN_SHORTHAND, PY_VER_MAJOR_MINOR, PYTHONHOME, and possible others) from BuildDepsCache.txt.
-:: TODO Simply make x64 takes precedence over x86, but it would be niced that the last used target arch would be used.
-if exist BuildDepsCache-x86.txt for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x86.txt) do set %%G=%%H
-if exist BuildDepsCache-x64.txt. for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x64.txt) do set %%G=%%H
+:: Read cached variables from the most recently modified BuildDepsCache.txt.
+for /f "tokens=*" %%f in ('dir BuildDepsCache-*.txt /o:-n /t:a /b') do (
+    for /f "delims== tokens=1,2" %%G in (%%f) do set %%G=%%H
+)
+
 set GENERATOR=%1
-if (%1)==() if defined GEN_SHORTHAND (
+if (%1)==() (
+    if not defined GEN_SHORTHAND (
+        echo BuildDepsCache file does and/or GEN_SHORTHAND missing from it. Run build-deps.cmd to create it.
+        set IFCOS_PAUSE_ON_ERROR=pause
+        goto :Error
+    )
     set GENERATOR=%GEN_SHORTHAND%
     echo Generator not passed, but GEN_SHORTHAND=!GENERATOR! read from BuildDepsCache
     echo.
@@ -107,6 +114,7 @@ goto :Finish
 :Error
 echo.
 call %~dp0\utils\cecho.cmd 0 12 "An error occurred! Aborting!"
+%IFCOS_PAUSE_ON_ERROR%
 set IFCOS_SCRIPT_RET=1
 goto :Finish
 

--- a/win/run-cmake.bat
+++ b/win/run-cmake.bat
@@ -24,7 +24,17 @@ set PROJECT_NAME=IfcOpenShell
 
 setlocal EnableDelayedExpansion
 
-call vs-cfg.cmd %1
+:: Read cached variables (GEN_SHORTHAND, PY_VER_MAJOR_MINOR, PYTHONHOME, and possible others) from BuildDepsCache.txt.
+:: TODO Simply make x64 takes precedence over x86, but it would be niced that the last used target arch would be used.
+if exist BuildDepsCache-x86.txt for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x86.txt) do set %%G=%%H
+if exist BuildDepsCache-x64.txt. for /f "delims== tokens=1,2" %%G in (BuildDepsCache-x64.txt) do set %%G=%%H
+set GENERATOR=%1
+if (%1)==() if defined GEN_SHORTHAND (
+    set GENERATOR=%GEN_SHORTHAND%
+    echo Generator not passed, but GEN_SHORTHAND=!GENERATOR! read from BuildDepsCache
+    echo.
+)
+call vs-cfg.cmd %GENERATOR%
 IF NOT %ERRORLEVEL%==0 GOTO :Error
 :: As CMake options are typically of format -DSOMETHING:BOOL=ON or -DSOMETHING=1, i.e. they contain an equal sign,
 :: they will mess up the batch file argument parsing if the arguments are passed on by splitting them %2 %3 %4 %5
@@ -33,9 +43,6 @@ if not (%1)==() (
     set ARGUMENTS=%*
     call set ARGUMENTS=%%ARGUMENTS:%1=%%
 )
-
-:: Read Python related variables from BuildDepsCache.txt
-for /f "delims== tokens=1,2" %%G in (BuildDepsCache-%TARGET_ARCH%.txt) do set %%G=%%H
 
 pushd ..
 set CMAKE_INSTALL_PREFIX=%CD%\installed-vs%VS_VER%-%TARGET_ARCH%
@@ -86,8 +93,8 @@ echo    CMAKE_INSTALL_PREFIX    = %CMAKE_INSTALL_PREFIX%
 echo.
 
 set CMAKELISTS_DIR=..\cmake
-:: For now clear CMakeCache.txt always in order to assure that when changing build options everything goes smoothly.
-IF EXIST CMakeCache.txt. del /Q CMakeCache.txt
+:: Delete CMakeCache.txt if command-line options were provided for this batch script.
+if not (%1)==() if exist CMakeCache.txt. del /Q CMakeCache.txt
 call cecho.cmd 0 13 "Running CMake for %PROJECT_NAME%."
 cmake.exe %CMAKELISTS_DIR% -G %GENERATOR% -DCMAKE_INSTALL_PREFIX="%CMAKE_INSTALL_PREFIX%" %ARGUMENTS%
 IF NOT %ERRORLEVEL%==0 GOTO :Error

--- a/win/vs-cfg.cmd
+++ b/win/vs-cfg.cmd
@@ -66,6 +66,7 @@ echo(!GENERATOR! | findstr /c:"vs20" >nul && (
 :GeneratorShorthandCheckDone
 
 :: Deduce desired architecture from the location of cl.exe
+:: TODO harmless "INFO: Could not find files for the given pattern(s)." spam if cl.exe not in path
 where cl.exe | findstr /c:"amd64" >nul
 set START=%ERRORLEVEL%
 
@@ -136,6 +137,7 @@ set GENERATOR=%GENERATOR: 2012=%
 set GENERATOR=%GENERATOR: 2010=%
 :CMake3AndNewer
 
+set GEN_SHORTHAND=vs%VS_VER%-%TARGET_ARCH%
 :: VS project file extension is different on older VS versions
 set VCPROJ_FILE_EXT=vcxproj
 IF %VS_VER%==2008 set VCPROJ_FILE_EXT=vcproj
@@ -150,10 +152,10 @@ set PATH=%PATH%;%~dp0utils
 :: set DEPS_DIR=%CD%\deps-%VS_VER%-%TARGET_ARCH%
 pushd ..
 set DEPS_DIR=%CD%\deps
-set INSTALL_DIR=%CD%\deps-vs%VS_VER%-%TARGET_ARCH%-installed
+set INSTALL_DIR=%CD%\deps-%GEN_SHORTHAND%-installed
 REM set INSTALL_DIR=%CD%\deps-vs%VS_VER%-%TARGET_ARCH%-%DEBUG_OR_RELEASE_LOWERCASE%-installed
 :: BUILD_DIR is a relative build directory used for CMake-based projects
-set BUILD_DIR=build-vs%VS_VER%-%TARGET_ARCH%
+set BUILD_DIR=build-%GEN_SHORTHAND%
 popd
 
 GOTO :EOF


### PR DESCRIPTION
Make possible to invoke run-cmake.bat, build-ifcopenshell.bat, and install-ifcopenshell.cmd directly from File Explorer or command prompt without VS env vars set, if BuildDepsCache file exists, by utilizing CMake's --build functionality.
