### PR TITLE
Removed one last remaining BOPCol_ListOfShapes

### DIFF
--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -2437,7 +2437,7 @@ bool IfcGeom::Kernel::split_solid_by_shell(const TopoDS_Shape& input, const Topo
 	}
 	apply_tolerance(solid, getValue(GV_PRECISION));
 
-	BOPCol_ListOfShape shapes;
+	TopTools_ListOfShape shapes;
 	shapes.Append(input);
 	shapes.Append(solid);
 	BOPAlgo_PaveFiller filler(new NCollection_IncAllocator); // TODO: Does this need to be freed?

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -2437,7 +2437,11 @@ bool IfcGeom::Kernel::split_solid_by_shell(const TopoDS_Shape& input, const Topo
 	}
 	apply_tolerance(solid, getValue(GV_PRECISION));
 
+#if OCC_VERSION_HEX >= 0x70300
 	TopTools_ListOfShape shapes;
+#else
+	BOPCol_ListOfShape shapes;
+#endif
 	shapes.Append(input);
 	shapes.Append(solid);
 	BOPAlgo_PaveFiller filler(new NCollection_IncAllocator); // TODO: Does this need to be freed?


### PR DESCRIPTION
Replaced one last remaining BOPCol_ListOfShapes with TopTools_ListOfShapes (BOPCol_ListOfShapes is removed from OCC7.3)