### PR TITLE
Length, depth and x angle properties now update when the field is updated

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/model/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/model/prop.py
@@ -202,7 +202,7 @@ class BIMModelProperties(PropertyGroup):
     constr_browser_state: bpy.props.PointerProperty(type=ConstrBrowserState)
     extrusion_depth: bpy.props.FloatProperty(
         min=0,
-        default=42.0, 
+        default=42.0,
         update=update_extrusion_depth,
     )
     cardinal_point: bpy.props.EnumProperty(
@@ -233,7 +233,7 @@ class BIMModelProperties(PropertyGroup):
     )
     length: bpy.props.FloatProperty(
         soft_min=0,
-        default=42.0, 
+        default=42.0,
         update=lambda self, context: bpy.ops.bim.change_layer_length(length=self.length),
     )
     openings: bpy.props.CollectionProperty(type=ObjProperty)
@@ -243,7 +243,7 @@ class BIMModelProperties(PropertyGroup):
     rl1: bpy.props.FloatProperty(name="RL", default=1)  # Used for things like walls, doors, flooring, skirting, etc
     rl2: bpy.props.FloatProperty(name="RL", default=1)  # Used for things like windows, other hosted furniture
     x_angle: bpy.props.FloatProperty(
-        name="X Angle", 
+        name="X Angle",
         default=0,
         update=lambda self, context: bpy.ops.bim.change_extrusion_x_angle(x_angle=self.x_angle),
     )

--- a/src/blenderbim/blenderbim/bim/module/model/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/model/prop.py
@@ -145,6 +145,15 @@ def update_preview_multiple(self, context):
             update_relating_type(self, context)
 
 
+def update_extrusion_depth(self, context):
+    if not AuthoringData.is_loaded:
+        AuthoringData.load()
+    if AuthoringData.data["active_material_usage"] == "LAYER2":
+        bpy.ops.bim.change_extrusion_depth(depth=self.extrusion_depth)
+    elif AuthoringData.data["active_material_usage"] == "PROFILE":
+        bpy.ops.bim.change_profile_depth(depth=self.extrusion_depth)
+
+
 class ConstrTypeInfo(PropertyGroup):
     name: bpy.props.StringProperty(name="Construction type ID")
     icon_id: bpy.props.IntProperty(name="Icon ID")
@@ -191,7 +200,11 @@ class BIMModelProperties(PropertyGroup):
     getter_enum = {"ifc_class": get_ifc_class, "relating_type": get_relating_type}
     constr_classes: bpy.props.CollectionProperty(type=ConstrClassInfo)
     constr_browser_state: bpy.props.PointerProperty(type=ConstrBrowserState)
-    extrusion_depth: bpy.props.FloatProperty(default=42.0)
+    extrusion_depth: bpy.props.FloatProperty(
+        min=0,
+        default=42.0, 
+        update=update_extrusion_depth,
+    )
     cardinal_point: bpy.props.EnumProperty(
         items=(
             # TODO: complain to buildingSMART
@@ -218,14 +231,22 @@ class BIMModelProperties(PropertyGroup):
         name="Cardinal Point",
         default="5",
     )
-    length: bpy.props.FloatProperty(default=42.0)
+    length: bpy.props.FloatProperty(
+        soft_min=0,
+        default=42.0, 
+        update=lambda self, context: bpy.ops.bim.change_layer_length(length=self.length),
+    )
     openings: bpy.props.CollectionProperty(type=ObjProperty)
     x: bpy.props.FloatProperty(name="X", default=0.5)
     y: bpy.props.FloatProperty(name="Y", default=0.5)
     z: bpy.props.FloatProperty(name="Z", default=0.5)
     rl1: bpy.props.FloatProperty(name="RL", default=1)  # Used for things like walls, doors, flooring, skirting, etc
     rl2: bpy.props.FloatProperty(name="RL", default=1)  # Used for things like windows, other hosted furniture
-    x_angle: bpy.props.FloatProperty(name="X Angle", default=0)
+    x_angle: bpy.props.FloatProperty(
+        name="X Angle", 
+        default=0,
+        update=lambda self, context: bpy.ops.bim.change_extrusion_x_angle(x_angle=self.x_angle),
+    )
     type_page: bpy.props.IntProperty(name="Type Page", default=1, update=update_type_page)
     type_template: bpy.props.EnumProperty(
         items=(

--- a/src/blenderbim/blenderbim/bim/module/model/workspace.py
+++ b/src/blenderbim/blenderbim/bim/module/model/workspace.py
@@ -142,18 +142,12 @@ class BimToolUI:
         if AuthoringData.data["active_material_usage"] == "LAYER2":
             row = cls.layout.row(align=True)
             row.prop(data=cls.props, property="extrusion_depth", text="Height")
-            op = row.operator("bim.change_extrusion_depth", icon="FILE_REFRESH", text="")
-            op.depth = cls.props.extrusion_depth
 
             row = cls.layout.row(align=True)
             row.prop(data=cls.props, property="length", text="Length")
-            op = row.operator("bim.change_layer_length", icon="FILE_REFRESH", text="")
-            op.length = cls.props.length
 
             row = cls.layout.row(align=True)
             row.prop(data=cls.props, property="x_angle", text="X Angle")
-            op = row.operator("bim.change_extrusion_x_angle", icon="FILE_REFRESH", text="")
-            op.x_angle = cls.props.x_angle
 
             row = cls.layout.row(align=True)
             row.label(text="", icon="EVENT_SHIFT")
@@ -197,8 +191,6 @@ class BimToolUI:
 
             row = cls.layout.row(align=True)
             row.prop(data=cls.props, property="x_angle", text="X Angle")
-            op = row.operator("bim.change_extrusion_x_angle", icon="FILE_REFRESH", text="")
-            op.x_angle = cls.props.x_angle
         elif AuthoringData.data["active_material_usage"] == "PROFILE":
             row = cls.layout.row(align=True)
             row.prop(data=cls.props, property="cardinal_point", text="Axis")
@@ -210,8 +202,6 @@ class BimToolUI:
                 "Height" if AuthoringData.data["active_class"] in ("IfcColumn", "IfcColumnStandardCase") else "Length"
             )
             row.prop(data=cls.props, property="extrusion_depth", text=label)
-            op = row.operator("bim.change_profile_depth", icon="FILE_REFRESH", text="")
-            op.depth = cls.props.extrusion_depth
 
             row = cls.layout.row(align=True)
             row.label(text="", icon="EVENT_SHIFT")


### PR DESCRIPTION
I find it mildly annoying to have to click the Refresh button next to the properties for the object geometry to be updated. 

This PR removes these buttons and adds a callbacks to the properties so the geometry is updated every time the fields are updated.

Pros : realtime feedback

Cons : may lag user computer when scrubing the fields with a lot of items selected. I think this is not really an issue since the purpose of these fields is to input a precise value so I think it's unlikely the users would scrub them in the case they have multiple elements selected. It's not that bad either for simple shapes.

![Animation (1)](https://user-images.githubusercontent.com/25156105/230718816-6093b7ea-02fe-4eb5-ac85-5ff757693a24.gif)

I also set the minimal values to 0 since negative lengths don't really make sense (unless they do in the ifc schema ?) and the geometry creator doesn't seem to like it either.
