### PR TITLE
Improve section cutaway shader

### DIFF
--- a/src/blenderbim/blenderbim/bim/__init__.py
+++ b/src/blenderbim/blenderbim/bim/__init__.py
@@ -81,7 +81,7 @@ classes = [
     operator.SelectSchemaDir,
     operator.SelectIfcFile,
     operator.OpenUpstream,
-    operator.AddSectionPlane,
+    operator.BIM_OT_add_section_plane,
     operator.RemoveSectionPlane,
     operator.ReloadIfcFile,
     operator.AddIfcFile,

--- a/src/blenderbim/blenderbim/bim/__init__.py
+++ b/src/blenderbim/blenderbim/bim/__init__.py
@@ -82,7 +82,7 @@ classes = [
     operator.SelectIfcFile,
     operator.OpenUpstream,
     operator.BIM_OT_add_section_plane,
-    operator.RemoveSectionPlane,
+    operator.BIM_OT_remove_section_plane,
     operator.ReloadIfcFile,
     operator.AddIfcFile,
     operator.RemoveIfcFile,

--- a/src/blenderbim/blenderbim/bim/operator.py
+++ b/src/blenderbim/blenderbim/bim/operator.py
@@ -338,7 +338,7 @@ class BIM_OT_remove_section_plane(bpy.types.Operator):
             previous_section_compare.location += Vector((offset_x, offset_y))
             if previous_section_compare.inputs[1].links:
                 previous_section_compare.inputs[1].links[0].from_node.location += Vector((offset_x, offset_y))
-            self.offset_previous_nodes(previous_section_compare)
+            self.offset_previous_nodes(previous_section_compare, offset_x, offset_y)
 
     def purge_all_section_data(self, context):
         bpy.data.materials.remove(bpy.data.materials.get("Section Override"))

--- a/src/blenderbim/blenderbim/bim/operator.py
+++ b/src/blenderbim/blenderbim/bim/operator.py
@@ -202,6 +202,7 @@ class BIM_OT_add_section_plane(bpy.types.Operator):
 
         section_mix = group.nodes.new(type="ShaderNodeMixShader")
         section_mix.name = "Section Mix"
+        section_mix.inputs[0].default_value = 1  # Directly pass input shader when there is no cutaway
         section_mix.location = group_output.location - Vector((200, 0))
 
         cut_obj = nodes.new(type="ShaderNodeTexCoord")

--- a/src/blenderbim/blenderbim/bim/prop.py
+++ b/src/blenderbim/blenderbim/bim/prop.py
@@ -150,6 +150,17 @@ def getMaterialPsetNames(self, context):
     return materialpsetnames_enum
 
 
+def update_section_color(self, context):
+    section_node_group = bpy.data.node_groups.get("Section Override")
+    if section_node_group is None:
+        return
+    try:
+        emission_node = next(n for n in section_node_group.nodes if isinstance(n, bpy.types.ShaderNodeEmission))
+        emission_node.inputs[0].default_value = list(self.section_plane_colour) + [1]
+    except StopIteration:
+        pass
+
+
 class StrProperty(PropertyGroup):
     pass
 
@@ -251,7 +262,12 @@ class BIMProperties(PropertyGroup):
     last_transaction: StringProperty(name="Last Transaction")
     should_section_selected_objects: BoolProperty(name="Section Selected Objects", default=False)
     section_plane_colour: FloatVectorProperty(
-        name="Temporary Section Cutaway Colour", subtype="COLOR", default=(1, 0, 0), min=0.0, max=1.0
+        name="Temporary Section Cutaway Colour",
+        subtype="COLOR",
+        default=(1, 0, 0),
+        min=0.0,
+        max=1.0,
+        update=update_section_color,
     )
     area_unit: EnumProperty(
         default="SQUARE_METRE",


### PR DESCRIPTION
Following https://github.com/IfcOpenShell/IfcOpenShell/issues/1997 and #1995

The Section Cutaway features are :

- Section shader must accept an input object, which will be used to make the geometry under its local Z axis transparent

- Backfaces must be drawn in another color defined in context.scene.BIMProperties.section_plane_colour

- Section shaders must stack

Summary of the PR :

- Optimize node network (removed ~8 nodes)

- Make node network "human readable" by tweaking the node positions
Before :
![image](https://user-images.githubusercontent.com/25156105/150695918-1fa2a81d-7f44-46f8-ae2f-5f786b8ae366.png)
After :
![image](https://user-images.githubusercontent.com/25156105/150695888-d621bf1e-c6df-4ae4-980a-70fc60389240.png)

- Dynamically update the backface color of the cutaway from the interface
![BES_56](https://user-images.githubusercontent.com/25156105/150695980-bcc10b8f-4903-4722-aa19-ea1818241e63.gif)

- Do not forcefully delete objects that are not a section cutway object from the "Remove Temporary Section" button

- Rearrange nodes neatly when deleting section objects
![BES_57](https://user-images.githubusercontent.com/25156105/150696039-3f9d6c2a-4e86-4de2-a3c2-ab228384a1dc.gif)

- Add tooltips to both operators

- Rename operator classes to adhere to blender guidelines

Possible improvements :

A lot of the code relies on fetching nodes and objects by name, which will throw errors if they are modified. It is unfortunately one of the problems of the node system. I think it's fair to assume that if the user is bold enough to modify things in the shader editor, they should be able to un-break things afterwards :p