### PR TITLE
action container image: bump python version

### DIFF
--- a/.github/workflows/ci-blenderbim-choco.yml
+++ b/.github/workflows/ci-blenderbim-choco.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2 # https://github.com/actions/setup-python
         with:
-          python-version: '3.7.7' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          python-version: '3.10.9' # Version range or exact version of a Python version to use, using SemVer's version range syntax
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
       - run: echo ${{ env.DATE }}
 


### PR DESCRIPTION
bumping python version, so it works with our ubuntu latest image and `actions/setup-python@v2`

@Moult I noticed the action error and thus choco upgrades were not coming in anymore. 
the above should fix it. 🙂 