### PR TITLE
Fix compilation using occt version < 7

### DIFF
--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -3701,8 +3701,12 @@ bool IfcGeom::Kernel::boolean_operation(const TopoDS_Shape& a, const TopTools_Li
 		}
 	} else {
 		std::stringstream str;
+#if OCC_VERSION_HEX >= 0x70000
 		builder->DumpErrors(str);
-		Logger::Notice(str.str());
+#else
+		str << "Error code :" << builder->ErrorStatus();
+#endif
+	Logger::Notice(str.str());
 	}
 	delete builder;
 	if (!success) {


### PR DESCRIPTION
The ```DumpErrors``` method is available only for occt versions >= 7