### PR TITLE
IfcCharacterDecoder.cpp: Explicitly include unicode.h

### DIFF
--- a/src/ifcparse/IfcCharacterDecoder.cpp
+++ b/src/ifcparse/IfcCharacterDecoder.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
+#include <unicode/unistr.h>
 
 #include "../ifcparse/IfcCharacterDecoder.h"
 #include "../ifcparse/IfcException.h"


### PR DESCRIPTION
In order to build on Ubuntu 18.04, I had to do this change. This is pretty much issue #308, where this change is suggested in a comment. For my case here, adding `-DCMAKE_CXX_STANDARD=11` is not necessary as long as we use this change.

Using this Dockerfile I can now build with both ubuntu 16.04 and 18.04 as base image
```
FROM ubuntu:18.04
RUN apt-get update && apt-get install -y \
    apt-utils \
    supervisor \
    git \
    cmake \
    build-essential \
    locales \
    libboost-all-dev \
    wget \
    unzip \
    libicu-dev \
    swig \
    liboce-foundation-dev \
    liboce-modeling-dev \
    liboce-ocaf-dev \
    liboce-visualization-dev \
    liboce-ocaf-lite-dev \
    libpcre3-dev \
    libxml2-dev

RUN mkdir -p /deploy/libs && \
    cd /deploy/libs && \
    git clone https://github.com/andersgb/IfcOpenShell.git && \
    cd IfcOpenShell && \
    git checkout 193556966205 && \
    pwd && \
    cd cmake && \
    mkdir build && \
    cd build && \
    cmake -DCOLLADA_SUPPORT=False -DUSE_IFC4=False -DBUILD_IFCPYTHON=True -DUNICODE_SUPPORT=True -DOCC_LIBRARY_DIR=/usr/lib/x86_64-linux-gnu .. && \
    make -j2 && \
    make install
```

I have no idea whether this may break other systems though.