### PR TITLE
choco nightly path

### DIFF
--- a/choco/blenderbim/tools/chocolateyinstall.ps1
+++ b/choco/blenderbim/tools/chocolateyinstall.ps1
@@ -8,7 +8,7 @@ $appDataUserDir  = [System.Environment]::GetEnvironmentVariable('appdata')
 $unzipTargetDir  = "$appDataUserDir\Blender Foundation\Blender\latest_blender_version_maj_min\scripts\addons"
 
 $chocoBaseDir    = [System.Environment]::GetEnvironmentVariable('ChocolateyInstall')
-$addonEnable     = "$chocoBaseDir\lib\blenderbim\tools\enable_blenderbim_addon.py"
+$addonEnable     = "$chocoBaseDir\lib\blenderbim-nightly\tools\enable_blenderbim_addon.py"
 
 $programFilesDir = [System.Environment]::GetEnvironmentVariable('ProgramFiles')
 $blenderExePath  = "$env:ProgramFiles\Blender Foundation\Blender latest_blender_version_maj_min\blender.exe"

--- a/choco/blenderbim/tools/chocolateyuninstall.ps1
+++ b/choco/blenderbim/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@
 $unzippedDir = "$appDataUserDir\Blender Foundation\Blender\latest_blender_version_maj_min\scripts\addons\blenderbim"
 
 $chocoBaseDir    = [System.Environment]::GetEnvironmentVariable('ChocolateyInstall')
-$addonDisable     = "$chocoBaseDir\lib\blenderbim\tools\disable_blenderbim_addon.py"
+$addonDisable     = "$chocoBaseDir\lib\blenderbim-nightly\tools\disable_blenderbim_addon.py"
 
 $programFilesDir = [System.Environment]::GetEnvironmentVariable('ProgramFiles')
 $blenderExePath  = "$env:ProgramFiles\Blender Foundation\Blender latest_blender_version_maj_min\blender.exe"


### PR DESCRIPTION
Now that the choco package id has changed from `blenderbim` to `blenderbim-nightly`, 
this needs to be reflected in the install/uninstall scripts choco lib directory env var, 
so blenderbim addon can conveniently be enabled/disabled on install/uninstall. 🙂 