### PR TITLE
Boundary geom creation : fix math + small ui fix

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/boundary/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/boundary/operator.py
@@ -305,6 +305,7 @@ class UpdateBoundaryGeometry(bpy.types.Operator):
         matrix[0].xyz = i
         matrix[1].xyz = j
         matrix[2].xyz = k
+        matrix.transpose()
         matrix.translation = location
 
         settings = {

--- a/src/blenderbim/blenderbim/bim/module/boundary/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/boundary/ui.py
@@ -145,6 +145,10 @@ class BIM_PT_SpaceBoundaries(Panel):
             boundary_data = Data.boundaries[boundary_id]
             building_element = self.ifc_file.by_id(boundary_data["RelatedBuildingElement"])
             row = self.layout.row()
-            row.label(text=f"{boundary_id} > {building_element.is_a()}/{building_element.Name}", icon="GHOST_ENABLED")
+            if building_element:
+                bld_el_description = f"{building_element.is_a()}/{building_element.Name}"
+            else:
+                bld_el_description = None
+            row.label(text=f"{boundary_id} > {bld_el_description}", icon="GHOST_ENABLED")
             op = row.operator("bim.load_boundary", text="", icon="RESTRICT_SELECT_OFF")
             op.boundary_id = boundary_id


### PR DESCRIPTION
_Neo accidentally took the red pill so I transposed the matrix to make it blue_

* Fix how placement matrix of updated geometry is created.
* Fix ui: was throwing an error when boundary had no `RelatedBuildingElement`