### PR TITLE
Interface to interact with brickschema PR #2

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/brick/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/__init__.py
@@ -36,6 +36,7 @@ classes = (
     operator.UndoBrick,
     operator.RedoBrick,
     operator.SerializeBrick,
+    operator.AddBrickNamespace,
     prop.Brick,
     prop.BIMBrickProperties,
     ui.BIM_PT_brickschema,

--- a/src/blenderbim/blenderbim/bim/module/brick/data.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/data.py
@@ -109,9 +109,10 @@ class BrickschemaData:
         if BrickStore.graph is None:
             return []
         results = []
+        filter = ["brick", "owl", "w3", "xml"]
         for alias, uri in BrickStore.graph.namespaces():
-            # results.append((uri, f"{alias}: {uri}", ""))
-            results.append((uri, f"{alias}", ""))
+            if alias not in filter:
+                results.append((uri, f"{alias}: {uri}", ""))
         return results
 
     @classmethod

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -22,7 +22,7 @@ import blenderbim.tool as tool
 import blenderbim.core.brick as core
 import blenderbim.bim.handler
 from blenderbim.bim.ifc import IfcStore
-
+from blenderbim.tool.brick import BrickStore
 
 class Operator:
     def execute(self, context):
@@ -207,6 +207,26 @@ class RedoBrick(bpy.types.Operator, Operator):
 class SerializeBrick(bpy.types.Operator, Operator):
     bl_idname = "bim.serialize_brick"
     bl_label = "Serialize Brick"
+    filter_glob: bpy.props.StringProperty(default="*.ttl", options={"HIDDEN"})
+    filepath: bpy.props.StringProperty(subtype="FILE_PATH")
+    should_save_as: bpy.props.BoolProperty(name="Should Save As", default=False, options={"HIDDEN"})
+
+    def invoke(self, context, event):
+        if self.should_save_as or not BrickStore.path:
+            WindowManager = context.window_manager
+            WindowManager.fileselect_add(self)
+            return {"RUNNING_MODAL"}
+        else:
+            return self.execute(context)
 
     def _execute(self, context):
+        if self.should_save_as or not BrickStore.path:
+            BrickStore.path = self.filepath
         core.serialize_brick(tool.Brick)
+        return {"FINISHED"}
+    
+    @classmethod
+    def description(cls, context, properties):
+        if properties.should_save_as:
+            return "Save Brick project to a selected file"
+        return "Save the Brick project"

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -126,6 +126,7 @@ class AddBrick(bpy.types.Operator, Operator):
             namespace=props.namespace,
             brick_class=props.brick_equipment_class,
             library=library,
+            label=props.new_brick_label
         )
 
 
@@ -230,3 +231,13 @@ class SerializeBrick(bpy.types.Operator, Operator):
         if properties.should_save_as:
             return "Save Brick project to a selected file"
         return "Save the Brick project"
+    
+class AddBrickNamespace(bpy.types.Operator, Operator):
+    bl_idname = "bim.add_brick_namespace"
+    bl_label = "Add Brick Namespace"
+
+    def _execute(self, context):
+        props = context.scene.BIMBrickProperties
+        alias = props.new_brick_namespace_alias
+        uri = props.new_brick_namespace_uri
+        core.add_namespace(tool.Brick, alias=alias, uri=uri)

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -30,7 +30,6 @@ from bpy.props import (
     FloatVectorProperty,
     CollectionProperty,
 )
-from blenderbim.tool.brick import BrickStore
 
 
 def update_active_brick_index(self, context):

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -30,6 +30,7 @@ from bpy.props import (
     FloatVectorProperty,
     CollectionProperty,
 )
+from blenderbim.tool.brick import BrickStore
 
 
 def update_active_brick_index(self, context):
@@ -69,3 +70,7 @@ class BIMBrickProperties(PropertyGroup):
     libraries: EnumProperty(name="Libraries", items=get_libraries)
     namespace: EnumProperty(name="Namespace", items=get_namespaces)
     brick_equipment_class: EnumProperty(name="Brick Equipment Class", items=get_brick_equipment_classes)
+    brick_settings_toggled: BoolProperty(name="Brick Settings Toggled", default=False)
+    new_brick_label: StringProperty(name="New Brick Label")
+    new_brick_namespace_alias: StringProperty(name="New Brick Namespace Alias")
+    new_brick_namespace_uri: StringProperty(name="New Brick Namespace URI")

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -20,7 +20,7 @@ import blenderbim.tool as tool
 from bpy.types import Panel, UIList
 from blenderbim.bim.helper import prop_with_search
 from blenderbim.bim.module.brick.data import BrickschemaData, BrickschemaReferencesData
-
+from blenderbim.tool.brick import BrickStore
 
 class BIM_PT_brickschema(Panel):
     bl_label = "Brickschema Project"
@@ -40,6 +40,10 @@ class BIM_PT_brickschema(Panel):
             row.operator("bim.new_brick_file", text="Create Project")
             row.operator("bim.load_brick_project", text="Load Project")
             return
+
+        if BrickStore.path:
+            row = self.layout.row(align=True)
+            row.label(text=BrickStore.path, icon='FILEBROWSER')
 
         row = self.layout.row(align=True)
         if len(self.props.brick_breadcrumbs):
@@ -63,7 +67,10 @@ class BIM_PT_brickschema(Panel):
         row.operator("bim.redo_brick", icon="LOOP_FORWARDS")
 
         row = self.layout.row(align=True)
-        row.operator("bim.serialize_brick")
+        op = row.operator("bim.serialize_brick", icon="EXPORT", text="Save")
+        op.should_save_as = False
+        op = row.operator("bim.serialize_brick", icon="FILE_TICK", text="Save As")
+        op.should_save_as = True
 
         self.layout.template_list("BIM_UL_bricks", "", self.props, "bricks", self.props, "active_brick_index")
 

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -49,11 +49,31 @@ class BIM_PT_brickschema(Panel):
         if len(self.props.brick_breadcrumbs):
             row.operator("bim.rewind_brick_class", text="", icon="FRAME_PREV")
         row.label(text=self.props.active_brick_class)
+        row.prop(data=self.props, property="brick_settings_toggled", text="", icon="PREFERENCES")
         row.operator("bim.refresh_brick_viewer", text="", icon="FILE_REFRESH")
         row.operator("bim.close_brick_project", text="", icon="CANCEL")
 
+        if self.props.brick_settings_toggled:
+            box = self.layout.box()
+            row = box.row(align=True)
+            row.label(text="Active Namespace:")
+            row = box.row(align=True)
+            prop_with_search(row, self.props, "namespace", text="")
+            row = box.row(align=True)
+            row.label(text="Bind New Namespace:")
+            row = box.row(align=True)
+            row.prop(data=self.props, property="new_brick_namespace_alias", text="")
+            col = row.column()
+            col.alignment = "CENTER"
+            col.scale_x = 1.1 
+            col.label(text=":")
+            row.prop(data=self.props, property="new_brick_namespace_uri", text="")
+            row.operator("bim.add_brick_namespace", text="", icon="ADD")
+
         row = self.layout.row(align=True)
-        prop_with_search(row, self.props, "namespace", text="")
+        row.label(text="Create Entity:")
+        row = self.layout.row(align=True)
+        row.prop(data=self.props, property="new_brick_label", text="")
         prop_with_search(row, self.props, "brick_equipment_class", text="")
         row.operator("bim.add_brick", text="", icon="ADD")
 

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -47,6 +47,7 @@ def rewind_brick_class(brick):
 
 def close_brick_project(brick):
     brick.clear_project()
+    brick.clear_brick_browser()
 
 
 def convert_brick_project(ifc, brick):
@@ -110,13 +111,16 @@ def remove_brick(ifc, brick, library=None, brick_uri=None):
     brick.remove_brick(brick_uri)
     brick.run_refresh_brick_viewer()
 
+
 def undo_brick(brick):
     brick.undo_brick()
     brick.run_refresh_brick_viewer()
 
+
 def redo_brick(brick):
     brick.redo_brick()
     brick.run_refresh_brick_viewer()
+
 
 def serialize_brick(brick):
     brick.serialize_brick()

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -118,5 +118,5 @@ def redo_brick(brick):
     brick.redo_brick()
     brick.run_refresh_brick_viewer()
 
-def serialize_brick(brick, file_name="BlenderBIMSerializeTest.ttl"):
-    brick.serialize_brick(file_name)
+def serialize_brick(brick):
+    brick.serialize_brick()

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -68,13 +68,13 @@ def assign_brick_reference(ifc, brick, element=None, library=None, brick_uri=Non
     brick.add_brickifc_reference(brick_uri, element, project)
 
 
-def add_brick(ifc, brick, element=None, namespace=None, brick_class=None, library=None):
+def add_brick(ifc, brick, element=None, namespace=None, brick_class=None, library=None, label="Unnamed"):
     if element:
         brick_uri = brick.add_brick_from_element(element, namespace, brick_class)
         if library:
             brick.run_assign_brick_reference(element=element, library=library, brick_uri=brick_uri)
     else:
-        brick_uri = brick.add_brick(namespace, brick_class)
+        brick_uri = brick.add_brick(namespace, brick_class, label)
     brick.run_refresh_brick_viewer()
 
 
@@ -124,3 +124,6 @@ def redo_brick(brick):
 
 def serialize_brick(brick):
     brick.serialize_brick()
+
+def add_namespace(brick, alias=None, uri=None):
+    brick.add_namespace(alias, uri)

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -332,12 +332,10 @@ class Brick(blenderbim.core.tool.Brick):
             BrickStore.graph.redo()  
 
     @classmethod
-    def serialize_brick(cls, file_name):
-        #temporary file path, could either be user selected for "save as" or use the BrickStore.path for simply "save"
-        cwd = os.path.dirname(os.path.realpath(__file__))
-        dest = os.path.join(cwd, "..", "bim", "schema", file_name)
-        BrickStore.get_project().serialize(destination=dest, format="turtle")
-
+    def serialize_brick(cls):
+        print(BrickStore.path)
+        BrickStore.get_project().serialize(destination=BrickStore.path, format="turtle")
+        
 class BrickStore:
     schema = None # this is now a os path
     path = None   # file path if the project was loaded in

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -41,12 +41,12 @@ logger.setLevel(logging.ERROR)
 
 class Brick(blenderbim.core.tool.Brick):
     @classmethod
-    def add_brick(cls, namespace, brick_class):
+    def add_brick(cls, namespace, brick_class, label):
         ns = Namespace(namespace)
         brick = ns[ifcopenshell.guid.expand(ifcopenshell.guid.new())]
         with BrickStore.graph.new_changeset("PROJECT") as cs:
             cs.add((brick, RDF.type, URIRef(brick_class)))
-            cs.add((brick, URIRef("http://www.w3.org/2000/01/rdf-schema#label"), Literal("Unnamed")))
+            cs.add((brick, URIRef("http://www.w3.org/2000/01/rdf-schema#label"), Literal(label)))
         return str(brick)
 
     @classmethod
@@ -333,8 +333,12 @@ class Brick(blenderbim.core.tool.Brick):
 
     @classmethod
     def serialize_brick(cls):
-        print(BrickStore.path)
         BrickStore.get_project().serialize(destination=BrickStore.path, format="turtle")
+    
+    @classmethod
+    def add_namespace(cls, alias, uri):
+        BrickStore.graph.bind(alias, Namespace(uri))
+        # need some way to reload namespace enum view
         
 class BrickStore:
     schema = None # this is now a os path

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -275,8 +275,6 @@ class Brick(blenderbim.core.tool.Brick):
         with BrickStore.graph.new_changeset("SCHEMA") as cs:
             cs.load_file(BrickStore.schema)
         BrickStore.graph.bind("digitaltwin", Namespace("https://example.org/digitaltwin#"))
-        BrickStore.graph.bind("brick", Namespace("https://brickschema.org/schema/Brick#"))
-        BrickStore.graph.bind("rdfs", Namespace("http://www.w3.org/2000/01/rdf-schema#"))
 
     @classmethod
     def pop_brick_breadcrumb(cls):


### PR DESCRIPTION
- Created "save" and "save as' options to serialize brick project
- Created settings toggle for namespace editing
- For now, filtered a few namespaces out of the namespace Enum (a better way to approach this may be just to populate the Enum with namespaces from the `brick.tool` rather than from `brick.data)`
- Creating an entity now gives the option to specify a label