### PR TITLE
Openings should be either polygonal or extrusion based

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/model/opening.py
+++ b/src/blenderbim/blenderbim/bim/module/model/opening.py
@@ -367,6 +367,8 @@ class AddPotentialOpening(Operator, AddObjectHelper):
     circle_radius: FloatProperty(name="Circle Radius", min=0, default=0.5)
     extrusion_resolution: IntProperty(name="Resolution", min=1, default=4)
     extrusion_depth: FloatProperty(name="Extrusion Depth", default=1)
+    rectangle_dim_x: FloatProperty(name="X Dimension", default=1, min=0)
+    rectangle_dim_y: FloatProperty(name="Y Dimension", default=1, min=0)
 
     def draw_settings(context, layout, tool):
         row = self.layout.row()
@@ -386,6 +388,10 @@ class AddPotentialOpening(Operator, AddObjectHelper):
         elif self.representation == "IfcExtrudedAreaSolid/IfcCircleProfileDef":
             layout.prop(self, "extrusion_resolution")
             layout.prop(self, "circle_radius")
+            layout.prop(self, "extrusion_depth")
+        elif self.representation == "IfcExtrudedAreaSolid/IfcRectangleProfileDef":
+            layout.prop(self, "rectangle_dim_x")
+            layout.prop(self, "rectangle_dim_y")
             layout.prop(self, "extrusion_depth")
 
     def invoke(self, context, event):
@@ -450,6 +456,16 @@ class AddPotentialOpening(Operator, AddObjectHelper):
                 radius2=self.circle_radius,
                 depth=self.extrusion_depth,
             )
+            bm.to_mesh(mesh)
+        elif self.representation == "IfcExtrudedAreaSolid/IfcRectangleProfileDef":
+            mesh = bpy.data.meshes.new("Opening")
+            bm = bmesh.new()
+            bm.from_mesh(mesh)
+            bmesh.ops.create_cube(
+                bm,
+                size=1,
+            )
+            bmesh.ops.scale(bm, vec=(self.rectangle_dim_x, self.rectangle_dim_y, self.extrusion_depth), verts=bm.verts)
             bm.to_mesh(mesh)
 
         obj = object_data_add(context, mesh, operator=self)

--- a/src/blenderbim/blenderbim/bim/module/model/opening.py
+++ b/src/blenderbim/blenderbim/bim/module/model/opening.py
@@ -327,11 +327,6 @@ class AddPotentialOpening(Operator, AddObjectHelper):
                 get_entity_doc("IFC4", "IfcArbitraryProfileDefWithVoids").get("description", ""),
             ),
             (
-                "IfcExtrudedAreaSolid/IfcMaterialProfileSetUsage",
-                "IfcMaterialProfileSetUsage",
-                get_entity_doc("IFC4", "IfcMaterialProfileSetUsage").get("description", ""),
-            ),
-            (
                 "IfcGeometricCurveSet/IfcTextLiteral",
                 "IfcGeometricCurveSet/IfcTextLiteral",
                 get_entity_doc("IFC4", "IfcTextLiteral").get("description", ""),

--- a/src/blenderbim/blenderbim/bim/module/model/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/model/prop.py
@@ -246,44 +246,7 @@ class BIMModelProperties(PropertyGroup):
     type_class: bpy.props.EnumProperty(items=get_type_class, name="IFC Class", update=update_type_class)
     type_predefined_type: bpy.props.EnumProperty(items=get_type_predefined_type, name="Predefined Type", default=None)
 
-    opening_representation: bpy.props.EnumProperty(
-        name="Void Representation",
-        items=(
-            ("None", "Arbitrary Mesh", ""),
-            (
-                "IfcExtrudedAreaSolid/IfcRectangleProfileDef",
-                "IfcRectangleProfileDef",
-                get_entity_doc("IFC4", "IfcRectangleProfileDef").get("description", ""),
-            ),
-            (
-                "IfcExtrudedAreaSolid/IfcCircleProfileDef",
-                "IfcCircleProfileDef",
-                get_entity_doc("IFC4", "IfcCircleProfileDef").get("description", ""),
-            ),
-            (
-                "IfcExtrudedAreaSolid/IfcArbitraryClosedProfileDef",
-                "IfcArbitraryClosedProfileDef",
-                get_entity_doc("IFC4", "IfcArbitraryClosedProfileDef").get("description", ""),
-            ),
-            (
-                "IfcExtrudedAreaSolid/IfcArbitraryProfileDefWithVoids",
-                "IfcArbitraryProfileDefWithVoids",
-                get_entity_doc("IFC4", "IfcArbitraryProfileDefWithVoids").get("description", ""),
-            ),
-            (
-                "IfcExtrudedAreaSolid/IfcMaterialProfileSetUsage",
-                "IfcMaterialProfileSetUsage",
-                get_entity_doc("IFC4", "IfcMaterialProfileSetUsage").get("description", ""),
-            ),
-            (
-                "IfcGeometricCurveSet/IfcTextLiteral",
-                "IfcGeometricCurveSet/IfcTextLiteral",
-                get_entity_doc("IFC4", "IfcTextLiteral").get("description", ""),
-            ),
-            ("IfcTextLiteral", "IfcTextLiteral", get_entity_doc("IFC4", "IfcTextLiteral").get("description", "")),
-        ),
-        default="None",
-    )
+    opening_representation: bpy.props.StringProperty()
 
 
 class BIMArrayProperties(PropertyGroup):

--- a/src/blenderbim/blenderbim/bim/module/model/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/model/prop.py
@@ -246,6 +246,45 @@ class BIMModelProperties(PropertyGroup):
     type_class: bpy.props.EnumProperty(items=get_type_class, name="IFC Class", update=update_type_class)
     type_predefined_type: bpy.props.EnumProperty(items=get_type_predefined_type, name="Predefined Type", default=None)
 
+    opening_representation: bpy.props.EnumProperty(
+        name="Void Representation",
+        items=(
+            ("None", "Arbitrary Mesh", ""),
+            (
+                "IfcExtrudedAreaSolid/IfcRectangleProfileDef",
+                "IfcRectangleProfileDef",
+                get_entity_doc("IFC4", "IfcRectangleProfileDef").get("description", ""),
+            ),
+            (
+                "IfcExtrudedAreaSolid/IfcCircleProfileDef",
+                "IfcCircleProfileDef",
+                get_entity_doc("IFC4", "IfcCircleProfileDef").get("description", ""),
+            ),
+            (
+                "IfcExtrudedAreaSolid/IfcArbitraryClosedProfileDef",
+                "IfcArbitraryClosedProfileDef",
+                get_entity_doc("IFC4", "IfcArbitraryClosedProfileDef").get("description", ""),
+            ),
+            (
+                "IfcExtrudedAreaSolid/IfcArbitraryProfileDefWithVoids",
+                "IfcArbitraryProfileDefWithVoids",
+                get_entity_doc("IFC4", "IfcArbitraryProfileDefWithVoids").get("description", ""),
+            ),
+            (
+                "IfcExtrudedAreaSolid/IfcMaterialProfileSetUsage",
+                "IfcMaterialProfileSetUsage",
+                get_entity_doc("IFC4", "IfcMaterialProfileSetUsage").get("description", ""),
+            ),
+            (
+                "IfcGeometricCurveSet/IfcTextLiteral",
+                "IfcGeometricCurveSet/IfcTextLiteral",
+                get_entity_doc("IFC4", "IfcTextLiteral").get("description", ""),
+            ),
+            ("IfcTextLiteral", "IfcTextLiteral", get_entity_doc("IFC4", "IfcTextLiteral").get("description", "")),
+        ),
+        default="None",
+    )
+
 
 class BIMArrayProperties(PropertyGroup):
     is_editing: bpy.props.IntProperty(default=-1)

--- a/src/blenderbim/blenderbim/bim/module/model/workspace.py
+++ b/src/blenderbim/blenderbim/bim/module/model/workspace.py
@@ -263,8 +263,6 @@ class BimToolUI:
         row.label(text="", icon="EVENT_O")
         if len(context.selected_objects) == 2:
             row.operator("bim.add_opening", text="Apply Void")
-            row_opening_representation = cls.layout.row(align=True)
-            row_opening_representation.prop(context.scene.BIMModelProperties, "opening_representation")
         else:
             row.operator("bim.add_potential_opening", text="Add Void")
         if AuthoringData.data["is_voidable_element"]:

--- a/src/blenderbim/blenderbim/bim/module/model/workspace.py
+++ b/src/blenderbim/blenderbim/bim/module/model/workspace.py
@@ -202,7 +202,9 @@ class BimToolUI:
             op.cardinal_point = int(cls.props.cardinal_point)
 
             row = cls.layout.row(align=True)
-            label = "Height" if AuthoringData.data["active_class"] in ("IfcColumn", "IfcColumnStandardCase") else "Length"
+            label = (
+                "Height" if AuthoringData.data["active_class"] in ("IfcColumn", "IfcColumnStandardCase") else "Length"
+            )
             row.prop(data=cls.props, property="extrusion_depth", text=label)
             op = row.operator("bim.change_profile_depth", icon="FILE_REFRESH", text="")
             op.depth = cls.props.extrusion_depth
@@ -261,6 +263,8 @@ class BimToolUI:
         row.label(text="", icon="EVENT_O")
         if len(context.selected_objects) == 2:
             row.operator("bim.add_opening", text="Apply Void")
+            row_opening_representation = cls.layout.row(align=True)
+            row_opening_representation.prop(context.scene.BIMModelProperties, "opening_representation")
         else:
             row.operator("bim.add_potential_opening", text="Add Void")
         if AuthoringData.data["is_voidable_element"]:

--- a/src/blenderbim/blenderbim/bim/module/void/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/void/operator.py
@@ -67,6 +67,9 @@ class AddOpening(bpy.types.Operator, tool.Ifc.Operator):
                 break
 
         body_context = ifcopenshell.util.representation.get_context(IfcStore.get_file(), "Model", "Body")
+        ifc_representation = context.scene.BIMModelProperties.opening_representation
+        if ifc_representation == "None":
+            ifc_representation = None
         element2 = blenderbim.core.root.assign_class(
             tool.Ifc,
             tool.Collector,
@@ -75,6 +78,7 @@ class AddOpening(bpy.types.Operator, tool.Ifc.Operator):
             ifc_class="IfcOpeningElement",
             should_add_representation=True,
             context=body_context,
+            ifc_representation_class=ifc_representation,
         )
         ifcopenshell.api.run("void.add_opening", tool.Ifc.get(), opening=element2, element=element1)
 


### PR DESCRIPTION
Following the task in the project board, I've added a dropdown in the tool interface to select which type of void the user wants to apply.

Here's a short video explaing the workflow

![capture](https://user-images.githubusercontent.com/25156105/199111563-2eead87e-02a7-4507-a7d0-cf1a4ae4086b.gif)

It seems all types works except for `IfcExtrudedAreaSolid/IfcMaterialProfileSetUsage` which throws an error. 

```
  File "c:\Program Files (x86)\Steam\steamapps\common\Blender\3.3\python\lib\site-packages\ifcopenshell\api\geometry\add_representation.py", line 69, in execute
    return self.create_model_representation()
  File "c:\Program Files (x86)\Steam\steamapps\common\Blender\3.3\python\lib\site-packages\ifcopenshell\api\geometry\add_representation.py", line 122, in create_model_representation
    return self.create_variable_representation()
  File "c:\Program Files (x86)\Steam\steamapps\common\Blender\3.3\python\lib\site-packages\ifcopenshell\api\geometry\add_representation.py", line 239, in create_variable_representation
    return self.create_material_profile_set_extrusion_representation()
  File "c:\Program Files (x86)\Steam\steamapps\common\Blender\3.3\python\lib\site-packages\ifcopenshell\api\geometry\add_representation.py", line 523, in create_material_profile_set_extrusion_representation
    profile_set = self.settings["profile_set_usage"].ForProfileSet
AttributeError: 'NoneType' object has no attribute 'ForProfileSet'
```

I don't really know how to test if everything is in order in the ifc file in the end though.
