### PR TITLE
Site local placement

### DIFF
--- a/src/ifcgeom/IfcGeom.h
+++ b/src/ifcgeom/IfcGeom.h
@@ -99,6 +99,10 @@ private:
 	std::map<int, SurfaceStyle> style_cache;
 
 	const SurfaceStyle* internalize_surface_style(const std::pair<IfcSchema::IfcSurfaceStyle*, IfcSchema::IfcSurfaceStyleShading*>& shading_style);
+
+	 // For stopping PlacementRelTo recursion in convert(const IfcSchema::IfcObjectPlacement* l, gp_Trsf& trsf)
+	IfcSchema::Type::Enum placement_rel_to;
+
 public:
 	Kernel()
 		: deflection_tolerance(0.001)
@@ -109,6 +113,7 @@ public:
 		, ifc_planeangle_unit(-1.0)
 		, modelling_precision(0.00001)
 		, dimensionality(1.)
+		, placement_rel_to(IfcSchema::Type::UNDEFINED)
 	{}
 
 	Kernel(const Kernel& other) {
@@ -312,6 +317,8 @@ public:
 		cache = Cache(); 
 #endif
 	}
+
+	void set_conversion_placement_rel_to(IfcSchema::Type::Enum type);
 
 #include "IfcRegisterGeomHeader.h"
 

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -755,6 +755,9 @@ namespace IfcGeom {
             kernel.setValue(IfcGeom::Kernel::GV_MAX_FACES_TO_SEW, settings.get(IteratorSettings::SEW_SHELLS) ? 1000 : -1);
             kernel.setValue(IfcGeom::Kernel::GV_DIMENSIONALITY, (settings.get(IteratorSettings::INCLUDE_CURVES)
                 ? (settings.get(IteratorSettings::EXCLUDE_SOLIDS_AND_SURFACES) ? -1. : 0.) : +1.));
+			if (settings.get(IteratorSettings::SITE_LOCAL_PLACEMENT)) {
+				kernel.set_conversion_placement_rel_to(IfcSchema::Type::IfcSite);
+			}
 		}
 
 		bool owns_ifc_file;

--- a/src/ifcgeom/IfcGeomIteratorSettings.h
+++ b/src/ifcgeom/IfcGeomIteratorSettings.h
@@ -80,8 +80,10 @@ namespace IfcGeom
             APPLY_LAYERSETS = 1 << 13,
 			/// Search for a parent of type IfcBuildingStorey for each representation
 			SEARCH_FLOOR = 1 << 14,
+			///
+			SITE_LOCAL_PLACEMENT = 1 << 15,
             /// Number of different setting flags.
-            NUM_SETTINGS = 14
+            NUM_SETTINGS = 15
         };
         /// Used to store logical OR combination of setting flags.
         typedef unsigned SettingField;


### PR DESCRIPTION
The problem:
```
Some IFC authoring tools may put the global origo at a large distance
away from the actual building geometry. Also, the global X- and Y-axes
may be at arbitrary angles with natural building axes. Using
--center-model or --model-offset may place the converted geometry closer
to origo, but will still use the global IFC definition of axis
directions. Also, in a scenario with multiple IFC files for one
construction site, using --center-model on each of them would not
generate consistent geometry across OBJ or DAE files.
```
See also discussion in issue #230 

This is an initial attempt at supporting site local placement in `IfcConvert`. It should be working now for OBJ conversion, but it's not completed and should not be merged as-is. Since I don't really know this codebase I need some feedback here. Questions:
- Does the generalization of `offset` -> `transform` in `SerializerSettings` make sense? It feels a bit hacky to first generate geometry in global coordinates, then partly reverse it by essentially applying `IfcSite.ObjectPlacement.inverse` to all geometry before writeout. But I tried doing it this way in order to keep the feature implemented mostly inside `src/ifconvert`.
- Is there a way to avoid exposing `IfcGeom::Iterator.kernel` through the public `getKernel` method? I.e. can we find the `ObjectPlacement` of `IfcSite` in a better way?
- Is `--site-local-placement` a good name for this? `--building-local-placement`? `--strip-site-coords`?
- I need some help on the DAE conversion. I'm not even compiling with COLLADA support currently and the last commit is very much work-in-progress. The unit conversion stuff included in `IfcGeom::Transformation` and `IfcGeom::Matrix` may complicate things, not sure.