### PR TITLE
Fix xml double value is rounded #1533

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -944,7 +944,7 @@ int main(int argc, char** argv) {
         }
 
         std::stringstream msg;
-        msg << std::setprecision (17) << "Using model offset (" << offset[0] << "," << offset[1] << "," << offset[2] << ")";
+        msg << std::setprecision (std::numeric_limits< double >::max_digits10) << "Using model offset (" << offset[0] << "," << offset[1] << "," << offset[2] << ")";
         Logger::Notice(msg.str());
     }
 

--- a/src/serializers/schema_dependent/XmlSerializer.cpp
+++ b/src/serializers/schema_dependent/XmlSerializer.cpp
@@ -89,7 +89,7 @@ boost::optional<std::string> format_attribute(const Argument* argument, IfcUtil:
 		case IfcUtil::Argument_DOUBLE: {
 			const double d = *argument;
 			std::stringstream stream;
-			stream << d;
+			stream << std::setprecision (std::numeric_limits< double >::max_digits10) << d;
 			value = stream.str();
 			break; }
 		case IfcUtil::Argument_STRING:
@@ -134,7 +134,7 @@ boost::optional<std::string> format_attribute(const Argument* argument, IfcUtil:
 					for (int i = 1; i < 5; ++i) {
 						for (int j = 1; j < 4; ++j) {
 							const double trsf_value = trsf.Value(j, i);
-							stream << trsf_value << " ";
+							stream << std::setprecision (std::numeric_limits< double >::max_digits10) << trsf_value << " ";
 						}
 						stream << ((i == 4) ? "1" : "0 ");
 					}


### PR DESCRIPTION
When we convert ifc to xml, double value is rounded so we loss position precision.