### PR TITLE
Removed apparently unused and buggy lines in BlenderBIM's IFC importer

### DIFF
--- a/src/blenderbim/blenderbim/bim/import_ifc.py
+++ b/src/blenderbim/blenderbim/bim/import_ifc.py
@@ -1356,12 +1356,12 @@ class IfcImporter:
         elif surface_style.ReflectanceMethod == "FLAT":
             blender_material.use_nodes = True
 
-            output = {n.type: n for n in self.settings["material"].node_tree.nodes}.get("OUTPUT_MATERIAL", None)
+            #output = {n.type: n for n in self.settings["material"].node_tree.nodes}.get("OUTPUT_MATERIAL", None)
             bsdf = blender_material.node_tree.nodes["Principled BSDF"]
 
             mix = blender_material.node_tree.nodes.new(type="ShaderNodeMixShader")
             mix.location = bsdf.location
-            blender_material.node_tree.links.new(lightpath.outputs[0], output.inputs["Surface"])
+            #blender_material.node_tree.links.new(lightpath.outputs[0], output.inputs["Surface"])
 
             blender_material.node_tree.nodes.remove(bsdf)
 


### PR DESCRIPTION
These two lines cause an error when importing https://gitlab.com/openingdesign/101_W_33rd_St/-/blob/main/Models%20and%20CAD/IFC/101_W_33rd_St_Details_D.ifc
Removing them seems safe, they seem buggy anyway (IfcOpenShell.geom.settings don't have a 'materials' member) and materials are still correctly created, but I'm creating this PR mostly to ping @Moult to have a better look.