### PR TITLE
Windows/MSVC: support spaces in the IfcOpenShell build directory's pa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Dependencies
 
 Building IfcOpenShell
 ---------------------
+
+**Note:** The path where the source code is cloned to can contain spaces but non-ASCII characters are very likely to cause problems with the build.
+
 ### Compiling on Windows
 The preferred way to fetch and build this project's dependencies is to use the build scripts
 in win/ folder. **See [win/readme.md] for more information**.
@@ -53,9 +56,8 @@ As the scripts default to using the `RelWithDebInfo` configuration, and a freshl
 to `Debug`, make sure to switch the used build configuration. Build the `INSTALL` project (right-click -> Project
 Only) to deploy the headers and binaries into a single location if wanted/needed.
 
-Alternatively, one can use the utility batch files to build and install the project easily from the command-line:
-
-    > build-ifcopenshell.bat
+Alternatively, one can use the utility batch file(s) to build and install the project easily from the command-line
+(installing a project will build it also, if required):
     > install-ifcopenshell.bat
 
 #### Using MSYS2 + MinGW
@@ -65,7 +67,6 @@ Start the MSYS2 Shell and then:
     $ cd IfcOpenShell/win
     $ ./build-deps.sh
     $ ./run-cmake.sh
-    $ ./build-ifcopenshell.sh
     $ ./install-ifcopenshell.sh
 
 #### Using Bash on Ubuntu on Windows
@@ -79,16 +80,16 @@ The following instructions are for Ubuntu, modify as required for other operatin
 can be experimented with and studied for pointers for other operating systems, but note that this script is not currently
 meant to be used for a typical IfcOpenShell workspace setup.
 
-Install most of the prerequisites and dependencies:
+**1)** Install most of the prerequisites and dependencies:
 
     $ sudo apt-get install git cmake gcc g++ libboost-all-dev libicu-dev
 
-There might be an Open CASCADE package in your operating system's software repository (see http://opencascade.org
-for additional information):
+**2a)** Either use an Open CASCADE package from your operating system's software repository (see http://opencascade.org
+for additional information)
 
     $ sudo apt-get install liboce-foundation-dev liboce-modeling-dev liboce-ocaf-dev liboce-visualization-dev liboce-ocaf-lite-dev
 
-If not, you will need to compile Open CASCADE yourself (note that the build takes a long time):
+**2b)** or (if not available, or the latest code is wanted) compile Open CASCADE yourself (note that the build takes a long time):
 
     $ sudo apt-get install libftgl-dev libtbb2 libtbb-dev libgl1-mesa-dev libfreetype6-dev
     $ git clone https://github.com/tpaviot/oce.git
@@ -98,7 +99,7 @@ If not, you will need to compile Open CASCADE yourself (note that the build take
     $ make -j
     $ sudo make install
 
-For building IfcConvert with COLLADA (.dae) support (on by default), OpenCOLLADA is needed:
+**3)** For building IfcConvert with COLLADA (.dae) support (on by default), OpenCOLLADA is needed:
 
     $ sudo apt-get install libpcre3-dev
     $ git clone https://github.com/KhronosGroup/OpenCOLLADA.git
@@ -110,11 +111,11 @@ For building IfcConvert with COLLADA (.dae) support (on by default), OpenCOLLADA
     $ make -j
     $ sudo make install
 
-For building the IfcPython wrapper (on by default), SWIG and Python development are needed, if not already available:
+**4)** For building the IfcPython wrapper (on by default), SWIG and Python development are needed, if not already available:
 
     $ sudo apt-get install python-all-dev swig
 
-To build IfcOpenShell please take the following steps. Alternatively use environment variables for setting the
+**5)** To build IfcOpenShell please take the following steps. Alternatively use environment variables for setting the
 dependencies' paths. `OCC_INCLUDE_DIR` might be needed to set also. `OPENCOLLADA_INCLUDE_DIR` and `OPENCOLLADA_LIBRARY_DIR`
 (and potentially `PCRE_LIBRARY_DIR`) are needed if building with COLLADA support. (`-DCOLLADA_SUPPORT=0` disables it).
 
@@ -128,7 +129,7 @@ dependencies' paths. `OCC_INCLUDE_DIR` might be needed to set also. `OPENCOLLADA
 
 If all worked out correctly you can now use IfcOpenShell. See the examples below.
 
-Install the project if wanted:
+**6)** Install the project if wanted:
 
     $ sudo make install
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -118,7 +118,7 @@ MESSAGE(STATUS "Boost libraries found in ${Boost_LIBRARY_DIRS}")
 
 # Usage:
 # set(SOME_LIRARIES foo bar)
-# add_debug_variants(SOME_LIRARIES "${SOME_LIRARIES}" "d")
+# add_debug_variants(SOME_LIRARIES "${SOME_LIRARIES}" d)
 # "foo bar" -> "optimized foo debug food optimized bar debug bard"
 # or
 # set(SOME_LIRARIES path/foo.lib)
@@ -128,19 +128,24 @@ MESSAGE(STATUS "Boost libraries found in ${Boost_LIBRARY_DIRS}")
 # make sure the lib variable ends with not just contains it.
 function(add_debug_variants NAME LIBRARIES POSTFIX)
     set(LIBRARIES_STR "${LIBRARIES}")
-    set(LIBRARIES "")
+    # the result, "optimized <lib> debug <lib>", needs to be a list instead of a string
     foreach(lib ${LIBRARIES_STR})
-        if("${lib}" MATCHES ".lib")
+        list(APPEND LIBRARIES optimized)
+        if ("${lib}" MATCHES ".lib")
             string(REPLACE ".lib" "" lib ${lib})
-            set(LIBRARIES "${LIBRARIES} optimized ${lib}.lib")
-            set(LIBRARIES "${LIBRARIES} debug ${lib}${POSTFIX}.lib")
+            list(APPEND LIBRARIES ${lib}.lib)
         else()
-            set(LIBRARIES "${LIBRARIES} optimized ${lib}")
-            set(LIBRARIES "${LIBRARIES} debug ${lib}${POSTFIX}")
+            list(APPEND LIBRARIES ${lib})
+        endif()
+
+        list(APPEND LIBRARIES debug)
+        if ("${lib}" MATCHES ".lib")
+            string(REPLACE ".lib" "" lib ${lib})
+            list(APPEND LIBRARIES ${lib}${POSTFIX}.lib)
+        else()
+            list(APPEND LIBRARIES ${lib}${POSTFIX})
         endif()
     endforeach()
-    string(STRIP ${LIBRARIES} LIBRARIES) # leading and trailing whitespace cause confusion
-    separate_arguments(LIBRARIES) # "optimized <lib> debug <lib>" needs to be a list instead of a string
     set(${NAME} ${LIBRARIES} PARENT_SCOPE)
 endfunction()
 
@@ -190,7 +195,7 @@ endforeach()
 
 if(MSVC)
     add_definitions(-DHAVE_NO_DLL)
-    add_debug_variants(OPENCASCADE_LIBRARIES "${OPENCASCADE_LIBRARIES}" "d")
+    add_debug_variants(OPENCASCADE_LIBRARIES "${OPENCASCADE_LIBRARIES}" d)
 endif()
 
 IF(UNICODE_SUPPORT)
@@ -216,7 +221,7 @@ IF(UNICODE_SUPPORT)
 		IF(WIN32)
 			FIND_LIBRARY(icudt NAMES icudt PATHS ${ICU_LIBRARY_DIR} NO_DEFAULT_PATH)
 			SET(ICU_LIBRARIES ${icu} ${icudt})
-			add_debug_variants(ICU_LIBRARIES "${ICU_LIBRARIES}" "d")
+			add_debug_variants(ICU_LIBRARIES "${ICU_LIBRARIES}" d)
 			# TODO MinGW build would appear to be using dynamic ICU regardless of this definition.
 			ADD_DEFINITIONS(-DU_STATIC_IMPLEMENTATION) # required for static ICU
 		ELSE()
@@ -286,7 +291,7 @@ IF(COLLADA_SUPPORT)
 		endif()
 
 		IF(MSVC)
-			add_debug_variants(OPENCOLLADA_LIBRARIES "${OPENCOLLADA_LIBRARIES}" "d")
+			add_debug_variants(OPENCOLLADA_LIBRARIES "${OPENCOLLADA_LIBRARIES}" d)
 		ENDIF()
 	ELSE()
 		MESSAGE(FATAL_ERROR "COLLADA_SUPPORT enabled, but unable to find OpenCOLLADA. Disable COLLADA_SUPPORT or fix OpenCOLLADA paths to proceed.")

--- a/win/build-ifcopenshell.bat
+++ b/win/build-ifcopenshell.bat
@@ -67,7 +67,7 @@ goto :End
 
 :Error
 echo.
-call %~dp0\utils\cecho.cmd 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% build failed!"
+call "%~dp0\utils\cecho.cmd" 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% build failed!"
 %IFCOS_PAUSE_ON_ERROR%
 set IFCOS_SCRIPT_RET=1
 

--- a/win/install-ifcopenshell.bat
+++ b/win/install-ifcopenshell.bat
@@ -66,7 +66,7 @@ goto :End
 
 :Error
 echo.
-call %~dp0\utils\cecho.cmd 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% installation failed!"
+call "%~dp0\utils\cecho.cmd" 0 12 "%VS_PLATFORM% %BUILD_CFG% %PROJECT_NAME% installation failed!"
 %IFCOS_PAUSE_ON_ERROR%
 set IFCOS_SCRIPT_RET=1
 

--- a/win/run-cmake.bat
+++ b/win/run-cmake.bat
@@ -33,7 +33,7 @@ for /f "tokens=*" %%f in ('dir BuildDepsCache-*.txt /o:-n /t:a /b') do (
 set GENERATOR=%1
 if (%1)==() (
     if not defined GEN_SHORTHAND (
-        echo BuildDepsCache file does and/or GEN_SHORTHAND missing from it. Run build-deps.cmd to create it.
+        echo BuildDepsCache file does not exist and/or GEN_SHORTHAND missing from it. Run build-deps.cmd to create it.
         set IFCOS_PAUSE_ON_ERROR=pause
         goto :Error
     )
@@ -59,6 +59,7 @@ IF NOT EXIST ..\%BUILD_DIR%. mkdir ..\%BUILD_DIR%
 pushd ..\%BUILD_DIR%
 
 set BOOST_ROOT=%DEPS_DIR%\boost
+REM set BOOST_INCLUDEDIR=%DEPS_DIR%\boost\boost
 set BOOST_LIBRARYDIR=%DEPS_DIR%\boost\stage\vs%VS_VER%-%VS_PLATFORM%\lib
 set ICU_INCLUDE_DIR=%INSTALL_DIR%\icu\include
 set ICU_LIBRARY_DIR=%INSTALL_DIR%\icu\lib
@@ -113,7 +114,7 @@ goto :Finish
 
 :Error
 echo.
-call %~dp0\utils\cecho.cmd 0 12 "An error occurred! Aborting!"
+call "%~dp0\utils\cecho.cmd" 0 12 "An error occurred! Aborting!"
 %IFCOS_PAUSE_ON_ERROR%
 set IFCOS_SCRIPT_RET=1
 goto :Finish

--- a/win/set-python-to-path.bat
+++ b/win/set-python-to-path.bat
@@ -22,13 +22,13 @@
 @echo off
 set TARGET_ARCH=%1
 if "%TARGET_ARCH%"=="" set TARGET_ARCH=x64
-if not exist %~dp0BuildDepsCache-%TARGET_ARCH%.txt. (
+if not exist "%~dp0BuildDepsCache-%TARGET_ARCH%.txt". (
     echo %~dp0BuildDepsCache-%TARGET_ARCH%.txt does not exist
     goto :EOF
 )
-for /f "delims== tokens=1,2" %%G in (%~dp0BuildDepsCache-%TARGET_ARCH%.txt) do set %%G=%%H
+for /f "delims== tokens=1,2" %%G in ("%~dp0BuildDepsCache-%TARGET_ARCH%.txt") do set %%G=%%H
 if not defined PYTHONHOME (
-    echo PYTHONHOME PYTHONHOME not defined
+    echo PYTHONHOME not defined
     goto :EOF
 )
 


### PR DESCRIPTION
…th. re: #171

I also tested a path with spaces and non-ASCII characters and non-ASCII characters caused problems for find_file(), but e.g. find_package(Boost) worked OK (I was able to build all of the dependencies fine though).

Thanks @klacol for pointers regarding the batch files.
