### PR TITLE
geom/app.py: ConfigParser py2/py3 fix

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/app.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/app.py
@@ -51,7 +51,7 @@ class configuration(object):
             Cfg = ConfigParser.RawConfigParser
         except:
             import configparser
-            Cfg = configparser.ConfigParser(interpolation=None)
+            Cfg = lambda: configparser.ConfigParser(interpolation=None)
             
         conf_file = os.path.expanduser(os.path.join("~", ".ifcopenshell", "app", "snippets.conf"))
         if conf_file.startswith("~"):


### PR DESCRIPTION
When running the viewer app in python3, I got the following crash:
```
Traceback (most recent call last):
  File "geom_app.py", line 2, in <module>
    ifcopenshell.geom.app.application().start()
  File "/usr/lib/python3/dist-packages/ifcopenshell/geom/app.py", line 534, in __init__
    self.editor = code_edit(self.canvas, configuration().options('snippets'))
  File "/usr/lib/python3/dist-packages/ifcopenshell/geom/app.py", line 68, in __init__
    config = Cfg()
TypeError: 'ConfigParser' object is not callable
```

The branching for ConfigParser (for py2) and configparser (for py3)
should set the same type on Cfg. This fixes python3 on my box, haven't
tested for python2 though.