### PR TITLE
Raise default section height from storey from 1.0 to 1.2

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -415,7 +415,7 @@ int main(int argc, char** argv) {
 		("door-arcs", "Draw door openings arcs for IfcDoor elements")
 		("section-height", po::value<double>(&section_height),
 		    "Specifies the cut section height for SVG 2D geometry.")
-		("section-height-from-storeys", "Derives section height from storey elevation. Use --section-height to override default offset of 1")
+		("section-height-from-storeys", "Derives section height from storey elevation. Use --section-height to override default offset of 1.2")
 		("use-element-names",
             "Use entity instance IfcRoot.Name instead of unique IDs for naming elements upon serialization. "
             "Applicable for OBJ, DAE, and SVG output.")

--- a/src/serializers/SvgSerializer.h
+++ b/src/serializers/SvgSerializer.h
@@ -239,7 +239,7 @@ public:
 	void setFile(IfcParse::IfcFile* f);
     void setBoundingRectangle(double width, double height);
 	void setSectionHeight(double h, IfcUtil::IfcBaseEntity* storey = 0);
-	void setSectionHeightsFromStoreys(double offset=1.);
+	void setSectionHeightsFromStoreys(double offset=1.2);
 	void setPrintSpaceNames(bool b) { print_space_names_ = b; }
 	void setPrintSpaceAreas(bool b) { print_space_areas_ = b; }
 	void setDrawStoreyHeights(storey_height_display_types sh) { storey_height_display_ = sh; }


### PR DESCRIPTION
When creating SVG plans, IfcConvert defaults to sectioning the plan at 1m above storey level.

A kitchen counter height of 0.9m typically results in kitchen window cills higher than 1m, so these windows don't appear in generated plans. This pull request raises the default section height from 1.0m to 1.2m.