### PR TITLE
Allow global listeners

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/__init__.py
@@ -60,9 +60,8 @@ def remove_pre_listener(callback, usecase_path=""):
         for fun in callbacks:
             if fun == callback:
                 pre_listeners[listener_key].remove(callback)
-                return
-
-            
+                
+                
 def remove_post_listener(callback, usecase_path=""):
     for listener_key, callbacks in post_listeners.items():
         if not listener_key.endswith(usecase_path):
@@ -70,8 +69,7 @@ def remove_post_listener(callback, usecase_path=""):
         for fun in callbacks:
             if fun == callback:
                 post_listeners[listener_key].remove(callback)
-                return
-
+                
  
 def remove_all_listeners():
     registered_ifcs.clear()

--- a/src/ifcopenshell-python/ifcopenshell/api/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/__init__.py
@@ -14,6 +14,12 @@ def run(usecase_path, ifc_file=None, should_run_listeners=True, **settings):
     if should_run_listeners:
         for listener in pre_listeners.get(".".join([ifc_key, usecase_path]), []):
             listener(usecase_path, ifc_file, **settings)
+
+        if None in registered_ifcs and ifc_key != registered_ifcs[None]:
+            global_key = registered_ifcs[None]
+            for listener in pre_listeners.get(".".join([global_key, usecase_path]), []):
+                listener(usecase_path, ifc_file, **settings)
+
     importlib.import_module(f"ifcopenshell.api.{usecase_path}")
     module, usecase = usecase_path.split(".")
     usecase_class = getattr(getattr(getattr(ifcopenshell.api, module), usecase), "Usecase")
@@ -26,34 +32,48 @@ def run(usecase_path, ifc_file=None, should_run_listeners=True, **settings):
     if should_run_listeners:
         for listener in post_listeners.get(".".join([ifc_key, usecase_path]), []):
             listener(usecase_path, ifc_file, **settings)
+
+        if None in registered_ifcs and ifc_key != registered_ifcs[None]:
+            global_key = registered_ifcs[None]
+            for listener in post_listeners.get(".".join([global_key, usecase_path]), []):
+                listener(usecase_path, ifc_file, **settings)
+
     return result
 
 
 def add_pre_listener(usecase_path, ifc_file, callback):
     ifc_key = registered_ifcs.setdefault(ifc_file, ifcopenshell.guid.new())
     pre_listeners.setdefault(".".join([ifc_key, usecase_path]), set()).add(callback)
+    return ifc_key
+
 
 def add_post_listener(usecase_path, ifc_file, callback):
     ifc_key = registered_ifcs.setdefault(ifc_file, ifcopenshell.guid.new())
     post_listeners.setdefault(".".join([ifc_key, usecase_path]), set()).add(callback)
-    
-def remove_pre_listener(callback):
-    for ifc_key, callbacks in pre_listeners.items():
+    return ifc_key
+
+
+def remove_pre_listener(callback, usecase_path=""):
+    for listener_key, callbacks in pre_listeners.items():
+        if not listener_key.endswith(usecase_path):
+            continue
         for fun in callbacks:
             if fun == callback:
-                pre_listeners[ifc_key].remove(callback)
+                pre_listeners[listener_key].remove(callback)
                 return
 
-def remove_post_listener(callback):
-    for ifc_key, callbacks in post_listeners.items():
+            
+def remove_post_listener(callback, usecase_path=""):
+    for listener_key, callbacks in post_listeners.items():
+        if not listener_key.endswith(usecase_path):
+            continue
         for fun in callbacks:
             if fun == callback:
-                post_listeners[ifc_key].remove(callback)
+                post_listeners[listener_key].remove(callback)
                 return
 
+ 
 def remove_all_listeners():
     registered_ifcs.clear()
     pre_listeners.clear()
     post_listeners.clear()
-
-


### PR DESCRIPTION
Add "global" listeners when ifc_file is None, listeners are run whatever the file.
This way allow to register listeners before a file exists, and "global" listeners.

Add listener returns the ifc_key
Remove listeners allow optional filtering by usecase_path / ifc_key.usecase_path.