### PR TITLE
[BlenderBIM] Update IfcTester (2023_07_21)

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/tester/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/tester/operator.py
@@ -58,10 +58,11 @@ class ExecuteIfcTester(bpy.types.Operator):
             print("Finished validating:", time.time() - start)
             start = time.time()
 
-            engine = ifctester.reporter.Html(specs)
-            engine.report()            
-            engine.to_file(output)
-            webbrowser.open("file://" + output)
+            if props.generate_html_report:
+                engine = ifctester.reporter.Html(specs)
+                engine.report()            
+                engine.to_file(output)
+                webbrowser.open("file://" + output)
             
             report = None
             report = ifctester.reporter.Json(specs).report()['specifications']
@@ -155,18 +156,19 @@ class ExportBcf(bpy.types.Operator):
 
     def execute(self, context):
         props = context.scene.IfcTesterProperties
+        if tool.Ifc.get():
+            ifc = tool.Ifc.get()
+        else:
+            ifc = ifcopenshell.open(props.ifc_file)
         with tempfile.TemporaryDirectory() as dirpath:
             output = os.path.join(dirpath, "{}.bcf".format(props.specs))
-            if props.should_load_from_memory and tool.Ifc.get():
-                ifc = tool.Ifc.get()
-            else:
-                ifc = ifcopenshell.open(props.ifc_file)
             specs = ifctester.ids.open(props.specs)
             specs.validate(ifc)
             bcf_reporter = ifctester.reporter.Bcf(specs)
             bcf_reporter.report()
             bcf_reporter.to_file(output)
-            print("Finished exporting:")
+            print("Finished exporting!")
+            self.report({"INFO"}, 'Finished exporting!')
 
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/tester/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/tester/prop.py
@@ -50,6 +50,7 @@ class IfcTesterProperties(PropertyGroup):
     specs: StringProperty(default="", name="IDS File")    
     ifc_file: StringProperty(default="", name="IFC File")
     should_load_from_memory: BoolProperty(default=False, name="Load from Memory")
+    generate_html_report: BoolProperty(default=False, name="Generate HTML report")
     
     active_specification_index: IntProperty(name="Active Specification Index")   
     active_requirement_index: IntProperty(name="Active Requirement Index")


### PR DESCRIPTION
The following improvements have been implemented:

1. The failed entities are now displayed even if the file is not loaded into memory. In this case they are displayed as in the HTML report;
2. The IFC ID now appears in the list of failed entities;
3. Fixed some syntax errors in the code;
4. HTML report generation is now optional.

