### PR TITLE
Limit retries for boolean op on OCCT 6.9 and higher

### DIFF
--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -2554,7 +2554,10 @@ bool IfcGeom::Kernel::boolean_operation(const TopoDS_Shape& a, const TopTools_Li
 	}
 	delete builder;
 	if (!success) {
-		return boolean_operation(a, b, op, result, fuzziness * 10.);
+        const double new_fuzziness = fuzziness * 10.;
+        if (new_fuzziness + 1e-15 <= getValue(GV_PRECISION) * 1000.) {
+            return boolean_operation(a, b, op, result, new_fuzziness);
+        }
 	}
 	return success;
 }


### PR DESCRIPTION
@Stinkfist0 can you have a look re your messages on IRC, seems like some oversight indeed that was not there for the OCCT < 6.9 specific code. Thanks.