### PR TITLE
Use model-offset in IfcGeom::Kernel and add model-rotation

### DIFF
--- a/src/ifcconvert/GeometrySerializer.h
+++ b/src/ifcconvert/GeometrySerializer.h
@@ -56,11 +56,11 @@ public:
     SerializerSettings()
         : precision(DEFAULT_PRECISION)
     {
-        memset(offset, 0, sizeof(offset));
+        memset(serializer_offset, 0, sizeof(serializer_offset));
     }
 
     /// Optional offset that is applied to serialized objects, (0,0,0) by default.
-    double offset[3];
+    double serializer_offset[3];
 
     /// Sets the precision used to format floating-point values, 15 by default.
     /// Use a negative value to use the system's default precision (should be 6 typically).

--- a/src/ifcconvert/WavefrontObjSerializer.cpp
+++ b/src/ifcconvert/WavefrontObjSerializer.cpp
@@ -93,9 +93,9 @@ void WaveFrontOBJSerializer::write(const IfcGeom::TriangulationElement<real_t>* 
 
 	const int vcount = (int)mesh.verts().size() / 3;
     for ( std::vector<real_t>::const_iterator it = mesh.verts().begin(); it != mesh.verts().end(); ) {
-        const real_t x = *(it++) + (real_t)settings().offset[0];
-        const real_t y = *(it++) + (real_t)settings().offset[1];
-        const real_t z = *(it++) + (real_t)settings().offset[2];
+        const real_t x = *(it++) + (real_t)settings().serializer_offset[0];
+        const real_t y = *(it++) + (real_t)settings().serializer_offset[1];
+        const real_t z = *(it++) + (real_t)settings().serializer_offset[2];
 		obj_stream << "v " << x << " " << y << " " << z << "\n";
 	}
 

--- a/src/ifcgeom/IfcGeom.h
+++ b/src/ifcgeom/IfcGeom.h
@@ -21,6 +21,7 @@
 #define IFCGEOM_H
 
 #include <cmath>
+#include <array>
 
 static const double ALMOST_ZERO = 1.e-9;
 
@@ -37,6 +38,7 @@ inline static bool ALMOST_THE_SAME(const T& a, const T& b, double tolerance=ALMO
 #include <gp_GTrsf2d.hxx>
 #include <gp_Trsf.hxx>
 #include <gp_Trsf2d.hxx>
+#include <gp_Quaternion.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Wire.hxx>
 #include <TopoDS_Face.hxx>
@@ -108,6 +110,9 @@ private:
 	double ifc_planeangle_unit;
 	double modelling_precision;
 	double dimensionality;
+	gp_Vec offset = gp_Vec{0.0, 0.0, 0.0};
+	gp_Quaternion rotation = gp_Quaternion{};
+	gp_Trsf offset_and_rotation = gp_Trsf();
 
 #ifndef NO_CACHE
 	Cache cache;
@@ -183,6 +188,9 @@ public:
 		// Whether to process shapes of type Face or higher (1) Wire or lower (-1) or all (0)
 		GV_DIMENSIONALITY
 	};
+
+	void set_offset(const std::array<double, 3>& offset);
+	void set_rotation(const std::array<double, 4>& rotation);
 
 	bool convert_wire_to_face(const TopoDS_Wire& wire, TopoDS_Face& face);
 	bool convert_curve_to_wire(const Handle(Geom_Curve)& curve, TopoDS_Wire& wire);

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -304,6 +304,28 @@ namespace {
 			}
 		}
 	}
+
+    gp_Trsf combine_offset_and_rotation(const gp_Vec &offset, const gp_Quaternion& rotation) {
+        auto offset_transform = gp_Trsf{};
+        offset_transform.SetTranslation(offset);
+
+        auto rotation_transform = gp_Trsf{};
+        rotation_transform.SetRotation(rotation);
+
+        return rotation_transform * offset_transform;
+	}
+}
+
+void IfcGeom::Kernel::set_offset(const std::array<double, 3> &p_offset) {
+    offset = gp_Vec(p_offset[0], p_offset[1], p_offset[2]);
+
+    offset_and_rotation = combine_offset_and_rotation(offset, rotation);
+}
+
+void IfcGeom::Kernel::set_rotation(const std::array<double, 4> &p_rotation) {
+    rotation = gp_Quaternion(p_rotation[0],p_rotation[1],p_rotation[2],p_rotation[3]);
+
+    offset_and_rotation = combine_offset_and_rotation(offset, rotation);
 }
 
 bool IfcGeom::Kernel::create_solid_from_compound(const TopoDS_Shape& compound, TopoDS_Shape& shape) {

--- a/src/ifcgeom/IfcGeomHelpers.cpp
+++ b/src/ifcgeom/IfcGeomHelpers.cpp
@@ -413,6 +413,9 @@ bool IfcGeom::Kernel::convert(const IfcSchema::IfcObjectPlacement* l, gp_Trsf& t
 			else break;
 		} else break;
 	}
+
+	trsf.PreMultiply(offset_and_rotation);
+
 	CACHE(IfcObjectPlacement,l,trsf)
 	return true;
 }

--- a/src/ifcgeom/IfcGeomIterator.h
+++ b/src/ifcgeom/IfcGeomIterator.h
@@ -720,6 +720,8 @@ namespace IfcGeom {
 			} else if (settings.get(IteratorSettings::SITE_LOCAL_PLACEMENT)) {
 				kernel.set_conversion_placement_rel_to(IfcSchema::Type::IfcSite);
 			}
+			kernel.set_offset(settings.offset);
+			kernel.set_rotation(settings.rotation);
 		}
 
 		bool owns_ifc_file;

--- a/src/ifcgeom/IfcGeomIteratorSettings.h
+++ b/src/ifcgeom/IfcGeomIteratorSettings.h
@@ -20,6 +20,8 @@
 #ifndef IFCGEOMITERATORSETTINGS_H
 #define IFCGEOMITERATORSETTINGS_H
 
+#include <array>
+
 #include "ifc_geom_api.h"
 #include "../ifcparse/IfcException.h"
 #include "../ifcparse/IfcBaseClass.h"
@@ -127,6 +129,11 @@ namespace IfcGeom
                 settings_ &= ~setting;
             }
         }
+
+        /// Optional offset x,y,z that is applied to all elements, (0,0,0) by default.
+        std::array<double,3> offset = {0.0, 0.0, 0.0};
+        /// Optional rotation x,y,z,w that is applied to all elements, (0,0,0,1) by default.
+        std::array<double,4> rotation = {0.0, 0.0, 0.0, 1.0};
 
     protected:
         SettingField settings_;

--- a/src/ifcgeom/IfcGeomIteratorSettings.h
+++ b/src/ifcgeom/IfcGeomIteratorSettings.h
@@ -131,9 +131,9 @@ namespace IfcGeom
         }
 
         /// Optional offset x,y,z that is applied to all elements, (0,0,0) by default.
-        std::array<double,3> offset = {0.0, 0.0, 0.0};
+        std::array<double,3> offset = std::array<double,3>{0.0, 0.0, 0.0};
         /// Optional rotation x,y,z,w that is applied to all elements, (0,0,0,1) by default.
-        std::array<double,4> rotation = {0.0, 0.0, 0.0, 1.0};
+        std::array<double,4> rotation = std::array<double,4>{0.0, 0.0, 0.0, 1.0};
 
     protected:
         SettingField settings_;


### PR DESCRIPTION
Applying model-offset in IfcGeom::Kernel makes it work independently
of the serializer.

`model-rotation` was also added to support rotation in the same
manner as `model-offset` supports offset.