### PR TITLE
Enable option to build QtViewer using Qt5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,15 @@
 /_installed-vs*-x*/
 /build/
 
+# output directories
+/cmake/out/
+/docs/out/
+/src/examples/out/
+/src/ifcmax/out/
+/src/ifcwrap/out/
+/src/qtviewer/out/
+
+
 /win/BuildDepsCache*.txt
 # IfcExpressParser residue
 /src/ifcexpressparser/express_parser.py
@@ -13,6 +22,7 @@ __pycache__
 *.py.bak
 # Visual Studio Code files
 .vscode
+.vs
 # PyCharm files
 .idea
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -66,8 +66,8 @@ IF(NOT CMAKE_BUILD_TYPE)
 	SET(CMAKE_BUILD_TYPE "Release")
 ENDIF()
 
-# QtViewer requires Qt5
-OPTION(BUILD_QTVIEWER "Build IfcOpenShell Qt GUI Viewer" ON)
+# TODO QtViewer is deprecated ATM as it uses the 0.4 API
+# OPTION(BUILD_QTVIEWER "Build IfcOpenShell Qt GUI Viewer (requires Qt 4 framework)." OFF)
 include(GNUInstallDirs)
 if((BUILD_CONVERT OR BUILD_GEOMSERVER OR BUILD_IFCPYTHON) AND (NOT BUILD_IFCGEOM))
     message(STATUS "'IfcGeom' is required with current outputs")
@@ -885,9 +885,6 @@ INSTALL(FILES  ${SERIALIZERS_S_FILES}
 )
 endif()
 
-IF(BUILD_QTVIEWER)
-    ADD_SUBDIRECTORY(../src/qtviewer qtviewer)
-endif()
 
 list(APPEND CPACK_SOURCE_IGNORE_FILES
   .git

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -66,8 +66,8 @@ IF(NOT CMAKE_BUILD_TYPE)
 	SET(CMAKE_BUILD_TYPE "Release")
 ENDIF()
 
-# TODO QtViewer is deprecated ATM as it uses the 0.4 API
-# OPTION(BUILD_QTVIEWER "Build IfcOpenShell Qt GUI Viewer (requires Qt 4 framework)." OFF)
+# QtViewer requires Qt5
+OPTION(BUILD_QTVIEWER "Build IfcOpenShell Qt GUI Viewer" ON)
 include(GNUInstallDirs)
 if((BUILD_CONVERT OR BUILD_GEOMSERVER OR BUILD_IFCPYTHON) AND (NOT BUILD_IFCGEOM))
     message(STATUS "'IfcGeom' is required with current outputs")
@@ -885,6 +885,9 @@ INSTALL(FILES  ${SERIALIZERS_S_FILES}
 )
 endif()
 
+IF(BUILD_QTVIEWER)
+    ADD_SUBDIRECTORY(../src/qtviewer qtviewer)
+endif()
 
 list(APPEND CPACK_SOURCE_IGNORE_FILES
   .git

--- a/src/qtviewer/CMakeLists.txt
+++ b/src/qtviewer/CMakeLists.txt
@@ -17,39 +17,25 @@
 #                                                                              #
 ################################################################################
 
-# Find QT header files
-SET(QT_MIN_VERSION "4.5.0")
-FIND_PACKAGE(Qt4 REQUIRED)
-FIND_PACKAGE(Qt4 COMPONENTS QtCore QtGui QtOpenGL)
+cmake_minimum_required(VERSION 3.1.3)
 
-INCLUDE(${QT_USE_FILE})
-SET(CMAKE_PACKAGE_QTGUI TRUE)
+message("Running CMakeLists.txt in /src/qtviewer")
+message("Provide the path to Qt5 via CMAKE_PREFIX_PATH")
 
-# Find QT header files
-IF("$ENV{QT_INCLUDE_DIR}" STREQUAL "") 
-        SET(QT_INCLUDE_DIR "/usr/include/QT4/" CACHE FILEPATH "QT4 header files")
-        MESSAGE(STATUS "Looking for QT4 include files in: ${QT_INCLUDE_DIR}")
-        MESSAGE(STATUS "Use QT_INCLUDE_DIR to specify another directory")
-ELSE()
-        SET(QT_INCLUDE_DIR $ENV{QT_INCLUDE_DIR} CACHE FILEPATH "QT4 header files")
-        MESSAGE(STATUS "Looking for QT4 include files in: ${QT_INCLUDE_DIR}")
-ENDIF()
+find_package(Qt5 COMPONENTS Core Gui OpenGL Widgets REQUIRED)
 
-
-INCLUDE_DIRECTORIES(${QT_INCLUDE_DIR})
-
-SET(QTviewer_SRCS
+add_executable(QtViewer
         ../../src/qtviewer/mainwindow.h
         ../../src/qtviewer/mainwindow.cpp
         ../../src/qtviewer/main.cpp
 )
-SET(QTviewer_MOC_SRCS 
-        ../../src/qtviewer/mainwindow.h
+
+set_target_properties(QtViewer PROPERTIES
+	AUTOMOC On
 )
 
-QT_WRAP_CPP(QTviewer QTviewer_SRCS ${QTviewer_MOC_SRCS})
-
-ADD_EXECUTABLE(  QTviewer ${QTviewer_SRCS} ${QTviewer_MOC_SRCS})
-#http://www.qtcentre.org/wiki/index.php?title=Compiling_Qt4_apps_with_CMake
-
-TARGET_LINK_LIBRARIES (QTviewer ${IFCLIBS} ${QT_LIBRARIES} ${OPENCASCADE_LIBRARIES})
+target_link_libraries(QtViewer
+	${IFCLIBS}
+	Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Widgets
+	${OPENCASCADE_LIBRARIES}
+)

--- a/src/qtviewer/CMakeLists.txt
+++ b/src/qtviewer/CMakeLists.txt
@@ -17,39 +17,25 @@
 #                                                                              #
 ################################################################################
 
-# Find QT header files
-SET(QT_MIN_VERSION "4.5.0")
-FIND_PACKAGE(Qt4 REQUIRED)
-FIND_PACKAGE(Qt4 COMPONENTS QtCore QtGui QtOpenGL)
+cmake_minimum_required(VERSION 3.1.3)
 
-INCLUDE(${QT_USE_FILE})
-SET(CMAKE_PACKAGE_QTGUI TRUE)
+message("Running CMakeLists.txt in /src/qtviewer")
+message("Provide the path to Qt5 via CMAKE_PREFIX_PATH")
 
-# Find QT header files
-IF("$ENV{QT_INCLUDE_DIR}" STREQUAL "") 
-        SET(QT_INCLUDE_DIR "/usr/include/QT4/" CACHE FILEPATH "QT4 header files")
-        MESSAGE(STATUS "Looking for QT4 include files in: ${QT_INCLUDE_DIR}")
-        MESSAGE(STATUS "Use QT_INCLUDE_DIR to specify another directory")
-ELSE()
-        SET(QT_INCLUDE_DIR $ENV{QT_INCLUDE_DIR} CACHE FILEPATH "QT4 header files")
-        MESSAGE(STATUS "Looking for QT4 include files in: ${QT_INCLUDE_DIR}")
-ENDIF()
+find_package(Qt5 COMPONENTS Core Gui OpenGL Widgets REQUIRED)
 
-
-INCLUDE_DIRECTORIES(${QT_INCLUDE_DIR})
-
-SET(QTviewer_SRCS
+add_executable(QtViewer
         ../../src/qtviewer/mainwindow.h
         ../../src/qtviewer/mainwindow.cpp
         ../../src/qtviewer/main.cpp
 )
-SET(QTviewer_MOC_SRCS 
-        ../../src/qtviewer/mainwindow.h
+
+set_target_properties(QtViewer PROPERTIES
+	AUTOMOC On
 )
 
-QT_WRAP_CPP(QTviewer QTviewer_SRCS ${QTviewer_MOC_SRCS})
-
-ADD_EXECUTABLE(  QTviewer ${QTviewer_SRCS} ${QTviewer_MOC_SRCS})
-#http://www.qtcentre.org/wiki/index.php?title=Compiling_Qt4_apps_with_CMake
-
-TARGET_LINK_LIBRARIES (QTviewer ${IFCLIBS} ${QT_LIBRARIES} ${OPENCASCADE_LIBRARIES})
+target_link_libraries(QTviewer
+	${IFCLIBS}
+	Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Widgets
+	${OPENCASCADE_LIBRARIES}
+)

--- a/src/qtviewer/CMakeLists.txt
+++ b/src/qtviewer/CMakeLists.txt
@@ -17,25 +17,39 @@
 #                                                                              #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.1.3)
+# Find QT header files
+SET(QT_MIN_VERSION "4.5.0")
+FIND_PACKAGE(Qt4 REQUIRED)
+FIND_PACKAGE(Qt4 COMPONENTS QtCore QtGui QtOpenGL)
 
-message("Running CMakeLists.txt in /src/qtviewer")
-message("Provide the path to Qt5 via CMAKE_PREFIX_PATH")
+INCLUDE(${QT_USE_FILE})
+SET(CMAKE_PACKAGE_QTGUI TRUE)
 
-find_package(Qt5 COMPONENTS Core Gui OpenGL Widgets REQUIRED)
+# Find QT header files
+IF("$ENV{QT_INCLUDE_DIR}" STREQUAL "") 
+        SET(QT_INCLUDE_DIR "/usr/include/QT4/" CACHE FILEPATH "QT4 header files")
+        MESSAGE(STATUS "Looking for QT4 include files in: ${QT_INCLUDE_DIR}")
+        MESSAGE(STATUS "Use QT_INCLUDE_DIR to specify another directory")
+ELSE()
+        SET(QT_INCLUDE_DIR $ENV{QT_INCLUDE_DIR} CACHE FILEPATH "QT4 header files")
+        MESSAGE(STATUS "Looking for QT4 include files in: ${QT_INCLUDE_DIR}")
+ENDIF()
 
-add_executable(QtViewer
+
+INCLUDE_DIRECTORIES(${QT_INCLUDE_DIR})
+
+SET(QTviewer_SRCS
         ../../src/qtviewer/mainwindow.h
         ../../src/qtviewer/mainwindow.cpp
         ../../src/qtviewer/main.cpp
 )
-
-set_target_properties(QtViewer PROPERTIES
-	AUTOMOC On
+SET(QTviewer_MOC_SRCS 
+        ../../src/qtviewer/mainwindow.h
 )
 
-target_link_libraries(QTviewer
-	${IFCLIBS}
-	Qt5::Core Qt5::Gui Qt5::OpenGL Qt5::Widgets
-	${OPENCASCADE_LIBRARIES}
-)
+QT_WRAP_CPP(QTviewer QTviewer_SRCS ${QTviewer_MOC_SRCS})
+
+ADD_EXECUTABLE(  QTviewer ${QTviewer_SRCS} ${QTviewer_MOC_SRCS})
+#http://www.qtcentre.org/wiki/index.php?title=Compiling_Qt4_apps_with_CMake
+
+TARGET_LINK_LIBRARIES (QTviewer ${IFCLIBS} ${QT_LIBRARIES} ${OPENCASCADE_LIBRARIES})


### PR DESCRIPTION
Edited cmake/CMakeLists.txt & src/qtviewer/CMakeLists.txt, to enable the option to be able to build QtViewer using Qt5. The path to Qt5 can be provided via **CMAKE_PREFIX_PATH** to **win/run-cmake.bat** file like:
`.\run-cmake.bat vs2019-x64 -DCMAKE_PREFIX_PATH="C:/Qt/5.15.2/msvc2019_64"`