### PR TITLE
Proposed implementation of #3332

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/model/array.py
+++ b/src/blenderbim/blenderbim/bim/module/model/array.py
@@ -142,13 +142,9 @@ class RemoveArray(bpy.types.Operator, tool.Ifc.Operator):
     bl_label = "Remove Array"
     bl_options = {"REGISTER", "UNDO"}
     item: bpy.props.IntProperty()
-    total_items: bpy.props.IntProperty()
     keep_objs: bpy.props.BoolProperty(name="Keep Objects", default=False)
 
     def _execute(self, context):
-        if (self.keep_objs) & (self.item < (self.total_items - 1)):
-            self.report({"INFO"}, "Keeping the objects is only allowed when you are removing the last Array of the object")
-            return {"FINISHED"}
         obj = context.active_object
         element = tool.Ifc.get_entity(obj)
         props = obj.BIMArrayProperties
@@ -156,6 +152,10 @@ class RemoveArray(bpy.types.Operator, tool.Ifc.Operator):
         pset = ifcopenshell.util.element.get_pset(element, "BBIM_Array")
         data = json.loads(pset["Data"])
         data[self.item]["count"] = 1
+        
+        if (self.keep_objs) & (self.item < (len(data) - 1)):
+            self.report({"INFO"}, "Keeping the objects is only allowed when you are removing the last Array of the object")
+            return {"FINISHED"}
 
         props.is_editing = -1
 

--- a/src/blenderbim/blenderbim/bim/module/model/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/model/ui.py
@@ -206,9 +206,7 @@ class BIM_PT_array(bpy.types.Panel):
                     name = f"{array['count']} Items ({array.get('method', 'OFFSET').capitalize()})"
                     row.label(text=name, icon="MOD_ARRAY")
                     row.operator("bim.enable_editing_array", icon="GREASEPENCIL", text="").item = i
-                    op = row.operator("bim.remove_array", icon="X", text="")
-                    op.item = i
-                    op.total_items = len(ArrayData.data["parameters"]["data_dict"])
+                    row.operator("bim.remove_array", icon="X", text="").item = i
                     row = box.row(align=True)
                     icon = "EMPTY_ARROWS" if array.get("use_local_space", False) else "EMPTY_AXIS"
                     row.label(text=f"X: {array['x']}", icon=icon)

--- a/src/blenderbim/blenderbim/bim/module/model/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/model/ui.py
@@ -206,7 +206,9 @@ class BIM_PT_array(bpy.types.Panel):
                     name = f"{array['count']} Items ({array.get('method', 'OFFSET').capitalize()})"
                     row.label(text=name, icon="MOD_ARRAY")
                     row.operator("bim.enable_editing_array", icon="GREASEPENCIL", text="").item = i
-                    row.operator("bim.remove_array", icon="X", text="").item = i
+                    op = row.operator("bim.remove_array", icon="X", text="")
+                    op.item = i
+                    op.total_items = len(ArrayData.data["parameters"]["data_dict"])
                     row = box.row(align=True)
                     icon = "EMPTY_ARROWS" if array.get("use_local_space", False) else "EMPTY_AXIS"
                     row.label(text=f"X: {array['x']}", icon=icon)

--- a/src/blenderbim/blenderbim/tool/model.py
+++ b/src/blenderbim/blenderbim/tool/model.py
@@ -530,7 +530,7 @@ class Model(blenderbim.core.tool.Model):
         return axes
 
     @classmethod
-    def regenerate_array(cls, parent, data):
+    def regenerate_array(cls, parent, data, keep_objs=False):
         unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
         obj_stack = [parent]
 
@@ -600,7 +600,12 @@ class Model(blenderbim.core.tool.Model):
                 element = tool.Ifc.get().by_guid(removed_child)
                 obj = tool.Ifc.get_object(element)
                 if obj:
-                    tool.Geometry.delete_ifc_object(obj)
+                    if keep_objs:
+                        pset = ifcopenshell.util.element.get_pset(element, "BBIM_Array")
+                        pset = tool.Ifc.get().by_id(pset["id"])
+                        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=element, pset=pset)
+                    else:
+                        tool.Geometry.delete_ifc_object(obj)
 
             bpy.context.view_layer.update()
 


### PR DESCRIPTION
Allows the users to keep objects when removing the array. In case of  an object that has multiple arrays, it's hard to keep track of the objects that should be removed from the array. For now, to make things simple, this PR only allows removing and array when the user is removing the last array of an object.