### PR TITLE
Fix #1013 - Visit Wiki goes direct to BlenderBIM OSArch Wiki pages

### DIFF
--- a/src/ifcblenderexport/blenderbim/bim/operator.py
+++ b/src/ifcblenderexport/blenderbim/bim/operator.py
@@ -2535,7 +2535,7 @@ class OpenUpstream(bpy.types.Operator):
         elif self.page == 'docs':
             webbrowser.open('https://blenderbim.org/docs/')
         elif self.page == 'wiki':
-            webbrowser.open('https://wiki.osarch.org/')
+            webbrowser.open('https://wiki.osarch.org/index.php?title=Category:BlenderBIM_Add-on')
         elif self.page == 'community':
             webbrowser.open('https://community.osarch.org/')
         return {'FINISHED'}


### PR DESCRIPTION
__Visit Wiki__ button should link to BlenderBIM pages.