### PR TITLE
Add IFC4 support for functions of get_connected_to and get_connected_from in util.system

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/system.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/system.py
@@ -83,31 +83,34 @@ def get_connected_port(port):
 
 
 def get_connected_to(element):
-    from blenderbim.bim.ifc import IfcStore
-    ifcSchema = IfcStore.get_file().schema
     results = []
-    if ifcSchema == "IFC4":
-        for port in ifcopenshell.util.system.get_ports(element):
-            for relConnectsPort in port.ConnectedTo:
-                for relNest in relConnectsPort.RelatedPort.Nests:
-                    results.extend(relNest.RelatingObject)
-    elif ifcSchema == "IFC2X3":
-        for port in element.HasPorts:
-            for relConnectsPort in port.RelatingPort.ConnectedTo:
-                results.extend([r.RelatedElement for r in relConnectsPort.RelatedPort.ContainedIn if r.RelatedElement != element])
-    return results
+    for port in ifcopenshell.util.system.get_ports(element):
+        for relConnectsPort in port.ConnectedTo:
+            for disPort in [relConnectsPort.RelatedPort,relConnectsPort.RelatingPort]:
+                if hasattr(disPort,"Nests"):
+                    for relNest in disPort.Nests:
+                        if relNest.RelatingObject != element:
+                            results.append(relNest.RelatingObject)
+                # IFC2X3 only, deprecated in IFC4
+                elif hasattr(disPort,"ContainedIn"):
+                    for relConPortToElement in disPort.ContainedIn:
+                        if relConPortToElement.RelatedElement != element:
+                            results.append(relConPortToElement.RelatedElement)
+    return(results)
+
 
 def get_connected_from(element):
-    from blenderbim.bim.ifc import IfcStore
-    ifcSchema = IfcStore.get_file().schema
     results = []
-    if ifcSchema == "IFC4":
-        for port in ifcopenshell.util.system.get_ports(element):
-            for relConnectsPort in port.ConnectedFrom:
-                for relNest in relConnectsPort.RelatedPort.Nests:
-                    results.extend(relNest.RelatingObject)
-    elif ifcSchema == "IFC2X3":
-        for port in element.HasPorts:
-            for relConnectsPort in port.RelatingPort.ConnectedFrom:
-                results.extend([r.RelatedElement for r in relConnectsPort.RelatingPort.ContainedIn if r.RelatedElement != element])
-    return results
+    for port in ifcopenshell.util.system.get_ports(element):
+        for relConnectsPort in port.ConnectedFrom:
+            for disPort in [relConnectsPort.RelatedPort,relConnectsPort.RelatingPort]:
+                if hasattr(disPort,"Nests"):
+                    for relNest in disPort.Nests:
+                        if relNest.RelatingObject != element:
+                            results.append(relNest.RelatingObject)
+                # IFC2X3 only, deprecated in IFC4
+                elif hasattr(disPort,"ContainedIn"):
+                    for relConPortToElement in disPort.ContainedIn:
+                        if relConPortToElement.RelatedElement != element:
+                            results.append(relConPortToElement.RelatedElement)
+    return(results)

--- a/src/ifcopenshell-python/ifcopenshell/util/system.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/system.py
@@ -83,17 +83,31 @@ def get_connected_port(port):
 
 
 def get_connected_to(element):
+    from blenderbim.bim.ifc import IfcStore
+    ifcSchema = IfcStore.get_file().schema
     results = []
-    for port in ifcopenshell.util.system.get_ports(element):
-        for relConnectsPort in port.ConnectedTo:
-            for relNest in relConnectsPort.RelatedPort.Nests:
-                results.extend(relNest.RelatingObject)
+    if ifcSchema == "IFC4":
+        for port in ifcopenshell.util.system.get_ports(element):
+            for relConnectsPort in port.ConnectedTo:
+                for relNest in relConnectsPort.RelatedPort.Nests:
+                    results.extend(relNest.RelatingObject)
+    elif ifcSchema == "IFC2X3":
+        for port in element.HasPorts:
+            for relConnectsPort in port.RelatingPort.ConnectedTo:
+                results.extend([r.RelatedElement for r in relConnectsPort.RelatedPort.ContainedIn if r.RelatedElement != element])
     return results
 
 def get_connected_from(element):
+    from blenderbim.bim.ifc import IfcStore
+    ifcSchema = IfcStore.get_file().schema
     results = []
-    for port in ifcopenshell.util.system.get_ports(element):
-        for relConnectsPort in port.ConnectedFrom:
-            for relNest in relConnectsPort.RelatingPort.Nests:
-                results.extend(relNest.RelatingObject)
+    if ifcSchema == "IFC4":
+        for port in ifcopenshell.util.system.get_ports(element):
+            for relConnectsPort in port.ConnectedFrom:
+                for relNest in relConnectsPort.RelatedPort.Nests:
+                    results.extend(relNest.RelatingObject)
+    elif ifcSchema == "IFC2X3":
+        for rel in element.HasPorts:
+            for rel2 in rel.RelatingPort.ConnectedFrom:
+                results.extend([r.RelatedElement for r in rel2.RelatingPort.ContainedIn if r.RelatedElement != element])
     return results

--- a/src/ifcopenshell-python/ifcopenshell/util/system.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/system.py
@@ -91,7 +91,6 @@ def get_connected_to(element):
     return results
 
 def get_connected_from(element):
-    # Note: this code is for IFC2X3. IFC4 has a different approach.
     results = []
     for port in ifcopenshell.util.system.get_ports(element):
         for relConnectsPort in port.ConnectedFrom:

--- a/src/ifcopenshell-python/ifcopenshell/util/system.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/system.py
@@ -83,18 +83,18 @@ def get_connected_port(port):
 
 
 def get_connected_to(element):
-    # Note: this code is for IFC2X3. IFC4 has a different approach.
     results = []
-    for rel in element.HasPorts:
-        for rel2 in rel.RelatingPort.ConnectedTo:
-            results.extend([r.RelatedElement for r in rel2.RelatedPort.ContainedIn if r.RelatedElement != element])
+    for port in ifcopenshell.util.system.get_ports(element):
+        for relConnectsPort in port.ConnectedTo:
+            for relNest in relConnectsPort.RelatedPort.Nests:
+                results.extend(relNest.RelatingObject)
     return results
-
 
 def get_connected_from(element):
     # Note: this code is for IFC2X3. IFC4 has a different approach.
     results = []
-    for rel in element.HasPorts:
-        for rel2 in rel.RelatingPort.ConnectedFrom:
-            results.extend([r.RelatedElement for r in rel2.RelatingPort.ContainedIn if r.RelatedElement != element])
+    for port in ifcopenshell.util.system.get_ports(element):
+        for relConnectsPort in port.ConnectedFrom:
+            for relNest in relConnectsPort.RelatingPort.Nests:
+                results.extend(relNest.RelatingObject)
     return results

--- a/src/ifcopenshell-python/ifcopenshell/util/system.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/system.py
@@ -107,7 +107,7 @@ def get_connected_from(element):
                 for relNest in relConnectsPort.RelatedPort.Nests:
                     results.extend(relNest.RelatingObject)
     elif ifcSchema == "IFC2X3":
-        for rel in element.HasPorts:
-            for rel2 in rel.RelatingPort.ConnectedFrom:
-                results.extend([r.RelatedElement for r in rel2.RelatingPort.ContainedIn if r.RelatedElement != element])
+        for port in element.HasPorts:
+            for relConnectsPort in port.RelatingPort.ConnectedFrom:
+                results.extend([r.RelatedElement for r in relConnectsPort.RelatingPort.ContainedIn if r.RelatedElement != element])
     return results


### PR DESCRIPTION
Due to the limitations of the original code base, support for IFC4 versions had been lacking. To address this, we have updated the relevant functions to better align with modern requirements. This new commit incorporates changes that represent a different approach to the problem.