### PR TITLE
Prevent crash on export for obj with no material

### DIFF
--- a/src/blenderbim/blenderbim/bim/prop.py
+++ b/src/blenderbim/blenderbim/bim/prop.py
@@ -341,4 +341,4 @@ class BIMMeshProperties(PropertyGroup):
     is_parametric: BoolProperty(name="Is Parametric", default=False)
     ifc_definition: StringProperty(name="IFC Definition")
     ifc_parameters: CollectionProperty(name="IFC Parameters", type=IfcParameter)
-    material_checksum: StringProperty(name="Material Checksum")
+    material_checksum: StringProperty(name="Material Checksum", default="[]")


### PR DESCRIPTION
During export material_checksum was always checked against a stringed
list `'[]'` for an empty material while default value
for material_checksum default was `''`. So it was trying to update
material of object which have none (eg. IfcRelSpaceBoundary).
See: https://github.com/IfcOpenShell/IfcOpenShell/blob/a3f27830c579e567218f79faa52dfc941a441241/src/blenderbim/blenderbim/bim/export_ifc.py#L145-L147