### PR TITLE
Fix building with -DIFCXML_SUPPORT=OFF

### DIFF
--- a/src/ifcwrap/IfcParseWrapper.i
+++ b/src/ifcwrap/IfcParseWrapper.i
@@ -522,7 +522,10 @@ static IfcUtil::ArgumentType helper_fn_attribute_type(const IfcUtil::IfcBaseClas
 // The IfcFile* returned by open() is to be freed by SWIG/Python
 %newobject open;
 %newobject read;
+
+#ifdef WITH_IFCXML
 %newobject parse_ifcxml;
+#endif
 
 %inline %{
 	IfcParse::IfcFile* open(const std::string& fn) {
@@ -530,9 +533,11 @@ static IfcUtil::ArgumentType helper_fn_attribute_type(const IfcUtil::IfcBaseClas
 		return f;
 	}
 
+#ifdef WITH_IFCXML
 	IfcParse::IfcFile* parse_ifcxml(const std::string& fn) {
 		return IfcParse::parse_ifcxml(fn);
 	}
+#endif
 
     IfcParse::IfcFile* read(const std::string& data) {
 		char* copiedData = new char[data.length()];


### PR DESCRIPTION
Without this patch compilation fails with:
```
/home/harald/IfcOpenShell/build_noxml/ifcwrap/CMakeFiles/_ifcopenshell_wrapper.dir/IfcPythonPYTHON_wrap.cxx: In function ‘IfcParse::IfcFile* parse_ifcxml(const string&)’:
/home/harald/IfcOpenShell/build_noxml/ifcwrap/CMakeFiles/_ifcopenshell_wrapper.dir/IfcPythonPYTHON_wrap.cxx:4292:20: error: ‘parse_ifcxml’ is not a member of ‘IfcParse’; did you mean ‘parse_ifcxml’?
 4292 |   return IfcParse::parse_ifcxml(fn);
      |                    ^~~~~~~~~~~~
/home/harald/IfcOpenShell/build_noxml/ifcwrap/CMakeFiles/_ifcopenshell_wrapper.dir/IfcPythonPYTHON_wrap.cxx:4291:21: note: ‘parse_ifcxml’ declared here
 4291 |  IfcParse::IfcFile* parse_ifcxml(const std::string& fn) {
      |                     ^~~~~~~~~~~~
```