### PR TITLE
Fixes initialization issue in IfcEntityInstanceData and Crash problem in debug builds

### DIFF
--- a/src/ifcparse/IfcCharacterDecoder.cpp
+++ b/src/ifcparse/IfcCharacterDecoder.cpp
@@ -317,7 +317,7 @@ IfcCharacterEncoder::operator std::string() {
 	// Either 2 or 4 to uses \X2 or \X4 respectively.
 	// Currently hardcoded to 4, but \X2 might be  
 	// sufficient for nearly all purposes.
-	const int num_bytes = *std::max_element(str.begin(), str.end()) > 0xffff ? 4 : 2;
+	const int num_bytes = (str.empty() || *std::max_element(str.begin(), str.end())) > 0xffff ? 4 : 2;
 	const std::string num_bytes_str = std::string(1,num_bytes + 0x30);
 		
 	bool in_extended = false;

--- a/src/ifcparse/IfcEntityInstanceData.h
+++ b/src/ifcparse/IfcEntityInstanceData.h
@@ -48,17 +48,13 @@ public:
 		: file(file_), id_(id), type_(type), attributes_(0), offset_in_file_(offset_in_file)
 	{}
 
-	IfcEntityInstanceData(IfcParse::IfcFile* file_, size_t size)
-		: file(file_), id_(0), type_(0), attributes_(new Argument*[size]), offset_in_file_(0)
+   IfcEntityInstanceData(IfcParse::IfcFile* file_, size_t size)
+      : file(file_), id_(0), type_(0), attributes_(new Argument*[size] {0}), offset_in_file_(0)
 	{}
 
-	IfcEntityInstanceData(const IfcParse::declaration* type)
-		: file(0), id_(0), type_(type), attributes_(new Argument*[getArgumentCount()])
-	{
-		for (size_t i = 0; i < getArgumentCount(); ++i) {
-			attributes_[i] = 0;
-		}
-	}
+   IfcEntityInstanceData(const IfcParse::declaration* type)
+      : file(0), id_(0), type_(type), attributes_(new Argument*[getArgumentCount()]{ 0 }), offset_in_file_(0)
+   {}
 
 	void load() const;
 

--- a/src/ifcparse/IfcSpfHeader.cpp
+++ b/src/ifcparse/IfcSpfHeader.cpp
@@ -43,11 +43,6 @@ HeaderEntity::HeaderEntity(const char * const datatype, size_t size, IfcFile* fi
 	if (file) {
 		offset_in_file_ = file->stream->Tell();
 		load();
-	} else {
-		// attributes_ = new Argument*[size];
-		for (size_t i = 0; i < size; ++i) {
-			attributes_[i] = 0;
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes data member initialization issues with IfcEntityInstanceData as discussed in #1437.

Also fixes crash problem in debug builds related to dereferencing the end iterator for empty std::string objects. See discussion thread https://sourceforge.net/p/ifcopenshell/discussion/1782716/thread/2930921968/