### PR TITLE
Update README travis badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more information, see
 * [http://ifcopenshell.org](http://ifcopenshell.org)  
 * [http://academy.ifcopenshell.org](http://academy.ifcopenshell.org)
 
-[![Build Status](https://travis-ci.org/IfcOpenShell/IfcOpenShell.svg?branch=v0.6.0)](https://travis-ci.org/IfcOpenShell/IfcOpenShell)
+[![Build Status](https://travis-ci.com/IfcOpenShell/IfcOpenShell.svg?branch=v0.6.0)](https://travis-ci.com/IfcOpenShell/IfcOpenShell)
 
 [![Financial Contributors](https://opencollective.com/opensourcebim/tiers/badge.svg)](https://opencollective.com/opensourcebim/)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For more information, see
 Prerequisites
 -------------
 * Git
-* CMake (2.6 or newer)
+* CMake (3.1.3 or newer)
 * Windows: [Visual Studio] 2008 to 2019 (2022 not yet supported by dependency CMake) with C++ toolset (or [Visual C++ Build Tools]) or [MSYS2] + MinGW
 * *nix: GCC 4.7 or newer, or Clang (any version)
 


### PR DESCRIPTION
Update README travis badge URL since travis-ci.org indicates to use travis-ci.com now.
One question, on github repo the default branch is v0.7.0 while on travis the default is v0.6.0.
Is it a divergence?