### PR TITLE
Display IFC schema in file selector right hand side panel

### DIFF
--- a/src/blenderbim/blenderbim/bim/operator.py
+++ b/src/blenderbim/blenderbim/bim/operator.py
@@ -75,7 +75,7 @@ class SelectIfcFile(bpy.types.Operator):
             max_lines_to_parse = 50
             for _ in range(max_lines_to_parse):
                 line = next(ifc_file)
-                if "schema" in line.lower():
+                if line.startswith("FILE_SCHEMA(('") and line.endswith("'));\n"):
                     schema = line.split("'")[1]
                     self.layout.label(text=f"File Schema : {schema}")
                     break

--- a/src/blenderbim/blenderbim/bim/operator.py
+++ b/src/blenderbim/blenderbim/bim/operator.py
@@ -65,12 +65,12 @@ class SelectIfcFile(bpy.types.Operator):
         # Access filepath & Directory https://blender.stackexchange.com/a/207665
         params  = context.space_data.params
         # Decode byte string https://stackoverflow.com/a/47737082/
-        directory = Path(params.directory.decode('utf-8'))
+        directory = Path(params.directory.decode("utf-8"))
         filepath = os.path.join(directory, params.filename)
         if self.is_existing_ifc_file(filepath):
             self.draw_ifc_specs(filepath)
     
-    def draw_ifc_specs(self, filepath):        
+    def draw_ifc_specs(self, filepath):
         with open(filepath) as ifc_file:
             max_lines_to_parse = 50
             for _ in range(max_lines_to_parse):


### PR DESCRIPTION
This commit is a proof of concept for displaying selected ifc information right in the file selector popup window.

Following https://github.com/IfcOpenShell/IfcOpenShell/issues/1956

Right now it works with `bpy.ops.bim.select_ifc_file` but could easily be extended to all the other file selector operators :

![image](https://user-images.githubusercontent.com/25156105/148769839-6ceaac1b-d66a-43a0-b9b3-5480c1c39fe0.png)

Pretend these are ifc files, I've hidden the names for privacy :

![BSE_80](https://user-images.githubusercontent.com/25156105/148769660-2a5f8943-4694-4e7b-8c80-23ec9d4d0ae1.gif)

