### PR TITLE
Fix wrong attribute name usage in IfcFile::getUnit

### DIFF
--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -2600,7 +2600,7 @@ std::pair<IfcUtil::IfcBaseClass*, double> IfcFile::getUnit(const std::string& un
 					);
 
 					IfcUtil::IfcBaseClass* unc = *mu->data().getArgument(
-						mu->declaration().as_entity()->attribute_index("ValueComponent")
+						mu->declaration().as_entity()->attribute_index("UnitComponent")
 					);
 
 					return_value.second *= static_cast<double>(*vlc->data().getArgument(0));


### PR DESCRIPTION
This PR is for #3076.
In IfcFile::getUnit in IfcParser.cpp, a wrong attribute "ValueComponent" was used to get the value of IfcConversionBasedUnit.
I fixed it to "UnitComponent".