### PR TITLE
build: actions: Don't hardcode parallel builds to 10 in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
          -DLIBXML2_INCLUDE_DIR=/usr/include/libxml2 \
          -DLIBXML2_LIBRARIES=/usr/lib/x86_64-linux-gnu/libxml2.so \
          ../cmake
-        make -j`nproc`
+        make -j $(nproc)
         make install
     - 
       name: Package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
            -DLIBXML2_INCLUDE_DIR=/usr/include/libxml2 \
            -DLIBXML2_LIBRARIES=/usr/lib/x86_64-linux-gnu/libxml2.so \
            ../cmake
-          make -j10
+          make -j $(nproc)
           make install
       - name: Package
         id: package


### PR DESCRIPTION
And convert from deprecated `` `backtick` `` syntax to POSIX-compatible `$(...)`