### PR TITLE
Bug Fix: Correct HeaderFile

### DIFF
--- a/src/bcf/src/bcf/v3/data.py
+++ b/src/bcf/src/bcf/v3/data.py
@@ -46,7 +46,7 @@ class RelatedTopic:
 
 class HeaderFile:
     def __init__(self):
-        self.file_name = ""
+        self.filename = ""
         self.date = None
         self.reference = ""
         self.ifc_project = None


### PR DESCRIPTION
The `HeaderFile` class of bcf.v3 has a incorrect attribute. Rename `file_name` to `filename` (without underline).

Otherwise `f.filename` in `writer_header()` of bcf.v3.bcxml.py raises an AttributeError.