### PR TITLE
IfcConvert and IfcGeomIterator filtering improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Prerequisites
 -------------
 * Git
 * CMake (2.6 or newer)
-* Windows: [Visual Studio] 2008 or newer with C++ toolset (or [Visual C++ Build Tools]) or [MSYS2] + MinGW
+* Windows: [Visual Studio] 2008 or newer (2017 not yet officially supported) with C++ toolset (or [Visual C++ Build Tools]) or [MSYS2] + MinGW
 * *nix: GCC 4.7 or newer, or Clang (any version)
 
 Dependencies
 -------------
 * [Boost](http://www.boost.org/)
-* Open Cascade - *optional*, but required for building IfcGeom
-  ([official](http://www.opencascade.org/getocc/download/loadocc/) or [community edition](https://github.com/tpaviot/oce))  
+* [Open Cascade](http://opencascade.org) - *optional*, but required for building IfcGeom
+  ([official](http://www.opencascade.org/getocc/download/loadocc/), "OCCT", or [community edition](https://github.com/tpaviot/oce), "OCE")  
   For converting IFC representation items into BRep solids and tesselated meshes
 * [ICU](http://site.icu-project.org/) - *optional*  
   For handling code pages and Unicode in the parser
@@ -58,6 +58,7 @@ Only) to deploy the headers and binaries into a single location if wanted/needed
 
 Alternatively, one can use the utility batch file(s) to build and install the project easily from the command-line
 (installing a project will build it also, if required):
+
     > install-ifcopenshell.bat
 
 #### Using MSYS2 + MinGW
@@ -84,12 +85,11 @@ meant to be used for a typical IfcOpenShell workspace setup.
 
     $ sudo apt-get install git cmake gcc g++ libboost-all-dev libicu-dev
 
-**2a)** Either use an Open CASCADE package from your operating system's software repository (see http://opencascade.org
-for additional information)
+**2a)** Either use an OCE package from your operating system's software repository
 
     $ sudo apt-get install liboce-foundation-dev liboce-modeling-dev liboce-ocaf-dev liboce-visualization-dev liboce-ocaf-lite-dev
 
-**2b)** or (if not available, or the latest code is wanted) compile Open CASCADE yourself (note that the build takes a long time):
+**2b)** or (if not available, or the latest code is wanted) compile OCE yourself (note that the build takes a long time):
 
     $ sudo apt-get install libftgl-dev libtbb2 libtbb-dev libgl1-mesa-dev libfreetype6-dev
     $ git clone https://github.com/tpaviot/oce.git
@@ -98,6 +98,8 @@ for additional information)
     $ cmake ..
     $ make -j
     $ sudo make install
+
+**2c)** or obtain and compile OCCT from http://www.opencascade.org/getocc/download/loadocc/
 
 **3)** For building IfcConvert with COLLADA (.dae) support (on by default), OpenCOLLADA is needed:
 

--- a/src/ifcconvert/ColladaSerializer.cpp
+++ b/src/ifcconvert/ColladaSerializer.cpp
@@ -338,6 +338,7 @@ void ColladaSerializer::ColladaExporter::endDocument() {
 	geometries.close();
 	for (std::vector<DeferredObject>::const_iterator it = deferreds.begin(); it != deferreds.end(); ++it) {
 		const std::string object_name = it->unique_id;
+        /// @todo redundant information using ID as both ID and Name, maybe omit Name or allow specifying what would be used as the name
 		scene.add(object_name, object_name, it->representation_id, it->material_references, it->matrix);
 	}
 	scene.write();

--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -596,7 +596,7 @@ int main(int argc, char** argv)
 	}
 	Logger::Status(msg.str());
 
-    return successful ? 0 : 1;
+    return successful ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 void write_log() {

--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -399,12 +399,12 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    if (!entity_filter.values.empty()) { entity_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, entity_filter.description); }
-    if (!layer_filter.values.empty()) { layer_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, layer_filter.description); }
-    if (!guid_filter.values.empty()) { guid_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, guid_filter.description); }
-    if (!name_filter.values.empty()) { name_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, name_filter.description); }
-    if (!desc_filter.values.empty()) { desc_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, desc_filter.description); }
-    if (!tag_filter.values.empty()) { tag_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, tag_filter.description); }
+    if (!entity_filter.values.empty()) { entity_filter.update_description(); Logger::Notice(entity_filter.description); }
+    if (!layer_filter.values.empty()) { layer_filter.update_description(); Logger::Notice(layer_filter.description); }
+    if (!guid_filter.values.empty()) { guid_filter.update_description(); Logger::Notice(guid_filter.description); }
+    if (!name_filter.values.empty()) { name_filter.update_description(); Logger::Notice(name_filter.description); }
+    if (!desc_filter.values.empty()) { desc_filter.update_description(); Logger::Notice(desc_filter.description); }
+    if (!tag_filter.values.empty()) { tag_filter.update_description(); Logger::Notice(tag_filter.description); }
 
 	if (output_extension == ".xml") {
 		int exit_code = 1;
@@ -412,7 +412,7 @@ int main(int argc, char** argv)
 			XmlSerializer s(output_temp_filename);
 			IfcParse::IfcFile f;
 			if (!f.Init(input_filename)) {
-				Logger::Message(Logger::LOG_ERROR, "Unable to parse input file '" + input_filename + "'");
+				Logger::Error("Unable to parse input file '" + input_filename + "'");
 			} else {
 				s.setFile(&f);
                 Logger::Status("Writing XML output...");
@@ -454,7 +454,7 @@ int main(int argc, char** argv)
         // Do not use temp file for MTL as it's such a small file.
         const std::string mtl_filename = change_extension(output_filename, "mtl");
 		if (!use_world_coords) {
-			Logger::Message(Logger::LOG_NOTICE, "Using world coords when writing WaveFront OBJ files");
+			Logger::Notice("Using world coords when writing WaveFront OBJ files");
 			settings.set(IfcGeom::IteratorSettings::USE_WORLD_COORDS, true);
 		}
 		serializer = new WaveFrontOBJSerializer(output_temp_filename, mtl_filename, settings);
@@ -474,7 +474,7 @@ int main(int argc, char** argv)
             static_cast<SvgSerializer*>(serializer)->setBoundingRectangle(bounding_width, bounding_height);
 		}
 	} else {
-		Logger::Message(Logger::LOG_ERROR, "Unknown output filename extension '" + output_extension + "'");
+		Logger::Error("Unknown output filename extension '" + output_extension + "'");
 		write_log();
 		print_usage();
 		return EXIT_FAILURE;
@@ -483,13 +483,13 @@ int main(int argc, char** argv)
     const bool is_tesselated = serializer->isTesselated(); // isTesselated() doesn't change at run-time
 	if (!is_tesselated) {
 		if (weld_vertices) {
-            Logger::Message(Logger::LOG_NOTICE, "Weld vertices setting ignored when writing non-tesselated output");
+            Logger::Notice("Weld vertices setting ignored when writing non-tesselated output");
 		}
         if (generate_uvs) {
-            Logger::Message(Logger::LOG_NOTICE, "Generate UVs setting ignored when writing non-tesselated output");
+            Logger::Notice("Generate UVs setting ignored when writing non-tesselated output");
         }
         if (center_model || model_offset) {
-            Logger::Message(Logger::LOG_NOTICE, "Centering/offsetting model setting ignored when writing non-tesselated output");
+            Logger::Notice("Centering/offsetting model setting ignored when writing non-tesselated output");
         }
 
         settings.set(IfcGeom::IteratorSettings::DISABLE_TRIANGULATION, true);
@@ -507,7 +507,7 @@ int main(int argc, char** argv)
 	if (!context_iterator.initialize()) {
         /// @todo It would be nice to know and print separate error prints for a case where we failed to parse
         /// the file and for a case where we found no entities that satisfy our filtering criteria.
-        Logger::Message(Logger::LOG_ERROR, "Unable to parse input file '" + input_filename + "' or no geometrical entities found");
+        Logger::Error("Unable to parse input file '" + input_filename + "' or no geometrical entities found");
 		write_log();
 		return EXIT_FAILURE;
 	}
@@ -541,7 +541,7 @@ int main(int argc, char** argv)
 
         std::stringstream msg;
         msg << "Using model offset (" << offset[0] << "," << offset[1] << "," << offset[2] << ")";
-        Logger::Message(Logger::LOG_NOTICE, msg.str());
+        Logger::Notice(msg.str());
     }
 
 	Logger::Status("Creating geometry...");
@@ -580,7 +580,7 @@ int main(int argc, char** argv)
     // Do not remove the temp file as user can salvage the conversion result from it.
     bool successful = rename_file(output_temp_filename, output_filename);
     if (!successful) {
-        Logger::Message(Logger::LOG_ERROR, "Unable to write output file '" + output_filename + "'");
+        Logger::Error("Unable to write output file '" + output_filename + "'");
     }
 
 	write_log();

--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -206,7 +206,7 @@ int main(int argc, char** argv)
 			"to their associated IfcMaterialLayerSet.")
         ("include", po::value<inclusion_filter>(&include_filter)->multitoken(),
             "Specifies that the entities that match a specific filtering criteria are to be included in the geometrical output:\n"
-            "1) 'entities': the following list of types should be included . SVG output defaults "
+            "1) 'entities': the following list of types should be included. SVG output defaults "
             "to IfcSpace to be included. The entity names are handled case-insensitively.\n"
             "2) 'layers': the entities that are assigned to presentation layers of which names "
             "match the given values should be included.\n"

--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -293,6 +293,7 @@ int main(int argc, char** argv)
     } catch (...) {
         print_usage();
         return EXIT_FAILURE;
+    }
 
     po::notify(vmap);
 
@@ -390,6 +391,8 @@ int main(int argc, char** argv)
 	std::string output_extension = output_filename.substr(output_filename.size()-4);
 	boost::to_lower(output_extension);
 
+    Logger::SetOutput(&std::cout, &log_stream);
+    Logger::Verbosity(verbose ? Logger::LOG_NOTICE : Logger::LOG_ERROR);
 
     std::vector<IfcGeom::filter_t> used_filters = setup_filters(include_filter, exclude_filter, output_extension, traverse);
     if (used_filters.empty()) {
@@ -419,7 +422,7 @@ int main(int argc, char** argv)
 		return exit_code;
 	}
 
-	    SerializerSettings settings;
+	SerializerSettings settings;
 	/// @todo Make APPLY_DEFAULT_MATERIALS configurable? Quickly tested setting this to false and using obj exporter caused the program to crash and burn.
 	settings.set(IfcGeom::IteratorSettings::APPLY_DEFAULT_MATERIALS,      true);
 	settings.set(IfcGeom::IteratorSettings::USE_WORLD_COORDS,             use_world_coords);
@@ -439,6 +442,7 @@ int main(int argc, char** argv)
     settings.set(SerializerSettings::USE_ELEMENT_NAMES, use_element_names);
     settings.set(SerializerSettings::USE_ELEMENT_GUIDS, use_element_guids);
     settings.set(SerializerSettings::USE_MATERIAL_NAMES, use_material_names);
+    settings.set_deflection_tolerance(deflection_tolerance);
     settings.precision = precision;
 
 	GeometrySerializer* serializer;

--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -39,7 +39,6 @@
 #include <Standard_Version.hxx>
 
 #include <boost/program_options.hpp>
-#include <boost/algorithm/string.hpp>
 
 #include <fstream>
 #include <sstream>
@@ -400,7 +399,12 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    ///@ todo Logger::Message(Logger::LOG_NOTICE, "Filtering by X, Y and Z.")
+    if (!entity_filter.values.empty()) { entity_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, entity_filter.description); }
+    if (!layer_filter.values.empty()) { layer_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, layer_filter.description); }
+    if (!guid_filter.values.empty()) { guid_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, guid_filter.description); }
+    if (!name_filter.values.empty()) { name_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, name_filter.description); }
+    if (!desc_filter.values.empty()) { desc_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, desc_filter.description); }
+    if (!tag_filter.values.empty()) { tag_filter.update_description(); Logger::Message(Logger::LOG_NOTICE, tag_filter.description); }
 
 	if (output_extension == ".xml") {
 		int exit_code = 1;
@@ -677,9 +681,6 @@ std::vector<IfcGeom::filter_t> setup_filters(
                 entities.insert("IfcOpeningElement");
             }
             entity_filter.populate(entities);
-
-            Logger::Message(Logger::LOG_NOTICE, entity_filter.include ? "Including" : "Excluding" +
-                std::string(" by default entities ") + boost::algorithm::join(entities, ", "));
         }
     } catch (const IfcParse::IfcException& e) {
         std::cerr << "[Error] " << e.what() << std::endl;

--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -436,7 +436,7 @@ int main(int argc, char** argv)
     }
 
     // IfcRoot.GlobalId
-    IfcGeom::arg_filter<IfcSchema::IfcRoot, 0, std::string> guid_filter;
+    IfcGeom::string_arg_filter guid_filter(IfcSchema::Type::IfcRoot, 0);
     guid_filter.traverse = traverse;
     if (include_filter.arg == GUID_ARG) {
         guid_filter.include = true;
@@ -452,7 +452,7 @@ int main(int argc, char** argv)
     // Note: skipping IfcRoot OwnerHistory, argument index 1
 
     // IfcRoot.Name
-    IfcGeom::arg_filter<IfcSchema::IfcRoot, 2, std::string> name_filter;
+    IfcGeom::string_arg_filter name_filter(IfcSchema::Type::IfcRoot, 2);
     name_filter.traverse = traverse;
     if (include_filter.arg == NAME_ARG) {
         name_filter.include = true;
@@ -466,7 +466,7 @@ int main(int argc, char** argv)
     }
 
     // IfcRoot.Description
-    IfcGeom::arg_filter<IfcSchema::IfcRoot, 3, std::string> desc_filter;
+    IfcGeom::string_arg_filter desc_filter(IfcSchema::Type::IfcRoot, 3);
     desc_filter.traverse = traverse;
     if (include_filter.arg == DESC_ARG) {
         desc_filter.include = true;
@@ -479,10 +479,11 @@ int main(int argc, char** argv)
         filters.push_back(boost::ref(desc_filter));
     }
 
-    /// @todo IfcProxy.Tag
-    //IfcGeom::arg_filter<IfcSchema::IfcProxy, 8, std::string> tag_filter;
-    // IfcElement.Tag
-    IfcGeom::arg_filter<IfcSchema::IfcElement, 7, std::string> tag_filter;
+    // IfcProxy.Tag & IfcElement.Tag
+    IfcGeom::string_arg_filter::arg_map_t tag_args;
+    tag_args[IfcSchema::Type::IfcProxy] = 8;
+    tag_args[IfcSchema::Type::IfcElement] = 7;
+    IfcGeom::string_arg_filter tag_filter(tag_args);
     tag_filter.traverse = traverse;
     if (include_filter.arg == TAG_ARG) {
         tag_filter.include = true;

--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -115,6 +115,7 @@ bool rename_file(const std::string& old_filename, const std::string& new_filenam
 static std::stringstream log_stream;
 void write_log();
 
+/// @todo make the filters non-global
 IfcGeom::entity_filter entity_filter; // Entity filter is used always by default.
 IfcGeom::layer_filter layer_filter;
 const std::string NAME_ARG = "Name", GUID_ARG = "GlobalId", DESC_ARG = "Description", TAG_ARG = "Tag";

--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -200,8 +200,8 @@ int main(int argc, char** argv)
             "geometrical output. The name patterns are handled case-sensitively. Cannot be placed right before input file argument. "
             "Only single option supported for now.")
         ("exclude", po::value<exclusion_filter>(&exclude_filter)->multitoken(),
-            "Specifies that the 'entities', 'names', or 'guids' provided are to be excluded. Defaults to IfcOpeningElement and IfcSpace "
-            "to be excluded. See --include for syntax and more details.")
+            "Specifies that the 'entities', 'names', 'guids', or 'layers' provided are to be excluded. "
+            "The default value is '--exclude=entities IfcOpeningElement IfcSpace'. See --include for syntax and more details.")
         ("no-normals",
             "Disables computation of normals. Saves time and file size and is useful "
             "in instances where you're going to recompute normals for the exported "
@@ -647,8 +647,8 @@ void validate(boost::any& v, const std::vector<std::string>& values, inclusion_f
         filter.type = geom_filter::ENTITY_NAME;
     } else if (type == "guids") {
         filter.type = geom_filter::ENTITY_GUID;
-    //} else if (type == "layers") {
-    //    filter.type = geom_filter::LAYER_NAME;
+    } else if (type == "layers") {
+        filter.type = geom_filter::LAYER_NAME;
     } else {
         throw po::validation_error(po::validation_error::invalid_option_value);
     }
@@ -671,8 +671,8 @@ void validate(boost::any& v, const std::vector<std::string>& values, exclusion_f
         filter.type = geom_filter::ENTITY_NAME;
     } else if (type == "guids") {
         filter.type = geom_filter::ENTITY_GUID;
-    //} else if (type == "layers") {
-    //    filter.type = geom_filter::LAYER_NAME;
+    } else if (type == "layers") {
+        filter.type = geom_filter::LAYER_NAME;
     } else {
         throw po::validation_error(po::validation_error::invalid_option_value);
     }

--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -57,13 +57,12 @@ namespace po = boost::program_options;
 
 void print_version()
 {
-    /// @todo Why cerr used for info prints? Change to cout.
-    std::cerr << "IfcOpenShell " << IfcSchema::Identifier << " IfcConvert " << IFCOPENSHELL_VERSION << std::endl;
+    std::cout << "IfcOpenShell " << IfcSchema::Identifier << " IfcConvert " << IFCOPENSHELL_VERSION << std::endl;
 }
 
 void print_usage(bool suggest_help = true)
 {
-    std::cerr << "Usage: IfcConvert [options] <input.ifc> [<output>]" << "\n"
+    std::cout << "Usage: IfcConvert [options] <input.ifc> [<output>]" << "\n"
         << "\n"
         << "Converts the geometry in an IFC file into one of the following formats:" << "\n"
         << "  .obj   WaveFront OBJ  (a .mtl file is also created)" << "\n"
@@ -77,15 +76,15 @@ void print_usage(bool suggest_help = true)
         << "\n"
         << "If no output filename given, <input>." + DEFAULT_EXTENSION + " will be used as the output file.\n";
     if (suggest_help) {
-        std::cerr << "\nRun 'IfcConvert --help' for more information.";
+        std::cout << "\nRun 'IfcConvert --help' for more information.";
     }
-    std::cerr << std::endl;
+    std::cout << std::endl;
 }
 
 void print_options(const po::options_description& options)
 {
-    std::cerr << "\n" << options;
-    std::cerr << std::endl;
+    std::cout << "\n" << options;
+    std::cout << std::endl;
 }
 
 std::string change_extension(const std::string& fn, const std::string& ext) {
@@ -605,7 +604,7 @@ int main(int argc, char** argv)
 void write_log() {
 	std::string log = log_stream.str();
 	if (!log.empty()) {
-		std::cerr << "\n" << "Log:\n" << log << std::endl;
+		std::cout << "\n" << "Log:\n" << log << std::endl;
 	}
 }
 

--- a/src/ifcconvert/XmlSerializer.cpp
+++ b/src/ifcconvert/XmlSerializer.cpp
@@ -270,41 +270,14 @@ ptree& descend(IfcObjectDefinition* product, ptree& tree) {
 	}
 
     if (product->is(Type::IfcProduct)) {
-        IfcProduct* prod = product->as<IfcProduct>();
-        if (prod->hasRepresentation()) {
-            IfcEntityList::ptr r = prod->entity->file->traverse(prod->Representation());
-
-            std::map<std::string, IfcPresentationLayerAssignment*> layers;
-            IfcRepresentation::list::ptr representations = r->as<IfcRepresentation>();
-            for (IfcRepresentation::list::it it = representations->begin(); it != representations->end(); ++it) {
-                IfcPresentationLayerAssignment::list::ptr a = (*it)->LayerAssignments();
-                for (IfcPresentationLayerAssignment::list::it jt = a->begin(); jt != a->end(); ++jt) {
-                    layers[(*jt)->Name()] = *jt;
-                }
-            }
-
-            IfcRepresentationItem::list::ptr items = r->as<IfcRepresentationItem>();
-            for (IfcRepresentationItem::list::it it = items->begin(); it != items->end(); ++it) {
-                IfcPresentationLayerAssignment::list::ptr a = (*it)->
-                    // LayerAssignments renamed from plural to singular, LayerAssignment, so work around that
-#ifdef USE_IFC4
-                    LayerAssignment();
-#else
-                    LayerAssignments();
-#endif
-                for (IfcPresentationLayerAssignment::list::it jt = a->begin(); jt != a->end(); ++jt) {
-                    layers[(*jt)->Name()] = *jt;
-                }
-            }
-
-            for (std::map<std::string, IfcPresentationLayerAssignment*>::const_iterator it = layers.begin(); it != layers.end(); ++it) {
-                // IfcPresentationLayerAssignments don't have GUIDs (only optional Identifier) so use name as the ID.
-                // Note that the IfcPresentationLayerAssignment passed here doesn't really matter as as_link is true
-                // for the format_entity_instance() call.
-                ptree node;
-                node.put("<xmlattr>.xlink:href", "#" + it->first);
-                format_entity_instance(it->second, node, child, true);
-            }
+        std::map<std::string, IfcPresentationLayerAssignment*> layers = IfcGeom::Kernel::get_layers(product->as<IfcProduct>());
+        for (std::map<std::string, IfcPresentationLayerAssignment*>::const_iterator it = layers.begin(); it != layers.end(); ++it) {
+            // IfcPresentationLayerAssignments don't have GUIDs (only optional Identifier) so use name as the ID.
+            // Note that the IfcPresentationLayerAssignment passed here doesn't really matter as as_link is true
+            // for the format_entity_instance() call.
+            ptree node;
+            node.put("<xmlattr>.xlink:href", "#" + it->first);
+            format_entity_instance(it->second, node, child, true);
         }
     }
 

--- a/src/ifcgeom/IfcGeom.h
+++ b/src/ifcgeom/IfcGeom.h
@@ -239,7 +239,7 @@ public:
 
 	std::pair<std::string, double> initializeUnits(IfcSchema::IfcUnitAssignment*);
 
-	IfcSchema::IfcObjectDefinition* get_decomposing_entity(IfcSchema::IfcProduct*);
+    static IfcSchema::IfcObjectDefinition* get_decomposing_entity(IfcSchema::IfcProduct*);
 
     static std::map<std::string, IfcSchema::IfcPresentationLayerAssignment*> get_layers(IfcSchema::IfcProduct* prod);
 

--- a/src/ifcgeom/IfcGeom.h
+++ b/src/ifcgeom/IfcGeom.h
@@ -241,6 +241,8 @@ public:
 
 	IfcSchema::IfcObjectDefinition* get_decomposing_entity(IfcSchema::IfcProduct*);
 
+    static std::map<std::string, IfcSchema::IfcPresentationLayerAssignment*> get_layers(IfcSchema::IfcProduct* prod);
+
 	template <typename P>
     IfcGeom::BRepElement<P>* create_brep_for_representation_and_product(
         const IteratorSettings&, IfcSchema::IfcRepresentation*, IfcSchema::IfcProduct*);

--- a/src/ifcgeom/IfcGeomElement.h
+++ b/src/ifcgeom/IfcGeomElement.h
@@ -80,6 +80,7 @@ namespace IfcGeom {
 		std::string _context;
 		std::string _unique_id;
 		Transformation<P> _transformation;
+        IfcSchema::IfcProduct* product_;
 	public:
 		int id() const { return _id; }
 		int parent_id() const { return _parent_id; }
@@ -89,8 +90,12 @@ namespace IfcGeom {
 		const std::string& context() const { return _context; }
 		const std::string& unique_id() const { return _unique_id; }
 		const Transformation<P>& transformation() const { return _transformation; }
-		Element(const ElementSettings& settings, int id, int parent_id, const std::string& name, const std::string& type, const std::string& guid, const std::string& context, const gp_Trsf& trsf)
+        IfcSchema::IfcProduct* product() const { return product_; }
+
+		Element(const ElementSettings& settings, int id, int parent_id, const std::string& name, const std::string& type,
+            const std::string& guid, const std::string& context, const gp_Trsf& trsf, IfcSchema::IfcProduct *product)
 			: _id(id), _parent_id(parent_id), _name(name), _type(type), _guid(guid), _context(context), _transformation(settings, trsf)
+            , product_(product)
 		{
 			std::ostringstream oss;
 			oss << "product-" << IfcParse::IfcGlobalId(guid).formatted();
@@ -112,8 +117,10 @@ namespace IfcGeom {
 	public:
 		const boost::shared_ptr<Representation::BRep>& geometry_pointer() const { return _geometry; }
 		const Representation::BRep& geometry() const { return *_geometry; }
-		BRepElement(int id, int parent_id, const std::string& name, const std::string& type, const std::string& guid, const std::string& context, const gp_Trsf& trsf, const boost::shared_ptr<Representation::BRep>& geometry)
-			: Element<P>(geometry->settings(),id,parent_id,name,type,guid,context,trsf)
+		BRepElement(int id, int parent_id, const std::string& name, const std::string& type, const std::string& guid,
+            const std::string& context, const gp_Trsf& trsf, const boost::shared_ptr<Representation::BRep>& geometry,
+            IfcSchema::IfcProduct* product)
+			: Element<P>(geometry->settings(),id,parent_id,name,type,guid,context,trsf, product)
 			, _geometry(geometry)
 		{}
 	private:

--- a/src/ifcgeom/IfcGeomFilter.h
+++ b/src/ifcgeom/IfcGeomFilter.h
@@ -1,0 +1,241 @@
+/********************************************************************************
+ *                                                                              *
+ * This file is part of IfcOpenShell.                                           *
+ *                                                                              *
+ * IfcOpenShell is free software: you can redistribute it and/or modify         *
+ * it under the terms of the Lesser GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3.0 of the License, or          *
+ * (at your option) any later version.                                          *
+ *                                                                              *
+ * IfcOpenShell is distributed in the hope that it will be useful,              *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 *
+ * Lesser GNU General Public License for more details.                          *
+ *                                                                              *
+ * You should have received a copy of the Lesser GNU General Public License     *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.         *
+ *                                                                              *
+ ********************************************************************************/
+
+/** @file   IfcGeomFilter.h
+    @brief  A set of predefined product filters for IfcGeom::Iterator */
+
+#ifndef IFCGEOMFILTER_H
+#define IFCGEOMFILTER_H
+
+#include "IfcGeom.h"
+#include <boost/regex.hpp>
+
+namespace IfcGeom
+{
+    typedef boost::function<bool(IfcSchema::IfcProduct*)> filter_t;
+
+    struct filter
+    {
+        filter() : include(false), traverse(false) {}
+        filter(bool incl, bool trav) : include(incl), traverse(trav) {}
+        /// Should the product be included (true) or excluded (false).
+        bool include;
+        /// If traversal requested, traverse to the parents to see if they satisfy the criteria. E.g. we might be looking for
+        /// children of a storey named "Level 20", or children of entities that have no representation, e.g. IfcCurtainWall.
+        bool traverse;
+
+        //static bool traverse_match(IfcSchema::IfcProduct* prod, filter_t pred)
+        //{
+        //    bool is_match = false;
+        //    IfcSchema::IfcProduct* parent, *current = prod;
+        //    while ((parent = static_cast<IfcSchema::IfcProduct*>(IfcGeom::Kernel::get_decomposing_entity(current))) != 0) {
+        //        if (pred(parent)) {
+        //            is_match = true;
+        //            break;
+        //        }
+        //        current = parent;
+        //    }
+        //}
+    };
+
+    struct wildcard_filter : public filter
+    {
+        wildcard_filter() : filter(false, false) {}
+        wildcard_filter(bool include, bool traverse, const std::set<std::string>& patterns)
+            : filter(include, traverse)
+        {
+            populate(patterns);
+        }
+
+        std::set<boost::regex> values;
+
+        void populate(const std::set<std::string>& patterns)
+        {
+            values.clear();
+            foreach(const std::string &pattern, patterns) {
+                values.insert(wildcard_string_to_regex(pattern));
+            }
+        }
+
+        bool match(const std::string &str) const
+        {
+            foreach(const boost::regex& r, values) {
+                if (boost::regex_match(str, r)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        static boost::regex wildcard_string_to_regex(std::string str)
+        {
+            // Escape all non-"*?" regex special chars
+            std::string special_chars = "\\^.$|()[]+/";
+            foreach(char c, special_chars) {
+                std::string char_str(1, c);
+                boost::replace_all(str, char_str, "\\" + char_str);
+            }
+            // Convert "*?" to their regex equivalents
+            boost::replace_all(str, "?", ".");
+            boost::replace_all(str, "*", ".*");
+            return boost::regex(str);
+        }
+    };
+
+    /// @todo Maybe not use template class for this after all. Attribute name would be better
+    /// than index, but IfcBaseClass doesn't have getArgument(name) (IfcLateBoundEntity would have though).
+    template<class ClassType, unsigned short ArgIndex, typename ArgType>
+    struct arg_filter : public wildcard_filter
+    {
+        arg_filter()
+        {
+#ifndef NDEBUG
+            ClassType dummy(0);
+            assert(ArgIndex < dummy.getArgumentCount());
+#endif
+        }
+        arg_filter(bool include, bool traverse, const std::set<std::string>& patterns)
+            : wildcard_filter(include, traverse, patterns)
+        {
+    #ifndef NDEBUG
+            ClassType dummy(0);
+            assert(ArgIndex < dummy.getArgumentCount());
+    #endif
+            populate(patterns);
+        }
+
+        ArgType value(IfcSchema::IfcProduct* prod) const
+        {
+            Argument *arg = prod->entity->getArgument(ArgIndex);
+            return !arg->isNull() ? *arg : ArgType();
+        }
+
+        bool operator()(IfcSchema::IfcProduct* prod) const
+        {
+            bool is_match = match(value(prod));
+            if (is_match != include && traverse) {
+                IfcSchema::IfcProduct* parent, *current = prod;
+                while ((parent = static_cast<IfcSchema::IfcProduct*>(IfcGeom::Kernel::get_decomposing_entity(current))) != 0) {
+                    if (match(value(parent))) {
+                        is_match = true;
+                        break;
+                    }
+                    current = parent;
+                }
+            }
+            return is_match == include;
+        }
+    };
+
+    struct layer_filter : public wildcard_filter
+    {
+        layer_filter() {}
+        layer_filter(bool include, bool traverse, const std::set<std::string>& patterns)
+            : wildcard_filter(include, traverse, patterns)
+        {
+        }
+
+        bool operator()(IfcSchema::IfcProduct* prod) const
+        {
+            bool is_match = false;
+            std::map<std::string, IfcSchema::IfcPresentationLayerAssignment*> layers = IfcGeom::Kernel::get_layers(prod);
+            std::map<std::string, IfcSchema::IfcPresentationLayerAssignment*>::const_iterator lit;
+            for (lit = layers.begin(); lit != layers.end(); ++lit) {
+                if (match(lit->first)) {
+                    is_match = true;
+                    break;
+                }
+            }
+
+            if (is_match != include && traverse) {
+                for (lit = layers.begin(); lit != layers.end(); ++lit) {
+                    IfcSchema::IfcProduct* parent, *current = prod;
+                    while ((parent = static_cast<IfcSchema::IfcProduct*>(IfcGeom::Kernel::get_decomposing_entity(current))) != 0) {
+                        if (match(lit->first)) {
+                            is_match = true;
+                            break;
+                        }
+                        current = parent;
+                    }
+                    if (is_match) {
+                        break;
+                    }
+                }
+            }
+
+            return is_match == include;
+        }
+    };
+
+    struct entity_filter : public filter
+    {
+        entity_filter() {}
+        entity_filter(bool include, bool traverse/*, const std::set<std::string>& types*/)
+            : filter(include, traverse)
+        {
+            //populate(types);
+        }
+
+        std::set<IfcSchema::Type::Enum> values;
+
+        void populate(const std::set<std::string>& types)
+        {
+            values.clear();
+            foreach(const std::string& type, types) {
+                IfcSchema::Type::Enum ty;
+                try {
+                    ty = IfcSchema::Type::FromString(boost::to_upper_copy(type));
+                } catch (const IfcParse::IfcException&) {
+                    throw IfcParse::IfcException("'" +  type + "' does not name a valid IFC entity");
+                }
+                values.insert(ty);
+                // TODO: Add child classes so that containment in set can be in O(log n)
+            }
+        }
+
+        bool match(IfcSchema::IfcProduct* prod) const
+        {
+            // The set is iterated over to able to filter on subtypes.
+            foreach(IfcSchema::Type::Enum type, values) {
+                if (prod->is(type)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        bool operator()(IfcSchema::IfcProduct* prod) const
+        {
+            bool is_match = match(prod);
+            if (is_match != include && traverse) {
+                IfcSchema::IfcProduct* parent, *current = prod;
+                while ((parent = static_cast<IfcSchema::IfcProduct*>(IfcGeom::Kernel::get_decomposing_entity(current))) != 0) {
+                    if (match(parent)) {
+                        is_match = true;
+                        break;
+                    }
+                    current = parent;
+                }
+            }
+            return is_match == include;
+        }
+    };
+}
+
+#endif

--- a/src/ifcgeom/IfcGeomFilter.h
+++ b/src/ifcgeom/IfcGeomFilter.h
@@ -113,6 +113,14 @@ namespace IfcGeom
         /// @todo Take only attribute name when IfcBaseClass and IfcLateBoundEntity are merged.
         string_arg_filter(arg_map_t args) : args(args) { assert_arguments(); }
         string_arg_filter(IfcSchema::Type::Enum type, unsigned short index) { args[type] = index;  assert_arguments(); }
+        string_arg_filter(
+            IfcSchema::Type::Enum type1, unsigned short index1,
+            IfcSchema::Type::Enum type2, unsigned short index2)
+        {
+            args[type1] = index1;
+            args[type2] = index2;
+            assert_arguments();
+        }
 
         /// @todo this won't be needed when we have the generic argument name access
         void assert_arguments()
@@ -131,7 +139,7 @@ namespace IfcGeom
         {
             for (arg_map_t::const_iterator it = args.begin(); it != args.end(); ++it) {
                 if (prod->is(it->first)) {
-                    Argument *arg = (it->second <= prod->entity->getArgumentCount() ? prod->entity->getArgument(it->second) : 0);
+                    Argument *arg = (it->second < prod->entity->getArgumentCount() ? prod->entity->getArgument(it->second) : 0);
                     if (arg && !arg->isNull()) {
                         return *arg;
                     }

--- a/src/ifcgeom/IfcGeomFilter.h
+++ b/src/ifcgeom/IfcGeomFilter.h
@@ -24,6 +24,9 @@
 #define IFCGEOMFILTER_H
 
 #include "IfcGeom.h"
+#ifndef NDEBUG
+#include "../ifcparse/IfcWritableEntity.h"
+#endif
 
 #include <boost/function.hpp>
 #include <boost/regex.hpp>
@@ -44,18 +47,17 @@ namespace IfcGeom
         /// children of a storey named "Level 20", or children of entities that have no representation, e.g. IfcCurtainWall.
         bool traverse;
 
-        //static bool traverse_match(IfcSchema::IfcProduct* prod, filter_t pred)
-        //{
-        //    bool is_match = false;
-        //    IfcSchema::IfcProduct* parent, *current = prod;
-        //    while ((parent = static_cast<IfcSchema::IfcProduct*>(IfcGeom::Kernel::get_decomposing_entity(current))) != 0) {
-        //        if (pred(parent)) {
-        //            is_match = true;
-        //            break;
-        //        }
-        //        current = parent;
-        //    }
-        //}
+        static bool traverse_match(IfcSchema::IfcProduct* prod, const filter_t& pred)
+        {
+            IfcSchema::IfcProduct* parent, *current = prod;
+            while ((parent = static_cast<IfcSchema::IfcProduct*>(IfcGeom::Kernel::get_decomposing_entity(current))) != 0) {
+                if (pred(parent)) {
+                    return true;
+                }
+                current = parent;
+            }
+            return false;
+        }
     };
 
     struct wildcard_filter : public filter
@@ -109,8 +111,21 @@ namespace IfcGeom
         arg_map_t args;
 
         /// @todo Take only attribute name when IfcBaseClass and IfcLateBoundEntity are merged.
-        string_arg_filter(arg_map_t args) : args(args) {}
-        string_arg_filter(IfcSchema::Type::Enum type, unsigned short index) { args[type] = index; }
+        string_arg_filter(arg_map_t args) : args(args) { assert_arguments(); }
+        string_arg_filter(IfcSchema::Type::Enum type, unsigned short index) { args[type] = index;  assert_arguments(); }
+
+        /// @todo this won't be needed when we have the generic argument name access
+        void assert_arguments()
+        {
+#ifndef NDEBUG
+            for (arg_map_t::const_iterator it = args.begin(); it != args.end(); ++it) {
+                IfcWrite::IfcWritableEntity dummy(it->first);
+                IfcUtil::IfcBaseClass* base = IfcSchema::SchemaEntity(&dummy);
+                assert(it->second < base->getArgumentCount() && "Invalid argument index");
+                delete base;
+            }
+#endif
+        }
 
         std::string value(IfcSchema::IfcProduct* prod) const
         {
@@ -129,14 +144,7 @@ namespace IfcGeom
         {
             bool is_match = match(value(prod));
             if (is_match != include && traverse) {
-                IfcSchema::IfcProduct* parent, *current = prod;
-                while ((parent = static_cast<IfcSchema::IfcProduct*>(IfcGeom::Kernel::get_decomposing_entity(current))) != 0) {
-                    if (match(value(parent))) {
-                        is_match = true;
-                        break;
-                    }
-                    current = parent;
-                }
+                is_match = traverse_match(prod, boost::ref(*this));
             }
             return is_match == include;
         }
@@ -144,42 +152,44 @@ namespace IfcGeom
 
     struct layer_filter : public wildcard_filter
     {
+        typedef std::map<std::string, IfcSchema::IfcPresentationLayerAssignment*> layer_map_t;
+
         layer_filter() {}
         layer_filter(bool include, bool traverse, const std::set<std::string>& patterns)
             : wildcard_filter(include, traverse, patterns)
         {
         }
 
+        bool match(IfcSchema::IfcProduct* prod) const
+        {
+            layer_map_t layers = IfcGeom::Kernel::get_layers(prod);
+            return std::find_if(layers.begin(), layers.end(), wildcards_match(values)) != layers.end();
+        }
+
         bool operator()(IfcSchema::IfcProduct* prod) const
         {
-            bool is_match = false;
-            std::map<std::string, IfcSchema::IfcPresentationLayerAssignment*> layers = IfcGeom::Kernel::get_layers(prod);
-            std::map<std::string, IfcSchema::IfcPresentationLayerAssignment*>::const_iterator lit;
-            for (lit = layers.begin(); lit != layers.end(); ++lit) {
-                if (match(lit->first)) {
-                    is_match = true;
-                    break;
-                }
-            }
-
+            bool is_match = match(prod);
             if (is_match != include && traverse) {
-                for (lit = layers.begin(); lit != layers.end(); ++lit) {
-                    IfcSchema::IfcProduct* parent, *current = prod;
-                    while ((parent = static_cast<IfcSchema::IfcProduct*>(IfcGeom::Kernel::get_decomposing_entity(current))) != 0) {
-                        if (match(lit->first)) {
-                            is_match = true;
-                            break;
-                        }
-                        current = parent;
-                    }
-                    if (is_match) {
-                        break;
-                    }
-                }
+                is_match = traverse_match(prod, boost::ref(*this));
             }
-
             return is_match == include;
         }
+
+        struct wildcards_match
+        {
+            wildcards_match(const std::set<boost::regex>& patterns) : patterns(patterns) {}
+            bool operator()(const layer_map_t::value_type& layer_map_value) const
+            {
+                foreach(const boost::regex& r, patterns) {
+                    if (boost::regex_match(layer_map_value.first, r)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            std::set<boost::regex> patterns;
+        };
     };
 
     struct entity_filter : public filter
@@ -223,14 +233,7 @@ namespace IfcGeom
         {
             bool is_match = match(prod);
             if (is_match != include && traverse) {
-                IfcSchema::IfcProduct* parent, *current = prod;
-                while ((parent = static_cast<IfcSchema::IfcProduct*>(IfcGeom::Kernel::get_decomposing_entity(current))) != 0) {
-                    if (match(parent)) {
-                        is_match = true;
-                        break;
-                    }
-                    current = parent;
-                }
+                is_match = traverse_match(prod, boost::ref(*this));
             }
             return is_match == include;
         }

--- a/src/ifcgeom/IfcGeomFilter.h
+++ b/src/ifcgeom/IfcGeomFilter.h
@@ -24,7 +24,11 @@
 #define IFCGEOMFILTER_H
 
 #include "IfcGeom.h"
+
+#include <boost/function.hpp>
 #include <boost/regex.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 
 namespace IfcGeom
 {
@@ -100,13 +104,13 @@ namespace IfcGeom
 
     /// @todo Maybe not use template class for this after all. Attribute name would be better
     /// than index, but IfcBaseClass doesn't have getArgument(name) (IfcLateBoundEntity would have though).
-    template<class ClassType, unsigned short ArgIndex, typename ArgType>
+    template<class IfcType, unsigned short ArgIndex, typename ArgType>
     struct arg_filter : public wildcard_filter
     {
         arg_filter()
         {
 #ifndef NDEBUG
-            ClassType dummy(0);
+            IfcType dummy(0);
             assert(ArgIndex < dummy.getArgumentCount());
 #endif
         }
@@ -114,7 +118,7 @@ namespace IfcGeom
             : wildcard_filter(include, traverse, patterns)
         {
     #ifndef NDEBUG
-            ClassType dummy(0);
+            IfcType dummy(0);
             assert(ArgIndex < dummy.getArgumentCount());
     #endif
             populate(patterns);
@@ -122,8 +126,8 @@ namespace IfcGeom
 
         ArgType value(IfcSchema::IfcProduct* prod) const
         {
-            Argument *arg = prod->entity->getArgument(ArgIndex);
-            return !arg->isNull() ? *arg : ArgType();
+            Argument *arg = prod->is(IfcType::Class()) ? prod->entity->getArgument(ArgIndex) : 0;
+            return arg && !arg->isNull() ? *arg : ArgType();
         }
 
         bool operator()(IfcSchema::IfcProduct* prod) const

--- a/src/ifcgeom/IfcGeomFilter.h
+++ b/src/ifcgeom/IfcGeomFilter.h
@@ -120,6 +120,7 @@ namespace IfcGeom
         }
     };
 
+    /// @note supports only string arguments for now
     struct string_arg_filter : public wildcard_filter
     {
         // Using this for now in order to overcome the fact that different classes have the argument at different indices.
@@ -145,7 +146,8 @@ namespace IfcGeom
             for (arg_map_t::const_iterator it = args.begin(); it != args.end(); ++it) {
                 IfcWrite::IfcWritableEntity dummy(it->first);
                 IfcUtil::IfcBaseClass* base = IfcSchema::SchemaEntity(&dummy);
-                assert(it->second < base->getArgumentCount() && "Invalid argument index");
+                assert(it->second < base->getArgumentType(it->second) == IfcUtil::Argument_STRING && "Argument type not string");
+                assert(it->second < base->getArgumentCount() && "Argument index out of bounds");
                 delete base;
             }
 #endif
@@ -154,7 +156,8 @@ namespace IfcGeom
         std::string value(IfcSchema::IfcProduct* prod) const
         {
             for (arg_map_t::const_iterator it = args.begin(); it != args.end(); ++it) {
-                if (prod->is(it->first) && it->second < prod->entity->getArgumentCount()) {
+                if (prod->is(it->first) && it->second < prod->entity->getArgumentCount() &&
+                    prod->getArgumentType(it->second) == IfcUtil::Argument_STRING) {
                     Argument *arg = prod->entity->getArgument(it->second);
                     if (!arg->isNull()) {
                         return *arg;

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -1174,7 +1174,8 @@ IfcGeom::BRepElement<P>* IfcGeom::Kernel::create_brep_for_representation_and_pro
 		guid,
 		context_string,
 		trsf,
-		boost::shared_ptr<IfcGeom::Representation::BRep>(shape)
+		boost::shared_ptr<IfcGeom::Representation::BRep>(shape),
+        product
 	);
 }
 
@@ -1216,7 +1217,8 @@ IfcGeom::BRepElement<P>* IfcGeom::Kernel::create_brep_for_processed_representati
 		guid,
 		context_string,
 		trsf,
-		brep->geometry_pointer()
+		brep->geometry_pointer(),
+        product
 	);
 }
 
@@ -1234,7 +1236,7 @@ IfcSchema::IfcObjectDefinition* IfcGeom::Kernel::get_decomposing_entity(IfcSchem
 	} else if ( product->is(IfcSchema::Type::IfcElement ) ) {
 		IfcSchema::IfcElement* element = (IfcSchema::IfcElement*)product;
 		IfcSchema::IfcRelFillsElement::list::ptr fills = element->FillsVoids();
-		// Incase of a RelatedBuildingElement parent to the opening element
+		// In case of a RelatedBuildingElement parent to the opening element
 		if ( fills->size() ) {
 			for ( IfcSchema::IfcRelFillsElement::list::it it = fills->begin(); it != fills->end(); ++ it ) {
 				IfcSchema::IfcRelFillsElement* fill = *it;

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -1275,6 +1275,37 @@ IfcSchema::IfcObjectDefinition* IfcGeom::Kernel::get_decomposing_entity(IfcSchem
 	return parent;
 }
 
+std::map<std::string, IfcSchema::IfcPresentationLayerAssignment*> IfcGeom::Kernel::get_layers(IfcSchema::IfcProduct* prod)
+{
+    using namespace IfcSchema;
+    std::map<std::string, IfcPresentationLayerAssignment*> layers;
+    if (prod->hasRepresentation()) {
+        IfcEntityList::ptr r = prod->entity->file->traverse(prod->Representation());
+        IfcRepresentation::list::ptr representations = r->as<IfcRepresentation>();
+        for (IfcRepresentation::list::it it = representations->begin(); it != representations->end(); ++it) {
+            IfcPresentationLayerAssignment::list::ptr a = (*it)->LayerAssignments();
+            for (IfcPresentationLayerAssignment::list::it jt = a->begin(); jt != a->end(); ++jt) {
+                layers[(*jt)->Name()] = *jt;
+            }
+        }
+
+        IfcRepresentationItem::list::ptr items = r->as<IfcRepresentationItem>();
+        for (IfcRepresentationItem::list::it it = items->begin(); it != items->end(); ++it) {
+            IfcPresentationLayerAssignment::list::ptr a = (*it)->
+                // LayerAssignments renamed from plural to singular, LayerAssignment, so work around that
+#ifdef USE_IFC4
+                LayerAssignment();
+#else
+                LayerAssignments();
+#endif
+            for (IfcPresentationLayerAssignment::list::it jt = a->begin(); jt != a->end(); ++jt) {
+                layers[(*jt)->Name()] = *jt;
+            }
+        }
+    }
+    return layers;
+}
+
 template IFC_GEOM_API IfcGeom::BRepElement<float>* IfcGeom::Kernel::create_brep_for_representation_and_product<float>(
     const IteratorSettings& settings, IfcSchema::IfcRepresentation* representation, IfcSchema::IfcProduct* product);
 template IFC_GEOM_API IfcGeom::BRepElement<double>* IfcGeom::Kernel::create_brep_for_representation_and_product<double>(

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -145,7 +145,18 @@ namespace IfcGeom {
 			}
 		}
 
+        /// @todo public/private sections all over the place: move all public to the beginning of the class
 	public:
+        Iterator(const IteratorSettings& settings, const std::string& filename, std::vector<filter_t>& filters)
+            : settings(settings)
+            , ifc_file(new IfcParse::IfcFile)
+            , owns_ifc_file(true)
+            , filters_(filters)
+        {
+            ifc_file->Init(filename);
+            _initialize();
+        }
+
 		bool initialize() {
 			try {
 				initUnits();
@@ -307,8 +318,8 @@ namespace IfcGeom {
 
 		IfcParse::IfcFile* getFile() const { return ifc_file; }
 
-        const std::vector<filter_t> &filters() const { return filters_; }
-        std::vector<filter_t> &filters() { return filters_; }
+        const std::vector<filter_t>& filters() const { return filters_; }
+        std::vector<filter_t>& filters() { return filters_; }
 
         const gp_XYZ& bounds_min() const { return bounds_min_; }
         const gp_XYZ& bounds_max() const { return bounds_max_; }

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -331,7 +331,7 @@ namespace IfcGeom {
 		}
 
         /// @note Arbitrary names or wildcard expressions are handled case-sensitively.
-        void include_entity_names(const std::vector<std::string>& names)
+        void include_entity_names(const std::set<std::string>& names)
         {
             names_to_include_or_exclude.clear();
             foreach(const std::string &name, names)
@@ -340,7 +340,7 @@ namespace IfcGeom {
         }
 
         /// @note Arbitrary names or wildcard expressions are handled case-sensitively.
-        void exclude_entity_names(const std::vector<std::string>& names)
+        void exclude_entity_names(const std::set<std::string>& names)
         {
             names_to_include_or_exclude.clear();
             foreach(const std::string &name, names)
@@ -546,7 +546,7 @@ namespace IfcGeom {
                             }
                         }
 
-                        if (!type_found && traverse) {
+                        if (type_found != include_entities_in_processing && traverse) {
                             foreach(IfcSchema::Type::Enum type, entities_to_include_or_exclude) {
                                 IfcSchema::IfcProduct* parent, * current = prod;
                                 while ((parent = static_cast<IfcSchema::IfcProduct*>(kernel.get_decomposing_entity(current))) != 0) {
@@ -570,7 +570,7 @@ namespace IfcGeom {
                             }
                         }
 
-                        if (!name_found && traverse) {
+                        if (name_found != include_names_in_processing_ && traverse) {
                             foreach(const boost::regex& r, names_to_include_or_exclude) {
                                 IfcSchema::IfcProduct* parent, *current = prod;
                                 while ((parent = static_cast<IfcSchema::IfcProduct*>(kernel.get_decomposing_entity(current))) != 0) {

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -147,7 +147,7 @@ namespace IfcGeom {
 
         /// @todo public/private sections all over the place: move all public to the beginning of the class
 	public:
-        Iterator(const IteratorSettings& settings, const std::string& filename, std::vector<filter_t>& filters)
+        Iterator(const IteratorSettings& settings, const std::string& filename, std::vector<IfcGeom::filter_t>& filters)
             : settings(settings)
             , ifc_file(new IfcParse::IfcFile)
             , owns_ifc_file(true)
@@ -318,8 +318,8 @@ namespace IfcGeom {
 
 		IfcParse::IfcFile* getFile() const { return ifc_file; }
 
-        const std::vector<filter_t>& filters() const { return filters_; }
-        std::vector<filter_t>& filters() { return filters_; }
+        const std::vector<IfcGeom::filter_t>& filters() const { return filters_; }
+        std::vector<IfcGeom::filter_t>& filters() { return filters_; }
 
         const gp_XYZ& bounds_min() const { return bounds_min_; }
         const gp_XYZ& bounds_max() const { return bounds_max_; }
@@ -589,12 +589,13 @@ namespace IfcGeom {
 			gp_Trsf trsf;
 			int parent_id = -1;
 			std::string instance_type, product_name, product_guid;
-			
+            IfcSchema::IfcProduct* ifc_product = 0;
+
 			try {
 				const IfcUtil::IfcBaseClass* ifc_entity = ifc_file->entityById(id);
 				instance_type = IfcSchema::Type::ToString(ifc_entity->type());
 				if ( ifc_entity->is(IfcSchema::Type::IfcProduct) ) {
-					IfcSchema::IfcProduct* ifc_product = (IfcSchema::IfcProduct*)ifc_entity;
+					ifc_product = (IfcSchema::IfcProduct*)ifc_entity;
 					
 					product_guid = ifc_product->GlobalId();
 					product_name = ifc_product->hasName() ? ifc_product->Name() : "";
@@ -614,7 +615,7 @@ namespace IfcGeom {
 			} catch(...) {}
 
 			ElementSettings element_settings(settings, unit_magnitude, instance_type);
-			Element<P>* ifc_object = new Element<P>(element_settings, id, parent_id, product_name, instance_type, product_guid, "", trsf);
+			Element<P>* ifc_object = new Element<P>(element_settings, id, parent_id, product_name, instance_type, product_guid, "", trsf, ifc_product);
 			
 			return ifc_object;
 		}

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -147,13 +147,12 @@ namespace IfcGeom {
 
         /// @todo public/private sections all over the place: move all public to the beginning of the class
 	public:
-        Iterator(const IteratorSettings& settings, const std::string& filename, std::vector<IfcGeom::filter_t>& filters)
+        Iterator(const IteratorSettings& settings, IfcParse::IfcFile* file, std::vector<IfcGeom::filter_t>& filters)
             : settings(settings)
-            , ifc_file(new IfcParse::IfcFile)
-            , owns_ifc_file(true)
+            , ifc_file(file)
+            , owns_ifc_file(false)
             , filters_(filters)
         {
-            ifc_file->Init(filename);
             _initialize();
         }
 

--- a/src/ifcgeom/IfcGeomIteratorSettings.h
+++ b/src/ifcgeom/IfcGeomIteratorSettings.h
@@ -78,9 +78,8 @@ namespace IfcGeom
             GENERATE_UVS = 1 << 12,
             /// Specifies whether to slice representations according to associated IfcLayerSets.
             APPLY_LAYERSETS = 1 << 13,
-            TRAVERSE = 1 << 14,
             /// Number of different setting flags.
-            NUM_SETTINGS = 14
+            NUM_SETTINGS = 13
         };
         /// Used to store logical OR combination of setting flags.
         typedef unsigned SettingField;

--- a/src/ifcgeom/IfcGeomIteratorSettings.h
+++ b/src/ifcgeom/IfcGeomIteratorSettings.h
@@ -78,9 +78,6 @@ namespace IfcGeom
             GENERATE_UVS = 1 << 12,
             /// Specifies whether to slice representations according to associated IfcLayerSets.
             APPLY_LAYERSETS = 1 << 13,
-            /// Marks that include/exclude filtering should be applied also to the decomposition
-            /// and/or containment (IsDecomposedBy, HasOpenings, FillsVoid, ContainedInStructure)
-            /// of the filtered entity.
             TRAVERSE = 1 << 14,
             /// Number of different setting flags.
             NUM_SETTINGS = 14

--- a/src/ifcgeomserver/IfcGeomServer.cpp
+++ b/src/ifcgeomserver/IfcGeomServer.cpp
@@ -516,7 +516,7 @@ int main () {
 		}
 		case NEXT: {
 			Next n; n.read(std::cin);
-			has_more = iterator->next();
+			has_more = iterator->next() != 0;
 			if (!has_more) {
 				delete iterator;
 				iterator = 0;

--- a/src/ifcparse/IfcLogger.h
+++ b/src/ifcparse/IfcLogger.h
@@ -55,6 +55,9 @@ public:
 	static Severity Verbosity();
 	/// Log a message to the output stream
 	static void Message(Severity type, const std::string& message, IfcAbstractEntity* entity=0);
+    static void Notice(const std::string& message, IfcAbstractEntity* entity = 0) { Message(LOG_NOTICE, message, entity); }
+    static void Warning(const std::string& message, IfcAbstractEntity* entity=0) { Message(LOG_WARNING, message, entity); }
+    static void Error(const std::string& message, IfcAbstractEntity* entity=0) { Message(LOG_ERROR, message, entity); }
 	static void Status(const std::string& message, bool new_line=true);
 	static void ProgressBar(int progress);
 	static std::string GetLog();

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -559,6 +559,9 @@ double TokenFunc::asFloat(const Token& t) {
 }
 
 const std::string &TokenFunc::asStringRef(const Token& t) {
+    if (t.type == Token_NONE) {
+        throw IfcParse::IfcException("Null token encountered, premature end of file?");
+    }
 	std::string &str = t.lexer->GetTempString();
 	t.lexer->TokenString(t.startPos, str);
 	if ((isString(t) || isEnumeration(t) || isBinary(t)) && !str.empty()) {

--- a/win/readme.md
+++ b/win/readme.md
@@ -1,30 +1,30 @@
 Windows Build Tools and Scripts
 ===============================
-This folder contains build tools and script for automatic building and deployment of IfcOpenShell (IFCOS)
+This folder contains build tools and script for automatic building and deployment of IfcOpenShell ("IFCOS")
 and its dependencies.
 
 As a general guideline, `.cmd` files are non-standalone batch files that need to be run from command prompt or from
-another batch file, and/or while the Visual Studio environment variables set, and `.bat` files are standalone batch
-files that can also be invoked e.g. by double-clicking in the File Explorer. `.sh` files are for MSYS2 + MinGW ("MSYS"
-hereafter) compilation.
+another batch file, and/or while the Visual Studio ("MSVC") environment variables set, and `.bat` files are standalone batch
+files that can also be invoked e.g. by double-clicking in the File Explorer. `.sh` files are for MSYS**2** + MinGW ("MSYS"
+) compilation.
 
 Usage Instructions
 ------------------
-### MSYS2 + MinGW
+### MSYS
 
-Building using MSYS is very similar to using the Visual Studio batch files, but instead the shell scripts
+Building using MSYS is very similar to using the MSVC batch files, but instead the shell scripts
 are used. Note that the MSYS support is currently a bit experimental. It is advised to check out the contents
-of the shell scripts before using them. Note that contrary to Visual Studio, with MinGW all of the dependencies are not
+of the shell scripts before using them. Note that contrary to MSVC, with MSYS all of the dependencies are not
 built or used as static libaries. Currently Release build is used for all libraries.
 
-### Visual Studio
+### MSVC
 Execute `build-deps.cmd` to fetch, build and install the dependencies. The batch file will print the requirements for
 a successful execution. The script allows a few user-configurable build options which are listed in the usage
 instructions. Either edit the script file or set these values before running the script.
 
 `build-deps.cmd` expects a CMake generator as `%1` and a build configuration type (`RelWithDebInfo`, `Release`,
 `MinSizeRel`, or `Debug`, defaults to `RelWithDebInfo`) as `%2`. If the generator is not provided, the generator is
-deduced from the Visual Studio environment variables. User-friendly VS generator shorthands are supported, e.g.
+deduced from the MSVC environment variables. User-friendly VS generator shorthands are supported, e.g.
 `vs2013-x86` or `vs2015-x64`, and these are converted to the appropriate CMake ones by the scripts. A build type
 (`Build`, `Rebuild`, or `Clean`, defaults to `Build`) can be provided as `%3`. See `vs-cfg.cmd` if you wish to change
 the defaults. The batch file will create `deps\` and `deps-vs<VERSION>-<ARCHITECTURE>-installed\` directories to the
@@ -44,7 +44,7 @@ the generator must be always passed as the first option:
 
 **If you wish to use any library from a custom location, modify the paths in `run-cmake.bat` accordingly**. The batch
 script will create a folder of form `build-vs<VERSION>-<ARCHITECTURE>\` which will contain the solution and project
-files for Visual Studio.
+files for MSVC.
 
 Note that building IfcOpenShell as 64-bit is recommended as many of real life IFC files has been observed to take
 easily more than 2 GBs of RAM while converting.
@@ -103,16 +103,16 @@ Directory Structure
 +---installed-*                     - Created by installing the IFCOS project, specific for a certain compiler and target architecture
 \---win
 |   build-all.cmd                   - Runs all of the build scripts for IFCOS and it dependencies in a row without pauses
-|   build-deps.cmd                  - Fetches and builds all needed dependencies for IFCOS using Visual Studio
+|   build-deps.cmd                  - Fetches and builds all needed dependencies for IFCOS using MSVC
 |   build-deps.sh                   - Fetches and builds all needed dependencies for IFCOS using MSYS
 |   BuildDepsCache-<ARCH>.txt       - Cache file created by build-deps.cmd
-|   build-ifcopenshell.bat          - Builds IFCOS using Visual Studio
+|   build-ifcopenshell.bat          - Builds IFCOS using MSVC
 |   build-ifcopenshell.sh           - Builds IFCOS using MSYS
 |   build-type-cfg.cmd              - Utility file used by the build scripts
-|   install-ifcopenshell.bat        - Installs/deployes IFCOS using Visual Studio.
-|   install-ifcopenshell.sh         - Installs/deployes IFCOS using MSYS.
+|   install-ifcopenshell.bat        - Installs/deploys IFCOS using MSVC.
+|   install-ifcopenshell.sh         - Installs/deploys IFCOS using MSYS.
 |   readme.md                       - This file
-|   run-cmake.bat                   - Sets environment variables for the dependencies and runs CMake for IFCOS using Visual Studio
+|   run-cmake.bat                   - Sets environment variables for the dependencies and runs CMake for IFCOS using MSVC
 |   run-cmake.sh                    - Sets environment variables for the dependencies and runs CMake for IFCOS using MSYS
 |   set-python-to-path.bat          - Utility for setting PYTHONHOME (read from BuildDepsCache-<ARCH>.txt) to PATH
 |   vs-cfg.cmd                      - Utility file used by the build scripts


### PR DESCRIPTION
- possibility to --include and --exclude simultaneously: however, only single --include and --exclude supported for now
- "outsourced" filtering from IfcGeomIterator to any possible client code instead, default implementations for old and new filters provided
- filtering by Description and Tag
- `--<include|exclude> --<enties|layers|guids|names> <value1 value2 ...>` syntax changed to `--<include|exclude>=<entities|layers|arg> (<GlobalId|Name|Description|Tag>) <value1 value2 ...>`
- closes #20 
- there's some room for more cleanup and refactoring, will continue the work after the discussed (on IRC) merging of IfcBaseEntity and IfcLateboundEntity happens and after tackling #104 
