### PR TITLE
Ifcfile entity look-up + Kernel::get_layers optimizations

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -116,6 +116,7 @@ bool rename_file(const std::string& old_filename, const std::string& new_filenam
 
 static std::stringstream log_stream;
 void write_log(bool);
+std::string format_duration(time_t start, time_t end);
 
 /// @todo make the filters non-global
 IfcGeom::entity_filter entity_filter; // Entity filter is used always by default.
@@ -473,11 +474,15 @@ int main(int argc, char** argv)
         int exit_code = EXIT_FAILURE;
         try {
             if (init_input_file(input_filename, ifc_file, no_progress || quiet, mmap)) {
+                time_t start, end;
+                time(&start);
                 XmlSerializer s(output_temp_filename);
                 s.setFile(&ifc_file);
                 Logger::Status("Writing XML output...");
                 s.finalize();
-                Logger::Status("Done!");
+                time(&end);
+                Logger::Status("Done! Conversion took " +  format_duration(start, end));
+
                 rename_file(output_temp_filename, output_filename);
                 exit_code = EXIT_SUCCESS;
             }
@@ -760,26 +765,31 @@ int main(int argc, char** argv)
 
 	time(&end);
 
-	if (!quiet) {
-		int seconds = (int)difftime(end, start);
-		std::stringstream msg;
-		int minutes = seconds / 60;
-		seconds = seconds % 60;
-		msg << "\nConversion took";
-		if (minutes > 0) {
-			msg << " " << minutes << " minute";
-			if (minutes > 1) {
-				msg << "s";
-			}
-		}
-		msg << " " << seconds << " second";
-		if (seconds > 1) {
-			msg << "s";
-		}
-		Logger::Status(msg.str());
-	}
+    if (!quiet) {
+        Logger::Status("\nConversion took " +  format_duration(start, end));
+    }
 
     return successful ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+std::string format_duration(time_t start, time_t end)
+{
+    int seconds = (int)difftime(end, start);
+    std::stringstream ss;
+    int minutes = seconds / 60;
+    seconds = seconds % 60;
+    if (minutes > 0) {
+        ss << minutes << " minute";
+        if (minutes == 0 || minutes > 1) {
+            ss << "s";
+        }
+        ss << " ";
+    }
+    ss << seconds << " second";
+    if (seconds == 0 || seconds > 1) {
+        ss << "s";
+    }
+    return ss.str();
 }
 
 void write_log(bool header) {
@@ -794,9 +804,12 @@ void write_log(bool header) {
 
 bool init_input_file(const std::string &filename, IfcParse::IfcFile &ifc_file, bool no_progress, bool mmap)
 {
+    time_t start, end;
+
     // Prevent IfcFile::Init() prints by setting output to null temporarily
     if (no_progress) { Logger::SetOutput(NULL, &log_stream); }
 
+    time(&start);
 #ifdef USE_MMAP
 	if (!ifc_file.Init(filename, mmap)) {
 #else
@@ -806,8 +819,10 @@ bool init_input_file(const std::string &filename, IfcParse::IfcFile &ifc_file, b
         Logger::Error("Unable to parse input file '" + filename + "'");
         return false;
     }
+    time(&end);
 
     if (no_progress) { Logger::SetOutput(&std::cout, &log_stream); }
+    else {  Logger::Status("Parsing input file took " + format_duration(start, end)); }
 
     return true;
 }

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -1752,20 +1752,6 @@ std::map<std::string, IfcSchema::IfcPresentationLayerAssignment*> IfcGeom::Kerne
                 layers[(*jt)->Name()] = *jt;
             }
         }
-
-        IfcRepresentationItem::list::ptr items = r->as<IfcRepresentationItem>();
-        for (IfcRepresentationItem::list::it it = items->begin(); it != items->end(); ++it) {
-            IfcPresentationLayerAssignment::list::ptr a = (*it)->
-                // LayerAssignments renamed from plural to singular, LayerAssignment, so work around that
-#ifdef USE_IFC4
-                LayerAssignment();
-#else
-                LayerAssignments();
-#endif
-            for (IfcPresentationLayerAssignment::list::it jt = a->begin(); jt != a->end(); ++jt) {
-                layers[(*jt)->Name()] = *jt;
-            }
-        }
     }
     return layers;
 }

--- a/src/ifcparse/IfcEntityList.h
+++ b/src/ifcparse/IfcEntityList.h
@@ -40,6 +40,7 @@ public:
 	it end();
 	IfcUtil::IfcBaseClass* operator[] (int i);
 	unsigned int size() const;
+    void reserve(unsigned capacity);
 	bool contains(IfcUtil::IfcBaseClass*) const;
 	template <class U>
 	typename U::list::ptr as() {

--- a/src/ifcparse/IfcFile.h
+++ b/src/ifcparse/IfcFile.h
@@ -146,6 +146,10 @@ public:
 	/// in the first function argument.
 	IfcEntityList::ptr traverse(IfcUtil::IfcBaseClass* instance, int max_level=-1);
 
+	/// Marks entity as modified so that potential cache for it is invalidated.
+	/// @todo Currently the whole cache is invalidated. Implement more fine-grained invalidation.
+	void mark_entity_as_modified(int id);
+
 #ifdef USE_MMAP
 	bool Init(const std::string& fn, bool mmap=false);
 #else

--- a/src/ifcparse/IfcFile.h
+++ b/src/ifcparse/IfcFile.h
@@ -39,6 +39,7 @@ public:
 	typedef boost::unordered_map<unsigned int, IfcUtil::IfcBaseClass*> entity_by_id_t;
 	typedef std::map<std::string, IfcSchema::IfcRoot*> entity_by_guid_t;
 	typedef std::map<unsigned int, std::vector<unsigned int> > entities_by_ref_t;
+	typedef std::map<unsigned int, IfcEntityList::ptr> ref_map_t;
 	typedef entity_by_id_t::const_iterator const_iterator;
 
 	class type_iterator : private entities_by_type_t::const_iterator {
@@ -75,6 +76,7 @@ private:
 	entities_by_type_t bytype;
 	entities_by_type_t bytype_excl;
 	entities_by_ref_t byref;
+	ref_map_t by_ref_cached_;
 	entity_by_guid_t byguid;
 	entity_entity_map_t entity_file_map;
 

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -1795,12 +1795,19 @@ IfcEntityList::ptr IfcFile::entitiesByReference(int t) {
 	entities_by_ref_t::const_iterator it = byref.find(t);
 	IfcEntityList::ptr ret;
 	if (it != byref.end()) {
-        ret.reset(new IfcEntityList);
-        ret->reserve((unsigned)it->second.size());
-		const std::vector<unsigned>& ids = it->second;
-		for (std::vector<unsigned>::const_iterator jt = ids.begin(); jt != ids.end(); ++jt) {
-			ret->push(entityById(*jt));
-		}
+        ref_map_t::const_iterator cached_it = by_ref_cached_.find(t);
+        if (cached_it != by_ref_cached_.end()) {
+            ret = cached_it->second;
+        }
+        else {
+            ret.reset(new IfcEntityList);
+            ret->reserve((unsigned)it->second.size());
+            const std::vector<unsigned>& ids = it->second;
+            for (std::vector<unsigned>::const_iterator jt = ids.begin(); jt != ids.end(); ++jt) {
+                ret->push(entityById(*jt));
+            }
+            by_ref_cached_[t] = ret;
+        }
 	}
 	return ret;
 }

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -1793,17 +1793,16 @@ IfcEntityList::ptr IfcFile::entitiesByType(const std::string& t) {
 
 IfcEntityList::ptr IfcFile::entitiesByReference(int t) {
 	entities_by_ref_t::const_iterator it = byref.find(t);
-	IfcEntityList::ptr return_value;
+	IfcEntityList::ptr ret;
 	if (it != byref.end()) {
+        ret.reset(new IfcEntityList);
+        ret->reserve((unsigned)it->second.size());
 		const std::vector<unsigned>& ids = it->second;
 		for (std::vector<unsigned>::const_iterator jt = ids.begin(); jt != ids.end(); ++jt) {
-			if (!return_value) {
-				return_value.reset(new IfcEntityList);
-			}
-			return_value->push(entityById(*jt));
+			ret->push(entityById(*jt));
 		}
 	}
-	return return_value;
+	return ret;
 }
 
 IfcUtil::IfcBaseClass* IfcFile::entityById(int id) {

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -1213,7 +1213,9 @@ void IfcEntityInstanceData::setArgument(unsigned int i, Argument* a, IfcUtil::Ar
 	if (this->file) {
 		register_inverse_visitor visitor(*this->file, *this);
 		apply_individual_instance_visitor(copy).apply(visitor);
-	}	
+
+		this->file->mark_entity_as_modified(id_);
+	}
 
 	if (i < attributes_.size()) {
 		attributes_[i] = copy;
@@ -1427,6 +1429,11 @@ IfcEntityList::ptr IfcParse::traverse(IfcUtil::IfcBaseClass* instance, int max_l
 /// @note: for backwards compatibility
 IfcEntityList::ptr IfcFile::traverse(IfcUtil::IfcBaseClass* instance, int max_level) {
 	return IfcParse::traverse(instance, max_level);
+}
+
+void IfcFile::mark_entity_as_modified(int /*id*/)
+{
+	by_ref_cached_.clear();
 }
 
 void IfcFile::addEntities(IfcEntityList::ptr es) {

--- a/src/ifcparse/IfcUtil.cpp
+++ b/src/ifcparse/IfcUtil.cpp
@@ -48,6 +48,7 @@ void IfcEntityList::push(const IfcEntityList::ptr& l) {
 	}
 }
 unsigned int IfcEntityList::size() const { return (unsigned int) ls.size(); }
+void IfcEntityList::reserve(unsigned capacity) { ls.reserve((size_t)capacity); }
 IfcEntityList::it IfcEntityList::begin() { return ls.begin(); }
 IfcEntityList::it IfcEntityList::end() { return ls.end(); }
 IfcUtil::IfcBaseClass* IfcEntityList::operator[] (int i) {


### PR DESCRIPTION
Recently we reran conversion for a file ("MEP File") that to our best of recollection was converted in somewhat orderly fashion a long time ago. This time, the XML conversion seemed to take forever, so I started to looking into the biggest time spenders in XML serialization code, which lead mostly to IfcFile::getInverse(). This lead me to optimize entity look-ups and to remove one particular slow part of layer retrieval code that doesn't seem to yield any results ever.

```
Timing includes only the conversion ("-layer code" == unnecessary(?) layer code removed, no other optimizations)
Conference center (http://openifcmodel.cs.auckland.ac.nz/_models/20160124OTC-Conference%20Center.ifc):
before:         1 m 15 s
-layer code:         8 s
after:               7 s

"Massive File" (1.1 GB)
before:         21 m 2 s
-layer code:    19 m 46 s
after:           6 m 58 s

"MEP File" (180 MB)
before:         did not finish (hours?)
-layer code:    14 m 58 s
after:           3 m 25 s
```