### PR TITLE
Automated Blenderbim releases using github actions ci

### DIFF
--- a/.github/workflows/ci-blenderbim-matrix.yml
+++ b/.github/workflows/ci-blenderbim-matrix.yml
@@ -10,7 +10,6 @@ env:
   major: 0
   minor: 0
   name: blenderbim
-  pyver: py37
 
 jobs:
   activate:
@@ -23,11 +22,12 @@ jobs:
       run: echo ok go
 
   build:
-    name: ${{ matrix.config.name }}
+    name: ${{ matrix.config.name }}-${{ matrix.pyver }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        pyver: [py37, py39]
         config:
           - {
             name: "Windows Build",
@@ -53,15 +53,15 @@ jobs:
         run: echo "::set-output name=date::$(date +'%y%m%d')"
       - name: Compile
         run: |
-          cp -r src/ifcblenderexport src/ifcblenderexport_${{ matrix.config.short_name }} &&
-          cd src/ifcblenderexport_${{ matrix.config.short_name }} &&
-          make dist PLATFORM=${{ matrix.config.short_name }} PYVERSION=${{ env.pyver }}
+          cp -r src/ifcblenderexport src/ifcblenderexport_${{ matrix.config.short_name }}_${{ matrix.pyver }} &&
+          cd src/ifcblenderexport_${{ matrix.config.short_name }}_${{ matrix.pyver }} &&
+          make dist PLATFORM=${{ matrix.config.short_name }} PYVERSION=${{ matrix.pyver }}
       - name: Upload Zip file to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: src/ifcblenderexport_${{ matrix.config.short_name }}/dist/blender28-bim-${{steps.date.outputs.date}}-${{ env.pyver }}-${{ matrix.config.short_name }}.zip
-          asset_name: blender28-bim-${{steps.date.outputs.date}}-${{ env.pyver }}-${{ matrix.config.short_name }}.zip
+          file: src/ifcblenderexport_${{ matrix.config.short_name }}_${{ matrix.pyver }}/dist/blender28-bim-${{steps.date.outputs.date}}-${{ matrix.pyver }}-${{ matrix.config.short_name }}.zip
+          asset_name: blender28-bim-${{steps.date.outputs.date}}-${{ matrix.pyver }}-${{ matrix.config.short_name }}.zip
           tag: "blenderbim-${{steps.date.outputs.date}}"
           overwrite: true
           body: "Package release blenderbim-${{steps.date.outputs.date}}"

--- a/.github/workflows/ci-blenderbim-matrix.yml
+++ b/.github/workflows/ci-blenderbim-matrix.yml
@@ -15,8 +15,8 @@ jobs:
   activate:
     runs-on: ubuntu-latest
     if: |
-      github.repository == 'krande/IfcOpenShell' &&
-      !contains(github.event.head_commit.message, '[skip ci]')
+      github.repository == 'IfcOpenShell/IfcOpenShell' &&
+      contains(github.event.head_commit.message, '[Release]')
     steps:
     - name: Set env
       run: echo ok go

--- a/.github/workflows/ci-blenderbim-matrix.yml
+++ b/.github/workflows/ci-blenderbim-matrix.yml
@@ -15,7 +15,7 @@ jobs:
   activate:
     runs-on: ubuntu-latest
     if: |
-      github.repository == 'krande/IfcOpenShell' &&
+      github.repository == 'IfcOpenShell/IfcOpenShell' &&
       !contains(github.event.head_commit.message, '[skip ci]')
     steps:
     - name: Set env

--- a/.github/workflows/ci-blenderbim-matrix.yml
+++ b/.github/workflows/ci-blenderbim-matrix.yml
@@ -1,0 +1,66 @@
+name: Publish-blenderbim-multiplatform
+
+on:
+  push:
+    paths:
+      - 'src/ifcblenderexport/blenderbim/*'
+      - '.github/workflows/ci-blenderbim-matrix.yml'
+
+env:
+  major: 0
+  minor: 0
+  name: blenderbim
+
+jobs:
+  activate:
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'krande/IfcOpenShell' &&
+      !contains(github.event.head_commit.message, '[skip ci]')
+    steps:
+    - name: Set env
+      run: echo ok go
+
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            name: "Windows Build",
+            short_name: win,
+          }
+          - {
+            name: "Linux Build",
+            short_name: linux
+          }
+          - {
+            name: "MacOS Build",
+            short_name: macos
+          }
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2 # https://github.com/actions/setup-python
+        with:
+          python-version: '3.7.7' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+      - run: echo ${{ env.DATE }}
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%y%m%d')"
+      - name: Compile
+        run: |
+          cp -r src/ifcblenderexport src/ifcblenderexport_${{ matrix.config.short_name }} &&
+          cd src/ifcblenderexport_${{ matrix.config.short_name }} &&
+          make dist PLATFORM=${{ matrix.config.short_name }}
+      - name: Upload Zip file to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: src/ifcblenderexport_${{ matrix.config.short_name }}/dist/blender28-bim-${{steps.date.outputs.date}}-${{ matrix.config.short_name }}.zip
+          asset_name: blender28-bim-${{steps.date.outputs.date}}-${{ matrix.config.short_name }}.zip
+          tag: "blenderbim-${{steps.date.outputs.date}}"
+          overwrite: true
+          body: "Package release blenderbim-${{steps.date.outputs.date}}"

--- a/.github/workflows/ci-blenderbim-matrix.yml
+++ b/.github/workflows/ci-blenderbim-matrix.yml
@@ -3,19 +3,20 @@ name: Publish-blenderbim-multiplatform
 on:
   push:
     paths:
-      - 'src/ifcblenderexport/blenderbim/*'
+      - 'src/ifcblenderexport/*'
       - '.github/workflows/ci-blenderbim-matrix.yml'
 
 env:
   major: 0
   minor: 0
   name: blenderbim
+  pyver: py37
 
 jobs:
   activate:
     runs-on: ubuntu-latest
     if: |
-      github.repository == 'IfcOpenShell/IfcOpenShell' &&
+      github.repository == 'krande/IfcOpenShell' &&
       !contains(github.event.head_commit.message, '[skip ci]')
     steps:
     - name: Set env
@@ -54,13 +55,13 @@ jobs:
         run: |
           cp -r src/ifcblenderexport src/ifcblenderexport_${{ matrix.config.short_name }} &&
           cd src/ifcblenderexport_${{ matrix.config.short_name }} &&
-          make dist PLATFORM=${{ matrix.config.short_name }}
+          make dist PLATFORM=${{ matrix.config.short_name }} PYVERSION=${{ env.pyver }}
       - name: Upload Zip file to release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: src/ifcblenderexport_${{ matrix.config.short_name }}/dist/blender28-bim-${{steps.date.outputs.date}}-${{ matrix.config.short_name }}.zip
-          asset_name: blender28-bim-${{steps.date.outputs.date}}-${{ matrix.config.short_name }}.zip
+          file: src/ifcblenderexport_${{ matrix.config.short_name }}/dist/blender28-bim-${{steps.date.outputs.date}}-${{ env.pyver }}-${{ matrix.config.short_name }}.zip
+          asset_name: blender28-bim-${{steps.date.outputs.date}}-${{ env.pyver }}-${{ matrix.config.short_name }}.zip
           tag: "blenderbim-${{steps.date.outputs.date}}"
           overwrite: true
           body: "Package release blenderbim-${{steps.date.outputs.date}}"

--- a/src/ifcblenderexport/Makefile
+++ b/src/ifcblenderexport/Makefile
@@ -239,6 +239,9 @@ endif
 	cd dist/working && unzip python_fcl*
 	cp -r dist/working/fcl dist/blenderbim/libs/site/packages/
 
+	# Cleanup after python_fcl
+	rm -rf dist/working
+
 	# Required by BIMTester
 	mkdir dist/working
 	cd dist/working && wget https://files.pythonhosted.org/packages/c8/4b/d0a8c23b6c8985e5544ea96d27105a273ea22051317f850c2cdbf2029fe4/behave-1.2.6.tar.gz


### PR DESCRIPTION
A suggestion for a Github actions workflow to automatically produce a new blenderbim addon release upon push to repo.

It will trigger the build process only when it detects a change in the `src/ifcblenderexport/blenderbim/*` subfolder or in the .yml file describing the workflow itself `.github/workflows/ci-blenderbim-matrix.yml`.

I have tested this on my local repo and created a test release [here](https://github.com/Krande/IfcOpenShell/releases/tag/blenderbim-210304)

![image](https://user-images.githubusercontent.com/9642232/109922256-57e1a180-7cbd-11eb-9323-75e8a8489f3a.png)


@Moult Last time I showed you the release sizes were too big. Does the release sizes shown here make more sense?

blender28-bim-210304-linux.zip 160 MB
blender28-bim-210304-macos.zip 144 MB
blender28-bim-210304-win.zip 81.7 MB

Anyways, take a look and let me know if there are any changes\improvements on the suggested workflow?

Best Regards
Kristoffer
