### PR TITLE
Prevent linking non-existant or non-ifc file

### DIFF
--- a/src/blenderbim/blenderbim/bim/operator.py
+++ b/src/blenderbim/blenderbim/bim/operator.py
@@ -153,7 +153,8 @@ class SelectIfcFile(bpy.types.Operator):
     filter_glob: bpy.props.StringProperty(default="*.ifc;*.ifczip;*.ifcxml", options={"HIDDEN"})
 
     def execute(self, context):
-        bpy.context.scene.BIMProperties.ifc_file = self.filepath
+        if os.path.exists(self.filepath) and "ifc" in os.path.splitext(self.filepath)[1]:
+            bpy.context.scene.BIMProperties.ifc_file = self.filepath
         return {"FINISHED"}
 
     def invoke(self, context, event):


### PR DESCRIPTION
Adds a check to only set the ifc file if the file actually exists and it is an ifc file. 
Theoretically the user can only choose ifc files, but if they deactivate the filter in the importer, it's possible to select any file type.
![image](https://user-images.githubusercontent.com/25156105/127445906-f768907a-a57b-4479-9cdd-8f52bee5de5a.png)

**Food for thought** : 
Maybe display a label, warning or error message if the user chooses a wrong file ? Currently it silently passes when the file is incorrect which may cause them to think there is a bug or something's not working.
