### PR TITLE
Use /permissive- introduced in VS 2017 to enforce standards-conformance.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -396,6 +396,10 @@ IF(MSVC)
 		# Disable overeager and false positives causing C4458 ("declaration of 'indentifier' hides class member"), at least for now.
 		ADD_DEFINITIONS(-wd4458)
 	ENDIF()
+    # Enforce standards-conformance on VS > 2015, older Boost versions fail to compile with this    
+    if (MSVC_VERSION GREATER 1900 AND (Boost_MAJOR_VERSION GREATER 1 OR Boost_MINOR_VERSION GREATER 66))
+        add_definitions(-permissive-)
+    endif()
 	# Link against the static VC runtime
     # TODO Make this configurable
 	FOREACH(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL


### PR DESCRIPTION
https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=vs-2017

Should alleviate the problem of breaking GCC/Clang builds occasionally.