### PR TITLE
Fix BCFv3 "get_comments" error #2212

### DIFF
--- a/src/bcf/src/bcf/v3/bcfxml.py
+++ b/src/bcf/src/bcf/v3/bcfxml.py
@@ -646,7 +646,7 @@ class BcfXml:
     def get_comments(self, guid):
         comments = {}
         data = self._read_xml(os.path.join(guid, "markup.bcf"), "markup.xsd")
-        if "Comments" not in data["Topics"]:
+        if "Comments" not in data["Topic"]:
             return comments
 
         for item in data["Topic"]["Comments"].get("Comment", []):


### PR DESCRIPTION
**Fix for Issue** #2212 

The method get_comments wasn't working as expected because on line 649, it was trying to access the element "Topics" instead of "Topic", based on the XSD "Topics" doesn't exist, this fix is supposed to solve that by changing this missclick.

