### PR TITLE
Filter by context id, not using curves or solids. See #1674.

### DIFF
--- a/src/ifcgeom/IfcGeomIteratorImplementation.h
+++ b/src/ifcgeom/IfcGeomIteratorImplementation.h
@@ -342,6 +342,11 @@ namespace IfcGeom {
 				// WR31: The parent context shall not be another geometric representation sub context. 
 			}
 
+			for (auto context_id : settings.context_ids()) {
+				IfcSchema::IfcGeometricRepresentationContext* context = ifc_file->instance_by_id(context_id)->as<IfcSchema::IfcGeometricRepresentationContext>();
+				representations->push(context->RepresentationsInContext());
+			}
+
 			if (any_precision_encountered) {
 				// Some arbitrary factor that has proven to work better for the models in the set of test files.
 				lowest_precision_encountered *= kernel.getValue(IfcGeom::Kernel::GV_PRECISION_FACTOR);

--- a/src/ifcgeom/IfcGeomIteratorSettings.h
+++ b/src/ifcgeom/IfcGeomIteratorSettings.h
@@ -112,6 +112,7 @@ namespace IfcGeom
         double deflection_tolerance() const { return deflection_tolerance_; }
 		double angular_tolerance() const { return angular_tolerance_; }
 		double force_space_transparency() const { return force_space_transparency_; }
+		std::set<int> context_ids() const { return context_ids_; }
 
         void set_deflection_tolerance(double value)
         {
@@ -130,7 +131,11 @@ namespace IfcGeom
 
 		void force_space_transparency(double value) {
 			force_space_transparency_ = value;
-		}		
+		}
+
+		void set_context_ids(std::vector<int> value) {
+			context_ids_ = std::set<int>(value.begin(), value.end());
+		}
 
         /// Get boolean value for a single settings or for a combination of settings.
         bool get(unsigned setting) const
@@ -158,6 +163,7 @@ namespace IfcGeom
     protected:
 		unsigned settings_;
         double deflection_tolerance_, angular_tolerance_, force_space_transparency_;
+		std::set<int> context_ids_;
     };
 
     class IFC_GEOM_API ElementSettings : public IteratorSettings

--- a/src/ifcgeom/IfcGeomShapes.cpp
+++ b/src/ifcgeom/IfcGeomShapes.cpp
@@ -887,6 +887,8 @@ bool IfcGeom::Kernel::convert(const IfcSchema::IfcGeometricSet* l, IfcRepresenta
 	// @nb the selection is partly duplicated from convert_curves() but it's needed as a
 	// geometric set by it's static class definition does not inform us of the type of elements.
 	// @todo handle this better so that this doesn't log an error.
+	const bool include_curves = getValue(GV_DIMENSIONALITY) != +1;
+	const bool include_solids_and_surfaces = getValue(GV_DIMENSIONALITY) != -1;
 
 	aggregate_of_instance::ptr elements = l->Elements();
 	if ( !elements->size() ) return false;
@@ -900,11 +902,11 @@ bool IfcGeom::Kernel::convert(const IfcSchema::IfcGeometricSet* l, IfcRepresenta
 			if (!(convert_shapes(element, items) && flatten_shape_list(items, s, false))) {
 				continue;
 			}
-		} else if (shape_type(element) == ST_SHAPE) {
+		} else if (shape_type(element) == ST_SHAPE && include_solids_and_surfaces) {
 			if (!convert_shape(element, s)) {
 				continue;
 			}
-		} else if (shape_type(element) == ST_WIRE) {
+		} else if (shape_type(element) == ST_WIRE && include_curves) {
 			TopoDS_Wire w;
 			if (!convert_wire(element, w)) {
 				continue;

--- a/src/ifcgeom/IfcGeomShapes.cpp
+++ b/src/ifcgeom/IfcGeomShapes.cpp
@@ -887,8 +887,6 @@ bool IfcGeom::Kernel::convert(const IfcSchema::IfcGeometricSet* l, IfcRepresenta
 	// @nb the selection is partly duplicated from convert_curves() but it's needed as a
 	// geometric set by it's static class definition does not inform us of the type of elements.
 	// @todo handle this better so that this doesn't log an error.
-	const bool include_curves = getValue(GV_DIMENSIONALITY) != +1;
-	const bool include_solids_and_surfaces = getValue(GV_DIMENSIONALITY) != -1;
 
 	aggregate_of_instance::ptr elements = l->Elements();
 	if ( !elements->size() ) return false;
@@ -902,11 +900,11 @@ bool IfcGeom::Kernel::convert(const IfcSchema::IfcGeometricSet* l, IfcRepresenta
 			if (!(convert_shapes(element, items) && flatten_shape_list(items, s, false))) {
 				continue;
 			}
-		} else if (shape_type(element) == ST_SHAPE && include_solids_and_surfaces) {
+		} else if (shape_type(element) == ST_SHAPE) {
 			if (!convert_shape(element, s)) {
 				continue;
 			}
-		} else if (shape_type(element) == ST_WIRE && include_curves) {
+		} else if (shape_type(element) == ST_WIRE) {
 			TopoDS_Wire w;
 			if (!convert_wire(element, w)) {
 				continue;

--- a/src/ifcgeom/IfcRegister.cpp
+++ b/src/ifcgeom/IfcRegister.cpp
@@ -54,34 +54,30 @@ bool IfcGeom::Kernel::convert_shape(const IfcBaseInterface* l, TopoDS_Shape& r) 
 	const unsigned int id = l->data().id();
 	bool success = false;
 	bool processed = false;
-	bool ignored = false;
 
 #ifndef NO_CACHE
 	std::map<int,TopoDS_Shape>::const_iterator it = cache.Shape.find(id);
 	if ( it != cache.Shape.end() ) { r = it->second; return true; }
 #endif
-	const bool include_curves = getValue(GV_DIMENSIONALITY) != +1;
-	const bool include_solids_and_surfaces = getValue(GV_DIMENSIONALITY) != -1;
 
 	IfcGeom::ShapeType st = shape_type(l);
-	ignored = (!include_solids_and_surfaces && (st == ST_SHAPE || st == ST_FACE)) || (!include_curves && (st == ST_WIRE || st == ST_CURVE));
 	if (st == ST_SHAPELIST) {
 		processed = true;
 		IfcRepresentationShapeItems items;
 		success = convert_shapes(l, items) && flatten_shape_list(items, r, false);
-	} else if (st == ST_SHAPE && include_solids_and_surfaces) {
+	} else if (st == ST_SHAPE) {
 #include "IfcRegisterConvertShape.h"
-	} else if (st == ST_FACE && include_solids_and_surfaces) {
+	} else if (st == ST_FACE) {
 		processed = true;
 		success = convert_face(l, r);
-	} else if (st == ST_WIRE && include_curves) {
+	} else if (st == ST_WIRE) {
 		processed = true;
 		TopoDS_Wire w;
 		success = convert_wire(l, w);
 		if (success) {
 			r = w;
 		}
-	} else if (st == ST_CURVE && include_curves) {
+	} else if (st == ST_CURVE) {
 		processed = true;
 		Handle(Geom_Curve) crv;
 		TopoDS_Wire w;
@@ -102,7 +98,7 @@ bool IfcGeom::Kernel::convert_shape(const IfcBaseInterface* l, TopoDS_Shape& r) 
 			BRepCheck_Analyzer ana(r);
 			Logger::Notice("Valid: " + std::to_string(ana.IsValid()), l);
 		}
-	} else if (!ignored) {
+	} else {
 		const char* const msg = processed
 			? "Failed to convert:"
 			: "No operation defined for:";


### PR DESCRIPTION
Work in progress. Needs discussion. Note: this PR is incomplete - do not merge, if you want to test it, you need to comment out https://github.com/IfcOpenShell/IfcOpenShell/blob/636d80093652db449168757dae6d1bb2dba788e6/src/ifcgeom/IfcGeomIteratorImplementation.h#L325-L340 to stop the old behaviour.

Assuming you have it commented out, this implementation now allows:

 1. If no context IDs are set, all representations are iterated through, courtesy of https://github.com/IfcOpenShell/IfcOpenShell/blob/636d80093652db449168757dae6d1bb2dba788e6/src/ifcgeom/IfcGeomIteratorImplementation.h#L365-L368
 2. If you set one or more context IDs that have representations, it only processes those, this allows you to filter out just things like axes, footprint, box (assuming we build box support), etc very easily. This solves #771.
 3. Because it only processes the context you want, in 99% of the cases you only want bodies, then fall back to other contexts, this results in significant speedups. This contributes to #1674.
 4. Because you specify exactly the context ID, it allows the user to have zero ambiguity (compared to include_curves/solids) about what is being processed and in what order. This solves #1290.

Sample code:

```python
s = ifcopenshell.geom.settings()
s.set_context_ids([123,234])
```

Here's a screenshot of me pulling out just annotations (but not axis) from the test drawing file.

![2021-09-22-103158_562x316_scrot](https://user-images.githubusercontent.com/88302/134266995-a656e4d6-3d87-4f2f-8392-39f66e76fc48.png)

Questions:

 1. To expose `set_context_ids` I had to use `std::vector<int>`, then cast to set later. Is this OK?
 2. This implementation makes `INCLUDE_CURVES` and `EXCLUDE_SOLIDS_AND_SURFACES` obsolete. Is there any value in retaining them? One value I can think of is that it an easy way for users to say I want 2D and/or 3D. With the new approach, users need to be more specific ... 3D - what 3D? Body? 2D? What 2D? Axis? Footprint? Annotation? Target view? Scale? All? etc. This means the user (e.g. ifcopenshell-python users, and IfcConvert too) needs to do more work (select contexts) and filter on their end. Due to the uncertainty in this, I have not yet purged these options yet and not touched tools like IfcConvert.
 3. What should be the default behaviour if no representations are found? Right now:
    - Nothing specified -> Everything iterated (expected)
    - Contexts with representations specified -> Only those representations iterated (expected)
    - Contexts with no representation specified -> Everything iterated (? - I would expect nothing to iterate and initialisation to return false? If you agree, happy to make this change.)
 4. I know you asked "Something that also works with strings would be nice for the symmetry with IfcConvert." but I didn't fully understand. Is what I did OK?