### PR TITLE
Make validate module write to logger

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -73,7 +73,7 @@ def try_valid(attr, val):
     except ValidationError as e:
         return False
         
-def validate(f):
+def validate(f, logger):
     schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(f.schema)
     for inst in f:
         entity = schema.declaration_by_name(inst.is_a())
@@ -88,17 +88,22 @@ def validate(f):
                 try: 
                     assert_valid(attr, val)
                 except ValidationError as e:
-                    print("In", inst)
-                    print(e)
-                    print()
+                    logger.error('In {}\n{}'.format(inst, e))
                 
         for attr in entity.all_inverse_attributes():
             val = getattr(inst, attr.name())
-            assert_valid_inverse(attr, val)
+            try:
+                assert_valid_inverse(attr, val)
+            except ValidationError as e:
+                logger.error('In {}\n{}'.format(inst, e))
+
             
 if __name__ == "__main__":
     import sys
+    import logging
     
     for fn in sys.argv[1:]:
+        logger = logging.getLogger('validate')
+        logger.setLevel(logging.DEBUG)
         print("Validating", fn)
-        validate(ifcopenshell.open(fn))
+        validate(ifcopenshell.open(fn), logger)

--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -81,7 +81,7 @@ def validate(f, logger):
         for attr, val, is_derived in zip(entity.all_attributes(), inst, entity.derived()):
         
             if val is None and not (is_derived or attr.optional()):
-               raise Exception("Attribute %s.%s not optional" % (entity, attr))
+               logger.error("Attribute %s.%s not optional" % (entity, attr))
 
             if val is not None:
                 attr_type = attr.type_of_attribute()


### PR DESCRIPTION
This changes two things:

 1. Adds a try/catch for validating inverse relationships, otherwise you only get the first error.
 2. Remove hardcoded print statement and use a logger instead. This allows you to use it as a function in a library with an error log or otherwise. Note that by default if you run it from a command line it will still write to stream output.