### PR TITLE
IfcConvert: Fix bug with --bounds for SVG

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -384,7 +384,8 @@ int main(int argc, char** argv)
     }
 #endif
 
-	int bounding_width = -1, bounding_height = -1;
+	boost::optional<double> bounding_width;
+	boost::optional<double> bounding_height;
 	if (vmap.count("bounds") == 1) {
 		int w, h;
 		if (sscanf(bounds.c_str(), "%ux%u", &w, &h) == 2 && w > 0 && h > 0) {
@@ -531,8 +532,8 @@ int main(int argc, char** argv)
 	} else if (output_extension == ".svg") {
 		settings.set(IfcGeom::IteratorSettings::DISABLE_TRIANGULATION, true);
 		serializer = new SvgSerializer(output_temp_filename, settings);
-		if (bounding_width && bounding_height) {
-            static_cast<SvgSerializer*>(serializer)->setBoundingRectangle(bounding_width, bounding_height);
+		if (bounding_width.is_initialized() && bounding_height.is_initialized()) {
+            static_cast<SvgSerializer*>(serializer)->setBoundingRectangle(bounding_width.get(), bounding_height.get());
 		}
 	} else {
         std::cerr << "[Error] Unknown output filename extension '" + output_extension + "'\n";


### PR DESCRIPTION
`if(bounding_width)` evaluates to true as long as `bounding_width` is
non-zero (including negative values). Since `bounding_width` and
`bounding_height` are default initialized to -1.0, we were erroneously
setting a bounding rectangle of (-1.0, -1.0) here. This means the SVG
output has been broken/malformed if we didn't specify --bounds.