### PR TITLE
Notify if file already contains library element

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,6 @@ jobs:
         run: |
           cd test
           sudo /usr/bin/python tests.py
-          sudo /usr/bin/python ../src/ifcopenshell-python/ifcopenshell/test_ids.py
+          cd ../src/ifcopenshell-python
+          sudo /usr/bin/python -m pip install pytest
+          make test

--- a/src/blenderbim/blenderbim/bim/module/project/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/project/operator.py
@@ -204,11 +204,13 @@ class ChangeLibraryElement(bpy.types.Operator):
 
     def execute(self, context):
         self.props = context.scene.BIMProjectProperties
+        self.file = IfcStore.get_file()
+        self.library_file = IfcStore.library_file
         ifc_classes = set()
         self.props.active_library_element = self.element_name
         crumb = self.props.library_breadcrumb.add()
         crumb.name = self.element_name
-        elements = IfcStore.library_file.by_type(self.element_name)
+        elements = self.library_file.by_type(self.element_name)
         [ifc_classes.add(e.is_a()) for e in elements]
         self.props.library_elements.clear()
         if len(ifc_classes) == 1 and list(ifc_classes)[0] == self.element_name:
@@ -234,11 +236,21 @@ class ChangeLibraryElement(bpy.types.Operator):
         new = self.props.library_elements.add()
         new.name = name
         new.ifc_definition_id = ifc_definition_id
-        element = IfcStore.library_file.by_id(ifc_definition_id)
-        if IfcStore.library_file.schema == "IFC2X3" or not IfcStore.library_file.by_type("IfcProjectLibrary"):
+        element = self.library_file.by_id(ifc_definition_id)
+        if self.library_file.schema == "IFC2X3" or not self.library_file.by_type("IfcProjectLibrary"):
             new.is_declared = False
         elif getattr(element, "HasContext", None) and element.HasContext[0].RelatingContext.is_a("IfcProjectLibrary"):
             new.is_declared = True
+        try:
+            if element.is_a("IfcMaterial"):
+                next(e for e in self.file.by_type("IfcMaterial") if e.Name == name)
+            elif element.is_a("IfcProfileDef"):
+                next(e for e in self.file.by_type("IfcProfileDef") if e.ProfileName == name)
+            else:
+                self.file.by_guid(element.GlobalId)
+            new.is_appended = True
+        except (AttributeError, RuntimeError, StopIteration):
+            new.is_appended = False
 
 
 class RewindLibrary(bpy.types.Operator):
@@ -345,6 +357,7 @@ class AppendLibraryElement(bpy.types.Operator):
     bl_label = "Append Library Element"
     bl_options = {"REGISTER", "UNDO"}
     definition: bpy.props.IntProperty()
+    prop_index: bpy.props.IntProperty()
 
     @classmethod
     def poll(cls, context):
@@ -367,6 +380,7 @@ class AppendLibraryElement(bpy.types.Operator):
             self.import_type_from_ifc(element, context)
         elif element.is_a("IfcMaterial"):
             self.import_material_from_ifc(element, context)
+        context.scene.BIMProjectProperties.library_elements[self.prop_index].is_appended = True
         blenderbim.bim.handler.purge_module_data()
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/project/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/project/prop.py
@@ -36,6 +36,7 @@ class LibraryElement(PropertyGroup):
     name: StringProperty(name="Name")
     ifc_definition_id: IntProperty(name="IFC Definition ID")
     is_declared: BoolProperty(name="Is Declared", default=False)
+    is_appended: BoolProperty(name="Is Appended", default=False)
 
 
 class BIMProjectProperties(PropertyGroup):
@@ -51,3 +52,6 @@ class BIMProjectProperties(PropertyGroup):
     library_breadcrumb: CollectionProperty(name="Library Breadcrumb", type=StrProperty)
     library_elements: CollectionProperty(name="Library Elements", type=LibraryElement)
     active_library_element_index: IntProperty(name="Active Library Element Index")
+
+    def get_library_element_index(self, lib_element):
+        return next((i for i in range(len(self.library_elements)) if self.library_elements[i] == lib_element))

--- a/src/blenderbim/blenderbim/bim/module/project/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/project/ui.py
@@ -178,16 +178,9 @@ class BIM_UL_library(UIList):
                     op = row.operator("bim.assign_library_declaration", text="", icon="KEYFRAME", emboss=False)
                     op.definition = item.ifc_definition_id
             if item.ifc_definition_id:
-                file = IfcStore.get_file()
-                try:
-                    element = IfcStore.library_file.by_id(item.ifc_definition_id)
-                    if element.is_a("IfcTypeProduct") or element.is_a("IfcCostSchedule"):
-                        file.by_guid(element.GlobalId)
-                    elif element.is_a("IfcMaterial"):
-                        next(e for e in file.by_type("IfcMaterial") if e.Name == element.Name)
-                    elif element.is_a("IfcProfileDef"):
-                        next(e for e in file.by_type("IfcProfileDef") if e.ProfileName == element.ProfileName)
+                if item.is_appended:
                     row.label(text="", icon="CHECKMARK")
-                except (AttributeError, RuntimeError, StopIteration):
+                else:
                     op = row.operator("bim.append_library_element", text="", icon="APPEND_BLEND")
                     op.definition = item.ifc_definition_id
+                    op.prop_index = data.get_library_element_index(item)

--- a/src/ifcopenshell-python/Makefile
+++ b/src/ifcopenshell-python/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	pytest -o "testpaths=test"
+	cd test && pytest
 
 .PHONY: coverage
 coverage:

--- a/src/ifcopenshell-python/ifcopenshell/file.py
+++ b/src/ifcopenshell-python/ifcopenshell/file.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 
 import numbers
 import functools
+import ifcopenshell.util.element
 
 from . import ifcopenshell_wrapper
 from .entity_instance import entity_instance
@@ -111,16 +112,10 @@ class Transaction:
         for inverse in self.file.get_inverse(element):
             inverse_references = []
             for i, attribute in enumerate(inverse):
-                if self.has_element_reference(attribute, element):
+                if ifcopenshell.util.element.has_element_reference(attribute, element):
                     inverse_references.append((i, self.serialise_value(inverse, attribute)))
             inverses[inverse.id()] = inverse_references
         return inverses
-
-    def has_element_reference(self, value, element):
-        if isinstance(value, (tuple, list)):
-            for v in value:
-                return self.has_element_reference(v, element)
-        return value == element
 
     def rollback(self):
         for operation in self.operations[::-1]:
@@ -259,11 +254,7 @@ class file(object):
             f.create_entity('IfcPerson', Identification='Foobar')
             >>> #3=IfcPerson('Foobar',$,$,$,$,$,$,$)
         """
-        eid = -1
-        try:
-            eid = kwargs.pop("id", -1)
-        except:
-            pass
+        eid = kwargs.pop("id", -1)
 
         e = entity_instance((self.schema, type), self)
 

--- a/src/ifcopenshell-python/ifcopenshell/util/element.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/element.py
@@ -26,7 +26,8 @@ def get_property_definition(definition):
             # Entity introduced in IFC4
             # definition.is_a('IfcPreDefinedPropertySet'):
             for prop in range(4, len(definition)):
-                props[definition.attribute_name(prop)] = definition[prop]
+                if definition[prop] is not None:
+                    props[definition.attribute_name(prop)] = definition[prop]
         return props
 
 
@@ -44,7 +45,7 @@ def get_properties(properties):
         if prop.is_a("IfcPropertySingleValue"):
             results[prop.Name] = prop.NominalValue.wrappedValue if prop.NominalValue else None
         elif prop.is_a("IfcComplexProperty"):
-            data = prop.get_info()
+            data = {k: v for k, v in prop.get_info().items() if v is not None and k != "Name"}
             data["properties"] = get_properties(prop.HasProperties)
             del data["HasProperties"]
             results[prop.Name] = data

--- a/src/ifcopenshell-python/test/bootstrap.py
+++ b/src/ifcopenshell-python/test/bootstrap.py
@@ -1,4 +1,5 @@
 import pytest
+import ifcopenshell
 import ifcopenshell.api
 
 

--- a/src/ifcopenshell-python/test/bootstrap.py
+++ b/src/ifcopenshell-python/test/bootstrap.py
@@ -1,0 +1,17 @@
+import pytest
+import ifcopenshell.api
+
+
+class IFC4:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.file = ifcopenshell.api.run("project.create_file")
+
+
+class IFC2X3:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.file = ifcopenshell.api.run("project.create_file", version="IFC2X3")
+        ifcopenshell.api.owner.settings.get_person = lambda ifc: ifc.createIfcPerson()
+        ifcopenshell.api.owner.settings.get_organisation = lambda ifc: ifc.createIfcOrganization()
+        ifcopenshell.api.owner.settings.get_application = lambda ifc: ifc.createIfcApplication()

--- a/src/ifcopenshell-python/test/test_file.py
+++ b/src/ifcopenshell-python/test/test_file.py
@@ -1,10 +1,11 @@
 import pytest
-import test.bootstrap
+import bootstrap
+import ifcopenshell
 import ifcopenshell.api
 import ifcopenshell.util.element
 
 
-class TestTransaction(test.bootstrap.IFC4):
+class TestTransaction(bootstrap.IFC4):
     def test_that_nothing_happens_without_a_transaction(self):
         wall = self.file.createIfcWall()
         self.file.undo()
@@ -133,7 +134,7 @@ class TestTransaction(test.bootstrap.IFC4):
         assert len(list(self.file)) == 2
 
 
-class TestFile(test.bootstrap.IFC4):
+class TestFile(bootstrap.IFC4):
     def test_creating_a_new_file(self):
         f = ifcopenshell.file(schema="IFC4")
         assert f.schema == "IFC4"

--- a/src/ifcopenshell-python/test/test_file.py
+++ b/src/ifcopenshell-python/test/test_file.py
@@ -1,0 +1,210 @@
+import pytest
+import test.bootstrap
+import ifcopenshell.api
+import ifcopenshell.util.element
+
+
+class TestTransaction(test.bootstrap.IFC4):
+    def test_that_nothing_happens_without_a_transaction(self):
+        wall = self.file.createIfcWall()
+        self.file.undo()
+        assert wall
+
+    def test_that_you_can_undo_and_redo_creation(self):
+        unchanged = self.file.createIfcWall()
+        self.file.begin_transaction()
+        wall = self.file.createIfcWall()
+        self.file.end_transaction()
+        self.file.undo()
+        assert unchanged
+        with pytest.raises(RuntimeError):
+            self.file.by_id(2)
+        self.file.redo()
+        self.file.by_id(2)
+
+    def test_that_you_can_undo_and_redo_editing(self):
+        element = self.file.createIfcWall(Name="foo")
+        self.file.begin_transaction()
+        element.Name = "bar"
+        self.file.end_transaction()
+        self.file.undo()
+        assert element.Name == "foo"
+        self.file.redo()
+        assert element.Name == "bar"
+
+    def test_that_you_can_undo_and_redo_deletion(self):
+        element = self.file.createIfcWall(GlobalId="id")
+        self.file.begin_transaction()
+        self.file.remove(element)
+        self.file.end_transaction()
+        self.file.undo()
+        assert self.file.by_id(1)
+        self.file.redo()
+        with pytest.raises(RuntimeError):
+            self.file.by_id(1)
+
+    def test_that_you_can_undo_and_redo_deletion_with_inverse_relationships(self):
+        element = self.file.createIfcWall(GlobalId="id")
+        rel = self.file.createIfcRelAggregates()
+        rel.RelatingObject = element
+        self.file.begin_transaction()
+        self.file.remove(element)
+        self.file.end_transaction()
+        self.file.undo()
+        assert rel.RelatingObject == self.file.by_id(1)
+        self.file.redo()
+        assert rel.RelatingObject is None
+
+    def test_that_you_can_undo_and_redo_batched_deletion_with_inverse_relationships(self):
+        element = self.file.createIfcWall(GlobalId="id")
+        rel = self.file.createIfcRelAggregates()
+        rel.RelatingObject = element
+        self.file.begin_transaction()
+        self.file.batch()
+        self.file.remove(element)
+        self.file.unbatch()
+        self.file.end_transaction()
+        self.file.undo()
+        assert rel.RelatingObject == self.file.by_id(1)
+        self.file.redo()
+        assert rel.RelatingObject is None
+
+    def test_that_you_can_undo_and_redo_deletion_with_aggregated_inverse_relationships(self):
+        element = self.file.createIfcWall(GlobalId="id")
+        rel = self.file.createIfcRelAggregates()
+        rel.RelatedObjects = [element]
+        self.file.begin_transaction()
+        self.file.remove(element)
+        self.file.end_transaction()
+        self.file.undo()
+        assert rel.RelatedObjects == (self.file.by_id(1),)
+        self.file.redo()
+        assert len(rel.RelatedObjects) == 0
+
+    def test_the_editing_of_invalid_default_values(self):
+        element = self.file.createIfcWall() # This element is invalid, as GlobalId is None
+        self.file.begin_transaction()
+        element.GlobalId = "id"
+        self.file.end_transaction()
+        self.file.undo()
+
+    def test_setting_the_history_size(self):
+        self.file.set_history_size(2)
+        self.file.begin_transaction()
+        self.file.end_transaction()
+        self.file.begin_transaction()
+        self.file.end_transaction()
+        self.file.begin_transaction()
+        self.file.end_transaction()
+        assert len(self.file.history) == 2
+        self.file.set_history_size(1)
+        assert len(self.file.history) == 1
+
+    def test_discarding_the_active_transaction(self):
+        self.file.begin_transaction()
+        self.file.discard_transaction()
+        self.file.end_transaction()
+        assert len(self.file.history) == 0
+
+    def test_redoing_without_anything_in_the_redo_stack(self):
+        self.file.redo()
+
+    def test_that_you_can_undo_and_redo_added_elements(self):
+        g = ifcopenshell.file()
+        element = g.createIfcWall()
+        self.file.begin_transaction()
+        self.file.add(element)
+        self.file.end_transaction()
+        self.file.undo()
+        assert len(list(self.file)) == 0
+        self.file.redo()
+        assert len(list(self.file)) == 1
+
+    def test_that_you_can_undo_and_redo_added_subelements(self):
+        g = ifcopenshell.file()
+        owner = g.createIfcOwnerHistory()
+        element = g.createIfcWall(OwnerHistory=owner)
+        self.file.begin_transaction()
+        self.file.add(element)
+        self.file.end_transaction()
+        self.file.undo()
+        assert len(list(self.file)) == 0
+        self.file.redo()
+        assert len(list(self.file)) == 2
+
+
+class TestFile(test.bootstrap.IFC4):
+    def test_creating_a_new_file(self):
+        f = ifcopenshell.file(schema="IFC4")
+        assert f.schema == "IFC4"
+
+    def test_creating_an_entity(self):
+        element = self.file.create_entity("IfcPerson")
+        assert element.is_a("IfcPerson")
+        element = self.file.create_entity("IfcPerson", "identification")
+        assert element.Identification == "identification"
+        element = self.file.create_entity("IfcPerson", Identification="identification")
+        assert element.Identification == "identification"
+        element = self.file.create_entity("IfcPerson", Identification="identification", id=42)
+        assert element.id() == 42
+        element = self.file.createIfcPerson()
+        assert element.is_a("IfcPerson")
+
+    def test_getting_an_element_by_id(self):
+        element = self.file.createIfcWall("id")
+        assert self.file.by_id(1) == element
+        assert self.file.by_id("id") == element
+
+    def test_getting_an_element_by_guid(self):
+        element = self.file.createIfcWall("id")
+        assert self.file.by_guid(1) == element
+        assert self.file.by_guid("id") == element
+
+    def test_adding_an_element(self):
+        g = ifcopenshell.file()
+        element = g.createIfcWall()
+        result = self.file.add(element)
+        assert result.is_a() == element.is_a()
+
+    def test_getting_elements_by_type(self):
+        wall = self.file.createIfcWall()
+        slab = self.file.createIfcSlab()
+        assert self.file.by_type("IfcWall") == [wall]
+
+    def test_getting_elements_by_exact_type(self):
+        wall = self.file.createIfcWall()
+        assert self.file.by_type("IfcElement") == [wall]
+        assert len(self.file.by_type("IfcElement", include_subtypes=False)) == 0
+
+    def test_traversing_direct_attributes_of_an_element(self):
+        owner = self.file.createIfcOwnerHistory()
+        element = self.file.createIfcWall(OwnerHistory=owner)
+        assert self.file.traverse(element) == [element, owner]
+
+    def test_traversing_direct_attributes_of_an_element_to_a_limited_level(self):
+        app = self.file.createIfcApplication()
+        owner = self.file.createIfcOwnerHistory(OwningApplication=app)
+        element = self.file.createIfcWall(OwnerHistory=owner)
+        assert self.file.traverse(element, max_levels=1) == [element, owner]
+
+    def test_getting_inverse_references_of_an_element(self):
+        owner = self.file.createIfcOwnerHistory()
+        element = self.file.createIfcWall(OwnerHistory=owner)
+        assert self.file.get_inverse(owner) == [element]
+
+    def test_removing_an_element(self):
+        element = self.file.createIfcWall(GlobalId="global_id")
+        self.file.remove(element)
+        assert len(list(self.file)) == 0
+
+    def test_batched_removing_an_element(self):
+        element = self.file.createIfcWall(GlobalId="global_id")
+        self.file.batch()
+        self.file.remove(element)
+        self.file.unbatch()
+        assert len(list(self.file)) == 0
+
+    def test_creating_ifc_data_from_a_string(self):
+        element = self.file.createIfcWall()
+        g = ifcopenshell.file.from_string(self.file.wrapped_data.to_string())
+        assert g.by_id(1).is_a("IfcWall")

--- a/src/ifcopenshell-python/test/test_ids.py
+++ b/src/ifcopenshell-python/test/test_ids.py
@@ -1,16 +1,11 @@
-import unittest
-from ifcopenshell import ids
-
-# from ids import ids
-import requests
 import os
 import logging
-
-# from xmlschema.validators.exceptions import XMLSchemaChildrenValidationError
+import unittest
+import tempfile
+import requests
 import ifcopenshell
 from bcf import bcfxml
-
-import tempfile
+from ifcopenshell import ids
 
 
 def read_web_file(URL):
@@ -320,7 +315,7 @@ class TestIdsReporting(unittest.TestCase):
 
     def test_bcf_report(self):
         ids_file = ids.ids.open(read_web_file(self.IDS_URL))
-        fn = tempfile.gettempdir() + r"\bcf_test.bcfzip"
+        fn = os.path.join(tempfile.gettempdir(), "test.bcf")
         bcf_handler = ids.BcfHandler(project_name="Default IDS Project", author="your@email.com", filepath=fn)
         self.logger.addHandler(bcf_handler)
         ids_file.validate(self.ifc_file, self.logger)

--- a/src/ifcopenshell-python/test/util/test_element.py
+++ b/src/ifcopenshell-python/test/util/test_element.py
@@ -1,0 +1,246 @@
+import pytest
+import test.bootstrap
+import ifcopenshell.api
+import ifcopenshell.util.element
+
+
+class TestGetPsetsIFC4(test.bootstrap.IFC4):
+    def test_getting_the_psets_of_a_product_as_a_dictionary(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        assert ifcopenshell.util.element.get_psets(element) == {}
+        pset = ifcopenshell.api.run("pset.add_pset", self.file, product=element, name="name")
+        ifcopenshell.api.run("pset.edit_pset", self.file, pset=pset, properties={"a": "b"})
+        assert ifcopenshell.util.element.get_psets(element) == {"name": {"a": "b"}}
+
+    def test_getting_the_psets_of_a_product_type_as_a_dictionary(self):
+        type_element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWallType")
+        assert ifcopenshell.util.element.get_psets(type_element) == {}
+        pset = ifcopenshell.api.run("pset.add_pset", self.file, product=type_element, name="name")
+        ifcopenshell.api.run("pset.edit_pset", self.file, pset=pset, properties={"x": "y"})
+        assert ifcopenshell.util.element.get_psets(type_element) == {"name": {"x": "y"}}
+
+    def test_getting_psets_from_an_element_which_cannot_have_psets(self):
+        assert ifcopenshell.util.element.get_psets(self.file.create_entity("IfcPerson")) == {}
+
+
+class TestGetPropertyDefinitionIFC4(test.bootstrap.IFC4):
+    def test_getting_the_properties_of_a_pset(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.run("pset.add_pset", self.file, product=element, name="name")
+        ifcopenshell.api.run("pset.edit_pset", self.file, pset=pset, properties={"a": "b"})
+        assert ifcopenshell.util.element.get_property_definition(pset) == {"a": "b"}
+
+    def test_getting_the_properties_of_a_qto(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        qto = ifcopenshell.api.run("pset.add_qto", self.file, product=element, name="name")
+        ifcopenshell.api.run("pset.edit_qto", self.file, qto=qto, properties={"x": 42})
+        assert ifcopenshell.util.element.get_property_definition(qto) == {"x": 42}
+
+    def test_getting_the_properties_of_a_predefined_pset(self):
+        pset = self.file.create_entity("IfcDoorLiningProperties", ifcopenshell.guid.new())
+        pset.LiningDepth = 42
+        assert ifcopenshell.util.element.get_property_definition(pset) == {"LiningDepth": 42}
+
+
+class TestGetQuantitiesIFC4(test.bootstrap.IFC4):
+    def test_getting_quantities_from_a_qto(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        qto = ifcopenshell.api.run("pset.add_qto", self.file, product=element, name="name")
+        ifcopenshell.api.run("pset.edit_qto", self.file, qto=qto, properties={"x": 42})
+        assert ifcopenshell.util.element.get_quantities(qto.Quantities) == {"x": 42}
+
+
+class TestGetPropertiesIFC4(test.bootstrap.IFC4):
+    def test_getting_single_properties_from_a_list_of_properties(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.run("pset.add_pset", self.file, product=element, name="name")
+        ifcopenshell.api.run("pset.edit_pset", self.file, pset=pset, properties={"a": "b"})
+        assert ifcopenshell.util.element.get_properties(pset.HasProperties) == {"a": "b"}
+
+    def test_getting_complex_properties_from_a_list_of_properties(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.run("pset.add_pset", self.file, product=element, name="pset")
+        complex_property = self.file.createIfcComplexProperty(Name="prop", UsageName="usage_name")
+        ifcopenshell.api.run("pset.edit_pset", self.file, pset=complex_property, properties={"a": "b"})
+        pset.HasProperties = [complex_property]
+        assert ifcopenshell.util.element.get_properties(pset.HasProperties) == {
+            "prop": {
+                "UsageName": "usage_name",
+                "id": 4,
+                "type": "IfcComplexProperty",
+                "properties": {"a": "b"},
+            }
+        }
+
+
+class TestGetTypeIFC4(test.bootstrap.IFC4):
+    def test_getting_the_type_of_a_product(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        element_type = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWallType")
+        ifcopenshell.api.run("type.assign_type", self.file, related_object=element, relating_type=element_type)
+        assert ifcopenshell.util.element.get_type(element) == element_type
+        assert ifcopenshell.util.element.get_type(element_type) == element_type
+
+
+class TestGetTypeIFC2X3(test.bootstrap.IFC2X3):
+    def test_getting_the_type_of_a_product(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        element_type = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWallType")
+        ifcopenshell.api.run("type.assign_type", self.file, related_object=element, relating_type=element_type)
+        assert ifcopenshell.util.element.get_type(element) == element_type
+        assert ifcopenshell.util.element.get_type(element_type) == element_type
+
+
+class TestGetMaterial(test.bootstrap.IFC4):
+    def test_getting_the_material_of_a_product(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        material = ifcopenshell.api.run("material.add_material", self.file)
+        ifcopenshell.api.run("material.assign_material", self.file, product=element, material=material)
+        assert ifcopenshell.util.element.get_material(element) == material
+
+    def test_getting_a_material_list_of_a_product(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        material = ifcopenshell.api.run("material.add_material", self.file)
+        rel = ifcopenshell.api.run(
+            "material.assign_material", self.file, product=element, type="IfcMaterialList", material=material
+        )
+        assert ifcopenshell.util.element.get_material(element) == rel.RelatingMaterial
+
+    def test_getting_a_material_layer_set_of_a_product(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        rel = ifcopenshell.api.run("material.assign_material", self.file, product=element, type="IfcMaterialLayerSet")
+        assert ifcopenshell.util.element.get_material(element) == rel.RelatingMaterial
+
+    def test_getting_a_material_profile_set_of_a_product(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        rel = ifcopenshell.api.run("material.assign_material", self.file, product=element, type="IfcMaterialProfileSet")
+        assert ifcopenshell.util.element.get_material(element) == rel.RelatingMaterial
+
+    def test_getting_a_material_layer_set_usage_of_a_product(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        rel = ifcopenshell.api.run(
+            "material.assign_material", self.file, product=element, type="IfcMaterialLayerSetUsage"
+        )
+        assert ifcopenshell.util.element.get_material(element) == rel.RelatingMaterial
+
+    def test_getting_a_material_profile_set_usage_of_a_product(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        rel = ifcopenshell.api.run(
+            "material.assign_material", self.file, product=element, type="IfcMaterialProfileSetUsage"
+        )
+        assert ifcopenshell.util.element.get_material(element) == rel.RelatingMaterial
+
+    def test_getting_a_material_layer_set_indirectly_from_an_assigned_usage(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        rel = ifcopenshell.api.run(
+            "material.assign_material", self.file, product=element, type="IfcMaterialLayerSetUsage"
+        )
+        assert (
+            ifcopenshell.util.element.get_material(element, should_skip_usage=True) == rel.RelatingMaterial.ForLayerSet
+        )
+
+    def test_getting_a_material_profile_set_indirectly_from_an_assigned_usage(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        rel = ifcopenshell.api.run(
+            "material.assign_material", self.file, product=element, type="IfcMaterialProfileSetUsage"
+        )
+        assert (
+            ifcopenshell.util.element.get_material(element, should_skip_usage=True)
+            == rel.RelatingMaterial.ForProfileSet
+        )
+
+    def test_getting_an_inherited_material_from_the_elements_type(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        element_type = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWallType")
+        ifcopenshell.api.run("type.assign_type", self.file, related_object=element, relating_type=element_type)
+        material = ifcopenshell.api.run("material.add_material", self.file)
+        ifcopenshell.api.run("material.assign_material", self.file, product=element_type, material=material)
+        assert ifcopenshell.util.element.get_material(element) == material
+
+
+class TestGetContainerIFC4(test.bootstrap.IFC4):
+    def test_getting_the_spatial_container_of_an_element(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        building = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcBuilding")
+        ifcopenshell.api.run("spatial.assign_container", self.file, product=element, relating_structure=building)
+        assert ifcopenshell.util.element.get_container(element) == building
+
+
+class TestGetAggregateIFC4(test.bootstrap.IFC4):
+    def test_getting_the_containing_aggregate_of_a_subelement(self):
+        element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
+        subelement = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcCovering")
+        ifcopenshell.api.run("aggregate.assign_object", self.file, product=subelement, relating_object=element)
+        assert ifcopenshell.util.element.get_aggregate(subelement) == element
+
+
+class TestReplaceAttributeIFC4(test.bootstrap.IFC4):
+    def test_replacing_an_elements_attribute(self):
+        element = self.file.createIfcWall("foo")
+        ifcopenshell.util.element.replace_attribute(element, "foo", "bar")
+        assert element.GlobalId == "bar"
+
+    def test_replacing_a_value_in_a_list(self):
+        old = self.file.createIfcWall()
+        new = self.file.createIfcWall()
+        rel = self.file.createIfcRelAggregates()
+        rel.RelatedObjects = [old]
+        ifcopenshell.util.element.replace_attribute(rel, old, new)
+        assert rel.RelatedObjects == (new,)
+
+
+class TestHasElementReferenceIFC4(test.bootstrap.IFC4):
+    def test_if_a_element_attribute_references_another_element(self):
+        old = self.file.createIfcWall()
+        new = self.file.createIfcWall()
+        rel = self.file.createIfcRelAggregates()
+        rel.RelatedObjects = [old]
+        assert ifcopenshell.util.element.has_element_reference(rel.RelatedObjects, old) is True
+        assert ifcopenshell.util.element.has_element_reference(rel.RelatedObjects, new) is False
+
+
+class TestRemoveDeepIFC4(test.bootstrap.IFC4):
+    def test_removing_an_element_along_with_all_direct_attributes_recursively(self):
+        owner = self.file.createIfcOwnerHistory()
+        element = self.file.createIfcWall(GlobalId="id", OwnerHistory=owner)
+        ifcopenshell.util.element.remove_deep(self.file, element)
+        with pytest.raises(RuntimeError):
+            self.file.by_id(1)
+            self.file.by_id(2)
+
+    def test_removing_an_element_recursively_except_if_an_element_is_referenced_elsewhere(self):
+        owner = self.file.createIfcOwnerHistory()
+        element = self.file.createIfcWall(GlobalId="id1", OwnerHistory=owner)
+        element2 = self.file.createIfcWall(GlobalId="id2", OwnerHistory=owner)
+        ifcopenshell.util.element.remove_deep(self.file, element)
+        with pytest.raises(RuntimeError):
+            self.file.by_guid("id1")
+        assert self.file.by_id(1)
+        assert self.file.by_guid("id2")
+
+
+class TestCopyIFC4(test.bootstrap.IFC4):
+    def test_copying_an_element(self):
+        element = self.file.createIfcWall(GlobalId="id", Name="name")
+        element2 = ifcopenshell.util.element.copy(self.file, element)
+        assert element.is_a() == element2.is_a()
+        assert element.GlobalId != element2.GlobalId
+        assert element.Name == element2.Name
+
+
+class TestCopyDeepIFC4(test.bootstrap.IFC4):
+    def test_copying_an_element_recursively(self):
+        owner = self.file.createIfcOwnerHistory()
+        owner.State = "READWRITE"
+        element = self.file.createIfcWall(GlobalId="id", Name="name", OwnerHistory=owner)
+        element2 = ifcopenshell.util.element.copy_deep(self.file, element)
+        assert element.OwnerHistory != element2.OwnerHistory
+        assert element.OwnerHistory.State == element2.OwnerHistory.State
+
+    def test_copying_an_element_recursively_even_if_references_are_aggregated(self):
+        element = self.file.createIfcWall(Name="name")
+        rel = self.file.createIfcRelAggregates()
+        rel.RelatedObjects = [element]
+        rel2 = ifcopenshell.util.element.copy_deep(self.file, rel)
+        assert rel.RelatedObjects != rel2.RelatedObjects
+        assert rel.RelatedObjects[0].Name == rel2.RelatedObjects[0].Name

--- a/src/ifcopenshell-python/test/util/test_element.py
+++ b/src/ifcopenshell-python/test/util/test_element.py
@@ -1,10 +1,10 @@
 import pytest
-import test.bootstrap
+import bootstrap
 import ifcopenshell.api
 import ifcopenshell.util.element
 
 
-class TestGetPsetsIFC4(test.bootstrap.IFC4):
+class TestGetPsetsIFC4(bootstrap.IFC4):
     def test_getting_the_psets_of_a_product_as_a_dictionary(self):
         element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
         assert ifcopenshell.util.element.get_psets(element) == {}
@@ -23,7 +23,7 @@ class TestGetPsetsIFC4(test.bootstrap.IFC4):
         assert ifcopenshell.util.element.get_psets(self.file.create_entity("IfcPerson")) == {}
 
 
-class TestGetPropertyDefinitionIFC4(test.bootstrap.IFC4):
+class TestGetPropertyDefinitionIFC4(bootstrap.IFC4):
     def test_getting_the_properties_of_a_pset(self):
         element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
         pset = ifcopenshell.api.run("pset.add_pset", self.file, product=element, name="name")
@@ -42,7 +42,7 @@ class TestGetPropertyDefinitionIFC4(test.bootstrap.IFC4):
         assert ifcopenshell.util.element.get_property_definition(pset) == {"LiningDepth": 42}
 
 
-class TestGetQuantitiesIFC4(test.bootstrap.IFC4):
+class TestGetQuantitiesIFC4(bootstrap.IFC4):
     def test_getting_quantities_from_a_qto(self):
         element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
         qto = ifcopenshell.api.run("pset.add_qto", self.file, product=element, name="name")
@@ -50,7 +50,7 @@ class TestGetQuantitiesIFC4(test.bootstrap.IFC4):
         assert ifcopenshell.util.element.get_quantities(qto.Quantities) == {"x": 42}
 
 
-class TestGetPropertiesIFC4(test.bootstrap.IFC4):
+class TestGetPropertiesIFC4(bootstrap.IFC4):
     def test_getting_single_properties_from_a_list_of_properties(self):
         element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
         pset = ifcopenshell.api.run("pset.add_pset", self.file, product=element, name="name")
@@ -73,7 +73,7 @@ class TestGetPropertiesIFC4(test.bootstrap.IFC4):
         }
 
 
-class TestGetTypeIFC4(test.bootstrap.IFC4):
+class TestGetTypeIFC4(bootstrap.IFC4):
     def test_getting_the_type_of_a_product(self):
         element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
         element_type = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWallType")
@@ -82,7 +82,7 @@ class TestGetTypeIFC4(test.bootstrap.IFC4):
         assert ifcopenshell.util.element.get_type(element_type) == element_type
 
 
-class TestGetTypeIFC2X3(test.bootstrap.IFC2X3):
+class TestGetTypeIFC2X3(bootstrap.IFC2X3):
     def test_getting_the_type_of_a_product(self):
         element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
         element_type = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWallType")
@@ -91,7 +91,7 @@ class TestGetTypeIFC2X3(test.bootstrap.IFC2X3):
         assert ifcopenshell.util.element.get_type(element_type) == element_type
 
 
-class TestGetMaterial(test.bootstrap.IFC4):
+class TestGetMaterial(bootstrap.IFC4):
     def test_getting_the_material_of_a_product(self):
         element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
         material = ifcopenshell.api.run("material.add_material", self.file)
@@ -158,7 +158,7 @@ class TestGetMaterial(test.bootstrap.IFC4):
         assert ifcopenshell.util.element.get_material(element) == material
 
 
-class TestGetContainerIFC4(test.bootstrap.IFC4):
+class TestGetContainerIFC4(bootstrap.IFC4):
     def test_getting_the_spatial_container_of_an_element(self):
         element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
         building = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcBuilding")
@@ -166,7 +166,7 @@ class TestGetContainerIFC4(test.bootstrap.IFC4):
         assert ifcopenshell.util.element.get_container(element) == building
 
 
-class TestGetAggregateIFC4(test.bootstrap.IFC4):
+class TestGetAggregateIFC4(bootstrap.IFC4):
     def test_getting_the_containing_aggregate_of_a_subelement(self):
         element = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcWall")
         subelement = ifcopenshell.api.run("root.create_entity", self.file, ifc_class="IfcCovering")
@@ -174,7 +174,7 @@ class TestGetAggregateIFC4(test.bootstrap.IFC4):
         assert ifcopenshell.util.element.get_aggregate(subelement) == element
 
 
-class TestReplaceAttributeIFC4(test.bootstrap.IFC4):
+class TestReplaceAttributeIFC4(bootstrap.IFC4):
     def test_replacing_an_elements_attribute(self):
         element = self.file.createIfcWall("foo")
         ifcopenshell.util.element.replace_attribute(element, "foo", "bar")
@@ -189,7 +189,7 @@ class TestReplaceAttributeIFC4(test.bootstrap.IFC4):
         assert rel.RelatedObjects == (new,)
 
 
-class TestHasElementReferenceIFC4(test.bootstrap.IFC4):
+class TestHasElementReferenceIFC4(bootstrap.IFC4):
     def test_if_a_element_attribute_references_another_element(self):
         old = self.file.createIfcWall()
         new = self.file.createIfcWall()
@@ -199,7 +199,7 @@ class TestHasElementReferenceIFC4(test.bootstrap.IFC4):
         assert ifcopenshell.util.element.has_element_reference(rel.RelatedObjects, new) is False
 
 
-class TestRemoveDeepIFC4(test.bootstrap.IFC4):
+class TestRemoveDeepIFC4(bootstrap.IFC4):
     def test_removing_an_element_along_with_all_direct_attributes_recursively(self):
         owner = self.file.createIfcOwnerHistory()
         element = self.file.createIfcWall(GlobalId="id", OwnerHistory=owner)
@@ -219,7 +219,7 @@ class TestRemoveDeepIFC4(test.bootstrap.IFC4):
         assert self.file.by_guid("id2")
 
 
-class TestCopyIFC4(test.bootstrap.IFC4):
+class TestCopyIFC4(bootstrap.IFC4):
     def test_copying_an_element(self):
         element = self.file.createIfcWall(GlobalId="id", Name="name")
         element2 = ifcopenshell.util.element.copy(self.file, element)
@@ -228,7 +228,7 @@ class TestCopyIFC4(test.bootstrap.IFC4):
         assert element.Name == element2.Name
 
 
-class TestCopyDeepIFC4(test.bootstrap.IFC4):
+class TestCopyDeepIFC4(bootstrap.IFC4):
     def test_copying_an_element_recursively(self):
         owner = self.file.createIfcOwnerHistory()
         owner.State = "READWRITE"


### PR DESCRIPTION
Proposal to display a checkmark instead of the "append library element" operator if said element already exists inside the current file.
I thought it would be nice for the user to visually know if the element they're trying to append already exists in their file.
I used the same logic as the one in the ifcopenshell api to know if the element already exists https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.6.0/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py

![BSE_42](https://user-images.githubusercontent.com/25156105/131333548-8c5efac4-850e-45a1-8b68-c9bccb4ad8a0.gif)

I thought about using another icon like the link one ![image](https://user-images.githubusercontent.com/25156105/131334328-5a9b9b97-a265-43d0-90eb-8dfd51651b2f.png) but that would imply a 2-way-relationship which is not the case here.
Could have detrimental effect on performance if hundreds of objects are displayed at once in the list though...
