### PR TITLE
Hiding all objects in the "Types" Collection

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/project/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/project/operator.py
@@ -371,7 +371,9 @@ class AppendLibraryElement(bpy.types.Operator):
             for collection in bpy.context.view_layer.layer_collection.children:
                 if "IfcProject/" in collection.name:
                     collection.collection.children.link(type_collection)
-                    collection.children["Types"].hide_viewport = True
+                    collection.children["Types"].hide_viewport = False
+                    for obj in bpy.data.collections.get("Types").objects:
+                        obj.hide_set(True)
                     break
 
         ifc_importer = import_ifc.IfcImporter(ifc_import_settings)


### PR DESCRIPTION
When all the objects in the "Types" collection are hidden, it makes it quicker to turn on, and isolate one type for viewing and/or toggling other types on to compare to.

verses how it is currently, where you would have to turn off all the type objects inside the Types collection before you wanted to isolate one or more types.  

Just less clicking. :)