### PR TITLE
Fix projection of origin onto camera plane. See #1153

### DIFF
--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -77,7 +77,6 @@
 #include <HLRBRep_PolyHLRToShape.hxx>
 
 #include <Extrema_ExtPElS.hxx>
-#include <GeomAPI_ProjectPointOnSurf.hxx>
 
 #include "../ifcparse/IfcGlobalId.h"
 
@@ -632,7 +631,6 @@ void SvgSerializer::write(const IfcGeom::BRepElement* brep_obj) {
 			// Move pln to have projection of origin at plane center.
 			// This is necessary to have Poly and BRep HLR at the same position
 			// (Poly) is wrong otherwise.
-
 			double pu, pv;
 			Extrema_ExtPElS ext;
 			ext.Perform(gp::Origin(), *pln, 1.e-5);

--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -634,26 +634,13 @@ void SvgSerializer::write(const IfcGeom::BRepElement* brep_obj) {
 			// (Poly) is wrong otherwise.
 
 			double pu, pv;
-			if (!emit_building_storeys_ && scale && size) {
-				Handle_Geom_Surface surf = new Geom_Plane(*pln);
-				GeomAPI_ProjectPointOnSurf project_point_on_surf = GeomAPI_ProjectPointOnSurf(
-					gp::Origin(), surf, size->first/-2, size->first/2, size->second/-2, size->second/2
-				);
-				project_point_on_surf.Parameters(1, pu, pv);
-			}
-
 			Extrema_ExtPElS ext;
 			ext.Perform(gp::Origin(), *pln, 1.e-5);
 			auto P0 = pln->Location();
 			pln->SetLocation(ext.Point(1).Value());
+			ext.Point(1).Parameter(pu, pv);
 
 			if (!emit_building_storeys_ && scale && size) {
-				auto P1 = pln->Location();
-				gp_Vec v(P1.XYZ() - P0.XYZ());
-				gp_Trsf pi;
-				pi.SetTransformation(pln->Position());
-				pi.Invert();
-				v.Transform(pi);			
 				offset_2d_ = std::make_pair(
 					((-size->first / 2.) - pu) * 1000 * *scale_,
 					((-size->second / 2.) + pv) * 1000 * *scale_


### PR DESCRIPTION
So I think I worked it out, but apologies if the C++ looks like an absolute mess so tips would really help.

I guess firstly I think the overall logic is that the projection is drawn using the correct rotation of the camera, but not the right UV (2D) offset. To get the right 2D offset, the 0,0,0 is originally at the top left of the SVG, so we need to 1. Move it to the center (origin) of the camera (by using size->first and second), then 2. Move it again, using the 2D projection of the 3D 0,0,0 on the camera plane.

The first step seems correct, but the 2D projection seems to be where the bug was. The existing logic uses stuff like Extrema_ExtPElS that I don't fully understand, so I implemented it using GeomAPI_ProjectPointOnSurf and getting the UV coords, which might be overkill for a simple perpendicular projection, but I guess it works.

So although it now seems to work with any camera I throw at it in Blender, I left some of your existing code there because I was afraid to delete it. In particular, I wanted the original camera location before its location was changed in this code block:

```
			Extrema_ExtPElS ext;
			ext.Perform(gp::Origin(), *pln, 1.e-5);
			auto P0 = pln->Location();
			pln->SetLocation(ext.Point(1).Value());
```

Hope it makes sense and I didn't make things confusing.