### PR TITLE
Search for ifc class when assigning ifc data to an object

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/root/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/root/__init__.py
@@ -26,6 +26,7 @@ classes = (
     operator.EnableReassignClass,
     operator.ReassignClass,
     operator.UnlinkObject,
+    operator.BIM_OT_root_property_textfield,
     prop.BIMRootProperties,
     ui.BIM_PT_class,
 )

--- a/src/blenderbim/blenderbim/bim/module/root/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/root/operator.py
@@ -31,7 +31,7 @@ import blenderbim.core.root as core
 import blenderbim.tool as tool
 from ifcopenshell.api.void.data import Data as VoidData
 from blenderbim.bim.ifc import IfcStore
-from blenderbim.bim.module.root.prop import get_contexts
+from blenderbim.bim.module.root.prop import get_contexts, get_ifc_classes_filtered
 
 
 class Operator:
@@ -189,3 +189,24 @@ class CopyClass(bpy.types.Operator, Operator):
         for obj in objects:
             core.copy_class(tool.Ifc, tool.Collector, tool.Geometry, tool.Root, obj=obj)
         blenderbim.bim.handler.purge_module_data()
+
+
+class BIM_OT_root_property_textfield(bpy.types.Operator):
+    bl_idname = "bim.root_ifc_class_filter"
+    bl_label = "Filter Property"
+    bl_options = {"REGISTER", "UNDO"}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+    def execute(self, context):
+        context.scene.BIMRootProperties.ifc_class = context.scene.BIMRootProperties.ifc_class_filter_enum
+        return {"FINISHED"}
+
+    def draw(self, context):
+        props = context.scene.BIMRootProperties
+        self.layout.prop(props, "ifc_class_filter_textfield")
+        if len(get_ifc_classes_filtered(props, context)) > 10:
+            self.layout.prop(props, "ifc_class_filter_enum")
+        else:
+            self.layout.props_enum(props, "ifc_class_filter_enum")

--- a/src/blenderbim/blenderbim/bim/module/root/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/root/prop.py
@@ -34,11 +34,14 @@ from bpy.props import (
 )
 
 types_enum = []
+classes_enum = []
 
 
 def purge():
     global types_enum
     types_enum = []
+    global classes_enum
+    classes_enum = []
 
 
 def getIfcPredefinedTypes(self, context):
@@ -69,6 +72,10 @@ def refreshPredefinedTypes(self, context):
         context.scene.BIMRootProperties.ifc_predefined_type = enum[0][0]
 
 
+def update_class_enum(self, context):
+    self.ifc_class = self.ifc_class_filter_enum
+
+
 def get_ifc_products(self, context):
     if not IfcClassData.is_loaded:
         IfcClassData.load()
@@ -81,6 +88,15 @@ def get_ifc_classes(self, context):
     return IfcClassData.data["ifc_classes"]
 
 
+def get_ifc_classes_filtered(self, context):
+    ifc_classes = get_ifc_classes(self, context)
+    global classes_enum
+    classes_enum = [
+        c for c in ifc_classes
+        if self.ifc_class_filter_textfield.lower() in c[0].lower()] or ifc_classes
+    return classes_enum
+
+
 def get_contexts(self, context):
     if not IfcClassData.is_loaded:
         IfcClassData.load()
@@ -91,5 +107,7 @@ class BIMRootProperties(PropertyGroup):
     contexts: EnumProperty(items=get_contexts, name="Contexts")
     ifc_product: EnumProperty(items=get_ifc_products, name="Products", update=refresh_classes)
     ifc_class: EnumProperty(items=get_ifc_classes, name="Class", update=refreshPredefinedTypes)
+    ifc_class_filter_textfield: StringProperty(name="Filter", options={"TEXTEDIT_UPDATE"})
+    ifc_class_filter_enum: EnumProperty(items=get_ifc_classes_filtered, name="Class", update=update_class_enum)
     ifc_predefined_type: EnumProperty(items=getIfcPredefinedTypes, name="Predefined Type", default=None)
     ifc_userdefined_type: StringProperty(name="Userdefined Type")

--- a/src/blenderbim/blenderbim/bim/module/root/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/root/ui.py
@@ -79,8 +79,9 @@ class BIM_PT_class(Panel):
         if not is_reassigning_class:
             row = self.layout.row()
             row.prop(props, "ifc_product")
-        row = self.layout.row()
+        row = self.layout.row(align=True)
         row.prop(props, "ifc_class")
+        row.operator("bim.root_ifc_class_filter", text="", icon="VIEWZOOM")
         if ifc_predefined_types:
             row = self.layout.row()
             row.prop(props, "ifc_predefined_type")


### PR DESCRIPTION
This has a simple goal : Allowing searching for ifc class when assigning ifc data to an object. Here's a preview :

![Animation](https://user-images.githubusercontent.com/25156105/176503950-b1d8c988-4f2f-424a-9d39-b38132d58d56.gif)

It adds a button on the right of the ifc class enum field. I am slightly annoyed by the fact the fields are not perfectly aligned and I will look for a way to fix it. In the meantime I consider this functional.

If there are less than 10 entries, they will be displayed individually, otherwise it wil display a regular, filtered enum field.

If wish Enum Props would implement builtin fuzzy search but AFAIK they don't so I think this is a good compromise.
