### PR TITLE
Duplicate aggregate

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/geometry/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/__init__.py
@@ -74,7 +74,7 @@ def register():
         kmi = km.keymap_items.new("bim.override_object_join", "J", "PRESS", ctrl=True)
         kmi = km.keymap_items.new("bim.override_object_duplicate_move_macro", "D", "PRESS", shift=True)
         kmi = km.keymap_items.new("bim.override_object_duplicate_move_linked_macro", "D", "PRESS", alt=True)
-        kmi = km.keymap_items.new("bim.override_object_duplicate_move_aggregate_macro", "F", "PRESS", ctrl=True)
+        kmi = km.keymap_items.new("bim.override_object_duplicate_move_aggregate_macro", "D", "PRESS", ctrl=True, shift=True)
         kmi = km.keymap_items.new("bim.override_paste_buffer", "V", "PRESS", ctrl=True)
         kmi = km.keymap_items.new("bim.override_mode_set_edit", "TAB", "PRESS")
         kmi = km.keymap_items.new("bim.override_object_delete", "X", "PRESS")

--- a/src/blenderbim/blenderbim/bim/module/geometry/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/__init__.py
@@ -29,6 +29,9 @@ classes = (
     operator.OverrideDuplicateMoveLinked,
     operator.OverrideDuplicateMoveLinkedMacro,
     operator.OverrideDuplicateMoveMacro,
+    operator.OverrideDuplicateMoveAggregate,
+    operator.OverrideDuplicateMoveAggregateMacro,
+    # operator.RefreshAggregate,
     operator.OverrideJoin,
     operator.OverrideModeSetEdit,
     operator.OverrideModeSetObject,
@@ -58,6 +61,8 @@ def register():
     operator.OverrideDuplicateMoveMacro.define("TRANSFORM_OT_translate")
     operator.OverrideDuplicateMoveLinkedMacro.define("BIM_OT_override_object_duplicate_move_linked")
     operator.OverrideDuplicateMoveLinkedMacro.define("TRANSFORM_OT_translate")
+    operator.OverrideDuplicateMoveAggregateMacro.define("BIM_OT_override_object_duplicate_move_aggregate")
+    operator.OverrideDuplicateMoveAggregateMacro.define("TRANSFORM_OT_translate")
 
     bpy.types.Object.BIMGeometryProperties = bpy.props.PointerProperty(type=prop.BIMObjectGeometryProperties)
     bpy.types.Scene.BIMGeometryProperties = bpy.props.PointerProperty(type=prop.BIMGeometryProperties)
@@ -69,6 +74,7 @@ def register():
         kmi = km.keymap_items.new("bim.override_object_join", "J", "PRESS", ctrl=True)
         kmi = km.keymap_items.new("bim.override_object_duplicate_move_macro", "D", "PRESS", shift=True)
         kmi = km.keymap_items.new("bim.override_object_duplicate_move_linked_macro", "D", "PRESS", alt=True)
+        kmi = km.keymap_items.new("bim.override_object_duplicate_move_aggregate_macro", "F", "PRESS", ctrl=True)
         kmi = km.keymap_items.new("bim.override_paste_buffer", "V", "PRESS", ctrl=True)
         kmi = km.keymap_items.new("bim.override_mode_set_edit", "TAB", "PRESS")
         kmi = km.keymap_items.new("bim.override_object_delete", "X", "PRESS")

--- a/src/blenderbim/blenderbim/bim/module/geometry/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/__init__.py
@@ -31,7 +31,7 @@ classes = (
     operator.OverrideDuplicateMoveMacro,
     operator.OverrideDuplicateMoveAggregate,
     operator.OverrideDuplicateMoveAggregateMacro,
-    # operator.RefreshAggregate,
+    operator.RefreshAggregate,
     operator.OverrideJoin,
     operator.OverrideModeSetEdit,
     operator.OverrideModeSetObject,

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -867,6 +867,10 @@ class OverrideDuplicateMoveAggregate(bpy.types.Operator):
             obj.select_set(False)
             new_obj.select_set(True)
 
+            # This is needed to make sure the new object gets unlink from
+            # the old object assembly collection
+            new_obj.BIMObjectProperties.collection = None
+
             # Copy the actual class
             new_entity = blenderbim.core.root.copy_class(tool.Ifc, tool.Collector, tool.Geometry, tool.Root, obj=new_obj)
 
@@ -878,7 +882,6 @@ class OverrideDuplicateMoveAggregate(bpy.types.Operator):
                     array_pset = tool.Ifc.get().by_id(array_pset["id"])
                     ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=new_entity, pset=array_pset)
 
-                print(obj)
                 blenderbim.core.aggregate.unassign_object(
                     tool.Ifc,
                     tool.Aggregate,
@@ -907,7 +910,6 @@ class OverrideDuplicateMoveAggregate(bpy.types.Operator):
 
         
         pset = ifcopenshell.util.element.get_pset(selected_root_entity, "BBIM_Aggregate_Data")
-        print("PSET", pset)
         
         selected_root_parent = selected_root_entity
 


### PR DESCRIPTION
This PR implements the idea presented in #3068 for duplication of aggregates. It also gives the possibility to refresh the copies if anything is changed in the original aggregates.

To duplicate, you have to select only the `IfcElementAssembly`. Right now, this operator is triggered by `crtl + shift + d`. It also works with sub-aggregates.

https://github.com/IfcOpenShell/IfcOpenShell/assets/57102715/ac112ab3-b30b-456d-af0a-9b0cb1f76e5d




After changing something in the original aggregate, select the `IfcElementAssembly`you want to refresh, press `F3` and type `refresh_aggregate`:

https://github.com/IfcOpenShell/IfcOpenShell/assets/57102715/356f8018-4126-4caa-bb3d-af4051955763








Also works with sub-aggregates copies that are detached:

https://github.com/IfcOpenShell/IfcOpenShell/assets/57102715/bff29454-6520-45d9-8607-34be2ca498d0






The current version might fix #3186 . There is still a problem with openings placement, but I think it's related to duplication in general (related to #3253 ). Nevertheless, this can be solved by refreshing the copy.

https://github.com/IfcOpenShell/IfcOpenShell/assets/57102715/a11c16bc-1061-4945-8cce-bb9c65174ec4



**Future improvements**
This PR is the basic implementation, and it's somewhat ready to use. I'm committed to work on the following improvements moving forward:
- Regarding the code, the operators are placed in the geometry module, because it was easier to start with the `OverrideDuplicate` as reference. Maybe this could evolve and go to the aggregate module.
- Create an ui for refresh operator, maybe here:
![image](https://github.com/IfcOpenShell/IfcOpenShell/assets/57102715/feac5433-3d37-493a-8eb3-ce685b478b62)

- Create an operator to refresh all instances
- Create an operator to select the base `IfcElementAssembly` of that group
- Create an operator to select the original instance of that aggregate
- Create an operator to unlink the aggregate from the original instance