### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/ifcgeom/IfcGeom.cpp
+++ b/src/ifcgeom/IfcGeom.cpp
@@ -1084,11 +1084,9 @@ bool IfcGeom::Kernel::convert_layerset(const IfcSchema::IfcProduct* product, std
 
 		TopExp_Explorer exp(axis_shape, TopAbs_EDGE);
 		TopoDS_Edge axis_edge;
-		int edge_count = 0;
 
 		if (exp.More()) {
 			axis_edge = TopoDS::Edge(exp.Current());
-			++ edge_count;
 		} else {
 			Logger::Message(Logger::LOG_WARNING, "No edge found in axis representation:", product);
 			return false;

--- a/src/ifcgeom_schema_agnostic/IfcGeomRepresentation.h
+++ b/src/ifcgeom_schema_agnostic/IfcGeomRepresentation.h
@@ -159,8 +159,8 @@ namespace IfcGeom {
 				, _normals(normals)
 				, uvs_(uvs)
 				, _material_ids(material_ids)
-				, styles_(styles)
 				, _item_ids(item_ids)
+				, styles_(styles)
 			{
 				for (auto& s : styles_) {
 					_materials.push_back(IfcGeom::Material(s));

--- a/src/ifcparse/IfcFile.h
+++ b/src/ifcparse/IfcFile.h
@@ -272,7 +272,7 @@ public:
 
 	unsigned int getMaxId() const { return MaxId; }
 
-	const IfcParse::declaration* const ifcroot_type() const { return ifcroot_type_; }
+	const IfcParse::declaration* ifcroot_type() const { return ifcroot_type_; }
 
 	void recalculate_id_counter();
 


### PR DESCRIPTION
fix for the following compiler warnings using llvm clang 16.0.2:
```shell
/IfcOpenShell/src/ifcgeom/../ifcgeom_schema_agnostic/../ifcgeom_schema_agnostic/IfcGeomRepresentation.h:162:7: warning: field 'styles_' will be initialized after field '_item_ids' [-Wreorder-ctor]
                                , styles_(styles)
                                  ^~~~~~~~~~~~~~~
                                  _item_ids(item_ids)
```

```shell
/IfcOpenShell/src/ifcgeom/../ifcgeom_schema_agnostic/../ifcparse/IfcFile.h:275:31: warning: 'const' type qualifier on return type has no effect [-Wignored-qualifiers]
        const IfcParse::declaration* const ifcroot_type() const { return ifcroot_type_; }
                                     ^~~~~~
```

```shell
/IfcOpenShell/src/ifcgeom/IfcGeom.cpp:1087:7: warning: variable 'edge_count' set but not used [-Wunused-but-set-variable]
                int edge_count = 0;
```