### PR TITLE
blenderbim: fix reference before assignment in PieAddOpening

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/model/pie.py
+++ b/src/blenderbim/blenderbim/bim/module/model/pie.py
@@ -85,8 +85,8 @@ class PieAddOpening(bpy.types.Operator):
                 if "IfcOpeningElement" in obj.name or not obj.BIMObjectProperties.ifc_definition_id:
                     opening_name = obj.name
                 else:
-                    opj_name = obj.name
-            bpy.ops.bim.add_opening(obj=opj_name, opening=opening_name)
+                    obj_name = obj.name
+            bpy.ops.bim.add_opening(obj=obj_name, opening=opening_name)
         return {"FINISHED"}
 
 


### PR DESCRIPTION
Hello, new `blender28-bim-210404-py37-linux.zip` user here.
I was trying to reproduce step by step what was done there: https://www.youtube.com/watch?v=qHG3qNjN1K4
though with a more recent Blender and BlenderBIM,
actually I'm using Blender 2.92 and Python 3.8 cause that's what is by default in the latest NixOS (should I really use older versions?).

I get this error when trying to add the door opening (through `Shift+E + 2` after having selected the wall and then the door):
```
Python: Traceback (most recent call last):
  File "/home/julm/.config/blender/2.92/scripts/addons/blenderbim/bim/module/model/pie.py", line 89, in execute
    bpy.ops.bim.add_opening(obj=opj_name, opening=opening_name)
UnboundLocalError: local variable 'opj_name' referenced before assignment

location: <unknown location>:-1
Error: Python: Traceback (most recent call last):
  File "/home/julm/.config/blender/2.92/scripts/addons/blenderbim/bim/module/model/pie.py", line 89, in execute
    bpy.ops.bim.add_opening(obj=opj_name, opening=opening_name)
UnboundLocalError: local variable 'opj_name' referenced before assignment

location: <unknown location>:-1
```

Looks like a typo, so I thought I would report it here to be sure, however fixing it get me this new error:
```
Python: Traceback (most recent call last):
  File "/home/julm/.config/blender/2.92/scripts/addons/blenderbim/bim/module/model/pie.py", line 89, in execute
    bpy.ops.bim.add_opening(obj=obj_name, opening=opening_name)
  File "/home/julm/work/sourcephile/nix/julm-nix/nixpkgs/pkgs/outputs/out/share/blender/2.92/scripts/modules/bpy/ops.py", line 132, in __call__
    ret = _op_call(self.idname_py(), None, kw)
TypeError: Converting py args to operator properties:  BIM_OT_add_opening.obj doesn't support None from string types

location: <unknown location>:-1
Error: Python: Traceback (most recent call last):
  File "/home/julm/.config/blender/2.92/scripts/addons/blenderbim/bim/module/model/pie.py", line 89, in execute
    bpy.ops.bim.add_opening(obj=obj_name, opening=opening_name)
  File "/home/julm/work/sourcephile/nix/julm-nix/nixpkgs/pkgs/outputs/out/share/blender/2.92/scripts/modules/bpy/ops.py", line 132, in __call__
    ret = _op_call(self.idname_py(), None, kw)
TypeError: Converting py args to operator properties:  BIM_OT_add_opening.obj doesn't support None from string types

location: <unknown location>:-1
```
I'm likely doing something wrong or not understanding what I'm supposed to do, maybe there is no need to add an opening because adding a dumb door directly adds a `Door Opening` nowadays it seems, at least I can see something named `Door Opening` as a child of the door, but AFAICS it is not removed from the wall like in the video, maybe it is missing a boolean modifier?
Also I notice that the names of the dumb door and dumb wall that I'm adding aren't prefixed by `IfcDoor/Dump ` nor `IfcWall/Dump ` though I'm adding them like in the video.
Thanks in advance if you answer here or point me to some documentation or working examples.