### PR TITLE
fix umlauts not showing up correctly in dynamic enums #1941

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/pset/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/pset/ui.py
@@ -19,6 +19,7 @@
 from bpy.types import Panel
 from blenderbim.bim.ifc import IfcStore
 from blenderbim.bim.helper import draw_attribute
+from blenderbim.bim.prop import getAttributeEnumValues
 from blenderbim.bim.module.pset.data import (
     ObjectPsetsData,
     ObjectQtosData,
@@ -95,6 +96,7 @@ def draw_psetqto_ui(context, pset_id, pset, props, layout, obj_type):
 
 def draw_psetqto_editable_ui(box, props, prop):
     row = box.row(align=True)
+    getAttributeEnumValues(prop, "")
     draw_attribute(prop, row, copy_operator="bim.copy_property_to_selection")
     if (
         "length" in prop.name.lower()

--- a/src/blenderbim/blenderbim/bim/module/pset/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/pset/ui.py
@@ -19,7 +19,6 @@
 from bpy.types import Panel
 from blenderbim.bim.ifc import IfcStore
 from blenderbim.bim.helper import draw_attribute
-from blenderbim.bim.prop import getAttributeEnumValues
 from blenderbim.bim.module.pset.data import (
     ObjectPsetsData,
     ObjectQtosData,
@@ -96,7 +95,6 @@ def draw_psetqto_ui(context, pset_id, pset, props, layout, obj_type):
 
 def draw_psetqto_editable_ui(box, props, prop):
     row = box.row(align=True)
-    getAttributeEnumValues(prop, "")
     draw_attribute(prop, row, copy_operator="bim.copy_property_to_selection")
     if (
         "length" in prop.name.lower()

--- a/src/blenderbim/blenderbim/bim/prop.py
+++ b/src/blenderbim/blenderbim/bim/prop.py
@@ -24,6 +24,7 @@ import ifcopenshell
 import ifcopenshell.util.pset
 import blenderbim.bim.handler
 from blenderbim.bim.ifc import IfcStore
+from collections import defaultdict
 from bpy.types import PropertyGroup
 from bpy.props import (
     PointerProperty,
@@ -80,12 +81,37 @@ def update_is_visible(self, context):
                 pass
 
 
-def getAttributeEnumValues(self, context):
+def InternStr(s):
+    if not hasattr(InternStr, "StringCache"):  # Another way to define a function attribute
+        InternStr.StringCache = defaultdict(str)
+    InternStr.StringCache[s] = s
+    return InternStr.StringCache[s]
+
+InternStr.StringCache = {}
+
+
+def getAttributeEnumValues(prop, context):
     # Support weird buildingSMART dictionary mappings which behave like enums
-    data = json.loads(self.enum_items)
+    items = []
+    data = json.loads(prop.enum_items)
+    
     if isinstance(data, dict):
-        getAttributeEnumValues.enum_values = [(str(k), v, "") for k, v in data.items()]
-    getAttributeEnumValues.enum_values = [(e, e, "") for e in data]
+        for k, v in data.items():
+            for e in data:
+                items.append((
+                InternStr(k),
+                InternStr(v),
+                "",
+        ))
+    else:
+        for e in data:
+            items.append((
+            InternStr(e),
+            InternStr(e),
+            "",
+        ))
+            
+    return items
 
 
 def update_schema_dir(self, context):
@@ -146,10 +172,7 @@ class Attribute(PropertyGroup):
     is_null: BoolProperty(name="Is Null")
     is_optional: BoolProperty(name="Is Optional")
     enum_items: StringProperty(name="Value")
-    enum_value: EnumProperty(
-        items=lambda self, context: getAttributeEnumValues.enum_values, 
-        name="Value", 
-        update=updateAttributeValue)
+    enum_value: EnumProperty(items=getAttributeEnumValues, name="Value", update=updateAttributeValue)
 
     def get_value(self):
         if self.is_null:

--- a/src/blenderbim/blenderbim/bim/prop.py
+++ b/src/blenderbim/blenderbim/bim/prop.py
@@ -84,8 +84,8 @@ def getAttributeEnumValues(self, context):
     # Support weird buildingSMART dictionary mappings which behave like enums
     data = json.loads(self.enum_items)
     if isinstance(data, dict):
-        return [(str(k), v, "") for k, v in data.items()]
-    return [(e, e, "") for e in data]
+        getAttributeEnumValues.enum_values = [(str(k), v, "") for k, v in data.items()]
+    getAttributeEnumValues.enum_values = [(e, e, "") for e in data]
 
 
 def update_schema_dir(self, context):
@@ -146,7 +146,10 @@ class Attribute(PropertyGroup):
     is_null: BoolProperty(name="Is Null")
     is_optional: BoolProperty(name="Is Optional")
     enum_items: StringProperty(name="Value")
-    enum_value: EnumProperty(items=getAttributeEnumValues, name="Value", update=updateAttributeValue)
+    enum_value: EnumProperty(
+        items=lambda self, context: getAttributeEnumValues.enum_values, 
+        name="Value", 
+        update=updateAttributeValue)
 
     def get_value(self):
         if self.is_null:

--- a/src/blenderbim/blenderbim/bim/prop.py
+++ b/src/blenderbim/blenderbim/bim/prop.py
@@ -97,11 +97,10 @@ def getAttributeEnumValues(prop, context):
     
     if isinstance(data, dict):
         for k, v in data.items():
-            for e in data:
-                items.append((
-                InternStr(k),
-                InternStr(v),
-                "",
+            items.append((
+            InternStr(k),
+            InternStr(v),
+            "",
         ))
     else:
         for e in data:


### PR DESCRIPTION
I've started working on this, but I've hit a small roadblock. The umlauts now show correctly, but the dropdown is actually showing the options from the previous enumeration. Once selected, the enum_value is correct
![umlaut bug](https://user-images.githubusercontent.com/83825269/146359274-2a1274fc-f459-4dd4-9b4f-5615a188ba5f.gif)
?

Edit - no matter what dropdown is selected, the same options are always shown..