### PR TITLE
Fix error if no ifc file set

### DIFF
--- a/src/blenderbim/blenderbim/bim/ifc.py
+++ b/src/blenderbim/blenderbim/bim/ifc.py
@@ -184,13 +184,9 @@ class IfcStore:
     def execute_ifc_operator(operator, context):
         is_top_level_operator = not bool(IfcStore.current_transaction)
 
-        file = IfcStore.get_file()
-        if not file:
-            return {'FINISHED'}
-
         if is_top_level_operator:
             IfcStore.begin_transaction(operator)
-            file.begin_transaction()
+            IfcStore.get_file().begin_transaction()
             # This empty transaction ensures that each operator has at least one transaction
             IfcStore.add_transaction_operation(operator, rollback=lambda data: True, commit=lambda data: True)
         else:
@@ -199,9 +195,9 @@ class IfcStore:
         result = getattr(operator, "_execute")(context)
 
         if is_top_level_operator:
-            file.end_transaction()
+            IfcStore.get_file().end_transaction()
             IfcStore.add_transaction_operation(
-                operator, rollback=lambda d: file.undo(), commit=lambda d: file.redo()
+                operator, rollback=lambda d: IfcStore.get_file().undo(), commit=lambda d: IfcStore.get_file().redo()
             )
             IfcStore.end_transaction(operator)
 

--- a/src/blenderbim/blenderbim/bim/module/model/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/model/ui.py
@@ -9,6 +9,10 @@ class BIM_PT_authoring(Panel):
     bl_region_type = "UI"
     bl_category = "BlenderBIM"
 
+    @classmethod
+    def poll(cls, context):
+        return IfcStore.get_file()
+
     def draw(self, context):
         tprops = context.scene.BIMTypeProperties
         col = self.layout.column(align=True)

--- a/src/blenderbim/blenderbim/bim/module/type/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/type/prop.py
@@ -42,7 +42,7 @@ def getIfcTypes(self, context):
 
 def getAvailableTypes(self, context):
     global available_types_enum
-    if len(available_types_enum) < 1:
+    if len(available_types_enum) < 1 and getIfcTypes(self, context):
         elements = IfcStore.get_file().by_type(self.ifc_class)
         available_types_enum.extend((str(e.id()), e.Name, "") for e in elements)
     return available_types_enum

--- a/src/blenderbim/blenderbim/bim/module/type/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/type/prop.py
@@ -43,8 +43,10 @@ def getIfcTypes(self, context):
 def getAvailableTypes(self, context):
     global available_types_enum
     if len(available_types_enum) < 1:
-        elements = IfcStore.get_file().by_type(self.ifc_class)
-        available_types_enum.extend((str(e.id()), e.Name, "") for e in elements)
+        file = IfcStore.get_file()
+        if file:
+            elements = file.by_type(self.ifc_class)
+            available_types_enum.extend((str(e.id()), e.Name, "") for e in elements)
     return available_types_enum
 
 
@@ -58,17 +60,21 @@ def updateTypeInstanceIfcClass(self, context):
 def getApplicableTypes(self, context):
     global applicable_types_enum
     if len(applicable_types_enum) < 1:
-        element = IfcStore.get_file().by_id(context.active_object.BIMObjectProperties.ifc_definition_id)
-        types = ifcopenshell.util.type.get_applicable_types(element.is_a(), schema=IfcStore.get_file().schema)
-        applicable_types_enum.extend((t, t, "") for t in types)
+        file = IfcStore.get_file()
+        if file:
+            element = file.by_id(context.active_object.BIMObjectProperties.ifc_definition_id)
+            types = ifcopenshell.util.type.get_applicable_types(element.is_a(), schema=IfcStore.get_file().schema)
+            applicable_types_enum.extend((t, t, "") for t in types)
     return applicable_types_enum
 
 
 def getRelatingTypes(self, context):
     global relating_types_enum
     if len(relating_types_enum) < 1:
-        elements = IfcStore.get_file().by_type(context.active_object.BIMTypeProperties.relating_type_class)
-        relating_types_enum.extend((str(e.id()), e.Name, "") for e in elements)
+        file = IfcStore.get_file()
+        if file:
+            elements = file.by_type(context.active_object.BIMTypeProperties.relating_type_class)
+            relating_types_enum.extend((str(e.id()), e.Name, "") for e in elements)
     return relating_types_enum
 
 

--- a/src/blenderbim/blenderbim/bim/module/type/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/type/prop.py
@@ -43,10 +43,8 @@ def getIfcTypes(self, context):
 def getAvailableTypes(self, context):
     global available_types_enum
     if len(available_types_enum) < 1:
-        file = IfcStore.get_file()
-        if file:
-            elements = file.by_type(self.ifc_class)
-            available_types_enum.extend((str(e.id()), e.Name, "") for e in elements)
+        elements = IfcStore.get_file().by_type(self.ifc_class)
+        available_types_enum.extend((str(e.id()), e.Name, "") for e in elements)
     return available_types_enum
 
 
@@ -60,21 +58,17 @@ def updateTypeInstanceIfcClass(self, context):
 def getApplicableTypes(self, context):
     global applicable_types_enum
     if len(applicable_types_enum) < 1:
-        file = IfcStore.get_file()
-        if file:
-            element = file.by_id(context.active_object.BIMObjectProperties.ifc_definition_id)
-            types = ifcopenshell.util.type.get_applicable_types(element.is_a(), schema=IfcStore.get_file().schema)
-            applicable_types_enum.extend((t, t, "") for t in types)
+        element = IfcStore.get_file().by_id(context.active_object.BIMObjectProperties.ifc_definition_id)
+        types = ifcopenshell.util.type.get_applicable_types(element.is_a(), schema=IfcStore.get_file().schema)
+        applicable_types_enum.extend((t, t, "") for t in types)
     return applicable_types_enum
 
 
 def getRelatingTypes(self, context):
     global relating_types_enum
     if len(relating_types_enum) < 1:
-        file = IfcStore.get_file()
-        if file:
-            elements = file.by_type(context.active_object.BIMTypeProperties.relating_type_class)
-            relating_types_enum.extend((str(e.id()), e.Name, "") for e in elements)
+        elements = IfcStore.get_file().by_type(context.active_object.BIMTypeProperties.relating_type_class)
+        relating_types_enum.extend((str(e.id()), e.Name, "") for e in elements)
     return relating_types_enum
 
 


### PR DESCRIPTION
This aims to fix two problems with the Authoring sub panel in the Blenderbim N panel :
- If no ifc file was set, the panel logic would throw an error. Added a check in the panel poll method. This has the side effect to also hide the Architectural sub-panel which is a child of this panel. It may not be desired ?
- The code for populating the `relating_types` enum was accessing the `ifc_class` enum which would throw a warning and an error in case it was empty. We check for `getIfcTypes` items rather than `self.ifc_class` because accessing an empty dynamic enum throws a (very cryptic) message in console :
`WARN (bpy.rna): C:\Users\blender\git\blender-v293\blender.git\source\blender\python\intern\bpy_rna.c:1505 pyrna_enum_to_py: current value '0' matches no enum in 'BIMTypeProperties', '', 'ifc_class'`