### PR TITLE
Cmake improvements: LINK_DIRECTORIES and OCCT 7

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -142,21 +142,17 @@ ELSE()
 	MESSAGE(STATUS "Looking for opencascade include files in: ${OCC_INCLUDE_DIR}")
 ENDIF()
 
-FIND_FILE(gp_Pnt_hxx "gp_Pnt.hxx" ${OCC_INCLUDE_DIR} /usr/inc /usr/local/inc /usr/local/include/oce)
+FIND_FILE(gp_Pnt_hxx "gp_Pnt.hxx" ${OCC_INCLUDE_DIR})
 IF(gp_Pnt_hxx)
 	MESSAGE(STATUS "Header files found")
 ELSE()
 	MESSAGE(FATAL_ERROR "Unable to find header files, aborting")
 ENDIF()
 
-SET(OPENCASCADE_LIBRARIES
+SET(OPENCASCADE_LIBRARY_NAMES
 	TKernel TKMath TKBRep TKGeomBase TKGeomAlgo TKG3d TKG2d TKShHealing TKTopAlgo TKMesh TKPrim TKBool TKBO
 	TKFillet TKSTEP TKSTEPBase TKSTEPAttr TKXSBase TKSTEP209 TKIGES TKOffset
 )
-
-IF(MSVC)
-	ADD_DEBUG_VARIANTS(OPENCASCADE_LIBRARIES "${OPENCASCADE_LIBRARIES}" "d")
-ENDIF()
 
 IF("${OCC_LIBRARY_DIR}" STREQUAL "")
 	SET(OCC_LIBRARY_DIR "/usr/lib/" CACHE FILEPATH "Open CASCADE library files")
@@ -167,41 +163,53 @@ ELSE()
 	MESSAGE(STATUS "Looking for opencascade library files in: ${OCC_LIBRARY_DIR}")
 ENDIF()
 
-FIND_LIBRARY(libTKernel NAMES TKernel TKerneld PATHS ${OCC_LIBRARY_DIR} /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64)
+FIND_LIBRARY(libTKernel NAMES TKernel TKerneld PATHS ${OCC_LIBRARY_DIR} NO_DEFAULT_PATH)
 IF(libTKernel)
 	MESSAGE(STATUS "Library files found")
 ELSE()
 	MESSAGE(FATAL_ERROR "Unable to find library files, aborting")
 ENDIF()
 
+# Use the found libTKernel as a template for all other OCC libraries
+foreach(lib ${OPENCASCADE_LIBRARY_NAMES})
+    string(REPLACE TKernel "${lib}" lib_path "${libTKernel}")
+    list(APPEND OPENCASCADE_LIBRARIES "${lib_path}")
+endforeach()
+
+IF(MSVC)
+	ADD_DEBUG_VARIANTS(OPENCASCADE_LIBRARIES "${OPENCASCADE_LIBRARIES}" "d")
+ENDIF()
+
 IF(UNICODE_SUPPORT)
 	# Find ICU 
 	IF("${ICU_INCLUDE_DIR}" STREQUAL "")
 		MESSAGE(STATUS "No ICU include directory specified")
-	ElSE()
-		SET(ICU_INCLUDE_DIR "${ICU_INCLUDE_DIR}" CACHE FILEPATH "ICU header files")
 	ENDIF()
 
 	IF("${ICU_LIBRARY_DIR}" STREQUAL "")
 		MESSAGE(STATUS "No ICU library directory specified")
-	ElSE()
-		SET(ICU_LIBRARY_DIR "${ICU_LIBRARY_DIR}" CACHE FILEPATH "ICU library files")
+		FIND_LIBRARY(icu NAMES icuuc icuucd PATHS ${ICU_LIBRARY_DIR})
+	ELSE()
+		FIND_LIBRARY(icu NAMES icuuc icuucd PATHS ${ICU_LIBRARY_DIR} NO_DEFAULT_PATH)
 	ENDIF()
 
-	FIND_LIBRARY(icu NAMES icuuc icuucd PATHS /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${ICU_LIBRARY_DIR})
-
 	IF(icu)
+		GET_FILENAME_COMPONENT(ICU_LIBRARY_DIR ${icu} PATH)
+
 		ADD_DEFINITIONS(-DHAVE_ICU)
 		MESSAGE(STATUS "ICU libraries found")
 		# NOTE icudata appears to be icudt on Windows/MSVC and icudata on others
 		#      dl is included to resolve dlopen and friends symbols
 		IF(WIN32)
-			SET(ICU_LIBRARIES icuuc icudt)
+			FIND_LIBRARY(icudt NAMES icudt PATHS ${ICU_LIBRARY_DIR} NO_DEFAULT_PATH)
+			SET(ICU_LIBRARIES ${icu} ${icudt})
 			ADD_DEBUG_VARIANTS(ICU_LIBRARIES "${ICU_LIBRARIES}" "d")
-            # TODO MinGW build would appear to be using dynamic ICU regardless of this definition.
-            ADD_DEFINITIONS(-DU_STATIC_IMPLEMENTATION) # required for static ICU
+			# TODO MinGW build would appear to be using dynamic ICU regardless of this definition.
+			ADD_DEFINITIONS(-DU_STATIC_IMPLEMENTATION) # required for static ICU
 		ELSE()
-			SET(ICU_LIBRARIES icuuc icudata dl)
+			FIND_LIBRARY(icudt NAMES icudata PATHS ${ICU_LIBRARY_DIR} NO_DEFAULT_PATH)
+			FIND_LIBRARY(dl NAMES dl)
+			SET(ICU_LIBRARIES ${icu} ${icudt} ${dl})
 		ENDIF()
 	ELSE()
 		MESSAGE(FATAL_ERROR "UNICODE_SUPPORT enabled, but unable to find ICU. Disable UNICODE_SUPPORT or fix ICU paths to proceed.")
@@ -219,9 +227,13 @@ IF(COLLADA_SUPPORT)
 
 	IF("${OPENCOLLADA_LIBRARY_DIR}" STREQUAL "")
 		MESSAGE(STATUS "No OpenCOLLADA library directory specified")
-		FIND_LIBRARY(OPENCOLLADA_FRAMEWORK_LIB NAMES OpenCOLLADAFramework PATHS /usr/lib64/opencollada /usr/lib/opencollada /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib)
+		FIND_LIBRARY(OPENCOLLADA_FRAMEWORK_LIB NAMES OpenCOLLADAFramework
+			PATHS /usr/lib64/opencollada /usr/lib/opencollada /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib)
 		GET_FILENAME_COMPONENT(OPENCOLLADA_LIBRARY_DIR ${OPENCOLLADA_FRAMEWORK_LIB} PATH)
 	ENDIF()
+
+	FIND_LIBRARY(OpenCOLLADAFramework NAMES OpenCOLLADAFramework PATHS ${OPENCOLLADA_LIBRARY_DIR} NO_DEFAULT_PATH)
+
 	SET(OPENCOLLADA_LIBRARY_DIR "${OPENCOLLADA_LIBRARY_DIR}" CACHE FILEPATH "OpenCOLLADA library files")
 
 	SET(OPENCOLLADA_INCLUDE_DIRS "${OPENCOLLADA_INCLUDE_DIR}/COLLADABaseUtils" "${OPENCOLLADA_INCLUDE_DIR}/COLLADAStreamWriter")
@@ -230,13 +242,29 @@ IF(COLLADA_SUPPORT)
 	IF(COLLADASWStreamWriter_h)
 		MESSAGE(STATUS "OpenCOLLADA header files found")
 		ADD_DEFINITIONS(-DWITH_OPENCOLLADA)
-		SET(OPENCOLLADA_LIBRARIES
+		SET(OPENCOLLADA_LIBRARY_NAMES
 			GeneratedSaxParser MathMLSolver OpenCOLLADABaseUtils OpenCOLLADAFramework OpenCOLLADASaxFrameworkLoader
-			OpenCOLLADAStreamWriter UTF buffer ftoa pcre
+			OpenCOLLADAStreamWriter UTF buffer ftoa
 		)
-		IF(NOT "${PCRE_LIBRARY_DIR}" STREQUAL "")
+
+		# Use the found libTKernel as a template for all other OCC libraries
+		foreach(lib ${OPENCOLLADA_LIBRARY_NAMES})
+			string(REPLACE OpenCOLLADAFramework "${lib}" lib_path "${OpenCOLLADAFramework}")
+			list(APPEND OPENCOLLADA_LIBRARIES "${lib_path}")
+		endforeach()
+
+		IF("${PCRE_LIBRARY_DIR}" STREQUAL "")
+			find_library(pcre_library NAMES pcre PATHS ${OPENCOLLADA_LIBRARY_DIR})
+			GET_FILENAME_COMPONENT(PCRE_LIBRARY_DIR ${pcre_library} PATH)
+		else()
+			find_library(pcre_library NAMES pcre PATHS ${PCRE_LIBRARY_DIR} NO_DEFAULT_PATH)
+		endif()
+		
+		if (${pcre_library})
 			SET(OPENCOLLADA_LIBRARY_DIR ${OPENCOLLADA_LIBRARY_DIR} ${PCRE_LIBRARY_DIR})
-		ENDIF()
+			list(APPEND OPENCOLLADA_LIBRARIES "${pcre_library}")
+		endif()
+		
 		IF(MSVC)
 			ADD_DEBUG_VARIANTS(OPENCOLLADA_LIBRARIES "${OPENCOLLADA_LIBRARIES}" "d")
 		ENDIF()
@@ -317,9 +345,6 @@ ENDIF()
 INCLUDE_DIRECTORIES(${INCLUDE_DIRECTORIES} ${OCC_INCLUDE_DIR} ${OPENCOLLADA_INCLUDE_DIRS}
 	${ICU_INCLUDE_DIR} ${Boost_INCLUDE_DIRS}
 )
-if(NOT WIN32)
-	INCLUDE_DIRECTORIES(${INCLUDE_DIRECTORIES} /usr/inc /usr/local/inc /usr/local/include/oce)
-endif()
 
 function(files_for_ifc_version IFC_VERSION RESULT_NAME)
     set(IFC_PARSE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../src/ifcparse)
@@ -401,13 +426,6 @@ endif()
 # Boost >= 1.58 requires BOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE to build on some Linux distros.
 if(NOT Boost_VERSION LESS 105800)
     add_definitions(-DBOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE)
-endif()
-
-LINK_DIRECTORIES(${LINK_DIRECTORIES} ${IfcOpenShell_BINARY_DIR} ${OCC_LIBRARY_DIR} ${OPENCOLLADA_LIBRARY_DIR}
-	${ICU_LIBRARY_DIR} ${Boost_LIBRARY_DIRS}
-)
-if(NOT WIN32)
-	LINK_DIRECTORIES(${LINK_DIRECTORIES} /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64)
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -335,7 +335,6 @@ IF(MSVC)
 ElSE()
     add_definitions(-Wno-non-virtual-dtor -Wall)
     # TODO Preferably use -Wextra too, but currently too much warning spam coming from the dependencies' headers.
-    add_definitions(-std=c++03)
     # -fPIC is not relevant on Windows and creates pointless warnings
     if (UNIX)
         add_definitions(-fPIC)
@@ -426,6 +425,54 @@ endif()
 # Boost >= 1.58 requires BOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE to build on some Linux distros.
 if(NOT Boost_VERSION LESS 105800)
     add_definitions(-DBOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE)
+endif()
+
+# Detect OCC version on gcc/clang/mingw as
+# -std=c++11 is needed for OCCT >= 7.0.0
+if(NOT MSVC)
+    FIND_FILE(Standard_Version "Standard_Version.hxx" ${OCC_INCLUDE_DIR})
+
+    set(CMAKE_CONFIGURABLE_FILE_CONTENT "
+        #include <Standard_Version.hxx>
+        #include <iostream>
+        int main(int argc, char** argv) {
+            std::cout << OCC_VERSION_COMPLETE;
+        }")
+    configure_file(
+        "${CMAKE_ROOT}/Modules/CMakeConfigurableFile.in"
+        "${CMAKE_BINARY_DIR}/version.cxx" @ONLY)
+
+    try_compile(VERSION_CHECK
+        ${CMAKE_BINARY_DIR}
+        "${CMAKE_BINARY_DIR}/version.cxx"
+        CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${OCC_INCLUDE_DIR}"
+        COPY_FILE "${CMAKE_BINARY_DIR}/version"
+        OUTPUT_VARIABLE OUT
+        COPY_FILE_ERROR ERR
+    )
+
+    if(${VERSION_CHECK})
+        EXECUTE_PROCESS(COMMAND ${CMAKE_BINARY_DIR}/version OUTPUT_VARIABLE OCC_VERSION)
+    else()
+        message(FATAL_ERROR "Failed to compile OCC version test:
+        ${OUT}
+        ------
+        ${ERR}")
+    endif()
+
+    MESSAGE(STATUS "OCC version is ${OCC_VERSION}. Detected from: ${Standard_Version}")
+
+    if(NOT ("${OCC_VERSION}" LESS "7.0.0"))
+        include(CheckCXXCompilerFlag)
+        CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+        if(COMPILER_SUPPORTS_CXX11)
+            add_definitions(-std=c++11)
+        else()
+            message(FATAL_ERROR "OCCT7 requires a compiler with C++11 support")
+        endif()
+    else()
+        add_definitions(-std=c++03)
+    endif()
 endif()
 
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
# Link directories

https://github.com/IfcOpenShell/IfcOpenShell/commit/e9bd18fd4bd3019d2c2fcfdd513f456b7d1b370a

Fixes #111. There are issues with `LINK_DIRECTORIES` and multiple installations of Open Cascade. This is brittle as linker is invoked with `-Lpath_1 ... -Lpath_n -llib_1 ... -llib_n` and nothing is known on which is lib is to be located from which path. By using absolute paths in cmake the linker is invoked with `path_1/lib_1 ... path_n/lib_n`.

From https://cmake.org/cmake/help/v3.0/command/link_directories.html
> Note that this command is rarely necessary. Library locations returned by find_package() and find_library() are absolute paths. Pass these absolute library file paths directly to the target_link_libraries() command. CMake will ensure the linker finds them.

# OCCT 7

https://github.com/IfcOpenShell/IfcOpenShell/commit/1def5db7e4214da6ab6b9f9c36aa198850208efd

It appears IfcOpenShell runs and compiles fine with OCCT 7. OCCT 7 comes with a relatively complete cmake script including the options for building static libs on Windows (no static runtime though), contrary to 6.9.1 and therefore is a now a suitable candidate for linking with IfcOpenShell. OCCT 7 requires `-std=c++11`, so the version number is determined in CMake. 

At first sight it seems that http://git.dev.opencascade.org/gitweb/?p=occt.git;a=tree;h=V7_0_0 is not completely identical to https://www.opencascade.com/sites/default/files/private/occt/OCC_7.0.0_release/opencascade-7.0.0.tgz 