### PR TITLE
build(bcf): remove conda dependency

### DIFF
--- a/src/bcf/Makefile
+++ b/src/bcf/Makefile
@@ -1,30 +1,10 @@
-.PHONY: test
-test:
+.PHONY: ci
+ci:
 	tox
-
-.PHONY: qa
-qa:
-	black .
-	isort .
-	pylint ./src --output-format=colorized
-
-.PHONY: typecheck
-typecheck:
-	mypy src/bcf
 
 .PHONY: license
 license:
 	copyright-header --license LGPL3 --copyright-holder "Andrea Ghensi <andrea.ghensi@gmail.com>" --copyright-year "2022" --copyright-software "IfcOpenShell" --copyright-software-description "BCF XML file handling" -a ./ -o ./
-
-.PHONY: coverage
-coverage:
-	coverage run --source bcf -m pytest tests
-	coverage html
-	xdg-open htmlcov/index.html
-
-.PHONY: clean
-clean:
-	rm -rf htmlcov
 
 # TODO: make this based on xsd file presence
 .PHONY: models

--- a/src/bcf/environment.yml
+++ b/src/bcf/environment.yml
@@ -1,7 +1,0 @@
-name: bcf-client
-channels:
-  - conda-forge
-dependencies:
-  - ifcopenshell
-  - xsdata
-  - numpy

--- a/src/bcf/pyproject.toml
+++ b/src/bcf/pyproject.toml
@@ -15,6 +15,7 @@ keywords = ["IFC", "BCF", "BIM", "eingineering"]
 dependencies = [
     "xsdata",
     "numpy",
+    "ifcopenshell",
 ]
 version = "0.0.1"
 classifiers = [
@@ -58,20 +59,34 @@ exclude_lines = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py310
-isolated_build = true
+env_list = lint, type, py3{10,11}
 skip_missing_interpreters = true
-requires = tox-conda
 
 [testenv]
-conda_deps =
+deps =
     pytest
     pytest-cov
     coverage
-conda_channels =
-    conda-forge
-conda_env = environment.yml
 commands = pytest --cov --cov-report=term tests
+
+[testenv:lint]
+description = run linters
+skip_install = true
+deps =
+    black
+    isort
+    pylint
+commands = 
+    black {posargs:.}
+    isort {posargs:.}
+    pylint {posargs:.} --output-format=colorized
+
+[testenv:type]
+description = run type checks
+deps =
+    mypy>=0.991
+commands =
+    - mypy {posargs:src}
 """
 
 [tool.mypy]

--- a/src/bcf/requirements-dev.txt
+++ b/src/bcf/requirements-dev.txt
@@ -4,4 +4,3 @@ pylint
 isort
 xsdata
 tox==3.27.1
-tox-conda

--- a/src/bcf/src/bcf/bcfxml.py
+++ b/src/bcf/src/bcf/bcfxml.py
@@ -23,8 +23,8 @@ from pathlib import Path
 from typing import Optional, Union
 
 from bcf.v2.bcfxml import BcfXml as BcfXml2
-from bcf.v3.bcfxml import BcfXml as BcfXml3
 from bcf.v2.model import Version as Version2
+from bcf.v3.bcfxml import BcfXml as BcfXml3
 from bcf.v3.model import Version as Version3
 from bcf.xml_parser import AbstractXmlParserSerializer, XmlParserSerializer
 

--- a/src/bcf/src/bcf/v2/topic.py
+++ b/src/bcf/src/bcf/v2/topic.py
@@ -1,8 +1,8 @@
 """BCF XML V2 Topic handler."""
+import datetime
+import tempfile
 import uuid
 import zipfile
-import tempfile
-import datetime
 from pathlib import Path
 from typing import Any, NoReturn, Optional
 

--- a/src/bcf/src/bcf/v3/topic.py
+++ b/src/bcf/src/bcf/v3/topic.py
@@ -190,7 +190,9 @@ class TopicHandler:
         self.viewpoints[new_viewpoint.guid + ".bcfv"] = new_viewpoint
         if self.topic.viewpoints is None:
             self.topic.viewpoints = mdl.TopicViewpoints()
-        self.topic.viewpoints.view_point.append(mdl.ViewPoint(viewpoint=new_viewpoint.guid + ".bcfv", guid=new_viewpoint.guid))
+        self.topic.viewpoints.view_point.append(
+            mdl.ViewPoint(viewpoint=new_viewpoint.guid + ".bcfv", guid=new_viewpoint.guid)
+        )
 
     def __eq__(self, other: object) -> bool | NoReturn:
         return (

--- a/src/bcf/tests/v2/test_ifcclash_api.py
+++ b/src/bcf/tests/v2/test_ifcclash_api.py
@@ -15,7 +15,7 @@ def test_create_clash_set_bcf() -> None:
     assert len(topic.viewpoints) == 1
     guid, vi_handler = next((k, v) for k, v in topic.viewpoints.items())
     v_info = vi_handler.visualization_info
-    assert v_info.guid == guid
+    assert f"{v_info.guid}.bcfv" == guid
     components = v_info.components.selection.component
     assert {c.ifc_guid for c in components} == {"firstId", "secondId"}
     camera = v_info.perspective_camera

--- a/src/bcf/tests/v3/test_ifcclash_api.py
+++ b/src/bcf/tests/v3/test_ifcclash_api.py
@@ -15,7 +15,7 @@ def test_create_clash_set_bcf() -> None:
     assert len(topic.viewpoints) == 1
     guid, vi_handler = next((k, v) for k, v in topic.viewpoints.items())
     v_info = vi_handler.visualization_info
-    assert v_info.guid == guid
+    assert f"{v_info.guid}.bcfv" == guid
     components = v_info.components.selection.component
     assert {c.ifc_guid for c in components} == {"firstId", "secondId"}
     camera = v_info.perspective_camera


### PR DESCRIPTION
Hi, this will close #2782, as @Moult suggested there's really no need for tox-conda and conda.

I thought that the ifcopenshell dependency wasn't available in pypi - I am using conda on windows for years to avoid binary dependencies hell, and didn't even tried to see if pip was enough!

tox is now also used for linting and type checking, and this makes the Makefile a bit useless (but it is still there for some infrequent tasks).

Other changes regards failing tests and linting caught by the new pipeline