### PR TITLE
Numerical Attribute validation callback

### DIFF
--- a/src/blenderbim/blenderbim/bim/helper.py
+++ b/src/blenderbim/blenderbim/bim/helper.py
@@ -109,6 +109,17 @@ def import_attribute(attribute, props, data, callback=None):
         if data[new.name]:
             new.enum_value = data[new.name]
     add_attribute_description(new)
+    add_attribute_min_max(new)
+
+
+ATTRIBUTE_MIN_MAX_CONSTRAINTS = {"IfcMaterialLayer": {"Priority": {"value_min": 0, "value_max": 100}}}
+
+
+def add_attribute_min_max(attribute_blender):
+    if attribute_blender.ifc_class in ATTRIBUTE_MIN_MAX_CONSTRAINTS:
+        constraints = ATTRIBUTE_MIN_MAX_CONSTRAINTS[attribute_blender.ifc_class].get(attribute_blender.name, {})
+        for constraint, value in constraints.items():
+            setattr(attribute_blender, constraint, value)
 
 
 def add_attribute_enum_items_descriptions(attribute_blender, enum_items):

--- a/src/blenderbim/blenderbim/bim/module/material/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/material/operator.py
@@ -626,7 +626,7 @@ class EnableEditingMaterialSetItem(bpy.types.Operator):
                 elif data_type == "boolean":
                     new.bool_value = False if new.is_null else material_set_item_data[attribute.name()]
                 blenderbim.bim.helper.add_attribute_description(new)
-
+                blenderbim.bim.helper.add_attribute_min_max(new)
 
 class DisableEditingMaterialSetItem(bpy.types.Operator):
     bl_idname = "bim.disable_editing_material_set_item"

--- a/src/blenderbim/blenderbim/bim/module/material/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/material/operator.py
@@ -628,6 +628,7 @@ class EnableEditingMaterialSetItem(bpy.types.Operator):
                 blenderbim.bim.helper.add_attribute_description(new)
                 blenderbim.bim.helper.add_attribute_min_max(new)
 
+
 class DisableEditingMaterialSetItem(bpy.types.Operator):
     bl_idname = "bim.disable_editing_material_set_item"
     bl_label = "Disable Editing Material Set Item"

--- a/src/blenderbim/blenderbim/bim/prop.py
+++ b/src/blenderbim/blenderbim/bim/prop.py
@@ -195,6 +195,23 @@ def update_attribute_value(self, context):
             self.is_null = False
 
 
+def get_numerical_value(self):
+    value_attr = self.get_value_name()
+    if value_attr == "int_value":
+        return int(self.get(value_attr) or 0)
+    elif value_attr == "float_value":
+        return float(self.get(value_attr) or 0)
+
+
+def set_numerical_value(self, new_value):
+    value_attr = self.get_value_name()
+    if new_value < self.value_min:
+        new_value = self.value_min
+    elif new_value > self.value_max:
+        new_value = self.value_max
+    self[value_attr] = new_value
+
+
 class Attribute(PropertyGroup):
     tooltip = "`Right Click > IFC Description` to read the attribute description and online documentation"
     name: StringProperty(name="Name")
@@ -203,8 +220,20 @@ class Attribute(PropertyGroup):
     data_type: StringProperty(name="Data Type")
     string_value: StringProperty(name="Value", update=update_attribute_value, description=tooltip)
     bool_value: BoolProperty(name="Value", update=update_attribute_value, description=tooltip)
-    int_value: IntProperty(name="Value", update=update_attribute_value, description=tooltip)
-    float_value: FloatProperty(name="Value", update=update_attribute_value, description=tooltip)
+    int_value: IntProperty(
+        name="Value",
+        description=tooltip,
+        update=update_attribute_value,
+        get=get_numerical_value,
+        set=set_numerical_value,
+    )
+    float_value: FloatProperty(
+        name="Value",
+        description=tooltip,
+        update=update_attribute_value,
+        get=get_numerical_value,
+        set=set_numerical_value,
+    )
     enum_items: StringProperty(name="Value")
     enum_descriptions: CollectionProperty(type=StrProperty)
     enum_value: EnumProperty(items=get_attribute_enum_values, name="Value", update=update_attribute_value)
@@ -213,6 +242,8 @@ class Attribute(PropertyGroup):
     is_uri: BoolProperty(name="Is Uri", default=False)
     is_selected: BoolProperty(name="Is Selected", default=False)
     has_calculator: BoolProperty(name="Has Calculator", default=False)
+    value_min: FloatProperty(default=-10e20, description="This is used to validate int_value and float_value")
+    value_max: FloatProperty(default=10e20, description="This is used to validate int_value and float_value")
 
     def get_value(self):
         if self.is_optional and self.is_null:


### PR DESCRIPTION
This is a proof of concept following #2545, to enforce constraints directly in the interface.

The [IfcMaterialLayer](https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD2_TC1/HTML/schema/ifcmaterialresource/lexical/ifcmateriallayer.htm) docs indicate its Priority attribute shall be an integer value between 0 and 100.

![Animation2](https://user-images.githubusercontent.com/25156105/199491546-31cc6787-8754-406b-ab84-085234aa71f8.gif)

How it works :
- Add two attributes to the Attribute class (for the minimum and maximum constraints)
- When creating the attribute, fetch from a custom dictionary if the attribute has specific numerical constraints
- If it has, change the two attributes to reflect it. Otherwise keep the min an max attributes to very low and very high values so they're never fired
- Use a callback when the integer or float value is changed

I can see this being updated also with values that should alway be > 0 like these ones ? 
![image](https://user-images.githubusercontent.com/25156105/199493270-734c852b-1e16-4ffc-b87e-ddd2ba4efce3.png)
 Although as far as I understand these are not supposed to be filled in by hand but computed automatically so maybe this doesn't apply here.

I'm of course open to any criticism regarding improvements.