### PR TITLE
Fix collections deprecation warning

### DIFF
--- a/src/ifcblenderexport/occ_utils.py
+++ b/src/ifcblenderexport/occ_utils.py
@@ -25,7 +25,11 @@ import random
 import operator
 import warnings
 
-from collections import namedtuple, Iterable
+from collections import namedtuple
+try:  # python 3.3+
+    from collections.abc import Iterable
+except ModuleNotFoundError: # python 2
+    from collections import Iterable
 
 try:
     from OCC.Core import TopoDS, gp, Quantity, BRepTools 

--- a/src/ifcopenshell-python/ifcopenshell/geom/app.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/app.py
@@ -11,7 +11,11 @@ import multiprocessing
 
 import OCC.AIS
 
-from collections import defaultdict, Iterable, OrderedDict
+from collections import defaultdict, OrderedDict
+try:  # python 3.3+
+    from collections.abc import Iterable
+except ModuleNotFoundError: # python 2
+    from collections import Iterable
 
 try:
     QString = unicode

--- a/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
@@ -25,7 +25,11 @@ import random
 import operator
 import warnings
 
-from collections import namedtuple, Iterable
+from collections import namedtuple
+try:  # python 3.3+
+    from collections.abc import Iterable
+except ModuleNotFoundError: # python 2
+    from collections import Iterable
 
 try:
     from OCC.Core import V3d, TopoDS, gp, AIS, Quantity, BRepTools, Graphic3d


### PR DESCRIPTION
# What it solves
```python
ifcopenshell/geom/occ_utils.py:28
  /home/cyril/git/BIMxBEM/ifcopenshell/geom/occ_utils.py:28: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import namedtuple, Iterable
```
(see [python3 doc](https://docs.python.org/3/library/collections.html?highlight=collections#module-collections))
Note : python 3.9 final should be released on [05.10.2020](https://www.python.org/dev/peps/pep-0596/)
# Potential issues
Concerning python3 I think it is not an issue as python 3.3 is not supported anymore.
Concerning python2, there is still many `from __future__ import *`. This new code will probably fail using python2. Is it an issue as support for python2 has been dropped on 01.01.2020 ?