### PR TITLE
Edit profile based representations with TAB

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -731,6 +731,10 @@ class OverrideModeSetEdit(bpy.types.Operator):
             if not obj:
                 continue
 
+            if not obj.data:
+                obj.select_set(False)
+                continue
+
             element = tool.Ifc.get_entity(obj)
             if not element:
                 continue

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -751,7 +751,7 @@ class OverrideModeSetEdit(bpy.types.Operator):
             if len(context.selected_objects) == 1:
                 if tool.Pset.get_element_pset(element, "BBIM_Railing"):
                     # Needs to run BEFORE is_meshlike check
-                    bpy.ops.bim.enable_editing_railing_path()
+                    bpy.ops.bim.hotkey(hotkey="S_E", description="")
                     obj.data.BIMMeshProperties.mesh_checksum = tool.Geometry.get_mesh_checksum(obj.data)
                     return {"FINISHED"}
                 elif len(context.selected_objects) == 1 and tool.Geometry.is_profile_based(representation):

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -737,6 +737,7 @@ class OverrideModeSetEdit(bpy.types.Operator):
 
             element = tool.Ifc.get_entity(obj)
             if not element:
+                obj.select_set(False)
                 continue
 
             # We are switching from OBJECT to EDIT mode.
@@ -752,10 +753,13 @@ class OverrideModeSetEdit(bpy.types.Operator):
             if not representation:
                 continue
 
-            if len(context.selected_objects) == 1:
-                if tool.Pset.get_element_pset(element, "BBIM_Railing"):
-                    # Needs to run BEFORE is_meshlike check
-                    bpy.ops.bim.hotkey(hotkey="S_E", description="")
+            if (
+                tool.Pset.get_element_pset(element, "BBIM_Door")
+                or tool.Pset.get_element_pset(element, "BBIM_Window")
+                or tool.Pset.get_element_pset(element, "BBIM_Stair")
+            ):
+                obj.select_set(False)
+                continue
                     obj.data.BIMMeshProperties.mesh_checksum = tool.Geometry.get_mesh_checksum(obj.data)
                     return {"FINISHED"}
                 elif len(context.selected_objects) == 1 and tool.Geometry.is_profile_based(representation):

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -763,6 +763,11 @@ class OverrideModeSetEdit(bpy.types.Operator):
                         apply_openings=False,
                     )
                 obj.data.BIMMeshProperties.mesh_checksum = tool.Geometry.get_mesh_checksum(obj.data)
+            elif len(context.selected_objects) == 1 and tool.Geometry.is_profile_based(representation):
+                # Only one profile can be edited at a time
+                bpy.ops.bim.enable_editing_extrusion_profile()
+                obj.data.BIMMeshProperties.mesh_checksum = tool.Geometry.get_mesh_checksum(obj.data)
+                return {"FINISHED"}
             else:
                 obj.select_set(False)
                 continue
@@ -859,7 +864,12 @@ class OverrideModeSetObject(bpy.types.Operator):
             if not element:
                 continue
 
-            if obj.data.BIMMeshProperties.ifc_definition_id:
+            if tool.Profile.is_editing_profile():
+                if obj.data.BIMMeshProperties.mesh_checksum == tool.Geometry.get_mesh_checksum(obj.data):
+                    continue
+                bpy.ops.bim.edit_extrusion_profile()
+                return {"FINISHED"}
+            elif obj.data.BIMMeshProperties.ifc_definition_id:
                 if not tool.Geometry.has_geometric_data(obj):
                     self.is_valid = False
                     self.should_save = False

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -865,9 +865,8 @@ class OverrideModeSetObject(bpy.types.Operator):
                 continue
 
             if tool.Profile.is_editing_profile():
-                if obj.data.BIMMeshProperties.mesh_checksum == tool.Geometry.get_mesh_checksum(obj.data):
-                    continue
-                bpy.ops.bim.edit_extrusion_profile()
+                if obj.data.BIMMeshProperties.mesh_checksum != tool.Geometry.get_mesh_checksum(obj.data):
+                    bpy.ops.bim.edit_extrusion_profile()
                 return {"FINISHED"}
             elif obj.data.BIMMeshProperties.ifc_definition_id:
                 if not tool.Geometry.has_geometric_data(obj):

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -867,7 +867,7 @@ class OverrideModeSetObject(bpy.types.Operator):
             if tool.Profile.is_editing_profile():
                 if obj.data.BIMMeshProperties.mesh_checksum != tool.Geometry.get_mesh_checksum(obj.data):
                     bpy.ops.bim.edit_extrusion_profile()
-                return {"FINISHED"}
+                return self.execute(context)
             elif obj.data.BIMMeshProperties.ifc_definition_id:
                 if not tool.Geometry.has_geometric_data(obj):
                     self.is_valid = False

--- a/src/blenderbim/blenderbim/tool/geometry.py
+++ b/src/blenderbim/blenderbim/tool/geometry.py
@@ -352,7 +352,11 @@ class Geometry(blenderbim.core.tool.Geometry):
         return False
 
     @classmethod
-    def is_profile_based(cls, representation):
+    def is_profile_based(cls, data):
+        return data.BIMMeshProperties.subshape_type == "PROFILE"
+
+    @classmethod
+    def is_swept_profile(cls, representation):
         return ifcopenshell.util.representation.resolve_representation(representation).RepresentationType in (
             "SweptSolid",
         )

--- a/src/blenderbim/blenderbim/tool/geometry.py
+++ b/src/blenderbim/blenderbim/tool/geometry.py
@@ -352,6 +352,12 @@ class Geometry(blenderbim.core.tool.Geometry):
         return False
 
     @classmethod
+    def is_profile_based(cls, representation):
+        return ifcopenshell.util.representation.resolve_representation(representation).RepresentationType in (
+            "SweptSolid",
+        )
+
+    @classmethod
     def is_type_product(cls, element):
         return element.is_a("IfcTypeProduct")
 

--- a/src/blenderbim/blenderbim/tool/profile.py
+++ b/src/blenderbim/blenderbim/tool/profile.py
@@ -21,6 +21,7 @@ import ifcopenshell.util.unit
 import ifcopenshell.util.placement
 import ifcopenshell.util.representation
 import blenderbim.core.tool
+from blenderbim.bim.module.model.decorator import ProfileDecorator
 
 
 class Profile(blenderbim.core.tool.Profile):
@@ -52,3 +53,7 @@ class Profile(blenderbim.core.tool.Profile):
 
         for e in grouped_edges:
             draw.line((tuple(grouped_verts[e[0]]), tuple(grouped_verts[e[1]])), fill="white", width=2)
+
+    @classmethod
+    def is_editing_profile(cls):
+        return ProfileDecorator.installed


### PR DESCRIPTION
Following #2983

This allows users to TAB into edit mode when one profiled-based (SweptSolid) representation is selected.
I didn't know how to check if the profile editor was active so I added a little helper in blenderbim.tool.Profile to check if the ProfileDecorator is installed. I guess it's a weak way to check if edition is going on but it seems reliable enough.

