### PR TITLE
No-mapped quantities in qto calculator has None value (see #2533)

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/pset/calc_quantity_function_mapper.py
+++ b/src/blenderbim/blenderbim/bim/module/pset/calc_quantity_function_mapper.py
@@ -1,10 +1,578 @@
 mapper = {
-    "Qto_WallBaseQuantities" : {
-        "Length" : "get_length",
-        "Width" : "get_width",
-        "Height" : "get_height",
+    'Qto_AudioVisualApplianceBaseQuantities' : {
+        'GrossWeight' : None,
     },
-    "Qto_SlabBaseQuantities" : {
-        "Depth" : "get_height",
+    'Qto_PlateBaseQuantities' : {
+        'Width' : None,
+        'Perimeter' : None,
+        'GrossArea' : None,
+        'NetArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_OpeningElementBaseQuantities' : {
+        'Width' : None,
+        'Height' : None,
+        'Depth' : None,
+        'Area' : None,
+        'Volume' : None,
+    },
+    'Qto_MarineFacilityBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Height' : None,
+        'Area' : None,
+        'Volume' : None,
+    },
+    'Qto_ChillerBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_PileBaseQuantities' : {
+        'Length' : None,
+        'CrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+        'GrossSurfaceArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_VibrationIsolatorBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_LampBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_VehicleBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Height' : None,
+    },
+    'Qto_PipeFittingBaseQuantities' : {
+        'Length' : None,
+        'GrossCrossSectionArea' : None,
+        'NetCrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_CableCarrierFittingBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_HeatExchangerBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_DoorBaseQuantities' : {
+        'Width' : None,
+        'Height' : None,
+        'Perimeter' : None,
+        'Area' : None,
+    },
+    'Qto_DuctSegmentBaseQuantities' : {
+        'Length' : None,
+        'GrossCrossSectionArea' : None,
+        'NetCrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+        'GrossWeight' : None,
+    },
+    'Qto_TransformerBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_FacilityPartBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Height' : None,
+        'Area' : None,
+        'Volume' : None,
+    },
+    'Qto_ProjectionElementBaseQuantities' : {
+        'Area' : None,
+        'Volume' : None,
+    },
+    'Qto_SignBaseQuantities' : {
+        'Height' : None,
+        'Width' : None,
+        'Thickness' : None,
+        'Weight' : None,
+    },
+    'Qto_CableSegmentBaseQuantities' : {
+        'GrossWeight' : None,
+        'Length' : None,
+        'CrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+    },
+    'Qto_BuildingBaseQuantities' : {
+        'Height' : None,
+        'EavesHeight' : None,
+        'FootPrintArea' : None,
+        'GrossFloorArea' : None,
+        'NetFloorArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+    },
+    'Qto_ElectricFlowStorageDeviceBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_CommunicationsApplianceBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_RailBaseQuantities' : {
+        'Length' : None,
+        'Volume' : None,
+        'Weight' : None,
+    },
+    'Qto_PictorialSignQuantities' : {
+        'Area' : None,
+        'SignArea' : None,
+    },
+    'Qto_SpaceHeaterBaseQuantities' : {
+        'Length' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_CoveringBaseQuantities' : {
+        'Width' : None,
+        'GrossArea' : None,
+        'NetArea' : None,
+    },
+    'Qto_PipeSegmentBaseQuantities' : {
+        'Length' : None,
+        'GrossCrossSectionArea' : None,
+        'NetCrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+        'FootPrintArea' : None,
+    },
+    'Qto_HumidifierBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_ConstructionEquipmentResourceBaseQuantities' : {
+        'UsageTime' : None,
+        'OperatingTime' : None,
+    },
+    'Qto_AlarmBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_JunctionBoxBaseQuantities' : {
+        'GrossWeight' : None,
+        'NumberOfGangs' : None,
+        'Length' : None,
+        'Width' : None,
+        'Height' : None,
+    },
+    'Qto_ArealStratumBaseQuantities' : {
+        'Area' : None,
+        'Length' : None,
+        'PlanLength' : None,
+    },
+    'Qto_SiteBaseQuantities' : {
+        'GrossPerimeter' : None,
+        'GrossArea' : None,
+    },
+    'Qto_MotorConnectionBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_RoofBaseQuantities' : {
+        'GrossArea' : None,
+        'NetArea' : None,
+        'ProjectedArea' : None,
+    },
+    'Qto_ChimneyBaseQuantities' : {
+        'Length' : None,
+    },
+    'Qto_ElectricTimeControlBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_ElectricMotorBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_EarthworksFillBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Depth' : None,
+        'CompactedVolume' : None,
+        'LooseVolume' : None,
+    },
+    'Qto_ConduitSegmentBaseQuantities' : {
+        'InnerDiameter' : None,
+        'OuterDiameter' : None,
+    },
+    'Qto_SignalBaseQuantities' : {
+        'Weight' : None,
+    },
+    'Qto_DuctFittingBaseQuantities' : {
+        'Length' : None,
+        'GrossCrossSectionArea' : None,
+        'NetCrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+        'GrossWeight' : None,
+    },
+    'Qto_UnitaryControlElementBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_ActuatorBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_CurtainWallQuantities' : {
+        'Length' : None,
+        'Height' : None,
+        'Width' : None,
+        'GrossSideArea' : None,
+        'NetSideArea' : None,
+    },
+    'Qto_BoilerBaseQuantities' : {
+        'GrossWeight' : None,
+        'NetWeight' : None,
+        'TotalSurfaceArea' : None,
+    },
+    'Qto_FlowMeterBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_AirTerminalBaseQuantities' : {
+        'GrossWeight' : None,
+        'Perimeter' : None,
+        'TotalSurfaceArea' : None,
+    },
+    'Qto_DuctSilencerBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_WasteTerminalBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_SlabBaseQuantities' : {
+        'Width' : None,
+        'Length' : None,
+        'Depth' : "get_height",
+        'Perimeter' : None,
+        'GrossArea' : None,
+        'NetArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_ImpactProtectionDeviceBaseQuantities' : {
+        'Weight' : None,
+    },
+    'Qto_LightFixtureBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_FlowInstrumentBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_BuildingStoreyBaseQuantities' : {
+        'GrossHeight' : None,
+        'NetHeight' : None,
+        'GrossPerimeter' : None,
+        'GrossFloorArea' : None,
+        'NetFloorArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+    },
+    'Qto_ReinforcedSoilBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Depth' : None,
+        'Area' : None,
+        'Volume' : None,
+    },
+    'Qto_DistributionBoardBaseQuantities' : {
+        'GrossWeight' : None,
+        'NumberOfCircuits' : None,
+    },
+    'Qto_FootingBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Height' : None,
+        'CrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+        'GrossSurfaceArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_PumpBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_CableCarrierSegmentBaseQuantities' : {
+        'GrossWeight' : None,
+        'Length' : None,
+        'CrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+    },
+    'Qto_InterceptorBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_ColumnBaseQuantities' : {
+        'Length' : None,
+        'CrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+        'GrossSurfaceArea' : None,
+        'NetSurfaceArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_EarthworksCutBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Depth' : None,
+        'UndisturbedVolume' : None,
+        'LooseVolume' : None,
+        'Weight' : None,
+    },
+    'Qto_StackTerminalBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_CoilBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_KerbBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Height' : None,
+        'Depth' : None,
+        'Volume' : None,
+        'Weight' : None,
+    },
+    'Qto_PavementBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Depth' : None,
+        'GrossArea' : None,
+        'NetArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+    },
+    'Qto_ControllerBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_SolarDeviceBaseQuantities' : {
+        'GrossWeight' : None,
+        'GrossArea' : None,
+    },
+    'Qto_RampFlightBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'GrossArea' : None,
+        'NetArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+    },
+    'Qto_ElectricApplianceBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_ValveBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_DamperBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_SurfaceFeatureBaseQuantities' : {
+        'Area' : None,
+        'Length' : None,
+    },
+    'Qto_WallBaseQuantities' : {
+        'Length' : "get_length",
+        'Width' : "get_width",
+        'Height' : None,
+        'GrossFootPrintArea' : None,
+        'NetFootPrintArea' : None,
+        'GrossSideArea' : None,
+        'NetSideArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_StairFlightBaseQuantities' : {
+        'Length' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+    },
+    'Qto_SwitchingDeviceBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_BurnerBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_ConstructionMaterialResourceBaseQuantities' : {
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_ElectricGeneratorBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_LinearStratumBaseQuantities' : {
+        'Diameter' : None,
+        'Length' : None,
+    },
+    'Qto_CableFittingBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_DistributionChamberElementBaseQuantities' : {
+        'GrossSurfaceArea' : None,
+        'NetSurfaceArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'Depth' : None,
+    },
+    'Qto_CompressorBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_ProtectiveDeviceTrippingUnitBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_EvaporatorBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_SpaceBaseQuantities' : {
+        'Height' : None,
+        'FinishCeilingHeight' : None,
+        'FinishFloorHeight' : None,
+        'GrossPerimeter' : None,
+        'NetPerimeter' : None,
+        'GrossFloorArea' : None,
+        'NetFloorArea' : None,
+        'GrossWallArea' : None,
+        'NetWallArea' : None,
+        'GrossCeilingArea' : None,
+        'NetCeilingArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+    },
+    'Qto_CourseBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Thickness' : None,
+        'Volume' : None,
+        'GrossVolume' : None,
+        'Weight' : None,
+    },
+    'Qto_CondenserBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_FireSuppressionTerminalBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_RailingBaseQuantities' : {
+        'Length' : None,
+    },
+    'Qto_TubeBundleBaseQuantities' : {
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_BeamBaseQuantities' : {
+        'Length' : None,
+        'CrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+        'GrossSurfaceArea' : None,
+        'NetSurfaceArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_SleeperBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Height' : None,
+    },
+    'Qto_ProtectiveDeviceBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_CooledBeamBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_TankBaseQuantities' : {
+        'GrossWeight' : None,
+        'NetWeight' : None,
+        'TotalSurfaceArea' : None,
+    },
+    'Qto_AirToAirHeatRecoveryBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_CoolingTowerBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_SensorBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_WindowBaseQuantities' : {
+        'Width' : None,
+        'Height' : None,
+        'Perimeter' : None,
+        'Area' : None,
+    },
+    'Qto_SanitaryTerminalBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_BuildingElementProxyQuantities' : {
+        'NetSurfaceArea' : None,
+        'NetVolume' : None,
+    },
+    'Qto_FanBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_OutletBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_UnitaryEquipmentBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_FilterBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_MemberBaseQuantities' : {
+        'Length' : None,
+        'CrossSectionArea' : None,
+        'OuterSurfaceArea' : None,
+        'GrossSurfaceArea' : None,
+        'NetSurfaceArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'GrossWeight' : None,
+        'NetWeight' : None,
+    },
+    'Qto_BodyGeometryValidation' : {
+        'GrossSurfaceArea' : None,
+        'NetSurfaceArea' : None,
+        'GrossVolume' : None,
+        'NetVolume' : None,
+        'SurfaceGenusBeforeFeatures' : None,
+        'SurfaceGenusAfterFeatures' : None,
+    },
+    'Qto_VolumetricStratumBaseQuantities' : {
+        'Area' : None,
+        'Mass' : None,
+        'PlanArea' : None,
+        'Volume' : None,
+    },
+    'Qto_SpatialZoneBaseQuantities' : {
+        'Length' : None,
+        'Width' : None,
+        'Height' : None,
+    },
+    'Qto_ReinforcingElementBaseQuantities' : {
+        'Count' : None,
+        'Length' : None,
+        'Weight' : None,
+    },
+    'Qto_EvaporativeCoolerBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_AirTerminalBoxTypeBaseQuantities' : {
+        'GrossWeight' : None,
+    },
+    'Qto_LaborResourceBaseQuantities' : {
+        'StandardWork' : None,
+        'OvertimeWork' : None,
     },
 }

--- a/src/blenderbim/blenderbim/bim/module/pset/qto_calculator.py
+++ b/src/blenderbim/blenderbim/bim/module/pset/qto_calculator.py
@@ -37,7 +37,10 @@ class QtoCalculator:
 
         for key in self.mapping_dict.keys():
             for item in self.mapping_dict[key].keys():
-                self.mapping_dict[key][item] = eval("self." + self.mapping_dict[key][item])
+                if self.mapping_dict[key][item]:
+                    self.mapping_dict[key][item] = eval("self." + self.mapping_dict[key][item])
+                else:
+                    self.mapping_dict[key][item] = None
 
     def calculate_quantity(self, qto_name, quantity_name, obj):
         return self.mapping_dict[qto_name][quantity_name](obj)


### PR DESCRIPTION
I've written all quantities with None value if there isn't the mapped calculating function