### PR TITLE
DLL export fixes in IfcParse.h

### DIFF
--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -256,9 +256,9 @@ namespace IfcParse {
 		std::string toString(bool upper=false) const;
 	};
 	
-	IfcEntityInstanceData* read(unsigned int i, IfcFile* t, boost::optional<unsigned> offset = boost::none);
+	IFC_PARSE_API IfcEntityInstanceData* read(unsigned int i, IfcFile* t, boost::optional<unsigned> offset = boost::none);
 
-	IfcEntityList::ptr traverse(IfcUtil::IfcBaseClass* instance, int max_level = -1);
+	IFC_PARSE_API IfcEntityList::ptr traverse(IfcUtil::IfcBaseClass* instance, int max_level = -1);
 }
 
 IFC_PARSE_API std::ostream& operator<< (std::ostream& os, const IfcParse::IfcFile& f);


### PR DESCRIPTION
Fixes missing DLL exports in IfcParse.h in issue #252
https://github.com/IfcOpenShell/IfcOpenShell/issues/252