### PR TITLE
Selection representation context

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -169,7 +169,8 @@ struct inclusion_filter : public geom_filter { inclusion_filter() : geom_filter(
 struct inclusion_traverse_filter : public geom_filter { inclusion_traverse_filter() : geom_filter(true, true) {} };
 struct exclusion_filter : public geom_filter { exclusion_filter() : geom_filter(false, false) {} };
 struct exclusion_traverse_filter : public geom_filter { exclusion_traverse_filter() : geom_filter(false, true) {} };
-struct geometricRepresentationContext_filter : public geom_filter { geometricRepresentationContext_filter() : geom_filter(true, false) {} };
+//struct geometricRepresentationContext_filter : public geom_filter { geometricRepresentationContext_filter() : geom_filter(true, false) {} };
+std::vector<std::string> include_geometricRepresentationContext_filter;
 
 size_t read_filters_from_file(const std::string&, inclusion_filter&, inclusion_traverse_filter&, exclusion_filter&, exclusion_traverse_filter&);
 void parse_filter(geom_filter &, const std::vector<std::string>&);
@@ -184,6 +185,20 @@ struct verbosity_counter {
 		count = c;
 	}
 };
+
+bool initialize_iterator(IfcGeom::Iterator<real_t> &localIterator)
+{
+	if (!include_geometricRepresentationContext_filter.empty())
+	{
+		std::set<std::string> tempSet;
+		tempSet.insert(include_geometricRepresentationContext_filter.begin(), include_geometricRepresentationContext_filter.end());
+		return localIterator.initialize(tempSet);
+	}
+	else
+	{
+		return localIterator.initialize();
+	}
+}
 
 #if defined(_MSC_VER) && defined(_UNICODE)
 int wmain(int argc, wchar_t** argv) {
@@ -203,7 +218,6 @@ int main(int argc, char** argv) {
 	inclusion_traverse_filter include_traverse_filter;
 	exclusion_filter exclude_filter;
 	exclusion_traverse_filter exclude_traverse_filter;
-	geometricRepresentationContext_filter include_geometricRepresentationContext_filter;
 	path_t filter_filename;
 	path_t default_material_filename;
 	path_t log_file;
@@ -306,7 +320,7 @@ int main(int argc, char** argv) {
 			"2) 'layers': the instances that are assigned to presentation layers of which names "
 			"match the given values should be included.\n"
 			"3) 'attribute <AttributeName>': products whose value for <AttributeName> should be included\n. "
-				"Currently supported arguments are GlobalId, Name, Description, and Tag.\n\n"
+			"Currently supported arguments are GlobalId, Name, Description, and Tag.\n\n"
 			"The values for 'layers' and 'arg' are handled case-sensitively (wildcards supported)."
 			"--include and --exclude cannot be placed right before input file argument and "
 			"only single of each argument supported for now. See also --exclude.")
@@ -320,9 +334,10 @@ int main(int argc, char** argv) {
 		("exclude+", po::value<exclusion_traverse_filter>(&exclude_traverse_filter)->multitoken(),
 			"Same as --exclude but applies filtering also to the decomposition and/or containment "
 			"of the filtered entity. See --include+ for more details.")
-		("geometricRepresentationContext", po::value<geometricRepresentationContext_filter>(&include_geometricRepresentationContext_filter)->multitoken(),
-				"Select the IfcGeometricRepresentation(Sub)Context for the geometries, which shall be exported. "
-				"If empty, all contexts are used for export.")
+		("geometricRepresentationContext", po::value<std::vector<std::string>>(&include_geometricRepresentationContext_filter)->multitoken(),
+				"Select the IfcGeometricRepresentation(Sub)Contexts for the geometries, which shall be exported. "
+				"All selected constexts must be of type 'model'. Includes all subcontexts. "
+				"If empty, all contexts of type 'model' are used for export.")
 		("filter-file", new po::typed_value<path_t, char_t>(&filter_filename),
 			"Specifies a filter file that describes the used filtering criteria. Supported formats "
 			"are '--include=arg GlobalId ...' and 'include arg GlobalId ...'. Spaces and tabs can be used as delimiters."
@@ -875,30 +890,17 @@ int main(int argc, char** argv) {
 			}*/
 
 			if (center_model_geometry) {
-				if (!include_geometricRepresentationContext_filter.values.empty())
-				{
-					if (tmp_context_iterator.initialize(include_geometricRepresentationContext_filter.values)) {
-						/// @todo It would be nice to know and print separate error prints for a case where we found no entities
-						/// and for a case we found no entities that satisfy our filtering criteria.
-						Logger::Notice("No geometrical elements found or none succesfully converted. "
-							"Check the Name of the geometric representation context");
-						serializer.reset();
-						IfcUtil::path::delete_file(IfcUtil::path::to_utf8(output_temp_filename));
-						write_log(!quiet);
-						return EXIT_FAILURE;
-					}
-				}
-				else
-				{
-					if (!tmp_context_iterator.initialize()) {
-						/// @todo It would be nice to know and print separate error prints for a case where we found no entities
-						/// and for a case we found no entities that satisfy our filtering criteria.
-						Logger::Notice("No geometrical elements found or none succesfully converted");
-						serializer.reset();
-						IfcUtil::path::delete_file(IfcUtil::path::to_utf8(output_temp_filename));
-						write_log(!quiet);
-						return EXIT_FAILURE;
-					}
+				std::set<std::string> tempSet;
+				tempSet.insert(include_geometricRepresentationContext_filter.begin (), include_geometricRepresentationContext_filter.end());
+				if (!initialize_iterator(tmp_context_iterator)) {
+					/// @todo It would be nice to know and print separate error prints for a case where we found no entities
+					/// and for a case we found no entities that satisfy our filtering criteria.
+					Logger::Notice("No geometrical elements found or none succesfully converted. "
+						"Check the Name of the geometric representation context");
+					serializer.reset();
+					IfcUtil::path::delete_file(IfcUtil::path::to_utf8(output_temp_filename));
+					write_log(!quiet);
+					return EXIT_FAILURE;
 				}
 			}
 		
@@ -926,7 +928,7 @@ int main(int argc, char** argv) {
     }
 
 	IfcGeom::Iterator<real_t> context_iterator(settings, ifc_file, filter_funcs, num_threads);
-    if (!context_iterator.initialize()) {
+    if (!initialize_iterator(context_iterator)) {
         /// @todo It would be nice to know and print separate error prints for a case where we found no entities
         /// and for a case we found no entities that satisfy our filtering criteria.
         Logger::Notice("No geometrical elements found or none succesfully converted");
@@ -1235,12 +1237,10 @@ void parse_filter(geom_filter &filter, const std::vector<std::string>& values)
         filter.type = geom_filter::ENTITY_TYPE;
     } else if (type == "layers") {
         filter.type = geom_filter::LAYER_NAME;
-	}
-	else if (type == "attribute" || type == "arg") {
-		filter.type = geom_filter::ENTITY_ARG;
-		filter.arg = *(values.begin() + 1);
-	}
-	else {
+    } else if (type == "attribute" || type == "arg") {
+        filter.type = geom_filter::ENTITY_ARG;
+        filter.arg = *(values.begin() + 1);
+    } else {
         throw po::validation_error(po::validation_error::invalid_option_value);
     }
     filter.values.insert(values.begin() + (filter.type == geom_filter::ENTITY_ARG ? 2 : 1), values.end());
@@ -1428,7 +1428,7 @@ void fix_quantities(IfcParse::IfcFile& f, bool no_progress, bool quiet, bool std
 
 	IfcGeom::Iterator<double> context_iterator(settings, &f);
 
-	if (!context_iterator.initialize()) {
+	if (!initialize_iterator(context_iterator)) {
 		return;
 	}
 

--- a/src/ifcgeom/IfcGeomIteratorImplementation.h
+++ b/src/ifcgeom/IfcGeomIteratorImplementation.h
@@ -184,6 +184,7 @@ namespace IfcGeom {
 		std::vector<IfcGeom::BRepElement<P, PP>*> all_processed_native_elements_;
 		typename std::vector<IfcGeom::Element<P, PP>*>::const_iterator task_result_iterator_;
 		typename std::vector<IfcGeom::BRepElement<P, PP>*>::const_iterator native_task_result_iterator_;
+		std::set<std::string> allowed_context_identifiers;
 
 		MAKE_TYPE_NAME(IteratorImplementation_)(const MAKE_TYPE_NAME(IteratorImplementation_)&); // N/I
 		MAKE_TYPE_NAME(IteratorImplementation_)& operator=(const MAKE_TYPE_NAME(IteratorImplementation_)&); // N/I
@@ -248,6 +249,11 @@ namespace IfcGeom {
 
 		boost::optional<bool> initialization_outcome_;
 
+		bool initialize(std::set<std::string> allowed_context_ids) {
+			allowed_context_identifiers.insert(allowed_context_ids.begin(), allowed_context_ids.end());
+			return initialize();
+		}
+
 		bool initialize() {
 			if (initialization_outcome_) {
 				return *initialization_outcome_;
@@ -308,7 +314,12 @@ namespace IfcGeom {
 							Logger::Warning(std::string("ContextType '") + context->ContextType() + "' not allowed:", context);
 						}
 						if (context_types.find(context_type) != context_types.end()) {
-							filtered_contexts->push(context);
+							std::string context_name = context->ContextIdentifier();
+							if (allowed_context_identifiers.empty()
+								|| allowed_context_identifiers.find(context_name) != allowed_context_identifiers.end())
+							{
+								filtered_contexts->push(context);
+							}
 						}
 					}
 				} catch (const std::exception& e) {

--- a/src/ifcgeom/IfcGeomIteratorImplementation.h
+++ b/src/ifcgeom/IfcGeomIteratorImplementation.h
@@ -313,9 +313,10 @@ namespace IfcGeom {
 						if (allowed_context_types.find(context_type) == allowed_context_types.end()) {
 							Logger::Warning(std::string("ContextType '") + context->ContextType() + "' not allowed:", context);
 						}
+
 						if (context_types.find(context_type) != context_types.end()) {
 							std::string context_name = context->ContextIdentifier();
-							if (allowed_context_identifiers.empty()
+							if (allowed_context_identifiers.empty()	 //Additional filtering if user aims for special context
 								|| allowed_context_identifiers.find(context_name) != allowed_context_identifiers.end())
 							{
 								filtered_contexts->push(context);
@@ -341,19 +342,32 @@ namespace IfcGeom {
 			for (it = filtered_contexts->begin(); it != filtered_contexts->end(); ++it) {
 				IfcSchema::IfcGeometricRepresentationContext* context = *it;
 
-				representations->push(context->RepresentationsInContext());
-				try {
-					if (context->hasPrecision() && context->Precision() < lowest_precision_encountered) {
-						lowest_precision_encountered = context->Precision();
-						any_precision_encountered = true;
+				std::string context_name = context->ContextIdentifier();
+				if (allowed_context_identifiers.empty() //Additional filtering if user aims for special context
+					|| allowed_context_identifiers.find(context_name) != allowed_context_identifiers.end())
+				{
+					representations->push(context->RepresentationsInContext());
+					try {
+						if (context->hasPrecision() && context->Precision() < lowest_precision_encountered) {
+							lowest_precision_encountered = context->Precision();
+							any_precision_encountered = true;
+						}
 					}
-				} catch (const std::exception& e) {
-					Logger::Error(e);
+					catch (const std::exception& e) {
+						Logger::Error(e);
+					}
 				}
-
+				
+				//Hier muss eingegriffen werden. Falls eine Liste mit erlaubten Kontexten übergeben --> Filtern
 				IfcSchema::IfcGeometricRepresentationSubContext::list::ptr sub_contexts = context->HasSubContexts();
 				for (jt = sub_contexts->begin(); jt != sub_contexts->end(); ++jt) {
-					representations->push((*jt)->RepresentationsInContext());
+					std::string sub_context_name = (*jt)->ContextIdentifier();
+					if (allowed_context_identifiers.empty()
+						|| allowed_context_identifiers.find(context_name) != allowed_context_identifiers.end()
+						|| allowed_context_identifiers.find(sub_context_name) != allowed_context_identifiers.end())
+					{
+						representations->push((*jt)->RepresentationsInContext());
+					}
 				}
 				// There is no need for full recursion as the following is governed by the schema:
 				// WR31: The parent context shall not be another geometric representation sub context. 

--- a/src/ifcgeom_schema_agnostic/IfcGeomIterator.h
+++ b/src/ifcgeom_schema_agnostic/IfcGeomIterator.h
@@ -40,7 +40,7 @@
  *     orientation and translation of the mesh in relation to the world origin  *
  *                                                                              *
  * IfcGeom::Iterator::initialize()                                              *
- *   finds the most suitable representation contexts. Returns true iff          *
+ *   finds the most suitable representation contexts. Returns true if           *
  *   at least a single representation will process successfully                 *
  *                                                                              *
  * IfcGeom::Iterator::get()                                                     *
@@ -112,6 +112,15 @@ namespace IfcGeom {
 			if (implementation_) {
 				return implementation_->initialize();
 			} else {
+				return false;
+			}
+		}
+
+		bool initialize(std::set<std::string> allowed_context_ids) {
+			if (implementation_) {
+				return implementation_->initialize(allowed_context_ids);
+			}
+			else {
 				return false;
 			}
 		}

--- a/src/ifcgeom_schema_agnostic/IteratorImplementation.h
+++ b/src/ifcgeom_schema_agnostic/IteratorImplementation.h
@@ -62,6 +62,7 @@ namespace IfcGeom {
 	class IteratorImplementation {
 	public:
 		virtual bool initialize() = 0;
+		virtual bool initialize(std::set<std::string> allowed_context_ids) = 0;
 		virtual void compute_bounds(bool with_geometry) = 0;
 		virtual const gp_XYZ& bounds_min() const = 0;
 		virtual const gp_XYZ& bounds_max() const = 0;

--- a/src/ifcgeom_schema_agnostic/Kernel.cpp
+++ b/src/ifcgeom_schema_agnostic/Kernel.cpp
@@ -207,7 +207,25 @@ namespace {
 		}
 		return layers;
 	}
+
+	template <typename Schema>
+	static std::map<std::string, IfcUtil::IfcBaseEntity*> get_representationContext_impl(typename Schema::IfcProduct* prod) {
+		std::map<std::string, IfcUtil::IfcBaseEntity*> representationContexts;
+		if (prod->hasRepresentation()) {
+			IfcEntityList::ptr r = IfcParse::traverse(prod->Representation());
+			typename Schema::IfcRepresentation::list::ptr representations = r->as<typename Schema::IfcRepresentation>();
+			for (typename Schema::IfcRepresentation::list::it it = representations->begin(); it != representations->end(); ++it) {
+				typename Schema::IfcPresentationLayerAssignment::list::ptr a = (*it)->LayerAssignments();
+				for (typename Schema::IfcPresentationLayerAssignment::list::it jt = a->begin(); jt != a->end(); ++jt) {
+					representationContexts[(*jt)->Name()] = *jt;
+				}
+			}
+		}
+		return representationContexts;
+	}
 }
+
+
 
 std::map<std::string, IfcUtil::IfcBaseEntity*> IfcGeom::Kernel::get_layers(IfcUtil::IfcBaseEntity* inst) {
 	if (inst->as<Ifc2x3::IfcProduct>()) {
@@ -221,6 +239,27 @@ std::map<std::string, IfcUtil::IfcBaseEntity*> IfcGeom::Kernel::get_layers(IfcUt
 	} else if (inst->as<Ifc4x3_rc1::IfcProduct>()) {
 		return get_layers_impl<Ifc4x3_rc1>(inst->as<Ifc4x3_rc1::IfcProduct>());
 	} else {
+		throw IfcParse::IfcException("Unexpected entity " + inst->declaration().name());
+	}
+}
+
+std::map<std::string, IfcUtil::IfcBaseEntity*> IfcGeom::Kernel::get_representationContexts(IfcUtil::IfcBaseEntity* inst) {
+	if (inst->as<Ifc2x3::IfcProduct>()) {
+		return get_layers_impl<Ifc2x3>(inst->as<Ifc2x3::IfcProduct>());
+	}
+	else if (inst->as<Ifc4::IfcProduct>()) {
+		return get_layers_impl<Ifc4>(inst->as<Ifc4::IfcProduct>());
+	}
+	else if (inst->as<Ifc4x1::IfcProduct>()) {
+		return get_layers_impl<Ifc4x1>(inst->as<Ifc4x1::IfcProduct>());
+	}
+	else if (inst->as<Ifc4x2::IfcProduct>()) {
+		return get_layers_impl<Ifc4x2>(inst->as<Ifc4x2::IfcProduct>());
+	}
+	else if (inst->as<Ifc4x3_rc1::IfcProduct>()) {
+		return get_layers_impl<Ifc4x3_rc1>(inst->as<Ifc4x3_rc1::IfcProduct>());
+	}
+	else {
 		throw IfcParse::IfcException("Unexpected entity " + inst->declaration().name());
 	}
 }

--- a/src/ifcgeom_schema_agnostic/Kernel.h
+++ b/src/ifcgeom_schema_agnostic/Kernel.h
@@ -90,6 +90,7 @@ namespace IfcGeom {
 		static bool is_manifold(const TopoDS_Shape& a);
 		static IfcUtil::IfcBaseEntity* get_decomposing_entity(IfcUtil::IfcBaseEntity*, bool include_openings=true);
 		static std::map<std::string, IfcUtil::IfcBaseEntity*> get_layers(IfcUtil::IfcBaseEntity*);
+		static std::map<std::string, IfcUtil::IfcBaseEntity*> get_representationContexts(IfcUtil::IfcBaseEntity*);
 	};
 
 	namespace impl {

--- a/win/readme.md
+++ b/win/readme.md
@@ -8,6 +8,16 @@ another batch file, and/or while the Visual Studio ("MSVC") environment variable
 files that can also be invoked e.g. by double-clicking in the File Explorer. `.sh` files are for MSYS**2** + MinGW ("MSYS"
 ) compilation.
 
+## Recommendations for building
+
+To build IfcOpenShell, we recommend the following software:
+
+- [Git](https://git-scm.com/downloads)
+- [CMake 3.19](https://cmake.org/files/v3.19/)
+- [Visual Studio 2017](https://my.visualstudio.com/Downloads?q=visual%20studio%202017&wt.mc_id=o~msft~vscom~older-downloads) with C++ Workload (see Visual Studio Installer)
+- Windows Powershell (shipped with Windows 8 and newer)
+- Windows SDK 10.0.18362 (See Visual Studio Installer)
+
 Usage Instructions
 ------------------
 ### MSYS
@@ -18,7 +28,7 @@ of the shell scripts before using them. Note that contrary to MSVC, with MSYS al
 built or used as static libraries. Currently Release build is used for all libraries.
 
 ### MSVC
-Execute `build-deps.cmd` to fetch, build and install the dependencies. The batch file will print the requirements for
+Use the `Developer Command prompt for Visual Studio 2017` to execute all mentioned commands. This command prompt comes together with Visual Studio and inherits all necessary environment variables. Execute `build-deps.cmd` to fetch, build and install the dependencies. The batch file will print the requirements for
 a successful execution. The script allows a few user-configurable build options which are listed in the usage
 instructions. Either edit the script file or set these values before running the script.
 
@@ -29,15 +39,29 @@ deduced from the MSVC environment variables. User-friendly VS generator shorthan
 (`Build`, `Rebuild`, or `Clean`, defaults to `Build`) can be provided as `%3`. See `vs-cfg.cmd` if you wish to change
 the defaults. The batch file will create `deps\` and `deps-vs<VERSION>-<ARCHITECTURE>-installed\` directories to the
 project root. Debug and release builds of the dependencies can co-exist by simply running
+
 ```
 > build-deps.cmd <GENERATOR> Debug
 > build-deps.cmd <GENERATOR> <Release|RelWithDebInfo|MinSizeRel>
+```
+
+If you want to build IfcOpenShell 32 bit release with Visual Studio 2017 with MSVC use the following command line
+
+```
+> build-deps.cmd "Visual Studio 15 2017" Release
+```
+
+Use the next command line below if you need the 64 bit version
+
+```
+> build-deps.cmd "Visual Studio 15 2017 Win64" Release
 ```
 
 After the dependencies are build, execute `run-cmake.bat`. The batch file expects a CMake generator as `%1` and the
 rest of possible parameters are passed as is. If a generator is not provided, the generator is read from the
 BuildDepsCache file, or tried to be deduced from the location of `cl.exe`. If passing build options for the script,
 the generator must be always passed as the first option:
+
 ```
 > run-cmake.bat vs2015-x64 -DUSE_IFC4=1 -DBUILD_IFCPYTHON=0
 ```
@@ -55,6 +79,12 @@ files expect `%1` and `%2` in same fashion as above and possible extra parameter
 `run-cmake.bat`, `build-ifcopenshell.bat`, and `install-ifcopenshell.bat` can also be directly invoked from Filer Explorer
 or regular Command Prompt if BuildDepsCache file exists (the last modified version is used). Running the scripts without extra
 parameters reads the build options from an existing CMakeCache.txt.
+
+You can use the command line below to Build the IfcOpenShell.
+
+```
+> build-ifcopenshell.bat "Visual Studio 15 2017 Win 64" Release
+```
 
 The project will be installed to `installed-vs<VERSION>-<ARCHITECTURE>\` folder in the project's root folder and the
 required IfcOpenShell-Python parts are deployed to the `<PYTHONHOME>\Lib\site-packages\` folder. The 3ds Max plug-in,


### PR DESCRIPTION
For the translation of ifc files to others, the selection of the geometry context would be helpful. The idea is to select the geometry representation context(s) by their ID(s). Hence, I have added this option to the `IfcConverter`. 

In short, I have extended the `initialize` method `IfcGeom:Iterator` with an overload that it takes a set of strings as argument. During the initialization this set of geometry representation names is respected to select related representations.