### PR TITLE
Fix some gcc/clang warnings

### DIFF
--- a/src/ifcgeom/IfcGeom.h
+++ b/src/ifcgeom/IfcGeom.h
@@ -255,13 +255,13 @@ public:
 		, ifc_planeangle_unit(-1.0)
 		, modelling_precision(0.00001)
 		, dimensionality(1.)
-		, placement_rel_to(nullptr)
-		, faceset_helper_(nullptr)
 		, layerset_first(-1.)
-		, disable_boolean_result(-1.)
 		, no_wire_intersection_check(-1)
 		, no_wire_intersection_tolerance(-1)
 		, precision_factor(10.)
+		, placement_rel_to(nullptr)
+		, faceset_helper_(nullptr)
+		, disable_boolean_result(-1.)
 	{}
 
 	MAKE_TYPE_NAME(Kernel)(const MAKE_TYPE_NAME(Kernel)& other)
@@ -272,10 +272,10 @@ public:
 		, ifc_planeangle_unit(other.ifc_planeangle_unit)
 		, modelling_precision(other.modelling_precision)
 		, dimensionality(other.dimensionality)
-		, placement_rel_to(other.placement_rel_to)
 		// @nb faceset_helper_ always initialized to 0
-		, faceset_helper_(nullptr)
 		, layerset_first(other.layerset_first)
+		, placement_rel_to(other.placement_rel_to)
+		, faceset_helper_(nullptr)
 		, disable_boolean_result(other.disable_boolean_result)
 
 		, offset(other.offset)

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -2789,7 +2789,6 @@ bool IfcGeom::Kernel::fold_layers(const IfcSchema::IfcWall* wall, const IfcRepre
 				Vs1.Cross(Vs2);
 
 				if (Vs1.IsNormal(Vc, 1.e-5)) {
-					int a = 1;
 					Logger::Warning("Connected walls are parallel");
 					parallel = true;
 				} else if (w < axis_u1 || w > axis_u2) {

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -167,7 +167,7 @@
 #ifdef _MSC_VER
 #pragma message("warning: You are linking against Open CASCADE version " OCC_VERSION_COMPLETE ". Version 6.9.0 introduces various improvements with relation to boolean operations. You are advised to upgrade.")
 #else
-#warning "You are linking against linking against an older version of Open CASCADE. Version 6.9.0 introduces various improvements with relation to boolean operations. You are advised to upgrade."
+#warning "You are linking against an older version of Open CASCADE. Version 6.9.0 introduces various improvements with relation to boolean operations. You are advised to upgrade."
 #endif
 #endif
 

--- a/src/ifcgeom/IfcGeomFunctions.cpp
+++ b/src/ifcgeom/IfcGeomFunctions.cpp
@@ -774,7 +774,7 @@ bool IfcGeom::Kernel::convert_openings(const IfcSchema::IfcProduct* entity, cons
 				convert_shapes(*it2,opening_shapes);
 			}
 
-			const unsigned int current_size = (const unsigned int) opening_shapes.size();
+			const unsigned int current_size = opening_shapes.size();
 			for ( unsigned int i = last_size; i < current_size; ++ i ) {
 				opening_shapes[i].prepend(opening_trsf);
 			}


### PR DESCRIPTION
Fix warnings: `-Wdeprecated-copy` and `-Wunused-variable`