### PR TITLE
BlenderBIM some data_dir / schema_dir workarounds

### DIFF
--- a/src/blenderbim/blenderbim/bim/operator.py
+++ b/src/blenderbim/blenderbim/bim/operator.py
@@ -2,6 +2,7 @@ import os
 import bpy
 import time
 import json
+import tempfile
 import logging
 import webbrowser
 import ifcopenshell
@@ -43,8 +44,11 @@ class ExportIFC(bpy.types.Operator):
     def _execute(self, context):
         start = time.time()
         logger = logging.getLogger("ExportIFC")
+        path_log = os.path.join(bpy.context.scene.BIMProperties.data_dir, "process.log"),
+        if not os.access(bpy.context.scene.BIMProperties.data_dir, os.W_OK):
+            path_log = os.path.join(tempfile.mkdtemp(), "process.log")
         logging.basicConfig(
-            filename=os.path.join(context.scene.BIMProperties.data_dir, "process.log"),
+            filename=path_log,
             filemode="a",
             level=logging.DEBUG,
         )
@@ -105,8 +109,11 @@ class ImportIFC(bpy.types.Operator, ImportHelper):
     def execute(self, context):
         start = time.time()
         logger = logging.getLogger("ImportIFC")
+        path_log = os.path.join(bpy.context.scene.BIMProperties.data_dir, "process.log"),
+        if not os.access(bpy.context.scene.BIMProperties.data_dir, os.W_OK):
+            path_log = os.path.join(tempfile.mkdtemp(), "process.log")
         logging.basicConfig(
-            filename=os.path.join(bpy.context.scene.BIMProperties.data_dir, "process.log"),
+            filename=path_log,
             filemode="a",
             level=logging.DEBUG,
         )

--- a/src/blenderbim/blenderbim/bim/operator.py
+++ b/src/blenderbim/blenderbim/bim/operator.py
@@ -175,7 +175,7 @@ class SelectDataDir(bpy.types.Operator):
     filepath: bpy.props.StringProperty(subtype="FILE_PATH")
 
     def execute(self, context):
-        bpy.context.scene.BIMProperties.data_dir = self.filepath
+        bpy.context.scene.BIMProperties.data_dir = os.path.dirname(self.filepath)
         return {"FINISHED"}
 
     def invoke(self, context, event):
@@ -190,7 +190,7 @@ class SelectSchemaDir(bpy.types.Operator):
     filepath: bpy.props.StringProperty(subtype="FILE_PATH")
 
     def execute(self, context):
-        bpy.context.scene.BIMProperties.schema_dir = self.filepath
+        bpy.context.scene.BIMProperties.schema_dir = os.path.dirname(self.filepath)
         return {"FINISHED"}
 
     def invoke(self, context, event):


### PR DESCRIPTION
Blenderbim creates a `process.log` file in `data_dir` when importing an IFC file, but it is not possible to change `data_dir` until a project already exists. My blenderbim is installed in `/usr/share/blender` so the default `data_dir` is not writable. 82dd395 detects a non-writable `data_dir` and writes the `process.log` file to a temp dir instead.

The GUI for `select_schema_dir()` and `select_data_dir()` selects files rather than directories. i.e. start blender, save the file `untitled.blend`, click Select Data Directory, close the dialog and `data_dir` is now set to `/home/bruno/untitled.blend` (which is a file not a directory). 703a66e strips the filename part from any path returned by the dialog.