### PR TITLE
Fix projection boolean for drawing generation. See #1153.

### DIFF
--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -989,7 +989,7 @@ void SvgSerializer::write(const geometry_data& data) {
 							BRepBuilderAPI_MakePolygon mp(points[0], points[1], points[2], points[3], true);
 							auto w = mp.Wire();
 							BRepBuilderAPI_MakeFace mf(w);
-							auto f = mf.Face();
+							TopoDS_Face f = BRepBuilderAPI_MakeFace(projection_plane);
 							gp_Pnt ref = projection_plane.Position().Location().XYZ() + projection_plane.Position().Direction().XYZ();
 							BRepPrimAPI_MakeHalfSpace mhs(f, ref);
 							auto s = mhs.Solid();


### PR DESCRIPTION
I think I fixed it but I was afraid to delete the existing code since I didn't quite understand the original logic. It seems as though the half space created for the boolean cut was invalid (in particular, I don't under the logic of `f` and that causes `auto s = mhs.Solid();` to throw an exception). I didn't understand why these xs, ys, and cut_z were used to create a face when the projection plane was already available (and furthermore the half space reference point uses projection plane anyway) so I simply used the projection plane directly.

Happy to clean up this PR with some hints of what the existing code does :)