### PR TITLE
Use lru_cache for pset module

### DIFF
--- a/src/ifcblenderexport/blenderbim/bim/import_ifc.py
+++ b/src/ifcblenderexport/blenderbim/bim/import_ifc.py
@@ -1382,8 +1382,9 @@ class IfcImporter:
     def add_pset(self, pset, props):
         new_pset = props.psets.add()
         new_pset.name = pset.Name
-        if new_pset.name in schema.ifc.psetqto.psets:
-            for prop_name in schema.ifc.psetqto.psets[new_pset.name]["HasPropertyTemplates"].keys():
+        pset_template = schema.ifc.psetqto.get_by_name(new_pset.name)
+        if pset_template:
+            for prop_name in (p.Name for p in pset_template.HasPropertyTemplates):
                 prop = new_pset.properties.add()
                 prop.name = prop_name
         try:
@@ -1409,8 +1410,9 @@ class IfcImporter:
     def add_qto(self, qto, obj):
         new_qto = obj.BIMObjectProperties.qtos.add()
         new_qto.name = str(qto.Name)
-        if new_qto.name in schema.ifc.psetqto.qtos:
-            for prop_name in schema.ifc.psetqto.qtos[new_qto.name]["HasPropertyTemplates"].keys():
+        qto_template = schema.ifc.psetqto.get_by_name(new_qto.name)
+        if qto_template:
+            for prop_name in (p.Name for p in qto_template.HasPropertyTemplates):
                 prop = new_qto.properties.add()
                 prop.name = prop_name
         for prop in qto.Quantities:

--- a/src/ifcblenderexport/blenderbim/bim/schema.py
+++ b/src/ifcblenderexport/blenderbim/bim/schema.py
@@ -30,7 +30,7 @@ class IfcSchema:
 
         self.property_files = []
         property_paths = self.data_dir.joinpath("pset").glob("*.ifc")
-        self.psetqto = ifcopenshell.util.pset.PsetQto("IFC4", use_cache=True)
+        self.psetqto = ifcopenshell.util.pset.PsetQto("IFC4")
         for path in property_paths:
             self.psetqto.templates.append(ifcopenshell.open(path))
 

--- a/src/ifcopenshell-python/ifcopenshell/util/pset.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/pset.py
@@ -1,6 +1,7 @@
 import pathlib
 import re
-from typing import List, Generator
+from functools import lru_cache
+from typing import List, Generator, Optional
 
 import ifcopenshell
 from ifcopenshell.entity_instance import entity_instance
@@ -11,34 +12,15 @@ class PsetQto:
         "IFC4": "Pset_IFC4_ADD2.ifc",
     }
 
-    def __init__(self, schema: str, templates=None, use_cache=False) -> None:
+    def __init__(self, schema: str, templates=None) -> None:
         self.schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema)
         if not templates:
             folder_path = pathlib.Path(__file__).parent.absolute()
             path = folder_path.joinpath("schema", self.templates_path[schema])
             templates = [ifcopenshell.open(path)]
         self.templates = templates
-        # Caching reduce request time. For 100 get_applicable_names requests ~3.6 s -> ~2 s
-        self.use_cache = use_cache
-        self.psets = {}
-        self.qtos = {}
-        self.applicable_psets = {}
-        self.applicable_qtos = {}
-        if use_cache:
-            for template in templates:
-                self.cache_template(template)
 
-    def cache_template(self, template):
-        for prop_set in template.by_type("IfcPropertySetTemplate"):
-            if prop_set.Name[0:4] == "Qto_":
-                self.qtos[prop_set.Name] = {"HasPropertyTemplates": {p.Name: p for p in prop_set.HasPropertyTemplates}}
-                entity = prop_set.ApplicableEntity if prop_set.ApplicableEntity else "IfcRoot"
-                self.applicable_qtos.setdefault(entity, []).append(prop_set.Name)
-            else:
-                self.psets[prop_set.Name] = {"HasPropertyTemplates": {p.Name: p for p in prop_set.HasPropertyTemplates}}
-                entity = prop_set.ApplicableEntity if prop_set.ApplicableEntity else "IfcRoot"
-                self.applicable_psets.setdefault(entity, []).append(prop_set.Name)
-
+    @lru_cache
     def get_applicable(
         self, ifc_class="", predefined_type="", pset_only=False, qto_only=False
     ) -> Generator[entity_instance, entity_instance, None]:
@@ -58,22 +40,9 @@ class PsetQto:
 
     def get_applicable_names(self, ifc_class: str, predefined_type="", pset_only=False, qto_only=False) -> List[str]:
         """Return names instead of objects for other use eg. enum"""
-        if self.use_cache:
-            results = []
-            entity = self.schema.declaration_by_name(ifc_class)
-            if not qto_only:
-                for applicable_class, pset_names in self.applicable_psets.items():
-                    if self.is_applicable(entity, applicable_class):
-                        results.extend(pset_names)
-            if not pset_only:
-                for applicable_class, pset_names in self.applicable_qtos.items():
-                    if self.is_applicable(entity, applicable_class):
-                        results.extend(pset_names)
-            return results
-
         return [prop_set.Name for prop_set in self.get_applicable(ifc_class, predefined_type, pset_only, qto_only)]
 
-    def is_applicable(self, entity: entity_instance, applicables: str, predefined_type=""):
+    def is_applicable(self, entity: entity_instance, applicables: str, predefined_type="") -> bool:
         """applicables can have multiple possible patterns :
         IfcBoilerType                               (IfcClass)
         IfcBoilerType/STEAM                         (IfcClass/PREDEFINEDTYPE)
@@ -95,3 +64,14 @@ class PsetQto:
             if entity.supertype():
                 return self.is_applicable(entity.supertype(), applicable_class)
         return False
+
+    @lru_cache
+    def get_by_name(self, name: str) -> Optional[entity_instance]:
+        for template in self.templates:
+            for prop_set in template.by_type("IfcPropertySetTemplate"):
+                if prop_set.Name == name:
+                    return prop_set
+        return None
+
+    def is_templated(self, name: str) -> bool:
+        return bool(self.get_by_name(name))


### PR DESCRIPTION
New features
===========
* `get_by_name` : get pset template by name
* `is_templated` : allow to check if a pset template correspond to given name

Enhancement
============
* Use of lru_cache simplify code and enhance performance largely
(10+ times more requests in 4 less time)
kudo to aothms for the idea. See https://github.com/IfcOpenShell/IfcOpenShell/pull/1221#issuecomment-752902996.
* Take advantages of new caching system and new features in blenderbim

Known issues
===========
* For some reason pset enum is not correctly filled.
It looks like `getPsetNames` is triggered multiple time when you press `Assign IFC Class` and works correctly only the first time.