### PR TITLE
Minor iterator optimisation to prevent inverse check for associated materials

### DIFF
--- a/src/ifcgeom/IfcGeomIteratorImplementation.h
+++ b/src/ifcgeom/IfcGeomIteratorImplementation.h
@@ -604,6 +604,10 @@ namespace IfcGeom {
 				return false;
 			}
 
+			if (products->size() == 1) {
+				return true;
+			}
+
 			std::set<const IfcSchema::IfcMaterial*> associated_single_materials;
 
 			for (IfcSchema::IfcProduct::list::it it = products->begin(); it != products->end(); ++it) {


### PR DESCRIPTION
You said `if (products->size() > 1) { return true } ` but it should be `== 1` right?