### PR TITLE
Unlink only from relevant collections

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/aggregate/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/aggregate/operator.py
@@ -45,7 +45,8 @@ class AssignObject(bpy.types.Operator):
                     self.remove_collection(collection, spatial_collection)
             else:
                 for collection in related_object.users_collection:
-                    collection.objects.unlink(related_object)
+                    if collection.name.startswith("Ifc"):
+                        collection.objects.unlink(related_object)
                 relating_collection.objects.link(related_object)
         return {"FINISHED"}
 


### PR DESCRIPTION
Objects may be linked to non ifc related collections, so keep those links whatever.