### PR TITLE
IFC Array: Option to sync children objects

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/model/array.py
+++ b/src/blenderbim/blenderbim/bim/module/model/array.py
@@ -34,7 +34,16 @@ class AddArray(bpy.types.Operator, tool.Ifc.Operator):
         obj = context.active_object
         element = tool.Ifc.get_entity(obj)
 
-        array = {"children": [], "count": 1, "x": 0.0, "y": 0.0, "z": 0.0, "use_local_space": True, "dimension_input_type": "Increment"}
+        array = {
+            "children": [],
+            "count": 1,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0,
+            "use_local_space": True,
+            "sync_children": False,
+            "dimension_input_type": "Increment",
+        }
 
         pset = ifcopenshell.util.element.get_pset(element, "BBIM_Array")
 
@@ -81,6 +90,7 @@ class EnableEditingArray(bpy.types.Operator, tool.Ifc.Operator):
         props.y = data["y"]
         props.z = data["z"]
         props.use_local_space = data.get("use_local_space", False)
+        props.sync_children = data.get("sync_children", False)
         props.dimension_input_type = data.get("dimension_input_type", "Increment")
         props.is_editing = self.item
         return {"FINISHED"}
@@ -106,6 +116,7 @@ class EditArray(bpy.types.Operator, tool.Ifc.Operator):
             "y": props.y,
             "z": props.z,
             "use_local_space": props.use_local_space,
+            "sync_children": props.sync_children,
             "dimension_input_type": props.dimension_input_type,
         }
 

--- a/src/blenderbim/blenderbim/bim/module/model/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/model/prop.py
@@ -252,7 +252,7 @@ class BIMArrayProperties(PropertyGroup):
     is_editing: bpy.props.IntProperty(
         default=-1, description="Currently edited array index. -1 if not in array editing mode."
     )
-    count: bpy.props.IntProperty(name="Count", default=0)
+    count: bpy.props.IntProperty(name="Count", default=0, min=0)
     x: bpy.props.FloatProperty(name="X", default=0)
     y: bpy.props.FloatProperty(name="Y", default=0)
     z: bpy.props.FloatProperty(name="Z", default=0)

--- a/src/blenderbim/blenderbim/bim/module/model/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/model/prop.py
@@ -269,6 +269,11 @@ class BIMArrayProperties(PropertyGroup):
         name="Type of input dimension",
         default="Increment",
     )
+    sync_children: bpy.props.BoolProperty(
+        name="Sync Children",
+        description="Keep children objects in sync with parent object",
+        default = False,
+    )
 
 
 class BIMStairProperties(PropertyGroup):

--- a/src/blenderbim/blenderbim/bim/module/model/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/model/ui.py
@@ -227,7 +227,7 @@ class BIM_PT_array(bpy.types.Panel):
                     row.prop(props, "dimension_input_type")
                     row = box.row(align=True)
                     row.prop(props, "use_local_space")
-                    #row = box.row(align=True)
+                    row.prop(props, "sync_children")
                     col = box.column()
                     row = col.row(align=True)
                     row.prop(props, "x")

--- a/src/blenderbim/blenderbim/tool/model.py
+++ b/src/blenderbim/blenderbim/tool/model.py
@@ -414,6 +414,14 @@ class Model(blenderbim.core.tool.Model):
         obj_stack = [parent]
 
         for array in data:
+            if array["sync_children"]:
+                removed_children = set(array["children"])
+                for removed_child in removed_children:
+                    element = tool.Ifc.get().by_guid(removed_child)
+                    obj = tool.Ifc.get_object(element)
+                    if obj:
+                        bpy.data.objects.remove(obj)
+                
             child_i = 0
             existing_children = set(array["children"])
             total_existing_children = len(array["children"])


### PR DESCRIPTION
This PR is related to #2937. It creates a toggle to enable the ability to sync children objects whenever an IFC Array is edited.
I added a minor fix, that sets a minimum of zero to the 'count' property, since it doesn't work with negative numbers.