### PR TITLE
Bring back logic for BUILD_SHARED_LIBS.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -432,7 +432,11 @@ if(NOT WIN32)
 	LINK_DIRECTORIES(${LINK_DIRECTORIES} /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64)
 endif()
 
-SET(IFCOPENSHELL_LIBRARIES IfcParse IfcGeom)
+if(BUILD_SHARED_LIBS)
+    SET(IFCOPENSHELL_LIBRARIES IfcGeom)
+else()
+    SET(IFCOPENSHELL_LIBRARIES IfcParse IfcGeom)
+endif()
 
 # IfcParse
 file(GLOB IFCPARSE_H_FILES ../src/ifcparse/*.h)
@@ -448,7 +452,7 @@ endforeach()
 
 set(IFCPARSE_FILES ${IFCPARSE_CPP_FILES} ${IFCPARSE_H_FILES})
 
-add_library(IfcParse ${IFCPARSE_FILES})
+add_library(IfcParse STATIC ${IFCPARSE_FILES})
 set_target_properties(IfcParse PROPERTIES COMPILE_FLAGS -DIfcParse_EXPORTS)
 
 IF(UNICODE_SUPPORT)
@@ -461,7 +465,7 @@ file(GLOB IFCGEOM_CPP_FILES ../src/ifcgeom/*.cpp)
 set(IFCGEOM_FILES ${IFCGEOM_CPP_FILES} ${IFCGEOM_H_FILES})
 IF(BUILD_SHARED_LIBS)
 	message(WARNING "Building IfcGeom as shared library not currently supported")
-        add_library(IfcGeom STATIC ${IFCGEOM_FILES})
+	add_library(IfcGeom SHARED ${IFCGEOM_FILES})
 ELSE()
         add_library(IfcGeom ${IFCGEOM_FILES})
 ENDIF()
@@ -524,7 +528,7 @@ INSTALL(FILES ${IFCGEOM_H_FILES}
 	DESTINATION ${INCLUDEDIR}/ifcgeom
 )
 
-INSTALL(TARGETS IfcParse IfcGeom IfcConvert IfcGeomServer
+INSTALL(TARGETS ${IFCOPENSHELL_LIBRARIES} IfcConvert IfcGeomServer
 	ARCHIVE DESTINATION ${LIBDIR}
 	LIBRARY DESTINATION ${LIBDIR}
 	RUNTIME DESTINATION ${BINDIR}

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -559,9 +559,9 @@ double TokenFunc::asFloat(const Token& t) {
 const std::string &TokenFunc::asStringRef(const Token& t) {
 	std::string &str = t.lexer->GetTempString();
 	t.lexer->TokenString(t.startPos, str);
-	if (isString(t) || isEnumeration(t) || isBinary(t)) {
+	if ((isString(t) || isEnumeration(t) || isBinary(t)) && !str.empty()) {
 		//remove start+end characters in-place
-		str.pop_back();
+		str.erase(str.end()-1);
 		str.erase(str.begin());
 	}
 	return str;


### PR DESCRIPTION
Also remove C++11 code.

An already implemented warning should be enough ...