### PR TITLE
Brick interface

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/brick/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/operator.py
@@ -233,7 +233,6 @@ class RefreshBrickViewer(bpy.types.Operator, Operator):
 
     def _execute(self, context):
         core.refresh_brick_viewer(tool.Brick)
-        core.refresh_brick_viewer(tool.Brick, split_screen=True)
 
 
 class RemoveBrick(bpy.types.Operator, Operator):
@@ -289,7 +288,7 @@ class AddBrickNamespace(bpy.types.Operator, Operator):
         props = context.scene.BIMBrickProperties
         alias = props.new_brick_namespace_alias
         uri = props.new_brick_namespace_uri
-        core.add_namespace(tool.Brick, alias=alias, uri=uri)
+        core.add_brick_namespace(tool.Brick, alias=alias, uri=uri)
 
 
 class RemoveBrickRelation(bpy.types.Operator, Operator):

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -45,12 +45,12 @@ def get_libraries(self, context):
 
 
 def get_namespaces(self, context):
-    return BrickStore.namespaces
+    return [(uri, f"{alias}: {uri}", "") for alias, uri in BrickStore.namespaces]
 
 
 def get_brick_entity_classes(self, context):
     entity = self.brick_entity_create_type
-    return BrickStore.entity_classes[entity]
+    return [(uri, uri.split("#")[-1], "") for uri in BrickStore.entity_classes[entity]]
 
 
 def get_brick_roots(self, context): 
@@ -58,12 +58,12 @@ def get_brick_roots(self, context):
 
 
 def get_brick_relations(self, context):
+    relations = [(uri, uri.split("#")[-1], "") for uri in BrickStore.relationships]
     for relation in BrickschemaData.data["active_relations"]:
         if relation["predicate_name"] == "label":
-            return BrickStore.relationships
-    new_relations = BrickStore.relationships.copy()
-    new_relations.append(("http://www.w3.org/2000/01/rdf-schema#label", "label", ""))
-    return new_relations
+            return relations
+    relations.append(("http://www.w3.org/2000/01/rdf-schema#label", "label", ""))
+    return relations
     
 
 

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -58,13 +58,13 @@ def get_brick_roots(self, context):
 
 
 def get_brick_relations(self, context):
-    def is_label(relation):
-        return relation["predicate_name"] == "label"
-    if not list(filter(is_label, BrickschemaData.data["active_relations"])):
-        new_relations = BrickStore.relationships.copy()
-        new_relations.append(("http://www.w3.org/2000/01/rdf-schema#label", "label", ""))
-        return new_relations
-    return BrickStore.relationships
+    for relation in BrickschemaData.data["active_relations"]:
+        if relation["predicate_name"] == "label":
+            return BrickStore.relationships
+    new_relations = BrickStore.relationships.copy()
+    new_relations.append(("http://www.w3.org/2000/01/rdf-schema#label", "label", ""))
+    return new_relations
+    
 
 
 def update_view(self, context):

--- a/src/blenderbim/blenderbim/bim/module/brick/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/prop.py
@@ -104,7 +104,7 @@ class BIMBrickProperties(PropertyGroup):
     brick_edit_relations_toggled: BoolProperty(name="Brick Edit Relations Toggled", default=False)
     new_brick_relation_type: EnumProperty(name="New Brick Relation Type", items=get_brick_relations)
     new_brick_relation_object: StringProperty(name="New Brick Relation Object")
-    add_relation_failed: BoolProperty(name="Add Relation Failed", default=False)
+    add_brick_relation_failed: BoolProperty(name="Add Relation Failed", default=False)
     # create relations split screen
     split_screen_toggled: BoolProperty(name="Split Screen Toggled", default=False)
     split_screen_bricks: CollectionProperty(name="Split Screen Bricks", type=Brick)

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -219,7 +219,7 @@ class BIM_PT_brickschema_viewport(Panel):
                 row.prop(data=self.props, property="new_brick_relation_object", text="")
                 row.operator("bim.add_brick_relation", text="", icon="ADD")
 
-            if self.props.brick_create_relations_toggled and self.props.add_relation_failed:
+            if self.props.brick_create_relations_toggled and self.props.add_brick_relation_failed:
                 row = self.layout.row(align=True)
                 row.label(text="Failed to find this entity!", icon="ERROR")
 

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -235,7 +235,7 @@ class BIM_PT_brickschema_viewport(Panel):
                 op = row.operator("bim.remove_brick_relation", text="", icon="UNLINKED")
                 op.predicate = relation["predicate_uri"]
                 op.object = relation["object_uri"]
-            if relation["is_uri"] and relation["object_name"] != self.props.active_brick_class:
+            if relation["is_uri"] and relation["object_uri"].toPython().split("#")[-1] != self.props.active_brick_class:
                 op = row.operator("bim.view_brick_item", text="", icon="DISCLOSURE_TRI_RIGHT")
                 op.item = relation["object_uri"]
             if relation["is_globalid"]:

--- a/src/blenderbim/blenderbim/bim/module/brick/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/brick/ui.py
@@ -205,8 +205,11 @@ class BIM_PT_brickschema_viewport(Panel):
 
             if self.props.brick_create_relations_toggled and self.props.split_screen_toggled:
                 row = self.layout.row(align=True)
-                split_screen_selection = self.props.split_screen_bricks[self.props.split_screen_active_brick_index]
-                if split_screen_selection.total_items:
+                try:
+                    split_screen_selection = self.props.split_screen_bricks[self.props.split_screen_active_brick_index]
+                except:
+                    split_screen_selection = None
+                if not split_screen_selection or split_screen_selection.total_items:
                     row.label(text="No selection", icon="INFO")
                 else:
                     prop_with_search(row, self.props, "new_brick_relation_type", text="")

--- a/src/blenderbim/blenderbim/core/brick.py
+++ b/src/blenderbim/blenderbim/core/brick.py
@@ -25,6 +25,14 @@ def load_brick_project(brick, filepath=None, brick_root=None):
     brick.set_active_brick_class(brick_root, split_screen=True)
 
 
+def new_brick_file(brick, brick_root=None):
+    brick.new_brick_file()
+    brick.import_brick_classes(brick_root)
+    brick.import_brick_classes(brick_root, split_screen=True)
+    brick.set_active_brick_class(brick_root)
+    brick.set_active_brick_class(brick_root, split_screen=True)
+
+
 def view_brick_class(brick, brick_class=None, split_screen=False):
     brick.add_brick_breadcrumb(split_screen=split_screen)
     brick.clear_brick_browser(split_screen=split_screen)
@@ -35,7 +43,7 @@ def view_brick_class(brick, brick_class=None, split_screen=False):
 
 def view_brick_item(brick, item=None, split_screen=False):
     brick_class = brick.get_item_class(item)
-    view_brick_class(brick, brick_class=brick_class, split_screen=split_screen)
+    brick.run_view_brick_class(brick_class=brick_class, split_screen=split_screen)
     brick.select_browser_item(item, split_screen=split_screen)
 
 
@@ -79,15 +87,13 @@ def add_brick(ifc, brick, element=None, namespace=None, brick_class=None, librar
         if library:
             brick.run_assign_brick_reference(element=element, library=library, brick_uri=brick_uri)
     else:
-        brick_uri = brick.add_brick(namespace, brick_class, label)
+        brick.add_brick(namespace, brick_class, label)
     brick.run_refresh_brick_viewer()
-    brick.run_refresh_brick_viewer(split_screen=True)
 
 
 def add_brick_relation(brick, brick_uri=None, predicate=None, object=None):
     brick.add_relation(brick_uri, predicate, object)
     brick.run_refresh_brick_viewer()
-    brick.run_refresh_brick_viewer(split_screen=True)
 
 
 def convert_ifc_to_brick(brick, namespace=None, library=None):
@@ -129,23 +135,13 @@ def convert_ifc_to_brick(brick, namespace=None, library=None):
         for downstream_equipment in feeds:
             brick.add_relation(equipment_uris[element], "https://brickschema.org/schema/Brick#feeds", equipment_uris[downstream_equipment])
     brick.run_refresh_brick_viewer()
-    brick.run_refresh_brick_viewer(split_screen=True)
 
 
-def new_brick_file(brick, brick_root=None):
-    brick.new_brick_file()
-    brick.import_brick_classes(brick_root)
-    brick.import_brick_classes(brick_root, split_screen=True)
-    brick.set_active_brick_class(brick_root)
-    brick.set_active_brick_class(brick_root, split_screen=True)
-
-
-def refresh_brick_viewer(brick, split_screen=False):
-    if split_screen:
-        brick.run_view_brick_class(brick_class=brick.get_active_brick_class(split_screen=split_screen), split_screen=split_screen)
-    else:
-        brick.run_view_brick_class(brick_class=brick.get_active_brick_class(), split_screen=split_screen)
-    brick.pop_brick_breadcrumb(split_screen=split_screen)
+def refresh_brick_viewer(brick):
+    brick.run_view_brick_class(brick_class=brick.get_active_brick_class())
+    brick.pop_brick_breadcrumb()
+    brick.run_view_brick_class(brick_class=brick.get_active_brick_class(split_screen=True), split_screen=True)
+    brick.pop_brick_breadcrumb(split_screen=True)
 
 
 def remove_brick(ifc, brick, library=None, brick_uri=None):
@@ -155,14 +151,13 @@ def remove_brick(ifc, brick, library=None, brick_uri=None):
             ifc.run("library.remove_reference", reference=reference)
     brick.remove_brick(brick_uri)
     brick.run_refresh_brick_viewer()
-    brick.run_refresh_brick_viewer(split_screen=True)
 
 
 def serialize_brick(brick):
     brick.serialize_brick()
 
 
-def add_namespace(brick, alias=None, uri=None):
+def add_brick_namespace(brick, alias=None, uri=None):
     brick.add_namespace(alias, uri)
 
 
@@ -173,4 +168,3 @@ def set_brick_list_root(brick, brick_root=None, split_screen=False):
 
 def remove_brick_relation(brick, brick_uri=None, predicate=None, object=None):
     brick.remove_relation(brick_uri, predicate, object)
-    brick.run_refresh_brick_viewer()

--- a/src/blenderbim/blenderbim/core/tool.py
+++ b/src/blenderbim/blenderbim/core/tool.py
@@ -94,36 +94,46 @@ class Boundary: pass
 
 @interface
 class Brick:
-    def add_brick(cls, namespace, brick_class): pass
-    def add_brick_breadcrumb(cls): pass
+    def add_brick(cls, namespace, brick_class, label): pass
+    def add_brick_breadcrumb(cls, split_screen=False): pass
     def add_brick_from_element(cls, element, namespace, brick_class): pass
     def add_brickifc_project(cls, namespace): pass
     def add_brickifc_reference(cls, brick, element, project): pass
-    def add_feed(cls, source, destination): pass
-    def clear_brick_browser(cls): pass
+    def add_relation(cls, brick_uri, predicate, object): pass
+    def remove_relation(cls, brick_uri, predicate, object): pass
+    def clear_brick_browser(cls, split_screen=False): pass
     def clear_project(cls): pass
     def export_brick_attributes(cls, brick_uri): pass
-    def get_active_brick_class(cls): pass
+    def get_active_brick_class(cls, split_screen=False): pass
     def get_brick(cls, element): pass
     def get_brick_class(cls, element): pass
     def get_brick_path(cls): pass
     def get_brick_path_name(cls): pass
     def get_brickifc_project(cls): pass
     def get_convertable_brick_elements(cls): pass
+    def get_convertable_brick_spaces(cls): pass
+    def get_convertable_brick_systems(cls): pass
+    def get_parent_space(cls, space): pass
+    def get_element_container(cls, element): pass
+    def get_element_systems(cls, element): pass
+    def get_element_feeds(cls, element): pass
     def get_item_class(cls, item): pass
     def get_library_brick_reference(cls, library, brick_uri): pass
     def get_namespace(cls, uri): pass
-    def import_brick_classes(cls, brick_class): pass
-    def import_brick_items(cls, brick_class): pass
+    def import_brick_classes(cls, brick_class, split_screen=False): pass
+    def import_brick_items(cls, brick_class, split_screen=False): pass
     def load_brick_file(cls, filepath): pass
     def new_brick_file(cls): pass
-    def pop_brick_breadcrumb(cls): pass
+    def pop_brick_breadcrumb(cls, split_screen=False): pass
     def remove_brick(cls, brick_uri): pass
     def run_assign_brick_reference(cls, element=None, library=None, brick_uri=None): pass
-    def run_refresh_brick_viewer(cls): pass
-    def run_view_brick_class(cls, brick_class=None): pass
-    def select_browser_item(cls, item): pass
-    def set_active_brick_class(cls, brick_class): pass
+    def run_refresh_brick_viewer(cls, split_screen=False): pass
+    def run_view_brick_class(cls, brick_class=None, split_screen=False): pass
+    def select_browser_item(cls, item, split_screen=False): pass
+    def set_active_brick_class(cls, brick_class, split_screen=False): pass
+    def serialize_brick(cls): pass
+    def add_namespace(cls, alias, uri): pass
+    def clear_breadcrumbs(cls, split_screen=False): pass
 
 
 @interface

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -106,15 +106,15 @@ class Brick(blenderbim.core.tool.Brick):
             with BrickStore.new_changeset() as cs:
                 cs.add((URIRef(brick_uri), URIRef(predicate), Literal(object)))
             bpy.context.scene.BIMBrickProperties.new_brick_relation_type = BrickStore.relationships[0][0]
-            bpy.context.scene.BIMBrickProperties.add_relation_failed = False
+            bpy.context.scene.BIMBrickProperties.add_brick_relation_failed = False
             return
         query = BrickStore.graph.query("ASK { <{object_uri}> a ?o . }".replace("{object_uri}", object))
         if query:
             with BrickStore.new_changeset() as cs:
                 cs.add((URIRef(brick_uri), URIRef(predicate), URIRef(object)))
-            bpy.context.scene.BIMBrickProperties.add_relation_failed = False
+            bpy.context.scene.BIMBrickProperties.add_brick_relation_failed = False
         else:
-            bpy.context.scene.BIMBrickProperties.add_relation_failed = True
+            bpy.context.scene.BIMBrickProperties.add_brick_relation_failed = True
 
     @classmethod
     def remove_relation(cls, brick_uri, predicate, object):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -105,7 +105,7 @@ class Brick(blenderbim.core.tool.Brick):
         if predicate == "http://www.w3.org/2000/01/rdf-schema#label":
             with BrickStore.new_changeset() as cs:
                 cs.add((URIRef(brick_uri), URIRef(predicate), Literal(object)))
-            bpy.context.scene.BIMBrickProperties.new_brick_relation_type = BrickStore.relationships[0][0]
+            bpy.context.scene.BIMBrickProperties.new_brick_relation_type = BrickStore.relationships[0]
             bpy.context.scene.BIMBrickProperties.add_brick_relation_failed = False
             return
         query = BrickStore.graph.query("ASK { <{object_uri}> a ?o . }".replace("{object_uri}", object))
@@ -150,7 +150,7 @@ class Brick(blenderbim.core.tool.Brick):
             LIMIT 1
         """.replace("{brick_uri}", brick_uri))
         for row in query:
-            name = row.get("label")
+            name = str(row.get("label"))
             if not name:
                 name = brick_uri.split("#")[-1]
             if tool.Ifc.get_schema() == "IFC2X3":
@@ -216,8 +216,8 @@ class Brick(blenderbim.core.tool.Brick):
     @classmethod
     def get_convertable_brick_spaces(cls):
         if tool.Ifc.get_schema() == "IFC2X3":
-            return tool.Ifc.get().by_type("IfcSpatialStructureElement")
-        return tool.Ifc.get().by_type("IfcSpatialElement")
+            return set(tool.Ifc.get().by_type("IfcSpatialStructureElement"))
+        return set(tool.Ifc.get().by_type("IfcSpatialElement"))
 
     @classmethod
     def get_convertable_brick_systems(cls):
@@ -520,7 +520,7 @@ class BrickStore:
                     ignore_namespace = True
                     break
             if not ignore_namespace:
-                BrickStore.namespaces.append((uri, f"{alias}: {uri}", ""))
+                BrickStore.namespaces.append((alias, str(uri)))
 
     @classmethod
     def load_entity_classes(cls):
@@ -542,7 +542,7 @@ class BrickStore:
             )
             BrickStore.entity_classes[root_class] = []
             for uri in sorted([x[0].toPython() for x in query]):
-                BrickStore.entity_classes[root_class].append((uri, uri.split("#")[-1], ""))
+                BrickStore.entity_classes[root_class].append(uri)
 
     @classmethod
     def load_relationships(cls):
@@ -556,7 +556,7 @@ class BrickStore:
             """
         )
         for uri in sorted([x[0].toPython() for x in query]):
-            BrickStore.relationships.append((uri, uri.split("#")[-1], ""))
+            BrickStore.relationships.append(uri)
 
     @classmethod
     def set_history_size(cls, size):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -151,12 +151,12 @@ class Brick(blenderbim.core.tool.Brick):
         """.replace("{brick_uri}", brick_uri))
         for row in query:
             name = row.get("label")
-        if not name:
-            name = brick_uri.split("#")[-1]
-        if tool.Ifc.get_schema() == "IFC2X3":
-            return {"ItemReference": brick_uri, "Name": name}
-        else:
-            return {"Identification": brick_uri, "Name": name}
+            if not name:
+                name = brick_uri.split("#")[-1]
+            if tool.Ifc.get_schema() == "IFC2X3":
+                return {"ItemReference": brick_uri, "Name": name}
+            else:
+                return {"Identification": brick_uri, "Name": name}
 
     @classmethod
     def get_active_brick_class(cls, split_screen=False):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -149,14 +149,15 @@ class Brick(blenderbim.core.tool.Brick):
             }
             LIMIT 1
         """.replace("{brick_uri}", brick_uri))
+        name = None
         for row in query:
             name = str(row.get("label"))
-            if not name:
-                name = brick_uri.split("#")[-1]
-            if tool.Ifc.get_schema() == "IFC2X3":
-                return {"ItemReference": brick_uri, "Name": name}
-            else:
-                return {"Identification": brick_uri, "Name": name}
+        if not name:
+            name = brick_uri.split("#")[-1]
+        if tool.Ifc.get_schema() == "IFC2X3":
+            return {"ItemReference": brick_uri, "Name": name}
+        else:
+            return {"Identification": brick_uri, "Name": name}
 
     @classmethod
     def get_active_brick_class(cls, split_screen=False):

--- a/src/blenderbim/blenderbim/tool/brick.py
+++ b/src/blenderbim/blenderbim/tool/brick.py
@@ -398,8 +398,8 @@ class Brick(blenderbim.core.tool.Brick):
         )
 
     @classmethod
-    def run_refresh_brick_viewer(cls, split_screen=False):
-        return blenderbim.core.brick.refresh_brick_viewer(tool.Brick, split_screen)
+    def run_refresh_brick_viewer(cls):
+        return blenderbim.core.brick.refresh_brick_viewer(tool.Brick)
 
     @classmethod
     def run_view_brick_class(cls, brick_class=None, split_screen=False):

--- a/src/blenderbim/test/bim/feature/brick.feature
+++ b/src/blenderbim/test/bim/feature/brick.feature
@@ -20,7 +20,7 @@ Scenario: View Brick class
 Scenario: View Brick item
     Given an empty Blender session
     And I press "bim.load_brick_project(filepath='{cwd}/test/files/spaces.ttl')"
-    When I press "bim.view_brick_item(item='https://brickschema.org/schema/Brick#Building')"
+    When I press "bim.view_brick_item(item='https://example.org/digitaltwin#lighting_zone_1')"
     Then nothing happens
 
 Scenario: Rewind Brick class
@@ -87,17 +87,11 @@ Scenario: Add Brick relation - vanilla Brick with no IFC
     Given an empty Blender session
     And I press "bim.load_brick_project(filepath='{cwd}/test/files/spaces.ttl')"
     And I set "scene.BIMBrickProperties.namespace" to "https://example.org/digitaltwin#"
-    And I set "scene.BIMBrickProperties.brick_entity_create_type" to "Location"
-    And I set "scene.BIMBrickProperties.new_brick_label" to "abc123"
-    And I set "scene.BIMBrickProperties.brick_entity_class" to "Room"
-    And I press "bim.add_brick"
     And I press "bim.view_brick_class(brick_class='Lighting_Zone')"
     And I set "scene.BIMBrickProperties.active_brick_index" to "0"
-    And I set "scene.BIMRootProperties.brick_create_relations_toggled" to "True"
-    And I set "scene.BIMRootProperties.new_brick_relation_namespace" to "https://example.org/digitaltwin#"
-    And I set "scene.BIMRootProperties.new_brick_relation_type" to "hasPart"
-    And I set "scene.BIMRootProperties.new_brick_relation_object" to "xyz789"
-    When I press "bim.add_brick_relation()"
+    And I set "scene.BIMBrickProperties.brick_create_relations_toggled" to "True"
+    And I set "scene.BIMBrickProperties.new_brick_relation_object" to "xyz789"
+    When I press "bim.add_brick_relation"
     Then nothing happens
 
 Scenario: Add Brick relation - vanilla Brick with no IFC and with split screen
@@ -106,15 +100,14 @@ Scenario: Add Brick relation - vanilla Brick with no IFC and with split screen
     And I set "scene.BIMBrickProperties.namespace" to "https://example.org/digitaltwin#"
     And I set "scene.BIMBrickProperties.brick_entity_create_type" to "Location"
     And I set "scene.BIMBrickProperties.new_brick_label" to "abc123"
-    And I set "scene.BIMBrickProperties.brick_entity_class" to "Room"
+    And I set "scene.BIMBrickProperties.brick_entity_class" to "https://brickschema.org/schema/Brick#Room"
     And I press "bim.add_brick"
     And I press "bim.view_brick_class(brick_class='Lighting_Zone')"
     And I set "scene.BIMBrickProperties.active_brick_index" to "0"
-    And I set "scene.BIMRootProperties.split_screen_toggled" to "True"
-    And I press "bim.view_brick_class(brick_class='Room')"
+    And I set "scene.BIMBrickProperties.split_screen_toggled" to "True"
+    And I press "bim.view_brick_class(brick_class='Room', split_screen=True)"
     And I set "scene.BIMBrickProperties.split_screen_active_brick_index" to "0"
-    And I set "scene.BIMRootProperties.brick_create_relations_toggled" to "True"
-    And I set "scene.BIMRootProperties.new_brick_relation_type" to "hasPart"
+    And I set "scene.BIMBrickProperties.brick_create_relations_toggled" to "True"
     When I press "bim.add_brick_relation"
     Then nothing happens
 
@@ -152,14 +145,14 @@ Scenario: Change viewer list root - split screen
     Given an empty Blender session
     And I press "bim.load_brick_project(filepath='{cwd}/test/files/spaces.ttl')"
     And I set "scene.BIMBrickProperties.set_list_root_toggled" to "True"
-    And I set "scene.BIMRootProperties.split_screen_toggled" to "True"
+    And I set "scene.BIMBrickProperties.split_screen_toggled" to "True"
     When I set "scene.BIMBrickProperties.split_screen_brick_list_root" to "Location"
     Then nothing happens
 
 Scenario: Toggle split screen
     Given an empty Blender session
     And I press "bim.load_brick_project(filepath='{cwd}/test/files/spaces.ttl')"
-    When I set "scene.BIMRootProperties.split_screen_toggled" to "True"
+    When I set "scene.BIMBrickProperties.split_screen_toggled" to "True"
     Then nothing happens
 
 Scenario: Set active namespace

--- a/src/blenderbim/test/core/test_brick.py
+++ b/src/blenderbim/test/core/test_brick.py
@@ -23,46 +23,80 @@ from test.core.bootstrap import ifc, brick
 class TestLoadBrickProject:
     def test_run(self, brick):
         brick.load_brick_file("filepath").should_be_called()
-        brick.import_brick_classes("Class").should_be_called()
-        brick.set_active_brick_class("Class").should_be_called()
-        subject.load_brick_project(brick, filepath="filepath")
+        brick.import_brick_classes("brick_root").should_be_called()
+        brick.import_brick_classes("brick_root", split_screen=True).should_be_called()
+        brick.set_active_brick_class("brick_root").should_be_called()
+        brick.set_active_brick_class("brick_root", split_screen=True).should_be_called()
+        subject.load_brick_project(brick, filepath="filepath", brick_root="brick_root")
+
+
+class TestNewBrickFile:
+    def test_run(self, brick):
+        brick.new_brick_file().should_be_called()
+        brick.import_brick_classes("brick_root").should_be_called()
+        brick.import_brick_classes("brick_root", split_screen=True).should_be_called()
+        brick.set_active_brick_class("brick_root").should_be_called()
+        brick.set_active_brick_class("brick_root", split_screen=True).should_be_called()
+        subject.new_brick_file(brick, brick_root="brick_root")
 
 
 class TestViewBrickClass:
     def test_run(self, brick):
-        brick.add_brick_breadcrumb().should_be_called()
-        brick.clear_brick_browser().should_be_called()
-        brick.import_brick_classes("brick_class").should_be_called()
-        brick.import_brick_items("brick_class").should_be_called()
-        brick.set_active_brick_class("brick_class").should_be_called()
-        subject.view_brick_class(brick, brick_class="brick_class")
+        brick.add_brick_breadcrumb(split_screen=False).should_be_called()
+        brick.clear_brick_browser(split_screen=False).should_be_called()
+        brick.import_brick_classes("brick_class", split_screen=False).should_be_called()
+        brick.import_brick_items("brick_class", split_screen=False).should_be_called()
+        brick.set_active_brick_class("brick_class", split_screen=False).should_be_called()
+        subject.view_brick_class(brick, brick_class="brick_class", split_screen=False)
+
+    def test_split_screen(self, brick):
+        brick.add_brick_breadcrumb(split_screen=True).should_be_called()
+        brick.clear_brick_browser(split_screen=True).should_be_called()
+        brick.import_brick_classes("brick_class", split_screen=True).should_be_called()
+        brick.import_brick_items("brick_class", split_screen=True).should_be_called()
+        brick.set_active_brick_class("brick_class", split_screen=True).should_be_called()
+        subject.view_brick_class(brick, brick_class="brick_class", split_screen=True)
 
 
 class TestViewBrickItem:
     def test_run(self, brick):
-        brick.add_brick_breadcrumb().should_be_called()
-        brick.clear_brick_browser().should_be_called()
         brick.get_item_class("item").should_be_called().will_return("brick_class")
-        brick.import_brick_classes("brick_class").should_be_called()
-        brick.import_brick_items("brick_class").should_be_called()
-        brick.set_active_brick_class("brick_class").should_be_called()
-        brick.select_browser_item("item").should_be_called()
-        subject.view_brick_item(brick, item="item")
+        brick.run_view_brick_class(brick_class="brick_class", split_screen=False).should_be_called()
+        brick.select_browser_item("item", split_screen=False).should_be_called()
+        subject.view_brick_item(brick, item="item", split_screen=False)
+
+    def test_split_screen(self, brick):
+        brick.get_item_class("item").should_be_called().will_return("brick_class")
+        brick.run_view_brick_class(brick_class="brick_class", split_screen=True).should_be_called()
+        brick.select_browser_item("item", split_screen=True).should_be_called()
+        subject.view_brick_item(brick, item="item", split_screen=True)
 
 
 class TestRewindBrickClass:
     def test_run(self, brick):
-        brick.pop_brick_breadcrumb().should_be_called().will_return("previous_class")
-        brick.clear_brick_browser().should_be_called()
-        brick.import_brick_classes("previous_class").should_be_called()
-        brick.import_brick_items("previous_class").should_be_called()
-        brick.set_active_brick_class("previous_class").should_be_called()
-        subject.rewind_brick_class(brick)
+        brick.pop_brick_breadcrumb(split_screen=False).should_be_called().will_return("previous_class")
+        brick.clear_brick_browser(split_screen=False).should_be_called()
+        brick.import_brick_classes("previous_class", split_screen=False).should_be_called()
+        brick.import_brick_items("previous_class", split_screen=False).should_be_called()
+        brick.set_active_brick_class("previous_class", split_screen=False).should_be_called()
+        subject.rewind_brick_class(brick, split_screen=False)
+
+    def test_split_screen(self, brick):
+        brick.pop_brick_breadcrumb(split_screen=True).should_be_called().will_return("previous_class")
+        brick.clear_brick_browser(split_screen=True).should_be_called()
+        brick.import_brick_classes("previous_class", split_screen=True).should_be_called()
+        brick.import_brick_items("previous_class", split_screen=True).should_be_called()
+        brick.set_active_brick_class("previous_class", split_screen=True).should_be_called()
+        subject.rewind_brick_class(brick, split_screen=True)
 
 
 class TestCloseBrickProject:
     def test_run(self, brick):
         brick.clear_project().should_be_called()
+        brick.clear_brick_browser().should_be_called()
+        brick.clear_brick_browser(split_screen=True).should_be_called()
+        brick.clear_breadcrumbs().should_be_called()
+        brick.clear_breadcrumbs(split_screen=True).should_be_called()
         subject.close_brick_project(brick)
 
 
@@ -86,84 +120,113 @@ class TestConvertBrickProject:
 
 class TestAssignBrickReference:
     def test_assigning_to_a_new_reference(self, ifc, brick):
-        brick.get_library_brick_reference("library", "brick").should_be_called().will_return(None)
+        brick.get_library_brick_reference("library", "brick_uri").should_be_called().will_return(None)
         ifc.run("library.add_reference", library="library").should_be_called().will_return("reference")
-        brick.export_brick_attributes("brick").should_be_called().will_return("attributes")
+        brick.export_brick_attributes("brick_uri").should_be_called().will_return("attributes")
         ifc.run("library.edit_reference", reference="reference", attributes="attributes").should_be_called()
         ifc.run("library.assign_reference", product="element", reference="reference").should_be_called()
         brick.get_brickifc_project().should_be_called().will_return("project")
-        brick.add_brickifc_reference("brick", "element", "project").should_be_called()
-        subject.assign_brick_reference(ifc, brick, element="element", library="library", brick_uri="brick")
+        brick.add_brickifc_reference("brick_uri", "element", "project").should_be_called()
+        subject.assign_brick_reference(ifc, brick, element="element", library="library", brick_uri="brick_uri")
 
     def test_assigning_to_an_existing_reference(self, ifc, brick):
-        brick.get_library_brick_reference("library", "brick").should_be_called().will_return("reference")
+        brick.get_library_brick_reference("library", "brick_uri").should_be_called().will_return("reference")
         ifc.run("library.assign_reference", product="element", reference="reference").should_be_called()
         brick.get_brickifc_project().should_be_called().will_return("project")
-        brick.add_brickifc_reference("brick", "element", "project").should_be_called()
-        subject.assign_brick_reference(ifc, brick, element="element", library="library", brick_uri="brick")
+        brick.add_brickifc_reference("brick_uri", "element", "project").should_be_called()
+        subject.assign_brick_reference(ifc, brick, element="element", library="library", brick_uri="brick_uri")
 
     def test_adding_a_brickifc_project_if_it_doesnt_exist(self, ifc, brick):
-        brick.get_library_brick_reference("library", "brick").should_be_called().will_return("reference")
+        brick.get_library_brick_reference("library", "brick_uri").should_be_called().will_return("reference")
         ifc.run("library.assign_reference", product="element", reference="reference").should_be_called()
         brick.get_brickifc_project().should_be_called().will_return(None)
-        brick.get_namespace("brick").should_be_called().will_return("namespace")
+        brick.get_namespace("brick_uri").should_be_called().will_return("namespace")
         brick.add_brickifc_project("namespace").should_be_called().will_return("project")
-        brick.add_brickifc_reference("brick", "element", "project").should_be_called()
-        subject.assign_brick_reference(ifc, brick, element="element", library="library", brick_uri="brick")
+        brick.add_brickifc_reference("brick_uri", "element", "project").should_be_called()
+        subject.assign_brick_reference(ifc, brick, element="element", library="library", brick_uri="brick_uri")
 
 
 class TestAddBrick:
     def test_adding_a_brick_from_an_element(self, ifc, brick):
         brick.add_brick_from_element("element", "namespace", "brick_class").should_be_called().will_return("brick_uri")
         brick.run_refresh_brick_viewer().should_be_called()
-        subject.add_brick(ifc, brick, element="element", namespace="namespace", brick_class="brick_class", library=None)
+        subject.add_brick(
+            ifc, brick, element="element", namespace="namespace", brick_class="brick_class", library=None, label="label"
+        )
 
-    def test_adding_a_brick_an_auto_assigning_it_to_the_ifc_element(self, ifc, brick):
+    def test_adding_a_brick_and_auto_assigning_it_to_the_ifc_element(self, ifc, brick):
         brick.add_brick_from_element("element", "namespace", "brick_class").should_be_called().will_return("brick_uri")
         brick.run_assign_brick_reference(element="element", library="library", brick_uri="brick_uri").should_be_called()
         brick.run_refresh_brick_viewer().should_be_called()
         subject.add_brick(
-            ifc, brick, element="element", namespace="namespace", brick_class="brick_class", library="library"
+            ifc, brick, element="element", namespace="namespace", brick_class="brick_class", library="library", label="label"
         )
 
     def test_adding_a_plain_brick(self, ifc, brick):
-        brick.add_brick("namespace", "brick_class").should_be_called()
+        brick.add_brick("namespace", "brick_class", "label").should_be_called()
         brick.run_refresh_brick_viewer().should_be_called()
-        subject.add_brick(ifc, brick, element=None, namespace="namespace", brick_class="brick_class", library=None)
+        subject.add_brick(ifc, brick, element=None, namespace="namespace", brick_class="brick_class", library=None, label="label")
 
 
-class TestAddBrickFeed:
+class TestAddBrickRelation:
     def test_run(self, ifc, brick):
-        brick.get_brick("source").should_be_called().will_return("source_brick")
-        brick.get_brick("destination").should_be_called().will_return("destination_brick")
-        brick.add_feed("source_brick", "destination_brick").should_be_called()
+        brick.add_relation("brick_uri", "predicate", "object").should_be_called()
         brick.run_refresh_brick_viewer().should_be_called()
-        subject.add_brick_feed(ifc, brick, source="source", destination="destination")
+        subject.add_brick_relation(brick, brick_uri="brick_uri", predicate="predicate", object="object")
 
 
 class TestConvertIfcToBrick:
     def test_run(self, brick):
-        brick.get_convertable_brick_elements().should_be_called().will_return(["element"])
-        brick.get_brick_class("element").should_be_called().will_return("brick_class")
-        brick.add_brick_from_element("element", "namespace", "brick_class").should_be_called().will_return("brick_uri")
-        brick.run_assign_brick_reference(element="element", library="library", brick_uri="brick_uri").should_be_called()
+        brick.get_convertable_brick_spaces().should_be_called().will_return({"space", "parent"})
+        brick.get_brick_class("space").should_be_called().will_return("space_class")
+        brick.add_brick_from_element("space", "namespace", "space_class").should_be_called().will_return("space_uri")
+        brick.run_assign_brick_reference(element="space", library="library", brick_uri="space_uri").should_be_called()
+
+        brick.get_brick_class("parent").should_be_called().will_return("parent_class")
+        brick.add_brick_from_element("parent", "namespace", "parent_class").should_be_called().will_return("parent_uri")
+        brick.run_assign_brick_reference(element="parent", library="library", brick_uri="parent_uri").should_be_called()
+
+        brick.get_parent_space("space").should_be_called().will_return("parent")
+        brick.get_parent_space("parent").should_be_called().will_return(None)
+        brick.add_relation("parent_uri", "https://brickschema.org/schema/Brick#hasPart", "space_uri").should_be_called()
+
+        brick.get_convertable_brick_systems().should_be_called().will_return({"system"})
+        brick.get_brick_class("system").should_be_called().will_return("system_class")
+        brick.add_brick_from_element("system", "namespace", "system_class").should_be_called().will_return("system_uri")
+        brick.run_assign_brick_reference(element="system", library="library", brick_uri="system_uri").should_be_called()
+
+        brick.get_convertable_brick_elements().should_be_called().will_return({"element", "downstream_element"})
+        brick.get_brick_class("element").should_be_called().will_return("element_class")
+        brick.add_brick_from_element("element", "namespace", "element_class").should_be_called().will_return("element_uri")
+        brick.get_element_container("element").should_be_called().will_return("space")
+        brick.add_relation("element_uri", "https://brickschema.org/schema/Brick#hasLocation", "space_uri").should_be_called()
+        brick.get_element_systems("element").should_be_called().will_return(["system"])
+        brick.add_relation("system_uri", "https://brickschema.org/schema/Brick#hasPart", "element_uri").should_be_called()
+        brick.run_assign_brick_reference(element="element", library="library", brick_uri="element_uri").should_be_called()
+
+        brick.get_brick_class("downstream_element").should_be_called().will_return("downstream_element_class")
+        brick.add_brick_from_element("downstream_element", "namespace", "downstream_element_class").should_be_called().will_return("downstream_element_uri")
+        brick.get_element_container("downstream_element").should_be_called().will_return("space")
+        brick.add_relation("downstream_element_uri", "https://brickschema.org/schema/Brick#hasLocation", "space_uri").should_be_called()
+        brick.get_element_systems("downstream_element").should_be_called().will_return(["system"])
+        brick.add_relation("system_uri", "https://brickschema.org/schema/Brick#hasPart", "downstream_element_uri").should_be_called()
+        brick.run_assign_brick_reference(element="downstream_element", library="library", brick_uri="downstream_element_uri").should_be_called()
+
+        brick.get_element_feeds("element").should_be_called().will_return(["downstream_element"])
+        brick.get_element_feeds("downstream_element").should_be_called().will_return([])
+        brick.add_relation("element_uri", "https://brickschema.org/schema/Brick#feeds", "downstream_element_uri").should_be_called()
         brick.run_refresh_brick_viewer().should_be_called()
         subject.convert_ifc_to_brick(brick, namespace="namespace", library="library")
 
 
-class TestNewBrickFile:
-    def test_run(self, brick):
-        brick.new_brick_file().should_be_called()
-        brick.import_brick_classes("Class").should_be_called()
-        brick.set_active_brick_class("Class").should_be_called()
-        subject.new_brick_file(brick)
-
-
 class TestRefreshBrickViewer:
     def test_run(self, brick):
-        brick.get_active_brick_class().should_be_called().will_return("class")
-        brick.run_view_brick_class(brick_class="class").should_be_called()
+        brick.get_active_brick_class().should_be_called().will_return("brick_class")
+        brick.run_view_brick_class(brick_class="brick_class").should_be_called()
         brick.pop_brick_breadcrumb().should_be_called()
+        brick.get_active_brick_class(split_screen=True).should_be_called().will_return("brick_class")
+        brick.run_view_brick_class(brick_class="brick_class", split_screen=True).should_be_called()
+        brick.pop_brick_breadcrumb(split_screen=True).should_be_called()
         subject.refresh_brick_viewer(brick)
 
 
@@ -185,3 +248,33 @@ class TestRemoveBrick:
         brick.remove_brick("brick_uri").should_be_called()
         brick.run_refresh_brick_viewer().should_be_called()
         subject.remove_brick(ifc, brick, library=None, brick_uri="brick_uri")
+
+
+class TestSerializeBrick:
+    def test_run(self, brick):
+        brick.serialize_brick().should_be_called()
+        subject.serialize_brick(brick)
+
+
+class TestAddBrickNamespace:
+    def test_run(self, brick):
+        brick.add_namespace("alias", "uri").should_be_called()
+        subject.add_brick_namespace(brick, alias="alias", uri="uri")
+
+
+class TestSetBrickListRoot:
+    def test_run(self, brick):
+        brick.run_view_brick_class(brick_class="brick_root", split_screen=False).should_be_called()
+        brick.clear_breadcrumbs(split_screen=False).should_be_called()
+        subject.set_brick_list_root(brick, brick_root="brick_root", split_screen=False)
+
+    def test_split_screen(self, brick):
+        brick.run_view_brick_class(brick_class="brick_root", split_screen=True).should_be_called()
+        brick.clear_breadcrumbs(split_screen=True).should_be_called()
+        subject.set_brick_list_root(brick, brick_root="brick_root", split_screen=True)
+
+
+class TestRemoveBrickRelation:
+    def test_run(self, brick):
+        brick.remove_relation("brick_uri", "predicate", "object").should_be_called()
+        subject.remove_brick_relation(brick, brick_uri="brick_uri", predicate="predicate", object="object")

--- a/src/blenderbim/test/tool/test_brick.py
+++ b/src/blenderbim/test/tool/test_brick.py
@@ -19,6 +19,8 @@
 import os
 import bpy
 import brickschema
+import brickschema.persistent
+from brickschema.namespaces import REF, A
 import ifcopenshell
 import blenderbim.core.tool
 import blenderbim.tool as tool
@@ -36,17 +38,17 @@ class TestImplementsTool(NewFile):
 
 class TestAddBrick(NewFile):
     def test_run(self):
-        BrickStore.graph = brickschema.Graph()
-        result = subject.add_brick("https://example.org/digitaltwin#", "https://brickschema.org/schema/Brick#Equipment")
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
+        result = subject.add_brick("https://example.org/digitaltwin#", "https://brickschema.org/schema/Brick#Equipment", "label")
         assert "https://example.org/digitaltwin#" in result
         assert list(
             BrickStore.graph.triples(
-                (URIRef(result), RDF.type, URIRef("https://brickschema.org/schema/Brick#Equipment"))
+                (URIRef(result), A, URIRef("https://brickschema.org/schema/Brick#Equipment"))
             )
         )
         assert list(
             BrickStore.graph.triples(
-                (URIRef(result), URIRef("http://www.w3.org/2000/01/rdf-schema#label"), Literal("Unnamed"))
+                (URIRef(result), URIRef("http://www.w3.org/2000/01/rdf-schema#label"), Literal("label"))
             )
         )
 
@@ -59,6 +61,13 @@ class TestAddBrickBreadcrumb(NewFile):
         subject.add_brick_breadcrumb()
         assert bpy.context.scene.BIMBrickProperties.brick_breadcrumbs[1].name == "brick_class"
 
+    def test_run_split_screen(self):
+        subject.set_active_brick_class("brick_class", split_screen=True)
+        subject.add_brick_breadcrumb(split_screen=True)
+        assert bpy.context.scene.BIMBrickProperties.split_screen_brick_breadcrumbs[0].name == "brick_class"
+        subject.add_brick_breadcrumb(split_screen=True)
+        assert bpy.context.scene.BIMBrickProperties.split_screen_brick_breadcrumbs[1].name == "brick_class"
+
 
 class TestAddBrickFromElement(NewFile):
     def test_run(self):
@@ -66,18 +75,37 @@ class TestAddBrickFromElement(NewFile):
         element = ifc.createIfcChiller()
         element.Name = "Chiller"
         element.GlobalId = ifcopenshell.guid.new()
-        BrickStore.graph = brickschema.Graph()
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
         result = subject.add_brick_from_element(
             element, "http://example.org/digitaltwin#", "https://brickschema.org/schema/Brick#Equipment"
         )
         uri = f"http://example.org/digitaltwin#{element.GlobalId}"
         assert result == uri
         assert list(
-            BrickStore.graph.triples((URIRef(uri), RDF.type, URIRef("https://brickschema.org/schema/Brick#Equipment")))
+            BrickStore.graph.triples((URIRef(uri), A, URIRef("https://brickschema.org/schema/Brick#Equipment")))
         )
         assert list(
             BrickStore.graph.triples(
                 (URIRef(uri), URIRef("http://www.w3.org/2000/01/rdf-schema#label"), Literal("Chiller"))
+            )
+        )
+    
+    def test_run_no_element_name(self):
+        ifc = ifcopenshell.file()
+        element = ifc.createIfcChiller()
+        element.GlobalId = ifcopenshell.guid.new()
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
+        result = subject.add_brick_from_element(
+            element, "http://example.org/digitaltwin#", "https://brickschema.org/schema/Brick#Equipment"
+        )
+        uri = f"http://example.org/digitaltwin#{element.GlobalId}"
+        assert result == uri
+        assert list(
+            BrickStore.graph.triples((URIRef(uri), A, URIRef("https://brickschema.org/schema/Brick#Equipment")))
+        )
+        assert list(
+            BrickStore.graph.triples(
+                (URIRef(uri), URIRef("http://www.w3.org/2000/01/rdf-schema#label"), Literal("Unnamed"))
             )
         )
 
@@ -88,30 +116,26 @@ class TestAddBrickifcProject(NewFile):
         tool.Ifc.set(ifc)
         project = ifc.createIfcProject(ifcopenshell.guid.new())
         project.Name = "My Project"
-        BrickStore.graph = brickschema.Graph()
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
         result = subject.add_brickifc_project("http://example.org/digitaltwin#")
         assert result == f"http://example.org/digitaltwin#{project.GlobalId}"
         brick = URIRef(result)
         assert list(
-            BrickStore.graph.triples((brick, RDF.type, URIRef("https://brickschema.org/extension/ifc#Project")))
+            BrickStore.graph.triples((brick, A, REF.ifcProject))
+        )
+        assert list(
+            BrickStore.graph.triples(
+                (brick, REF.ifcProjectID, Literal(project.GlobalId))
+            )
+        )
+        assert list(
+            BrickStore.graph.triples(
+                (brick, REF.ifcFileLocation, Literal(bpy.context.scene.BIMProperties.ifc_file))
+            )
         )
         assert list(
             BrickStore.graph.triples(
                 (brick, URIRef("http://www.w3.org/2000/01/rdf-schema#label"), Literal("My Project"))
-            )
-        )
-        assert list(
-            BrickStore.graph.triples(
-                (brick, URIRef("https://brickschema.org/extension/ifc#projectID"), Literal(project.GlobalId))
-            )
-        )
-        assert list(
-            BrickStore.graph.triples(
-                (
-                    brick,
-                    URIRef("https://brickschema.org/extension/ifc#fileLocation"),
-                    Literal(bpy.context.scene.BIMProperties.ifc_file),
-                )
             )
         )
 
@@ -120,34 +144,66 @@ class TestAddBrickifcReference(NewFile):
     def test_run(self):
         TestAddBrickifcProject().test_run()
         element = tool.Ifc.get().createIfcChiller(ifcopenshell.guid.new())
+        element.Name = "Chiller"
         project = URIRef(f"http://example.org/digitaltwin#{tool.Ifc.get().by_type('IfcProject')[0].GlobalId}")
         subject.add_brickifc_reference("http://example.org/digitaltwin#foo", element, project)
         brick = URIRef("http://example.org/digitaltwin#foo")
         bnode = list(
-            BrickStore.graph.triples((brick, URIRef("https://brickschema.org/extension/ifc#hasIFCReference"), None))
-        )[0][2]
+            BrickStore.graph.triples((brick, A, REF.IFCReference))
+        )
         assert list(
             BrickStore.graph.triples(
-                (bnode, URIRef("https://brickschema.org/extension/ifc#hasProjectReference"), project)
+                (bnode, REF.hasIfcProjectReference, URIRef(project))
             )
         )
         assert list(
             BrickStore.graph.triples(
-                (bnode, URIRef("https://brickschema.org/extension/ifc#globalID"), Literal(element.GlobalId))
+                (bnode, REF.ifcGlobalID, Literal(element.GlobalId))
+            )
+        )
+        assert list(
+            BrickStore.graph.triples(
+                (bnode, REF.ifcName, Literal(element.Name))
             )
         )
 
 
-class TestAddFeed(NewFile):
+class TestAddRelation(NewFile):
     def test_run(self):
-        BrickStore.graph = brickschema.Graph()
-        subject.add_feed("http://example.org/digitaltwin#source", "http://example.org/digitaltwin#destination")
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
+        source = subject.add_brick(
+            "http://example.org/digitaltwin#",
+            "https://brickschema.org/schema/Brick#Equipment",
+            "source"
+        )
+        destination = subject.add_brick(
+            "http://example.org/digitaltwin#",
+            "https://brickschema.org/schema/Brick#Equipment",
+            "destination"
+        )
+        subject.add_relation(source, "https://brickschema.org/schema/Brick#feeds", destination)
         assert list(
             BrickStore.graph.triples(
                 (
-                    URIRef("http://example.org/digitaltwin#source"),
+                    URIRef(source),
                     URIRef("https://brickschema.org/schema/Brick#feeds"),
-                    URIRef("http://example.org/digitaltwin#destination"),
+                    URIRef(destination),
+                )
+            )
+        )
+
+
+class TestRemoveRelation(NewFile):
+    def test_run(self):
+        TestAddRelation().test_run()
+        source, relation, destination = list(BrickStore.graph.triples((None, URIRef("https://brickschema.org/schema/Brick#feeds"), None)))[0]
+        subject.remove_relation(source, relation, destination)
+        assert not list(
+            BrickStore.graph.triples(
+                (
+                    URIRef(source),
+                    URIRef(relation),
+                    URIRef(destination),
                 )
             )
         )
@@ -158,31 +214,40 @@ class TestClearBrickBrowser(NewFile):
         bpy.context.scene.BIMBrickProperties.bricks.add()
         subject.clear_brick_browser()
         assert len(bpy.context.scene.BIMBrickProperties.bricks) == 0
+    
+    def test_run_split_screen(self):
+        bpy.context.scene.BIMBrickProperties.split_screen_bricks.add()
+        subject.clear_brick_browser(split_screen=True)
+        assert len(bpy.context.scene.BIMBrickProperties.split_screen_bricks) == 0
 
 
 class TestClearProject(NewFile):
     def test_run(self):
         BrickStore.graph = "graph"
         bpy.context.scene.BIMBrickProperties.active_brick_class == "brick_class"
-        bpy.context.scene.BIMBrickProperties.brick_breadcrumbs.add().name = "foo"
+        bpy.context.scene.BIMBrickProperties.split_screen_active_brick_class == "brick_class2"
         subject.clear_project()
         assert BrickStore.graph is None
         assert bpy.context.scene.BIMBrickProperties.active_brick_class == ""
-        assert len(bpy.context.scene.BIMBrickProperties.brick_breadcrumbs) == 0
+        assert bpy.context.scene.BIMBrickProperties.split_screen_active_brick_class == ""
 
 
 class TestExportBrickAttributes(NewFile):
     def test_run(self):
-        assert subject.export_brick_attributes("http://example.org/digitaltwin#floor") == {
-            "Identification": "http://example.org/digitaltwin#floor",
-            "Name": "floor",
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
+        brick = subject.add_brick("https://example.org/digitaltwin#", "https://brickschema.org/schema/Brick#Equipment", "name")
+        assert subject.export_brick_attributes(brick) == {
+            "Identification": brick,
+            "Name": "name",
         }
 
     def test_run_ifc2x3(self):
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
+        brick = subject.add_brick("https://example.org/digitaltwin#", "https://brickschema.org/schema/Brick#Equipment", "name")
         tool.Ifc.set(ifcopenshell.file(schema="IFC2X3"))
-        assert subject.export_brick_attributes("http://example.org/digitaltwin#floor") == {
-            "ItemReference": "http://example.org/digitaltwin#floor",
-            "Name": "floor",
+        assert subject.export_brick_attributes(brick) == {
+            "ItemReference": brick,
+            "Name": "name",
         }
 
 
@@ -190,6 +255,10 @@ class TestGetActiveBrickClass(NewFile):
     def test_run(self):
         subject.set_active_brick_class("brick_class")
         assert subject.get_active_brick_class() == "brick_class"
+
+    def test_run_split_screen(self):
+        subject.set_active_brick_class("brick_class", split_screen=True)
+        assert subject.get_active_brick_class(split_screen=True) == "brick_class"
 
 
 class TestGetBrick(NewFile):
@@ -247,6 +316,50 @@ class TestGetConvertableBrickElements(NewFile):
         assert subject.get_convertable_brick_elements() == {element}
 
 
+class TestGetConvertableBrickSpaces(NewFile):
+    def test_run(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        element = ifc.createIfcBuildingStorey()
+        ifc.createIfcWall()
+        assert subject.get_convertable_brick_spaces() == {element}
+
+
+class TestGetConvertableBrickSystems(NewFile):
+    def test_run(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        element = ifc.createIfcSystem()
+        ifc.createIfcWall()
+        assert subject.get_convertable_brick_systems() == {element}
+
+
+class TestGetParentSpace(NewFile):
+    def test_run(cls):
+        ifc = ifcopenshell.file()
+        element = ifcopenshell.api.run("root.create_entity", ifc, ifc_class="IfcBuildingStorey")
+        subelement = ifcopenshell.api.run("root.create_entity", ifc, ifc_class="IfcSpace")
+        project = ifcopenshell.api.run("root.create_entity", ifc, ifc_class="IfcProject")
+        ifcopenshell.api.run("aggregate.assign_object", ifc, product=subelement, relating_object=element)
+        ifcopenshell.api.run("aggregate.assign_object", ifc, product=element, relating_object=project)
+        assert subject.get_parent_space(subelement) == element
+        assert subject.get_parent_space(element) is None
+
+class TestGetElementContainer(NewFile):
+    def test_nothing(cls):
+        pass
+
+
+class TestGetElementSystems(NewFile):
+    def test_nothing(cls):
+        pass
+
+
+class TestGetElementFeeds(NewFile):
+    def test_run(cls):
+        pass
+
+
 class TestGetItemClass(NewFile):
     def test_run(self):
         TestLoadBrickFile().test_run()
@@ -291,6 +404,21 @@ class TestImportBrickClasses(NewFile):
         assert brick.total_items == 1
         assert not brick.label
 
+    def test_run_split_sccreen(self):
+        TestLoadBrickFile().test_run()
+        subject.import_brick_classes("Class", split_screen=True)
+        assert len(bpy.context.scene.BIMBrickProperties.split_screen_bricks) == 2
+        brick = bpy.context.scene.BIMBrickProperties.split_screen_bricks[0]
+        assert brick.name == "Building"
+        assert brick.uri == "https://brickschema.org/schema/Brick#Building"
+        assert brick.total_items == 1
+        assert not brick.label
+        brick = bpy.context.scene.BIMBrickProperties.split_screen_bricks[1]
+        assert brick.name == "Location"
+        assert brick.uri == "https://brickschema.org/schema/Brick#Location"
+        assert brick.total_items == 1
+        assert not brick.label
+
 
 class TestImportBrickItems(NewFile):
     def test_run(self):
@@ -298,6 +426,16 @@ class TestImportBrickItems(NewFile):
         subject.import_brick_items("Building")
         assert len(bpy.context.scene.BIMBrickProperties.bricks) == 1
         brick = bpy.context.scene.BIMBrickProperties.bricks[0]
+        assert brick.name == "bldg"
+        assert brick.label == "My Building"
+        assert brick.uri == "https://example.org/digitaltwin#bldg"
+        assert brick.total_items == 0
+
+    def test_run_split_screen(self):
+        TestLoadBrickFile().test_run()
+        subject.import_brick_items("Building", split_screen=True)
+        assert len(bpy.context.scene.BIMBrickProperties.split_screen_bricks) == 1
+        brick = bpy.context.scene.BIMBrickProperties.split_screen_bricks[0]
         assert brick.name == "bldg"
         assert brick.label == "My Building"
         assert brick.uri == "https://example.org/digitaltwin#bldg"
@@ -315,6 +453,8 @@ class TestLoadBrickFile(NewFile):
         filepath = os.path.join(cwd, "..", "files", "spaces.ttl")
         subject.load_brick_file(filepath)
         assert BrickStore.graph
+        namespaces = [(ns[0], ns[1].toPython()) for ns in BrickStore.graph.namespaces()]
+        assert ("brick", "https://brickschema.org/schema/Brick#") in namespaces
 
 
 class TestNewBrickFile(NewFile):
@@ -340,13 +480,32 @@ class TestPopBrickBreadcrumb(NewFile):
         assert len(bpy.context.scene.BIMBrickProperties.brick_breadcrumbs) == 1
         assert bpy.context.scene.BIMBrickProperties.brick_breadcrumbs[0].name == "foo"
 
+    def test_run_split_screen(self):
+        bpy.context.scene.BIMBrickProperties.split_screen_brick_breadcrumbs.add().name = "foo"
+        bpy.context.scene.BIMBrickProperties.split_screen_brick_breadcrumbs.add().name = "bar"
+        assert subject.pop_brick_breadcrumb(split_screen=True) == "bar"
+        assert len(bpy.context.scene.BIMBrickProperties.split_screen_brick_breadcrumbs) == 1
+        assert bpy.context.scene.BIMBrickProperties.split_screen_brick_breadcrumbs[0].name == "foo"
+
 
 class TestRemoveBrick(NewFile):
     def test_run(self):
-        BrickStore.graph = brickschema.Graph()
-        result = subject.add_brick("http://example.org/digitaltwin#", "https://brickschema.org/schema/Brick#Equipment")
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
+        result = subject.add_brick("http://example.org/digitaltwin#", "https://brickschema.org/schema/Brick#Equipment", "label")
         subject.remove_brick(result)
         assert not list(BrickStore.graph.triples((URIRef(result), None, None)))
+
+    def test_run_with_bnode(self):
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
+        result = subject.add_brick("http://example.org/digitaltwin#", "https://brickschema.org/schema/Brick#Equipment", "label")
+        TestAddBrickifcProject().test_run()
+        element = tool.Ifc.get().createIfcChiller(ifcopenshell.guid.new())
+        element.Name = "Chiller"
+        project = URIRef(f"http://example.org/digitaltwin#{tool.Ifc.get().by_type('IfcProject')[0].GlobalId}")
+        subject.add_brickifc_reference(result, element, project)
+        subject.remove_brick(result)
+        assert not list(BrickStore.graph.triples((URIRef(result), None, None)))
+        assert not list(BrickStore.graph.triples((None, REF.hasIfcProjectReference, None)))
 
 
 class TestRunAssignBrickReference(NewFile):
@@ -359,7 +518,7 @@ class TestRunRefreshBrickViewer(NewFile):
         pass
 
 
-class TestViewBrickClass(NewFile):
+class TestRunViewBrickClass(NewFile):
     def test_nothing(self):
         pass
 
@@ -369,6 +528,10 @@ class TestSelectBrowserItem(NewFile):
         subject.set_active_brick_class("brick_class")
         assert bpy.context.scene.BIMBrickProperties.active_brick_class == "brick_class"
 
+    def test_run(self):
+        subject.set_active_brick_class("brick_class", split_screen=True)
+        assert bpy.context.scene.BIMBrickProperties.split_screen_active_brick_class == "brick_class"
+
 
 class TestSetActiveBrickClass(NewFile):
     def test_run(self):
@@ -376,3 +539,15 @@ class TestSetActiveBrickClass(NewFile):
         bpy.context.scene.BIMBrickProperties.bricks.add().name = "bar"
         subject.select_browser_item("namespace#bar")
         assert bpy.context.scene.BIMBrickProperties.active_brick_index == 1
+
+
+class TestSerializeBrick(NewFile):
+    def test_nothing(self):
+        pass
+
+
+class TestAddNamespace(NewFile):
+    def test_run(self):
+        BrickStore.graph = brickschema.persistent.VersionedGraphCollection("sqlite://")
+        subject.add_namespace("digitaltwin", "http://example.org/digitaltwin")
+        assert ("digitaltwin", "http://example.org/digitaltwin") in BrickStore.namespaces


### PR DESCRIPTION
- Update feature, core, and tool tests
- Data is now stored regularly in `BrickStore` and instead parsed in props
- Refresh viewer now reloads both screens by default
- Fix Brick tool
    - `get_convertable_brick_spaces` now returns a set
    - Fix assign brick reference bug from last merge
- Fix Brick Core
    - Fix error where `view_brick_class` was run instead of `brick.run_view_brick_class`