### PR TITLE
Optimize/fix geometry filtering and reusability checks

### DIFF
--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -416,6 +416,18 @@ namespace IfcGeom {
 				if (!ifcproducts) {
 					ifcproducts = IfcSchema::IfcProduct::list::ptr(new IfcSchema::IfcProduct::list);
 					IfcSchema::IfcProduct::list::ptr unfiltered_products = kernel.products_represented_by(representation);
+                    // Filter the products based on the set of entities and/or names being included or excluded for processing.
+                    for (IfcSchema::IfcProduct::list::it jt = unfiltered_products->begin(); jt != unfiltered_products->end(); ++jt) {
+                        IfcSchema::IfcProduct* prod = *jt;
+                        if (boost::all(filters_, filter_match(prod))) {
+                            ifcproducts->push(prod);
+                        }
+                    }
+
+                    if (ifcproducts->size() == 0) {
+                        _nextShape();
+                        continue;
+                    }
 
 					geometry_reuse_ok_for_current_representation_ = reuse_ok_(unfiltered_products);
 
@@ -449,14 +461,6 @@ namespace IfcGeom {
 						_nextShape();
 						continue;
 					}
-
-                    // Filter the products based on the set of entities and/or names being included or excluded for processing.
-                    for (IfcSchema::IfcProduct::list::it jt = unfiltered_products->begin(); jt != unfiltered_products->end(); ++jt) {
-                        IfcSchema::IfcProduct* prod = *jt;
-                        if (boost::all(filters_, filter_match(prod))) {
-                            ifcproducts->push(prod);
-                        }
-                    }
 
 					ifcproduct_iterator = ifcproducts->begin();
 				}

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -405,18 +405,17 @@ namespace IfcGeom {
 			for (;;) {
 				IfcSchema::IfcRepresentation* representation;
 
-				// Have we reached the end of our list of representations?
 				if ( representation_iterator == representations->end() ) {
 					representations.reset();
-					return 0;
+					return 0; // reached the end of our list of representations
 				}
 				representation = *representation_iterator;
 
-				// Has the list of IfcProducts for this representation been initialized?
 				if (!ifcproducts) {
+					// Init. the list of filtered IfcProducts for this representation
 					ifcproducts = IfcSchema::IfcProduct::list::ptr(new IfcSchema::IfcProduct::list);
 					IfcSchema::IfcProduct::list::ptr unfiltered_products = kernel.products_represented_by(representation);
-                    // Filter the products based on the set of entities and/or names being included or excluded for processing.
+                    // Include only the desired products for processing.
                     for (IfcSchema::IfcProduct::list::it jt = unfiltered_products->begin(); jt != unfiltered_products->end(); ++jt) {
                         IfcSchema::IfcProduct* prod = *jt;
                         if (boost::all(filters_, filter_match(prod))) {
@@ -429,7 +428,7 @@ namespace IfcGeom {
                         continue;
                     }
 
-					geometry_reuse_ok_for_current_representation_ = reuse_ok_(unfiltered_products);
+                    geometry_reuse_ok_for_current_representation_ = reuse_ok_(ifcproducts);
 
 					IfcSchema::IfcRepresentationMap::list::ptr maps = representation->RepresentationMap();
 
@@ -447,13 +446,12 @@ namespace IfcGeom {
 						}
 					}
 
+					// Check if this represenation has (or will be) processed as part its mapped representation
 					bool representation_processed_as_mapped_item = false;
-
-					IfcSchema::IfcRepresentation* representation_mapped_to = kernel.representation_mapped_to(representation);
+                    IfcSchema::IfcRepresentation* representation_mapped_to = kernel.representation_mapped_to(representation);
 					if (representation_mapped_to) {
-						// Check if this representation has (or will be) processed as part its mapped representation
-						representation_processed_as_mapped_item = ok_mapped_representations->contains(representation_mapped_to) ||
-                                reuse_ok_(kernel.products_represented_by(representation_mapped_to));
+                        representation_processed_as_mapped_item = geometry_reuse_ok_for_current_representation_ ||
+                            ok_mapped_representations->contains(representation_mapped_to);
 					}
 
 					if (representation_processed_as_mapped_item) {


### PR DESCRIPTION
I'll try to provide exact test/profiling measurements later today, but some weeks ago we were working with a huge IFC file (1,1 GB file with 36.7 million STEP entities) and including only a subset (250 objects) for the conversion. With these fixes the conversion reduced approx. from 60 minutes to 6 minutes and the resulting DAE file size reduced from 935 MB to 48 MB.