### PR TITLE
IfcConvert: Add --building-local-placement argument

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -298,6 +298,8 @@ int main(int argc, char** argv)
 		("site-local-placement",
 			"Place elements locally in the IfcSite coordinate system, instead of placing "
 			"them in the IFC global coords. Applicable for OBJ and DAE output.")
+		("building-local-placement",
+			"Similar to --site-local-placement, but placing elements in locally in the parent IfcBuilding coord system")
         ("precision", po::value<short>(&precision)->default_value(SerializerSettings::DEFAULT_PRECISION),
             "Sets the precision to be used to format floating-point values, 15 by default. "
             "Use a negative value to use the system's default precision (should be 6 typically). "
@@ -370,6 +372,7 @@ int main(int argc, char** argv)
     const bool center_model = vmap.count("center-model") != 0 ;
     const bool model_offset = vmap.count("model-offset") != 0 ;
 	const bool site_local_placement = vmap.count("site-local-placement") != 0 ;
+	const bool building_local_placement = vmap.count("building-local-placement") != 0 ;
     const bool generate_uvs = vmap.count("generate-uvs") != 0 ;
 
 #ifdef HAVE_ICU
@@ -504,6 +507,8 @@ int main(int argc, char** argv)
     settings.set(IfcGeom::IteratorSettings::GENERATE_UVS, generate_uvs);
 	settings.set(IfcGeom::IteratorSettings::SEARCH_FLOOR, use_element_hierarchy);
 	settings.set(IfcGeom::IteratorSettings::SITE_LOCAL_PLACEMENT, site_local_placement);
+	settings.set(IfcGeom::IteratorSettings::BUILDING_LOCAL_PLACEMENT, building_local_placement);
+
 
     settings.set(SerializerSettings::USE_ELEMENT_NAMES, use_element_names);
     settings.set(SerializerSettings::USE_ELEMENT_GUIDS, use_element_guids);
@@ -614,8 +619,8 @@ int main(int argc, char** argv)
     if (center_model || model_offset) {
         double* offset = serializer->settings().offset;
         if (center_model) {
-			if (site_local_placement) {
-				Logger::Error("Cannot use --center-model together with --site-local-placement");
+			if (site_local_placement || building_local_placement) {
+				Logger::Error("Cannot use --center-model together with --{site,building}-local-placement");
 				delete serializer;
 				return EXIT_FAILURE;
 			}

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -683,7 +683,12 @@ namespace IfcGeom {
             kernel.setValue(IfcGeom::Kernel::GV_MAX_FACES_TO_SEW, settings.get(IteratorSettings::SEW_SHELLS) ? 1000 : -1);
             kernel.setValue(IfcGeom::Kernel::GV_DIMENSIONALITY, (settings.get(IteratorSettings::INCLUDE_CURVES)
                 ? (settings.get(IteratorSettings::EXCLUDE_SOLIDS_AND_SURFACES) ? -1. : 0.) : +1.));
-			if (settings.get(IteratorSettings::SITE_LOCAL_PLACEMENT)) {
+			if (settings.get(IteratorSettings::BUILDING_LOCAL_PLACEMENT)) {
+				if (settings.get(IteratorSettings::SITE_LOCAL_PLACEMENT)) {
+					Logger::Message(Logger::LOG_WARNING, "building-local-placement takes precedence over site-local-placement");
+				}
+				kernel.set_conversion_placement_rel_to(IfcSchema::Type::IfcBuilding);
+			} else if (settings.get(IteratorSettings::SITE_LOCAL_PLACEMENT)) {
 				kernel.set_conversion_placement_rel_to(IfcSchema::Type::IfcSite);
 			}
 		}

--- a/src/ifcgeom/IfcGeomIteratorSettings.h
+++ b/src/ifcgeom/IfcGeomIteratorSettings.h
@@ -82,8 +82,10 @@ namespace IfcGeom
 			SEARCH_FLOOR = 1 << 14,
 			///
 			SITE_LOCAL_PLACEMENT = 1 << 15,
-            /// Number of different setting flags.
-            NUM_SETTINGS = 15
+			///
+			BUILDING_LOCAL_PLACEMENT = 1 << 16,
+			/// Number of different setting flags.
+			NUM_SETTINGS = 16
         };
         /// Used to store logical OR combination of setting flags.
         typedef unsigned SettingField;


### PR DESCRIPTION
Similar to --site-local-placement. Motivated by dealing with at least
two examples where IFC files for the same construction site have
inconsistent ObjectPlacement hierarchy:

- MEP models exported from MagiCAD for Revit:
   ObjectPlacement.PlacementRelTo of IfcBuilding is empty
- Regular construction models exported from Revit:
   ObjectPlacement.PlacementRelTo of IfcBuilding is pointing to
   IfcSite's placement

----

This feels a bit like a hack. If I had known about this mess before adding `--site-local-placement` #240 , maybe exposing a `--placement-rel-to IFC_TYPE` (e.g. `--placement-rel-to IfcSite`) would have been a better choice. 

But anyway this solved my immediate problem, I can now run
```
IfcConvert --building-local-placement
```

on a bunch of IFC files (originating from both MagiCAD and Revit exports) and get the OBJ files into common local coord system like I want.