### PR TITLE
Added option to generate selection sets

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/search/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/search/__init__.py
@@ -30,6 +30,8 @@ classes = (
     operator.SelectGlobalId,
     operator.SelectIfcClass,
     operator.SelectPset,
+    operator.CreateIfcClassSelSet,
+    operator.CreatePropSelSet,
     prop.BIMFilterClasses,
     prop.BIMSearchProperties,
     ui.BIM_PT_search,

--- a/src/blenderbim/blenderbim/bim/module/search/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/search/operator.py
@@ -420,10 +420,10 @@ class CreateIfcClassSelSet(bpy.types.Operator):
             if obj.name not in bpy.data.collections[ifc_type].objects.keys():
                 ifc_class.objects.link(obj)
             
-            try:#Try to link the collection to the scene, do nothing if already linked
-                bpy.context.scene.collection.children.link(ss)
-            except:
-                pass
+        try:#Try to link the collection to the scene, do nothing if already linked
+            bpy.context.scene.collection.children.link(ss)
+        except:
+            pass
                 
         return {"FINISHED"}        
     
@@ -478,9 +478,9 @@ class CreatePropSelSet(bpy.types.Operator):
             if obj.name not in bpy.data.collections[propval].objects.keys():
                 propval_col.objects.link(obj)    
                 
-            try:#Try to link the collection to the scene, do nothing if already linked
-                bpy.context.scene.collection.children.link(ss)
-            except:
-                pass
+        try:#Try to link the collection to the scene, do nothing if already linked
+            bpy.context.scene.collection.children.link(ss)
+        except:
+            pass
                 
         return {"FINISHED"}  

--- a/src/blenderbim/blenderbim/bim/module/search/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/search/ui.py
@@ -52,12 +52,14 @@ class BIM_PT_search(Panel):
         row.prop(props, "ifc_class", text="", icon="OBJECT_DATA")
         row.operator("bim.select_ifc_class", text="", icon="VIEWZOOM").ifc_class = props.ifc_class
         row.operator("bim.colour_by_class", text="", icon="BRUSH_DATA")
+        row.operator("bim.create_ifcclass_ss", text="", icon="COLLECTION_NEW")
 
         row = self.layout.row(align=True)
         row.prop(props, "search_attribute_name", text="", icon="PROPERTIES")
         row.prop(props, "search_attribute_value", text="")
         row.operator("bim.select_attribute", text="", icon="VIEWZOOM")
         row.operator("bim.colour_by_attribute", text="", icon="BRUSH_DATA")
+        row.operator("bim.create_prop_ss", text="", icon="COLLECTION_NEW")
 
         row = self.layout.row(align=True)
         row.prop(props, "search_pset_name", text="", icon="COPY_ID")


### PR DESCRIPTION
I added two new operators to the search ui that allow the user to generate selection sets à la bimcollab-zoom or similar.  I used the  in-built collections system as it meant no additional code was necessary.  Here's how it looks in action:
![selectionsets](https://user-images.githubusercontent.com/83825269/141960957-220cabe5-35f1-408e-b9ae-bacebae91b51.gif)

Some things I want to add at some point in the future:
- Multi-Level selection sets
- Selection sets based on numerical values, grouped according to user specification. For example:  Volume, grouped in intervals of 10m3

Performance isn't great atm - Generating the 2nd pset in the example above took about ~10seconds.  Ideas on how to improve?