### PR TITLE
Fix #1717 : Disable task editing if task was deleted as a result of deleting its parent

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/sequence/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/sequence/operator.py
@@ -523,14 +523,13 @@ class RemoveTask(bpy.types.Operator):
         Data.load(self.file)
         bpy.ops.bim.enable_editing_tasks(work_schedule=props.active_work_schedule_id)
 
-        for i, task in enumerate(context.scene.BIMTaskTreeProperties.tasks):
-            if (
-                task.ifc_definition_id == props.active_task_id
-                and self.file.by_id(props.active_task_id) == active_task_ifc
-            ):  # Task was not deleted
-                break
-            if i == len(context.scene.BIMTaskTreeProperties.tasks) - 1:  # Task was deleted
-                bpy.ops.bim.disable_editing_task()
+        if not any(
+            task
+            for task in context.scene.BIMTaskTreeProperties.tasks
+            if task.ifc_definition_id == props.active_task_id
+            and self.file.by_id(props.active_task_id) == active_task_ifc
+        ):  # Task was deleted
+            bpy.ops.bim.disable_editing_task()
 
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/sequence/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/sequence/operator.py
@@ -513,7 +513,7 @@ class RemoveTask(bpy.types.Operator):
     def _execute(self, context):
         props = context.scene.BIMWorkScheduleProperties
         self.file = IfcStore.get_file()
-        active_task_ifc = self.file.by_id(props.active_task_id)
+        edited_task_ifc = self.file.by_id(props.active_task_id) if props.active_task_id else None
 
         ifcopenshell.api.run(
             "sequence.remove_task",
@@ -523,13 +523,14 @@ class RemoveTask(bpy.types.Operator):
         Data.load(self.file)
         bpy.ops.bim.enable_editing_tasks(work_schedule=props.active_work_schedule_id)
 
-        if not any(
-            task
-            for task in context.scene.BIMTaskTreeProperties.tasks
-            if task.ifc_definition_id == props.active_task_id
-            and self.file.by_id(props.active_task_id) == active_task_ifc
-        ):  # Task was deleted
-            bpy.ops.bim.disable_editing_task()
+        if edited_task_ifc:
+            if not any(
+                task
+                for task in context.scene.BIMTaskTreeProperties.tasks
+                if task.ifc_definition_id == props.active_task_id
+                and self.file.by_id(props.active_task_id) == edited_task_ifc
+            ):  # Task was deleted
+                bpy.ops.bim.disable_editing_task()
 
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/sequence/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/sequence/operator.py
@@ -513,13 +513,25 @@ class RemoveTask(bpy.types.Operator):
     def _execute(self, context):
         props = context.scene.BIMWorkScheduleProperties
         self.file = IfcStore.get_file()
+        active_task_ifc = self.file.by_id(props.active_task_id)
+
         ifcopenshell.api.run(
             "sequence.remove_task",
             self.file,
-            task=IfcStore.get_file().by_id(self.task),
+            task=self.file.by_id(self.task),
         )
         Data.load(self.file)
         bpy.ops.bim.enable_editing_tasks(work_schedule=props.active_work_schedule_id)
+
+        for i, task in enumerate(context.scene.BIMTaskTreeProperties.tasks):
+            if (
+                task.ifc_definition_id == props.active_task_id
+                and self.file.by_id(props.active_task_id) == active_task_ifc
+            ):  # Task was not deleted
+                break
+            if i == len(context.scene.BIMTaskTreeProperties.tasks) - 1:  # Task was deleted
+                bpy.ops.bim.disable_editing_task()
+
         return {"FINISHED"}
 
 


### PR DESCRIPTION
Following   #1717
I elected to disable editing if the edited task has been removed, although maybe there are some more intricate dependencies that make it not ideal ?

**Basically :**

Store currently edited task before removing a task.
Check after removing the task if the previsously edited task still exists, if not, disable editing it to prevent softlock.

@Moult while testing this I noticed the behaviour is a bit weird when adding a new task to the list, usually when adding an element in a list (at least in Blender) this element becomes active, here it does not. Do you reckon it would be interesting to change the behaviour to select the element that's just been added in the list ? I can work on it if needed.

Also I'm wondering if you think it's doable to write unit tests for this, since I remember you saying testing UI is hard.

