### PR TITLE
*nix script build-all.py improved: solves the Issues #637 (segmentation fault 11) for Mac OS X

### DIFF
--- a/nix/build-all.py
+++ b/nix/build-all.py
@@ -58,6 +58,11 @@ import time
 import tarfile
 import multiprocessing
 
+import platform
+import sysconfig
+from datetime import datetime
+
+
 PYTHON_MAJOR = sys.version_info[0]
 
 if PYTHON_MAJOR >= 3:
@@ -76,7 +81,8 @@ ch.setLevel(logging.INFO)
 logger.addHandler(ch)
 
 PROJECT_NAME="IfcOpenShell"
-PYTHON_VERSIONS=["2.7.16", "3.2.6", "3.3.6", "3.4.6", "3.5.3", "3.6.2", "3.7.3"]
+# PYTHON_VERSIONS=["2.7.16", "3.2.6", "3.3.6", "3.4.6", "3.5.3", "3.6.2", "3.7.3"]
+PYTHON_VERSIONS=["3.7.3"]
 JSON_VERSION="v3.6.1"
 OCE_VERSION="0.18"
 # OCCT_VERSION="7.1.0"
@@ -86,13 +92,13 @@ OCE_VERSION="0.18"
 OCCT_VERSION="7.3.0p3"
 BOOST_VERSION="1.59.0"
 #PCRE_VERSION="8.39"
-PCRE_VERSION="8.41"
+PCRE_VERSION="8.43"
 #LIBXML2_VERSION="2.9.3"
 LIBXML2_VERSION="2.9.9"
-CMAKE_VERSION="3.4.1"
-#CMAKE_VERSION="3.14.5"
+#CMAKE_VERSION="3.4.1"
+CMAKE_VERSION="3.14.5"
 SWIG_VERSION="3.0.12"
-#SWIG_VERSION="4.0.0"
+#SWIG_VERSION="4.0.0" # the version doesnt work with Mac OS X
 #OPENCOLLADA_VERSION="v1.6.63"
 OPENCOLLADA_VERSION="v1.6.68"
 
@@ -136,13 +142,14 @@ def which(cmd):
     return None
 
 def get_os():
-    ret_value = sp.check_output([uname, "-s"]).strip()
+    #    ret_value = to_pystring(sp.check_output([uname, "-s"]).strip())
+    ret_value = platform.system()
     return ret_value
 
 def to_pystring(x):
-    """ Python 2 & 3 compatibility function for strings handling 
-    (to solve TypeError "Can't mix strings and bytes in path components" for Python 3).
-    Reference https://github.com/hugsy/gef/issues/382 """
+    """ Python 2 & 3 compatibility function for strings handling
+        (to solve TypeError "Can't mix strings and bytes in path components" for Python 3).
+        Reference https://github.com/hugsy/gef/issues/382 """
     res = str(x, encoding="utf-8") if PYTHON_MAJOR == 3 else x
     substs = [("\n","\\n"), ("\r","\\r"), ("\t","\\t"), ("\v","\\v"), ("\b","\\b"), ]
     for x,y in substs: res = res.replace(x,y)
@@ -152,11 +159,11 @@ def to_pystring(x):
 
 USE_OCCT = os.environ.get("USE_OCCT", "true").lower() == "true"
 
-TOOLSET = None
+MIN_VERSION = None
 if get_os() == "Darwin":
     # C++11 features used in OCCT 7+ need a more recent stdlib
-    TOOLSET = "10.9" if USE_OCCT else "10.6"
-   
+    MIN_VERSION = "10.9" if USE_OCCT else "10.6"
+
 try:
     IFCOS_NUM_BUILD_PROCS = os.environ["IFCOS_NUM_BUILD_PROCS"]
 except KeyError:
@@ -165,18 +172,16 @@ except KeyError:
 try:
     TARGET_ARCH = os.environ["TARGET_ARCH"]
 except KeyError:
-    TARGET_ARCH = sp.check_output([uname, "-m"]).strip()
+    TARGET_ARCH = platform.uname()[4] #to_pystring(sp.check_output([uname, "-m"]).strip())
 
 CMAKE_DIR=os.path.realpath(os.path.join("..", "cmake"))
 
 try:
     DEPS_DIR = os.environ["DEPS_DIR"]
 except KeyError:
-    path = [b"..", b"build", sp.check_output(uname).strip(), TARGET_ARCH]
-    if TOOLSET:
-        path.append(TOOLSET)
-        
-    DEPS_DIR = to_pystring(os.path.realpath(os.path.join(*path)))
+    path = ['..', 'build', platform.system(), platform.release(), TARGET_ARCH]
+    #path.append(platform.release())
+    DEPS_DIR = os.path.realpath(os.path.join(*path))
 
 if not os.path.exists(DEPS_DIR):
     os.makedirs(DEPS_DIR)
@@ -190,10 +195,10 @@ except KeyError:
 # Print build configuration information
 
 cecho ("""This script fetches and builds %s and its dependencies
-""" % (PROJECT_NAME,), BLACK_ON_WHITE)
+    """ % (PROJECT_NAME,), BLACK_ON_WHITE)
 cecho("""Script configuration:
-
-""", GREEN)
+    
+    """, GREEN)
 cecho("""* Target Architecture    = %s""" % (TARGET_ARCH,), MAGENTA)
 cecho(" - Whether 32-bit (i686) or 64-bit (x86_64) will be built.")
 cecho("""* USE_OCCT               = %r""" % (USE_OCCT,), MAGENTA)
@@ -205,14 +210,14 @@ cecho("* Dependency Directory   = %s" % (DEPS_DIR,), MAGENTA)
 cecho(" - The directory where %s dependencies are installed." % (PROJECT_NAME,))
 cecho("* Build Config Type      = %s" % (BUILD_CFG,), MAGENTA)
 cecho(""" - The used build configuration type for the dependencies.
-   Defaults to RelWithDebInfo if not specified.""")
+    Defaults to RelWithDebInfo if not specified.""")
 
 if BUILD_CFG == "MinSizeRel":
     cecho("     WARNING: MinSizeRel build can suffer from a significant performance loss.", RED)
 
 cecho("* IFCOS_NUM_BUILD_PROCS  = %s" % (IFCOS_NUM_BUILD_PROCS,), MAGENTA)
 cecho(""" - How many compiler processes may be run in parallel.
-""")
+    """)
 
 dependency_tree = {
     'IfcParse': ('boost',  'libxml2'),
@@ -232,10 +237,10 @@ dependency_tree = {
 }
 
 def v(dep):
-   yield dep
-   for d in dependency_tree[dep]:
-     for x in v(d):
-       yield x
+    yield dep
+        for d in dependency_tree[dep]:
+            for x in v(d):
+                yield x
 
 tgts = [s for s in sys.argv[1:] if not s.startswith("-")]
 flags = set(s for s in sys.argv[1:] if s.startswith("-"))
@@ -262,27 +267,40 @@ for cmd in [git, bunzip2, tar, cc, cplusplus, autoconf, automake, yacc, make, "p
         raise ValueError("Required tool '%s' not installed or not added to PATH" % (cmd,))
 
 # identifiers for the download tool (could be less memory consuming as ints, but are more verbose as strings)
-download_tool_default = download_tool_py = "py"
+download_tool_curl="curl"
+download_tool_wget="wget"
 download_tool_git = "git"
+
+if which(wget) != None:
+    download_tool_default = download_tool_wget
+elif which(curl) != None:
+    download_tool_default = download_tool_curl
+else:
+    raise ValueError("No download application found, tried: curl, wget")
+
+CURL = ["curl", "-sL"]
+WGET= ["wget", "-q", "--no-check-certificate"]
 
 # Create log directory and file
 
 log_dir = os.path.join(DEPS_DIR, "logs")
 if not os.path.exists(log_dir):
     os.makedirs(log_dir)
-LOG_FILE="%s.log" % (os.path.join(log_dir, to_pystring(sp.check_output([date, "+%Y%m%d"]).strip())),)
+
+datetoday = datetime.now().strftime("%Y%m%d")
+LOG_FILE="%s.log" % (os.path.join(log_dir, datetoday),)
 if not os.path.exists(LOG_FILE):
     open(LOG_FILE, "w").close()
 logger.info("using command log file '%s'" % (LOG_FILE,))
 
 def run(cmds, cwd=None):
-
+    
     """
-    Wraps `subprocess.Popen.communicate()` and logs the command being executed,
-    sets up logging `stderr` to `LOG_FILE` (in append mode) and returns stdout
-    with leading and trailing whitespace removed.
-    """
-
+        Wraps `subprocess.Popen.communicate()` and logs the command being executed,
+        sets up logging `stderr` to `LOG_FILE` (in append mode) and returns stdout
+        with leading and trailing whitespace removed.
+        """
+    
     logger.debug("running command %r in directory %r" % (" ".join(cmds), cwd))
     log_file_handle = open(LOG_FILE, "ab")
     proc = sp.Popen(cmds, cwd=cwd, stdout=sp.PIPE, stderr=sp.PIPE)
@@ -291,13 +309,13 @@ def run(cmds, cwd=None):
     log_file_handle.write(stderr)
     log_file_handle.close()
     logger.debug("command returned %r" % proc.returncode)
-
+    
     if proc.returncode != 0:
         print("-" * 70)
         print(stderr)
         print("-" * 70)
         raise Exception("Command `%s` returned exit code %d" % (" ".join(cmds), proc.returncode))
-
+    
     return stdout.strip()
 
 BOOST_VERSION_UNDERSCORE=BOOST_VERSION.replace(".", "_")
@@ -312,7 +330,7 @@ def run_autoconf(arg1, configure_args, cwd):
     configure_path = os.path.realpath(os.path.join(cwd, "..", "configure"))
     if not os.path.exists(configure_path):
         run([bash, "./autogen.sh"], cwd=os.path.realpath(os.path.join(cwd, ".."))) # only run autogen.sh in the directory it is located and use cwd to achieve that in order to not mess up things
-    # Using `sh` over `bash` fixes issues with building swig 
+    # Using `sh` over `bash` fixes issues with building swig
     run(["/bin/sh", "../configure"]+configure_args+["--prefix=%s" % (os.path.realpath("%s/install/%s" % (DEPS_DIR, arg1)),)], cwd=cwd)
 
 def run_cmake(arg1, cmake_args, cmake_dir=None, cwd=None):
@@ -325,25 +343,25 @@ def run_cmake(arg1, cmake_args, cmake_dir=None, cwd=None):
 
 def git_clone_or_pull_repository(clone_url, target_dir, revision=None):
     """Lazily clones the `git` repository denoted by `clone_url` into
-    the `target_dir` or pulls latest changes if the `target_dir` exists (naively assumes
-    that a working clone exists there) and optionally checks out a revision
-    `revision` after cloning or in the existing clone if `revision` is not
-    `None`."""
+        the `target_dir` or pulls latest changes if the `target_dir` exists (naively assumes
+        that a working clone exists there) and optionally checks out a revision
+        `revision` after cloning or in the existing clone if `revision` is not
+        `None`."""
     if not os.path.exists(target_dir):
         logger.info("cloning '%s' into '%s'" % (clone_url, target_dir))
         run([git, "clone", clone_url, target_dir])
     else:
         logger.info("directory '%s' already cloned. Pulling latest changes." % (target_dir,))
-        run([git, "pull", clone_url], cwd=target_dir)       
-        
-    if revision != None:
-        run([git, "checkout", revision], cwd=target_dir)
+        run([git, "pull", clone_url], cwd=target_dir)
 
-def build_dependency(name, mode, build_tool_args, download_url, download_name, download_tool=download_tool_default, revision=None, patch=None, additional_files={}, no_append_name=False):
+if revision != None:
+    run([git, "checkout", revision], cwd=target_dir)
+
+def python_system_homedir(name, mode, build_tool_args, download_url, download_name, download_tool=download_tool_default, revision=None, patch=None, additional_files={}, no_append_name=False):
     """Handles building of dependencies with different tools (which are
-    distinguished with the `mode` argument. `build_tool_args` is expected to be
-    a list which is necessary in order to not mess up quoting of compiler and
-    linker flags."""
+        distinguished with the `mode` argument. `build_tool_args` is expected to be
+        a list which is necessary in order to not mess up quoting of compiler and
+        linker flags."""
     check_dir = os.path.join(DEPS_DIR, "install", name)
     if os.path.exists(check_dir):
         logger.info( "Found existing %s, skipping" % (name,))
@@ -351,18 +369,25 @@ def build_dependency(name, mode, build_tool_args, download_url, download_name, d
     build_dir = os.path.join(DEPS_DIR, "build")
     if not os.path.exists(build_dir):
         os.makedirs(build_dir)
-        
-    logger.info("\rFetching %s...   " % (name,))
     
-    if download_tool == download_tool_py:
+    if download_tool == download_tool_curl or download_tool == download_tool_wget:
         if no_append_name:
             url = download_url
         else:
             url = os.path.join(download_url, download_name)
-            
+    
+    if download_tool == download_tool_curl:
         download_path = os.path.join(build_dir, download_name)
         if not os.path.exists(download_path):
-            urlretrieve(url, os.path.join(build_dir, download_path))
+            logger.info("\rDownloading %s...   " % (name,))
+            run(CURL + ["-o", download_name, url], cwd=build_dir)
+        else:
+            logger.info("Download '%s' already exists, assuming it's an undamaged download and that it has been extracted if possible, skipping" % (download_path,))
+    elif download_tool == download_tool_wget:
+        download_path = os.path.join(build_dir, download_name)
+        if not os.path.exists(download_path):
+            logger.info("\rDownloading %s...   " % (name,))
+            run(WGET + ["-O", download_name, url], cwd=build_dir)
         else:
             logger.info("Download '%s' already exists, assuming it's an undamaged download and that it has been extracted if possible, skipping" % (download_path,))
     elif download_tool == download_tool_git:
@@ -395,41 +420,41 @@ def build_dependency(name, mode, build_tool_args, download_url, download_name, d
     for path, url in additional_files.items():
         if not os.path.exists(path):
             urlretrieve(url, os.path.join(extract_dir, path))
-            
-    if patch is not None:
-        patch_abs = os.path.abspath(os.path.join(os.path.dirname(__file__), patch))
-        if os.path.exists(patch_abs):
-            try: run(["patch", "-p1", "--batch", "--forward", "-i", patch_abs], cwd=extract_dir)
-            except Exception as e:
-                # Assert that the patch has already been applied
-                run(["patch", "-p1", "--batch", "--reverse", "--dry-run", "-i", patch_abs], cwd=extract_dir)
-            
-    if mode != "bjam":
-        extract_build_dir = os.path.join(extract_dir, "build")
-        if os.path.exists(extract_build_dir):
-            shutil.rmtree(extract_build_dir)
-        os.makedirs(extract_build_dir)
 
+if patch is not None:
+    patch_abs = os.path.abspath(os.path.join(os.path.dirname(__file__), patch))
+    if os.path.exists(patch_abs):
+        try: run(["patch", "-p1", "--batch", "--forward", "-i", patch_abs], cwd=extract_dir)
+        except Exception as e:
+            # Assert that the patch has already been applied
+            run(["patch", "-p1", "--batch", "--reverse", "--dry-run", "-i", patch_abs], cwd=extract_dir)
+
+if mode != "bjam":
+    extract_build_dir = os.path.join(extract_dir, "build")
+    if os.path.exists(extract_build_dir):
+        shutil.rmtree(extract_build_dir)
+        os.makedirs(extract_build_dir)
+        
         logger.info("\rConfiguring %s..." % (name,))
         if mode == "autoconf":
             run_autoconf(name, build_tool_args, cwd=extract_build_dir)
         elif mode == "cmake":
             run_cmake(name, build_tool_args, cwd=extract_build_dir)
-        else:
-            raise ValueError()
+    else:
+        raise ValueError()
         logger.info("\rBuilding %s...   " % (name,))
         run([make, "-j%s" % (IFCOS_NUM_BUILD_PROCS,)], cwd=extract_build_dir)
         logger.info( "\rInstalling %s... " % (name,))
         run([make, "install"], cwd=extract_build_dir)
         logger.info( "\rInstalled %s     \n" % (name,))
-    else:
-        logger.info( "\rConfiguring %s..." % (name,))
-        run([bash, "./bootstrap.sh"], cwd=extract_dir)
-        logger.info("\rBuilding %s...   " % (name,))
-        run(["./b2", "-j%s" % (IFCOS_NUM_BUILD_PROCS,)]+build_tool_args, cwd=extract_dir)
-        logger.info("\rInstalling %s... " % (name,))
-        shutil.copytree(os.path.join(extract_dir, "boost"), os.path.join(DEPS_DIR, "install", "boost-%s" % BOOST_VERSION, "boost"))
-        logger.info("\rInstalled %s     \n" % (name,))
+else:
+    logger.info( "\rConfiguring %s..." % (name,))
+    run([bash, "./bootstrap.sh"], cwd=extract_dir)
+    logger.info("\rBuilding %s...   " % (name,))
+    run(["./b2", "-j%s" % (IFCOS_NUM_BUILD_PROCS,)]+build_tool_args, cwd=extract_dir)
+    logger.info("\rInstalling %s... " % (name,))
+    shutil.copytree(os.path.join(extract_dir, "boost"), os.path.join(DEPS_DIR, "install", "boost-%s" % BOOST_VERSION, "boost"))
+    logger.info("\rInstalled %s     \n" % (name,))
 
 cecho("Collecting dependencies:", GREEN)
 
@@ -443,7 +468,7 @@ if TARGET_ARCH == "i686" and run([uname, "-m"]).strip() == "x86_64":
     BOOST_ADDRESS_MODEL=["architecture=x86", "address-model=32"]
 
 if get_os() == "Darwin":
-    ADDITIONAL_ARGS=["-mmacosx-version-min=%s" % TOOLSET]+ADDITIONAL_ARGS
+    ADDITIONAL_ARGS=["-mmacosx-version-min=%s" % MIN_VERSION]+ADDITIONAL_ARGS
 
 # If the linker supports GC sections, set it up to reduce binary file size
 # -fPIC is required for the shared libraries to work
@@ -461,7 +486,7 @@ if sp.call([bash, "-c", "ld --gc-sections 2>&1 | grep -- --gc-sections &> /dev/n
     else:
         CXXFLAGS=CXXFLAGS_MINIMAL
         CFLAGS=CFLAGS_MINIMAL
-    LDFLAGS="%s  -Wl,--gc-sections %s" % (LDFLAGS, str.join(" ", ADDITIONAL_ARGS))
+    LDFLAGS="%s -Wl,--gc-sections %s" % (LDFLAGS, str.join(" ", ADDITIONAL_ARGS))
 else:
     CXXFLAGS_MINIMAL="%s %s %s" % (CXXFLAGS, PIC, str.join(" ", ADDITIONAL_ARGS))
     CFLAGS_MINIMAL="%s   %s %s" % (CFLAGS, PIC, str.join(" ", ADDITIONAL_ARGS))
@@ -472,13 +497,13 @@ else:
         CXXFLAGS=CXXFLAGS_MINIMAL
         CFLAGS=CFLAGS_MINIMAL
     LDFLAGS="%s %s" % (LDFLAGS, str.join(" ", ADDITIONAL_ARGS))
-    
+
 os.environ["CXXFLAGS"] = CXXFLAGS
 os.environ["CFLAGS"] = CFLAGS
 os.environ["LDFLAGS"] = LDFLAGS
 
 # Some dependencies need a more recent CMake version than most distros provide
-build_dependency(name="cmake-%s" % (CMAKE_VERSION,), mode="autoconf", build_tool_args=[], download_url="https://cmake.org/files/v%s" % (CMAKE_VERSION_2,), download_name="cmake-%s.tar.gz" % (CMAKE_VERSION,))
+python_system_homedir(name="cmake-%s" % (CMAKE_VERSION,), mode="autoconf", build_tool_args=[], download_url="https://cmake.org/files/v%s" % (CMAKE_VERSION_2,), download_name="cmake-%s.tar.gz" % (CMAKE_VERSION,))
 
 # Extract compiler flags from CMake to harmonize settings with other autoconf dependencies
 CMAKE_FLAG_EXTRACT_DIR="ifcopenshell_cmake_test_%s" % (time.time(),)
@@ -489,8 +514,8 @@ os.makedirs(CMAKE_FLAG_EXTRACT_DIR)
 BUILD_CFG_UPPER=BUILD_CFG.upper()
 for FL in ["C", "CXX"]:
     run([bash, "-c", """echo "
-    message(\"\${CMAKE_%s_FLAGS_%s}\")
-    " > CMakeLists.txt""" % (FL, BUILD_CFG_UPPER)], cwd=CMAKE_FLAG_EXTRACT_DIR)
+        message(\"\${CMAKE_%s_FLAGS_%s}\")
+        " > CMakeLists.txt""" % (FL, BUILD_CFG_UPPER)], cwd=CMAKE_FLAG_EXTRACT_DIR)
     FL="%sFLAGS" % (FL,)
     FLM="%sFLAGS_MINIMAL" % (FL,)
 # @TODO: bash code unclear
@@ -501,98 +526,97 @@ shutil.rmtree(CMAKE_FLAG_EXTRACT_DIR)
 if "json" in targets:
     json_url = "https://github.com/nlohmann/json/releases/download/{JSON_VERSION}/json.hpp".format(**locals())
     json_install_path = "{DEPS_DIR}/install/json/nlohmann/json.hpp".format(**locals())
-    if not os.path.exists(os.path.dirname(json_install_path)):
-        os.makedirs(os.path.dirname(json_install_path))
     if not os.path.exists(json_install_path):
+        os.makedirs(os.path.dirname(json_install_path))
         urlretrieve(json_url, json_install_path)
 
 if "pcre" in targets:
-    build_dependency(
-        name="pcre-{PCRE_VERSION}".format(**locals()),
-        mode="autoconf",
-        build_tool_args=[DISABLE_FLAG],
-        download_url="https://downloads.sourceforge.net/project/pcre/pcre/{PCRE_VERSION}/".format(**locals()),
-        download_name="pcre-{PCRE_VERSION}.tar.bz2".format(**locals())
-    )
+    python_system_homedir(
+                          name="pcre-{PCRE_VERSION}".format(**locals()),
+                          mode="autoconf",
+                          build_tool_args=[DISABLE_FLAG],
+                          download_url="https://downloads.sourceforge.net/project/pcre/pcre/{PCRE_VERSION}/".format(**locals()),
+                          download_name="pcre-{PCRE_VERSION}.tar.bz2".format(**locals())
+                          )
 
 # An issue exists with swig-1.3 and python >= 3.2
 # Therefore, build a recent copy from source
 if "swig" in targets:
-    build_dependency(
-        name="swig",
-        mode="autoconf",
-        build_tool_args=["--with-pcre-prefix={DEPS_DIR}/install/pcre-{PCRE_VERSION}".format(**locals())],
-        download_url="https://github.com/swig/swig.git",
-        download_name="swig",
-        download_tool=download_tool_git,
-        revision="rel-{SWIG_VERSION}".format(**locals())
-    )
+    python_system_homedir(
+                          name="swig",
+                          mode="autoconf",
+                          build_tool_args=["--with-pcre-prefix={DEPS_DIR}/install/pcre-{PCRE_VERSION}".format(**locals())],
+                          download_url="https://github.com/swig/swig.git",
+                          download_name="swig",
+                          download_tool=download_tool_git,
+                          revision="rel-{SWIG_VERSION}".format(**locals())
+                          )
 
 if USE_OCCT and "occ" in targets:
-    build_dependency(
-        name="occt-{OCCT_VERSION}".format(**locals()),
-        mode="cmake",
-        build_tool_args=[
-            "-DINSTALL_DIR={DEPS_DIR}/install/occt-{OCCT_VERSION}".format(**locals()),
-            "-DBUILD_LIBRARY_TYPE={LINK_TYPE_UCFIRST}".format(**locals()),
-            "-DBUILD_MODULE_Draw=0",
-        ],
-        download_url = "https://git.dev.opencascade.org/repos/occt.git",
-        download_name = "occt",
-        download_tool=download_tool_git,
-        patch="./patches/occt/enable-exception-handling.patch",
-        revision="V" + OCCT_VERSION.replace('.', '_')
-    )
+    python_system_homedir(
+                          name="occt-{OCCT_VERSION}".format(**locals()),
+                          mode="cmake",
+                          build_tool_args=[
+                                           "-DINSTALL_DIR={DEPS_DIR}/install/occt-{OCCT_VERSION}".format(**locals()),
+                                           "-DBUILD_LIBRARY_TYPE={LINK_TYPE_UCFIRST}".format(**locals()),
+                                           "-DBUILD_MODULE_Draw=0",
+                                           ],
+                          download_url = "https://git.dev.opencascade.org/repos/occt.git",
+                          download_name = "occt",
+                          download_tool=download_tool_git,
+                          patch="./patches/occt/enable-exception-handling.patch",
+                          revision="V" + OCCT_VERSION.replace('.', '_')
+                          )
 elif "occ" in targets:
-    build_dependency(
-        name="oce-{OCE_VERSION}".format(**locals()),
-        mode="cmake",
-        build_tool_args=[
-            "-DOCE_DISABLE_TKSERVICE_FONT=ON",
-            "-DOCE_TESTING=OFF",
-            "-DOCE_BUILD_SHARED_LIB=OFF",
-            "-DOCE_DISABLE_X11=ON",
-            "-DOCE_VISUALISATION=OFF",
-            "-DOCE_OCAF=OFF",
-            "-DOCE_INSTALL_PREFIX={DEPS_DIR}/install/oce-{OCE_VERSION}".format(**locals())
-        ],
-        download_url="https://github.com/tpaviot/oce/archive/",
-        download_name="OCE-{OCE_VERSION}.tar.gz".format(**locals())
-    )
-        
+    python_system_homedir(
+                          name="oce-{OCE_VERSION}".format(**locals()),
+                          mode="cmake",
+                          build_tool_args=[
+                                           "-DOCE_DISABLE_TKSERVICE_FONT=ON",
+                                           "-DOCE_TESTING=OFF",
+                                           "-DOCE_BUILD_SHARED_LIB=OFF",
+                                           "-DOCE_DISABLE_X11=ON",
+                                           "-DOCE_VISUALISATION=OFF",
+                                           "-DOCE_OCAF=OFF",
+                                           "-DOCE_INSTALL_PREFIX={DEPS_DIR}/install/oce-{OCE_VERSION}".format(**locals())
+                                           ],
+                          download_url="https://github.com/tpaviot/oce/archive/",
+                          download_name="OCE-{OCE_VERSION}.tar.gz".format(**locals())
+                          )
+
 if "libxml2" in targets:
-    build_dependency(
-        "libxml2-{LIBXML2_VERSION}".format(**locals()),
-        "autoconf",
-        build_tool_args=[
-            "--without-python",
-            ENABLE_FLAG,
-            DISABLE_FLAG,
-            "--without-zlib",
-            "--without-iconv",
-            "--without-lzma"
-        ],
-        download_url="ftp://xmlsoft.org/libxml2/",
-        download_name="libxml2-{LIBXML2_VERSION}.tar.gz".format(**locals())
-    )
-    
+    python_system_homedir(
+                          "libxml2-{LIBXML2_VERSION}".format(**locals()),
+                          "autoconf",
+                          build_tool_args=[
+                                           "--without-python",
+                                           ENABLE_FLAG,
+                                           DISABLE_FLAG,
+                                           "--without-zlib",
+                                           "--without-iconv",
+                                           "--without-lzma"
+                                           ],
+                          download_url="ftp://xmlsoft.org/libxml2/",
+                          download_name="libxml2-{LIBXML2_VERSION}.tar.gz".format(**locals())
+                          )
+
 if "OpenCOLLADA" in targets:
-    build_dependency(
-        "OpenCOLLADA",
-        "cmake",
-        build_tool_args=[
-            "-DLIBXML2_INCLUDE_DIR={DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/include/libxml2".format(**locals()),
-            "-DLIBXML2_LIBRARIES={DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/lib/libxml2.{LIBRARY_EXT}".format(**locals()),
-            "-DPCRE_INCLUDE_DIR={DEPS_DIR}/install/pcre-{PCRE_VERSION}/include".format(**locals()),
-            "-DPCRE_PCREPOSIX_LIBRARY={DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib/libpcreposix.{LIBRARY_EXT}".format(**locals()),
-            "-DPCRE_PCRE_LIBRARY={DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib/libpcre.{LIBRARY_EXT}".format(**locals()),
-            "-DCMAKE_INSTALL_PREFIX={DEPS_DIR}/install/OpenCOLLADA/".format(**locals())
-        ],
-        download_url="https://github.com/KhronosGroup/OpenCOLLADA.git",
-        download_name="OpenCOLLADA",
-        download_tool=download_tool_git,
-        revision=OPENCOLLADA_VERSION
-    )
+    python_system_homedir(
+                          "OpenCOLLADA",
+                          "cmake",
+                          build_tool_args=[
+                                           "-DLIBXML2_INCLUDE_DIR={DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/include/libxml2".format(**locals()),
+                                           "-DLIBXML2_LIBRARIES={DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/lib/libxml2.{LIBRARY_EXT}".format(**locals()),
+                                           "-DPCRE_INCLUDE_DIR={DEPS_DIR}/install/pcre-{PCRE_VERSION}/include".format(**locals()),
+                                           "-DPCRE_PCREPOSIX_LIBRARY={DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib/libpcreposix.{LIBRARY_EXT}".format(**locals()),
+                                           "-DPCRE_PCRE_LIBRARY={DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib/libpcre.{LIBRARY_EXT}".format(**locals()),
+                                           "-DCMAKE_INSTALL_PREFIX={DEPS_DIR}/install/OpenCOLLADA/".format(**locals())
+                                           ],
+                          download_url="https://github.com/KhronosGroup/OpenCOLLADA.git",
+                          download_name="OpenCOLLADA",
+                          download_tool=download_tool_git,
+                          revision=OPENCOLLADA_VERSION
+                          )
 
 if "python" in targets:
     # Python should not be built with -fvisibility=hidden, from experience that introduces segfaults
@@ -600,7 +624,7 @@ if "python" in targets:
     OLD_C_FLAGS=os.environ["CFLAGS"]
     os.environ["CXXFLAGS"]=CXXFLAGS_MINIMAL
     os.environ["CFLAGS"]=CFLAGS_MINIMAL
-
+    
     # On OSX a dynamic python library is built or it would not be compatible
     # with the system python because of some threading initialization
     PYTHON_CONFIGURE_ARGS=[]
@@ -612,46 +636,46 @@ if "python" in targets:
             return [("--enable-unicode=ucs2",""), ("--enable-unicode=ucs4","u")]
         else: return [("","")]
 
-    def PYTHON_VERSION_CONFS():
-        for v in PYTHON_VERSIONS:
-            for unicode_conf, abi_tag in get_python_unicode_confs(v):
-                yield v, unicode_conf, abi_tag
+def PYTHON_VERSION_CONFS():
+    for v in PYTHON_VERSIONS:
+        for unicode_conf, abi_tag in get_python_unicode_confs(v):
+            yield v, unicode_conf, abi_tag
 
-    for PYTHON_VERSION, unicode_conf, abi_tag in PYTHON_VERSION_CONFS():
-        build_dependency(
-            "python-{PYTHON_VERSION}{abi_tag}".format(**locals()),
-            "autoconf",
-            PYTHON_CONFIGURE_ARGS + [unicode_conf],
-            "http://www.python.org/ftp/python/{PYTHON_VERSION}/".format(**locals()),
-            "Python-{PYTHON_VERSION}.tgz".format(**locals())
-        )
-
-    os.environ["CXXFLAGS"]=OLD_CXX_FLAGS
-    os.environ["CFLAGS"]=OLD_C_FLAGS
+for PYTHON_VERSION, unicode_conf, abi_tag in PYTHON_VERSION_CONFS():
+    python_system_homedir(
+                          "python-{PYTHON_VERSION}{abi_tag}".format(**locals()),
+                          "autoconf",
+                          PYTHON_CONFIGURE_ARGS + [unicode_conf],
+                          "http://www.python.org/ftp/python/{PYTHON_VERSION}/".format(**locals()),
+                          "Python-{PYTHON_VERSION}.tgz".format(**locals())
+                          )
+        
+                          os.environ["CXXFLAGS"]=OLD_CXX_FLAGS
+                          os.environ["CFLAGS"]=OLD_C_FLAGS
 
 if "boost" in targets:
     str_concat = lambda prefix: lambda postfix: "" if postfix.strip() == "" else "=".join((prefix, postfix.strip()))
-    build_dependency(
-        "boost-{BOOST_VERSION}".format(**locals()),
-        mode="bjam",
-        build_tool_args=[
-            "--stagedir={DEPS_DIR}/install/boost-{BOOST_VERSION}".format(**locals()),
-            "--with-system",
-            "--with-program_options",
-            "--with-regex",
-            "--with-thread",
-            "--with-date_time",
-            "--with-iostreams",
-            "link={LINK_TYPE}".format(**locals())
-                                                                         ] + \
-            BOOST_ADDRESS_MODEL                                            + \
-            list(map(str_concat("cxxflags"), CXXFLAGS.strip().split(' '))) + \
-            list(map(str_concat("linkflags"), LDFLAGS.strip().split(' '))) + \
-            ["stage", "-s", "NO_BZIP2=1"],
-        download_url="http://downloads.sourceforge.net/project/boost/boost/{BOOST_VERSION}/".format(**locals()),
-        download_name="boost_{BOOST_VERSION_UNDERSCORE}.tar.bz2".format(**locals())
-    )
-    
+    python_system_homedir(
+                          "boost-{BOOST_VERSION}".format(**locals()),
+                          mode="bjam",
+                          build_tool_args=[
+                                           "--stagedir={DEPS_DIR}/install/boost-{BOOST_VERSION}".format(**locals()),
+                                           "--with-system",
+                                           "--with-program_options",
+                                           "--with-regex",
+                                           "--with-thread",
+                                           "--with-date_time",
+                                           "--with-iostreams",
+                                           "link={LINK_TYPE}".format(**locals())
+                                           ] + \
+                          BOOST_ADDRESS_MODEL                                            + \
+                          list(map(str_concat("cxxflags"), CXXFLAGS.strip().split(' '))) + \
+                          list(map(str_concat("linkflags"), LDFLAGS.strip().split(' '))) + \
+                          ["stage", "-s", "NO_BZIP2=1"],
+                          download_url="http://downloads.sourceforge.net/project/boost/boost/{BOOST_VERSION}/".format(**locals()),
+                          download_name="boost_{BOOST_VERSION_UNDERSCORE}.tar.bz2".format(**locals())
+                          )
+
 cecho("Building IfcOpenShell:", GREEN)
 
 IFCOS_DIR=os.path.join(DEPS_DIR, "build", "ifcopenshell")
@@ -668,108 +692,130 @@ logger.info("\rConfiguring executables...")
 OFF_ON = ["OFF", "ON"]
 
 cmake_args=[
-    "-DUSE_MMAP="                      "OFF",
-    "-DBUILD_EXAMPLES="                "OFF",
-    "-DBUILD_IFCPYTHON="               "OFF",
-    "-DBUILD_SHARED_LIBS="            +OFF_ON[not BUILD_STATIC],
-    "-DBUILD_IFCGEOM="                +OFF_ON["IfcGeom" in targets],
-    "-DBUILD_GEOMSERVER="             +OFF_ON["IfcGeomServer" in targets],
-    "-DBUILD_CONVERT="                +OFF_ON["IfcConvert" in targets],
-    "-DCMAKE_INSTALL_PREFIX="          "{DEPS_DIR}/install/ifcopenshell".format(**locals()),
-    "-DBOOST_ROOT="                    "{DEPS_DIR}/install/boost-{BOOST_VERSION}".format(**locals()),
-    "-DGLTF_SUPPORT="                  "ON",
-    "-DJSON_INCLUDE_DIR="              "{DEPS_DIR}/install/json".format(**locals())
-]
+            "-DUSE_MMAP="                      "OFF",
+            "-DBUILD_EXAMPLES="                "OFF",
+            "-DBUILD_IFCPYTHON="               "OFF",
+            "-DBUILD_SHARED_LIBS="            +OFF_ON[not BUILD_STATIC],
+            "-DBUILD_IFCGEOM="                +OFF_ON["IfcGeom" in targets],
+            "-DBUILD_GEOMSERVER="             +OFF_ON["IfcGeomServer" in targets],
+            "-DBUILD_CONVERT="                +OFF_ON["IfcConvert" in targets],
+            "-DCMAKE_INSTALL_PREFIX="          "{DEPS_DIR}/install/ifcopenshell".format(**locals()),
+            "-DBOOST_ROOT="                    "{DEPS_DIR}/install/boost-{BOOST_VERSION}".format(**locals()),
+            "-DGLTF_SUPPORT="                  "ON",
+            "-DJSON_INCLUDE_DIR="              "{DEPS_DIR}/install/json".format(**locals())
+            ]
 
 if "occ" in targets and USE_OCCT:
     occ_include_dir =                  "{DEPS_DIR}/install/occt-{OCCT_VERSION}/include/opencascade".format(**locals())
     occ_library_dir =                  "{DEPS_DIR}/install/occt-{OCCT_VERSION}/lib".format(**locals())
     cmake_args.extend([
-        "-DOCC_INCLUDE_DIR="           +occ_include_dir,
-        "-DOCC_LIBRARY_DIR="           +occ_library_dir
-    ])
+                       "-DOCC_INCLUDE_DIR="           +occ_include_dir,
+                       "-DOCC_LIBRARY_DIR="           +occ_library_dir
+                       ])
 elif "occ" in targets:
     occ_include_dir =                  "{DEPS_DIR}/install/oce-{OCE_VERSION}/include/oce".format(**locals())
     occ_library_dir =                  "{DEPS_DIR}/install/oce-{OCE_VERSION}/lib"
     cmake_args.extend([
-        "-DOCC_INCLUDE_DIR="           +occ_include_dir,
-        "-DOCC_LIBRARY_DIR="           +occ_library_dir
-    ])
+                       "-DOCC_INCLUDE_DIR="           +occ_include_dir,
+                       "-DOCC_LIBRARY_DIR="           +occ_library_dir
+                       ])
 
 if "OpenCOLLADA" in targets:
     cmake_args.extend([
-        "-DOPENCOLLADA_INCLUDE_DIR="   "{DEPS_DIR}/install/OpenCOLLADA/include/opencollada".format(**locals()),
-        "-DOPENCOLLADA_LIBRARY_DIR="   "{DEPS_DIR}/install/OpenCOLLADA/lib/opencollada".format(**locals())
-    ])
+                       "-DOPENCOLLADA_INCLUDE_DIR="   "{DEPS_DIR}/install/OpenCOLLADA/include/opencollada".format(**locals()),
+                       "-DOPENCOLLADA_LIBRARY_DIR="   "{DEPS_DIR}/install/OpenCOLLADA/lib/opencollada".format(**locals())
+                       ])
 
 if "pcre" in targets:
     cmake_args.append(
-        "-DPCRE_LIBRARY_DIR="          "{DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib".format(**locals())
-    )
+                      "-DPCRE_LIBRARY_DIR="          "{DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib".format(**locals())
+                      )
 
 if "libxml2" in targets:
     cmake_args.extend([
-        "-DLIBXML2_INCLUDE_DIR="       "{DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/include/libxml2".format(**locals()),
-        "-DLIBXML2_LIBRARIES="         "{DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/lib/libxml2.{LIBRARY_EXT}".format(**locals())
-    ])
+                       "-DLIBXML2_INCLUDE_DIR="       "{DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/include/libxml2".format(**locals()),
+                       "-DLIBXML2_LIBRARIES="         "{DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/lib/libxml2.{LIBRARY_EXT}".format(**locals())
+                       ])
 
 run_cmake("", cmake_args, cmake_dir=CMAKE_DIR, cwd=executables_dir)
 
-logger.info("\rBuilding executables...   ")
+logger.info("\rBuilding executables...")
 
 run([make, "-j{IFCOS_NUM_BUILD_PROCS}".format(**locals())], cwd=executables_dir)
 run([make, "install/strip" if BUILD_CFG == "Release" else "install"], cwd=executables_dir)
 
 if "IfcOpenShell-Python" in targets:
-
+    
     # On OSX the actual Python library is not linked against.
     ADDITIONAL_ARGS=""
     if get_os() == "Darwin":
-        ADDITIONAL_ARGS="-Wl,-flat_namespace,-undefined,suppress"
+        ADDITIONAL_ARGS="-Wl -flat_namespace -undefined suppress"
 
     os.environ["CXXFLAGS"]="%s %s" % (CXXFLAGS_MINIMAL, ADDITIONAL_ARGS)
     os.environ["CFLAGS"]="%s %s" % (CFLAGS_MINIMAL, ADDITIONAL_ARGS)
     os.environ["LDFLAGS"]="%s %s" % (LDFLAGS, ADDITIONAL_ARGS)
 
-    for PYTHON_VERSION, _, TAG in PYTHON_VERSION_CONFS():
-        logger.info("\rConfiguring python {PYTHON_VERSION}{TAG} wrapper...".format(**locals()))
-
-        python_dir = os.path.join(IFCOS_DIR, "python-{PYTHON_VERSION}{TAG}".format(**locals()))
+for PYTHON_VERSION, _, TAG in PYTHON_VERSION_CONFS():
+    logger.info("\rConfiguring python {PYTHON_VERSION}{TAG} wrapper...".format(**locals()))
+    
+    python_dir = os.path.join(IFCOS_DIR, "python-{PYTHON_VERSION}{TAG}".format(**locals()))
         if not os.path.exists(python_dir):
             os.makedirs(python_dir)
 
-        PYTHON_LIBRARY=run([bash, "-c", "ls    {DEPS_DIR}/install/python-{PYTHON_VERSION}{TAG}/lib/libpython*.*".format(**locals())])
-        PYTHON_INCLUDE=run([bash, "-c", "ls -d {DEPS_DIR}/install/python-{PYTHON_VERSION}{TAG}/include/python*".format(**locals())])
-        PYTHON_EXECUTABLE=os.path.join(DEPS_DIR, "install", "python-{PYTHON_VERSION}{TAG}".format(**locals()), "bin", "python{PYTHON_VERSION[0]}".format(**locals()))
-        os.environ["PYTHON_LIBRARY_BASENAME"]=os.path.basename(PYTHON_LIBRARY)
-
-        run_cmake("",
-            cmake_args=[
-                "-DBUILD_SHARED_LIBS="       "OFF" if BUILD_STATIC else "ON",
-                "-DBOOST_ROOT="              "{DEPS_DIR}/install/boost-{BOOST_VERSION}".format(**locals()),
-                "-DOCC_INCLUDE_DIR="         +occ_include_dir,
-                "-DOCC_LIBRARY_DIR="         +occ_library_dir,
-                "-DPYTHON_LIBRARY="          +PYTHON_LIBRARY,
-                "-DPYTHON_EXECUTABLE="       +PYTHON_EXECUTABLE,
-                "-DPYTHON_INCLUDE_DIR="      +PYTHON_INCLUDE,
-                "-DSWIG_EXECUTABLE="         "{DEPS_DIR}/install/swig/bin/swig".format(**locals()),
-                "-DCMAKE_INSTALL_PREFIX="    "{DEPS_DIR}/install/ifcopenshell/tmp".format(**locals()),
-                "-DLIBXML2_INCLUDE_DIR="     "{DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/include/libxml2".format(**locals()),
-                "-DLIBXML2_LIBRARIES="       "{DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/lib/libxml2.{LIBRARY_EXT}".format(**locals()),
-                "-DCOLLADA_SUPPORT=OFF"
-            ], cmake_dir=CMAKE_DIR, cwd=python_dir)
+    # idea is to use system installed python located in "which python" or "which python3"
+    # find system python site-specific home folder and extract its version from its path
+    # tail is home folder of the system python installation denoted by version number (i.e. Mac OS X, 3.7 = major.minor)
+    head,tail = os.path.split(sys.exec_prefix)
+        # extract individual version numbers from the python version currently used for the build process
+        major, minor, revision = PYTHON_VERSION.split('.')
         
-        logger.info("\rBuilding python %s%s wrapper...   " % (PYTHON_VERSION, TAG))
-
-        run([make, "-j%s" % (IFCOS_NUM_BUILD_PROCS,), "_ifcopenshell_wrapper"], cwd=python_dir)
-        run([make, "install/local"], cwd=os.path.join(python_dir, "ifcwrap"))
-
-        module_dir = os.path.dirname(run([PYTHON_EXECUTABLE, "-c", "from __future__ import print_function; import inspect, ifcopenshell; print(inspect.getfile(ifcopenshell))"]))
-
-        if get_os() != "Darwin":
-            # TODO: This symbol name depends on the Python version?
-            run([strip, "-s", "-K", "PyInit__ifcopenshell_wrapper", "_ifcopenshell_wrapper.so"], cwd=module_dir)
-
-        run([cp, "-R", module_dir, os.path.join(DEPS_DIR, "install", "ifcopenshell", "python-%s%s" % (PYTHON_VERSION, TAG))])
+        # determine full path for homedir of the system python
+        python_system_homedir = "{head}/{major}.{minor}".format(**locals())
+        
+        # determine key python folders to use during the build process
+        PYTHON_EXECUTABLE= "{python_system_homedir}/bin/python{major}.{minor}".format(**locals())
+        PYTHON_LIBRARY= "{python_system_homedir}/lib/libpython*.*".format(**locals())
+        PYTHON_INCLUDE= "{python_system_homedir}/include/python{major}.{minor}m".format(**locals())
+        
+        cecho("System python version %s used: " % (PYTHON_VERSION,), GREEN)
+        logger.info("\rPYTHON_EXECUTABLE = %s""" % (PYTHON_EXECUTABLE,))
+        logger.info("\rPYTHON_LIBRARY = %s""" % (PYTHON_LIBRARY,))
+        logger.info("\rPYTHON_INCLUDE = %s""" % (PYTHON_INCLUDE,))
+        
+        os.environ["PYTHON_LIBRARY_BASENAME"]=os.path.basename(PYTHON_LIBRARY)
+        
+        run_cmake("",
+                  cmake_args=[
+                              "-DBUILD_SHARED_LIBS="       "OFF" if BUILD_STATIC else "ON",
+                              "-DBOOST_ROOT="              "{DEPS_DIR}/install/boost-{BOOST_VERSION}".format(**locals()),
+                              "-DOCC_INCLUDE_DIR="         +occ_include_dir,
+                              "-DOCC_LIBRARY_DIR="         +occ_library_dir,
+                              "-DPYTHON_LIBRARY="          +PYTHON_LIBRARY,
+                              "-DPYTHON_EXECUTABLE="       +PYTHON_EXECUTABLE,
+                              "-DPYTHON_INCLUDE_DIR="      +PYTHON_INCLUDE,
+                              "-DSWIG_EXECUTABLE="         "{DEPS_DIR}/install/swig/bin/swig".format(**locals()),
+                              "-DCMAKE_INSTALL_PREFIX="    "{DEPS_DIR}/install/ifcopenshell/tmp".format(**locals()),
+                              "-DLIBXML2_INCLUDE_DIR="     "{DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/include/libxml2".format(**locals()),
+                              "-DLIBXML2_LIBRARIES="       "{DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/lib/libxml2.{LIBRARY_EXT}".format(**locals()),
+                              "-DCOLLADA_SUPPORT=OFF"
+                              ], cmake_dir=CMAKE_DIR, cwd=python_dir)
+                      
+                              logger.info("\rBuilding python %s%s wrapper..." % (PYTHON_VERSION, TAG))
+                              
+                              run([make, "-j%s" % (IFCOS_NUM_BUILD_PROCS,), "_ifcopenshell_wrapper"], cwd=python_dir)
+                              run([make, "install/local"], cwd=os.path.join(python_dir, "ifcwrap"))
+                              
+                              # here build with swig 4.0 will break the process, use swig 3.0.12 for the time being
+                              ifcos_built_dir = to_pystring(run([PYTHON_EXECUTABLE, "-c", "import os, ifcopenshell; print(os.path.dirname(ifcopenshell.__file__))"]))
+                              logger.info("IfcOpenShell package built to: %s" % (ifcos_built_dir))
+                              
+                              if get_os() == "Darwin":
+                                  run([strip, "-x", "_ifcopenshell_wrapper.so"], cwd=ifcos_built_dir)
+                              else:
+                                  # ToDo: needs to be tested on non Mac OS X platforms!
+                                  run([strip, "-s", "-K", "PyInit__ifcopenshell_wrapper", "_ifcopenshell_wrapper.so"], cwd=ifcos_built_dir)
+ifcos_archive_dir = os.path.join(DEPS_DIR, "install", "ifcopenshell", "python-%s%s" % (PYTHON_VERSION, TAG))
+logger.info("IfcOpenShell package copied to: %s" % (ifcos_archive_dir))
+run([cp, "-R", ifcos_built_dir, ifcos_archive_dir])
 
 logger.info("\rBuilt IfcOpenShell...\n\n")

--- a/nix/build-all.py
+++ b/nix/build-all.py
@@ -803,4 +803,4 @@ for PYTHON_VERSION, _, TAG in PYTHON_VERSION_CONFS():
     logger.info("IfcOpenShell package copied to: %s" % (ifcos_archive_dir))
     run([cp, "-R", ifcos_built_dir, ifcos_archive_dir])
 
-    logger.info("\rBuilt IfcOpenShell...\n\n")
+logger.info("\rBuilt IfcOpenShell...\n\n")

--- a/nix/build-all.py
+++ b/nix/build-all.py
@@ -172,7 +172,7 @@ except KeyError:
 try:
     TARGET_ARCH = os.environ["TARGET_ARCH"]
 except KeyError:
-    TARGET_ARCH = platform.uname()[4] #to_pystring(sp.check_output([uname, "-m"]).strip())
+    TARGET_ARCH = platform.uname()[4]
 
 CMAKE_DIR=os.path.realpath(os.path.join("..", "cmake"))
 
@@ -194,11 +194,8 @@ except KeyError:
 
 # Print build configuration information
 
-cecho ("""This script fetches and builds %s and its dependencies
-    """ % (PROJECT_NAME,), BLACK_ON_WHITE)
-cecho("""Script configuration:
-    
-    """, GREEN)
+cecho ("""This script fetches and builds %s and its dependencies """ % (PROJECT_NAME,), BLACK_ON_WHITE)
+cecho("""Script configuration:""", GREEN)
 cecho("""* Target Architecture    = %s""" % (TARGET_ARCH,), MAGENTA)
 cecho(" - Whether 32-bit (i686) or 64-bit (x86_64) will be built.")
 cecho("""* USE_OCCT               = %r""" % (USE_OCCT,), MAGENTA)
@@ -216,8 +213,7 @@ if BUILD_CFG == "MinSizeRel":
     cecho("     WARNING: MinSizeRel build can suffer from a significant performance loss.", RED)
 
 cecho("* IFCOS_NUM_BUILD_PROCS  = %s" % (IFCOS_NUM_BUILD_PROCS,), MAGENTA)
-cecho(""" - How many compiler processes may be run in parallel.
-    """)
+cecho(""" - How many compiler processes may be run in parallel.""")
 
 dependency_tree = {
     'IfcParse': ('boost',  'libxml2'),
@@ -242,7 +238,6 @@ def v(dep):
         for x in v(d):
             yield x
 
-       
 tgts = [s for s in sys.argv[1:] if not s.startswith("-")]
 flags = set(s for s in sys.argv[1:] if s.startswith("-"))
 
@@ -331,10 +326,9 @@ def run_cmake(arg1, cmake_args, cmake_dir=None, cwd=None):
 
 def git_clone_or_pull_repository(clone_url, target_dir, revision=None):
     """Lazily clones the `git` repository denoted by `clone_url` into
-        the `target_dir` or pulls latest changes if the `target_dir` exists (naively assumes
-        that a working clone exists there) and optionally checks out a revision
-        `revision` after cloning or in the existing clone if `revision` is not
-        `None`."""
+       the `target_dir` or pulls latest changes if the `target_dir` exists (naively assumes
+       that a working clone exists there) and optionally checks out a revision
+       `revision` after cloning or in the existing clone if `revision` is not `None`."""
     if not os.path.exists(target_dir):
         logger.info("cloning '%s' into '%s'" % (clone_url, target_dir))
         run([git, "clone", clone_url, target_dir])
@@ -494,9 +488,9 @@ if os.path.exists(CMAKE_FLAG_EXTRACT_DIR):
 os.makedirs(CMAKE_FLAG_EXTRACT_DIR)
 BUILD_CFG_UPPER=BUILD_CFG.upper()
 for FL in ["C", "CXX"]:
-    run([bash, "-c", """echo "
-        message(\"\${CMAKE_%s_FLAGS_%s}\")
-        " > CMakeLists.txt""" % (FL, BUILD_CFG_UPPER)], cwd=CMAKE_FLAG_EXTRACT_DIR)
+    run([bash, "-c", """echo "message(\"\${CMAKE_%s_FLAGS_%s}\")" > CMakeLists.txt""" % (FL, BUILD_CFG_UPPER)], 
+        cwd=CMAKE_FLAG_EXTRACT_DIR
+    )
     FL="%sFLAGS" % (FL,)
     FLM="%sFLAGS_MINIMAL" % (FL,)
 # @TODO: bash code unclear
@@ -541,7 +535,7 @@ if USE_OCCT and "occ" in targets:
              "-DINSTALL_DIR={DEPS_DIR}/install/occt-{OCCT_VERSION}".format(**locals()),
              "-DBUILD_LIBRARY_TYPE={LINK_TYPE_UCFIRST}".format(**locals()),
              "-DBUILD_MODULE_Draw=0",
-            ],
+        ],
         download_url = "https://git.dev.opencascade.org/repos/occt.git",
         download_name = "occt",
         download_tool=download_tool_git,
@@ -553,14 +547,14 @@ elif "occ" in targets:
         name="oce-{OCE_VERSION}".format(**locals()),
         mode="cmake",
         build_tool_args=[
-             "-DOCE_DISABLE_TKSERVICE_FONT=ON",
-             "-DOCE_TESTING=OFF",
-             "-DOCE_BUILD_SHARED_LIB=OFF",
-             "-DOCE_DISABLE_X11=ON",
-             "-DOCE_VISUALISATION=OFF",
-             "-DOCE_OCAF=OFF",
-             "-DOCE_INSTALL_PREFIX={DEPS_DIR}/install/oce-{OCE_VERSION}".format(**locals())
-            ],
+            "-DOCE_DISABLE_TKSERVICE_FONT=ON",
+            "-DOCE_TESTING=OFF",
+            "-DOCE_BUILD_SHARED_LIB=OFF",
+            "-DOCE_DISABLE_X11=ON",
+            "-DOCE_VISUALISATION=OFF",
+            "-DOCE_OCAF=OFF",
+            "-DOCE_INSTALL_PREFIX={DEPS_DIR}/install/oce-{OCE_VERSION}".format(**locals())
+        ],
         download_url="https://github.com/tpaviot/oce/archive/",
         download_name="OCE-{OCE_VERSION}.tar.gz".format(**locals())
     )
@@ -576,7 +570,7 @@ if "libxml2" in targets:
             "--without-zlib",
             "--without-iconv",
             "--without-lzma"
-            ],
+        ],
         download_url="ftp://xmlsoft.org/libxml2/",
         download_name="libxml2-{LIBXML2_VERSION}.tar.gz".format(**locals())
     )
@@ -586,13 +580,13 @@ if "OpenCOLLADA" in targets:
         "OpenCOLLADA",
         "cmake",
         build_tool_args=[
-             "-DLIBXML2_INCLUDE_DIR={DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/include/libxml2".format(**locals()),
-             "-DLIBXML2_LIBRARIES={DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/lib/libxml2.{LIBRARY_EXT}".format(**locals()),
-             "-DPCRE_INCLUDE_DIR={DEPS_DIR}/install/pcre-{PCRE_VERSION}/include".format(**locals()),
-             "-DPCRE_PCREPOSIX_LIBRARY={DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib/libpcreposix.{LIBRARY_EXT}".format(**locals()),
-             "-DPCRE_PCRE_LIBRARY={DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib/libpcre.{LIBRARY_EXT}".format(**locals()),
-             "-DCMAKE_INSTALL_PREFIX={DEPS_DIR}/install/OpenCOLLADA/".format(**locals())
-             ],
+            "-DLIBXML2_INCLUDE_DIR={DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/include/libxml2".format(**locals()),
+            "-DLIBXML2_LIBRARIES={DEPS_DIR}/install/libxml2-{LIBXML2_VERSION}/lib/libxml2.{LIBRARY_EXT}".format(**locals()),
+            "-DPCRE_INCLUDE_DIR={DEPS_DIR}/install/pcre-{PCRE_VERSION}/include".format(**locals()),
+            "-DPCRE_PCREPOSIX_LIBRARY={DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib/libpcreposix.{LIBRARY_EXT}".format(**locals()),
+            "-DPCRE_PCRE_LIBRARY={DEPS_DIR}/install/pcre-{PCRE_VERSION}/lib/libpcre.{LIBRARY_EXT}".format(**locals()),
+            "-DCMAKE_INSTALL_PREFIX={DEPS_DIR}/install/OpenCOLLADA/".format(**locals())
+        ],
         download_url="https://github.com/KhronosGroup/OpenCOLLADA.git",
         download_name="OpenCOLLADA",
         download_tool=download_tool_git,
@@ -640,15 +634,15 @@ if "boost" in targets:
         "boost-{BOOST_VERSION}".format(**locals()),
         mode="bjam",
         build_tool_args=[
-             "--stagedir={DEPS_DIR}/install/boost-{BOOST_VERSION}".format(**locals()),
-             "--with-system",
-             "--with-program_options",
-             "--with-regex",
-             "--with-thread",
-             "--with-date_time",
-             "--with-iostreams",
-             "link={LINK_TYPE}".format(**locals())
-             ] + \
+            "--stagedir={DEPS_DIR}/install/boost-{BOOST_VERSION}".format(**locals()),
+            "--with-system",
+            "--with-program_options",
+            "--with-regex",
+            "--with-thread",
+            "--with-date_time",
+            "--with-iostreams",
+            "link={LINK_TYPE}".format(**locals())
+            ] + \
         BOOST_ADDRESS_MODEL                                            + \
         list(map(str_concat("cxxflags"), CXXFLAGS.strip().split(' '))) + \
         list(map(str_concat("linkflags"), LDFLAGS.strip().split(' '))) + \
@@ -684,7 +678,7 @@ cmake_args=[
     "-DBOOST_ROOT="                    "{DEPS_DIR}/install/boost-{BOOST_VERSION}".format(**locals()),
     "-DGLTF_SUPPORT="                  "ON",
     "-DJSON_INCLUDE_DIR="              "{DEPS_DIR}/install/json".format(**locals())
-    ]
+]
 
 if "occ" in targets and USE_OCCT:
     occ_include_dir =                  "{DEPS_DIR}/install/occt-{OCCT_VERSION}/include/opencascade".format(**locals())

--- a/nix/build-all.py
+++ b/nix/build-all.py
@@ -741,16 +741,16 @@ for PYTHON_VERSION, _, TAG in PYTHON_VERSION_CONFS():
     # find system python site-specific home folder and extract its version from its path
     # tail is home folder of the system python installation denoted by version number (i.e. Mac OS X, 3.7 = major.minor)
     head,tail = os.path.split(sys.exec_prefix)
-        # extract individual version numbers from the python version currently used for the build process
+    # extract individual version numbers from the python version currently used for the build process
     major, minor, revision = PYTHON_VERSION.split('.')
         
-        # determine full path for homedir of the system python
-    build_dependency = "{head}/{major}.{minor}".format(**locals())
+    # determine full path for homedir of the system python
+    system_python_dir = "{head}/{major}.{minor}".format(**locals())
         
-        # determine key python folders to use during the build process
-    PYTHON_EXECUTABLE= "{build_dependency}/bin/python{major}.{minor}".format(**locals())
-    PYTHON_LIBRARY= "{build_dependency}/lib/libpython*.*".format(**locals())
-    PYTHON_INCLUDE= "{build_dependency}/include/python{major}.{minor}m".format(**locals())
+    # determine key python folders to use during the build process
+    PYTHON_EXECUTABLE= "{system_python_dir}/bin/python{major}.{minor}".format(**locals())
+    PYTHON_LIBRARY= "{system_python_dir}/lib/libpython*.*".format(**locals())
+    PYTHON_INCLUDE= "{system_python_dir}/include/python{major}.{minor}m".format(**locals())
     
     cecho("System python version %s used: " % (PYTHON_VERSION,), GREEN)
     logger.info("\rPYTHON_EXECUTABLE = %s""" % (PYTHON_EXECUTABLE,))
@@ -790,8 +790,8 @@ for PYTHON_VERSION, _, TAG in PYTHON_VERSION_CONFS():
     if get_os() == "Darwin":
         run([strip, "-x", "_ifcopenshell_wrapper.so"], cwd=ifcos_built_dir)
     else:
-      # ToDo: needs to be tested on non Mac OS X platforms!
-      run([strip, "-s", "-K", "PyInit__ifcopenshell_wrapper", "_ifcopenshell_wrapper.so"], cwd=ifcos_built_dir)
+        # ToDo: needs to be tested on non Mac OS X platforms!
+        run([strip, "-s", "-K", "PyInit__ifcopenshell_wrapper", "_ifcopenshell_wrapper.so"], cwd=ifcos_built_dir)
 
     ifcos_archive_dir = os.path.join(DEPS_DIR, "install", "ifcopenshell", "python-%s%s" % (PYTHON_VERSION, TAG))
     logger.info("IfcOpenShell package copied to: %s" % (ifcos_archive_dir))


### PR DESCRIPTION
Improvements:
- use of system installed python in the build-all.py script for Mac OS X
- reverted to the use of swig 3.0.12 for the time being becaue swig version 4.0 causes error in the build process with Mac OS X
- use of the to_pystring() was minimized