### PR TITLE
Parametric object gizmo scale follows scene unit

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/drawing/gizmos.py
+++ b/src/blenderbim/blenderbim/bim/module/drawing/gizmos.py
@@ -548,5 +548,5 @@ class ExtrusionWidget(types.GizmoGroup):
             elif length_unit == "INCHES":
                 scale_value /= si_conversions["inch"]
             elif length_unit == "THOU":
-                scale_value /= si_conversions["thousandth of an inch"]
+                scale_value /= si_conversions["thou"]
         return scale_value

--- a/src/blenderbim/blenderbim/bim/module/drawing/gizmos.py
+++ b/src/blenderbim/blenderbim/bim/module/drawing/gizmos.py
@@ -26,6 +26,7 @@ from mathutils import Vector, Matrix
 from mathutils import geometry
 from bpy_extras import view3d_utils
 from blenderbim.bim.module.drawing.shaders import DotsGizmoShader, ExtrusionGuidesShader, BaseLinesShader
+from ifcopenshell.util.unit import si_conversions
 
 
 """Gizmos under the hood
@@ -470,8 +471,6 @@ class ExtrusionWidget(types.GizmoGroup):
     bl_region_type = "WINDOW"
     bl_options = {"3D", "PERSISTENT", "SHOW_MODAL_ALL"}
 
-    # FIXME: use proper scale from ifc value to blender units
-
     @classmethod
     def poll(cls, ctx):
         obj = ctx.object
@@ -487,6 +486,7 @@ class ExtrusionWidget(types.GizmoGroup):
 
         basis = target.matrix_world.normalized()
         theme = ctx.preferences.themes[0].user_interface
+        scale_value = self.get_scale_value(ctx.scene.unit_settings.system, ctx.scene.unit_settings.length_unit)
 
         gz = self.handle = self.gizmos.new("BIM_GT_uglydot_3d")
         gz.matrix_basis = basis
@@ -496,7 +496,7 @@ class ExtrusionWidget(types.GizmoGroup):
         gz.alpha_highlight = 1.0
         gz.use_draw_modal = True
         gz.target_set_prop("offset", prop, "value")
-        gz.scale_value = 1000
+        gz.scale_value = scale_value
 
         gz = self.guides = self.gizmos.new("BIM_GT_extrusion_guides")
         gz.matrix_basis = basis
@@ -504,7 +504,7 @@ class ExtrusionWidget(types.GizmoGroup):
         gz.alpha = gz.alpha_highlight = 0.5
         gz.use_draw_modal = True
         gz.target_set_prop("depth", prop, "value")
-        gz.scale_value = 1000
+        gz.scale_value = scale_value
 
         # gz = self.label = self.gizmos.new('GIZMO_GT_dimension_label')
         # gz.matrix_basis = basis
@@ -527,3 +527,26 @@ class ExtrusionWidget(types.GizmoGroup):
         prop = target.data.BIMMeshProperties.ifc_parameters.get("IfcExtrudedAreaSolid/Depth")
         self.handle.target_set_prop("offset", prop, "value")
         self.guides.target_set_prop("depth", prop, "value")
+
+    @staticmethod
+    def get_scale_value(system, length_unit):
+        scale_value = 1
+        if system == "METRIC":
+            if length_unit == "KILOMETERS":
+                scale_value /= 1000
+            elif length_unit == "CENTIMETERS":
+                scale_value *= 100
+            elif length_unit == "MILLIMETERS":
+                scale_value *= 1000
+            elif length_unit == "MICROMETERS":
+                scale_value *= 1000000
+        elif system == "IMPERIAL":
+            if length_unit == "MILES":
+                scale_value /= si_conversions["mile"]
+            elif length_unit == "FEET":
+                scale_value /= si_conversions["foot"]
+            elif length_unit == "INCHES":
+                scale_value /= si_conversions["inch"]
+            elif length_unit == "THOU":
+                scale_value /= si_conversions["thousandth of an inch"]
+        return scale_value

--- a/src/ifcopenshell-python/ifcopenshell/api/unit/assign_unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/unit/assign_unit.py
@@ -86,7 +86,7 @@ class Usecase:
         elif data["raw"] == "MILES":
             name = "{}mile".format(name_prefix + " " if name_prefix else "")
         elif data["raw"] == "THOU":
-            name = "{}thousandth of an inch".format(name_prefix + " " if name_prefix else "")
+            name = "{}thou".format(name_prefix + " " if name_prefix else "")
         value_component = self.file.create_entity(
             "IfcReal", **{"wrappedValue": ifcopenshell.util.unit.si_conversions[name]}
         )

--- a/src/ifcopenshell-python/ifcopenshell/api/unit/assign_unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/unit/assign_unit.py
@@ -83,6 +83,10 @@ class Usecase:
             name = "{}inch".format(name_prefix + " " if name_prefix else "")
         elif data["raw"] == "FEET":
             name = "{}foot".format(name_prefix + " " if name_prefix else "")
+        elif data["raw"] == "MILES":
+            name = "{}mile".format(name_prefix + " " if name_prefix else "")
+        elif data["raw"] == "THOU":
+            name = "{}thousandth of an inch".format(name_prefix + " " if name_prefix else "")
         value_component = self.file.create_entity(
             "IfcReal", **{"wrappedValue": ifcopenshell.util.unit.si_conversions[name]}
         )

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -154,18 +154,18 @@ named_dimensions = {
 }
 
 si_conversions = {
-    "thousandth of an inch": 0.0000254,
+    "thou": 0.0000254,
     "inch": 0.0254,
     "foot": 0.3048,
     "yard": 0.914,
     "mile": 1609,
-    "square thousandth of an inch": 6.4516e-10,
+    "square thou": 6.4516e-10,
     "square inch": 0.0006452,
     "square foot": 0.09290304,
     "square yard": 0.83612736,
     "acre": 4046.86,
     "square mile": 2588881,
-    "cubic thousandth of an inch": 1.6387064e-14,
+    "cubic thou": 1.6387064e-14,
     "cubic inch": 0.00001639,
     "cubic foot": 0.02831684671168849,
     "cubic yard": 0.7636,

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -154,18 +154,22 @@ named_dimensions = {
 }
 
 si_conversions = {
+    "thousandth of an inch": 0.0000254,
     "inch": 0.0254,
     "foot": 0.3048,
     "yard": 0.914,
     "mile": 1609,
+    "square thousandth of an inch": 6.4516e-10,
     "square inch": 0.0006452,
     "square foot": 0.09290304,
     "square yard": 0.83612736,
     "acre": 4046.86,
     "square mile": 2588881,
+    "cubic thousandth of an inch": 1.6387064e-14,
     "cubic inch": 0.00001639,
     "cubic foot": 0.02831684671168849,
     "cubic yard": 0.7636,
+    "cubic mile": 4165509529,
     "litre": 0.001,
     "fluid ounce UK": 0.0000284130625,
     "fluid ounce US": 0.00002957353,


### PR DESCRIPTION
This (I hope) fixes https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.6.0/src/blenderbim/blenderbim/bim/module/drawing/gizmos.py#L473

Previously the parametric gizmo that's used to interactively change a parametric object's `IfcExtrudedAreaSolid/Depth` parameter would only be visually correct when using Millimeters as a unit.

![image](https://user-images.githubusercontent.com/25156105/131518767-2ca9d5f4-62e6-4e2a-975d-92fd8ffc9d76.png)

Now it detects the unit at runtime and scales the gizmo depending on it.
Example using imperial system and feets :
![BSE_45](https://user-images.githubusercontent.com/25156105/131519240-c9c05f5c-b205-46e2-9d44-87c8b266cea6.gif)

This PR also fixes an error when setting project units to MILES or THOU (thousandth of an inch) by adding entries in the `conversion_si` dictionary and 2 cases when assigning units.

There still is a problem with the gizmo in that the teal guide lines don't scale with the units and I don't really know how to achieve it. Gizmo documentation is pretty sparse online... It's problematic when using really small units like micrometers.

![image](https://user-images.githubusercontent.com/25156105/131519815-992b7c4c-a49d-4595-8606-72e0441675b3.png)

