### PR TITLE
choco yesterday

### DIFF
--- a/.github/workflows/ci-blenderbim-choco.yml
+++ b/.github/workflows/ci-blenderbim-choco.yml
@@ -8,7 +8,7 @@ on:
     #         │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
     #         │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
     #         *  * * * *
-    - cron: "56 23 * * *" # 4min before utc midnight
+    - cron:  "30 0 * * *" # 30min past utc midnight
 
 env:
   major: 0
@@ -55,7 +55,7 @@ jobs:
       - name: Fill chocolatey scripts on win with latest blender python
         if: ${{steps.do_choco.outputs.choco_release}} == 'do_choco_release'
         run: |
-          today_non_iso="$(date +'%y%m%d' | tr -d '\n')" &&
+          yesterday_non_iso="$(date  --date='yesterday' +'%y%m%d' | tr -d '\n')" &&
           target_os=${{ matrix.config.short_name }} &&
           latest_blender_python_version_maj_min=$(python3 /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/check_repo_infos.py --latest_blender_python_version_maj_min?) &&
           echo "latest_blender_python_version_maj_min?: $latest_blender_python_version_maj_min" &&
@@ -63,10 +63,10 @@ jobs:
           export latest_blender_version_maj_min=$(python3 /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/check_repo_infos.py --latest_blender_release_maj_min?) &&
           export latest_blender_version_maj_min_pat=$(python3 /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/check_repo_infos.py --latest_blender_release_maj_min_pat?) &&
           echo   latest_blender_version_maj_min_pat?: $latest_blender_version_maj_min_pat &&
-          export blenderbim_build_version="${{ env.major }}.${{ env.minor }}.$today_non_iso" &&
-          export url_blenderbim_py310_win_zip="https://github.com/IfcOpenShell/IfcOpenShell/releases/download/blenderbim-$today_non_iso/blenderbim-$today_non_iso-$pyver-$target_os.zip" &&
+          export blenderbim_build_version="${{ env.major }}.${{ env.minor }}.$yesterday_non_iso" &&
+          export url_blenderbim_py310_win_zip="https://github.com/IfcOpenShell/IfcOpenShell/releases/download/blenderbim-$yesterday_non_iso/blenderbim-$yesterday_non_iso-$pyver-$target_os.zip" &&
           wget $url_blenderbim_py310_win_zip --no-verbose &&
-          export sha256sum_blenderbim_py310_win_zip=$( sha256sum blenderbim-$today_non_iso-$pyver-$target_os.zip  --tag | cut -d ' ' -f 4  | tr -d '\n') &&
+          export sha256sum_blenderbim_py310_win_zip=$( sha256sum blenderbim-$yesterday_non_iso-$pyver-$target_os.zip  --tag | cut -d ' ' -f 4  | tr -d '\n') &&
           echo   sha256sum_blenderbim_py310_win_zip: $sha256sum_blenderbim_py310_win_zip &&
           python3 choco/blenderbim/fill_dynamic_parameters.py &&
           echo __build choco with mono &&

--- a/choco/blenderbim/check_repo_infos.py
+++ b/choco/blenderbim/check_repo_infos.py
@@ -15,10 +15,11 @@ def request_repo_info(url: str):
 
 if sys.argv[1] == "--do_choco_release?":
     now = datetime.datetime.now()
-    blenderbim_date = now.strftime("%y%m%d")
+    blenderbim_date = (now - datetime.timedelta(days=1)).strftime("%y%m%d")
     url = "https://github.com/IfcOpenShell/IfcOpenShell/releases/latest"
     resp = request_repo_info(url)
-    if blenderbim_date in resp.url:
+    text = str(resp.read())
+    if blenderbim_date in text:
         print("do_choco_release", end="")
 
 

--- a/choco/blenderbim/check_repo_infos.py
+++ b/choco/blenderbim/check_repo_infos.py
@@ -16,7 +16,7 @@ def request_repo_info(url: str):
 if sys.argv[1] == "--do_choco_release?":
     now = datetime.datetime.now()
     blenderbim_date = (now - datetime.timedelta(days=1)).strftime("%y%m%d")
-    url = "https://github.com/IfcOpenShell/IfcOpenShell/releases/latest"
+    url = "https://github.com/IfcOpenShell/IfcOpenShell/releases"
     resp = request_repo_info(url)
     text = str(resp.read())
     if blenderbim_date in text:


### PR DESCRIPTION
I had a closer look at the previous failed and successful action runs and realized, 
that they were all triggered far later than scheduled: 
They were scheduled for 23:55 but actually run between 00:30 and 00:55 - 
so one day later, where usually no bbim release would be there yet. 
But even if, then it would be a release with a high probability to be overwritten 
again during the day, which would cause sha256sum in choco to be off.

So I switch now to - what I think - is a far more robust approach: 

We now run the action well past midnight, but instead just check for **yesterday's** bbim releases. 💡 
With this approach, there are also no more late sha256sum colliding releases possible, as yesterday is really over. 🙂 