### PR TITLE
Improve Debug Panel UI

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/debug/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/debug/operator.py
@@ -122,17 +122,9 @@ class SelectHighPolygonMeshes(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
-        results = {}
-        for obj in bpy.data.objects:
-            if not isinstance(obj.data, bpy.types.Mesh) or len(obj.data.polygons) < int(
-                context.scene.BIMDebugProperties.number_of_polygons
-            ):
-                continue
-            try:
-                obj.select_set(True)
-            except:
-                # If it is not in the view layer
-                pass
+        [o.select_set(True) for o in context.view_layer.objects
+            if o.type == 'MESH'
+            and len(o.data.polygons) > context.scene.BIMDebugProperties.number_of_polygons]
         return {"FINISHED"}
 
 

--- a/src/blenderbim/blenderbim/bim/module/debug/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/debug/operator.py
@@ -30,6 +30,7 @@ class PurgeIfcLinks(bpy.types.Operator):
         for material in bpy.data.materials:
             material.BIMMaterialProperties.ifc_style_id = False
         context.scene.BIMProperties.ifc_file = ""
+        context.scene.BIMDebugProperties.attributes.clear()
         IfcStore.purge()
         blenderbim.bim.handler.purge_module_data()
         return {"FINISHED"}

--- a/src/blenderbim/blenderbim/bim/module/debug/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/debug/operator.py
@@ -12,6 +12,10 @@ class PrintIfcFile(bpy.types.Operator):
     bl_idname = "bim.print_ifc_file"
     bl_label = "Print IFC File"
 
+    @classmethod
+    def poll(cls, context):
+        return IfcStore.get_file()
+
     def execute(self, context):
         print(IfcStore.get_file().wrapped_data.to_string())
         return {"FINISHED"}
@@ -40,6 +44,10 @@ class ValidateIfcFile(bpy.types.Operator):
     bl_idname = "bim.validate_ifc_file"
     bl_label = "Validate IFC File"
 
+    @classmethod
+    def poll(cls, context):
+        return IfcStore.get_file()
+
     def execute(self, context):
         import ifcopenshell.validate
 
@@ -52,6 +60,10 @@ class ValidateIfcFile(bpy.types.Operator):
 class ProfileImportIFC(bpy.types.Operator):
     bl_idname = "bim.profile_import_ifc"
     bl_label = "Profile Import IFC"
+
+    @classmethod
+    def poll(cls, context):
+        return IfcStore.get_file()
 
     def execute(self, context):
         import cProfile
@@ -69,6 +81,10 @@ class ProfileImportIFC(bpy.types.Operator):
 class CreateAllShapes(bpy.types.Operator):
     bl_idname = "bim.create_all_shapes"
     bl_label = "Create All Shapes"
+
+    @classmethod
+    def poll(cls, context):
+        return IfcStore.get_file()
 
     def execute(self, context):
         self.file = IfcStore.get_file()
@@ -97,6 +113,10 @@ class CreateShapeFromStepId(bpy.types.Operator):
     bl_idname = "bim.create_shape_from_step_id"
     bl_label = "Create Shape From STEP ID"
     bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        return IfcStore.get_file()
 
     def execute(self, context):
         return IfcStore.execute_ifc_operator(self, context)
@@ -148,7 +168,11 @@ class RewindInspector(bpy.types.Operator):
 class InspectFromStepId(bpy.types.Operator):
     bl_idname = "bim.inspect_from_step_id"
     bl_label = "Inspect From STEP ID"
-    step_id: bpy.props.IntProperty()
+    step_id: bpy.props.IntProperty()   
+    
+    @classmethod
+    def poll(cls, context):
+        return IfcStore.get_file()
 
     def execute(self, context):
         self.file = IfcStore.get_file()

--- a/src/blenderbim/blenderbim/bim/module/debug/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/debug/operator.py
@@ -168,8 +168,8 @@ class RewindInspector(bpy.types.Operator):
 class InspectFromStepId(bpy.types.Operator):
     bl_idname = "bim.inspect_from_step_id"
     bl_label = "Inspect From STEP ID"
-    step_id: bpy.props.IntProperty()   
-    
+    step_id: bpy.props.IntProperty()
+
     @classmethod
     def poll(cls, context):
         return IfcStore.get_file()

--- a/src/blenderbim/blenderbim/bim/module/debug/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/debug/operator.py
@@ -63,7 +63,7 @@ class ProfileImportIFC(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return IfcStore.get_file()
+        return IfcStore.get_file() and context.scene.BIMProperties.ifc_file
 
     def execute(self, context):
         import cProfile

--- a/src/blenderbim/blenderbim/bim/module/debug/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/debug/prop.py
@@ -14,7 +14,7 @@ from bpy.props import (
 
 class BIMDebugProperties(PropertyGroup):
     step_id: IntProperty(name="STEP ID")
-    number_of_polygons: IntProperty(name="Number of Polygons")
+    number_of_polygons: IntProperty(name="Number of Polygons", min=0)
     active_step_id: IntProperty(name="STEP ID")
     step_id_breadcrumb: CollectionProperty(name="STEP ID Breadcrumb", type=StrProperty)
     attributes: CollectionProperty(name="Attributes", type=Attribute)

--- a/src/blenderbim/blenderbim/bim/module/debug/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/debug/ui.py
@@ -32,15 +32,13 @@ class BIM_PT_debug(Panel):
         row = layout.row()
         row.operator("bim.profile_import_ifc")
 
-        row = layout.row()
-        row.prop(props, "step_id", text="")
-        row = layout.row()
+        row = layout.split(factor=0.7, align=True)
         row.operator("bim.create_shape_from_step_id")
+        row.prop(props, "step_id", text="")
 
-        row = layout.row()
-        row.prop(props, "number_of_polygons", text="")
-        row = layout.row()
+        row = layout.split(factor=0.7, align=True)
         row.operator("bim.select_high_polygon_meshes")
+        row.prop(props, "number_of_polygons", text="")
 
         layout.label(text="Inspector:")
 


### PR DESCRIPTION
This aims to improve usability of the Debug Panel.
- Disable operators which rely on the ifc file if it's not loaded.
- Inline the parameters from 2 operators
- Simplify (IMO) the mesh selection code
- Change Min number of polygons to 0 (previously could go into negative numbers)
- Add statement to purge debug attributes when using the purge operator

Before :
![image](https://user-images.githubusercontent.com/25156105/127785782-b26ce5ef-08a2-4a27-a9dd-49fa06f912a7.png)
After, if no file is loaded :
![image](https://user-images.githubusercontent.com/25156105/127785725-a3584908-2973-4c1d-912b-d4c96e4fcecd.png)
After, if a file is loaded :
![image](https://user-images.githubusercontent.com/25156105/127785749-f8f23c91-ccc8-4293-b716-d9b48ed0a98a.png)
