### PR TITLE
Modification of triangulated face set creation

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/add_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/add_representation.py
@@ -543,6 +543,20 @@ class Usecase:
         else:
             items = [self.file.createIfcTriangulatedFaceSet(coordinates, None, None, i) for i in ifc_raw_items if i]
 
+#This assigns every triangle their own Cartesian Points.          
+        tempCoord_IndexList=[]
+        finalCoord_IndexList=[]
+        if self.settings["should_generate_uvs"]:
+            for x in (coord_index):
+                tempCoord_IndexList = x
+                for v in range(len(tempCoord_IndexList)):
+                    if not tempCoord_IndexList:
+                        continue
+                    if len(tempCoord_IndexList) >= v:
+                        finalCoord_IndexList.append(coordinates.CoordList[tempCoord_IndexList[v]-1])
+            coordinates.CoordList = finalCoord_IndexList
+            items[0].CoordIndex = ifc_raw_uv_items[0]
+#-----------------------------------
         return self.file.createIfcShapeRepresentation(
             self.settings["context"],
             self.settings["context"].ContextIdentifier,


### PR DESCRIPTION
This is a small modification to the IfcTriangulatedFaceSet creation. In the case of geometry having a UV Map, IfcTriangulatedFaceSet and IfcIndexedTriangleTextureMap values should match for interoperability reasons. This code block rewrites the IfcCartesianPointList3D and assigns every triangle their own cartesian points instead of reusing one cartesian point for different triangles.