### PR TITLE
Added USERSPACE_PYTHON_PREFIX cmake variable

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -49,6 +49,7 @@ endif()
 if (${BUILD_CONVERT})
 OPTION(GLTF_SUPPORT "Build IfcConvert with glTF support (requires json.hpp)." OFF)
 endif()
+OPTION(USERSPACE_PYTHON_PREFIX "Installs IfcPython for the current user only instead of system-wide." OFF)
 
 # TODO QtViewer is deprecated ATM as it uses the 0.4 API
 # OPTION(BUILD_QTVIEWER "Build IfcOpenShell Qt GUI Viewer (requires Qt 4 framework)." OFF)

--- a/src/ifcwrap/CMakeLists.txt
+++ b/src/ifcwrap/CMakeLists.txt
@@ -68,10 +68,17 @@ endif()
 # directory in which the wrapper can be installed.
 FIND_PACKAGE(PythonInterp)
 IF(PYTHONINTERP_FOUND AND NOT "${PYTHON_EXECUTABLE}" STREQUAL "")
-    EXECUTE_PROCESS(
-        COMMAND ${PYTHON_EXECUTABLE} -c "import sys; from distutils.sysconfig import get_python_lib; sys.stdout.write(get_python_lib(1))"
-        OUTPUT_VARIABLE python_package_dir
-    )
+    IF (USERSPACE_PYTHON_PREFIX)
+        EXECUTE_PROCESS(
+            COMMAND ${PYTHON_EXECUTABLE} -c "import sys; import site; sys.stdout.write(site.USER_SITE)"
+            OUTPUT_VARIABLE python_package_dir
+        )
+    ELSE ()
+        EXECUTE_PROCESS(
+            COMMAND ${PYTHON_EXECUTABLE} -c "import sys; from distutils.sysconfig import get_python_lib; sys.stdout.write(get_python_lib(1))"
+            OUTPUT_VARIABLE python_package_dir
+        )
+    ENDIF()
 
     IF("${python_package_dir}" STREQUAL "")
         MESSAGE(WARNING "Unable to locate Python site-package directory, unable to install the Python wrapper")


### PR DESCRIPTION
Added USERSPACE_PYTHON_PREFIX cmake variable to allow install IfcPython in userspace instead of system-wide.

This allows you to install IfcOpenShell entirely in user-space, for ex. by setting CMAKE_INSTALL_PREFIX to /$USER/SomeDir and USERSPACE_PYTHON_PREFIX on, which installs IfcPython to $USER/.local/lib/python3/site-packages (as provided by python's built-in site module) instead of /usr/lib/python3/site-packages