### PR TITLE
Add basic BCF pypi upload CI action.

### DIFF
--- a/.github/workflows/ci-bcf.yml
+++ b/.github/workflows/ci-bcf.yml
@@ -22,6 +22,7 @@ jobs:
           python-version: '3.x'
       - name: Build package
         run: |
+          cd src/bcf
           pip install build
           python -m build
       - name: Publish package
@@ -29,6 +30,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+          packages_dir: src/bcf/dist
 
 
 


### PR DESCRIPTION
For now I propose a simple trigger using a commit tag "[bcf release]". I think this is just as well since we do not (yet) have an automatic versioning for the bcf package