### PR TITLE
adjust attribute type comparison character and characterization

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/search/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/search/operator.py
@@ -523,7 +523,7 @@ class FilterModelElements(Operator):
             selection += "["
 
             if f.selector == "IfcPropertySet":
-                selection += f'{f.active_option.split(": ")[1]}.{f.active_sub_option.split(": ")[1]} {"!" if f.negation else ""}="{f.value}"'
+                selection += f'{f.active_option.split(": ")[1]}.{f.active_sub_option.split(": ")[1]} {"!" if f.negation else ""}{f.comparison}{f.value}'
             elif f.selector == "Attribute":
                 selection += f'{f.attribute} {"!" if f.negation else ""}= "{f.value}"'
 


### PR DESCRIPTION
Ifc Selector does not work in comparisons with numbers and boolean properties, I propose to mischaracterize the attribute type in string and leave this attribution up to the user, using quotation marks in the case of string attributes. in addition, I included 'f.comparison' in the query because it is always using the equals comparator.