### PR TITLE
Pset Templates tests

### DIFF
--- a/src/blenderbim/pytest.ini
+++ b/src/blenderbim/pytest.ini
@@ -3,3 +3,4 @@ markers =
     context
     owner
     void
+    pset_template

--- a/src/blenderbim/test/bim/feature/pset_template.feature
+++ b/src/blenderbim/test/bim/feature/pset_template.feature
@@ -1,0 +1,87 @@
+@pset_template
+Feature: Pset_Template
+    Covers property sets and property templates creation, edition, deletion.
+
+Scenario: Add pset template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    Then nothing happens
+
+Scenario: Remove pset template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    And I press "bim.remove_pset_template"
+    Then nothing happens
+
+Scenario: Enable editing pset template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    And I press "bim.enable_editing_pset_template"
+    Then nothing happens
+
+Scenario: Edit pset template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    And I press "bim.enable_editing_pset_template"
+    And I press "bim.edit_pset_template"
+    Then nothing happens
+
+Scenario: Disable editing pset template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    And I press "bim.enable_editing_pset_template"
+    And I press "bim.disable_editing_pset_template"
+    Then nothing happens
+
+Scenario: Save pset template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.save_pset_template_file"
+    Then nothing happens
+
+Scenario: Add prop template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    And I press "bim.add_prop_template"
+    Then nothing happens
+
+Scenario: Remove prop template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    And I press "bim.add_prop_template"
+    And the variable "prop_template" is "2"
+    And I press "bim.remove_prop_template(prop_template={prop_template})"
+    Then nothing happens
+
+Scenario: Enable editing prop template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    And the variable "prop_template" is "2"
+    And I press "bim.enable_editing_prop_template(prop_template={prop_template})"
+    Then nothing happens
+
+Scenario: Edit prop template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    And the variable "prop_template" is "2"
+    And I press "bim.enable_editing_prop_template(prop_template={prop_template})"
+    And I press "bim.edit_prop_template"
+    Then nothing happens
+
+Scenario: Disable editing prop template
+    Given an empty IFC project
+    When I load a new pset template file
+    And I press "bim.add_pset_template"
+    And the variable "prop_template" is "2"
+    And I press "bim.enable_editing_prop_template(prop_template={prop_template})"
+    And I press "bim.disable_editing_prop_template"
+    Then nothing happens

--- a/src/blenderbim/test/bim/test_feature.py
+++ b/src/blenderbim/test/bim/test_feature.py
@@ -18,6 +18,7 @@
 
 import os
 import bpy
+import ifcopenshell
 from blenderbim.bim.ifc import IfcStore
 from pytest_bdd import scenarios, given, when, then, parsers
 
@@ -36,10 +37,21 @@ def replace_variables(value):
 def an_empty_ifc_project():
     IfcStore.purge()
     bpy.ops.wm.read_homefile(app_template="")
-    while bpy.data.objects:
-        bpy.data.objects.remove(bpy.data.objects[0])
-    bpy.ops.outliner.orphans_purge(do_local_ids=True, do_linked_ids=True, do_recursive=True)
+    if len(bpy.data.objects) > 0:
+        while bpy.data.objects:
+            bpy.data.objects.remove(bpy.data.objects[0])
+        bpy.ops.outliner.orphans_purge(do_local_ids=True, do_linked_ids=True, do_recursive=True)
     bpy.ops.bim.create_project()
+
+
+@when("I load a new pset template file")
+def i_load_a_new_pset_template_file():
+    IfcStore.pset_template_path = os.path.join(
+        bpy.context.scene.BIMProperties.data_dir,
+        "pset",
+        bpy.context.scene.BIMPsetTemplateProperties.pset_template_files + ".ifc",
+    )
+    IfcStore.pset_template_file = ifcopenshell.open(IfcStore.pset_template_path)
 
 
 @given("I add a cube")


### PR DESCRIPTION
Adding feature scenarios for pset and property templates.
In summary :
- Didn't find how to test the undo / redo functionality since it seems it's disabled in the test configuration
- Added a sentence to load the default pset templates file
- Didn't find a way to get a property template id from the ifc file, so I hardcoded it to 2. I tried `{ifc}.by_type('IfcSimplePropertyTemplate')[0].id()` but that wasn't it.

I also added an if statement before purging the file to prevent info message saying there is no object to purge cluttering console if the default file contains no object.