### PR TITLE
Fix https://github.com/IfcOpenShell/IfcOpenShell/issues/1695 :

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/material/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/material/operator.py
@@ -365,6 +365,7 @@ class RemoveListItem(bpy.types.Operator):
     obj: bpy.props.StringProperty()
     list_item_set: bpy.props.IntProperty()
     list_item: bpy.props.IntProperty()
+    list_item_index: bpy.props.IntProperty()
 
     def execute(self, context):
         return IfcStore.execute_ifc_operator(self, context)
@@ -377,7 +378,7 @@ class RemoveListItem(bpy.types.Operator):
             self.file,
             **{
                 "material_list": self.file.by_id(self.list_item_set),
-                "material": self.file.by_id(self.list_item),
+                "material_index": self.list_item_index,
             },
         )
         Data.load_lists()

--- a/src/blenderbim/blenderbim/bim/module/material/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/material/ui.py
@@ -258,6 +258,8 @@ class BIM_PT_object_material(Panel):
         if self.product_data["type"] == "IfcMaterialList":
             setattr(op, "list_item_set", self.material_set_id)
         setattr(op, self.set_item_name, item["id"])
+        if hasattr(op, f"{self.set_item_name}_index"):
+            setattr(op, f"{self.set_item_name}_index", index)
 
     def draw_read_only_set_ui(self):
         if (

--- a/src/ifcopenshell-python/ifcopenshell/api/material/remove_list_item.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/material/remove_list_item.py
@@ -4,10 +4,11 @@ import ifcopenshell
 class Usecase:
     def __init__(self, file, **settings):
         self.file = file
-        self.settings = {"material_list": None, "material": None}
+        self.settings = {"material_list": None, "material_index": None}
         for key, value in settings.items():
             self.settings[key] = value
 
     def execute(self):
-        materials = [m for m in self.settings["material_list"].Materials if m != self.settings["material"]]
+        materials = list(self.settings["material_list"].Materials)
+        materials.pop(self.settings["material_index"])
         self.settings["material_list"].Materials = materials


### PR DESCRIPTION
Fix https://github.com/IfcOpenShell/IfcOpenShell/issues/1695 : Removing material from IfcMaterialList removes all occurences of the material

I don't really like sets because their random access tends to make interface well... random :)
Turns out the `ui.py` code is not straightforward to hack so I added a new optional index parameter to the operator.