### PR TITLE
fix error on load an existing drawing layout created on a different os

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/drawing/sheeter.py
+++ b/src/blenderbim/blenderbim/bim/module/drawing/sheeter.py
@@ -28,6 +28,7 @@ import blenderbim.tool as tool
 import ifcopenshell.util.geolocation
 from xml.dom import minidom
 from mathutils import Vector
+from sys import platform
 
 VIEW_TITLE_OFFSET_Y = 5
 DEFAULT_POSITION = Vector((30, 30))
@@ -351,7 +352,12 @@ class SheetBuilder:
                 view.remove(image)
 
     def get_href(self, element):
-        return urllib.parse.unquote(element.attrib.get("{http://www.w3.org/1999/xlink}href"))
+        path = urllib.parse.unquote(element.attrib.get("{http://www.w3.org/1999/xlink}href"))
+        if platform == 'linux' or platform == 'linux2' or platform == 'darwin':
+            path = path.replace('\\', os.path.sep)
+        if platform == 'win32':
+            path = path.replace('/', os.path.sep)
+        return path
 
     def parse_embedded_svg(self, image, data):
         group = ET.Element("g")


### PR DESCRIPTION
If a layout was created on windows and i try to load it on linux i get this error
![image](https://github.com/IfcOpenShell/IfcOpenShell/assets/79401028/deb72233-b501-4638-9c24-073cf1cbd385)
This fix prevents this error