### PR TITLE
Update wall.py

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/model/wall.py
+++ b/src/blenderbim/blenderbim/bim/module/model/wall.py
@@ -552,7 +552,7 @@ class DumbWallGenerator:
         nearest_degree = (math.pi / 180) * 5
         self.rotation = nearest_degree * round(self.rotation / nearest_degree)
         self.location = coords[0]
-        data["obj"] = self.create_wall()
+        data["obj"] = self.create_wall(link_to_scene=True)
         return data
 
     def has_end_near_stroke(self, stroke, stroke2):


### PR DESCRIPTION
create_wall_from_2_points was outdated. After some updates to the DumbWall-class it needed an positional argument "link_to_scene". This has now been added.