### PR TITLE
Changing opencollada version to "v1.6.63"

### DIFF
--- a/nix/build-all.py
+++ b/nix/build-all.py
@@ -248,7 +248,8 @@ CMAKE_VERSION_2=CMAKE_VERSION[:CMAKE_VERSION.rindex('.')]
 OCE_LOCATION="https://github.com/tpaviot/oce/archive/OCE-%s.tar.gz" % (OCE_VERSION,)
 BOOST_LOCATION="http://downloads.sourceforge.net/project/boost/boost/%s/boost_%s.tar.bz2" % (BOOST_VERSION, BOOST_VERSION_UNDERSCORE)
 OPENCOLLADA_LOCATION="https://github.com/KhronosGroup/OpenCOLLADA.git"
-OPENCOLLADA_COMMIT="f99d59e73e565a41715eaebc00c7664e1ee5e628"
+#OPENCOLLADA_COMMIT="f99d59e73e565a41715eaebc00c7664e1ee5e628"
+OPENCOLLADA_COMMIT="v1.6.63"
 
 # Helper functions
 


### PR DESCRIPTION
Discussion:
https://github.com/IfcOpenShell/IfcOpenShell/issues/480

Summary:
"... Compiling OpenCOLLADA  fail on fedora 27... changing  opencollada version to "v1.6.63" (since some time now they do proper tagging over there, the commit we track now is from 19 Dec 2013, probably worth updating as newer compilers might rightfully complain)...

Probably best to rm -rf ... IfcOpenShell/build/Linux/x86_64/build/OpenCOLLADA before restarting."