### PR TITLE
IfcConvert/IfcGeom --traverse option

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -197,10 +197,10 @@ int main(int argc, char** argv) {
         ("generate-uvs",
             "Generates UVs (texture coordinates) by using simple box projection. Requires normals. "
             "Not guaranteed to work properly if used with --weld-vertices.")
-        ("with-children",
+        ("traverse",
             "Applies --include or --exclude also to the decomposition and/or containment (IsDecomposedBy, "
-            "HasOpenings, FillsVoid, ContainedInStructure) of the filtered element, e.g. "
-            "--include --with-children --names \"Level 1\" includes element with name \"Level 1\" and all of its children.");
+            "HasOpenings, FillsVoid, ContainedInStructure) of the filtered entity, e.g. "
+            "--include --traverse --names \"Level 1\" includes entity with name \"Level 1\" and all of its children.");
 
     std::string bounds;
     boost::program_options::options_description serializer_options("Serialization options");
@@ -281,7 +281,7 @@ int main(int argc, char** argv) {
     const bool no_normals = vmap.count("no-normals") != 0 ;
     bool center_model = vmap.count("center-model") != 0 ;
     const bool generate_uvs = vmap.count("generate-uvs") != 0 ;
-    const bool with_children = vmap.count("with-children") != 0;
+    const bool traverse = vmap.count("traverse") != 0;
     const bool deflection_tolerance_specified = vmap.count("deflection-tolerance") != 0 ;
 
 	int bounding_width = -1, bounding_height = -1;
@@ -383,7 +383,7 @@ int main(int argc, char** argv) {
     settings.set(IfcGeom::IteratorSettings::NO_NORMALS, no_normals);
     settings.set(IfcGeom::IteratorSettings::CENTER_MODEL, center_model);
     settings.set(IfcGeom::IteratorSettings::GENERATE_UVS, generate_uvs);
-    settings.set(IfcGeom::IteratorSettings::WITH_CHILDREN, with_children);
+    settings.set(IfcGeom::IteratorSettings::TRAVERSE, traverse);
     if (deflection_tolerance_specified) {
         settings.set_deflection_tolerance(deflection_tolerance);
     }

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -532,9 +532,9 @@ namespace IfcGeom {
 					}
 
                     // Filter the products based on the set of entities and/or names being included or excluded for processing.
-                    // If with_children set, traverse to the parents to see if they satisfy the criteria. E.g. we might be looking for
+                    // If traversal requested, traverse to the parents to see if they satisfy the criteria. E.g. we might be looking for
                     // children of a storey named "Level 20", or children of entities that have no representation, e.g. IfcCurtainWall.
-                    const bool with_children = settings.get(IteratorSettings::WITH_CHILDREN);
+                    const bool traverse = settings.get(IteratorSettings::TRAVERSE);
                     for (IfcSchema::IfcProduct::list::it jt = unfiltered_products->begin(); jt != unfiltered_products->end(); ++jt) {
                         IfcSchema::IfcProduct* prod = *jt;
                         bool type_found = false;
@@ -546,7 +546,7 @@ namespace IfcGeom {
                             }
                         }
 
-                        if (!type_found && with_children) {
+                        if (!type_found && traverse) {
                             foreach(IfcSchema::Type::Enum type, entities_to_include_or_exclude) {
                                 IfcSchema::IfcProduct* parent, * current = prod;
                                 while ((parent = static_cast<IfcSchema::IfcProduct*>(kernel.get_decomposing_entity(current))) != 0) {
@@ -570,7 +570,7 @@ namespace IfcGeom {
                             }
                         }
 
-                        if (!name_found && with_children) {
+                        if (!name_found && traverse) {
                             foreach(const boost::regex& r, names_to_include_or_exclude) {
                                 IfcSchema::IfcProduct* parent, *current = prod;
                                 while ((parent = static_cast<IfcSchema::IfcProduct*>(kernel.get_decomposing_entity(current))) != 0) {
@@ -699,9 +699,7 @@ namespace IfcGeom {
 
 			try {
 				next_shape_model = create_shape_model_for_next_entity();
-			} catch (IfcParse::IfcInvalidTokenException e) {
-                std::cout << e.what() << std::endl;
-            }
+			} catch (...) {}
 
 			if (next_shape_model) {
 				if (settings.get(IteratorSettings::USE_BREP_DATA)) {

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -138,6 +138,7 @@ namespace IfcGeom {
         std::set<boost::regex> names_to_include_or_exclude; // regex containing a name or a wildcard expression
 		std::set<IfcSchema::Type::Enum> entities_to_include_or_exclude;
 		bool include_entities_in_processing;
+        bool include_names_in_processing_;
 
 		void populate_set(const std::set<std::string>& include_or_ignore) {
 			entities_to_include_or_exclude.clear();
@@ -335,7 +336,7 @@ namespace IfcGeom {
             names_to_include_or_exclude.clear();
             foreach(const std::string &name, names)
                 names_to_include_or_exclude.insert(wildcard_string_to_regex(name));
-            include_entities_in_processing = true;
+            include_names_in_processing_ = true;
         }
 
         /// @note Arbitrary names or wildcard expressions are handled case-sensitively.
@@ -344,7 +345,7 @@ namespace IfcGeom {
             names_to_include_or_exclude.clear();
             foreach(const std::string &name, names)
                 names_to_include_or_exclude.insert(wildcard_string_to_regex(name));
-            include_entities_in_processing = false;
+            include_names_in_processing_ = false;
         }
 
         static boost::regex wildcard_string_to_regex(std::string str)
@@ -530,27 +531,64 @@ namespace IfcGeom {
 						}
 					}
 
-					// Filter the products based on the set of entities being included or excluded for
-					// processing. The set is iterated over to able to filter on subtypes.
-					for ( IfcSchema::IfcProduct::list::it jt = unfiltered_products->begin(); jt != unfiltered_products->end(); ++jt ) {
-						bool found = false;
-						for (std::set<IfcSchema::Type::Enum>::const_iterator kt = entities_to_include_or_exclude.begin(); kt != entities_to_include_or_exclude.end(); ++kt) {
-							if ((*jt)->is(*kt)) {
-								found = true;
-								break;
-							}
-						}
-                        
-                        foreach(const boost::regex& r, names_to_include_or_exclude) {
-                            if (boost::regex_match((*jt)->Name(), r)) {
-                                found = true;
+                    // Filter the products based on the set of entities and/or names being included or excluded for processing.
+                    // If with_children set, traverse to the parents to see if they satisfy the criteria. E.g. we might be looking for
+                    // children of a storey named "Level 20", or children of entities that have no representation, e.g. IfcCurtainWall.
+                    const bool with_children = settings.get(IteratorSettings::WITH_CHILDREN);
+                    for (IfcSchema::IfcProduct::list::it jt = unfiltered_products->begin(); jt != unfiltered_products->end(); ++jt) {
+                        IfcSchema::IfcProduct* prod = *jt;
+                        bool type_found = false;
+                        // The set is iterated over to able to filter on subtypes.
+                        foreach(IfcSchema::Type::Enum type, entities_to_include_or_exclude) {
+                            if (prod->is(type)) {
+                                type_found = true;
                                 break;
                             }
                         }
-                        
-						if (found == include_entities_in_processing) {
-							ifcproducts->push(*jt);
-						}
+
+                        if (!type_found && with_children) {
+                            foreach(IfcSchema::Type::Enum type, entities_to_include_or_exclude) {
+                                IfcSchema::IfcProduct* parent, * current = prod;
+                                while ((parent = static_cast<IfcSchema::IfcProduct*>(kernel.get_decomposing_entity(current))) != 0) {
+                                    if (parent->is(type)) {
+                                        type_found = true;
+                                        break;
+                                    }
+                                    current = parent;
+                                }
+                                if (type_found) {
+                                    break;
+                                }
+                            }
+                        }
+
+                        bool name_found = false;
+                        foreach(const boost::regex& r, names_to_include_or_exclude) {
+                            if (prod->hasName() && boost::regex_match(prod->Name(), r)) {
+                                name_found = true;
+                                break;
+                            }
+                        }
+
+                        if (!name_found && with_children) {
+                            foreach(const boost::regex& r, names_to_include_or_exclude) {
+                                IfcSchema::IfcProduct* parent, *current = prod;
+                                while ((parent = static_cast<IfcSchema::IfcProduct*>(kernel.get_decomposing_entity(current))) != 0) {
+                                    if (parent->hasName() && boost::regex_match(parent->Name(), r)) {
+                                        name_found = true;
+                                        break;
+                                    }
+                                    current = parent;
+                                }
+                                if (name_found) {
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (type_found == include_entities_in_processing && name_found == include_names_in_processing_) {
+                            ifcproducts->push(prod);
+                        }
 					}
 
 					ifcproduct_iterator = ifcproducts->begin();
@@ -661,7 +699,9 @@ namespace IfcGeom {
 
 			try {
 				next_shape_model = create_shape_model_for_next_entity();
-			} catch (...) {}
+			} catch (IfcParse::IfcInvalidTokenException e) {
+                std::cout << e.what() << std::endl;
+            }
 
 			if (next_shape_model) {
 				if (settings.get(IteratorSettings::USE_BREP_DATA)) {
@@ -704,7 +744,8 @@ namespace IfcGeom {
 			// Upon initialisation, the (empty) set of entity names,
 			// should be excluded, or no products would be processed.
 			include_entities_in_processing = false;
-		
+            include_names_in_processing_ = false;
+
 			unit_name = "METER";
 			unit_magnitude = 1.f;
 

--- a/src/ifcgeom/IfcGeomIteratorSettings.h
+++ b/src/ifcgeom/IfcGeomIteratorSettings.h
@@ -92,8 +92,8 @@ namespace IfcGeom
             APPLY_LAYERSETS = 1 << 17,
             /// Marks that include/exclude filtering should be applied also to the decomposition
             /// and/or containment (IsDecomposedBy, HasOpenings, FillsVoid, ContainedInStructure)
-            /// of the filtered element.
-            WITH_CHILDREN = 1 << 18,
+            /// of the filtered entity.
+            TRAVERSE = 1 << 18,
             /// Number of different setting flags.
             NUM_SETTINGS = 18
         };

--- a/src/ifcgeom/IfcGeomIteratorSettings.h
+++ b/src/ifcgeom/IfcGeomIteratorSettings.h
@@ -83,15 +83,19 @@ namespace IfcGeom
             /// Applicable for OBJ and DAE output.
             USE_MATERIAL_NAMES = 1 << 14,
             /// Centers the models upon serialization by the applying the center point of
-            /// the scene bounds as an offset. Applicable only for DAE output currently.
+            /// the scene bounds as an offset. Applicable for OBJ and DAE output currently.
             CENTER_MODEL = 1 << 15,
             /// Generates UVs by using simple box projection. Requires normals.
-            /// Applicable only for DAE output currently.
+            /// Applicable for OBJ and DAE output.
             GENERATE_UVS = 1 << 16,
             /// Specifies whether to slice representations according to associated IfcLayerSets.
             APPLY_LAYERSETS = 1 << 17,
+            /// Marks that include/exclude filtering should be applied also to the decomposition
+            /// and/or containment (IsDecomposedBy, HasOpenings, FillsVoid, ContainedInStructure)
+            /// of the filtered element.
+            WITH_CHILDREN = 1 << 18,
             /// Number of different setting flags.
-            NUM_SETTINGS = 17
+            NUM_SETTINGS = 18
         };
         /// Used to store logical OR combination of setting flags.
         typedef unsigned SettingField;


### PR DESCRIPTION
e.g. `IfcConvert Duplex_A_20110907.ifc level1.dae --include --traverse --names "Level 1"` will produce a DAE that contains only the objects of the 1st floor:

![image](https://cloud.githubusercontent.com/assets/227876/20218609/1e72cce8-a82e-11e6-951d-3c9d9c7461ae.png)

Note that the results is slightly different compared to e.g. Solibri:
![image](https://cloud.githubusercontent.com/assets/227876/20218896/69aa6cce-a82f-11e6-91c3-23ad01c340bb.png)

![image](https://cloud.githubusercontent.com/assets/227876/20218919/872fbea2-a82f-11e6-8d01-1399a77a7fb6.png)
