### PR TITLE
proposed fix for #744

### DIFF
--- a/src/ifcgeom/IfcGeomWires.cpp
+++ b/src/ifcgeom/IfcGeomWires.cpp
@@ -558,7 +558,7 @@ bool IfcGeom::Kernel::convert(const IfcSchema::IfcTrimmedCurve* l, TopoDS_Wire& 
 				flts[1] -= M_PI / 2.;
 			}
 		}
-		if ( isConic && ALMOST_THE_SAME(fmod(flts[1]-flts[0],M_PI*2.),0.) ) {
+                if ( isConic && (fmod(flts[1]-flts[0],M_PI*2.) > getValue(GV_PRECISION) ) )  {
 			e = BRepBuilderAPI_MakeEdge(curve).Edge();
 		} else {
 			BRepBuilderAPI_MakeEdge me (curve,flts[0],flts[1]);


### PR DESCRIPTION
Issue with #744 is that some programs export full circles as trimmed circles, with trimparams at 0 and 2*pi. But due to floating point precision this trim could flip from full circle to an infinitesimally small line segment. 