### PR TITLE
Add dynamic tool tip for parametrized operator "Export IFC"

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/project/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/project/operator.py
@@ -890,13 +890,12 @@ class ExportIFC(bpy.types.Operator):
             bpy.ops.wm.save_mainfile(filepath=bpy.data.filepath)
         blenderbim.bim.handler.purge_module_data()
         return {"FINISHED"}
-    
+
     @classmethod
     def description(cls, context, properties):
         if properties.should_save_as:
             return "Export the IFC project to a selected file"
-        else:
-            return "Export the IFC project to this file"
+        return "Export the IFC project to this file"
 
 
 class ImportIFC(bpy.types.Operator):

--- a/src/blenderbim/blenderbim/bim/module/project/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/project/operator.py
@@ -819,7 +819,7 @@ class ExportIFC(bpy.types.Operator):
     json_compact: bpy.props.BoolProperty(name="Export Compact IFCJSON", default=False)
     should_save_as: bpy.props.BoolProperty(name="Should Save As", default=False)
     use_relative_path: bpy.props.BoolProperty(name="Use Relative Path", default=False)
-    
+
     def invoke(self, context, event):
         if not IfcStore.get_file():
             self.report({"ERROR"}, "No IFC project is available for export - create or import a project first.")
@@ -893,10 +893,10 @@ class ExportIFC(bpy.types.Operator):
     
     @classmethod
     def description(cls, context, properties):
-        if properties.should_save_as == False:
-            return "Export the IFC project to this file"
-        else:
+        if properties.should_save_as:
             return "Export the IFC project to a selected file"
+        else:
+            return "Export the IFC project to this file"
 
 
 class ImportIFC(bpy.types.Operator):

--- a/src/blenderbim/blenderbim/bim/module/project/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/project/operator.py
@@ -812,7 +812,6 @@ class ExportIFC(bpy.types.Operator):
     bl_idname = "export_ifc.bim"
     bl_label = "Export IFC"
     bl_options = {"REGISTER", "UNDO"}
-    bl_description = "Export the IFC project"
     filename_ext = ".ifc"
     filter_glob: bpy.props.StringProperty(default="*.ifc;*.ifczip;*.ifcxml;*.ifcjson", options={"HIDDEN"})
     filepath: bpy.props.StringProperty(subtype="FILE_PATH")
@@ -820,7 +819,7 @@ class ExportIFC(bpy.types.Operator):
     json_compact: bpy.props.BoolProperty(name="Export Compact IFCJSON", default=False)
     should_save_as: bpy.props.BoolProperty(name="Should Save As", default=False)
     use_relative_path: bpy.props.BoolProperty(name="Use Relative Path", default=False)
-
+    
     def invoke(self, context, event):
         if not IfcStore.get_file():
             self.report({"ERROR"}, "No IFC project is available for export - create or import a project first.")
@@ -891,6 +890,13 @@ class ExportIFC(bpy.types.Operator):
             bpy.ops.wm.save_mainfile(filepath=bpy.data.filepath)
         blenderbim.bim.handler.purge_module_data()
         return {"FINISHED"}
+    
+    @classmethod
+    def description(cls, context, properties):
+        if properties.should_save_as == False:
+            return "Export the IFC project to this file"
+        else:
+            return "Export the IFC project to a selected file"
 
 
 class ImportIFC(bpy.types.Operator):


### PR DESCRIPTION
- reworked the `bl_description` of the "Export IFC" operator to change based on the class variable `should_save_as` which is dynamically set in the IFC project panel `UI.py` file. 
- there doesn't seem to be a standard for where this method is put, so I put it at the bottom of all the class's definitions.