### PR TITLE
Section cutaway plane cut line decoration

### DIFF
--- a/src/blenderbim/blenderbim/bim/operator.py
+++ b/src/blenderbim/blenderbim/bim/operator.py
@@ -210,12 +210,12 @@ class BIM_OT_add_section_plane(bpy.types.Operator):
         return bpy.data.node_groups.get("Section Override")
 
     def create_section_compare_node(self):
-        # Add a new socket to group input / output https://blender.stackexchange.com/a/5446/86891
         group = bpy.data.node_groups.new("Section Compare", type="ShaderNodeTree")
         group.inputs.new("NodeSocketFloat", "Value")
         group.inputs["Value"].default_value = 1.0  # Mandatory multiplier for the last node group
         group.inputs.new("NodeSocketVector", "Vector")
         group.outputs.new("NodeSocketFloat", "Value")
+        group.outputs.new("NodeSocketFloat", "Line Decorator")
         group_input = group.nodes.new(type="NodeGroupInput")
         group_input.location = 0, 50
 
@@ -226,6 +226,12 @@ class BIM_OT_add_section_plane(bpy.types.Operator):
         greater.operation = "GREATER_THAN"
         greater.inputs[1].default_value = 0
         greater.location = 400, 0
+
+        compare = group.nodes.new(type="ShaderNodeMath")
+        compare.operation = "COMPARE"
+        compare.inputs[1].default_value = 0
+        compare.inputs[2].default_value = 0.04
+        compare.location = 400, -200
 
         multiply = group.nodes.new(type="ShaderNodeMath")
         multiply.operation = "MULTIPLY"
@@ -240,6 +246,8 @@ class BIM_OT_add_section_plane(bpy.types.Operator):
         group.links.new(separate_xyz.outputs[2], greater.inputs[0])
         group.links.new(greater.outputs[0], multiply.inputs[1])
         group.links.new(multiply.outputs[0], group_output.inputs["Value"])
+        group.links.new(separate_xyz.outputs[2], compare.inputs[0])
+        group.links.new(compare.outputs[0], group_output.inputs["Line Decorator"])
 
     def create_section_override_node(self, obj, context):
         # Add a new socket to group input / output https://blender.stackexchange.com/a/5446/86891

--- a/src/blenderbim/blenderbim/bim/prop.py
+++ b/src/blenderbim/blenderbim/bim/prop.py
@@ -173,6 +173,18 @@ def update_section_color(self, context):
         pass
 
 
+def update_section_line_decorator(self, context):
+    compare_node_group = bpy.data.node_groups.get("Section Compare")
+    if compare_node_group is None:
+        return
+    for node in compare_node_group.nodes:
+        if not hasattr(node, "operation"):
+            continue
+        if node.operation == "COMPARE":
+            node.inputs[2].default_value = self.section_line_decorator_width
+            break
+
+
 class StrProperty(PropertyGroup):
     pass
 
@@ -313,12 +325,19 @@ class BIMProperties(PropertyGroup):
     last_transaction: StringProperty(name="Last Transaction")
     should_section_selected_objects: BoolProperty(name="Section Selected Objects", default=False)
     section_plane_colour: FloatVectorProperty(
-        name="Temporary Section Cutaway Colour",
+        name="Cutaway Colour",
         subtype="COLOR",
         default=(1, 0, 0),
         min=0.0,
         max=1.0,
         update=update_section_color,
+    )
+    section_line_decorator_width: FloatProperty(
+        name="Line Decorator Width",
+        default=0.04,
+        min=0.0,
+        soft_max=1.0,
+        update=update_section_line_decorator,
     )
     area_unit: EnumProperty(
         default="SQUARE_METRE",

--- a/src/blenderbim/blenderbim/bim/ui.py
+++ b/src/blenderbim/blenderbim/bim/ui.py
@@ -78,11 +78,9 @@ class BIM_PT_section_plane(Panel):
         layout.use_property_split = True
         props = context.scene.BIMProperties
 
-        row = layout.row()
-        row.prop(props, "should_section_selected_objects")
-
-        row = layout.row()
-        row.prop(props, "section_plane_colour")
+        layout.prop(props, "should_section_selected_objects")
+        layout.prop(props, "section_plane_colour")
+        layout.prop(props, "section_line_decorator_width")
 
         row = layout.row(align=True)
         row.operator("bim.add_section_plane")


### PR DESCRIPTION
Re the discussion on #2547

This is a proposal to display a thick black line at the section limit on the mesh, when using the temporary section cutaway tool.

Here it is in action

![Animation3](https://user-images.githubusercontent.com/25156105/230080482-114b01f7-28d4-4091-91bc-b14a2b7f6297.gif)

The PR adds a new parameter to tweak the line width in the output properties. It can be set to 0 to display like it was before. The value is in Blender units, but due to how it's setup I think it generates a line double the width of what is set in the field. (absolute on signed distance)

![image](https://user-images.githubusercontent.com/25156105/230080667-26f7a13d-cc77-4ce3-bab9-ccfdfa080291.png)

Pros : Realtime, does not create any new geometry

Cons : 

Doesn't work when viewing the section orthogonally, 

![image](https://user-images.githubusercontent.com/25156105/230081178-9fba4289-f87b-4382-8aab-1533f0d4a184.png)

Doesn't work well for faces parallel or next to parallel to the section plane (it creates black surfaces instead of a thick line since the effect is distance base)

![image](https://user-images.githubusercontent.com/25156105/230081136-f89a8d40-7e49-4458-b299-40e2adc23f72.png)

Edit : Also it doesn't work with more than one section object. I think I have a solution if it's really a problem but it requires a bit more tinkering with the node group.


