### PR TITLE
Fix #883 by adding correct number of edges

### DIFF
--- a/src/ifcblenderexport/blenderbim/bim/annotation.py
+++ b/src/ifcblenderexport/blenderbim/bim/annotation.py
@@ -62,7 +62,7 @@ class Annotator:
             obj.data.vertices.add(2)
             obj.data.vertices[-2].co = co1
             obj.data.vertices[-1].co = co2
-            obj.data.edges.add(2)
+            obj.data.edges.add(1)
             obj.data.edges[-1].vertices = (obj.data.vertices[-2].index, obj.data.vertices[-1].index)
         if isinstance(obj.data, bpy.types.Curve):
             polyline = obj.data.splines.new('POLY')


### PR DESCRIPTION
The mesh structure was invalid because the vertex indices for only one edge were set. The other edge had the same index for both vertices. See [T77537](https://developer.blender.org/T77537) for the ticket on Blender's bug tracker.