### PR TITLE
Casting default timestamp template to integer

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/template.py
+++ b/src/ifcopenshell-python/ifcopenshell/template.py
@@ -66,7 +66,7 @@ DEFAULTS = {
     "application_version": lambda d: main.version,
     "project_globalid": lambda d: compress(uuid.uuid4().hex),
     "schema_identifier": lambda d: main.schema_identifier,
-    "timestamp": lambda d: time.time(),
+    "timestamp": lambda d: int(time.time()),
     "timestring": lambda d: time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(d.get('timestamp') or time.time()))
 }
 


### PR DESCRIPTION
The documentation of IFC indicates that the timestamp must be of type Integer. [IfcTimeStamp](https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/link/ifctimestamp.htm)
If not, it cause some problems importing the generated IFC file in some platforms