### PR TITLE
Add more subdirs for blenderbim build trigger

### DIFF
--- a/.github/workflows/ci-blenderbim-matrix.yml
+++ b/.github/workflows/ci-blenderbim-matrix.yml
@@ -3,8 +3,18 @@ name: Publish-blenderbim-multiplatform
 on:
   push:
     paths:
-      - 'src/blenderbim/**'
       - '.github/workflows/ci-blenderbim-matrix.yml'
+      - 'src/blenderbim/**'
+      - 'src/ifcopenshell-python/ifcopenshell/**'
+      - 'src/bcf/src/bcf/**'
+      - 'src/ifcclash/ifcclash/**'
+      - 'src/ifccobie/**'
+      - 'src/ifcdiff/**'
+      - 'src/ifccsv/**'
+      - 'src/ifcpatch/ifcpatch/**'
+      - 'src/ifc4d/ifc4d/**'
+      - 'src/ifc5d/ifc5d/**'
+      - 'src/ifccityjson/**'
     branches:
       - v0.7.0
 


### PR DESCRIPTION
Added more subdirectories to the github actions workflow to trigger builds whenever a change occurs in relevant directories.

@Moult : If you can take a look at the directories I've added and see if there are any other directories we should monitor for changes in order to trigger new blenderbim builds?