### PR TITLE
Append all library elements

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/project/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/project/__init__.py
@@ -20,6 +20,7 @@ import bpy
 from . import ui, prop, operator
 
 classes = (
+    operator.AppendAllLibraryElements,
     operator.AppendLibraryElement,
     operator.AssignLibraryDeclaration,
     operator.ChangeLibraryElement,

--- a/src/blenderbim/blenderbim/bim/module/project/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/project/operator.py
@@ -282,6 +282,29 @@ class SaveLibraryFile(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class AppendAllLibraryElements(bpy.types.Operator):
+    bl_idname = "bim.append_all_library_elements"
+    bl_label = "Append All Library Elements"
+    bl_options = {"REGISTER", "UNDO"}
+    
+    @classmethod
+    def poll(cls, context):
+        return IfcStore.get_file()
+
+    def execute(self, context):
+        return IfcStore.execute_ifc_operator(self, context)
+    
+    def _execute(self, context):
+        props = context.scene.BIMProjectProperties.library_elements
+        
+        for prop in props:
+            bpy.ops.bim.append_library_element(
+                definition = prop.ifc_definition_id,
+                prop_index = context.scene.BIMProjectProperties.get_library_element_index(prop)
+            )
+        return {"FINISHED"}
+    
+    
 class AppendLibraryElement(bpy.types.Operator):
     bl_idname = "bim.append_library_element"
     bl_label = "Append Library Element"

--- a/src/blenderbim/blenderbim/bim/module/project/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/project/ui.py
@@ -17,6 +17,7 @@
 # along with BlenderBIM Add-on.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+from blenderbim.bim.ui import prop_with_search
 from bpy.types import Panel, UIList
 from blenderbim.bim.ifc import IfcStore
 from blenderbim.bim.module.project.data import ProjectData
@@ -48,10 +49,8 @@ class BIM_PT_project(Panel):
 
     def draw_load_ui(self, context):
         pprops = context.scene.BIMProjectProperties
-        row = self.layout.row()
-        row.prop(pprops, "collection_mode")
-        row = self.layout.row()
-        row.prop(pprops, "filter_mode")
+        prop_with_search(self.layout, pprops, "collection_mode")
+        prop_with_search(self.layout, pprops, "filter_mode")
         if pprops.filter_mode in ["DECOMPOSITION", "IFC_CLASS", "IFC_TYPE"]:
             row = self.layout.row(align=True)
             row.label(text=f"Total: {pprops.total_elements}")
@@ -84,8 +83,7 @@ class BIM_PT_project(Panel):
         row = self.layout.row()
         row.prop(pprops, "is_coordinating")
         if pprops.is_coordinating:
-            row = self.layout.row()
-            row.prop(pprops, "merge_mode")
+            prop_with_search(self.layout, pprops, "merge_mode")
         row = self.layout.row()
         row.prop(pprops, "deflection_tolerance")
         row = self.layout.row()
@@ -170,8 +168,7 @@ class BIM_PT_project(Panel):
     def draw_create_project_ui(self, context):
         props = context.scene.BIMProperties
         pprops = context.scene.BIMProjectProperties
-        row = self.layout.row()
-        row.prop(pprops, "export_schema")
+        prop_with_search(self.layout, pprops, "export_schema")
         row = self.layout.row()
         row.prop(context.scene.unit_settings, "system")
         row = self.layout.row()
@@ -180,8 +177,7 @@ class BIM_PT_project(Panel):
         row.prop(props, "area_unit", text="Area Unit")
         row = self.layout.row()
         row.prop(props, "volume_unit", text="Volume Unit")
-        row = self.layout.row()
-        row.prop(pprops, "template_file", text="Template")
+        prop_with_search(self.layout, pprops, "template_file", text="Template")
 
         row = self.layout.row(align=True)
         row.operator("bim.create_project")
@@ -220,6 +216,7 @@ class BIM_PT_project_library(Panel):
         if self.props.active_library_element:
             row.operator("bim.rewind_library", icon="FRAME_PREV", text="")
         row.operator("bim.refresh_library", icon="FILE_REFRESH", text="")
+        row.operator("bim.append_all_library_elements", icon="APPEND_BLEND",text="")
         self.layout.template_list(
             "BIM_UL_library",
             "",


### PR DESCRIPTION
Not sure if this is a desired change or not?  In my current usecase I always want to import all of the types at once, since I will use them later in an automated script.
![pull](https://user-images.githubusercontent.com/83825269/177342319-5f736c59-9b76-4fb3-b468-f7cdf2c58496.gif)

