### PR TITLE
Brickschema interface PR 3

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/brick/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/__init__.py
@@ -35,6 +35,7 @@ classes = (
     operator.ViewBrickItem,
     operator.SerializeBrick,
     operator.AddBrickNamespace,
+    operator.SetBrickListRoot,
     prop.Brick,
     prop.BIMBrickProperties,
     ui.BIM_PT_brickschema,

--- a/src/blenderbim/blenderbim/bim/module/brick/data.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/data.py
@@ -57,8 +57,11 @@ class BrickschemaData:
             brick = props.bricks[props.active_brick_index]
         except:
             return []
-        results = []
         uri = brick.uri
+        namespace = str(uri.split("#")[0])
+        if namespace == "https://brickschema.org/schema/Brick":
+            return []
+        results = []
         query = BrickStore.graph.query(
             """
             PREFIX brick: <https://brickschema.org/schema/Brick#>

--- a/src/blenderbim/blenderbim/bim/module/brick/data.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/data.py
@@ -42,7 +42,6 @@ class BrickschemaData:
         cls.data = {
             "is_loaded": cls.get_is_loaded(),
             "attributes": cls.attributes(),
-            "namespaces": cls.namespaces(),
             "brick_equipment_classes": cls.brick_equipment_classes(),
         }
 
@@ -102,17 +101,6 @@ class BrickschemaData:
                             "is_globalid": p.toPython().split("#")[-1] == "globalID",
                         }
                     )
-        return results
-
-    @classmethod
-    def namespaces(cls):
-        if BrickStore.graph is None:
-            return []
-        results = []
-        filter = ["brick", "owl", "w3", "xml"]
-        for alias, uri in BrickStore.graph.namespaces():
-            if alias not in filter:
-                results.append((uri, f"{alias}: {uri}", ""))
         return results
 
     @classmethod

--- a/src/blenderbim/blenderbim/bim/module/brick/data.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/data.py
@@ -42,7 +42,6 @@ class BrickschemaData:
         cls.data = {
             "is_loaded": cls.get_is_loaded(),
             "attributes": cls.attributes(),
-            "brick_equipment_classes": cls.brick_equipment_classes(),
         }
 
     @classmethod
@@ -101,24 +100,6 @@ class BrickschemaData:
                             "is_globalid": p.toPython().split("#")[-1] == "globalID",
                         }
                     )
-        return results
-
-    @classmethod
-    def brick_equipment_classes(cls):
-        if BrickStore.graph is None:
-            return []
-        results = []
-        query = BrickStore.graph.query(
-            """
-            PREFIX brick: <https://brickschema.org/schema/Brick#>
-            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            SELECT ?class WHERE {
-                ?class rdfs:subClassOf* brick:Equipment .
-            }
-        """
-        )
-        for uri in sorted([x[0].toPython() for x in query]):
-            results.append((uri, uri.split("#")[-1], ""))
         return results
 
 

--- a/src/blenderbim/blenderbim/bim/module/brick/data.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/data.py
@@ -64,39 +64,38 @@ class BrickschemaData:
             PREFIX brick: <https://brickschema.org/schema/Brick#>
             PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
             PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-            SELECT DISTINCT ?name ?value ?sp ?sv WHERE {
-               <{uri}> ?name ?value .
+            SELECT DISTINCT ?predicate ?object ?sp ?sv WHERE {
+               <{uri}> ?predicate ?object .
                OPTIONAL {
-               { ?name rdfs:range brick:TimeseriesReference . }
+               { ?predicate rdfs:range brick:TimeseriesReference . }
                 UNION
-               { ?name a brick:EntityProperty . }
-                ?value ?sp ?sv }
+               { ?predicate a brick:EntityProperty . }
+                ?object ?sp ?sv }
             }
         """.replace(
                 "{uri}", uri
             )
         )
-
         for row in query:
-            name = row.get("name").toPython().split("#")[-1]
-            value = row.get("value")
+            predicate = row.get("predicate").toPython().split("#")[-1]
+            object = row.get("object")
             results.append(
                 {
-                    "name": name,
-                    "value": value.toPython().split("#")[-1],
-                    "is_uri": isinstance(value, URIRef),
-                    "value_uri": value.toPython(),
-                    "is_globalid": name == "globalID",
+                    "predicate": predicate,
+                    "object": object.toPython().split("#")[-1],
+                    "is_uri": isinstance(object, URIRef),
+                    "object_uri": object.toPython(),
+                    "is_globalid": predicate == "globalID",
                 }
             )
-            if isinstance(row.get("value"), BNode):
-                for s, p, o in BrickStore.graph.triples((value, None, None)):
+            if isinstance(row.get("object"), BNode):
+                for s, p, o in BrickStore.graph.triples((object, None, None)):
                     results.append(
                         {
-                            "name": name + ":" + p.toPython().split("#")[-1],
-                            "value": o.toPython().split("#")[-1],
+                            "predicate": predicate + ":" + p.toPython().split("#")[-1],
+                            "object": o.toPython().split("#")[-1],
                             "is_uri": isinstance(o, URIRef),
-                            "value_uri": o.toPython(),
+                            "object_uri": o.toPython(),
                             "is_globalid": p.toPython().split("#")[-1] == "globalID",
                         }
                     )

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -126,7 +126,7 @@ class AddBrick(bpy.types.Operator, Operator):
             tool.Brick,
             element=tool.Ifc.get_entity(context.active_object) if context.selected_objects else None,
             namespace=props.namespace,
-            brick_class=props.brick_equipment_class,
+            brick_class=props.brick_entity_classes,
             library=library,
             label=props.new_brick_label,
         )

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -40,7 +40,8 @@ class LoadBrickProject(bpy.types.Operator, Operator):
     filter_glob: bpy.props.StringProperty(default="*.ttl", options={"HIDDEN"})
 
     def _execute(self, context):
-        core.load_brick_project(tool.Brick, filepath=self.filepath)
+        root = context.scene.BIMBrickProperties.brick_list_root
+        core.load_brick_project(tool.Brick, filepath=self.filepath, brick_root=root)
 
     def invoke(self, context, event):
         context.window_manager.fileselect_add(self)
@@ -180,7 +181,8 @@ class NewBrickFile(bpy.types.Operator):
         return {"FINISHED"}
 
     def _execute(self, context):
-        core.new_brick_file(tool.Brick)
+        root = context.scene.BIMBrickProperties.brick_list_root
+        core.new_brick_file(tool.Brick, brick_root=root)
 
     def rollback(self, data):
         BrickStore.purge()
@@ -252,3 +254,13 @@ class AddBrickNamespace(bpy.types.Operator, Operator):
         alias = props.new_brick_namespace_alias
         uri = props.new_brick_namespace_uri
         core.add_namespace(tool.Brick, alias=alias, uri=uri)
+
+
+class SetBrickListRoot(bpy.types.Operator, Operator):
+    bl_idname = "bim.set_brick_list_root"
+    bl_label = "Set Brick View Type"
+    bl_options = {"REGISTER", "UNDO"}
+
+    def _execute(self, context):
+        root = context.scene.BIMBrickProperties.brick_list_root
+        core.set_brick_list_root(tool.Brick, brick_root=root)

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -47,13 +47,13 @@ def get_namespaces(self, context):
 
 
 def get_brick_entity_classes(self, context):
-    entity = context.scene.BIMBrickProperties.brick_entity_create_type
+    entity = self.brick_entity_create_type
     return BrickStore.entity_classes[entity]
 
 
-def get_brick_roots(self, context):
-    return BrickStore.root_classes
-            
+def get_brick_roots(self, context): 
+    return [(root, root, "") for root in BrickStore.root_classes]
+
 
 class Brick(PropertyGroup):
     name: StringProperty(name="Name")

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -30,7 +30,7 @@ from bpy.props import (
     FloatVectorProperty,
     CollectionProperty,
 )
-
+from blenderbim.tool.brick import BrickStore
 
 def update_active_brick_index(self, context):
     BrickschemaData.is_loaded = False
@@ -43,9 +43,7 @@ def get_libraries(self, context):
 
 
 def get_namespaces(self, context):
-    if not BrickschemaData.is_loaded:
-        BrickschemaData.load()
-    return BrickschemaData.data["namespaces"]
+    return BrickStore.namespaces
 
 
 def get_brick_equipment_classes(self, context):

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -54,7 +54,7 @@ def get_brick_equipment_classes(self, context):
     return BrickschemaData.data["brick_equipment_classes"]
 
 
-def get_brick_view_types(self, context):
+def get_brick_roots(self, context):
     return [("System", "System", ""),
             ("Location", "Location", ""),
             ("Equipment", "Equipment", ""),
@@ -81,4 +81,4 @@ class BIMBrickProperties(PropertyGroup):
     new_brick_label: StringProperty(name="New Brick Label")
     new_brick_namespace_alias: StringProperty(name="New Brick Namespace Alias")
     new_brick_namespace_uri: StringProperty(name="New Brick Namespace URI")
-    brick_view_type: EnumProperty(name="Brick View Type", items=get_brick_view_types)
+    brick_list_root: EnumProperty(name="Brick List Root", items=get_brick_roots)

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -46,10 +46,9 @@ def get_namespaces(self, context):
     return BrickStore.namespaces
 
 
-def get_brick_equipment_classes(self, context):
-    if not BrickschemaData.is_loaded:
-        BrickschemaData.load()
-    return BrickschemaData.data["brick_equipment_classes"]
+def get_brick_entity_classes(self, context):
+    entity = context.scene.BIMBrickProperties.brick_entity_create_type
+    return BrickStore.entity_classes[entity]
 
 
 def get_brick_roots(self, context):
@@ -74,9 +73,10 @@ class BIMBrickProperties(PropertyGroup):
     active_brick_index: IntProperty(name="Active Brick Index", update=update_active_brick_index)
     libraries: EnumProperty(name="Libraries", items=get_libraries)
     namespace: EnumProperty(name="Namespace", items=get_namespaces)
-    brick_equipment_class: EnumProperty(name="Brick Equipment Class", items=get_brick_equipment_classes)
+    brick_entity_classes: EnumProperty(name="Brick Equipment Class", items=get_brick_entity_classes)
     brick_settings_toggled: BoolProperty(name="Brick Settings Toggled", default=False)
     new_brick_label: StringProperty(name="New Brick Label")
     new_brick_namespace_alias: StringProperty(name="New Brick Namespace Alias")
     new_brick_namespace_uri: StringProperty(name="New Brick Namespace URI")
     brick_list_root: EnumProperty(name="Brick List Root", items=get_brick_roots)
+    brick_entity_create_type: EnumProperty(name="Brick Entity Types", items=get_brick_roots)

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -54,6 +54,14 @@ def get_brick_equipment_classes(self, context):
     return BrickschemaData.data["brick_equipment_classes"]
 
 
+def get_brick_view_types(self, context):
+    return [("System", "System", ""),
+            ("Location", "Location", ""),
+            ("Equipment", "Equipment", ""),
+            ("Point", "Point", "")
+        ]
+            
+
 class Brick(PropertyGroup):
     name: StringProperty(name="Name")
     label: StringProperty(name="Label")
@@ -73,3 +81,4 @@ class BIMBrickProperties(PropertyGroup):
     new_brick_label: StringProperty(name="New Brick Label")
     new_brick_namespace_alias: StringProperty(name="New Brick Namespace Alias")
     new_brick_namespace_uri: StringProperty(name="New Brick Namespace URI")
+    brick_view_type: EnumProperty(name="Brick View Type", items=get_brick_view_types)

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -52,11 +52,7 @@ def get_brick_entity_classes(self, context):
 
 
 def get_brick_roots(self, context):
-    return [("System", "System", ""),
-            ("Location", "Location", ""),
-            ("Equipment", "Equipment", ""),
-            ("Point", "Point", "")
-        ]
+    return BrickStore.root_classes
             
 
 class Brick(PropertyGroup):

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -51,21 +51,26 @@ class BIM_PT_brickschema(Panel):
             row.label(text=BrickStore.path, icon="FILEBROWSER")
 
         row = self.layout.row(align=True)
-        if len(self.props.brick_breadcrumbs):
-            row.operator("bim.rewind_brick_class", text="", icon="FRAME_PREV")
-        row.label(text=self.props.active_brick_class)
-        row.prop(data=self.props, property="brick_settings_toggled", text="", icon="PREFERENCES")
-        row.operator("bim.refresh_brick_viewer", text="", icon="FILE_REFRESH")
+        op = row.operator("bim.serialize_brick", icon="EXPORT", text="Save")
+        op.should_save_as = False
+        op = row.operator("bim.serialize_brick", icon="FILE_TICK", text="Save As")
+        op.should_save_as = True
         row.operator("bim.close_brick_project", text="", icon="CANCEL")
 
+        row = self.layout.row(align=True)
+        row.prop(data=self.props, property="brick_settings_toggled", text="", icon="PREFERENCES")
+        
         if self.props.brick_settings_toggled:
             box = self.layout.box()
             row = box.row(align=True)
             row.label(text="Active Namespace:")
+
             row = box.row(align=True)
             prop_with_search(row, self.props, "namespace", text="")
+
             row = box.row(align=True)
             row.label(text="Bind New Namespace:")
+
             row = box.row(align=True)
             row.prop(data=self.props, property="new_brick_namespace_alias", text="")
             col = row.column()
@@ -75,6 +80,9 @@ class BIM_PT_brickschema(Panel):
             row.prop(data=self.props, property="new_brick_namespace_uri", text="")
             row.operator("bim.add_brick_namespace", text="", icon="ADD")
 
+            row = box.row(align=True)
+            row.prop(data=self.props, property="brick_view_type", text="List View")
+
         row = self.layout.row(align=True)
         row.label(text="Create Entity:")
         row = self.layout.row(align=True)
@@ -83,15 +91,18 @@ class BIM_PT_brickschema(Panel):
         row.operator("bim.add_brick", text="", icon="ADD")
 
         row = self.layout.row(align=True)
-        row.alignment = "RIGHT"
-        row.operator("bim.add_brick_feed", text="", icon="PLUGIN")
+        col = row.column()
+        col.alignment = "LEFT"
+        if len(self.props.brick_breadcrumbs):
+            row.operator("bim.rewind_brick_class", text="", icon="FRAME_PREV")
+        col = row.column()
+        col.alignment = "RIGHT"
+        # row.operator("bim.add_brick_feed", text="", icon="PLUGIN")
         row.operator("bim.remove_brick", text="", icon="X")
+        # row.operator("bim.refresh_brick_viewer", text="", icon="FILE_REFRESH")
 
         row = self.layout.row(align=True)
-        op = row.operator("bim.serialize_brick", icon="EXPORT", text="Save")
-        op.should_save_as = False
-        op = row.operator("bim.serialize_brick", icon="FILE_TICK", text="Save As")
-        op.should_save_as = True
+        row.label(text=self.props.active_brick_class)
 
         self.layout.template_list("BIM_UL_bricks", "", self.props, "bricks", self.props, "active_brick_index")
 

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -86,9 +86,13 @@ class BIM_PT_brickschema(Panel):
 
         row = self.layout.row(align=True)
         row.label(text="Create Entity:")
+
+        row = self.layout.row(align=True)
+        row.prop(data=self.props, property="brick_entity_create_type", text="")
+
         row = self.layout.row(align=True)
         row.prop(data=self.props, property="new_brick_label", text="")
-        prop_with_search(row, self.props, "brick_equipment_class", text="")
+        prop_with_search(row, self.props, "brick_entity_classes", text="")
         row.operator("bim.add_brick", text="", icon="ADD")
 
         row = self.layout.row(align=True)

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -113,14 +113,14 @@ class BIM_PT_brickschema(Panel):
 
         for attribute in BrickschemaData.data["attributes"]:
             row = self.layout.row(align=True)
-            row.label(text=attribute["name"])
-            row.label(text=attribute["value"])
+            row.label(text=attribute["predicate"])
+            row.label(text=attribute["object"])
             if attribute["is_uri"]:
                 op = row.operator("bim.view_brick_item", text="", icon="DISCLOSURE_TRI_RIGHT")
-                op.item = attribute["value_uri"]
+                op.item = attribute["object_uri"]
             if attribute["is_globalid"]:
                 op = row.operator("bim.select_global_id", icon="RESTRICT_SELECT_OFF", text="")
-                op.global_id = attribute["value"]
+                op.global_id = attribute["object"]
 
 
 class BIM_PT_ifc_brickschema_references(Panel):

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -81,7 +81,8 @@ class BIM_PT_brickschema(Panel):
             row.operator("bim.add_brick_namespace", text="", icon="ADD")
 
             row = box.row(align=True)
-            row.prop(data=self.props, property="brick_view_type", text="List View")
+            row.operator("bim.set_brick_list_root", text="Set View")
+            row.prop(data=self.props, property="brick_list_root", text="")
 
         row = self.layout.row(align=True)
         row.label(text="Create Entity:")

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -17,10 +17,10 @@
 # along with BlenderBIM Add-on.  If not, see <http://www.gnu.org/licenses/>.
 
 
-def load_brick_project(brick, filepath=None):
+def load_brick_project(brick, filepath=None, brick_root=None):
     brick.load_brick_file(filepath)
-    brick.import_brick_classes("Class")
-    brick.set_active_brick_class("Class")
+    brick.import_brick_classes(brick_root)
+    brick.set_active_brick_class(brick_root)
 
 
 def view_brick_class(brick, brick_class=None):
@@ -92,10 +92,10 @@ def convert_ifc_to_brick(brick, namespace=None, library=None):
     brick.run_refresh_brick_viewer()
 
 
-def new_brick_file(brick):
+def new_brick_file(brick, brick_root=None):
     brick.new_brick_file()
-    brick.import_brick_classes("Class")
-    brick.set_active_brick_class("Class")
+    brick.import_brick_classes(brick_root)
+    brick.set_active_brick_class(brick_root)
 
 
 def refresh_brick_viewer(brick):
@@ -118,3 +118,11 @@ def serialize_brick(brick):
 
 def add_namespace(brick, alias=None, uri=None):
     brick.add_namespace(alias, uri)
+
+
+def set_brick_list_root(brick, brick_root=None):
+    brick.clear_brick_browser()
+    brick.import_brick_classes(brick_root)
+    brick.set_active_brick_class(brick_root)
+    brick.clear_breadcrumbs()
+

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -345,7 +345,7 @@ class BrickStore:
     current_changesets = 0
     history_size = 64
     namespaces = []
-    root_classes = [("Equipment", "Equipment", ""), ("Location", "Location", ""), ("System", "System", ""), ("Point", "Point", "")]
+    root_classes = ["Equipment", "Location", "System", "Point"]
     entity_classes = {}
 
     @staticmethod
@@ -376,7 +376,7 @@ class BrickStore:
     @classmethod
     def load_entity_classes(cls):
         
-        for root_class, __, __ in BrickStore.root_classes:
+        for root_class in BrickStore.root_classes:
             query = BrickStore.graph.query(
                 """
                 PREFIX brick: <https://brickschema.org/schema/Brick#>

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -326,6 +326,10 @@ class Brick(blenderbim.core.tool.Brick):
     def add_namespace(cls, alias, uri):
         BrickStore.graph.bind(alias, Namespace(uri))
         # need some way to reload namespace enum view
+    
+    @classmethod
+    def clear_breadcrumbs(cls):
+        bpy.context.scene.BIMBrickProperties.brick_breadcrumbs.clear()
 
 
 class BrickStore:

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -345,6 +345,7 @@ class BrickStore:
     current_changesets = 0
     history_size = 64
     namespaces = []
+    root_classes = [("Equipment", "Equipment", ""), ("Location", "Location", ""), ("System", "System", ""), ("Point", "Point", "")]
     entity_classes = {}
 
     @staticmethod
@@ -374,8 +375,8 @@ class BrickStore:
 
     @classmethod
     def load_entity_classes(cls):
-        root_classes = ["System", "Location", "Equipment", "Point"]
-        for root_class in root_classes:
+        
+        for root_class, __, __ in BrickStore.root_classes:
             query = BrickStore.graph.query(
                 """
                 PREFIX brick: <https://brickschema.org/schema/Brick#>


### PR DESCRIPTION
- reformat the UI a little.
- improve filter for namespaces by ignoring any namespaces that included unwanted URL’s ("brickschema.org", "schema.org", "w3.org", etc).
- improve hierarchy in viewer by adding UI option to set the hierarchy display type.
    - sort by system
    - sort by location
    - sort by all equipment
    - show all points
- move `namespaces` and `brick_equipement_classes` data into `BrickStore`, so that it isn't refreshed every time the Blender UI changes.
- drop down to select what type of thing you are adding (location, system, equipment, point) and populates the entity options with the relative type.
- simple filter for blacklisting populating the attribute of entitles that are part of the Brick ontology.







