### PR TITLE
Delete unuseful functions and improve speed

### DIFF
--- a/src/blenderbim/blenderbim/core/qto.py
+++ b/src/blenderbim/blenderbim/core/qto.py
@@ -24,10 +24,12 @@ def calculate_circle_radius(qto, obj=None):
 
 def assign_pset_qto(qto, selected_objects):
     for obj in selected_objects:
+        qto.set_active_object(obj)
         qto.assign_pset_qto_to_selected_object(obj)
 
 def calculate_all_qtos(qto, selected_objects):
     for obj in selected_objects:
+        qto.set_active_object(obj)
         if not qto.get_pset_qto_object_ifc_info(obj):
             print(f"There is no pset qto instance associated to object {obj.name}")
             continue

--- a/src/blenderbim/blenderbim/core/qto.py
+++ b/src/blenderbim/blenderbim/core/qto.py
@@ -24,7 +24,7 @@ def calculate_circle_radius(qto, obj=None):
 
 def assign_pset_qto(qto, selected_objects):
     for obj in selected_objects:
-        qto.assign_pset_qto_to_selected_object(obj)
+        qto.assign_base_qto_to_object(obj)
 
 def calculate_all_qtos(qto, selected_objects):
     for obj in selected_objects:
@@ -32,9 +32,9 @@ def calculate_all_qtos(qto, selected_objects):
             print(f"There is no pset qto instance associated to object {obj.name}")
             continue
 
-        pset_qto_properties = qto.get_pset_qto_properties(obj)
+        applicable_quantity_names = qto.get_applicable_quantity_names(obj)
 
-        calculated_quantities = qto.get_calculated_quantities(obj, pset_qto_properties)
+        calculated_quantities = qto.get_calculated_quantities(obj, applicable_quantity_names)
 
         qto.edit_qto(obj, calculated_quantities)
 
@@ -44,8 +44,8 @@ def guess_all_qtos(qto, selected_objects):
             print(f"There is no pset qto instance associated to object {obj.name}")
             continue
 
-        pset_qto_properties = qto.get_pset_qto_properties(obj)
+        applicable_quantity_names = qto.get_base_quantities_name(obj)
 
-        calculated_quantities = qto.get_calculated_quantities(obj, pset_qto_properties)
+        calculated_quantities = qto.get_calculated_quantities(obj, applicable_quantity_names)
 
         qto.edit_qto(obj, calculated_quantities)

--- a/src/blenderbim/blenderbim/core/qto.py
+++ b/src/blenderbim/blenderbim/core/qto.py
@@ -24,12 +24,10 @@ def calculate_circle_radius(qto, obj=None):
 
 def assign_pset_qto(qto, selected_objects):
     for obj in selected_objects:
-        qto.set_active_object(obj)
         qto.assign_pset_qto_to_selected_object(obj)
 
 def calculate_all_qtos(qto, selected_objects):
     for obj in selected_objects:
-        qto.set_active_object(obj)
         if not qto.get_pset_qto_object_ifc_info(obj):
             print(f"There is no pset qto instance associated to object {obj.name}")
             continue

--- a/src/blenderbim/blenderbim/core/tool.py
+++ b/src/blenderbim/blenderbim/core/tool.py
@@ -403,9 +403,9 @@ class Pset:
 class Qto:
     def get_radius_of_selected_vertices(cls, obj): pass
     def set_qto_result(cls, result): pass
-    def assign_pset_qto_to_selected_object(cls, object): pass
+    def assign_base_qto_to_object(cls, object): pass
     def get_pset_qto_object_ifc_info(cls, object): pass
-    def get_pset_qto_properties(cls, object): pass
+    def get_applicable_quantity_names(cls, object): pass
     def get_qto_applicable_name(cls, object): pass
     def edit_qto(cls, object, calculated_quantities): pass
     def get_qto_entity(cls, object): pass

--- a/src/blenderbim/blenderbim/core/tool.py
+++ b/src/blenderbim/blenderbim/core/tool.py
@@ -403,6 +403,7 @@ class Pset:
 class Qto:
     def get_radius_of_selected_vertices(cls, obj): pass
     def set_qto_result(cls, result): pass
+    def set_active_object(cls, obj): pass
     def get_pset_qto_object_ifc_info(cls, object): pass
     def get_pset_qto_properties(cls, object): pass
     def get_pset_qto_name(cls, object): pass

--- a/src/blenderbim/blenderbim/core/tool.py
+++ b/src/blenderbim/blenderbim/core/tool.py
@@ -403,18 +403,15 @@ class Pset:
 class Qto:
     def get_radius_of_selected_vertices(cls, obj): pass
     def set_qto_result(cls, result): pass
-    def set_active_object(cls, obj): pass
+    def assign_pset_qto_to_selected_object(cls, object): pass
     def get_pset_qto_object_ifc_info(cls, object): pass
     def get_pset_qto_properties(cls, object): pass
-    def get_pset_qto_name(cls, object): pass
-    def get_applicable_pset_names(cls, object): pass
+    def get_qto_applicable_name(cls, object): pass
     def edit_qto(cls, object, calculated_quantities): pass
-    def get_pset_qto_id(cls, object): pass
-    def get_pset_qto_name(cls, object): pass
+    def get_qto_entity(cls, object): pass
     def get_new_quantity(cls, object, quantity_name, alternative_prop_names): pass
     def get_rounded_value(cls, new_quantity): pass
     def get_calculated_quantities(cls, object, pset_qto_properties): pass
-    def assign_pset_qto_to_selected_object(cls, object): pass
 
 @interface
 class Resource:

--- a/src/blenderbim/blenderbim/tool/qto.py
+++ b/src/blenderbim/blenderbim/tool/qto.py
@@ -42,6 +42,10 @@ class Qto(blenderbim.core.tool.Qto):
         bpy.context.scene.BIMQtoProperties.qto_result = str(round(result, 3))
 
     @classmethod
+    def set_active_object(cls, obj):
+        bpy.context.view_layer.objects.active = obj
+
+    @classmethod
     def get_pset_qto_object_ifc_info(cls, obj):
         element = tool.Ifc.get_entity(obj)
         pset_qto_ifc_info = ifcopenshell.util.element.get_psets(element, qtos_only = True)
@@ -52,25 +56,9 @@ class Qto(blenderbim.core.tool.Qto):
         file = tool.Ifc.get()
         schema = file.schema
         pset_qto = util.pset.PsetQto(schema)
-#        pset_qto_name = cls.get_pset_qto_name(obj)
-        pset_qto_name = cls.get_assigned_pset_qto_name(obj)
+        pset_qto_name = obj.PsetProperties.qto_name
         pset_qto_properties = pset_qto.get_by_name(pset_qto_name).get_info()['HasPropertyTemplates']
         return pset_qto_properties
-
-    @classmethod
-    def get_pset_qto_name(cls, obj):
-        applicable_pset_names = cls.get_applicable_pset_names(obj)
-        for applicable_pset_name in applicable_pset_names:
-            if 'Qto_' in applicable_pset_name:
-                pset_qto_name = applicable_pset_name
-                return pset_qto_name
-
-    @classmethod
-    def get_assigned_pset_qto_name(cls, obj):
-        entity = tool.Ifc.get_entity(obj)
-        assigned_pset_qto_name = ifcopenshell.util.element.get_psets(entity, qtos_only = True)
-        assigned_pset_qto_name = list(assigned_pset_qto_name.keys())[0]
-        return assigned_pset_qto_name
 
     @classmethod
     def get_applicable_pset_names(cls, obj):
@@ -85,7 +73,7 @@ class Qto(blenderbim.core.tool.Qto):
     @classmethod
     def edit_qto(cls, obj, calculated_quantities):
         file = tool.Ifc.get()
-        pset_qto_name = cls.get_pset_qto_name(obj)
+        pset_qto_name = obj.PsetProperties.qto_name
         pset_qto_id = cls.get_pset_qto_id(obj, pset_qto_name)
 
         ifcopenshell.api.run("pset.edit_qto",
@@ -126,7 +114,7 @@ class Qto(blenderbim.core.tool.Qto):
     @classmethod
     def get_calculated_quantities(cls, obj, pset_qto_properties):
         calculated_quantities = {}
-        qto_name = cls.get_pset_qto_name(obj)
+        qto_name = obj.PsetProperties.qto_name
         calculator = QtoCalculator()
 
         for pset_qto_property in pset_qto_properties:
@@ -168,7 +156,7 @@ class Qto(blenderbim.core.tool.Qto):
     def assign_pset_qto_to_selected_object(cls, obj):
         file = tool.Ifc.get()
         entity = tool.Ifc.get_entity(obj)
-        pset_qto_name = cls.get_pset_qto_name(obj)
+        pset_qto_name = obj.PsetProperties.qto_name
         ifcopenshell.api.run(
             "pset.add_qto",
             file,


### PR DESCRIPTION
Using PsetProperties.qto_name for retrieve all available object pset_qto, performance is better and the code is clearer.