### PR TITLE
Make GLTF materials double-sided

### DIFF
--- a/src/serializers/GltfSerializer.cpp
+++ b/src/serializers/GltfSerializer.cpp
@@ -98,7 +98,7 @@ int GltfSerializer::writeMaterial(const IfcGeom::Material& style) {
 		base[3] = 1. - style.transparency();
 	}
 
-	json_["materials"].push_back({ {"pbrMetallicRoughness", {{"baseColorFactor", base}, {"metallicFactor", 0}}} });
+	json_["materials"].push_back({ {"doubleSided", true}, {"pbrMetallicRoughness", {{"baseColorFactor", base}, {"metallicFactor", 0}}} });
 	
 	if (style.hasTransparency() && style.transparency() > 1.e-9) {
 		json_["materials"].back()["alphaMode"] = "BLEND";


### PR DESCRIPTION
When creating a GLTF file, make the material double sided to fix a bug where some surfaces were transparent. This will allow surfaces created from a mesh to be be viewed from all angles regardless of the shape of the mesh or the directions of the normals. An in-depth discussion of this can be found [here](https://github.com/IfcOpenShell/IfcOpenShell/discussions/3519)

