### PR TITLE
Apply object operators to all selected objects

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/classification/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/classification/operator.py
@@ -47,6 +47,10 @@ class AddClassification(bpy.types.Operator):
     bl_label = "Add Classification"
     bl_options = {"REGISTER", "UNDO"}
 
+    @classmethod
+    def poll(cls, context):
+        return getClassifications(context.scene.BIMClassificationProperties, context)
+
     def execute(self, context):
         return IfcStore.execute_ifc_operator(self, context)
 
@@ -77,9 +81,9 @@ class EnableEditingClassification(bpy.types.Operator):
             new.is_null = classification_data[attribute.name()] is None
             new.is_optional = attribute.optional()
             if attribute.name() == "ReferenceTokens":
-                new.string_value = "" if new.is_null else json.dumps(classification_data[attribute.name()])
+                new.set_value("" if new.is_null else json.dumps(classification_data[attribute.name()]))
             else:
-                new.string_value = "" if new.is_null else classification_data[attribute.name()]
+                new.set_value("" if new.is_null else classification_data[attribute.name()])
         props.active_classification_id = self.classification
         return {"FINISHED"}
 
@@ -162,7 +166,7 @@ class EnableEditingClassificationReference(bpy.types.Operator):
             new.name = attribute.name()
             new.is_null = reference_data[attribute.name()] is None
             new.is_optional = attribute.optional()
-            new.string_value = "" if new.is_null else reference_data[attribute.name()]
+            new.set_value("" if new.is_null else reference_data[attribute.name()])
         props.active_reference_id = self.reference
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/constraint/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/constraint/operator.py
@@ -187,17 +187,21 @@ class AssignConstraint(bpy.types.Operator):
         return IfcStore.execute_ifc_operator(self, context)
 
     def _execute(self, context):
-        obj = bpy.data.objects.get(self.obj) if self.obj else context.active_object
         self.file = IfcStore.get_file()
-        ifcopenshell.api.run(
-            "constraint.assign_constraint",
-            self.file,
-            **{
-                "product": self.file.by_id(obj.BIMObjectProperties.ifc_definition_id),
-                "constraint": self.file.by_id(self.constraint),
-            }
-        )
-        Data.load(IfcStore.get_file(), obj.BIMObjectProperties.ifc_definition_id)
+        objs = [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects
+        for obj in objs:
+            obj_id = obj.BIMObjectProperties.ifc_definition_id
+            if not obj_id:
+                continue
+            ifcopenshell.api.run(
+                "constraint.assign_constraint",
+                self.file,
+                **{
+                    "product": self.file.by_id(obj_id),
+                    "constraint": self.file.by_id(self.constraint),
+                }
+            )
+            Data.load(self.file, obj_id)
         return {"FINISHED"}
 
 
@@ -212,15 +216,19 @@ class UnassignConstraint(bpy.types.Operator):
         return IfcStore.execute_ifc_operator(self, context)
 
     def _execute(self, context):
-        obj = bpy.data.objects.get(self.obj) if self.obj else context.active_object
         self.file = IfcStore.get_file()
-        ifcopenshell.api.run(
-            "constraint.unassign_constraint",
-            self.file,
-            **{
-                "product": self.file.by_id(obj.BIMObjectProperties.ifc_definition_id),
-                "constraint": self.file.by_id(self.constraint),
-            }
-        )
-        Data.load(IfcStore.get_file(), obj.BIMObjectProperties.ifc_definition_id)
+        objs = [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects
+        for obj in objs:
+            obj_id = obj.BIMObjectProperties.ifc_definition_id
+            if not obj_id:
+                continue
+            ifcopenshell.api.run(
+                "constraint.unassign_constraint",
+                self.file,
+                **{
+                    "product": self.file.by_id(obj_id),
+                    "constraint": self.file.by_id(self.constraint),
+                }
+            )
+            Data.load(self.file, obj_id)
         return {"FINISHED"}

--- a/src/blenderbim/blenderbim/bim/module/document/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/document/operator.py
@@ -276,17 +276,21 @@ class AssignDocument(bpy.types.Operator):
         return IfcStore.execute_ifc_operator(self, context)
 
     def _execute(self, context):
-        obj = bpy.data.objects.get(self.obj) if self.obj else context.active_object
         self.file = IfcStore.get_file()
-        ifcopenshell.api.run(
-            "document.assign_document",
-            self.file,
-            **{
-                "product": self.file.by_id(obj.BIMObjectProperties.ifc_definition_id),
-                "document": self.file.by_id(self.document),
-            }
-        )
-        Data.load(IfcStore.get_file(), obj.BIMObjectProperties.ifc_definition_id)
+        objs = [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects
+        for obj in objs:
+            obj_id = obj.BIMObjectProperties.ifc_definition_id
+            if not obj_id:
+                continue
+            ifcopenshell.api.run(
+                "document.assign_document",
+                self.file,
+                **{
+                    "product": self.file.by_id(obj_id),
+                    "document": self.file.by_id(self.document),
+                }
+            )
+            Data.load(self.file, obj_id)
         return {"FINISHED"}
 
 
@@ -301,15 +305,19 @@ class UnassignDocument(bpy.types.Operator):
         return IfcStore.execute_ifc_operator(self, context)
 
     def _execute(self, context):
-        obj = bpy.data.objects.get(self.obj) if self.obj else context.active_object
         self.file = IfcStore.get_file()
-        ifcopenshell.api.run(
-            "document.unassign_document",
-            self.file,
-            **{
-                "product": self.file.by_id(obj.BIMObjectProperties.ifc_definition_id),
-                "document": self.file.by_id(self.document),
-            }
-        )
-        Data.load(IfcStore.get_file(), obj.BIMObjectProperties.ifc_definition_id)
+        objs = [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects
+        for obj in objs:
+            obj_id = obj.BIMObjectProperties.ifc_definition_id
+            if not obj_id:
+                continue
+            ifcopenshell.api.run(
+                "document.unassign_document",
+                self.file,
+                **{
+                    "product": self.file.by_id(obj_id),
+                    "document": self.file.by_id(self.document),
+                }
+            )
+            Data.load(self.file, obj_id)
         return {"FINISHED"}

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -92,13 +92,14 @@ class AddRepresentation(bpy.types.Operator):
         gprop = context.scene.BIMGeoreferenceProperties
         objs = [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects
         for obj in objs:
-            if not obj.BIMObjectProperties.ifc_definition_id:
+            obj_id = obj.BIMObjectProperties.ifc_definition_id
+            if not obj_id:
                 continue
             bpy.ops.bim.edit_object_placement(obj=obj.name)
             if not obj.data or not hasattr(obj.data, "polygons"):
                 continue
 
-            product = self.file.by_id(obj.BIMObjectProperties.ifc_definition_id)
+            product = self.file.by_id(obj_id)
 
             context_id = self.context_id or int(context.scene.BIMProperties.contexts)
             context_of_items = self.file.by_id(context_id)
@@ -158,7 +159,7 @@ class AddRepresentation(bpy.types.Operator):
             mesh.name = "{}/{}".format(context_id, result.id())
             mesh.BIMMeshProperties.ifc_definition_id = int(result.id())
             obj.data = mesh
-            Data.load(IfcStore.get_file(), obj.BIMObjectProperties.ifc_definition_id)
+            Data.load(self.file, obj_id)
 
             if product.is_a("IfcTypeProduct"):
                 if self.file.schema == "IFC2X3":
@@ -167,7 +168,7 @@ class AddRepresentation(bpy.types.Operator):
                     types = product.Types
                 if types:
                     for element in types[0].RelatedObjects:
-                        Data.load(IfcStore.get_file(), element.id())
+                        Data.load(self.file, element.id())
         return {"FINISHED"}
 
 

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -95,7 +95,7 @@ class AddRepresentation(bpy.types.Operator):
             if not obj.BIMObjectProperties.ifc_definition_id:
                 continue
             bpy.ops.bim.edit_object_placement(obj=obj.name)
-            if not obj.data:
+            if not obj.data or not hasattr(obj.data, "polygons"):
                 continue
 
             product = self.file.by_id(obj.BIMObjectProperties.ifc_definition_id)

--- a/src/blenderbim/blenderbim/bim/module/georeference/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/operator.py
@@ -49,14 +49,7 @@ class EnableEditingGeoreferencing(bpy.types.Operator):
             new.is_null = Data.projected_crs[attribute.name()] is None
             new.is_optional = attribute.optional()
             new.data_type = data_type
-            if data_type == "string":
-                new.string_value = "" if new.is_null else Data.projected_crs[attribute.name()]
-            elif data_type == "float":
-                new.float_value = 0.0 if new.is_null else Data.projected_crs[attribute.name()]
-            elif data_type == "integer":
-                new.int_value = 0 if new.is_null else Data.projected_crs[attribute.name()]
-            elif data_type == "boolean":
-                new.bool_value = False if new.is_null else Data.projected_crs[attribute.name()]
+            new.set_value(new.get_value_default() if new.is_null else Data.projected_crs[attribute.name()])
 
         props.is_map_unit_null = Data.projected_crs["MapUnit"] is None
         if not props.is_map_unit_null:
@@ -79,8 +72,7 @@ class EnableEditingGeoreferencing(bpy.types.Operator):
             new.is_null = Data.map_conversion[attribute.name()] is None
             new.is_optional = attribute.optional()
             # Enforce a string data type to prevent data loss in single-precision Blender props
-            new.data_type = "string"
-            new.string_value = "" if new.is_null else str(Data.map_conversion[attribute.name()])
+            new.set_value("" if new.is_null else str(Data.map_conversion[attribute.name()]))
 
         props.has_true_north = bool(Data.true_north)
         if Data.true_north:

--- a/src/blenderbim/blenderbim/bim/module/group/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/group/operator.py
@@ -130,7 +130,7 @@ class EnableEditingGroup(bpy.types.Operator):
             new.name = attribute.name()
             new.is_null = data[attribute.name()] is None
             new.is_optional = attribute.optional()
-            new.string_value = "" if new.is_null else data[attribute.name()]
+            new.set_value("" if new.is_null else data[attribute.name()])
         props.active_group_id = self.group
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/layer/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/layer/operator.py
@@ -73,7 +73,7 @@ class EnableEditingLayer(bpy.types.Operator):
             new.name = attribute.name()
             new.is_null = data[attribute.name()] is None
             new.is_optional = attribute.optional()
-            new.string_value = "" if new.is_null else data[attribute.name()]
+            new.set_value("" if new.is_null else data[attribute.name()])
         props.active_layer_id = self.layer
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/material/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/material/operator.py
@@ -124,21 +124,24 @@ class AssignMaterial(bpy.types.Operator):
         return IfcStore.execute_ifc_operator(self, context)
 
     def _execute(self, context):
-        obj = bpy.data.objects.get(self.obj) if self.obj else context.active_object
-        material_type = self.material_type or obj.BIMObjectMaterialProperties.material_type
         self.file = IfcStore.get_file()
-        element = self.file.by_id(obj.BIMObjectProperties.ifc_definition_id)
-        ifcopenshell.api.run(
-            "material.assign_material",
-            self.file,
-            **{
-                "product": element,
-                "type": material_type,
-                "material": self.file.by_id(int(obj.BIMObjectMaterialProperties.material)),
-            },
-        )
-        Data.load(IfcStore.get_file())
-        Data.load(IfcStore.get_file(), obj.BIMObjectProperties.ifc_definition_id)
+        objs = [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects
+        for obj in objs:            
+            if not obj.BIMObjectProperties.ifc_definition_id:
+                continue
+            material_type = self.material_type or obj.BIMObjectMaterialProperties.material_type
+            element = self.file.by_id(obj.BIMObjectProperties.ifc_definition_id)
+            ifcopenshell.api.run(
+                "material.assign_material",
+                self.file,
+                **{
+                    "product": element,
+                    "type": material_type,
+                    "material": self.file.by_id(int(obj.BIMObjectMaterialProperties.material)),
+                },
+            )
+            Data.load(IfcStore.get_file())
+            Data.load(IfcStore.get_file(), obj.BIMObjectProperties.ifc_definition_id)
         return {"FINISHED"}
 
 
@@ -152,13 +155,16 @@ class UnassignMaterial(bpy.types.Operator):
         return IfcStore.execute_ifc_operator(self, context)
 
     def _execute(self, context):
-        obj = bpy.data.objects.get(self.obj) if self.obj else context.active_object
         self.file = IfcStore.get_file()
-        ifcopenshell.api.run(
-            "material.unassign_material",
-            self.file,
-            **{"product": self.file.by_id(obj.BIMObjectProperties.ifc_definition_id)},
-        )
+        objs = [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects
+        for obj in objs:                       
+            if not obj.BIMObjectProperties.ifc_definition_id:
+                continue
+            ifcopenshell.api.run(
+                "material.unassign_material",
+                self.file,
+                **{"product": self.file.by_id(obj.BIMObjectProperties.ifc_definition_id)},
+            )
         Data.purge()
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/material/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/material/operator.py
@@ -444,7 +444,7 @@ class EnableEditingAssignedMaterial(bpy.types.Operator):
                 new = props.material_set_attributes.add()
                 new.name = attribute.name()
                 new.is_null = material_set_data[attribute.name()] is None
-                new.string_value = "" if new.is_null else material_set_data[attribute.name()]
+                new.set_value("" if new.is_null else material_set_data[attribute.name()])
         return {"FINISHED"}
 
     def import_attributes(self, name, prop, data):
@@ -600,14 +600,7 @@ class EnableEditingMaterialSetItem(bpy.types.Operator):
                 new.name = attribute.name()
                 new.is_null = material_set_item_data[attribute.name()] is None
                 new.data_type = data_type
-                if data_type == "string":
-                    new.string_value = "" if new.is_null else material_set_item_data[attribute.name()]
-                elif data_type == "float":
-                    new.float_value = 0.0 if new.is_null else material_set_item_data[attribute.name()]
-                elif data_type == "integer":
-                    new.int_value = 0 if new.is_null else material_set_item_data[attribute.name()]
-                elif data_type == "boolean":
-                    new.bool_value = False if new.is_null else material_set_item_data[attribute.name()]
+                new.set_value(new.get_value_default() if new.is_null else material_set_item_data[attribute.name()])
 
     def load_profile_attributes(self, material_set_item, material_set_item_data):
         self.props.material_set_item_profile_attributes.clear()
@@ -628,18 +621,12 @@ class EnableEditingMaterialSetItem(bpy.types.Operator):
                 new.is_null = profile_data[attribute.name()] is None
                 new.is_optional = attribute.optional()
                 new.data_type = data_type
-                if data_type == "string":
-                    new.string_value = "" if new.is_null else profile_data[attribute.name()]
-                elif data_type == "float":
-                    new.float_value = 0.0 if new.is_null else profile_data[attribute.name()]
-                elif data_type == "integer":
-                    new.int_value = 0 if new.is_null else profile_data[attribute.name()]
-                elif data_type == "boolean":
-                    new.bool_value = False if new.is_null else profile_data[attribute.name()]
-                elif data_type == "enum":
+                if data_type == "enum":
                     new.enum_items = json.dumps(ifcopenshell.util.attribute.get_enum_items(attribute))
                     if profile_data[attribute.name()]:
                         new.enum_value = profile_data[attribute.name()]
+                else:
+                    new.set_value(new.get_value_default() if new.is_null else profile_data[attribute.name()])
 
                 # Force null to be false if the attribute is mandatory because when we first assign a profile, all of
                 # its fields are null (which is illegal).

--- a/src/blenderbim/blenderbim/bim/module/pset/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/pset/operator.py
@@ -141,18 +141,12 @@ class EnablePsetEditing(bpy.types.Operator):
             new.is_optional = True
             new.data_type = data_type
 
-            if data_type == "string":
-                new.string_value = "" if new.is_null else data[prop_template.Name]
-            elif data_type == "integer":
-                new.int_value = 0 if new.is_null else data[prop_template.Name]
-            elif data_type == "float":
-                new.float_value = 0.0 if new.is_null else data[prop_template.Name]
-            elif data_type == "boolean":
-                new.bool_value = False if new.is_null else data[prop_template.Name]
-            elif data_type == "enum":
+            if data_type == "enum":
                 new.enum_items = json.dumps(enum_items)
                 if data.get(prop_template.Name):
                     new.enum_value = data[prop_template.Name]
+            else:
+                new.set_value(new.get_value_default() if new.is_null else data[prop_template.Name])
 
     def load_from_pset_data(self, pset_data):
         for prop_id in pset_data["Properties"]:

--- a/src/blenderbim/blenderbim/bim/module/spatial/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/spatial/operator.py
@@ -48,7 +48,9 @@ class AssignContainer(bpy.types.Operator):
             self.relating_structure or sprops.spatial_elements[sprops.active_spatial_element_index].ifc_definition_id
         )
         for related_element in related_elements:
-            oprops = related_element.BIMObjectProperties
+            oprops = related_element.BIMObjectProperties            
+            if not oprops.ifc_definition_id:
+                continue
             props = related_element.BIMObjectSpatialProperties
 
             ifcopenshell.api.run(
@@ -137,6 +139,8 @@ class RemoveContainer(bpy.types.Operator):
         active_object = context.active_object
         for obj in [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects:
             oprops = obj.BIMObjectProperties
+            if not oprops.ifc_definition_id:
+                continue
             self.file = IfcStore.get_file()
             ifcopenshell.api.run(
                 "spatial.remove_container", self.file, **{"product": self.file.by_id(oprops.ifc_definition_id)}

--- a/src/blenderbim/blenderbim/bim/module/spatial/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/spatial/operator.py
@@ -137,15 +137,20 @@ class RemoveContainer(bpy.types.Operator):
 
     def _execute(self, context):
         active_object = context.active_object
-        for obj in [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects:
-            oprops = obj.BIMObjectProperties
-            if not oprops.ifc_definition_id:
+        self.file = IfcStore.get_file()
+        objs = [bpy.data.objects.get(self.obj)] if self.obj else context.selected_objects
+        for obj in objs:
+            obj_id = obj.BIMObjectProperties.ifc_definition_id
+            if not obj_id:
                 continue
-            self.file = IfcStore.get_file()
             ifcopenshell.api.run(
-                "spatial.remove_container", self.file, **{"product": self.file.by_id(oprops.ifc_definition_id)}
+                "spatial.remove_container", 
+                self.file, 
+                **{
+                    "product": self.file.by_id(obj_id)
+                }
             )
-            Data.load(IfcStore.get_file(), oprops.ifc_definition_id)
+            Data.load(self.file, obj_id)
 
             aggregate_collection = bpy.data.collections.get(obj.name)
             if aggregate_collection:

--- a/src/blenderbim/blenderbim/bim/module/structural/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/structural/operator.py
@@ -176,8 +176,7 @@ class EnableEditingStructuralBoundaryCondition(bpy.types.Operator):
                 new.data_type = "float"
                 new.enum_value = [i for i in enum_items if i != "IfcBoolean"][0]
             elif data_type == "string":
-                new.string_value = "" if new.is_null else data[attribute.name()]
-                new.data_type = "string"
+                new.set_value("" if new.is_null else data[attribute.name()])
 
         props.active_boundary_condition = self.boundary_condition
         return {"FINISHED"}
@@ -359,8 +358,7 @@ class EnableEditingStructuralAnalysisModel(bpy.types.Operator):
                 if data[attribute.name()]:
                     new.enum_value = data[attribute.name()]
             else:
-                new.string_value = "" if new.is_null else data[attribute.name()]
-                new.data_type = "string"
+                new.set_value("" if new.is_null else data[attribute.name()])
         props.active_structural_analysis_model_id = self.structural_analysis_model
         return {"FINISHED"}
 
@@ -1097,8 +1095,7 @@ class EnableEditingBoundaryCondition(bpy.types.Operator):
                 new.data_type = "float"
                 new.enum_value = [i for i in enum_items if i != "IfcBoolean"][0]
             elif data_type == "string":
-                new.string_value = "" if new.is_null else data[attribute.name()]
-                new.data_type = "string"
+                new.set_value("" if new.is_null else data[attribute.name()])
         props.active_boundary_condition_id = self.boundary_condition
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/system/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/system/operator.py
@@ -130,7 +130,7 @@ class EnableEditingSystem(bpy.types.Operator):
             new.name = attribute.name()
             new.is_null = data[attribute.name()] is None
             new.is_optional = attribute.optional()
-            new.string_value = "" if new.is_null else data[attribute.name()]
+            new.set_value("" if new.is_null else data[attribute.name()])
         props.active_system_id = self.system
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/unit/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/unit/operator.py
@@ -248,8 +248,7 @@ class EnableEditingUnit(bpy.types.Operator):
             new.name = name
             new.is_null = data[name] is None
             new.is_optional = False
-            new.data_type = "string"
-            new.string_value = json.dumps([e for e in IfcStore.get_file().by_id(data["id"]).Dimensions])
+            new.set_value(json.dumps([e for e in IfcStore.get_file().by_id(data["id"]).Dimensions]))
             return True
 
 


### PR DESCRIPTION
This change adds functionality to extend some operators to affect all selected objects rather than only the active one :

- Remove container
- Assign / Unassign Material
- Add Representation (silently passes on non-mesh objects)
- Assign / Unassign Constraint
- Assign / Unassign Document
- Small tweaks to attribute assignments which `data_type` wasn't updated when created
- Use poll method to `bim.add_classification` operator to avoid error if no classification is available

The PR is showing a lot more line additions and deletions than in reality mainly because I changed the order of some lines that didn't need retrieving on each iteration like `self.file = IfcStore.get_file()`.