### PR TITLE
Travis updates: Python3 / Ubuntu 20.04 / ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,27 @@ language: cpp
 compiler: gcc
 cache: ccache
 os: linux
-dist: bionic
-sudo: required
-
-before_install:
-  - "sudo add-apt-repository -y ppa:freecad-community/ppa"
-  - sudo apt-get update -qq
-
-
-install:
-  - |
-    sudo apt-get install -y \
-    libocct-data-exchange-dev libocct-foundation-dev libocct-modeling-algorithms-dev libocct-modeling-data-dev nlohmann-json3-dev \
-    libboost-system-dev libboost-program-options-dev libboost-regex-dev libboost-thread-dev libboost-date-time-dev libboost-iostreams-dev libboost-filesystem-dev \
-    build-essential cmake python2.7 libpython2.7-dev swig zlib1g liblzma5 opencollada-dev wget apt-transport-https
-    #- sudo mkdir -p /usr/include/json/nlohmann/
-    #- sudo wget https://github.com/nlohmann/json/releases/download/v3.6.1/json.hpp -O /usr/include/json/nlohmann/json.hpp
-  # - sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
-  # - sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-  # - sudo apt-get update -qq && sudo apt-get install -y dart
-  # - export PATH=$PATH:/usr/lib/dart/bin:$HOME/.pub-cache/bin
-  # - git clone https://github.com/KhronosGroup/glTF-Validator && pushd glTF-Validator && pub get && pub global activate --source path ./ && popd
+dist: focal
+addons:
+  apt:
+    update: true
+    packages:
+    - libboost-date-time-dev
+    - libboost-filesystem-dev
+    - libboost-iostreams-dev
+    - libboost-program-options-dev
+    - libboost-regex-dev
+    - libboost-system-dev
+    - libboost-thread-dev
+    - libocct-data-exchange-dev
+    - libocct-foundation-dev
+    - libocct-modeling-algorithms-dev
+    - libocct-modeling-data-dev
+    - libxml2-dev
+    - nlohmann-json3-dev
+    - opencollada-dev
+    - python3-all-dev
+    - swig
 
 before_script:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then ccache -z; fi
@@ -36,26 +36,25 @@ script:
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DOCC_INCLUDE_DIR=/usr/include/opencascade \
     -DOCC_LIBRARY_DIR=/usr/lib/x86_64-linux-gnu \
-    -DPYTHON_LIBRARY=/usr/lib/python2.7/config-x86_64-linux-gnu/libpython2.7.so \
-    -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 \
-    -DPYTHON_EXECUTABLE=/usr/bin/python2.7 \
-    -DLIBXML2_INCLUDE_DIR=/usr/include/libxml2 \
-    -DLIBXML2_LIBRARIES="/usr/lib/x86_64-linux-gnu/libxml2.so;/lib/x86_64-linux-gnu/libz.so.1;/lib/x86_64-linux-gnu/liblzma.so.5;/usr/lib/x86_64-linux-gnu/libicuuc.so.60;/usr/lib/x86_64-linux-gnu/libicudata.so.60" \
+    -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 \
+    -DPYTHON_INCLUDE_DIR:PATH=/usr/include/python3.8 \
+    -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython3.8.so \
     -DGLTF_SUPPORT=On \
     -DJSON_INCLUDE_DIR=/usr/include \
     ../cmake
 
-  - sudo make -j$(nproc) install
+  # TODO: Drop sudo
+  - sudo make -j $(nproc) install
     
   - cd ../test
-  - /usr/bin/python2.7 tests.py
+  - /usr/bin/python tests.py
 
   - cd input
   
   - /usr/local/bin/IfcConvert -yv acad2010_walls.ifc acad2010_walls.glb
   # - gltf_validator acad2010_walls.glb
   
-  - /usr/bin/python2.7 -c "from __future__ import print_function; from io import open; import ifcopenshell; f = ifcopenshell.open('encoding.ifc'); assert list(map(ord, f[1][0])) == [39, 97, 39, 32, 49, 109, 179, 32, 8804, 32, 53, 109, 179, 32, 8805, 32, 49, 48, 109, 179]"
+  - /usr/bin/python -c "from io import open; import ifcopenshell; f = ifcopenshell.open('encoding.ifc'); assert list(map(ord, f[1][0])) == [39, 97, 39, 32, 49, 109, 179, 32, 8804, 32, 53, 109, 179, 32, 8805, 32, 49, 48, 109, 179]"
   
   - |
     (for i in *.ifc; do \

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 compiler: gcc
+cache: ccache
 os: linux
 dist: bionic
 sudo: required
@@ -23,6 +24,9 @@ install:
   # - export PATH=$PATH:/usr/lib/dart/bin:$HOME/.pub-cache/bin
   # - git clone https://github.com/KhronosGroup/glTF-Validator && pushd glTF-Validator && pub get && pub global activate --source path ./ && popd
 
+before_script:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then ccache -z; fi
+
 script:
   - pwd
   - cd cmake
@@ -30,6 +34,8 @@ script:
   - cd build
   - |
     cmake \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DOCC_INCLUDE_DIR=/usr/include/opencascade \
     -DOCC_LIBRARY_DIR=/usr/lib/x86_64-linux-gnu \
     -DPYTHON_LIBRARY=/usr/lib/python2.7/config-x86_64-linux-gnu/libpython2.7.so \
@@ -64,3 +70,6 @@ script:
   - echo Succeeded
   - grep 0$ statuses
   - grep 0$ statuses | wc -l
+
+after_script:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then ccache -s; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ before_install:
 install:
   - |
     sudo apt-get install -y \
-    libocct-data-exchange-dev libocct-foundation-dev libocct-modeling-algorithms-dev libocct-modeling-data-dev \
+    libocct-data-exchange-dev libocct-foundation-dev libocct-modeling-algorithms-dev libocct-modeling-data-dev nlohmann-json3-dev \
     libboost-system-dev libboost-program-options-dev libboost-regex-dev libboost-thread-dev libboost-date-time-dev libboost-iostreams-dev libboost-filesystem-dev \
     build-essential cmake python2.7 libpython2.7-dev swig zlib1g liblzma5 opencollada-dev wget apt-transport-https
-  - sudo mkdir -p /usr/include/json/nlohmann/
-  - sudo wget https://github.com/nlohmann/json/releases/download/v3.6.1/json.hpp -O /usr/include/json/nlohmann/json.hpp
+    #- sudo mkdir -p /usr/include/json/nlohmann/
+    #- sudo wget https://github.com/nlohmann/json/releases/download/v3.6.1/json.hpp -O /usr/include/json/nlohmann/json.hpp
   # - sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
   # - sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
   # - sudo apt-get update -qq && sudo apt-get install -y dart
@@ -42,7 +42,7 @@ script:
     -DLIBXML2_INCLUDE_DIR=/usr/include/libxml2 \
     -DLIBXML2_LIBRARIES="/usr/lib/x86_64-linux-gnu/libxml2.so;/lib/x86_64-linux-gnu/libz.so.1;/lib/x86_64-linux-gnu/liblzma.so.5;/usr/lib/x86_64-linux-gnu/libicuuc.so.60;/usr/lib/x86_64-linux-gnu/libicudata.so.60" \
     -DGLTF_SUPPORT=On \
-    -DJSON_INCLUDE_DIR=/usr/include/json \
+    -DJSON_INCLUDE_DIR=/usr/include \
     ../cmake
 
   - sudo make -j$(nproc) install

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,7 @@ before_script:
 
 script:
   - pwd
-  - cd cmake
-  - mkdir build
-  - cd build
+  - mkdir build && cd build
   - |
     cmake \
     -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -45,10 +43,11 @@ script:
     -DLIBXML2_LIBRARIES="/usr/lib/x86_64-linux-gnu/libxml2.so;/lib/x86_64-linux-gnu/libz.so.1;/lib/x86_64-linux-gnu/liblzma.so.5;/usr/lib/x86_64-linux-gnu/libicuuc.so.60;/usr/lib/x86_64-linux-gnu/libicudata.so.60" \
     -DGLTF_SUPPORT=On \
     -DJSON_INCLUDE_DIR=/usr/include/json \
-    ..
+    ../cmake
+
   - sudo make -j$(nproc) install
     
-  - cd ../../test
+  - cd ../test
   - /usr/bin/python2.7 tests.py
 
   - cd input

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
     -DGLTF_SUPPORT=On \
     -DJSON_INCLUDE_DIR=/usr/include/json \
     ..
-  - sudo make -j2 install
+  - sudo make -j$(nproc) install
     
   - cd ../../test
   - /usr/bin/python2.7 tests.py


### PR DESCRIPTION
* Enable ccache and use `$(nproc)`
* Distro upgraded to 20.04 / Focal
* Switch to Python3

Build now takes ~15 minutes in case we don't touch any c++ files. Previously it took ~35m.