### PR TITLE
Detect units from project libraries, and convert nested double aggregates

### DIFF
--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -1747,6 +1747,18 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
 					IfcWrite::IfcWriteArgument* copy = new IfcWrite::IfcWriteArgument();
 					copy->set(v);
 					we->setArgument(i, copy);
+				} else if (attr_type == IfcUtil::Argument_AGGREGATE_OF_AGGREGATE_OF_DOUBLE) {
+					std::vector<std::vector<double>> v = *attr;
+					for (std::vector<std::vector<double>>::iterator it = v.begin(); it != v.end(); ++it) {
+						std::vector<double>& v2 = (*it);
+						for (std::vector<double>::iterator jt = v2.begin(); jt != v2.end(); ++jt) {
+							(*jt) *= conversion_factor;
+						}
+					}
+
+					IfcWrite::IfcWriteArgument* copy = new IfcWrite::IfcWriteArgument();
+					copy->set(v);
+					we->setArgument(i, copy);
 				}
 			}
 		}
@@ -2247,6 +2259,11 @@ void IfcFile::setDefaultHeaderValues() {
 std::pair<IfcUtil::IfcBaseClass*, double> IfcFile::getUnit(const std::string& unit_type) {
 	std::pair<IfcUtil::IfcBaseClass*, double> return_value(0, 1.);
 	IfcEntityList::ptr projects = instances_by_type(schema()->declaration_by_name("IfcProject"));
+	if ( ! projects) {
+		try {
+			projects = instances_by_type(schema()->declaration_by_name("IfcContext"));
+		} catch ( IfcException& e ) {}
+	}
 
 	if (projects && projects->size() == 1) {
 		IfcUtil::IfcBaseClass* project = *projects->begin();


### PR DESCRIPTION
See #1684

I opted to check project first, then only do the try catch for project library because there are two scenarios:

 1. A regular IfcProject which may have zero or more IfcProjectLibraries. In this case, the check for IfcProject passes and we're done.
 2. An IfcProjectLibrary, which there is only one allowed. In this case, the check for IfcProject fails, and we do the try/catch for IfcContext.

In addition, I found that length unit conversion didn't seem to work for cartesianpointlist3d, which I use in tessellations. I hope my fix makes sense.

There seem to be multiple potentially more concise ways of writing the same thing, like:

```c++
for (std::vector<double>& v2 : v) {  for (double& elem : v2) {  elem *= conversion_factor; } }
```

... or ...

```c++
for (auto&& v2 : v) {  for (auto&& elem : v2) {  elem *= conversion_factor;  }  }
```

... but I opted to follow the coding style already present, but please correct me if you have a preference or if there is a pro/con to each approach.