### PR TITLE
apply matrix to object in BlenderClasher

### DIFF
--- a/src/ifcblenderexport/blenderbim/bim/operator.py
+++ b/src/ifcblenderexport/blenderbim/bim/operator.py
@@ -4778,11 +4778,10 @@ class BlenderClasher:
             name = object_name.name
             obj = bpy.data.objects[name]
             triangulated_mesh = self.triangulate_mesh(obj)
-            mat = np.array(obj.matrix_world)
             mesh = ifcclash.Mesh()
-            mesh.vertices = np.array([tuple(v.co) for v in triangulated_mesh.vertices])
+            mesh.vertices = np.array([tuple(obj.matrix_world @ v.co) for v in triangulated_mesh.vertices])
             mesh.faces = np.array([tuple(p.vertices) for p in triangulated_mesh.polygons])
-            cm.add_object(name, mesh, mat)
+            cm.add_object(name, mesh)
 
     def triangulate_mesh(self, obj):
         import bmesh


### PR DESCRIPTION
Since scale is not supported in fcl upstream as found in https://github.com/IfcOpenShell/IfcOpenShell/issues/1129