### PR TITLE
 [BlenderBIM] Boundaries: add relations editing

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/boundary/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/boundary/__init__.py
@@ -17,7 +17,7 @@
 # along with BlenderBIM Add-on.  If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
-from . import ui, operator
+from . import ui, operator, prop
 
 classes = (
     operator.LoadProjectSpaceBoundaries,
@@ -25,14 +25,19 @@ classes = (
     operator.LoadBoundary,
     operator.SelectProjectBoundaries,
     operator.ColourByRelatedBuildingElement,
+    operator.EnableEditingBoundary,
+    operator.DisableEditingBoundary,
+    operator.EditBoundaryAttributes,
     ui.BIM_PT_Boundary,
+    ui.BIM_PT_SpaceBoundaries,
     ui.BIM_PT_SceneBoundaries,
+    prop.BIMBoundaryProperties,
 )
 
 
 def register():
-    pass
+    bpy.types.Object.bim_boundary_properties = bpy.props.PointerProperty(type=prop.BIMBoundaryProperties)
 
 
 def unregister():
-    pass
+    del bpy.types.Object.bim_boundary_properties

--- a/src/blenderbim/blenderbim/bim/module/boundary/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/boundary/prop.py
@@ -1,0 +1,60 @@
+# BlenderBIM Add-on - OpenBIM Blender Add-on
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of BlenderBIM Add-on.
+#
+# BlenderBIM Add-on is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BlenderBIM Add-on is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BlenderBIM Add-on.  If not, see <http://www.gnu.org/licenses/>.
+
+import bpy
+from bpy.types import PropertyGroup
+from bpy.props import (
+    PointerProperty,
+    StringProperty,
+    EnumProperty,
+    BoolProperty,
+    IntProperty,
+    FloatProperty,
+    FloatVectorProperty,
+    CollectionProperty,
+)
+import blenderbim.tool as tool
+
+
+def space_filter(self, object):
+    entity = tool.Ifc.get_entity(object)
+    if entity:
+        return entity.is_a("IfcSpace") or entity.is_a("IfcExternalSpatialElement")
+    return False
+
+
+def boundary_filter(self, object):
+    entity = tool.Ifc.get_entity(object)
+    if entity:
+        return entity.is_a("IfcRelSpaceBoundary")
+    return False
+
+
+def element_filter(self, object):
+    entity = tool.Ifc.get_entity(object)
+    if entity:
+        return entity.is_a("IfcElement")
+    return False
+
+
+class BIMBoundaryProperties(PropertyGroup):
+    is_editing: BoolProperty(name="Is Editing")
+    relating_space: PointerProperty(name="RelatingSpace", type=bpy.types.Object, poll=space_filter)
+    related_building_element: PointerProperty(name="RelatedBuildingElement", type=bpy.types.Object, poll=element_filter)
+    parent_boundary: PointerProperty(name="ParentBoundary", type=bpy.types.Object, poll=boundary_filter)
+    corresponding_boundary: PointerProperty(name="CorrespondingBoundary", type=bpy.types.Object, poll=boundary_filter)

--- a/src/blenderbim/blenderbim/bim/module/search/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/search/operator.py
@@ -63,16 +63,13 @@ class SelectGlobalId(bpy.types.Operator):
     global_id: bpy.props.StringProperty()
 
     def execute(self, context):
-        self.file = IfcStore.get_file()
+        ifc_file = tool.Ifc.get()
         props = context.scene.BIMSearchProperties
         global_id = self.global_id or props.global_id
-        for obj in context.visible_objects:
-            if not obj.BIMObjectProperties.ifc_definition_id:
-                continue
-            element = self.file.by_id(obj.BIMObjectProperties.ifc_definition_id)
-            if element.GlobalId == global_id:
-                obj.select_set(True)
-                break
+        entity = ifc_file.by_guid(global_id)
+        obj = tool.Ifc.get_object(entity)
+        obj.select_set(True)
+        bpy.context.view_layer.objects.active = obj
         return {"FINISHED"}
 
 


### PR DESCRIPTION
For entity of class IfcRelSpaceBoundary :
* Display relationship attributes
* Add button to jump to related objects
* Allow to edit relations attributes including entity filter.
UI similar to current base attributes editing.

Small modification of SelectGlobalId to set object as active as discussed.