### PR TITLE
Improve mesh IFC Representation User Experience

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -425,6 +425,7 @@ class GetRepresentationIfcParameters(bpy.types.Operator):
         obj = context.active_object
         props = obj.data.BIMMeshProperties
         elements = self.file.traverse(self.file.by_id(props.ifc_definition_id))
+        props.ifc_parameters.clear()
         for element in elements:
             if element.is_a("IfcRepresentationItem") or element.is_a("IfcParameterizedProfileDef"):
                 for i in range(0, len(element)):

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -302,6 +302,10 @@ class UpdateRepresentation(bpy.types.Operator):
     obj: bpy.props.StringProperty()
     ifc_representation_class: bpy.props.StringProperty()
 
+    @classmethod
+    def poll(cls, context):
+        return context.active_object.mode == "OBJECT"
+
     def execute(self, context):
         return IfcStore.execute_ifc_operator(self, context)
 
@@ -389,6 +393,10 @@ class UpdateParametricRepresentation(bpy.types.Operator):
     bl_label = "Update Parametric Representation"
     bl_options = {"REGISTER", "UNDO"}
     index: bpy.props.IntProperty()
+
+    @classmethod
+    def poll(cls, context):
+        return context.active_object.mode == "OBJECT"
 
     def execute(self, context):
         self.file = IfcStore.get_file()

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -386,6 +386,8 @@ class UpdateRepresentation(bpy.types.Operator):
         obj.data.name = f"{old_representation.ContextOfItems.id()}/{new_representation.id()}"
         bpy.ops.bim.remove_representation(representation_id=old_representation.id(), obj=obj.name)
         Data.load(self.file, obj.BIMObjectProperties.ifc_definition_id)
+        if obj.data.BIMMeshProperties.ifc_parameters:
+            bpy.ops.bim.get_representation_ifc_parameters()
 
 
 class UpdateParametricRepresentation(bpy.types.Operator):
@@ -404,9 +406,12 @@ class UpdateParametricRepresentation(bpy.types.Operator):
         props = obj.data.BIMMeshProperties
         parameter = props.ifc_parameters[self.index]
         self.file.by_id(parameter.step_id)[parameter.index] = parameter.value
+        show_representation_parameters = bool(props.ifc_parameters)
         bpy.ops.bim.switch_representation(
             ifc_definition_id=props.ifc_definition_id, should_reload=True, should_switch_all_meshes=True
         )
+        if show_representation_parameters:
+            bpy.ops.bim.get_representation_ifc_parameters()
         return {"FINISHED"}
 
 


### PR DESCRIPTION
This is a proposal to improve user experience when tweaking and updating representation parameters.

- It's no longer possible to update mesh representation or individual parameter values when not in object mode :

![image](https://user-images.githubusercontent.com/25156105/131354793-433bf9e4-0d17-4b65-8c18-86eae7b5fe52.png)
On my end this fixed random CTDs when going out of edit mode.

- The parameters stay expanded when updating the mesh representation or updating individual parameters. Previously it would stop displaying these parameters since the process creates a brand new mesh.

![BSE_43](https://user-images.githubusercontent.com/25156105/131355575-e73f1d00-d271-4110-9399-b800786c50c9.gif)

- The parameters are overwritten when executing the "Get parameters" operator. Previously they would get added on top of the other ones.

![BSE_44](https://user-images.githubusercontent.com/25156105/131355931-1e521518-3034-47e9-8ae2-c89cf416c4f2.gif)

