### PR TITLE
Fixes to enable building shared library in windows

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -494,7 +494,7 @@ function(files_for_ifc_version IFC_VERSION RESULT_NAME)
     )
 endfunction()
 
-set(SCHEMA_VERSIONS "2x3" "4" "4x1" "4x2" "4x3_rc1" "4x3_rc2")
+set(SCHEMA_VERSIONS "2x3" "4")
 
 foreach(s ${SCHEMA_VERSIONS})
 	add_definitions(-DHAS_SCHEMA_${s})
@@ -638,7 +638,7 @@ if (UNIX)
 find_package(Threads)
 endif()
 
-TARGET_LINK_LIBRARIES(IfcGeom IFCParse ${IFCGEOM_SCHEMA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+TARGET_LINK_LIBRARIES(IfcGeom IfcParse ${IFCGEOM_SCHEMA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 endif(BUILD_IFCGEOM)
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -23,7 +23,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)  # not necessary, but encouraged
 
 project (IfcOpenShell VERSION 0.6.0)
 
-# use extra version to make pre-release using eg semver 
+# use extra version to make pre-release using eg semver
 set( EXTRA_VERSION "-alpha.3")
 
 foreach(max_year RANGE 2014 2030)
@@ -441,7 +441,7 @@ IF(MSVC)
 		# Disable overeager and false positives causing C4458 ("declaration of 'indentifier' hides class member"), at least for now.
 		ADD_DEFINITIONS(-wd4458)
 	ENDIF()
-    # Enforce standards-conformance on VS > 2015, older Boost versions fail to compile with this    
+    # Enforce standards-conformance on VS > 2015, older Boost versions fail to compile with this
     if (MSVC_VERSION GREATER 1900 AND (Boost_MAJOR_VERSION GREATER 1 OR Boost_MINOR_VERSION GREATER 66))
         add_definitions(-permissive-)
     endif()
@@ -486,8 +486,8 @@ INCLUDE_DIRECTORIES(${INCLUDE_DIRECTORIES} ${OCC_INCLUDE_DIR} ${OPENCOLLADA_INCL
 
 function(files_for_ifc_version IFC_VERSION RESULT_NAME)
     set(IFC_PARSE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../src/ifcparse)
-    set(${RESULT_NAME} 
-        ${IFC_PARSE_DIR}/Ifc${IFC_VERSION}.h 
+    set(${RESULT_NAME}
+        ${IFC_PARSE_DIR}/Ifc${IFC_VERSION}.h
         ${IFC_PARSE_DIR}/Ifc${IFC_VERSION}enum.h
         ${IFC_PARSE_DIR}/Ifc${IFC_VERSION}.cpp
 		PARENT_SCOPE
@@ -504,13 +504,13 @@ if(COMPILE_SCHEMA)
 	# @todo, this appears to be untested at the moment
 
     find_package(PythonInterp)
-    
+
     IF(NOT PYTHONINTERP_FOUND)
         MESSAGE(FATAL_ERROR "A Python interpreter is necessary when COMPILE_SCHEMA is enabled. Disable COMPILE_SCHEMA or fix Python paths to proceed.")
     ENDIF()
-    
+
     set(IFC_RELEASE_NOT_USED ${SCHEMA_VERSIONS})
-    
+
     # Install pyparsing if necessary
     execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip freeze OUTPUT_VARIABLE PYTHON_PACKAGE_LIST)
     if ("${PYTHON_PACKAGE_LIST}" STREQUAL "")
@@ -532,23 +532,23 @@ if(COMPILE_SCHEMA)
     else()
         message(STATUS "Python interpreter with pyparsing found")
     endif()
-    
+
     # Bootstrap the parser
     message(STATUS "Compiling schema, this will take a while...")
-    execute_process(COMMAND ${PYTHON_EXECUTABLE} bootstrap.py express.bnf 
-        WORKING_DIRECTORY ../src/ifcexpressparser 
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} bootstrap.py express.bnf
+        WORKING_DIRECTORY ../src/ifcexpressparser
         OUTPUT_FILE express_parser.py
         RESULT_VARIABLE SUCCESS)
 
     if (NOT "${SUCCESS}" STREQUAL "0")
         MESSAGE(FATAL_ERROR "Failed to bootstrap parser. Make sure pyparsing is installed")
     endif()
-        
+
     # Generate code
     execute_process(COMMAND ${PYTHON_EXECUTABLE} ../ifcexpressparser/express_parser.py ../../${COMPILE_SCHEMA}
         WORKING_DIRECTORY ../src/ifcparse
         OUTPUT_VARIABLE COMPILED_SCHEMA_NAME)
-    
+
     # Prevent the schema that had just been compiled from being excluded
 	foreach(s ${SCHEMA_VERSIONS})
 		if("${COMPILED_SCHEMA_NAME}" STREQUAL "${s}")
@@ -638,7 +638,7 @@ if (UNIX)
 find_package(Threads)
 endif()
 
-TARGET_LINK_LIBRARIES(IfcGeom ${IFCGEOM_SCHEMA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+TARGET_LINK_LIBRARIES(IfcGeom IFCParse ${IFCGEOM_SCHEMA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 endif(BUILD_IFCGEOM)
 
@@ -708,7 +708,7 @@ INSTALL(TARGETS IfcGeomServer
 
 endif()
 
-# Documentation	
+# Documentation
 IF(BUILD_DOCUMENTATION)
 	set(CMAKE_MODULE_PATH "../docs/cmake")
 	ADD_SUBDIRECTORY(../docs docs)
@@ -727,7 +727,7 @@ IF(BUILD_IFCMAX)
 ENDIF()
 
 # CMake installation targets
-INSTALL(FILES ${IFCPARSE_H_FILES} 
+INSTALL(FILES ${IFCPARSE_H_FILES}
 	DESTINATION ${INCLUDEDIR}/ifcparse
 )
 
@@ -738,11 +738,11 @@ INSTALL(TARGETS IfcParse
 )
 
 if(BUILD_IFCGEOM)
-INSTALL(FILES ${IFCGEOM_H_FILES} 
+INSTALL(FILES ${IFCGEOM_H_FILES}
 	DESTINATION ${INCLUDEDIR}/ifcgeom
 )
 
-INSTALL(FILES  ${SCHEMA_AGNOSTIC_H_FILES} 
+INSTALL(FILES  ${SCHEMA_AGNOSTIC_H_FILES}
 	DESTINATION ${INCLUDEDIR}/ifcgeom_schema_agnostic
 )
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -494,7 +494,7 @@ function(files_for_ifc_version IFC_VERSION RESULT_NAME)
     )
 endfunction()
 
-set(SCHEMA_VERSIONS "2x3" "4")
+set(SCHEMA_VERSIONS "2x3" "4" "4x1" "4x2" "4x3_rc1" "4x3_rc2")
 
 foreach(s ${SCHEMA_VERSIONS})
 	add_definitions(-DHAS_SCHEMA_${s})

--- a/src/ifcparse/IfcSIPrefix.cpp
+++ b/src/ifcparse/IfcSIPrefix.cpp
@@ -71,7 +71,7 @@ double IfcParse::get_SI_equivalent(typename Schema::IfcNamedUnit* named_unit) {
 			si_unit = component->template as<typename Schema::IfcSIUnit>();
 			typename Schema::IfcValue* v = factor->ValueComponent();
 			scale = *v->data().getArgument(0);
-		}		
+		}
 	} else if (named_unit->declaration().is(Schema::IfcSIUnit::Class())) {
 		si_unit = named_unit->template as<typename Schema::IfcSIUnit>();
 	}
@@ -89,43 +89,44 @@ double IfcParse::get_SI_equivalent(typename Schema::IfcNamedUnit* named_unit) {
 #if defined(_MSC_VER) && _MSC_VER < 1900
 
 #ifdef HAS_SCHEMA_2x3
-template double IfcParse::get_SI_equivalent<Ifc2x3>(Ifc2x3::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc2x3>(Ifc2x3::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4
-template double IfcParse::get_SI_equivalent<Ifc4>(Ifc4::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4>(Ifc4::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4x1
-template double IfcParse::get_SI_equivalent<Ifc4x1>(Ifc4x1::IfcNamedUnit* named_unit);
+
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4x1>(Ifc4x1::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4x2
-template double IfcParse::get_SI_equivalent<Ifc4x2>(Ifc4x2::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4x2>(Ifc4x2::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4x3_rc1
-template double IfcParse::get_SI_equivalent<Ifc4x3_rc1>(Ifc4x3_rc1::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4x3_rc1>(Ifc4x3_rc1::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4x3_rc2
-template double IfcParse::get_SI_equivalent<Ifc4x3_rc2>(Ifc4x3_rc2::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4x3_rc2>(Ifc4x3_rc2::IfcNamedUnit* named_unit);
 #endif
 
 #else
 
 #ifdef HAS_SCHEMA_2x3
-template double IfcParse::get_SI_equivalent<Ifc2x3>(typename Ifc2x3::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc2x3>(typename Ifc2x3::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4
-template double IfcParse::get_SI_equivalent<Ifc4>(typename Ifc4::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4>(typename Ifc4::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4x1
-template double IfcParse::get_SI_equivalent<Ifc4x1>(typename Ifc4x1::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4x1>(typename Ifc4x1::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4x2
-template double IfcParse::get_SI_equivalent<Ifc4x2>(typename Ifc4x2::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4x2>(typename Ifc4x2::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4x3_rc1
-template double IfcParse::get_SI_equivalent<Ifc4x3_rc1>(typename Ifc4x3_rc1::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4x3_rc1>(typename Ifc4x3_rc1::IfcNamedUnit* named_unit);
 #endif
 #ifdef HAS_SCHEMA_4x3_rc2
-template double IfcParse::get_SI_equivalent<Ifc4x3_rc2>(typename Ifc4x3_rc2::IfcNamedUnit* named_unit);
+template double IFC_PARSE_API IfcParse::get_SI_equivalent<Ifc4x3_rc2>(typename Ifc4x3_rc2::IfcNamedUnit* named_unit);
 #endif
 
 #endif

--- a/src/ifcparse/IfcSchema.h
+++ b/src/ifcparse/IfcSchema.h
@@ -38,11 +38,11 @@ namespace IfcUtil {
 
 namespace IfcParse {
 
-	class declaration; 
-	
-	class type_declaration; 
-	class select_type; 
-	class enumeration_type; 
+	class declaration;
+
+	class type_declaration;
+	class select_type;
+	class enumeration_type;
 	class entity;
 
 	class named_type;
@@ -121,7 +121,7 @@ namespace IfcParse {
 		int index_in_schema_;
 		mutable const schema_definition* schema_;
 
-	public:		
+	public:
 		declaration(const std::string& name, int index_in_schema)
 			: name_(name)
 			, name_lower_(boost::to_lower_copy(name))
@@ -305,7 +305,7 @@ namespace IfcParse {
 		const std::vector<const entity*>& subtypes() const { return subtypes_; }
 		const std::vector<const attribute*>& attributes() const { return attributes_; }
 		const std::vector<bool>& derived() const { return derived_; }
-	
+
 		const std::vector<const attribute*> all_attributes() const {
 			std::vector<const attribute*> attrs;
 			attrs.reserve(derived_.size());
@@ -416,7 +416,7 @@ namespace IfcParse {
 		instance_factory* factory_;
 
 	public:
-		
+
 		schema_definition(const std::string& name, const std::vector<const declaration*>& declarations, instance_factory* factory);
 
 		~schema_definition();
@@ -446,7 +446,7 @@ namespace IfcParse {
 		IfcUtil::IfcBaseClass* instantiate(IfcEntityInstanceData* data) const;
 	};
 
-	const schema_definition* schema_by_name(const std::string&);
+	IFC_PARSE_API const schema_definition* schema_by_name(const std::string&);
 
 	void register_schema(schema_definition*);
 }


### PR DESCRIPTION
https://github.com/IfcOpenShell/IfcOpenShell/issues/1029 is still a problem when you try to build shared libraries in windows. This can be bypassed with reducing the number of schemas to compile. However there are still some linking errors:

1. IFCGeom needs `IfcParse.lib` as a dependency during compilation
2. Several functions are used by IfcGeom within IfcParse that are missing `IFC_PARSE_API` declaration