### PR TITLE
Fix bug #2825

### DIFF
--- a/src/blenderbim/blenderbim/bim/__init__.py
+++ b/src/blenderbim/blenderbim/bim/__init__.py
@@ -17,6 +17,7 @@
 # along with BlenderBIM Add-on.  If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
+import blenderbim
 import importlib
 from . import handler, ui, prop, operator, helper
 
@@ -171,7 +172,21 @@ def register():
 
 def unregister():
     for cls in reversed(classes):
-        bpy.utils.unregister_class(cls)
+        if ( #these panels haven't the cls.is_registered attribute
+            cls == blenderbim.bim.module.drawing.gizmos.ExtrusionWidget or
+            cls == blenderbim.bim.module.drawing.gizmos.ExtrusionGuidesGizmo or
+            cls == blenderbim.bim.module.drawing.gizmos.DimensionLabelGizmo or
+            cls == blenderbim.bim.module.drawing.gizmos.DotGizmo or
+            cls == blenderbim.bim.module.drawing.gizmos.UglyDotGizmo
+        ):
+            if bpy.data.scenes['Scene'].BIMProperties.module_visibility['drawing'].is_visible is True:
+                bpy.utils.unregister_class(cls)
+                continue
+            else:
+                continue
+        if cls.is_registered is not False:
+            bpy.utils.unregister_class(cls)
+
     bpy.app.handlers.load_post.remove(handler.setDefaultProperties)
     bpy.app.handlers.load_post.remove(handler.loadIfcStore)
     bpy.app.handlers.save_pre.remove(handler.ensureIfcExported)


### PR DESCRIPTION
Looking at the bug in the subject, actually i think it's not a real bug as i wrote in the bug comments.

However, looking at the gif, there is another bug that is related to unregistering panels that are not visible: it seems that these panels are unregistered two times and that causes an error on blender exit.

So i tried to fix that bug: the majorities of panels have the .is_registered attribute (so it's easy to fix) but there are some gizmo related panels that haven't that attribute so i did a sort of workaround...