### PR TITLE
Check shell validity before passing it over to TOPODB::Shell()

### DIFF
--- a/src/ifcgeom/IfcGeom.h
+++ b/src/ifcgeom/IfcGeom.h
@@ -253,6 +253,8 @@ public:
 	bool wire_intersections(const TopoDS_Wire & wire, TopTools_ListOfShape & wires);
 	void select_largest(const TopTools_ListOfShape& shapes, TopoDS_Shape& largest);
 
+	bool is_valid_shell(const TopoDS_Shape &shape) const;
+
 	static double shape_volume(const TopoDS_Shape& s);
 	static double face_area(const TopoDS_Face& f);
 


### PR DESCRIPTION
A shell validity check that was found to be useful earlier this year.