### PR TITLE
add choco alpha version tag, description fixes

### DIFF
--- a/choco/blenderbim/blenderbim.nuspec
+++ b/choco/blenderbim/blenderbim.nuspec
@@ -3,14 +3,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>blenderbim-nightly</id>
-    <version>blenderbim_build_version</version>
+    <version>blenderbim_build_version-alpha</version>
     <packageSourceUrl>https://github.com/IfcOpenShell/IfcOpenShell</packageSourceUrl>
     <owners>fbpyr</owners>
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <title>BlenderBIM install nightly</title>
     <authors>Dion Moult and many more, see: https://github.com/IfcOpenShell/IfcOpenShell/graphs/contributors</authors>
     <projectUrl>https://github.com/IfcOpenShell/IfcOpenShell</projectUrl>
-    <iconUrl>https://rawcdn.githack.com/fbpyr/IfcOpenShell/9662598ad4a7e4b6cd8980e430d07263835d0eda/choco/blenderbim/blenderbim.png</iconUrl>
+    <iconUrl>https://rawcdn.githack.com/IfcOpenShell/IfcOpenShell/c6ee1d1679d1298de0d7447ff108c22709c68e54/choco/blenderbim/blenderbim.png</iconUrl>
     <!-- <copyright>Year Software Vendor</copyright> -->
     <licenseUrl>https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.7.0/COPYING</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -18,9 +18,9 @@
     <docsUrl>https://blenderbim.org/docs/</docsUrl>
     <!--<mailingListUrl></mailingListUrl>-->
     <bugTrackerUrl>https://github.com/IfcOpenShell/IfcOpenShell/issues</bugTrackerUrl>
-    <tags>blender bim blenderbim python opensource foss</tags>
+    <tags>blender bim blenderbim ifc python opensource foss</tags>
     <summary>opensource bim</summary>
-    <description>opensource bim addon for blender</description>
+    <description>opensource bim addon for blender - source code at: https://github.com/IfcOpenShell/IfcOpenShell</description>
     <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
 
     <dependencies>


### PR DESCRIPTION
As suggested by our chocolatey reviewer, we would this time try the route of blenderbim being taged as `-alpha` version. 
This supposedly should skip human review process. 🤞 