### PR TITLE
Refactor georeference module (see issue #1711)

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/georeference/data.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/data.py
@@ -24,6 +24,7 @@ def refresh():
 class GeoreferenceData:
     is_loaded = False
     data = {
+        "georeferencing" : {},
         "map_conversion" : {},
         "projected_crs" : {},
         "true_north" : {},
@@ -36,10 +37,21 @@ class GeoreferenceData:
         if cls.file.schema == "IFC2X3":
             return
 
+        cls.data["georeferencing"] = cls.get_georeferencing()
         cls.data["map_conversion"] = cls.get_map_conversion()
         cls.data["projected_crs"] = cls.get_projected_crs()
         cls.data["true_north"] = cls.get_true_north()
         cls.is_loaded = True
+
+    @classmethod
+    def get_georeferencing(cls):
+        results = {}
+        for context in cls.file.by_type("IfcGeometricRepresentationContext", include_subtypes=False):
+            if not context.HasCoordinateOperation:
+                continue
+            map_conversion = context.HasCoordinateOperation[0]
+            results["id"] = map_conversion.id()
+        return results
 
     @classmethod
     def get_map_conversion(cls):

--- a/src/blenderbim/blenderbim/bim/module/georeference/data.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/data.py
@@ -1,0 +1,77 @@
+# BlenderBIM Add-on - OpenBIM Blender Add-on
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of BlenderBIM Add-on.
+#
+# BlenderBIM Add-on is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BlenderBIM Add-on is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BlenderBIM Add-on.  If not, see <http://www.gnu.org/licenses/>.
+
+import blenderbim.tool as tool
+
+def refresh():
+    GeoreferenceData.is_loaded = False
+
+class GeoreferenceData:
+    is_loaded = False
+    data = {
+        "map_conversion" : {},
+        "projected_crs" : {},
+        "true_north" : {},
+    }
+
+    @classmethod
+    def load(cls):
+        cls.file = tool.Ifc.get()
+
+        if cls.file.schema == "IFC2X3":
+            return
+
+        cls.data["map_conversion"] = cls.get_map_conversion()
+        cls.data["projected_crs"] = cls.get_projected_crs()
+        cls.data["true_north"] = cls.get_true_north()
+        cls.is_loaded = True
+
+    @classmethod
+    def get_map_conversion(cls):
+        results = {}
+        for context in cls.file.by_type("IfcGeometricRepresentationContext", include_subtypes=False):
+            if not context.HasCoordinateOperation:
+                continue
+            map_conversion = context.HasCoordinateOperation[0]
+            results = map_conversion.get_info()
+            results["SourceCRS"] = results["SourceCRS"].id()
+            results["TargetCRS"] = results["TargetCRS"].id()
+        return results
+
+    @classmethod
+    def get_projected_crs(cls):
+        results = {}
+        for context in cls.file.by_type("IfcGeometricRepresentationContext", include_subtypes=False):
+            if not context.HasCoordinateOperation:
+                continue
+            map_conversion = context.HasCoordinateOperation[0]
+            results = map_conversion.TargetCRS.get_info()
+            if results["MapUnit"]:
+                results["MapUnit"] = map_conversion.TargetCRS.MapUnit.get_info()
+        return results
+            
+    @classmethod
+    def get_true_north(cls):
+        results = {}
+        for context in cls.file.by_type("IfcGeometricRepresentationContext", include_subtypes=False):
+            if not context.TrueNorth:
+                continue
+            results = context.TrueNorth.DirectionRatios
+        return results
+        
+        

--- a/src/blenderbim/blenderbim/bim/module/georeference/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/operator.py
@@ -72,18 +72,21 @@ class AddGeoreferencing(bpy.types.Operator, Operator):
         core.add_georeferencing(tool.Georeference)
 
 
-class RemoveGeoreferencing(bpy.types.Operator):
+class RemoveGeoreferencing(bpy.types.Operator, Operator):
     bl_idname = "bim.remove_georeferencing"
     bl_label = "Remove Georeferencing"
     bl_options = {"REGISTER", "UNDO"}
 
-    def execute(self, context):
-        return IfcStore.execute_ifc_operator(self, context)
-
     def _execute(self, context):
-        ifcopenshell.api.run("georeference.remove_georeferencing", IfcStore.get_file())
-        GeoreferenceData.load()
-        return {"FINISHED"}
+        core.remove_georeferencing(tool.Georeference)
+
+    # def execute(self, context):
+    #     return IfcStore.execute_ifc_operator(self, context)
+
+    # def _execute(self, context):
+    #     ifcopenshell.api.run("georeference.remove_georeferencing", IfcStore.get_file())
+    #     GeoreferenceData.load()
+    #     return {"FINISHED"}
 
 
 class SetBlenderGridNorth(bpy.types.Operator, Operator):

--- a/src/blenderbim/blenderbim/bim/module/georeference/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/operator.py
@@ -80,14 +80,6 @@ class RemoveGeoreferencing(bpy.types.Operator, Operator):
     def _execute(self, context):
         core.remove_georeferencing(tool.Georeference)
 
-    # def execute(self, context):
-    #     return IfcStore.execute_ifc_operator(self, context)
-
-    # def _execute(self, context):
-    #     ifcopenshell.api.run("georeference.remove_georeferencing", IfcStore.get_file())
-    #     GeoreferenceData.load()
-    #     return {"FINISHED"}
-
 
 class SetBlenderGridNorth(bpy.types.Operator, Operator):
     bl_idname = "bim.set_blender_grid_north"

--- a/src/blenderbim/blenderbim/bim/module/georeference/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/operator.py
@@ -60,7 +60,7 @@ class EditGeoreferencing(bpy.types.Operator, Operator):
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
-        core.edit_georeferencing(tool.Ifc, tool.Georeference)
+        core.edit_georeferencing(tool.Georeference)
 
 
 class AddGeoreferencing(bpy.types.Operator, Operator):

--- a/src/blenderbim/blenderbim/bim/module/georeference/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/operator.py
@@ -63,19 +63,44 @@ class EditGeoreferencing(bpy.types.Operator, Operator):
         core.edit_georeferencing(tool.Ifc, tool.Georeference)
 
 
-class SetBlenderGridNorth(bpy.types.Operator):
+class AddGeoreferencing(bpy.types.Operator, Operator):
+    bl_idname = "bim.add_georeferencing"
+    bl_label = "Add Georeferencing"
+    bl_options = {"REGISTER", "UNDO"}
+
+    def _execute(self, context):
+        core.add_georeferencing(tool.Georeference)
+
+    # def execute(self, context):
+    #     return IfcStore.execute_ifc_operator(self, context)
+
+    # def _execute(self, context):
+    #     ifcopenshell.api.run("georeference.add_georeferencing", IfcStore.get_file())
+    #     GeoreferenceData.load()
+    #     return {"FINISHED"}
+
+
+class RemoveGeoreferencing(bpy.types.Operator):
+    bl_idname = "bim.remove_georeferencing"
+    bl_label = "Remove Georeferencing"
+    bl_options = {"REGISTER", "UNDO"}
+
+    def execute(self, context):
+        return IfcStore.execute_ifc_operator(self, context)
+
+    def _execute(self, context):
+        ifcopenshell.api.run("georeference.remove_georeferencing", IfcStore.get_file())
+        GeoreferenceData.load()
+        return {"FINISHED"}
+
+
+class SetBlenderGridNorth(bpy.types.Operator, Operator):
     bl_idname = "bim.set_blender_grid_north"
     bl_label = "Set Blender Grid North"
     bl_options = {"REGISTER", "UNDO"}
 
-    def execute(self, context):
-        context.scene.sun_pos_properties.north_offset = -radians(
-            ifcopenshell.util.geolocation.xaxis2angle(
-                float(context.scene.BIMGeoreferenceProperties.map_conversion.get("XAxisAbscissa").string_value),
-                float(context.scene.BIMGeoreferenceProperties.map_conversion.get("XAxisOrdinate").string_value),
-            )
-        )
-        return {"FINISHED"}
+    def _execute(self, context):
+        core.set_blender_grid_north(tool.Georeference)
 
 
 class SetIfcGridNorth(bpy.types.Operator):
@@ -114,34 +139,6 @@ class SetIfcTrueNorth(bpy.types.Operator):
         y_angle = -context.scene.sun_pos_properties.north_offset + radians(90)
         context.scene.BIMGeoreferenceProperties.true_north_abscissa = str(cos(y_angle))
         context.scene.BIMGeoreferenceProperties.true_north_ordinate = str(sin(y_angle))
-        return {"FINISHED"}
-
-
-class RemoveGeoreferencing(bpy.types.Operator):
-    bl_idname = "bim.remove_georeferencing"
-    bl_label = "Remove Georeferencing"
-    bl_options = {"REGISTER", "UNDO"}
-
-    def execute(self, context):
-        return IfcStore.execute_ifc_operator(self, context)
-
-    def _execute(self, context):
-        ifcopenshell.api.run("georeference.remove_georeferencing", IfcStore.get_file())
-        GeoreferenceData.load()
-        return {"FINISHED"}
-
-
-class AddGeoreferencing(bpy.types.Operator):
-    bl_idname = "bim.add_georeferencing"
-    bl_label = "Add Georeferencing"
-    bl_options = {"REGISTER", "UNDO"}
-
-    def execute(self, context):
-        return IfcStore.execute_ifc_operator(self, context)
-
-    def _execute(self, context):
-        ifcopenshell.api.run("georeference.add_georeferencing", IfcStore.get_file())
-        GeoreferenceData.load()
         return {"FINISHED"}
 
 

--- a/src/blenderbim/blenderbim/bim/module/georeference/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/operator.py
@@ -71,14 +71,6 @@ class AddGeoreferencing(bpy.types.Operator, Operator):
     def _execute(self, context):
         core.add_georeferencing(tool.Georeference)
 
-    # def execute(self, context):
-    #     return IfcStore.execute_ifc_operator(self, context)
-
-    # def _execute(self, context):
-    #     ifcopenshell.api.run("georeference.add_georeferencing", IfcStore.get_file())
-    #     GeoreferenceData.load()
-    #     return {"FINISHED"}
-
 
 class RemoveGeoreferencing(bpy.types.Operator):
     bl_idname = "bim.remove_georeferencing"

--- a/src/blenderbim/blenderbim/bim/module/georeference/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/prop.py
@@ -32,6 +32,7 @@ from bpy.props import (
 
 
 class BIMGeoreferenceProperties(PropertyGroup):
+    active_georeferencing_id: IntProperty(name="Active Georeferencing Id")
     is_editing: BoolProperty(name="Is Editing")
     map_conversion: CollectionProperty(name="Map Conversion", type=Attribute)
     projected_crs: CollectionProperty(name="Projected CRS", type=Attribute)

--- a/src/blenderbim/blenderbim/bim/module/georeference/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/ui.py
@@ -44,11 +44,12 @@ class BIM_PT_gis(Panel):
 
         if props.is_editing:
             return self.draw_editable_ui(context)
-        self.draw_ui(context)
+        self.draw_ui(context, GeoreferenceData.data["georeferencing"])
 
     def draw_editable_ui(self, context):
         props = context.scene.BIMGeoreferenceProperties
         row = self.layout.row(align=True)
+        
         row.label(text="Projected CRS", icon="WORLD")
         row.operator("bim.edit_georeferencing", icon="CHECKMARK", text="")
         row.operator("bim.disable_editing_georeferencing", icon="CANCEL", text="")
@@ -78,7 +79,7 @@ class BIM_PT_gis(Panel):
             row.operator("bim.set_ifc_true_north", text="Set IFC North")
             row.operator("bim.set_blender_true_north", text="Set Blender North")
 
-    def draw_ui(self, context):
+    def draw_ui(self, context, georeferencing):
         props = context.scene.BIMGeoreferenceProperties
 
         if not GeoreferenceData.data["projected_crs"]:
@@ -125,7 +126,7 @@ class BIM_PT_gis(Panel):
         if GeoreferenceData.data["projected_crs"]:
             row = self.layout.row(align=True)
             row.label(text="Projected CRS", icon="WORLD")
-            row.operator("bim.enable_editing_georeferencing", icon="GREASEPENCIL", text="")
+            row.operator("bim.enable_editing_georeferencing", icon="GREASEPENCIL", text="").georeferencing = georeferencing["id"]
             row.operator("bim.remove_georeferencing", icon="X", text="")
 
         for key, value in GeoreferenceData.data["projected_crs"].items():

--- a/src/blenderbim/blenderbim/bim/module/georeference/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/georeference/ui.py
@@ -18,7 +18,7 @@
 
 import ifcopenshell.util.geolocation
 from bpy.types import Panel
-from ifcopenshell.api.georeference.data import Data
+from blenderbim.bim.module.georeference.data import GeoreferenceData
 from blenderbim.bim.ifc import IfcStore
 from blenderbim.bim.helper import draw_attributes, draw_attribute
 
@@ -39,8 +39,8 @@ class BIM_PT_gis(Panel):
         self.layout.use_property_split = True
         self.layout.use_property_decorate = False
         props = context.scene.BIMGeoreferenceProperties
-        if not Data.is_loaded:
-            Data.load(IfcStore.get_file())
+        if not GeoreferenceData.is_loaded:
+            GeoreferenceData.load()
 
         if props.is_editing:
             return self.draw_editable_ui(context)
@@ -81,7 +81,7 @@ class BIM_PT_gis(Panel):
     def draw_ui(self, context):
         props = context.scene.BIMGeoreferenceProperties
 
-        if not Data.projected_crs:
+        if not GeoreferenceData.data["projected_crs"]:
             row = self.layout.row(align=True)
             row.label(text="Not Georeferenced")
             if IfcStore.get_file().schema != "IFC2X3":
@@ -122,13 +122,13 @@ class BIM_PT_gis(Panel):
             row = self.layout.row()
             row.label(text="Not Georeferenced")
 
-        if Data.projected_crs:
+        if GeoreferenceData.data["projected_crs"]:
             row = self.layout.row(align=True)
             row.label(text="Projected CRS", icon="WORLD")
             row.operator("bim.enable_editing_georeferencing", icon="GREASEPENCIL", text="")
             row.operator("bim.remove_georeferencing", icon="X", text="")
 
-        for key, value in Data.projected_crs.items():
+        for key, value in GeoreferenceData.data["projected_crs"].items():
             if key == "id" or key == "type" or not value:
                 continue
             if key == "MapUnit":
@@ -139,11 +139,11 @@ class BIM_PT_gis(Panel):
             row.label(text=key)
             row.label(text=str(value))
 
-        if Data.map_conversion:
+        if GeoreferenceData.data["map_conversion"]:
             row = self.layout.row(align=True)
             row.label(text="Map Conversion", icon="GRID")
 
-        for key, value in Data.map_conversion.items():
+        for key, value in GeoreferenceData.data["map_conversion"].items():
             if key == "id" or key == "type" or key == "SourceCRS" or key == "TargetCRS" or value is None:
                 continue
             row = self.layout.row(align=True)
@@ -156,22 +156,22 @@ class BIM_PT_gis(Panel):
                     text=str(
                         round(
                             ifcopenshell.util.geolocation.xaxis2angle(
-                                Data.map_conversion["XAxisAbscissa"], Data.map_conversion["XAxisOrdinate"]
+                                GeoreferenceData.data["map_conversion"]["XAxisAbscissa"], GeoreferenceData.data["map_conversion"]["XAxisOrdinate"]
                             ),
                             3,
                         )
                     )
                 )
 
-        if Data.true_north:
+        if GeoreferenceData.data["true_north"]:
             row = self.layout.row()
             row.label(text="True North", icon="LIGHT_SUN")
             row = self.layout.row(align=True)
             row.label(text="Vector")
-            row.label(text=str(Data.true_north[0:2])[1:-1])
+            row.label(text=str(GeoreferenceData.data["true_north"][0:2])[1:-1])
             row = self.layout.row(align=True)
             row.label(text="Derived Angle")
-            row.label(text=str(round(ifcopenshell.util.geolocation.yaxis2angle(*Data.true_north[0:2]), 3)))
+            row.label(text=str(round(ifcopenshell.util.geolocation.yaxis2angle(*GeoreferenceData.data["true_north"][0:2]), 3)))
 
 
 class BIM_PT_gis_utilities(Panel):

--- a/src/blenderbim/blenderbim/core/georeference.py
+++ b/src/blenderbim/blenderbim/core/georeference.py
@@ -1,0 +1,29 @@
+# BlenderBIM Add-on - OpenBIM Blender Add-on
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of BlenderBIM Add-on.
+#
+# BlenderBIM Add-on is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BlenderBIM Add-on is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BlenderBIM Add-on.  If not, see <http://www.gnu.org/licenses/>.
+
+def enable_editing_georeferencing(georeference, georeferencing = None):
+    georeference.set_georeferencing(georeferencing)
+    georeference.import_georeferencing_attributes()
+
+def disable_editing_georeferencing(georeference):
+    georeference.clear_georeferencing()
+
+def edit_georeferencing(ifc, georeference):
+    ifc.run("georeference.edit_georeferencing", georeferencing=georeference.get_georeferencing(), attributes=georeference.export_georeferencing_attributes())
+    disable_editing_georeferencing(georeference)
+

--- a/src/blenderbim/blenderbim/core/georeference.py
+++ b/src/blenderbim/blenderbim/core/georeference.py
@@ -23,7 +23,7 @@ def enable_editing_georeferencing(georeference, georeferencing = None):
 def disable_editing_georeferencing(georeference):
     georeference.clear_georeferencing()
 
-def edit_georeferencing(ifc, georeference):
+def edit_georeferencing(georeference):
     georeference.export_georeferencing_attributes()
     disable_editing_georeferencing(georeference)
 

--- a/src/blenderbim/blenderbim/core/georeference.py
+++ b/src/blenderbim/blenderbim/core/georeference.py
@@ -25,6 +25,5 @@ def disable_editing_georeferencing(georeference):
 
 def edit_georeferencing(ifc, georeference):
     georeference.export_georeferencing_attributes()
-    #ifc.run("georeference.edit_georeferencing", georeferencing=georeference.get_georeferencing(), attributes=georeference.export_georeferencing_attributes())
     disable_editing_georeferencing(georeference)
 

--- a/src/blenderbim/blenderbim/core/georeference.py
+++ b/src/blenderbim/blenderbim/core/georeference.py
@@ -27,3 +27,8 @@ def edit_georeferencing(ifc, georeference):
     georeference.export_georeferencing_attributes()
     disable_editing_georeferencing(georeference)
 
+def add_georeferencing(georeference):
+    georeference.add_georeferencing()
+
+def set_blender_grid_north(georeference):
+    georeference.set_blender_grid_north()

--- a/src/blenderbim/blenderbim/core/georeference.py
+++ b/src/blenderbim/blenderbim/core/georeference.py
@@ -30,5 +30,8 @@ def edit_georeferencing(ifc, georeference):
 def add_georeferencing(georeference):
     georeference.add_georeferencing()
 
+def remove_georeferencing(georeference):
+    georeference.remove_georeferencing()
+
 def set_blender_grid_north(georeference):
     georeference.set_blender_grid_north()

--- a/src/blenderbim/blenderbim/core/georeference.py
+++ b/src/blenderbim/blenderbim/core/georeference.py
@@ -24,6 +24,7 @@ def disable_editing_georeferencing(georeference):
     georeference.clear_georeferencing()
 
 def edit_georeferencing(ifc, georeference):
-    ifc.run("georeference.edit_georeferencing", georeferencing=georeference.get_georeferencing(), attributes=georeference.export_georeferencing_attributes())
+    georeference.export_georeferencing_attributes()
+    #ifc.run("georeference.edit_georeferencing", georeferencing=georeference.get_georeferencing(), attributes=georeference.export_georeferencing_attributes())
     disable_editing_georeferencing(georeference)
 

--- a/src/blenderbim/blenderbim/core/tool.py
+++ b/src/blenderbim/blenderbim/core/tool.py
@@ -122,6 +122,7 @@ class Georeference:
     def export_map_attributes(self, attributes, prop): pass
     def export_crs_attributes(self, attributes, prop): pass
     def add_georeferencing(cls): pass
+    def remove_georeferencing(cls): pass
     def set_blender_grid_north(cls): pass
 
 

--- a/src/blenderbim/blenderbim/core/tool.py
+++ b/src/blenderbim/blenderbim/core/tool.py
@@ -111,6 +111,17 @@ class Geometry:
     def should_force_triangulation(cls): pass
     def should_use_presentation_style_assignment(cls): pass
 
+@interface
+class Georeference:
+    def set_georeferencing(cls, georeferencing): pass
+    def import_georeferencing_attributes(cls): pass
+    def import_projected_crs_attributes(cls, name, prop, data): pass
+    def clear_georeferencing(cls): pass
+    def get_georeferencing(cls): pass
+    def export_georeferencing_attributes(cls): pass
+    def export_map_attributes(self, attributes, prop): pass
+    def export_crs_attributes(self, attributes, prop): pass
+
 
 @interface
 class Ifc:

--- a/src/blenderbim/blenderbim/core/tool.py
+++ b/src/blenderbim/blenderbim/core/tool.py
@@ -121,6 +121,8 @@ class Georeference:
     def export_georeferencing_attributes(cls): pass
     def export_map_attributes(self, attributes, prop): pass
     def export_crs_attributes(self, attributes, prop): pass
+    def add_georeferencing(cls): pass
+    def set_blender_grid_north(cls): pass
 
 
 @interface

--- a/src/blenderbim/blenderbim/tool/__init__.py
+++ b/src/blenderbim/blenderbim/tool/__init__.py
@@ -22,6 +22,7 @@ from blenderbim.tool.brick import Brick
 from blenderbim.tool.collector import Collector
 from blenderbim.tool.context import Context
 from blenderbim.tool.geometry import Geometry
+from blenderbim.tool.georeference import Georeference
 from blenderbim.tool.ifc import Ifc
 from blenderbim.tool.material import Material
 from blenderbim.tool.misc import Misc

--- a/src/blenderbim/blenderbim/tool/georeference.py
+++ b/src/blenderbim/blenderbim/tool/georeference.py
@@ -1,0 +1,125 @@
+from blenderbim.bim.ifc import IfcStore
+import bpy
+import json
+import blenderbim.core.tool  #TODO check this
+import blenderbim.tool as tool  #TODO check this
+import ifcopenshell
+import blenderbim.bim.helper
+from blenderbim.bim.module.georeference.data import GeoreferenceData
+from ifcopenshell.api.unit.data import Data as UnitData #TODO Connect new module data
+
+class Georeference(blenderbim.core.tool.Georeference):
+    @classmethod
+    def set_georeferencing(cls, georeferencing):
+        bpy.context.scene.BIMGeoreferenceProperties.active_georeferencing_id = georeferencing.id()
+
+    @classmethod
+    def import_georeferencing_attributes(cls):
+        georeferencing = tool.Ifc.get().by_id(bpy.context.scene.BIMGeoreferenceProperties.active_georeferencing_id)  #TODO IS IT NECESSARY?
+
+        props = bpy.context.scene.BIMGeoreferenceProperties
+
+        props.projected_crs.clear()
+
+        blenderbim.bim.helper.import_attributes(
+            "IfcProjectedCRS", props.projected_crs, GeoreferenceData.data["projected_crs"], cls.import_projected_crs_attributes
+        )
+
+        props.map_conversion.clear()
+        blenderbim.bim.helper.import_attributes(
+            "IfcMapConversion", props.map_conversion, GeoreferenceData.data["map_conversion"], cls.import_map_conversion_attributes
+        )
+
+        props.has_true_north = bool(GeoreferenceData.data["true_north"])
+        if GeoreferenceData.data["true_north"]:
+            props.true_north_abscissa = str(GeoreferenceData.data["true_north"][0])
+            props.true_north_ordinate = str(GeoreferenceData.data["true_north"][1])
+        
+        props.is_editing = True
+    
+    @classmethod
+    def import_projected_crs_attributes(cls, name, prop, data):
+        props = bpy.context.scene.BIMGeoreferenceProperties
+        if name == "MapUnit":
+            new = props.projected_crs.add()
+            new.name = name
+            new.data_type = "enum"
+            new.is_null = data[name] is None
+            new.is_optional = True
+            new.enum_items = json.dumps(
+                {u["id"]: u["Name"] for u in UnitData.units.values() if u["UnitType"] == "LENGTHUNIT"}
+            )
+            if data["MapUnit"]:
+                new.enum_value = str(data["MapUnit"]["id"])
+            return True
+
+    @classmethod
+    def import_map_conversion_attributes(cls, name, prop, data):
+        if name not in ["SourceCRS", "TargetCRS"]:
+            # Enforce a string data type to prevent data loss in single-precision Blender props
+            prop.data_type = "string"
+            prop.string_value = "" if prop.is_null else str(data[name])
+            return True
+    
+    @classmethod
+    def clear_georeferencing(cls):
+        bpy.context.scene.BIMGeoreferenceProperties.active_georeferencing_id = 0
+        props = bpy.context.scene.BIMGeoreferenceProperties
+        props.is_editing = False
+        
+
+    @classmethod
+    def get_georeferencing(cls):
+        return tool.Ifc().get().by_id(bpy.context.scene.BIMGeoreferenceProperties.active_georeferencing_id)
+    
+    @classmethod
+    def export_georeferencing_attributes(cls):
+        props = bpy.context.scene.BIMGeoreferenceProperties
+
+        file = IfcStore.get_file()
+        #attributes = {}
+        #attributes["projected_crs"] = blenderbim.bim.helper.export_attributes(props.projected_crs, cls.export_crs_attributes)
+        #attributes["map_conversion"] = blenderbim.bim.helper.export_attributes(props.map_conversion, cls.export_map_attributes)
+
+        #attributes["true_north"] = None
+
+        projected_crs = blenderbim.bim.helper.export_attributes(props.projected_crs, cls.export_crs_attributes)
+        map_conversion = blenderbim.bim.helper.export_attributes(props.map_conversion, cls.export_map_attributes)
+
+        true_north = None
+
+        if props.has_true_north:
+            try:
+                true_north = [float(props.true_north_abscissa), float(props.true_north_ordinate)]
+            except ValueError:
+                cls.report({"ERROR"}, "True North Abscissa and Ordinate expect a number")
+
+
+        #TODO is it correct to run the api here??? Other modules runs api in core
+        
+        ifcopenshell.api.run(
+            "georeference.edit_georeferencing",
+            file,
+            **{
+                "map_conversion": map_conversion,
+                "projected_crs": projected_crs,
+                "true_north": true_north,
+            }
+        )
+
+        return {"FINISHED"}
+
+    @classmethod
+    def export_map_attributes(self, attributes, prop):
+        if not prop.is_null and prop.data_type == "string":
+            # We store our floats as string to prevent single precision data loss
+            attributes[prop.name] = float(prop.string_value)
+            return True
+
+    @classmethod
+    def export_crs_attributes(self, attributes, prop):
+        if not prop.is_null and prop.name == "MapUnit":
+            attributes[prop.name] = self.file.by_id(int(prop.enum_value))
+            return True
+
+    

--- a/src/blenderbim/blenderbim/tool/georeference.py
+++ b/src/blenderbim/blenderbim/tool/georeference.py
@@ -7,6 +7,7 @@ import ifcopenshell
 import blenderbim.bim.helper
 from blenderbim.bim.module.georeference.data import GeoreferenceData
 from ifcopenshell.api.unit.data import Data as UnitData #TODO Connect new module data
+from math import radians, degrees, atan, tan, cos, sin
 
 class Georeference(blenderbim.core.tool.Georeference):
     @classmethod
@@ -111,5 +112,17 @@ class Georeference(blenderbim.core.tool.Georeference):
         if not prop.is_null and prop.name == "MapUnit":
             attributes[prop.name] = self.file.by_id(int(prop.enum_value))
             return True
-
     
+    @classmethod
+    def add_georeferencing(cls):
+        file = IfcStore.get_file()
+        ifcopenshell.api.run("georeference.add_georeferencing", file)
+
+    @classmethod
+    def set_blender_grid_north(cls):
+        bpy.context.scene.sun_pos_properties.north_offset = -radians(
+            ifcopenshell.util.geolocation.xaxis2angle(
+                float(bpy.context.scene.BIMGeoreferenceProperties.map_conversion.get("XAxisAbscissa").string_value),
+                float(bpy.context.scene.BIMGeoreferenceProperties.map_conversion.get("XAxisOrdinate").string_value),
+            )
+        )

--- a/src/blenderbim/blenderbim/tool/georeference.py
+++ b/src/blenderbim/blenderbim/tool/georeference.py
@@ -119,6 +119,11 @@ class Georeference(blenderbim.core.tool.Georeference):
         ifcopenshell.api.run("georeference.add_georeferencing", file)
 
     @classmethod
+    def remove_georeferencing(cls):
+        file = IfcStore.get_file()
+        ifcopenshell.api.run("georeference.remove_georeferencing", file)
+
+    @classmethod
     def set_blender_grid_north(cls):
         bpy.context.scene.sun_pos_properties.north_offset = -radians(
             ifcopenshell.util.geolocation.xaxis2angle(

--- a/src/blenderbim/blenderbim/tool/georeference.py
+++ b/src/blenderbim/blenderbim/tool/georeference.py
@@ -75,25 +75,17 @@ class Georeference(blenderbim.core.tool.Georeference):
     @classmethod
     def export_georeferencing_attributes(cls):
         props = bpy.context.scene.BIMGeoreferenceProperties
-
         file = IfcStore.get_file()
-        #attributes = {}
-        #attributes["projected_crs"] = blenderbim.bim.helper.export_attributes(props.projected_crs, cls.export_crs_attributes)
-        #attributes["map_conversion"] = blenderbim.bim.helper.export_attributes(props.map_conversion, cls.export_map_attributes)
-
-        #attributes["true_north"] = None
 
         projected_crs = blenderbim.bim.helper.export_attributes(props.projected_crs, cls.export_crs_attributes)
         map_conversion = blenderbim.bim.helper.export_attributes(props.map_conversion, cls.export_map_attributes)
 
         true_north = None
-
         if props.has_true_north:
             try:
                 true_north = [float(props.true_north_abscissa), float(props.true_north_ordinate)]
             except ValueError:
                 cls.report({"ERROR"}, "True North Abscissa and Ordinate expect a number")
-
 
         #TODO is it correct to run the api here??? Other modules runs api in core
         
@@ -106,8 +98,6 @@ class Georeference(blenderbim.core.tool.Georeference):
                 "true_north": true_north,
             }
         )
-
-        return {"FINISHED"}
 
     @classmethod
     def export_map_attributes(self, attributes, prop):


### PR DESCRIPTION
Refactor the Georeference Module, following the n.1 of this comment #1711 and following also this issue #1848.

The code runs ok but i'm not sure i did the correct things. Basically, i did these things:
- created a `blenderbim.bim.module.GeoreferenceData` data class
- update `ui` that calls the correct data class
- update `operator` calling a new `core` and `tool` class

These are my doubts:
- `tool/georeference` calls directly the api.run (see line 93 of blenderbim/tool/georeference.py) but other modules call the api.run from core.py (see for example owner module).
I tried to do the same thing but it didn't worked.
- i didn't update (yet) some operator functions like SetIfcGridNorth, SetBlenderTrueNorth, ... etc because they aren't called directly from ui and i'm not sure that they have to be updated, but i can easly follow the same pattern as before and update them also 

