### PR TITLE
Construction Types Browser: Solution to most of the current issues

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/model/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/model/__init__.py
@@ -23,6 +23,7 @@ classes = (
     product.AddEmptyType,
     product.AddConstrTypeInstance,
     product.DisplayConstrTypes,
+    product.ReinvokeOperator,
     product.AlignProduct,
     product.DynamicallyVoidProduct,
     workspace.Hotkey,

--- a/src/blenderbim/blenderbim/bim/module/model/data.py
+++ b/src/blenderbim/blenderbim/bim/module/model/data.py
@@ -131,6 +131,7 @@ class AuthoringData:
             if new_obj is not None:
                 to_be_deleted = True
                 obj = new_obj
+                obj.hide_set(True)
         obj.asset_mark()
         obj.asset_generate_preview()
         blender33_or_above = bpy.app.version >= (3, 3, 0)

--- a/src/blenderbim/blenderbim/bim/module/model/data.py
+++ b/src/blenderbim/blenderbim/bim/module/model/data.py
@@ -133,9 +133,11 @@ class AuthoringData:
                 obj = new_obj
         obj.asset_mark()
         obj.asset_generate_preview()
+        blender33_or_above = bpy.app.version >= (3, 3, 0)
+        interval = 1e-4
 
-        def wait_for_asset_previews_generation(check_interval_seconds=0.0001):
-            if bpy.app.is_job_running("RENDER_PREVIEW"):
+        def wait_for_asset_previews_generation(check_interval_seconds=interval):
+            if blender33_or_above and bpy.app.is_job_running("RENDER_PREVIEW"):
                 return check_interval_seconds
             else:
                 if ifc_class not in cls.props.constr_classes:
@@ -157,7 +159,8 @@ class AuthoringData:
                         collection.objects.unlink(obj)
                 return None
 
-        bpy.app.timers.register(wait_for_asset_previews_generation)
+        first_interval = 0 if blender33_or_above else interval
+        bpy.app.timers.register(wait_for_asset_previews_generation, first_interval=first_interval)
 
     @classmethod
     def assetize_relating_type_from_selection(cls, browser=False):

--- a/src/blenderbim/blenderbim/bim/module/model/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/model/prop.py
@@ -52,8 +52,9 @@ def update_icon_id(self, context, browser=False):
             except ConstrTypeEntityNotFound:
                 return
 
-        def set_icon(update_interval_seconds=0.0001):
-            if ifc_class not in self.constr_classes or relating_type_id not in self.constr_classes[ifc_class].constr_types:
+        def set_icon(update_interval_seconds=1e-4):
+            if (ifc_class not in self.constr_classes
+                    or relating_type_id not in self.constr_classes[ifc_class].constr_types):
                 return update_interval_seconds
             else:
                 self.icon_id = self.constr_classes[ifc_class].constr_types[relating_type_id].icon_id

--- a/src/blenderbim/blenderbim/bim/module/model/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/model/prop.py
@@ -41,23 +41,24 @@ def get_relating_type_browser(self, context):
 
 
 def update_icon_id(self, context, browser=False):
-    ifc_class = self.ifc_class_browser if browser else self.ifc_class
-    relating_type_id = self.relating_type_id_browser if browser else self.relating_type_id
-    # relating_type = AuthoringData.relating_type_name_by_id(ifc_class, relating_type_id)
+    if context.region is not None and context.region.type != "TOOL_HEADER":
+        ifc_class = self.ifc_class_browser if browser else self.ifc_class
+        relating_type_id = self.relating_type_id_browser if browser else self.relating_type_id
+        # relating_type = AuthoringData.relating_type_name_by_id(ifc_class, relating_type_id)
 
-    if ifc_class not in self.constr_classes or relating_type_id not in self.constr_classes[ifc_class].constr_types:
-        try:
-            AuthoringData.assetize_relating_type_from_selection(browser=browser)
-        except ConstrTypeEntityNotFound:
-            return
-
-    def set_icon(update_interval_seconds=0.0001):
         if ifc_class not in self.constr_classes or relating_type_id not in self.constr_classes[ifc_class].constr_types:
-            return update_interval_seconds
-        else:
-            self.icon_id = self.constr_classes[ifc_class].constr_types[relating_type_id].icon_id
+            try:
+                AuthoringData.assetize_relating_type_from_selection(browser=browser)
+            except ConstrTypeEntityNotFound:
+                return
 
-    bpy.app.timers.register(set_icon)
+        def set_icon(update_interval_seconds=0.0001):
+            if ifc_class not in self.constr_classes or relating_type_id not in self.constr_classes[ifc_class].constr_types:
+                return update_interval_seconds
+            else:
+                self.icon_id = self.constr_classes[ifc_class].constr_types[relating_type_id].icon_id
+
+        bpy.app.timers.register(set_icon)
 
 
 def update_ifc_class(self, context):
@@ -68,15 +69,16 @@ def update_ifc_class(self, context):
 
 
 def update_ifc_class_browser(self, context):
-    AuthoringData.load_ifc_classes()
-    AuthoringData.load_relating_types_browser()
-    if self.updating:
-        return
-    ifc_class = self.ifc_class_browser
-    constr_class_info = AuthoringData.constr_class_info(ifc_class)
+    if context.region is not None and context.region.type != "TOOL_HEADER":
+        AuthoringData.load_ifc_classes()
+        AuthoringData.load_relating_types_browser()
+        if self.updating:
+            return
+        ifc_class = self.ifc_class_browser
+        constr_class_info = AuthoringData.constr_class_info(ifc_class)
 
-    if constr_class_info is None or not constr_class_info.fully_loaded:
-        AuthoringData.assetize_constr_class(ifc_class)
+        if constr_class_info is None or not constr_class_info.fully_loaded:
+            AuthoringData.assetize_constr_class(ifc_class)
 
 
 def update_relating_type(self, context):
@@ -103,13 +105,14 @@ def get_constr_class_info(props, ifc_class):
 
 
 def update_preview_multiple(self, context):
-    if self.preview_multiple_constr_types:
-        ifc_class = self.ifc_class
-        constr_class_info = get_constr_class_info(self, ifc_class)
-        if constr_class_info is None or not constr_class_info.fully_loaded:
-            AuthoringData.assetize_constr_class(ifc_class)
-    else:
-        update_relating_type(self, context)
+    if context.region is not None and context.region.type != "TOOL_HEADER":
+        if self.preview_multiple_constr_types:
+            ifc_class = self.ifc_class
+            constr_class_info = get_constr_class_info(self, ifc_class)
+            if constr_class_info is None or not constr_class_info.fully_loaded:
+                AuthoringData.assetize_constr_class(ifc_class)
+        else:
+            update_relating_type(self, context)
 
 
 class ConstrTypeInfo(PropertyGroup):

--- a/src/blenderbim/blenderbim/bim/module/model/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/model/prop.py
@@ -41,7 +41,7 @@ def get_relating_type_browser(self, context):
 
 
 def update_icon_id(self, context, browser=False):
-    if context.region is not None and context.region.type != "TOOL_HEADER":
+    if context == "lost_context" or (context.region is not None and context.region.type != "TOOL_HEADER"):
         ifc_class = self.ifc_class_browser if browser else self.ifc_class
         relating_type_id = self.relating_type_id_browser if browser else self.relating_type_id
         # relating_type = AuthoringData.relating_type_name_by_id(ifc_class, relating_type_id)

--- a/src/blenderbim/blenderbim/bim/module/model/workspace.py
+++ b/src/blenderbim/blenderbim/bim/module/model/workspace.py
@@ -74,10 +74,10 @@ class BimTool(WorkSpaceTool):
             AuthoringData.data["relating_types_ids"] if "relating_types_ids" in AuthoringData.data else False
         )
 
-        if ifc_classes and relating_types_ids and not props.icon_id:
+        if ifc_classes and relating_types_ids and not props.icon_id and not is_tool_header:
             # hack Dion won't like to show a preview also on the first time the sidebar is shown
-            bpy.app.timers.register(lambda: prop.update_ifc_class_browser(props, context))
-            bpy.app.timers.register(lambda: prop.update_relating_type(props, context))
+            bpy.app.timers.register(lambda: prop.update_ifc_class(props, "lost_context"))
+            bpy.app.timers.register(lambda: prop.update_relating_type(props, "lost_context"))
 
         ifc_class = props.ifc_class
         relating_type_id = props.relating_type_id


### PR DESCRIPTION
Hopefully flickering is gone, it sort of works with 3.2, things are previewed on the first popup and there are no insane object creations.

The mouse position when displaying multiple types still needs some fine-tuning.