### PR TITLE
Misc cleanups for build-all.py script

### DIFF
--- a/nix/build-all.py
+++ b/nix/build-all.py
@@ -75,7 +75,7 @@ ch.setLevel(logging.INFO)
 logger.addHandler(ch)
 
 PROJECT_NAME="IfcOpenShell"
-PYTHON_VERSIONS=["2.7.16", "3.2.6", "3.3.6", "3.4.6", "3.5.3", "3.6.2", "3.7.3", "3.8.6", "3.9.1"]
+PYTHON_VERSIONS=["2.7.16", "3.5.3", "3.6.2", "3.7.3", "3.8.6", "3.9.1"]
 JSON_VERSION="v3.6.1"
 OCE_VERSION="0.18"
 # OCCT_VERSION="7.1.0"
@@ -154,13 +154,6 @@ if get_os() == "Darwin":
     # C++11 features used in OCCT 7+ need a more recent stdlib
     TOOLSET = "10.9" if USE_OCCT else "10.6"
 
-# python 3.4 doesn't seem to build anymore on recent versions of clang
-if get_os() == "Darwin":
-    try:
-        PYTHON_VERSIONS.remove("3.4.6")
-    except ValueError as e:
-        pass
-   
 try:
     IFCOS_NUM_BUILD_PROCS = os.environ["IFCOS_NUM_BUILD_PROCS"]
 except KeyError:

--- a/nix/build-all.py
+++ b/nix/build-all.py
@@ -75,7 +75,7 @@ ch.setLevel(logging.INFO)
 logger.addHandler(ch)
 
 PROJECT_NAME="IfcOpenShell"
-PYTHON_VERSIONS=["2.7.16", "3.5.3", "3.6.2", "3.7.3", "3.8.6", "3.9.1"]
+PYTHON_VERSIONS=["2.7.18", "3.5.5", "3.6.13", "3.7.10", "3.8.8", "3.9.2"]
 JSON_VERSION="v3.6.1"
 OCE_VERSION="0.18"
 # OCCT_VERSION="7.1.0"

--- a/nix/build-all.py
+++ b/nix/build-all.py
@@ -49,15 +49,11 @@
 #          $ brew install git bison autoconf automake freetype libffi cmake   #
 #                                                                             #
 ###############################################################################
-
-from __future__ import print_function
-
 import logging
 import os
 import sys
 import subprocess as sp
 import shutil
-import time
 import tarfile
 import multiprocessing
 
@@ -773,7 +769,7 @@ if "IfcOpenShell-Python" in targets:
         run([make, "-j%s" % (IFCOS_NUM_BUILD_PROCS,), "_ifcopenshell_wrapper"], cwd=python_dir)
         run([make, "install/local"], cwd=os.path.join(python_dir, "ifcwrap"))
 
-        module_dir = os.path.dirname(run([PYTHON_EXECUTABLE, "-c", "from __future__ import print_function; import inspect, ifcopenshell; print(inspect.getfile(ifcopenshell))"]))
+        module_dir = os.path.dirname(run([PYTHON_EXECUTABLE, "-c", "import inspect, ifcopenshell; print(inspect.getfile(ifcopenshell))"]))
 
         if get_os() != "Darwin":
             # TODO: This symbol name depends on the Python version?


### PR DESCRIPTION
Drops really obsolete Python versions and bumps minor versions.