### PR TITLE
Update documentation.py

### DIFF
--- a/src/ifcexpressparser/documentation.py
+++ b/src/ifcexpressparser/documentation.py
@@ -31,7 +31,7 @@ import re
 import os
 import csv
 
-from schema import OrderedCaseInsensitiveDict 
+from schema import OrderedCaseInsensitiveDict
 
 try: from html.entities import entitydefs
 except: from htmlentitydefs import entitydefs
@@ -47,7 +47,7 @@ regices = list(zip([re.compile(s,re.M) for s in [r'<[\w\n=" \-/\.;_\t:%#,\?\(\)]
 definition_files = ['DocEntity.csv', 'DocEnumeration.csv', 'DocDefined.csv', 'DocSelect.csv']
 definition_files = map(make_absolute, definition_files)
 for fn in definition_files:
-    with open(fn) as f:
+    with open(fn,'r', encoding='mac_roman', newline='') as f:
         for oid, name, desc in csv.reader(f, delimiter=';', quotechar='"'):
             name_to_oid[name] = oid
             oid_to_name[oid] = name


### PR DESCRIPTION
On macOS Mojave v10.14. Using python3.6 conda environment (named ifcbridge). 

Got this error:  

(ifcbridge) Sigves-MacBook-Pro:ifcexpressparser Sigve$ python bootstrap.py express.bnf > express_parser.py && python express_parser.py /Users/Sigve/Projects/bSN/ifcbridge-test/ifc4x2-draft/IFC4x2.exp
Traceback (most recent call last):
  File "express_parser.py", line 460, in <module>
    import header
  File "/Users/Sigve/Projects/bSN/ifcbridge-test/IfcOpenShell/src/ifcexpressparser/header.py", line 24, in <module>
    import documentation
  File "/Users/Sigve/Projects/bSN/ifcbridge-test/IfcOpenShell/src/ifcexpressparser/documentation.py", line 51, in <module>
    for oid, name, desc in csv.reader(f, delimiter=';', quotechar='"'):
  File "/Users/Sigve/anaconda/envs/ifcbridge/lib/python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 6602: invalid start byte

*** 
Found a solution through this: https://stackoverflow.com/questions/21504319/python-3-csv-file-giving-unicodedecodeerror-utf-8-codec-cant-decode-byte-err

Changed line 50 in documentation.py from: 

*    with open(fn) as f:

to

*    with open(fn,'r', encoding='mac_roman', newline='') as f:

It now generates these successfully: 

Ifc4x2-latebound.cpp		
Ifc4x2-latebound.h		
Ifc4x2.cpp			
Ifc4x2.h		
Ifc4x2enum.h

Haven't tested on other platforms, so don't know if it will work or break somehting for other platforms. Create a pull request.. 