### PR TITLE
Add check before showing potentially empty enum

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/model/product.py
+++ b/src/blenderbim/blenderbim/bim/module/model/product.py
@@ -22,8 +22,9 @@ class AddTypeInstance(bpy.types.Operator):
 
     def _execute(self, context):
         tprops = context.scene.BIMTypeProperties
-        ifc_class = self.ifc_class or tprops.ifc_class
-        relating_type = self.relating_type or tprops.relating_type
+        ifc_class = self.ifc_class or (len(tprops.bl_rna.properties["ifc_class"].enum_items) > 0 and tprops.ifc_class)
+        relating_type = self.relating_type or \
+            (len(tprops.bl_rna.properties["relating_type"].enum_items) > 0 and tprops.relating_type)
         if not ifc_class or not relating_type:
             return {"FINISHED"}
         self.file = IfcStore.get_file()

--- a/src/blenderbim/blenderbim/bim/module/model/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/model/ui.py
@@ -12,8 +12,10 @@ class BIM_PT_authoring(Panel):
     def draw(self, context):
         tprops = context.scene.BIMTypeProperties
         col = self.layout.column(align=True)
-        col.prop(tprops, "ifc_class", text="", icon="FILE_VOLUME")
-        col.prop(tprops, "relating_type", text="", icon="FILE_3D")
+        if len(tprops.bl_rna.properties["ifc_class"].enum_items) > 0:
+            col.prop(tprops, "ifc_class", text="", icon="FILE_VOLUME")
+        if len(tprops.bl_rna.properties["relating_type"].enum_items) > 0:
+            col.prop(tprops, "relating_type", text="", icon="FILE_3D")
         col.operator("bim.add_type_instance", icon="ADD")
 
 

--- a/src/blenderbim/blenderbim/bim/module/model/workspace.py
+++ b/src/blenderbim/blenderbim/bim/module/model/workspace.py
@@ -33,8 +33,10 @@ class BimTool(WorkSpaceTool):
     def draw_settings(context, layout, tool):
         row = layout.row(align=True)
         props = context.scene.BIMTypeProperties
-        row.prop(props, "ifc_class", text="")
-        row.prop(props, "relating_type", text="")
+        if len(props.bl_rna.properties["ifc_class"].enum_items) > 0:
+            row.prop(props, "ifc_class", text="")            
+        if len(props.bl_rna.properties["relating_type"].enum_items) > 0:
+            row.prop(props, "relating_type", text="")
 
         row.label(text="", icon="BLANK1")
 


### PR DESCRIPTION
This was not trivial since trying to access the enum to check if it is empty by regular means (`props.ifc_class`) would throw out the warning error anyway.

Found the solution there https://blender.stackexchange.com/a/35162/86891