### PR TITLE
gcc and clang warning fixes

### DIFF
--- a/src/ifcgeom/IfcGeom.h
+++ b/src/ifcgeom/IfcGeom.h
@@ -224,6 +224,11 @@ private:
 	double modelling_precision;
 	double dimensionality;
 	double layerset_first;
+
+	// For stopping PlacementRelTo recursion in convert(const IfcSchema::IfcObjectPlacement* l, gp_Trsf& trsf)
+	const IfcParse::declaration* placement_rel_to;
+
+	faceset_helper* faceset_helper_;
 	gp_Vec offset = gp_Vec{0.0, 0.0, 0.0};
 	gp_Quaternion rotation = gp_Quaternion{};
 	gp_Trsf offset_and_rotation = gp_Trsf();
@@ -235,11 +240,6 @@ private:
 	std::map<int, SurfaceStyle> style_cache;
 
 	const SurfaceStyle* internalize_surface_style(const std::pair<IfcUtil::IfcBaseClass*, IfcUtil::IfcBaseClass*>& shading_style);
-
-	 // For stopping PlacementRelTo recursion in convert(const IfcSchema::IfcObjectPlacement* l, gp_Trsf& trsf)
-	const IfcParse::declaration* placement_rel_to;
-
-	faceset_helper* faceset_helper_;
 
 public:
 	MAKE_TYPE_NAME(Kernel)()

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -3767,23 +3767,6 @@ namespace {
 
 		operator int() { return i; }
 	};
-
-	inline std::string format_pnt(const gp_Pnt& p) {
-		std::stringstream ss;
-		ss << std::fixed << std::setprecision(4) << p.X() << " " << p.Y() << " " << p.Z();
-		return ss.str();
-	}
-
-	inline std::string format_edge(const TopoDS_Edge& e) {
-		std::stringstream ss;
-		TopoDS_Vertex v1, v2;
-		TopExp::Vertices(e, v1, v2);
-		gp_Pnt p1 = BRep_Tool::Pnt(v1);
-		gp_Pnt p2 = BRep_Tool::Pnt(v2);
-		ss << "edge " << format_pnt(p1) << " -> " << format_pnt(p2);
-		return ss.str();
-	}
-
 }
 
 bool IfcGeom::Kernel::wire_intersections(const TopoDS_Wire& wire, TopTools_ListOfShape& wires) {

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -2902,7 +2902,7 @@ namespace {
 			auto result_shape = split.Shape();
 			std::list<TopoDS_Shape> subs;
 			subshapes(result_shape, subs);
-			if (subs.size() == 1 && operands.Size() - 2 > subs.size() && (subs.front().ShapeType() == TopAbs_COMPSOLID || subs.front().ShapeType() == TopAbs_COMPOUND)) {
+			if (subs.size() == 1 && operands.Size() - 2 > (int)subs.size() && (subs.front().ShapeType() == TopAbs_COMPSOLID || subs.front().ShapeType() == TopAbs_COMPOUND)) {
 				auto s = subs.front();
 				subs.clear();
 				subshapes(s, subs);

--- a/src/ifcgeom/IfcGeomRepresentation.h
+++ b/src/ifcgeom/IfcGeomRepresentation.h
@@ -284,7 +284,6 @@ namespace IfcGeom {
 							BRepAdaptor_Curve crv(TopoDS::Edge(texp.Current()));
 							GCPnts_QuasiUniformDeflection tessellater(crv, settings().deflection_tolerance());
 							int n = tessellater.NbPoints();
-							int start = (int)_verts.size() / 3;
 							int previous = -1;
 							
 							for (int i = 1; i <= n; ++i) {

--- a/src/ifcgeom/IfcGeomShapes.cpp
+++ b/src/ifcgeom/IfcGeomShapes.cpp
@@ -1302,26 +1302,6 @@ namespace {
 		}
 	}
 
-	void segment_tiny_edges(const TopoDS_Wire& wire, std::vector<TopoDS_Wire>& wires, double eps) {
-		std::vector<TopoDS_Edge> sorted_edges;
-		sort_edges(wire, sorted_edges);
-
-		bool segment_next = true;
-
-		BRep_Builder B;
-		
-		for (const auto& e : sorted_edges) {
-			GProp_GProps prop;
-			BRepGProp::LinearProperties(e, prop);
-			const double l = prop.Mass();
-			if (l < eps || segment_next) {
-				wires.emplace_back();
-				B.MakeWire(wires.back());
-				segment_next = l < eps;
-			}
-			B.Add(wires.back(), e);
-		}
-	}
 
 	// #939: a closed loop causes failed triangulation in 7.3 and artefacts
 	// in 7.4 so we break up a closed wire into two equal parts.
@@ -1335,12 +1315,11 @@ namespace {
 		}
 
 		BRep_Builder B;
-		double u, v;
 
 		wires.emplace_back();
 		B.MakeWire(wires.back());
 
-		for (int i = 0; i < sorted_edges.size(); ++i) {
+		for (uint i = 0; i < sorted_edges.size(); ++i) {
 			if (i == sorted_edges.size() / 2) {
 				wires.emplace_back();
 				B.MakeWire(wires.back());

--- a/src/ifcgeom/IfcGeomWires.cpp
+++ b/src/ifcgeom/IfcGeomWires.cpp
@@ -100,13 +100,7 @@
 #define Kernel MAKE_TYPE_NAME(Kernel)
 
 namespace {
-	// Returns the other vertex of an edge
-	TopoDS_Vertex other(const TopoDS_Edge& e, const TopoDS_Vertex& v) {
-		TopoDS_Vertex a, b;
-		TopExp::Vertices(e, a, b);
-		return v.IsSame(b) ? a : b;
-	}
-
+	// Returns the first edge of a wire
 	TopoDS_Edge first_edge(const TopoDS_Wire& w) {
 		TopoDS_Vertex v1, v2;
 		TopExp::Vertices(w, v1, v2);

--- a/src/ifcgeom/IfcGeomWires.cpp
+++ b/src/ifcgeom/IfcGeomWires.cpp
@@ -775,7 +775,7 @@ namespace {
 		BRepBuilderAPI_MakeEdge me(crv, v1, v2);
 		if (!me.IsDone()) {
 			const double eps2 = eps * eps;
-			if (me.Error() == BRepLib_PointProjectionFailed) {
+			if (me.Error() == BRepBuilderAPI_PointProjectionFailed) {
 				GeomAdaptor_Curve GAC(crv);
 				const gp_Pnt* ps[2] = { &p1, &p2 };
 				for (int i = 0; i < 2; ++i) {

--- a/src/ifcgeomserver/IfcGeomServer.cpp
+++ b/src/ifcgeomserver/IfcGeomServer.cpp
@@ -366,7 +366,7 @@ protected:
 			std::vector<float> diffuse_color_array_condensed;
 			
 			int new_index = 0;
-			for (int orig = 0; orig < diffuse_color_array.size(); ++orig) {
+			for (uint orig = 0; orig < diffuse_color_array.size(); ++orig) {
 				auto& m = diffuse_color_array[orig];
 				if (m) {
 					for (int i = 0; i < 4; ++i) {

--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -461,7 +461,7 @@ void SvgSerializer::write(const geometry_data& data) {
 			Logger::Error(e);
 		}
 
-		if (operation_type && (*operation_type == "SINGLE_SWING_LEFT") || (*operation_type == "SINGLE_SWING_RIGHT")) {
+		if (operation_type && ((*operation_type == "SINGLE_SWING_LEFT") || (*operation_type == "SINGLE_SWING_RIGHT"))) {
 			const bool is_left = *operation_type == "SINGLE_SWING_LEFT";
 
 			Bnd_Box bb;

--- a/src/serializers/SvgSerializer.h
+++ b/src/serializers/SvgSerializer.h
@@ -118,18 +118,18 @@ protected:
 	boost::optional<std::vector<section_data>> deferred_section_data_;
 	boost::optional<double> scale_, calculated_scale_, center_x_, center_y_;
 
-	bool rescale, print_space_names_, print_space_areas_, draw_door_arcs_;
-	bool with_section_heights_from_storey_, buffer_elements_;
-	bool is_floor_plan_;
+	bool with_section_heights_from_storey_, rescale, print_space_names_, print_space_areas_;
+	bool draw_door_arcs_, buffer_elements_, is_floor_plan_;
 
+	IfcParse::IfcFile* file;
+	IfcUtil::IfcBaseEntity* storey_;
 	std::multimap<drawing_key, path_object, storey_sorter> paths;
 
 	float_item_list xcoords, ycoords, radii;
 	size_t xcoords_begin, ycoords_begin, radii_begin;
 
 	boost::optional<std::string> section_ref_, elevation_ref_;
-	IfcParse::IfcFile* file;
-	IfcUtil::IfcBaseEntity* storey_;
+	
 	std::list<geometry_data> element_buffer_;
 
 	Handle(HLRBRep_Algo) hlr;


### PR DESCRIPTION
Fix a bunch of compiler warnings occurring on Ubuntu Linux 18.04 and higher (both gcc and clang). commits are atomic and can be cherry-picked if ever the PR is not merged. Tested with opencascade 7.4.0 and 7.4.0p1