### PR TITLE
[BlenderBIM] Import materials psets and display it

### DIFF
--- a/src/ifcblenderexport/blenderbim/bim/ui.py
+++ b/src/ifcblenderexport/blenderbim/bim/ui.py
@@ -700,6 +700,15 @@ class BIM_PT_material(Panel):
             row = layout.row(align=True)
             row.prop(pset, 'name', text='')
             row.operator('bim.remove_material_pset', icon='X', text='').pset_index = index
+            op = row.operator('bim.copy_property_to_selection', icon='COPYDOWN', text='')
+            for prop in pset.properties:
+                row = layout.row(align=True)
+                row.prop(prop, 'name', text='')
+                row.prop(prop, 'string_value', text='')
+                op = row.operator('bim.copy_property_to_selection', icon='COPYDOWN', text='')
+                op.pset_name = pset.name
+                op.prop_name = prop.name
+                op.prop_value = prop.string_value
 
         row = layout.row()
         row.prop(props, 'psets', text='')


### PR DESCRIPTION
Import psets similarly to objects.
Display in the UI similarly to objects.
Basic handling for ConstituentSet and MaterialList.