### PR TITLE
Brickschema interface PR #5

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/brick/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/__init__.py
@@ -35,7 +35,6 @@ classes = (
     operator.ViewBrickItem,
     operator.SerializeBrick,
     operator.AddBrickNamespace,
-    operator.SetBrickListRoot,
     operator.RemoveBrickRelation,
     prop.Brick,
     prop.BIMBrickProperties,

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -270,20 +270,6 @@ class AddBrickNamespace(bpy.types.Operator, Operator):
         core.add_namespace(tool.Brick, alias=alias, uri=uri)
 
 
-class SetBrickListRoot(bpy.types.Operator, Operator):
-    bl_idname = "bim.set_brick_list_root"
-    bl_label = "Set Brick View Type"
-    bl_options = {"REGISTER", "UNDO"}
-    split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
-
-    def _execute(self, context):
-        if self.split_screen:
-            root = context.scene.BIMBrickProperties.split_screen_brick_list_root
-        else:
-            root = context.scene.BIMBrickProperties.brick_list_root
-        core.set_brick_list_root(tool.Brick, brick_root=root, split_screen=self.split_screen)
-
-
 class RemoveBrickRelation(bpy.types.Operator, Operator):
     bl_idname = "bim.remove_brick_relation"
     bl_label = "Remove Relation"

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -37,6 +37,7 @@ class LoadBrickProject(bpy.types.Operator, Operator):
     bl_idname = "bim.load_brick_project"
     bl_label = "Load Brickschema Project"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Load in a Brick project from a file"
     filepath: bpy.props.StringProperty(subtype="FILE_PATH")
     filter_glob: bpy.props.StringProperty(default="*.ttl", options={"HIDDEN"})
 
@@ -56,6 +57,7 @@ class ViewBrickClass(bpy.types.Operator, Operator):
     bl_idname = "bim.view_brick_class"
     bl_label = "View Brick Class"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Inspect the subclasses of this class"
     brick_class: bpy.props.StringProperty(name="Brick Class")
     split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
@@ -67,6 +69,7 @@ class ViewBrickItem(bpy.types.Operator, Operator):
     bl_idname = "bim.view_brick_item"
     bl_label = "View Brick Item"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Inspect this entity in the viewer"
     item: bpy.props.StringProperty(name="Brick Item")
     split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
@@ -78,6 +81,7 @@ class RewindBrickClass(bpy.types.Operator, Operator):
     bl_idname = "bim.rewind_brick_class"
     bl_label = "Rewind Brick Class"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Go back to the previous list view"
     split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
     def _execute(self, context):
@@ -88,6 +92,7 @@ class CloseBrickProject(bpy.types.Operator, Operator):
     bl_idname = "bim.close_brick_project"
     bl_label = "Close Brick Project"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Close the Brick project"
 
     def _execute(self, context):
         core.close_brick_project(tool.Brick)
@@ -122,6 +127,7 @@ class AddBrick(bpy.types.Operator, Operator):
     bl_idname = "bim.add_brick"
     bl_label = "Add Brick"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Create the Brick entity"
 
     def _execute(self, context):
         props = context.scene.BIMBrickProperties
@@ -143,6 +149,7 @@ class AddBrickRelation(bpy.types.Operator, Operator):
     bl_idname = "bim.add_brick_relation"
     bl_label = "Add Brick Relation"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Create the Brick relationship"
 
     def _execute(self, context):
         props = context.scene.BIMBrickProperties
@@ -178,6 +185,7 @@ class NewBrickFile(bpy.types.Operator):
     bl_idname = "bim.new_brick_file"
     bl_label = "New Brick File"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Create a Brick project from scratch"
 
     def execute(self, context):
         IfcStore.begin_transaction(self)
@@ -210,6 +218,7 @@ class RefreshBrickViewer(bpy.types.Operator, Operator):
     bl_idname = "bim.refresh_brick_viewer"
     bl_label = "Refresh Brick Viewer"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Refresh the list view"
     split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
     def _execute(self, context):
@@ -220,6 +229,7 @@ class RemoveBrick(bpy.types.Operator, Operator):
     bl_idname = "bim.remove_brick"
     bl_label = "Remove Brick"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Delete this entity"
 
     def _execute(self, context):
         props = context.scene.BIMBrickProperties
@@ -262,6 +272,7 @@ class SerializeBrick(bpy.types.Operator):
 class AddBrickNamespace(bpy.types.Operator, Operator):
     bl_idname = "bim.add_brick_namespace"
     bl_label = "Add Brick Namespace"
+    bl_description = "Bind a new namespace to the Brick project"
 
     def _execute(self, context):
         props = context.scene.BIMBrickProperties
@@ -274,6 +285,7 @@ class RemoveBrickRelation(bpy.types.Operator, Operator):
     bl_idname = "bim.remove_brick_relation"
     bl_label = "Remove Relation"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Delete this relationship"
     predicate: bpy.props.StringProperty(name="Relation")
     object: bpy.props.StringProperty(name="Object")
 

--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -219,10 +219,10 @@ class RefreshBrickViewer(bpy.types.Operator, Operator):
     bl_label = "Refresh Brick Viewer"
     bl_options = {"REGISTER", "UNDO"}
     bl_description = "Refresh the list view"
-    split_screen: bpy.props.BoolProperty(name="Split Screen", default=False, options={"HIDDEN"})
 
     def _execute(self, context):
-        core.refresh_brick_viewer(tool.Brick, split_screen=self.split_screen)
+        core.refresh_brick_viewer(tool.Brick)
+        core.refresh_brick_viewer(tool.Brick, split_screen=True)
 
 
 class RemoveBrick(bpy.types.Operator, Operator):

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -30,6 +30,8 @@ from bpy.props import (
     FloatVectorProperty,
     CollectionProperty,
 )
+import blenderbim.core.brick as core
+import blenderbim.tool.brick as tool
 from blenderbim.tool.brick import BrickStore
 
 def update_active_brick_index(self, context):
@@ -65,6 +67,15 @@ def get_brick_relations(self, context):
     return BrickStore.relationships
 
 
+def update_view(self, context):
+    root = context.scene.BIMBrickProperties.brick_list_root
+    core.set_brick_list_root(tool.Brick, brick_root=root, split_screen=False)
+
+def split_screen_update_view(self, context):
+    root = context.scene.BIMBrickProperties.split_screen_brick_list_root
+    core.set_brick_list_root(tool.Brick, brick_root=root, split_screen=True)
+
+
 class Brick(PropertyGroup):
     name: StringProperty(name="Name")
     label: StringProperty(name="Label")
@@ -79,7 +90,7 @@ class BIMBrickProperties(PropertyGroup):
     active_brick_index: IntProperty(name="Active Brick Index", update=update_active_brick_index)
     libraries: EnumProperty(name="Libraries", items=get_libraries)
     set_list_root_toggled: BoolProperty(name="Set List Root Toggled", default=False)
-    brick_list_root: EnumProperty(name="Brick List Root", items=get_brick_roots)
+    brick_list_root: EnumProperty(name="Brick List Root", items=get_brick_roots, update=update_view)
     # namespace manager
     namespace: EnumProperty(name="Namespace", items=get_namespaces)
     brick_settings_toggled: BoolProperty(name="Brick Settings Toggled", default=False)
@@ -102,4 +113,4 @@ class BIMBrickProperties(PropertyGroup):
     split_screen_active_brick_index: IntProperty(name="Split Screen Active Brick Index", update=update_active_brick_index)
     split_screen_active_brick_class: StringProperty(name="Split Screen Active Brick Class")
     split_screen_brick_breadcrumbs: CollectionProperty(name="Split Screen Brick Breadcrumbs", type=StrProperty)
-    split_screen_brick_list_root: EnumProperty(name="Split Screen Brick List Root", items=get_brick_roots)
+    split_screen_brick_list_root: EnumProperty(name="Split Screen Brick List Root", items=get_brick_roots, update=split_screen_update_view)

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -42,9 +42,17 @@ class BIM_PT_brickschema(Panel):
             row.operator("bim.load_brick_project", text="Load Project")
             return
 
+        row = self.layout.row(align=True)
         if BrickStore.path:
-            row = self.layout.row(align=True)
             row.label(text=BrickStore.path, icon="FILEBROWSER")
+        else:
+            row.label(text="No file", icon="FILEBROWSER")
+        
+        row = self.layout.row(align=True)
+        if BrickStore.last_saved:
+            row.label(text=BrickStore.last_saved, icon="TIME")
+        else:
+            row.label(text="Not saved", icon="TIME")
 
         row = self.layout.row(align=True)
         op = row.operator("bim.serialize_brick", icon="EXPORT", text="Save")
@@ -55,7 +63,7 @@ class BIM_PT_brickschema(Panel):
 
         row = self.layout.row(align=True)
         row.prop(data=self.props, property="brick_settings_toggled", text="", icon="PREFERENCES")
-        
+
         if self.props.brick_settings_toggled:
             box = self.layout.box()
             row = box.row(align=True)
@@ -86,43 +94,43 @@ class BIM_PT_brickschema(Panel):
         row.prop(data=self.props, property="new_brick_label", text="")
         prop_with_search(row, self.props, "brick_entity_class", text="")
         row.operator("bim.add_brick", text="", icon="ADD")
-        # row.operator("bim.refresh_brick_viewer", text="", icon="FILE_REFRESH")
 
         row = self.layout.row(align=True)
         col = row.column()
         col.alignment = "RIGHT"
         row.prop(data=self.props, property="set_list_root_toggled", text="", icon="OUTLINER")
         row.prop(data=self.props, property="split_screen_toggled", text="", icon="WINDOW")
+        row.operator("bim.refresh_brick_viewer", text="", icon="FILE_REFRESH")
 
         grid = self.layout.grid_flow(even_columns=True)
-        grid1 = grid.column(align=True)
-        row = grid1.row(align=True)
+        grid_left = grid.column(align=True)
+        row = grid_left.row(align=True)
         if len(self.props.brick_breadcrumbs):
             op = row.operator("bim.rewind_brick_class", text="", icon="FRAME_PREV")
             op.split_screen = False
         row.label(text=self.props.active_brick_class)
 
         if self.props.set_list_root_toggled:
-            row = grid1.row(align=True)
+            row = grid_left.row(align=True)
             row.prop(data=self.props, property="brick_list_root", text="")
 
-        row = grid1.row()
+        row = grid_left.row()
         BIM_UL_bricks.split_screen = False
         row.template_list("BIM_UL_bricks", "", self.props, "bricks", self.props, "active_brick_index")
 
         if self.props.split_screen_toggled:
-            grid2 = grid.column(align=True)
-            row = grid2.row(align=True)
+            grid_right = grid.column(align=True)
+            row = grid_right.row(align=True)
             if len(self.props.split_screen_brick_breadcrumbs):
                 op = row.operator("bim.rewind_brick_class", text="", icon="FRAME_PREV")
                 op.split_screen = True
             row.label(text=self.props.split_screen_active_brick_class)
 
             if self.props.set_list_root_toggled:
-                row = grid2.row(align=True)
+                row = grid_right.row(align=True)
                 row.prop(data=self.props, property="split_screen_brick_list_root", text="")
 
-            row = grid2.row()
+            row = grid_right.row()
             BIM_UL_bricks.split_screen = True
             row.template_list("BIM_UL_bricks", "", self.props, "split_screen_bricks", self.props, "split_screen_active_brick_index")
 
@@ -161,12 +169,10 @@ class BIM_PT_brickschema(Panel):
                 prop_with_search(row, self.props, "new_brick_relation_type", text="")
                 row.prop(data=self.props, property="new_brick_relation_object", text="")
                 row.operator("bim.add_brick_relation", text="", icon="ADD")
-            
 
             if self.props.brick_create_relations_toggled and self.props.add_relation_failed:
                 row = self.layout.row(align=True)
                 row.label(text="Failed to find this entity!", icon="ERROR")
-                
 
         for relation in BrickschemaData.data["active_relations"]:
             row = self.layout.row(align=True)

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -91,6 +91,7 @@ class BIM_PT_brickschema(Panel):
         row = self.layout.row(align=True)
         col = row.column()
         col.alignment = "RIGHT"
+        row.prop(data=self.props, property="set_list_root_toggled", text="", icon="OUTLINER")
         row.prop(data=self.props, property="split_screen_toggled", text="", icon="WINDOW")
 
         grid = self.layout.grid_flow(even_columns=True)
@@ -99,13 +100,10 @@ class BIM_PT_brickschema(Panel):
         if len(self.props.brick_breadcrumbs):
             op = row.operator("bim.rewind_brick_class", text="", icon="FRAME_PREV")
             op.split_screen = False
-        row.prop(data=self.props, property="set_list_root_toggled", text="", icon="OUTLINER")
         row.label(text=self.props.active_brick_class)
 
         if self.props.set_list_root_toggled:
             row = grid1.row(align=True)
-            op = row.operator("bim.set_brick_list_root", text="Set View")
-            op.split_screen = False
             row.prop(data=self.props, property="brick_list_root", text="")
 
         row = grid1.row()
@@ -122,8 +120,6 @@ class BIM_PT_brickschema(Panel):
 
             if self.props.set_list_root_toggled:
                 row = grid2.row(align=True)
-                op = row.operator("bim.set_brick_list_root", text="Set View")
-                op.split_screen = True
                 row.prop(data=self.props, property="split_screen_brick_list_root", text="")
 
             row = grid2.row()

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -132,9 +132,7 @@ def add_namespace(brick, alias=None, uri=None):
 
 
 def set_brick_list_root(brick, brick_root=None, split_screen=False):
-    brick.clear_brick_browser(split_screen=split_screen)
-    brick.import_brick_classes(brick_root, split_screen=split_screen)
-    brick.set_active_brick_class(brick_root, split_screen=split_screen)
+    brick.run_view_brick_class(brick_class=brick_root, split_screen=split_screen)
     brick.clear_breadcrumbs(split_screen=split_screen)
 
 

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -51,6 +51,8 @@ def close_brick_project(brick):
     brick.clear_project()
     brick.clear_brick_browser()
     brick.clear_brick_browser(split_screen=True)
+    brick.clear_breadcrumbs()
+    brick.clear_breadcrumbs(split_screen=True)
 
 
 def convert_brick_project(ifc, brick):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -340,10 +340,9 @@ class Brick(blenderbim.core.tool.Brick):
 
     @classmethod
     def remove_brick(cls, brick_uri):
-        if BrickStore.graph.triples((URIRef(brick_uri), None, None)):
-            with BrickStore.new_changeset() as cs:
-                for triple in BrickStore.graph.triples((URIRef(brick_uri), None, None)):
-                    cs.remove(triple)
+        with BrickStore.new_changeset() as cs:
+            for triple in BrickStore.graph.triples((URIRef(brick_uri), None, None)):
+                cs.remove(triple)
 
     @classmethod
     def run_assign_brick_reference(cls, element=None, library=None, brick_uri=None):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -443,8 +443,12 @@ class BrickStore:
                 """
                 PREFIX brick: <https://brickschema.org/schema/Brick#>
                 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                PREFIX owl: <http://www.w3.org/2002/07/owl#>
                 SELECT ?class WHERE {
                     ?class rdfs:subClassOf* brick:{root_class} .
+                    FILTER NOT EXISTS {
+                        ?class owl:deprecated true .
+                    } 
                 }
             """.replace(
                     "{root_class}", root_class

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -426,7 +426,7 @@ class BrickStore:
     @classmethod
     def load_namespaces(cls):
         BrickStore.namespaces = []
-        keyword_filter = ["brickschema.org", "schema.org", "w3.org", "purl.org", "rdfs.org", "qudt.org", "ashrae.org"]
+        keyword_filter = ["brickschema.org", "schema.org", "w3.org", "purl.org", "rdfs.org", "qudt.org", "ashrae.org", "usefulinc.com", "xmlns.com", "opengis.net"]
         for alias, uri in BrickStore.graph.namespaces():
             ignore_namespace = False
             for keyword in keyword_filter:


### PR DESCRIPTION
- polish UI
- add “last saved” time tracker
- filter out deprecated brick classes
- filter out all namespaces that are a result of the ontology (there may be a better way to do this)
- give operators descriptions
- bring back the refresh button
- populate subclasses of “equipment” and “points” through a query on the schema
- replace “set view” operator with an update callback function on the list root enumerator