### PR TITLE
IfcSiPrefix and IfcHierarchyHelper changes

### DIFF
--- a/src/ifcparse/IfcHierarchyHelper.h
+++ b/src/ifcparse/IfcHierarchyHelper.h
@@ -173,13 +173,16 @@ public:
 		bool found = false;
 		for (typename T::list::it i = li->begin(); i != li->end(); ++i) {
 			T* rel = *i;
-			if (get_parent_of_relation(rel) == relating_object) {
-				IfcEntityList::ptr products = get_children_of_relation(rel);
-				products->push(related_object);
-				set_children_of_relation(rel, products);
-				found = true;
-				break;
-			}
+            try {
+                if (get_parent_of_relation(rel) == relating_object) {
+                    IfcEntityList::ptr products = get_children_of_relation(rel);
+                    products->push(related_object);
+                    set_children_of_relation(rel, products);
+                    found = true;
+                    break;
+                }
+            }
+            catch (...) { /* */ }
 		}
 		if (! found) {
 			if (! owner_hist) {

--- a/src/ifcparse/IfcSIPrefix.cpp
+++ b/src/ifcparse/IfcSIPrefix.cpp
@@ -73,8 +73,16 @@ double IfcParse::get_SI_equivalent(typename Schema::IfcNamedUnit* named_unit) {
 	return scale;
 }
 
+#if _MSC_VER < 1900
+template double IfcParse::get_SI_equivalent<Ifc2x3>(Ifc2x3::IfcNamedUnit* named_unit);
+template double IfcParse::get_SI_equivalent<Ifc4>(Ifc4::IfcNamedUnit* named_unit);
+template double IfcParse::get_SI_equivalent<Ifc4x1>(Ifc4x1::IfcNamedUnit* named_unit);
+template double IfcParse::get_SI_equivalent<Ifc4x2>(Ifc4x2::IfcNamedUnit* named_unit);
+template double IfcParse::get_SI_equivalent<Ifc4x3_rc1>(Ifc4x3_rc1::IfcNamedUnit* named_unit);
+#else
 template double IfcParse::get_SI_equivalent<Ifc2x3>(typename Ifc2x3::IfcNamedUnit* named_unit);
 template double IfcParse::get_SI_equivalent<Ifc4>(typename Ifc4::IfcNamedUnit* named_unit);
 template double IfcParse::get_SI_equivalent<Ifc4x1>(typename Ifc4x1::IfcNamedUnit* named_unit);
 template double IfcParse::get_SI_equivalent<Ifc4x2>(typename Ifc4x2::IfcNamedUnit* named_unit);
 template double IfcParse::get_SI_equivalent<Ifc4x3_rc1>(typename Ifc4x3_rc1::IfcNamedUnit* named_unit);
+#endif


### PR DESCRIPTION
IfcSiPrefix.cpp changes for MSVC 2013
IfcHierarchyHelper.h:176,185 changes in addRelatedObject about throw exception
exception comes from

ifcparse/IfcHierarchyHelper.h line 176 get_parent_of_relation(rel)
if (get_parent_of_relation(rel) == relating_object) {

ifcparse/IfcHierarchyHelper.h line 47
IfcUtil::IfcBaseClass* get_parent_of_relation(IfcUtil::IfcBaseClass* t)

ifcparse/IfcSchema.h
ptrdiff_t attribute_index(const std::string& attr_name) const {

ptrdiff_t index = -1;

-1 return but getArgument(..) Parameter is unsigned int
in the methode -1 is ca. 42123423423423 and throw IfcParse::IfcAttributeOutOfRangeException
we catch this exception and all works as expected and before in 0.5-rc1
