### PR TITLE
Brickschema interface PR #4

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/brick/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/__init__.py
@@ -36,6 +36,7 @@ classes = (
     operator.SerializeBrick,
     operator.AddBrickNamespace,
     operator.SetBrickListRoot,
+    operator.RemoveBrickRelation,
     prop.Brick,
     prop.BIMBrickProperties,
     ui.BIM_PT_brickschema,

--- a/src/blenderbim/blenderbim/bim/module/brick/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/__init__.py
@@ -21,7 +21,7 @@ from . import ui, prop, operator
 
 classes = (
     operator.AddBrick,
-    operator.AddBrickFeed,
+    operator.AddBrickRelation,
     operator.AssignBrickReference,
     operator.CloseBrickProject,
     operator.ConvertBrickProject,

--- a/src/blenderbim/blenderbim/bim/module/brick/data.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/data.py
@@ -41,7 +41,7 @@ class BrickschemaData:
         cls.is_loaded = True
         cls.data = {
             "is_loaded": cls.get_is_loaded(),
-            "relations": cls.relations(),
+            "active_relations": cls.active_relations(),
         }
 
     @classmethod
@@ -49,7 +49,7 @@ class BrickschemaData:
         return BrickStore.graph is not None
 
     @classmethod
-    def relations(cls):
+    def active_relations(cls):
         if BrickStore.graph is None:
             return []
         props = bpy.context.scene.BIMBrickProperties

--- a/src/blenderbim/blenderbim/bim/module/brick/data.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/data.py
@@ -41,7 +41,7 @@ class BrickschemaData:
         cls.is_loaded = True
         cls.data = {
             "is_loaded": cls.get_is_loaded(),
-            "attributes": cls.attributes(),
+            "relations": cls.relations(),
         }
 
     @classmethod
@@ -49,7 +49,7 @@ class BrickschemaData:
         return BrickStore.graph is not None
 
     @classmethod
-    def attributes(cls):
+    def relations(cls):
         if BrickStore.graph is None:
             return []
         props = bpy.context.scene.BIMBrickProperties

--- a/src/blenderbim/blenderbim/bim/module/brick/data.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/data.py
@@ -80,28 +80,32 @@ class BrickschemaData:
             )
         )
         for row in query:
-            predicate = row.get("predicate").toPython().split("#")[-1]
+            predicate = row.get("predicate")
+            predicate_name = predicate.toPython().split("#")[-1]
             object = row.get("object")
+            object_name = object.toPython().split("#")[-1]
             results.append(
                 {
                     "predicate": predicate,
-                    "object": object.toPython().split("#")[-1],
+                    "predicate_name": predicate_name,
+                    "object": object,
+                    "object_name": object_name,
                     "is_uri": isinstance(object, URIRef),
                     "object_uri": object.toPython(),
                     "is_globalid": predicate == "globalID",
                 }
             )
-            if isinstance(row.get("object"), BNode):
-                for s, p, o in BrickStore.graph.triples((object, None, None)):
-                    results.append(
-                        {
-                            "predicate": predicate + ":" + p.toPython().split("#")[-1],
-                            "object": o.toPython().split("#")[-1],
-                            "is_uri": isinstance(o, URIRef),
-                            "object_uri": o.toPython(),
-                            "is_globalid": p.toPython().split("#")[-1] == "globalID",
-                        }
-                    )
+            # if isinstance(row.get("object"), BNode):
+            #     for s, p, o in BrickStore.graph.triples((object, None, None)):
+            #         results.append(
+            #             {
+            #                 "predicate": predicate + ":" + p.toPython().split("#")[-1],
+            #                 "object": o.toPython().split("#")[-1],
+            #                 "is_uri": isinstance(o, URIRef),
+            #                 "object_uri": o.toPython(),
+            #                 "is_globalid": p.toPython().split("#")[-1] == "globalID",
+            #             }
+            #         )
         return results
 
 

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -149,7 +149,9 @@ class AddBrickRelation(bpy.types.Operator, Operator):
         brick = props.bricks[props.active_brick_index]
         if props.new_brick_relation_type == "http://www.w3.org/2000/01/rdf-schema#label":
             object = props.new_brick_relation_object
-        else: 
+        elif props.split_screen_toggled:
+            object = props.split_screen_bricks[props.split_screen_active_brick_index].uri
+        else:
             object = props.new_brick_relation_namespace + props.new_brick_relation_object
         core.add_brick_relation(
             tool.Brick,

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -57,9 +57,10 @@ class ViewBrickClass(bpy.types.Operator, Operator):
     bl_label = "View Brick Class"
     bl_options = {"REGISTER", "UNDO"}
     brick_class: bpy.props.StringProperty(name="Brick Class")
+    split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
     def _execute(self, context):
-        core.view_brick_class(tool.Brick, brick_class=self.brick_class)
+        core.view_brick_class(tool.Brick, brick_class=self.brick_class, split_screen=self.split_screen)
 
 
 class ViewBrickItem(bpy.types.Operator, Operator):
@@ -67,18 +68,20 @@ class ViewBrickItem(bpy.types.Operator, Operator):
     bl_label = "View Brick Item"
     bl_options = {"REGISTER", "UNDO"}
     item: bpy.props.StringProperty(name="Brick Item")
+    split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
     def _execute(self, context):
-        core.view_brick_item(tool.Brick, item=self.item)
+        core.view_brick_item(tool.Brick, item=self.item, split_screen=self.split_screen)
 
 
 class RewindBrickClass(bpy.types.Operator, Operator):
     bl_idname = "bim.rewind_brick_class"
     bl_label = "Rewind Brick Class"
     bl_options = {"REGISTER", "UNDO"}
+    split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
     def _execute(self, context):
-        core.rewind_brick_class(tool.Brick)
+        core.rewind_brick_class(tool.Brick, split_screen=self.split_screen)
 
 
 class CloseBrickProject(bpy.types.Operator, Operator):
@@ -205,9 +208,10 @@ class RefreshBrickViewer(bpy.types.Operator, Operator):
     bl_idname = "bim.refresh_brick_viewer"
     bl_label = "Refresh Brick Viewer"
     bl_options = {"REGISTER", "UNDO"}
+    split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
     def _execute(self, context):
-        core.refresh_brick_viewer(tool.Brick)
+        core.refresh_brick_viewer(tool.Brick, split_screen=self.split_screen)
 
 
 class RemoveBrick(bpy.types.Operator, Operator):
@@ -268,10 +272,14 @@ class SetBrickListRoot(bpy.types.Operator, Operator):
     bl_idname = "bim.set_brick_list_root"
     bl_label = "Set Brick View Type"
     bl_options = {"REGISTER", "UNDO"}
+    split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
     def _execute(self, context):
-        root = context.scene.BIMBrickProperties.brick_list_root
-        core.set_brick_list_root(tool.Brick, brick_root=root)
+        if self.split_screen:
+            root = context.scene.BIMBrickProperties.split_screen_brick_list_root
+        else:
+            root = context.scene.BIMBrickProperties.brick_list_root
+        core.set_brick_list_root(tool.Brick, brick_root=root, split_screen=self.split_screen)
 
 
 class RemoveBrickRelation(bpy.types.Operator, Operator):

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with BlenderBIM Add-on.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import bpy
 import ifcopenshell.api
 import blenderbim.tool as tool
@@ -40,8 +41,11 @@ class LoadBrickProject(bpy.types.Operator, Operator):
     filter_glob: bpy.props.StringProperty(default="*.ttl", options={"HIDDEN"})
 
     def _execute(self, context):
-        root = context.scene.BIMBrickProperties.brick_list_root
-        core.load_brick_project(tool.Brick, filepath=self.filepath, brick_root=root)
+        if os.path.exists(self.filepath) and "ttl" in os.path.splitext(self.filepath)[1].lower():
+            root = context.scene.BIMBrickProperties.brick_list_root
+            core.load_brick_project(tool.Brick, filepath=self.filepath, brick_root=root)
+        else:
+            self.report({'ERROR'}, f'Failed to load {self.filepath}')
 
     def invoke(self, context, event):
         context.window_manager.fileselect_add(self)

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -144,12 +144,15 @@ class AddBrickRelation(bpy.types.Operator, Operator):
     def _execute(self, context):
         props = context.scene.BIMBrickProperties
         brick = props.bricks[props.active_brick_index]
+        if props.new_brick_relation_type == "http://www.w3.org/2000/01/rdf-schema#label":
+            object = props.new_brick_relation_object
+        else: 
+            object = props.new_brick_relation_namespace + props.new_brick_relation_object
         core.add_brick_relation(
             tool.Brick,
             brick_uri=brick.uri,
             predicate=props.new_brick_relation_type,
-            namespace=props.new_brick_relation_namespace,
-            object=props.new_brick_relation_object
+            object=object
         )
 
 

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -130,7 +130,7 @@ class AddBrick(bpy.types.Operator, Operator):
             tool.Brick,
             element=tool.Ifc.get_entity(context.active_object) if context.selected_objects else None,
             namespace=props.namespace,
-            brick_class=props.brick_entity_classes,
+            brick_class=props.brick_entity_class,
             library=library,
             label=props.new_brick_label,
         )

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -264,3 +264,16 @@ class SetBrickListRoot(bpy.types.Operator, Operator):
     def _execute(self, context):
         root = context.scene.BIMBrickProperties.brick_list_root
         core.set_brick_list_root(tool.Brick, brick_root=root)
+
+
+class RemoveBrickRelation(bpy.types.Operator, Operator):
+    bl_idname = "bim.remove_brick_relation"
+    bl_label = "Remove Relation"
+    bl_options = {"REGISTER", "UNDO"}
+    predicate: bpy.props.StringProperty(name="Relation")
+    object: bpy.props.StringProperty(name="Object")
+
+    def _execute(self, context):
+        props = context.scene.BIMBrickProperties
+        brick = props.bricks[props.active_brick_index]
+        core.remove_brick_relation(tool.Brick, brick_uri=brick.uri, predicate=self.predicate, object=self.object)

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -132,19 +132,20 @@ class AddBrick(bpy.types.Operator, Operator):
         )
 
 
-class AddBrickFeed(bpy.types.Operator, Operator):
-    bl_idname = "bim.add_brick_feed"
-    bl_label = "Add Brick Feed"
+class AddBrickRelation(bpy.types.Operator, Operator):
+    bl_idname = "bim.add_brick_relation"
+    bl_label = "Add Brick Relation"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
-        source = tool.Ifc.get_entity([o for o in context.selected_objects if o != context.active_object][0])
-        destination = tool.Ifc.get_entity(context.active_object)
-        core.add_brick_feed(
-            tool.Ifc,
+        props = context.scene.BIMBrickProperties
+        brick = props.bricks[props.active_brick_index]
+        core.add_brick_relation(
             tool.Brick,
-            source=source,
-            destination=destination,
+            brick_uri=brick.uri,
+            predicate=props.new_brick_relation_type,
+            namespace=props.new_brick_relation_namespace,
+            object=props.new_brick_relation_object
         )
 
 

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -55,6 +55,18 @@ def get_brick_roots(self, context):
     return [(root, root, "") for root in BrickStore.root_classes]
 
 
+def get_brick_relations(self, context): # this will be queried from graph
+    return [("https://brickschema.org/schema/Brick#hasLocation", "hasLocation", ""),
+            ("https://brickschema.org/schema/Brick#isLocationOf", "isLocationOf", ""),
+            ("https://brickschema.org/schema/Brick#hasPart", "hasPart", ""),
+            ("https://brickschema.org/schema/Brick#isPartOf", "isPartOf", ""),
+            ("https://brickschema.org/schema/Brick#hasPoint", "hasPoint", ""),
+            ("https://brickschema.org/schema/Brick#isPointOf", "isPointOf", ""),
+            ("https://brickschema.org/schema/Brick#feeds", "feeds", ""),
+            ("https://brickschema.org/schema/Brick#isFedBy", "isFedBy", ""),
+            ("http://www.w3.org/2000/01/rdf-schema#label", "label", "")]
+
+
 class Brick(PropertyGroup):
     name: StringProperty(name="Name")
     label: StringProperty(name="Label")
@@ -78,3 +90,8 @@ class BIMBrickProperties(PropertyGroup):
     brick_entity_create_type: EnumProperty(name="Brick Entity Types", items=get_brick_roots)
     brick_create_relations_toggled: BoolProperty(name="Brick Create Relations Toggled", default=False)
     brick_edit_relations_toggled: BoolProperty(name="Brick Edit Relations Toggled", default=False)
+    new_brick_relation_type: EnumProperty(name="New Brick Relation Type", items=get_brick_relations)
+    new_brick_relation_namespace: EnumProperty(name="New Brick Relation Namespace", items=get_namespaces)
+    new_brick_relation_object: StringProperty(name="New Brick Relation Object")
+    add_relation_failed: BoolProperty(name="Add Relation Failed", default=False)
+    split_screen_toggled: BoolProperty(name="Split Screen Toggled", default=False)

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -78,6 +78,7 @@ class BIMBrickProperties(PropertyGroup):
     bricks: CollectionProperty(name="Bricks", type=Brick)
     active_brick_index: IntProperty(name="Active Brick Index", update=update_active_brick_index)
     libraries: EnumProperty(name="Libraries", items=get_libraries)
+    set_list_root_toggled: BoolProperty(name="Set List Root Toggled", default=False)
     brick_list_root: EnumProperty(name="Brick List Root", items=get_brick_roots)
     # namespace manager
     namespace: EnumProperty(name="Namespace", items=get_namespaces)

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -98,3 +98,8 @@ class BIMBrickProperties(PropertyGroup):
     add_relation_failed: BoolProperty(name="Add Relation Failed", default=False)
     # create relations split screen
     split_screen_toggled: BoolProperty(name="Split Screen Toggled", default=False)
+    split_screen_bricks: CollectionProperty(name="Split Screen Bricks", type=Brick)
+    split_screen_active_brick_index: IntProperty(name="Split Screen Active Brick Index", update=update_active_brick_index)
+    split_screen_active_brick_class: StringProperty(name="Split Screen Active Brick Class")
+    split_screen_brick_breadcrumbs: CollectionProperty(name="Split Screen Brick Breadcrumbs", type=StrProperty)
+    split_screen_brick_list_root: EnumProperty(name="Split Screen Brick List Root", items=get_brick_roots)

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -78,18 +78,22 @@ class BIMBrickProperties(PropertyGroup):
     bricks: CollectionProperty(name="Bricks", type=Brick)
     active_brick_index: IntProperty(name="Active Brick Index", update=update_active_brick_index)
     libraries: EnumProperty(name="Libraries", items=get_libraries)
+    brick_list_root: EnumProperty(name="Brick List Root", items=get_brick_roots)
+    # namespace manager
     namespace: EnumProperty(name="Namespace", items=get_namespaces)
-    brick_entity_classes: EnumProperty(name="Brick Equipment Class", items=get_brick_entity_classes)
     brick_settings_toggled: BoolProperty(name="Brick Settings Toggled", default=False)
-    new_brick_label: StringProperty(name="New Brick Label")
     new_brick_namespace_alias: StringProperty(name="New Brick Namespace Alias")
     new_brick_namespace_uri: StringProperty(name="New Brick Namespace URI")
-    brick_list_root: EnumProperty(name="Brick List Root", items=get_brick_roots)
+    # create brick entity
+    new_brick_label: StringProperty(name="New Brick Label")
     brick_entity_create_type: EnumProperty(name="Brick Entity Types", items=get_brick_roots)
+    brick_entity_class: EnumProperty(name="Brick Equipment Class", items=get_brick_entity_classes)
+    # create relations
     brick_create_relations_toggled: BoolProperty(name="Brick Create Relations Toggled", default=False)
     brick_edit_relations_toggled: BoolProperty(name="Brick Edit Relations Toggled", default=False)
     new_brick_relation_type: EnumProperty(name="New Brick Relation Type", items=get_brick_relations)
     new_brick_relation_namespace: EnumProperty(name="New Brick Relation Namespace", items=get_namespaces)
     new_brick_relation_object: StringProperty(name="New Brick Relation Object")
     add_relation_failed: BoolProperty(name="Add Relation Failed", default=False)
+    # create relations split screen
     split_screen_toggled: BoolProperty(name="Split Screen Toggled", default=False)

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -55,7 +55,13 @@ def get_brick_roots(self, context):
     return [(root, root, "") for root in BrickStore.root_classes]
 
 
-def get_brick_relations(self, context): # this will be queried from graph
+def get_brick_relations(self, context):
+    def is_label(relation):
+        return relation["predicate_name"] == "label"
+    if not list(filter(is_label, BrickschemaData.data["active_relations"])):
+        new_relations = BrickStore.relationships.copy()
+        new_relations.append(("http://www.w3.org/2000/01/rdf-schema#label", "label", ""))
+        return new_relations
     return BrickStore.relationships
 
 

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -56,15 +56,7 @@ def get_brick_roots(self, context):
 
 
 def get_brick_relations(self, context): # this will be queried from graph
-    return [("https://brickschema.org/schema/Brick#hasLocation", "hasLocation", ""),
-            ("https://brickschema.org/schema/Brick#isLocationOf", "isLocationOf", ""),
-            ("https://brickschema.org/schema/Brick#hasPart", "hasPart", ""),
-            ("https://brickschema.org/schema/Brick#isPartOf", "isPartOf", ""),
-            ("https://brickschema.org/schema/Brick#hasPoint", "hasPoint", ""),
-            ("https://brickschema.org/schema/Brick#isPointOf", "isPointOf", ""),
-            ("https://brickschema.org/schema/Brick#feeds", "feeds", ""),
-            ("https://brickschema.org/schema/Brick#isFedBy", "isFedBy", ""),
-            ("http://www.w3.org/2000/01/rdf-schema#label", "label", "")]
+    return BrickStore.relationships
 
 
 class Brick(PropertyGroup):

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -76,3 +76,5 @@ class BIMBrickProperties(PropertyGroup):
     new_brick_namespace_uri: StringProperty(name="New Brick Namespace URI")
     brick_list_root: EnumProperty(name="Brick List Root", items=get_brick_roots)
     brick_entity_create_type: EnumProperty(name="Brick Entity Types", items=get_brick_roots)
+    brick_create_relations_toggled: BoolProperty(name="Brick Create Relations Toggled", default=False)
+    brick_edit_relations_toggled: BoolProperty(name="Brick Edit Relations Toggled", default=False)

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -76,10 +76,6 @@ class BIM_PT_brickschema(Panel):
             row.prop(data=self.props, property="new_brick_namespace_uri", text="")
             row.operator("bim.add_brick_namespace", text="", icon="ADD")
 
-            row = box.row(align=True)
-            row.operator("bim.set_brick_list_root", text="Set View")
-            row.prop(data=self.props, property="brick_list_root", text="")
-
         row = self.layout.row(align=True)
         row.label(text="Create Entity:")
 
@@ -103,6 +99,12 @@ class BIM_PT_brickschema(Panel):
 
         row = self.layout.row(align=True)
         row.label(text=self.props.active_brick_class)
+        row.prop(data=self.props, property="set_list_root_toggled", text="", icon="OUTLINER")
+
+        if self.props.set_list_root_toggled:
+            row = self.layout.row(align=True)
+            row.operator("bim.set_brick_list_root", text="Set View")
+            row.prop(data=self.props, property="brick_list_root", text="")
 
         self.layout.template_list("BIM_UL_bricks", "", self.props, "bricks", self.props, "active_brick_index")
 

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -88,7 +88,7 @@ class BIM_PT_brickschema(Panel):
 
         row = self.layout.row(align=True)
         row.prop(data=self.props, property="new_brick_label", text="")
-        prop_with_search(row, self.props, "brick_entity_classes", text="")
+        prop_with_search(row, self.props, "brick_entity_class", text="")
         row.operator("bim.add_brick", text="", icon="ADD")
 
         row = self.layout.row(align=True)

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -122,8 +122,9 @@ class BIM_PT_brickschema(Panel):
                 col.alignment = "RIGHT"
                 row.prop(data=self.props, property="split_screen_toggled", text="", icon="WINDOW")
 
-                row = self.layout.row(align=True)
-                prop_with_search(row, self.props, "new_brick_relation_namespace", text="")
+                if not self.props.new_brick_relation_type == "http://www.w3.org/2000/01/rdf-schema#label":
+                    row = self.layout.row(align=True)
+                    prop_with_search(row, self.props, "new_brick_relation_namespace", text="")
 
                 row = self.layout.row(align=True)
                 prop_with_search(row, self.props, "new_brick_relation_type", text="")

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -104,7 +104,8 @@ class BIM_PT_brickschema(Panel):
 
         if self.props.set_list_root_toggled:
             row = grid1.row(align=True)
-            row.operator("bim.set_brick_list_root", text="Set View")
+            op = row.operator("bim.set_brick_list_root", text="Set View")
+            op.split_screen = False
             row.prop(data=self.props, property="brick_list_root", text="")
 
         row = grid1.row()
@@ -137,22 +138,39 @@ class BIM_PT_brickschema(Panel):
             row.prop(data=self.props, property="brick_edit_relations_toggled", text="", icon="TOOL_SETTINGS")
             row.operator("bim.remove_brick", text="", icon="X")
 
-            if self.props.brick_create_relations_toggled:
-                row = self.layout.row(align=True)
-                row.label(text="Create Relation:")
+            row = self.layout.row(align=True)
+            row.label(text="Create Relation:")
 
-                if not self.props.new_brick_relation_type == "http://www.w3.org/2000/01/rdf-schema#label":
-                    row = self.layout.row(align=True)
-                    prop_with_search(row, self.props, "new_brick_relation_namespace", text="")
-
+            if self.props.brick_create_relations_toggled and self.props.new_brick_relation_type == "http://www.w3.org/2000/01/rdf-schema#label":
                 row = self.layout.row(align=True)
                 prop_with_search(row, self.props, "new_brick_relation_type", text="")
                 row.prop(data=self.props, property="new_brick_relation_object", text="")
                 row.operator("bim.add_brick_relation", text="", icon="ADD")
 
-                if self.props.add_relation_failed:
-                    row = self.layout.row(align=True)
-                    row.label(text="Failed to find this entity!", icon="ERROR")
+            elif self.props.brick_create_relations_toggled and self.props.split_screen_toggled:
+                row = self.layout.row(align=True)
+                split_screen_selection = self.props.split_screen_bricks[self.props.split_screen_active_brick_index]
+                if split_screen_selection.total_items:
+                    row.label(text="No selection", icon="INFO")
+                else:
+                    prop_with_search(row, self.props, "new_brick_relation_type", text="")
+                    row.label(text=split_screen_selection.label if split_screen_selection.label else split_screen_selection.name)
+                    row.operator("bim.add_brick_relation", text="", icon="ADD")
+
+            elif self.props.brick_create_relations_toggled: 
+                row = self.layout.row(align=True)
+                prop_with_search(row, self.props, "new_brick_relation_namespace", text="")
+
+                row = self.layout.row(align=True)
+                prop_with_search(row, self.props, "new_brick_relation_type", text="")
+                row.prop(data=self.props, property="new_brick_relation_object", text="")
+                row.operator("bim.add_brick_relation", text="", icon="ADD")
+            
+
+            if self.props.brick_create_relations_toggled and self.props.add_relation_failed:
+                row = self.layout.row(align=True)
+                row.label(text="Failed to find this entity!", icon="ERROR")
+                
 
         for relation in BrickschemaData.data["active_relations"]:
             row = self.layout.row(align=True)

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -107,16 +107,27 @@ class BIM_PT_brickschema(Panel):
 
         self.layout.template_list("BIM_UL_bricks", "", self.props, "bricks", self.props, "active_brick_index")
 
+        if BrickschemaData.data["relations"]:
+            row = self.layout.row(align=True)
+            col = row.column()
+            col.alignment = "RIGHT"
+            row.prop(data=self.props, property="brick_create_relations_toggled", text="", icon="OUTLINER_DATA_GP_LAYER")
+            row.prop(data=self.props, property="brick_edit_relations_toggled", text="", icon="TOOL_SETTINGS")
+
         for relation in BrickschemaData.data["relations"]:
             row = self.layout.row(align=True)
-            row.label(text=relation["predicate"])
-            row.label(text=relation["object"])
-            if relation["is_uri"]:
+            row.label(text=relation["predicate_name"])
+            row.label(text=relation["object_name"])
+            if self.props.brick_edit_relations_toggled and relation["predicate_name"] != "type":
+                op = row.operator("bim.remove_brick_relation", text="", icon="UNLINKED")
+                op.predicate = relation["predicate"]
+                op.object = relation["object"]
+            if relation["is_uri"] and relation["predicate_name"] != "type":
                 op = row.operator("bim.view_brick_item", text="", icon="DISCLOSURE_TRI_RIGHT")
                 op.item = relation["object_uri"]
             if relation["is_globalid"]:
                 op = row.operator("bim.select_global_id", icon="RESTRICT_SELECT_OFF", text="")
-                op.global_id = relation["object"]
+                op.global_id = relation["object_name"]
 
 
 class BIM_PT_ifc_brickschema_references(Panel):

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -107,16 +107,16 @@ class BIM_PT_brickschema(Panel):
 
         self.layout.template_list("BIM_UL_bricks", "", self.props, "bricks", self.props, "active_brick_index")
 
-        for attribute in BrickschemaData.data["attributes"]:
+        for relation in BrickschemaData.data["relations"]:
             row = self.layout.row(align=True)
-            row.label(text=attribute["predicate"])
-            row.label(text=attribute["object"])
-            if attribute["is_uri"]:
+            row.label(text=relation["predicate"])
+            row.label(text=relation["object"])
+            if relation["is_uri"]:
                 op = row.operator("bim.view_brick_item", text="", icon="DISCLOSURE_TRI_RIGHT")
-                op.item = attribute["object_uri"]
-            if attribute["is_globalid"]:
+                op.item = relation["object_uri"]
+            if relation["is_globalid"]:
                 op = row.operator("bim.select_global_id", icon="RESTRICT_SELECT_OFF", text="")
-                op.global_id = attribute["object"]
+                op.global_id = relation["object"]
 
 
 class BIM_PT_ifc_brickschema_references(Panel):

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -98,7 +98,6 @@ class BIM_PT_brickschema(Panel):
             row.operator("bim.rewind_brick_class", text="", icon="FRAME_PREV")
         col = row.column()
         col.alignment = "RIGHT"
-        # row.operator("bim.add_brick_feed", text="", icon="PLUGIN")
         row.operator("bim.remove_brick", text="", icon="X")
         # row.operator("bim.refresh_brick_viewer", text="", icon="FILE_REFRESH")
 
@@ -111,8 +110,29 @@ class BIM_PT_brickschema(Panel):
             row = self.layout.row(align=True)
             col = row.column()
             col.alignment = "RIGHT"
-            row.prop(data=self.props, property="brick_create_relations_toggled", text="", icon="OUTLINER_DATA_GP_LAYER")
+            row.prop(data=self.props, property="brick_create_relations_toggled", text="", icon="PLUGIN")
             row.prop(data=self.props, property="brick_edit_relations_toggled", text="", icon="TOOL_SETTINGS")
+            
+            if self.props.brick_create_relations_toggled:
+                row = self.layout.row(align=True)
+                col = row.column()
+                col.alignment = "LEFT"
+                row.label(text="Create Relation:")
+                col = row.column()
+                col.alignment = "RIGHT"
+                row.prop(data=self.props, property="split_screen_toggled", text="", icon="WINDOW")
+
+                row = self.layout.row(align=True)
+                prop_with_search(row, self.props, "new_brick_relation_namespace", text="")
+
+                row = self.layout.row(align=True)
+                prop_with_search(row, self.props, "new_brick_relation_type", text="")
+                row.prop(data=self.props, property="new_brick_relation_object", text="")
+                row.operator("bim.add_brick_relation", text="", icon="ADD")
+
+                if self.props.add_relation_failed:
+                    row = self.layout.row(align=True)
+                    row.label(text="Failed to find this entity!", icon="ERROR")
 
         for relation in BrickschemaData.data["relations"]:
             row = self.layout.row(align=True)

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -106,7 +106,7 @@ class BIM_PT_brickschema(Panel):
 
         self.layout.template_list("BIM_UL_bricks", "", self.props, "bricks", self.props, "active_brick_index")
 
-        if BrickschemaData.data["relations"]:
+        if BrickschemaData.data["active_relations"]:
             row = self.layout.row(align=True)
             col = row.column()
             col.alignment = "RIGHT"
@@ -134,7 +134,7 @@ class BIM_PT_brickschema(Panel):
                     row = self.layout.row(align=True)
                     row.label(text="Failed to find this entity!", icon="ERROR")
 
-        for relation in BrickschemaData.data["relations"]:
+        for relation in BrickschemaData.data["active_relations"]:
             row = self.layout.row(align=True)
             row.label(text=relation["predicate_name"])
             row.label(text=relation["object_name"])

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -78,8 +78,8 @@ def add_brick(ifc, brick, element=None, namespace=None, brick_class=None, librar
     brick.run_refresh_brick_viewer()
 
 
-def add_brick_feed(ifc, brick, source=None, destination=None):
-    brick.add_feed(brick.get_brick(source), brick.get_brick(destination))
+def add_brick_relation(brick, brick_uri=None, predicate=None, namespace=None, object=None):
+    brick.add_relation(brick_uri, predicate, namespace, object)
     brick.run_refresh_brick_viewer()
 
 

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -78,8 +78,8 @@ def add_brick(ifc, brick, element=None, namespace=None, brick_class=None, librar
     brick.run_refresh_brick_viewer()
 
 
-def add_brick_relation(brick, brick_uri=None, predicate=None, namespace=None, object=None):
-    brick.add_relation(brick_uri, predicate, namespace, object)
+def add_brick_relation(brick, brick_uri=None, predicate=None, object=None):
+    brick.add_relation(brick_uri, predicate, object)
     brick.run_refresh_brick_viewer()
 
 

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -126,3 +126,7 @@ def set_brick_list_root(brick, brick_root=None):
     brick.set_active_brick_class(brick_root)
     brick.clear_breadcrumbs()
 
+
+def remove_brick_relation(brick, brick_uri=None, predicate=None, object=None):
+    brick.remove_relation(brick_uri, predicate, object)
+    brick.run_refresh_brick_viewer()

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -20,34 +20,37 @@
 def load_brick_project(brick, filepath=None, brick_root=None):
     brick.load_brick_file(filepath)
     brick.import_brick_classes(brick_root)
+    brick.import_brick_classes(brick_root, split_screen=True)
     brick.set_active_brick_class(brick_root)
+    brick.set_active_brick_class(brick_root, split_screen=True)
 
 
-def view_brick_class(brick, brick_class=None):
-    brick.add_brick_breadcrumb()
-    brick.clear_brick_browser()
-    brick.import_brick_classes(brick_class)
-    brick.import_brick_items(brick_class)
-    brick.set_active_brick_class(brick_class)
+def view_brick_class(brick, brick_class=None, split_screen=False):
+    brick.add_brick_breadcrumb(split_screen=split_screen)
+    brick.clear_brick_browser(split_screen=split_screen)
+    brick.import_brick_classes(brick_class, split_screen=split_screen)
+    brick.import_brick_items(brick_class, split_screen=split_screen)
+    brick.set_active_brick_class(brick_class, split_screen=split_screen)
 
 
-def view_brick_item(brick, item=None):
+def view_brick_item(brick, item=None, split_screen=False):
     brick_class = brick.get_item_class(item)
-    view_brick_class(brick, brick_class=brick_class)
-    brick.select_browser_item(item)
+    view_brick_class(brick, brick_class=brick_class, split_screen=split_screen)
+    brick.select_browser_item(item, split_screen=split_screen)
 
 
-def rewind_brick_class(brick):
-    previous_class = brick.pop_brick_breadcrumb()
-    brick.clear_brick_browser()
-    brick.import_brick_classes(previous_class)
-    brick.import_brick_items(previous_class)
-    brick.set_active_brick_class(previous_class)
+def rewind_brick_class(brick, split_screen=False):
+    previous_class = brick.pop_brick_breadcrumb(split_screen=split_screen)
+    brick.clear_brick_browser(split_screen=split_screen)
+    brick.import_brick_classes(previous_class, split_screen=split_screen)
+    brick.import_brick_items(previous_class, split_screen=split_screen)
+    brick.set_active_brick_class(previous_class, split_screen=split_screen)
 
 
 def close_brick_project(brick):
     brick.clear_project()
     brick.clear_brick_browser()
+    brick.clear_brick_browser(split_screen=True)
 
 
 def convert_brick_project(ifc, brick):
@@ -76,11 +79,13 @@ def add_brick(ifc, brick, element=None, namespace=None, brick_class=None, librar
     else:
         brick_uri = brick.add_brick(namespace, brick_class, label)
     brick.run_refresh_brick_viewer()
+    brick.run_refresh_brick_viewer(split_screen=True)
 
 
 def add_brick_relation(brick, brick_uri=None, predicate=None, object=None):
     brick.add_relation(brick_uri, predicate, object)
     brick.run_refresh_brick_viewer()
+    brick.run_refresh_brick_viewer(split_screen=True)
 
 
 def convert_ifc_to_brick(brick, namespace=None, library=None):
@@ -95,12 +100,17 @@ def convert_ifc_to_brick(brick, namespace=None, library=None):
 def new_brick_file(brick, brick_root=None):
     brick.new_brick_file()
     brick.import_brick_classes(brick_root)
+    brick.import_brick_classes(brick_root, split_screen=True)
     brick.set_active_brick_class(brick_root)
+    brick.set_active_brick_class(brick_root, split_screen=True)
 
 
-def refresh_brick_viewer(brick):
-    brick.run_view_brick_class(brick_class=brick.get_active_brick_class())
-    brick.pop_brick_breadcrumb()
+def refresh_brick_viewer(brick, split_screen=False):
+    if split_screen:
+        brick.run_view_brick_class(brick_class=brick.get_active_brick_class(split_screen=split_screen), split_screen=split_screen)
+    else:
+        brick.run_view_brick_class(brick_class=brick.get_active_brick_class(), split_screen=split_screen)
+    brick.pop_brick_breadcrumb(split_screen=split_screen)
 
 
 def remove_brick(ifc, brick, library=None, brick_uri=None):
@@ -110,6 +120,7 @@ def remove_brick(ifc, brick, library=None, brick_uri=None):
             ifc.run("library.remove_reference", reference=reference)
     brick.remove_brick(brick_uri)
     brick.run_refresh_brick_viewer()
+    brick.run_refresh_brick_viewer(split_screen=True)
 
 
 def serialize_brick(brick):
@@ -120,11 +131,11 @@ def add_namespace(brick, alias=None, uri=None):
     brick.add_namespace(alias, uri)
 
 
-def set_brick_list_root(brick, brick_root=None):
-    brick.clear_brick_browser()
-    brick.import_brick_classes(brick_root)
-    brick.set_active_brick_class(brick_root)
-    brick.clear_breadcrumbs()
+def set_brick_list_root(brick, brick_root=None, split_screen=False):
+    brick.clear_brick_browser(split_screen=split_screen)
+    brick.import_brick_classes(brick_root, split_screen=split_screen)
+    brick.set_active_brick_class(brick_root, split_screen=split_screen)
+    brick.clear_breadcrumbs(split_screen=split_screen)
 
 
 def remove_brick_relation(brick, brick_uri=None, predicate=None, object=None):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -286,6 +286,7 @@ class Brick(blenderbim.core.tool.Brick):
         BrickStore.path = filepath
         BrickStore.load_namespaces()
         BrickStore.load_entity_classes()
+        BrickStore.load_relationships()
 
     @classmethod
     def new_brick_file(cls):
@@ -298,6 +299,7 @@ class Brick(blenderbim.core.tool.Brick):
         BrickStore.graph.bind("digitaltwin", Namespace("https://example.org/digitaltwin#"))
         BrickStore.load_namespaces()
         BrickStore.load_entity_classes()
+        BrickStore.load_relationships()
 
     @classmethod
     def pop_brick_breadcrumb(cls):
@@ -363,6 +365,7 @@ class BrickStore:
     namespaces = []
     root_classes = ["Equipment", "Location", "System", "Point"]
     entity_classes = {}
+    relationships = []
 
     @staticmethod
     def purge():
@@ -371,6 +374,7 @@ class BrickStore:
         BrickStore.path = None
         BrickStore.namespaces = []
         BrickStore.entity_classes = {}
+        BrickStore.relationships = []
 
     @classmethod
     def get_project(cls):
@@ -406,6 +410,20 @@ class BrickStore:
             BrickStore.entity_classes[root_class] = []
             for uri in sorted([x[0].toPython() for x in query]):
                 BrickStore.entity_classes[root_class].append((uri, uri.split("#")[-1], ""))
+
+    @classmethod
+    def load_relationships(cls):
+        query = BrickStore.graph.query(
+            """
+            PREFIX brick: <https://brickschema.org/schema/Brick#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+            SELECT DISTINCT ?relation WHERE {
+                ?relation rdfs:subPropertyOf brick:Relationship .
+            }
+            """
+        )
+        for uri in sorted([x[0].toPython() for x in query]):
+            BrickStore.relationships.append((uri, uri.split("#")[-1], ""))
 
     @classmethod
     def set_history_size(cls, size):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -101,6 +101,12 @@ class Brick(blenderbim.core.tool.Brick):
 
     @classmethod
     def add_relation(cls, brick_uri, predicate, namespace, object):
+        if predicate == "http://www.w3.org/2000/01/rdf-schema#label":
+            with BrickStore.new_changeset() as cs:
+                cs.add((URIRef(brick_uri), URIRef(predicate), Literal(object)))
+            bpy.context.scene.BIMBrickProperties.new_brick_relation_type = BrickStore.relationships[0][0]
+            bpy.context.scene.BIMBrickProperties.add_relation_failed = False
+            return
         object_uri = namespace + object
         query = BrickStore.graph.query(
             "ASK { <{object_uri}> ?predicate ?object . }".replace(

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -100,22 +100,21 @@ class Brick(blenderbim.core.tool.Brick):
         )
 
     @classmethod
-    def add_relation(cls, brick_uri, predicate, namespace, object):
+    def add_relation(cls, brick_uri, predicate, object):
         if predicate == "http://www.w3.org/2000/01/rdf-schema#label":
             with BrickStore.new_changeset() as cs:
                 cs.add((URIRef(brick_uri), URIRef(predicate), Literal(object)))
             bpy.context.scene.BIMBrickProperties.new_brick_relation_type = BrickStore.relationships[0][0]
             bpy.context.scene.BIMBrickProperties.add_relation_failed = False
             return
-        object_uri = namespace + object
         query = BrickStore.graph.query(
-            "ASK { <{object_uri}> ?predicate ?object . }".replace(
-                "{object_uri}", object_uri
+            "ASK { <{object_uri}> a ?o . }".replace(
+                "{object_uri}", object
             )
         )
         if query:
             with BrickStore.new_changeset() as cs:
-                cs.add((URIRef(brick_uri), URIRef(predicate), URIRef(object_uri)))
+                cs.add((URIRef(brick_uri), URIRef(predicate), URIRef(object)))
             bpy.context.scene.BIMBrickProperties.add_relation_failed = False
         else:
             bpy.context.scene.BIMBrickProperties.add_relation_failed = True

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -100,9 +100,19 @@ class Brick(blenderbim.core.tool.Brick):
         )
 
     @classmethod
-    def add_feed(cls, source, destination):
-        ns_brick = Namespace("https://brickschema.org/schema/Brick#")
-        BrickStore.graph.add((URIRef(source), ns_brick["feeds"], URIRef(destination)))
+    def add_relation(cls, brick_uri, predicate, namespace, object):
+        object_uri = namespace + object
+        query = BrickStore.graph.query(
+            "ASK { <{object_uri}> ?predicate ?object . }".replace(
+                "{object_uri}", object_uri
+            )
+        )
+        if query:
+            with BrickStore.new_changeset() as cs:
+                cs.add((URIRef(brick_uri), URIRef(predicate), URIRef(object_uri)))
+            bpy.context.scene.BIMBrickProperties.add_relation_failed = False
+        else:
+            bpy.context.scene.BIMBrickProperties.add_relation_failed = True
 
     @classmethod
     def remove_relation(cls, brick_uri, predicate, object):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -105,6 +105,13 @@ class Brick(blenderbim.core.tool.Brick):
         BrickStore.graph.add((URIRef(source), ns_brick["feeds"], URIRef(destination)))
 
     @classmethod
+    def remove_relation(cls, brick_uri, predicate, object):
+        if BrickStore.graph.triples((brick_uri, predicate, object)):
+            with BrickStore.new_changeset() as cs:
+                for triple in BrickStore.graph.triples((brick_uri, predicate, object)):
+                    cs.remove(triple)
+
+    @classmethod
     def clear_brick_browser(cls):
         bpy.context.scene.BIMBrickProperties.bricks.clear()
 

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -368,7 +368,12 @@ class BrickStore:
     current_changesets = 0
     history_size = 64
     namespaces = []
-    root_classes = ["Equipment", "Location", "System", "Point"]
+    root_classes = ["Equipment",
+                        "Electrical_Equipment", "Fire_Safety_Equipment", "HVAC_Equipment", "Lighting_Equipment", "Meter", 
+                    "Location",
+                    "System",
+                    "Point", 
+                        "Alarm", "Command", "Parameter", "Sensor", "Setpoint", "Status"]
     entity_classes = {}
     relationships = []
 

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -116,10 +116,9 @@ class Brick(blenderbim.core.tool.Brick):
 
     @classmethod
     def remove_relation(cls, brick_uri, predicate, object):
-        if BrickStore.graph.triples((brick_uri, predicate, object)):
-            with BrickStore.new_changeset() as cs:
-                for triple in BrickStore.graph.triples((brick_uri, predicate, object)):
-                    cs.remove(triple)
+        with BrickStore.new_changeset() as cs:
+            for triple in BrickStore.graph.triples((brick_uri, predicate, object)):
+                cs.remove(triple)
 
     @classmethod
     def clear_brick_browser(cls):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -375,7 +375,6 @@ class BrickStore:
 
     @classmethod
     def load_entity_classes(cls):
-        
         for root_class in BrickStore.root_classes:
             query = BrickStore.graph.query(
                 """


### PR DESCRIPTION
- renamed “attributes” to “relations”
- create operator to remove relations
- create split screen with its own data
- add an `os.path.exists` check for loading in Brick projects
- create relation operator
    - one special case where the relation is `rdfs:label`
    - one case where we are using a split screen
    - base case where the split screen is disabled and info needs to be added manually
 - added more roots to Brick "roots" Enum list. (May want to make this a query in the future)