### PR TITLE
Fix: get_applicable return empty generator

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/pset.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/pset.py
@@ -23,10 +23,11 @@ class PsetQto:
     @lru_cache()
     def get_applicable(
         self, ifc_class="", predefined_type="", pset_only=False, qto_only=False
-    ) -> Generator[entity_instance, entity_instance, None]:
+    ) -> List[entity_instance]:
         any_class = not ifc_class
         if not any_class:
             entity = self.schema.declaration_by_name(ifc_class)
+        result = []
         for template in self.templates:
             for prop_set in template.by_type("IfcPropertySetTemplate"):
                 if pset_only:
@@ -36,8 +37,10 @@ class PsetQto:
                     if not prop_set.Name.startswith("Qto_"):
                         continue
                 if any_class or self.is_applicable(entity, prop_set.ApplicableEntity or "IfcRoot", predefined_type):
-                    yield prop_set
+                    result.append(prop_set)
+        return result
 
+    @lru_cache()
     def get_applicable_names(self, ifc_class: str, predefined_type="", pset_only=False, qto_only=False) -> List[str]:
         """Return names instead of objects for other use eg. enum"""
         return [prop_set.Name for prop_set in self.get_applicable(ifc_class, predefined_type, pset_only, qto_only)]

--- a/src/ifcopenshell-python/ifcopenshell/util/test_pset.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/test_pset.py
@@ -1,0 +1,17 @@
+"""Run this test from src/ifcopenshell-python folder: pytest --durations=0 ifcopenshell/util/test_pset.py"""
+from ifcopenshell.util import pset
+from ifcopenshell import util
+
+
+class TestPsetQto:
+    @classmethod
+    def setup_class(cls):
+        cls.pset_qto = util.pset.PsetQto("IFC4")
+
+    def test_get_applicables(self):
+        for i in range(1000):
+            assert len(self.pset_qto.get_applicable("IfcMaterial")) == 14
+
+    def test_get_applicables_names(self):
+        for i in range(1000):
+            assert len(self.pset_qto.get_applicable_names("IfcMaterial")) == 14


### PR DESCRIPTION
`PsetQto.get_applicable` was returning an empty generator when called
multiple times. Combination on lru_cache and generator seems to lead to
this unwanted behavior.
It now returns a list to keep gains of lru_cache performance.