### PR TITLE
Clone opening feature

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/model/__init__.py
+++ b/src/blenderbim/blenderbim/bim/module/model/__init__.py
@@ -78,6 +78,7 @@ classes = (
     opening.AddPotentialHalfSpaceSolid,
     opening.AddPotentialOpening,
     opening.EditOpenings,
+    opening.CloneOpening,
     opening.FlipFill,
     opening.HideBooleans,
     opening.HideOpenings,

--- a/src/blenderbim/blenderbim/bim/module/model/workspace.py
+++ b/src/blenderbim/blenderbim/bim/module/model/workspace.py
@@ -51,6 +51,7 @@ class BimTool(WorkSpaceTool):
         ("bim.hotkey", {"type": "K", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_K")]}),
         ("bim.hotkey", {"type": "M", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_M")]}),
         ("bim.hotkey", {"type": "O", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_O")]}),
+        ("bim.hotkey", {"type": "L", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_L")]}),
         ("bim.hotkey", {"type": "Q", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_Q")]}),
         ("bim.hotkey", {"type": "R", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_R")]}),
         ("bim.hotkey", {"type": "T", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_T")]}),
@@ -393,6 +394,15 @@ class BimToolUI:
             else:
                 row.operator("bim.show_openings", icon="HIDE_OFF", text="")
 
+        if AuthoringData.data["active_class"] in (
+            "IfcOpeningElement",
+        ):
+            if len(context.selected_objects) == 2:
+                row = cls.layout.row(align=True)
+                row.label(text="", icon="EVENT_SHIFT")
+                row.label(text="", icon="EVENT_L")
+                row.operator("bim.clone_opening", text="Clone Opening")
+
         cls.layout.row(align=True).label(text="Align")
         add_layout_hotkey_operator(cls.layout, "Align Exterior", "S_X", "")
         add_layout_hotkey_operator(cls.layout, "Align Centerline", "S_C", "")
@@ -725,6 +735,13 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
             self.props.x = self.x
             self.props.y = self.y
             self.props.z = self.z
+
+    def hotkey_S_L(self):
+        if AuthoringData.data["active_class"] in (
+            "IfcOpeningElement",
+        ):
+            if len(bpy.context.selected_objects) == 2:
+                bpy.ops.bim.clone_opening()
 
     def hotkey_A_D(self):
         if not bpy.context.selected_objects:


### PR DESCRIPTION
Following [this thread](https://community.osarch.org/discussion/1590/blenderbim-sharing-ifcvoids-with-different-elements) i wanted to create a new feature that allows to share the same IfcOpeningElement with different elements.
The goal is to allow the user to create a void that can be assigned to different elements.
This is useful, for example, with steel structures that has holes for bolts (think about a steel beam and a plate that can be connected together with bolts): if a hole needs to be modified, all "related" holes should be modified too.

In order to do that, assumed that it is not possible to assign the same IfcOpeningElement to different elements, i used [this tip](https://forums.buildingsmart.org/t/openings-with-multiple-hosts/1165/3) to create this "clone opening feature".
Basically, the feature creates one IfcOpeningElement for every element, but every IfcOpeningElement share the same IfcObjectPlacement and IfcProductRepresentation.
In this way, when an IfcOpeningElement is modified, every "cloned" IfcOpeningElement is modified too.

To try this feature, follow this steps:
- create two walls
- add an opening to one wall and apply it
- visualize the opening with alt+o
- select first the other wall and second the IfcOpeningElement (order is importat)
- click "clone opening" in n-panel (or ctrl+l shortcut)
- select the first wall and click "edit opening" in order to apply the opening to the first wall
- regen the second wall...et voilà!

This feature needs to be improved in order to improve the usability and so on but first i wanted to know if this could be useful or not and also if this is allowed by the IFC schema...
Thanks,
Massimo