### PR TITLE
cmake: merge v0.7.0 changes to v0.8.0

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.1.3)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON) # not necessary, but encouraged
 
-project(IfcOpenShell VERSION 0.7.0)
+project(IfcOpenShell VERSION 0.8.0)
 
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0074 NEW)
@@ -55,11 +55,14 @@ option(BUILD_IFCMAX "Build IfcMax, a 3ds Max plug-in, Windows-only." OFF)
 option(BUILD_QTVIEWER "Build IfcOpenShell Qt GUI Viewer" OFF) # QtViewer requires Qt6
 option(BUILD_PACKAGE "" OFF)
 
+option(WITH_OPENCASCADE "Enable geometry interpretation using Open CASCADE" ON)
+option(WITH_CGAL "Enable geometry interpretation using CGAL" ON)
 option(COLLADA_SUPPORT "Build IfcConvert with COLLADA support (requires OpenCOLLADA)." ON)
 option(GLTF_SUPPORT "Build IfcConvert with glTF support (requires json.hpp)." OFF)
 option(HDF5_SUPPORT "Enable HDF5 support (requires HDF5, zlib)" ON)
 option(IFCXML_SUPPORT "Build IfcParse with ifcXML support (requires libxml2)." ON)
 option(USD_SUPPORT "Build IfcConvert with USD support (requires pixar's USD library)." OFF)
+option(CITYJSON_SUPPORT "Build IfcConvert with CityJSON support (requires CityJSON library)." ON)
 
 option(USERSPACE_PYTHON_PREFIX "Installs IfcPython for the current user only instead of system-wide." OFF)
 option(ADD_COMMIT_SHA "Add commit sha and branch in version number, warning results in many rebuilds, requires git" OFF)
@@ -68,6 +71,7 @@ if(MINIMAL_BUILD)
     message(STATUS "Setting options for minimal build")
     set(BUILD_GEOMSERVER OFF)
     set(BUILD_IFCPYTHON OFF)
+    set(WITH_CGAL OFF)
     set(COLLADA_SUPPORT OFF)
     set(GLTF_SUPPORT OFF)
     set(HDF5_SUPPORT OFF)
@@ -144,6 +148,7 @@ UNIFY_ENVVARS_AND_CACHE(OCC_INCLUDE_DIR)
 UNIFY_ENVVARS_AND_CACHE(OCC_LIBRARY_DIR)
 UNIFY_ENVVARS_AND_CACHE(BOOST_ROOT)
 UNIFY_ENVVARS_AND_CACHE(BOOST_LIBRARYDIR)
+UNIFY_ENVVARS_AND_CACHE(EIGEN_DIR)
 
 if(NOT MINIMAL_BUILD)
     UNIFY_ENVVARS_AND_CACHE(OPENCOLLADA_INCLUDE_DIR)
@@ -163,12 +168,38 @@ if(NOT MINIMAL_BUILD)
     UNIFY_ENVVARS_AND_CACHE(MPFR_LIBRARY_DIR)
 endif()
 
+# Include the 'convert_env_var_to_bool' and 'get_all_option_flags' functions
+include(utilities.cmake)
+
+# Get a list of all OPTION flags from the CMakeLists.txt
+get_all_option_flags(option_flags)
+
+# Loop through the list of OPTION flags and convert the corresponding environment variables
+foreach(option_flag IN LISTS option_flags)
+    convert_env_var_to_bool("${option_flag}")
+endforeach()
+
 if(WASM_BUILD)
     # when using the nix/build-all.py build script we should not
     # look into the sysroot for most of the dependencies but rather
     # in the designated build/ folder created by the script.
     set(CMAKE_FIND_ROOT_PATH_BACKUP "${CMAKE_FIND_ROOT_PATH}")
     set(CMAKE_FIND_ROOT_PATH "")
+endif()
+
+if(WITH_CGAL)
+    if(CITYJSON_SUPPORT)
+        add_definitions(-DIFOPSH_WITH_CGAL)
+        set(SWIG_DEFINES ${SWIG_DEFINES} -DIFOPSH_WITH_CGAL)
+    endif()
+
+    list(APPEND GEOMETRY_KERNELS cgal)
+endif()
+
+if(WITH_OPENCASCADE)
+    add_definitions(-DIFOPSH_WITH_OPENCASCADE)
+    set(SWIG_DEFINES ${SWIG_DEFINES} -DIFOPSH_WITH_OPENCASCADE)
+    list(APPEND GEOMETRY_KERNELS opencascade)
 endif()
 
 if(GLTF_SUPPORT AND BUILD_CONVERT)
@@ -230,7 +261,7 @@ if(USD_SUPPORT)
 
     add_definitions(-DWITH_USD)
     set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_USD)
-endif()
+endif(USD_SUPPORT)
 
 # Set INSTALL_RPATH for target
 macro(SET_INSTALL_RPATHS _target _paths)
@@ -276,7 +307,7 @@ else()
     endif()
 endif()
 
-if (WASM_BUILD)
+if(WASM_BUILD)
     set(BOOST_COMPONENTS)
 else()
     # @todo review this, shouldn't this be all possible header-only now?
@@ -353,6 +384,7 @@ if(BUILD_IFCGEOM)
     endif()
 
     # Open CASCADE
+    if(WITH_OPENCASCADE)
     if("${OCC_INCLUDE_DIR}" STREQUAL "")
         find_path(OCC_INCLUDE_DIR Standard_Version.hxx
             PATHS
@@ -443,14 +475,14 @@ if(BUILD_IFCGEOM)
             set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
         endif()
         
-        if (NOT APPLE AND NOT WIN32)
+        if(NOT APPLE AND NOT WIN32)
             set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} "rt")
         endif()
-        if (NOT WIN32)
+        if(NOT WIN32)
             set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} "dl")
         endif()
     endif()
-
+    endif(WITH_OPENCASCADE)
 endif(BUILD_IFCGEOM)
 
 if(COLLADA_SUPPORT)
@@ -535,7 +567,7 @@ if(COLLADA_SUPPORT)
         message(FATAL_ERROR "COLLADA_SUPPORT enabled, but unable to find OpenCOLLADA headers. "
             "Disable COLLADA_SUPPORT or fix OpenCOLLADA paths to proceed.")
     endif()
-endif()
+endif(COLLADA_SUPPORT)
 
 if(HDF5_SUPPORT)
     if("${HDF5_INCLUDE_DIR}" STREQUAL "")
@@ -613,7 +645,7 @@ if(HDF5_SUPPORT)
 
     add_definitions(-DWITH_HDF5)
     set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_HDF5)
-endif()
+endif(HDF5_SUPPORT)
 
 if(WASM_BUILD)
     # reset to use sysroot
@@ -643,12 +675,11 @@ if(ENABLE_BUILD_OPTIMIZATIONS)
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
         set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} -O3")
     endif()
-endif()
+endif(ENABLE_BUILD_OPTIMIZATIONS)
 
 if(MSVC)
     # warning due to virtual inheritance
     add_definitions(-wd4250)
-
     # warning due to select definitions in the schema being redundant
     add_definitions(-wd4584)
 
@@ -684,20 +715,21 @@ if(MSVC)
         add_definitions(-permissive-)
     endif()
 
-# Link against the static VC runtime
-# TODO Make this configurable
-# IF("$ENV{CONDA_BUILD}" STREQUAL "")
-# FOREACH(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL
-# CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-# CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
-# IF(${flag} MATCHES "/MD")
-# STRING(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
-# ENDIF()
-# IF(${flag} MATCHES "/MDd")
-# STRING(REGEX REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
-# ENDIF()
-# ENDFOREACH()
-# ENDIF()
+    # Link against the static VC runtime
+    # TODO Make this configurable
+    # if("$ENV{CONDA_BUILD}" STREQUAL "")
+    #     foreach(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL
+    #     CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+    #     CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+    #         if(${flag} MATCHES "/MD")
+    #             STRING(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+    #         endif()
+    #         if(${flag} MATCHES "/MDd")
+    #             STRING(REGEX REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
+    #         endif()
+    #     endforeach()
+    # endif()
+
 else()
     add_definitions(-Wall -Wextra)
 
@@ -716,11 +748,11 @@ else()
     if(UNIX)
         add_definitions(-fPIC)
     endif()
-endif()
+endif(MSVC)
 
 include_directories(${INCLUDE_DIRECTORIES} ${OCC_INCLUDE_DIR} ${OPENCOLLADA_INCLUDE_DIRS}
 	${Boost_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIR} ${JSON_INCLUDE_DIR} ${HDF5_INCLUDE_DIR}
-    ${USD_INCLUDE_DIR}
+    ${EIGEN_DIR} ${CGAL_INCLUDE_DIR} ${GMP_INCLUDE_DIR} ${MPFR_INCLUDE_DIR} ${USD_INCLUDE_DIR}
 )
 
 function(files_for_ifc_version IFC_VERSION RESULT_NAME)
@@ -809,7 +841,7 @@ if(COMPILE_SCHEMA)
             list(REMOVE_ITEM IFC_RELEASE_NOT_USED "${schema}")
         endif()
     endforeach()
-endif()
+endif(COMPILE_SCHEMA)
 
 # Boost >= 1.58 requires BOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE to build on some Linux distros.
 if(NOT Boost_VERSION LESS 105800)
@@ -817,22 +849,37 @@ if(NOT Boost_VERSION LESS 105800)
 endif()
 
 set(IFCOPENSHELL_LIBRARIES IfcParse)
-if (BUILD_IFCGEOM)
+
+if(BUILD_IFCGEOM)
 	foreach(schema ${SCHEMA_VERSIONS})
-		set(IFCGEOM_SCHEMA_LIBRARIES ${IFCGEOM_SCHEMA_LIBRARIES} IfcGeom_ifc${schema})
+		set(IFCGEOM_SCHEMA_LIBRARIES ${IFCGEOM_SCHEMA_LIBRARIES} geometry_mapping_ifc${schema})
 	endforeach()
-	if (WASM_BUILD)
+	if(WASM_BUILD)
 	    set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} IfcGeom ${IFCGEOM_SCHEMA_LIBRARIES})
 	else()
 	    set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} IfcGeom ${IFCGEOM_SCHEMA_LIBRARIES} IfcGeom ${IFCGEOM_SCHEMA_LIBRARIES})	
 	endif()
 endif()
 
-if (BUILD_CONVERT OR BUILD_IFCPYTHON)
+if(BUILD_CONVERT OR BUILD_IFCPYTHON)
 	foreach(schema ${SCHEMA_VERSIONS})
 		set(SERIALIZER_SCHEMA_LIBRARIES ${SERIALIZER_SCHEMA_LIBRARIES} Serializers_ifc${schema})
 	endforeach()
 	set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} Serializers ${SERIALIZER_SCHEMA_LIBRARIES})
+
+    if(WITH_OPENCASCADE)
+        foreach(schema ${SCHEMA_VERSIONS})
+            set(GEOM_SERIALIZER_SCHEMA_LIBRARIES ${GEOM_SERIALIZER_SCHEMA_LIBRARIES} GeometrySerializers_ifc${schema})
+
+            add_library(geometry_serializer_ifc${schema} STATIC ../src/ifcgeom/Serialization/schema/Serialization.cpp)
+            set_target_properties(geometry_serializer_ifc${schema} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${schema}")
+            list(APPEND geometry_serializer_libraries geometry_serializer_ifc${schema})
+        endforeach()
+
+        add_library(geometry_serializer STATIC ../src/ifcgeom/Serialization/Serialization.cpp)
+        target_link_libraries(geometry_serializer ${geometry_serializer_libraries})
+        set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} geometry_serializer ${geometry_serializer_libraries})
+    endif()
 endif()
 
 # IfcParse
@@ -871,29 +918,68 @@ set(IFCPARSE_FILES ${IFCPARSE_CPP_FILES} ${IFCPARSE_H_FILES})
 add_library(IfcParse ${IFCPARSE_FILES})
 set_target_properties(IfcParse PROPERTIES COMPILE_FLAGS -DIFC_PARSE_EXPORTS VERSION "${PROJECT_VERSION}" SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
-if (WASM_BUILD)
+if(WASM_BUILD)
     target_link_libraries(IfcParse ${BCRYPT_LIBRARIES} ${LIBXML2_LIBRARIES})
 else()
     target_link_libraries(IfcParse ${Boost_LIBRARIES} ${BCRYPT_LIBRARIES} ${LIBXML2_LIBRARIES})
 endif()
 
 if(BUILD_IFCGEOM)
-    # IfcGeom
-    file(GLOB IFCGEOM_H_FILES ../src/ifcgeom/*.h ../src/ifcgeom/*.i)
-    file(GLOB IFCGEOM_CPP_FILES ../src/ifcgeom/*.cpp)
-    set(IFCGEOM_FILES ${IFCGEOM_CPP_FILES} ${IFCGEOM_H_FILES})
+    if(WITH_CGAL)
+        find_library(libGMP NAMES gmp mpir PATHS ${GMP_LIBRARY_DIR} NO_DEFAULT_PATH)
+        find_library(libMPFR NAMES mpfr PATHS ${MPFR_LIBRARY_DIR} NO_DEFAULT_PATH)
+        if(NOT libGMP)
+            message(FATAL_ERROR "Unable to find GMP library files, aborting")
+        endif()
+        if(NOT libMPFR)
+            message(FATAL_ERROR "Unable to find MPFR library files, aborting")
+        endif()
 
-    foreach(schema ${SCHEMA_VERSIONS})
-        add_library(IfcGeom_ifc${schema} STATIC ${IFCGEOM_FILES})
-        set_target_properties(IfcGeom_ifc${schema} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${schema}")
-        if (NOT WASM_BUILD)
-            target_link_libraries(IfcGeom_ifc${schema} IfcParse ${OPENCASCADE_LIBRARIES})	    
+        list(APPEND CGAL_LIBRARIES "${libMPFR}")
+        list(APPEND CGAL_LIBRARIES "${libGMP}")
+    endif()
+
+    foreach(kernel ${GEOMETRY_KERNELS})
+        string(TOUPPER ${kernel} KERNEL_UPPER)
+        file(GLOB IFCGEOM_H_FILES ../src/ifcgeom/kernels/${kernel}/*.h)
+        file(GLOB IFCGEOM_CPP_FILES ../src/ifcgeom/kernels/${kernel}/*.cpp)
+        set(IFCGEOM_FILES ${IFCGEOM_CPP_FILES} ${IFCGEOM_H_FILES})
+        
+        add_library(geometry_kernel_${kernel} ${IFCGEOM_FILES})
+        set_target_properties(geometry_kernel_${kernel} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS")
+        # needed?
+        # if(NOT WASM_BUILD)
+        # endif()
+        target_link_libraries(geometry_kernel_${kernel} ${${KERNEL_UPPER}_LIBRARIES})
+        list(APPEND kernel_libraries geometry_kernel_${kernel})
+        
+        if(${kernel} STREQUAL "cgal")
+            add_library(geometry_kernel_${kernel}_simple ${IFCGEOM_FILES})
+            set_target_properties(geometry_kernel_${kernel}_simple PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIFOPSH_SIMPLE_KERNEL")
+            # needed?
+            # if(NOT WASM_BUILD)
+            # endif()
+            target_link_libraries(geometry_kernel_${kernel}_simple ${${KERNEL_UPPER}_LIBRARIES})
+            list(APPEND kernel_libraries geometry_kernel_${kernel}_simple)
         endif()
     endforeach()
 
+    # IfcGeom
+    foreach(schema ${SCHEMA_VERSIONS})
+        file(GLOB IFCGEOM_I_FILES ../src/ifcgeom/mapping/*.i)
+        file(GLOB IFCGEOM_H_FILES ../src/ifcgeom/mapping/*.h)
+        file(GLOB IFCGEOM_CPP_FILES ../src/ifcgeom/mapping/*.cpp)
+        set(IFCGEOM_FILES ${IFCGEOM_CPP_FILES} ${IFCGEOM_H_FILES} ${IFCGEOM_I_FILES})
+        
+        add_library(geometry_mapping_ifc${schema} STATIC ${IFCGEOM_FILES})
+        set_target_properties(geometry_mapping_ifc${schema} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${schema}")
+        target_link_libraries(geometry_mapping_ifc${schema} IfcParse)
+        list(APPEND mapping_libraries geometry_mapping_ifc${schema})
+    endforeach()
+
     # IfcGeom (schema agnostic)
-    file(GLOB SCHEMA_AGNOSTIC_H_FILES ../src/ifcgeom_schema_agnostic/*.h)
-    file(GLOB SCHEMA_AGNOSTIC_CPP_FILES ../src/ifcgeom_schema_agnostic/*.cpp)
+    file(GLOB SCHEMA_AGNOSTIC_H_FILES ../src/ifcgeom/*.h)
+    file(GLOB SCHEMA_AGNOSTIC_CPP_FILES ../src/ifcgeom/*.cpp)
     set(SCHEMA_AGNOSTIC_FILES ${SCHEMA_AGNOSTIC_H_FILES} ${SCHEMA_AGNOSTIC_CPP_FILES})
 
     add_library(IfcGeom ${SCHEMA_AGNOSTIC_FILES})
@@ -903,10 +989,10 @@ if(BUILD_IFCGEOM)
         find_package(Threads)
     endif()
 
-    if (WASM_BUILD)
-        target_link_libraries(IfcGeom ${IFCGEOM_SCHEMA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    if(WASM_BUILD)
+        target_link_libraries(IfcGeom ${kernel_libraries} ${mapping_libraries} ${CMAKE_THREAD_LIBS_INIT})
     else()
-        target_link_libraries(IfcGeom IfcParse ${IFCGEOM_SCHEMA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+        target_link_libraries(IfcGeom IfcParse ${kernel_libraries} ${mapping_libraries} ${CMAKE_THREAD_LIBS_INIT})
     endif()
 
 endif(BUILD_IFCGEOM)
@@ -924,7 +1010,7 @@ if(BUILD_CONVERT OR BUILD_IFCPYTHON)
         add_library(Serializers_ifc${schema} STATIC ${SERIALIZERS_S_FILES})
         set_target_properties(Serializers_ifc${schema} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${schema}")
         
-        if (WASM_BUILD)
+        if(WASM_BUILD)
             target_link_libraries(Serializers_ifc${schema} ${HDF5_LIBRARIES})
         else()
             target_link_libraries(Serializers_ifc${schema} IfcGeom ${OPENCASCADE_LIBRARIES} ${HDF5_LIBRARIES})
@@ -939,6 +1025,23 @@ if(BUILD_CONVERT OR BUILD_IFCPYTHON)
 endif(BUILD_CONVERT OR BUILD_IFCPYTHON)
 
 if(BUILD_CONVERT)
+    if(WITH_CGAL AND CITYJSON_SUPPORT)
+        message(STATUS "Building CityJSON support")
+        set(CITYJSON_CONVERT_FILES
+            ../src/ifcconvert/cityjson/geobim.cpp
+            ../src/ifcconvert/cityjson/global_execution_context.cpp
+            ../src/ifcconvert/cityjson/opening_collector.cpp
+            ../src/ifcconvert/cityjson/processing.cpp
+            ../src/ifcconvert/cityjson/radius_comparison.cpp
+            ../src/ifcconvert/cityjson/radius_execution_context.cpp
+            ../src/ifcconvert/cityjson/settings.cpp
+            ../src/ifcconvert/cityjson/writer.cpp
+        )
+        add_library(cityjson_converter ${CITYJSON_CONVERT_FILES})
+        target_include_directories(cityjson_converter PRIVATE ../src)
+        set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} cityjson_converter)
+    endif()
+
     # IfcConvert
     file(GLOB IFCCONVERT_CPP_FILES ../src/ifcconvert/*.cpp)
     file(GLOB IFCCONVERT_H_FILES ../src/ifcconvert/*.h)
@@ -978,7 +1081,7 @@ if(BUILD_GEOMSERVER)
         LIBRARY DESTINATION ${LIBDIR}
         RUNTIME DESTINATION ${BINDIR}
     )
-endif()
+endif(BUILD_GEOMSERVER)
 
 if(ADD_COMMIT_SHA)
     find_package(Git)
@@ -995,7 +1098,7 @@ if(ADD_COMMIT_SHA)
         foreach(git_branch_candidate IN ITEMS ${git_branch_list})
 		    string(REPLACE "*" "" git_branch_candidate_temp "${git_branch_candidate}")
 		    string(STRIP "${git_branch_candidate_temp}" git_branch_candidate_2)
-            if (NOT git_branch_candidate_2 MATCHES "^HEAD$")
+            if(NOT git_branch_candidate_2 MATCHES "^HEAD$")
                 string(REPLACE "/" ";" git_branch_candidate_2_list "${git_branch_candidate_2}")
                 list(GET git_branch_candidate_2_list -1 git_branch)
             endif()
@@ -1011,6 +1114,13 @@ if(ADD_COMMIT_SHA)
         add_definitions(-DIFCOPENSHELL_BRANCH=${git_branch})
         add_definitions(-DIFCOPENSHELL_COMMIT=${git_sha})
     endif()
+endif(ADD_COMMIT_SHA)
+
+if(MSVC)
+    # @todo still needs to be understood better, but the cgal and cgal-simple kernel cause multiply defined boost lambda placeholders _1 ... _3
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /FORCE:MULTIPLE")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /FORCE:MULTIPLE")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /FORCE:MULTIPLE")
 endif()
 
 # Documentation
@@ -1031,8 +1141,8 @@ if(BUILD_IFCMAX)
     add_subdirectory(../src/ifcmax ifcmax)
 endif()
 
-if(NOT MINIMAL_BUILD)
-    add_subdirectory(../src/svgfill svgfill)
+if(WITH_CGAL)
+    add_subdirectory(../src/svgfill svgfill)        
 endif()
 
 if(BUILD_QTVIEWER)
@@ -1064,7 +1174,7 @@ if(BUILD_IFCGEOM)
         LIBRARY DESTINATION ${LIBDIR}
         RUNTIME DESTINATION ${BINDIR}
     )
-endif()
+endif(BUILD_IFCGEOM)
 
 if(BUILD_CONVERT)
     install(TARGETS Serializers ${SERIALIZER_SCHEMA_LIBRARIES}
@@ -1080,7 +1190,7 @@ if(BUILD_CONVERT)
     install(FILES ${SERIALIZERS_S_FILES}
         DESTINATION ${INCLUDEDIR}/serializers/schema_dependent
     )
-endif()
+endif(BUILD_CONVERT)
 
 # Cmake uninstall target
 if(NOT TARGET uninstall)
@@ -1127,6 +1237,6 @@ set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 set(CPACK_DEBIAN_PACKAGE_SECTION "science")
 set(CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}${EXTRA_VERSION}")
 set(CPACK_DEBIAN_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
-
 # set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/cmake/debian/postinst")
+
 include(CPack)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -18,153 +18,150 @@
 ################################################################################
 
 cmake_minimum_required(VERSION 3.1.3)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)  # not necessary, but encouraged
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON) # not necessary, but encouraged
 
-project (IfcOpenShell VERSION 0.7.0)
+project(IfcOpenShell VERSION 0.7.0)
 
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0074 NEW)
 cmake_policy(SET CMP0078 OLD)
 cmake_policy(SET CMP0086 NEW)
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
 # use extra version to make pre-release using eg semver
-set( EXTRA_VERSION "-alpha.3")
+set(EXTRA_VERSION "-alpha.3")
 
-foreach(max_year RANGE 2014 2030)
-set(max_sdk "$ENV{ADSK_3DSMAX_SDK_${max_year}}")
-if (NOT "${max_sdk}" STREQUAL "")
-MESSAGE(STATUS "Autodesk 3ds Max SDK found at ${max_sdk}")
-set(HAS_MAX TRUE)
-endif()
-endforeach()
-OPTION(MINIMAL_BUILD "The build is to make a minimal version of IFC converter from OCCT into IFC." OFF)
-OPTION(COLLADA_SUPPORT "Build IfcConvert with COLLADA support (requires OpenCOLLADA)." ON)
-OPTION(IFCXML_SUPPORT "Build IfcParse with ifcXML support (requires libxml2)." ON)
-OPTION(ENABLE_BUILD_OPTIMIZATIONS "Enable certain compiler and linker optimizations on RelWithDebInfo and Release builds." OFF)
-OPTION(BUILD_PACKAGE "" OFF)
-OPTION(BUILD_IFCGEOM "Build IfcGeom." ON)
-OPTION(BUILD_DOCUMENTATION "Build IfcOpenShell Documentation." OFF)
-OPTION(BUILD_IFCPYTHON "Build IfcPython." ON)
-OPTION(BUILD_EXAMPLES "Build example applications." ON)
-OPTION(BUILD_GEOMSERVER "Build IfcGeomServer executable." ON)
-OPTION(BUILD_CONVERT "Build IfcConvert executable." ON)
-OPTION(HDF5_SUPPORT "Enable HDF5 support (requires HDF5, zlib)" ON)
-OPTION(USE_VLD "Use Visual Leak Detector for debugging memory leaks, MSVC-only." OFF)
-OPTION(USE_MMAP "Adds a command line options to parse IFC files from memory mapped files using Boost.Iostreams" OFF)
-OPTION(BUILD_SHARED_LIBS "Build IfcParse and IfcGeom as shared libs (SO/DLL)." OFF)
-OPTION(MSVC_PARALLEL_BUILD "Multi-threaded compilation in Microsoft Visual Studio (/MP)" OFF)
-OPTION(WASM_BUILD OFF)
-if (${HAS_MAX})
-OPTION(BUILD_IFCMAX "Build IfcMax, a 3ds Max plug-in, Windows-only." OFF)
-endif()
-if (${BUILD_CONVERT})
-OPTION(GLTF_SUPPORT "Build IfcConvert with glTF support (requires json.hpp)." OFF)
-endif()
-OPTION(USERSPACE_PYTHON_PREFIX "Installs IfcPython for the current user only instead of system-wide." OFF)
-OPTION(ADD_COMMIT_SHA "Add commit sha and branch in version number, warning results in many rebuilds, requires git" OFF)
-OPTION(WITH_OPENCASCADE "Enable geometry interpretation using Open CASCADE" ON)
-OPTION(WITH_CGAL "Enable geometry interpretation using CGAL" ON)
-OPTION(CITYJSON_SUPPORT "Build IfcConvert with CityJSON support (requires CityJSON library)." ON)
+option(MINIMAL_BUILD "The build is to make a minimal version of IFC converter from OCCT into IFC." OFF)
+option(WASM_BUILD "Build a WebAssembly binary." OFF)
 
-IF(NOT CMAKE_BUILD_TYPE)
-	SET(CMAKE_BUILD_TYPE "Release")
-ENDIF()
+option(ENABLE_BUILD_OPTIMIZATIONS "Enable certain compiler and linker optimizations on RelWithDebInfo and Release builds." OFF)
+option(BUILD_SHARED_LIBS "Build IfcParse and IfcGeom as shared libs (SO/DLL)." OFF)
+option(MSVC_PARALLEL_BUILD "Multi-threaded compilation in Microsoft Visual Studio (/MP)" OFF)
+option(USE_VLD "Use Visual Leak Detector for debugging memory leaks, MSVC-only." OFF)
+option(USE_MMAP "Adds a command line options to parse IFC files from memory mapped files using Boost.Iostreams" OFF)
+option(NO_WARN "Disable all warnings" OFF)
 
-if(MSVC AND MSVC_PARALLEL_BUILD)
-	add_definitions("/MP")
+option(BUILD_IFCGEOM "Build IfcGeom." ON)
+option(BUILD_IFCPYTHON "Build IfcPython." ON)
+option(BUILD_CONVERT "Build IfcConvert executable." ON)
+option(BUILD_DOCUMENTATION "Build IfcOpenShell Documentation." OFF)
+option(BUILD_EXAMPLES "Build example applications." ON)
+option(BUILD_GEOMSERVER "Build IfcGeomServer executable." ON)
+option(BUILD_IFCMAX "Build IfcMax, a 3ds Max plug-in, Windows-only." OFF)
+option(BUILD_QTVIEWER "Build IfcOpenShell Qt GUI Viewer" OFF) # QtViewer requires Qt6
+option(BUILD_PACKAGE "" OFF)
+
+option(COLLADA_SUPPORT "Build IfcConvert with COLLADA support (requires OpenCOLLADA)." ON)
+option(GLTF_SUPPORT "Build IfcConvert with glTF support (requires json.hpp)." OFF)
+option(HDF5_SUPPORT "Enable HDF5 support (requires HDF5, zlib)" ON)
+option(IFCXML_SUPPORT "Build IfcParse with ifcXML support (requires libxml2)." ON)
+option(USD_SUPPORT "Build IfcConvert with USD support (requires pixar's USD library)." OFF)
+
+option(USERSPACE_PYTHON_PREFIX "Installs IfcPython for the current user only instead of system-wide." OFF)
+option(ADD_COMMIT_SHA "Add commit sha and branch in version number, warning results in many rebuilds, requires git" OFF)
+
+if(MINIMAL_BUILD)
+    message(STATUS "Setting options for minimal build")
+    set(BUILD_GEOMSERVER OFF)
+    set(BUILD_IFCPYTHON OFF)
+    set(COLLADA_SUPPORT OFF)
+    set(GLTF_SUPPORT OFF)
+    set(HDF5_SUPPORT OFF)
+    set(IFCXML_SUPPORT OFF)
+    set(USD_SUPPORT OFF)
 endif()
 
-# QtViewer requires Qt5
-OPTION(BUILD_QTVIEWER "Build IfcOpenShell Qt GUI Viewer" OFF)
-include(GNUInstallDirs)
-if((BUILD_CONVERT OR BUILD_GEOMSERVER OR BUILD_IFCPYTHON) AND (NOT BUILD_IFCGEOM))
+if((BUILD_CONVERT OR BUILD_GEOMSERVER OR BUILD_IFCPYTHON) AND(NOT BUILD_IFCGEOM))
     message(STATUS "'IfcGeom' is required with current outputs")
     set(BUILD_IFCGEOM ON)
 endif()
 
-# Specify where to install files
-IF(NOT BINDIR)
+if(MSVC AND MSVC_PARALLEL_BUILD)
+    add_definitions("/MP")
+endif()
+
+if(NO_WARN)
+    if(MSVC)
+        add_compile_options("/w")
+    else()
+        add_compile_options("-w")
+    endif()
+endif()
+
+include(GNUInstallDirs)
+
+# Specify paths to install files
+if(NOT BINDIR)
     set(BINDIR bin)
-ENDIF()
-IF(NOT IS_ABSOLUTE ${BINDIR})
+endif()
+if(NOT IS_ABSOLUTE ${BINDIR})
     set(BINDIR ${CMAKE_INSTALL_BINDIR})
-ENDIF()
-MESSAGE(STATUS "BINDIR: ${BINDIR}")
+endif()
+message(STATUS "BINDIR: ${BINDIR}")
 
-IF(NOT INCLUDEDIR)
+if(NOT INCLUDEDIR)
     set(INCLUDEDIR include)
-ENDIF()
-IF(NOT IS_ABSOLUTE ${INCLUDEDIR})
+endif()
+if(NOT IS_ABSOLUTE ${INCLUDEDIR})
     set(INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
-ENDIF()
-MESSAGE(STATUS "INCLUDEDIR: ${INCLUDEDIR}")
+endif()
+message(STATUS "INCLUDEDIR: ${INCLUDEDIR}")
 
-IF(NOT LIBDIR)
+if(NOT LIBDIR)
     set(LIBDIR lib)
-ENDIF()
-IF(NOT IS_ABSOLUTE ${LIBDIR})
+endif()
+if(NOT IS_ABSOLUTE ${LIBDIR})
     set(LIBDIR ${CMAKE_INSTALL_LIBDIR})
-ENDIF()
-MESSAGE(STATUS "LIBDIR: ${LIBDIR}")
+endif()
+message(STATUS "LIBDIR: ${LIBDIR}")
 
 set(IFCOPENSHELL_LIBRARY_DIR "") # for *nix rpaths
 
-if (BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS)
     add_definitions(-DIFC_SHARED_BUILD)
-    if (MSVC)
+    if(MSVC)
         message(WARNING "Building DLLs against the static VC run-time. This is not recommended if the DLLs are to be redistributed.")
         # C4521: 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
         # There will be couple hundreds of these so suppress them away, https://msdn.microsoft.com/en-us/library/esew7y1w.aspx
         add_definitions(-wd4251)
     endif()
+
     set(IFCOPENSHELL_LIBRARY_DIR "${LIBDIR}")
 endif()
 
 # Create cache entries if absent for environment variables
-MACRO(UNIFY_ENVVARS_AND_CACHE VAR)
-	IF ((NOT DEFINED ${VAR}) AND (NOT "$ENV{${VAR}}" STREQUAL ""))
-		SET(${VAR} "$ENV{${VAR}}" CACHE STRING "${VAR}" FORCE)
-	ENDIF()
-ENDMACRO()
+macro(UNIFY_ENVVARS_AND_CACHE VAR)
+    if((NOT DEFINED ${VAR}) AND(NOT "$ENV{${VAR}}" STREQUAL ""))
+        set(${VAR} "$ENV{${VAR}}" CACHE STRING "${VAR}" FORCE)
+    endif()
+endmacro()
 
 UNIFY_ENVVARS_AND_CACHE(OCC_INCLUDE_DIR)
 UNIFY_ENVVARS_AND_CACHE(OCC_LIBRARY_DIR)
-if (NOT MINIMAL_BUILD)
-UNIFY_ENVVARS_AND_CACHE(OPENCOLLADA_INCLUDE_DIR)
-UNIFY_ENVVARS_AND_CACHE(OPENCOLLADA_LIBRARY_DIR)
-UNIFY_ENVVARS_AND_CACHE(LIBXML2_INCLUDE_DIR)
-UNIFY_ENVVARS_AND_CACHE(LIBXML2_LIBRARIES)
-UNIFY_ENVVARS_AND_CACHE(PCRE_LIBRARY_DIR)
-UNIFY_ENVVARS_AND_CACHE(PYTHON_EXECUTABLE)
-UNIFY_ENVVARS_AND_CACHE(HDF5_INCLUDE_DIR)
-UNIFY_ENVVARS_AND_CACHE(HDF5_LIBRARY_DIR)
-UNIFY_ENVVARS_AND_CACHE(HDF5_LIBRARIES)
-endif()
 UNIFY_ENVVARS_AND_CACHE(BOOST_ROOT)
 UNIFY_ENVVARS_AND_CACHE(BOOST_LIBRARYDIR)
 
-if (NOT MINIMAL_BUILD)
-UNIFY_ENVVARS_AND_CACHE(CGAL_INCLUDE_DIR)
-UNIFY_ENVVARS_AND_CACHE(CGAL_LIBRARY_DIR)
-UNIFY_ENVVARS_AND_CACHE(GMP_INCLUDE_DIR)
-UNIFY_ENVVARS_AND_CACHE(GMP_LIBRARY_DIR)
-UNIFY_ENVVARS_AND_CACHE(MPFR_INCLUDE_DIR)
-UNIFY_ENVVARS_AND_CACHE(MPFR_LIBRARY_DIR)
+if(NOT MINIMAL_BUILD)
+    UNIFY_ENVVARS_AND_CACHE(OPENCOLLADA_INCLUDE_DIR)
+    UNIFY_ENVVARS_AND_CACHE(OPENCOLLADA_LIBRARY_DIR)
+    UNIFY_ENVVARS_AND_CACHE(LIBXML2_INCLUDE_DIR)
+    UNIFY_ENVVARS_AND_CACHE(LIBXML2_LIBRARIES)
+    UNIFY_ENVVARS_AND_CACHE(PCRE_LIBRARY_DIR)
+    UNIFY_ENVVARS_AND_CACHE(PYTHON_EXECUTABLE)
+    UNIFY_ENVVARS_AND_CACHE(HDF5_INCLUDE_DIR)
+    UNIFY_ENVVARS_AND_CACHE(HDF5_LIBRARY_DIR)
+    UNIFY_ENVVARS_AND_CACHE(HDF5_LIBRARIES)
+    UNIFY_ENVVARS_AND_CACHE(CGAL_INCLUDE_DIR)
+    UNIFY_ENVVARS_AND_CACHE(CGAL_LIBRARY_DIR)
+    UNIFY_ENVVARS_AND_CACHE(GMP_INCLUDE_DIR)
+    UNIFY_ENVVARS_AND_CACHE(GMP_LIBRARY_DIR)
+    UNIFY_ENVVARS_AND_CACHE(MPFR_INCLUDE_DIR)
+    UNIFY_ENVVARS_AND_CACHE(MPFR_LIBRARY_DIR)
 endif()
-
-UNIFY_ENVVARS_AND_CACHE(EIGEN_DIR)
-
-# Include the 'convert_env_var_to_bool' and 'get_all_option_flags' functions
-include(utilities.cmake)
-
-# Get a list of all OPTION flags from the CMakeLists.txt
-get_all_option_flags(option_flags)
-
-# Loop through the list of OPTION flags and convert the corresponding environment variables
-foreach(option_flag IN LISTS option_flags)
-    convert_env_var_to_bool("${option_flag}")
-endforeach()
 
 if(WASM_BUILD)
     # when using the nix/build-all.py build script we should not
@@ -174,74 +171,110 @@ if(WASM_BUILD)
     set(CMAKE_FIND_ROOT_PATH "")
 endif()
 
-if (NOT MINIMAL_BUILD AND GLTF_SUPPORT AND BUILD_CONVERT)
-UNIFY_ENVVARS_AND_CACHE(JSON_INCLUDE_DIR)
-FIND_FILE(json_hpp "json.hpp" ${JSON_INCLUDE_DIR}/nlohmann)
-IF(json_hpp)
-	MESSAGE(STATUS "JSON for Modern C++ header file found")
-ELSE()
-	MESSAGE(FATAL_ERROR "Unable to find JSON for Modern C++ header file, aborting")
-ENDIF()
-add_definitions(-DWITH_GLTF)
-set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_GLTF)
+if(GLTF_SUPPORT AND BUILD_CONVERT)
+    UNIFY_ENVVARS_AND_CACHE(JSON_INCLUDE_DIR)
+    find_file(json_hpp "json.hpp" ${JSON_INCLUDE_DIR}/nlohmann)
+
+    if(json_hpp)
+        message(STATUS "JSON for Modern C++ header file found")
+    else()
+        message(FATAL_ERROR "Unable to find JSON for Modern C++ header file, aborting")
+    endif()
+
+    add_definitions(-DWITH_GLTF)
+    set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_GLTF)
 endif()
 
+# Add USD support to serializers 
+if(USD_SUPPORT)
+    UNIFY_ENVVARS_AND_CACHE(USD_INCLUDE_DIR)
+    UNIFY_ENVVARS_AND_CACHE(USD_LIBRARY_DIR)
 
+    if("${USD_INCLUDE_DIR}" STREQUAL "")
+        find_path(USD_INCLUDE_DIR pxr.h
+            PATHS
+                /usr/include/pxr
+                /usr/local/include/pxr
+            REQUIRED
+        )
+        if(USD_INCLUDE_DIR)
+            message(STATUS "Found USD include files in: ${USD_INCLUDE_DIR}")
+        else()
+            message(FATAL_ERROR "Unable to find USD include directory, specify USD_INCLUDE_DIR manually.")
+        endif()
+    else()
+        set(USD_INCLUDE_DIR ${USD_INCLUDE_DIR} CACHE FILEPATH "USD header files")
+        message(STATUS "Looking for USD include files in: ${USD_INCLUDE_DIR}")
+    endif()
 
-if (NOT MINIMAL_BUILD)
-if (WITH_CGAL)
-    if (CITYJSON_SUPPORT)
-        add_definitions(-DIFOPSH_WITH_CGAL)
-        set(SWIG_DEFINES ${SWIG_DEFINES} -DIFOPSH_WITH_CGAL)
-    endif ()
+    set(USD_LIBRARIES
+            usd_usd 
+            usd_usdGeom
+            usd_usdShade 
+            usd_usdLux 
+            usd_vt 
+            usd_sdf 
+            usd_tf 
+            usd_gf
+        )
 
-list(APPEND GEOMETRY_KERNELS cgal)
-endif()
-endif()
+    find_library(USD_LIBRARY
+        NAMES ${USD_LIBRARIES}
+        PATHS ${USD_LIBRARY_DIR})
+    if(USD_LIBRARY)
+        message(STATUS "USD libraries ${USD_LIBRARIES} found in: ${USD_LIBRARY_DIR}")
+        link_directories(${USD_LIBRARY_DIR})
+    else()
+        message(FATAL_ERROR "Unable to find USD libraries in: ${USD_LIBRARY_DIR}")
+    endif()
 
-if (WITH_OPENCASCADE)
-add_definitions(-DIFOPSH_WITH_OPENCASCADE)
-set(SWIG_DEFINES ${SWIG_DEFINES} -DIFOPSH_WITH_OPENCASCADE)
-list(APPEND GEOMETRY_KERNELS opencascade)
+    add_definitions(-DWITH_USD)
+    set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_USD)
 endif()
 
 # Set INSTALL_RPATH for target
-MACRO(SET_INSTALL_RPATHS _target _paths)
-    SET(${_target}_rpaths "")
-    FOREACH(_path ${_paths})
-        LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${_path}" isSystemDir)
-        IF("${isSystemDir}" STREQUAL "-1")
-            LIST(APPEND ${_target}_rpaths ${_path})
-        ENDIF()
-    ENDFOREACH()
-    MESSAGE(STATUS "Set INSTALL_RPATH for ${_target}: ${${_target}_rpaths}")
-    SET_TARGET_PROPERTIES(${_target} PROPERTIES INSTALL_RPATH "${${_target}_rpaths}")
-ENDMACRO()
+macro(SET_INSTALL_RPATHS _target _paths)
+    set(${_target}_rpaths "")
+
+    foreach(_path ${_paths})
+        list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${_path}" isSystemDir)
+
+        if("${isSystemDir}" STREQUAL "-1")
+            list(APPEND ${_target}_rpaths ${_path})
+        endif()
+    endforeach()
+
+    message(STATUS "Set INSTALL_RPATH for ${_target}: ${${_target}_rpaths}")
+    set_target_properties(${_target} PROPERTIES INSTALL_RPATH "${${_target}_rpaths}")
+endmacro()
 
 # Find Boost: On win32 the (hardcoded) default is to use static libraries and
 # runtime, when doing running conda-build we pick what conda prepared for us.
-IF(WIN32 AND ("$ENV{CONDA_BUILD}" STREQUAL ""))
-	SET(Boost_USE_STATIC_LIBS ON)
-	SET(Boost_USE_STATIC_RUNTIME OFF)
-	SET(Boost_USE_MULTITHREADED ON)
+if(WIN32 AND("$ENV{CONDA_BUILD}" STREQUAL ""))
+    set(Boost_USE_STATIC_LIBS ON)
+    set(Boost_USE_STATIC_RUNTIME OFF)
+    set(Boost_USE_MULTITHREADED ON)
+
     # Disable Boost's autolinking as the libraries to be linked to are supplied
     # already by CMake, and wrong libraries would be asked for when code is
     # compiled with a toolset different from default.
     if(MSVC)
-        ADD_DEFINITIONS(-DBOOST_ALL_NO_LIB)
+        add_definitions(-DBOOST_ALL_NO_LIB)
+
         # Necessary for boost version >= 1.67
-        SET(BCRYPT_LIBRARIES "bcrypt.lib")
-    ENDIF()
-ELSE()
+        set(BCRYPT_LIBRARIES "bcrypt.lib")
+    endif()
+else()
     # Disable Boost's autolinking as the libraries to be linked to are supplied
     # already by CMake, and it's going to conflict if there are multiple, as is
     # the case in conda-forge's libboost feedstock.
-    ADD_DEFINITIONS(-DBOOST_ALL_NO_LIB)
-    IF(WIN32)
+    add_definitions(-DBOOST_ALL_NO_LIB)
+
+    if(WIN32)
         # Necessary for boost version >= 1.67
-        SET(BCRYPT_LIBRARIES "bcrypt.lib")
-    ENDIF()
-ENDIF()
+        set(BCRYPT_LIBRARIES "bcrypt.lib")
+    endif()
+endif()
 
 if (WASM_BUILD)
     set(BOOST_COMPONENTS)
@@ -258,21 +291,22 @@ if(USE_MMAP)
     else()
         set(BOOST_COMPONENTS ${BOOST_COMPONENTS} iostreams)
     endif()
+
     add_definitions(-DUSE_MMAP)
 endif()
 
-FIND_PACKAGE(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
-MESSAGE(STATUS "Boost include files found in ${Boost_INCLUDE_DIRS}")
-MESSAGE(STATUS "Boost libraries found in ${Boost_LIBRARY_DIRS}")
+find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+message(STATUS "Boost include files found in ${Boost_INCLUDE_DIRS}")
+message(STATUS "Boost libraries found in ${Boost_LIBRARY_DIRS}")
 
-if (NOT MINIMAL_BUILD)
-# libxml2 is required for IFCXML (optional) and SVGFILL (mandatory)
-  find_package(LibXml2 REQUIRED)
+if(NOT MINIMAL_BUILD)
+    # libxml2 is required for IFCXML (optional) and SVGFILL (mandatory)
+    find_package(LibXml2 REQUIRED)
 endif()
 
-if (NOT MINIMAL_BUILD AND IFCXML_SUPPORT)
+if(IFCXML_SUPPORT)
     add_definitions(-DWITH_IFCXML)
-	set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_IFCXML)
+    set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_IFCXML)
 endif()
 
 # Usage:
@@ -288,10 +322,12 @@ endif()
 function(add_debug_variants NAME LIBRARIES POSTFIX)
     set(LIBRARIES_STR "${LIBRARIES}")
     set(LIBRARIES "")
+
     # the result, "optimized <lib> debug <lib>", needs to be a list instead of a string
     foreach(lib ${LIBRARIES_STR})
         list(APPEND LIBRARIES optimized)
-        if ("${lib}" MATCHES ".lib")
+
+        if("${lib}" MATCHES ".lib")
             string(REPLACE ".lib" "" lib ${lib})
             list(APPEND LIBRARIES ${lib}.lib)
         else()
@@ -299,194 +335,189 @@ function(add_debug_variants NAME LIBRARIES POSTFIX)
         endif()
 
         list(APPEND LIBRARIES debug)
-        if ("${lib}" MATCHES ".lib")
+
+        if("${lib}" MATCHES ".lib")
             string(REPLACE ".lib" "" lib ${lib})
             list(APPEND LIBRARIES ${lib}${POSTFIX}.lib)
         else()
             list(APPEND LIBRARIES ${lib}${POSTFIX})
         endif()
     endforeach()
+
     set(${NAME} ${LIBRARIES} PARENT_SCOPE)
 endfunction()
 
 if(BUILD_IFCGEOM)
+    if(MSVC)
+        add_debug_variants(LIBXML2_LIBRARIES "${LIBXML2_LIBRARIES}" d)
+    endif()
 
-IF(MSVC)
-    add_debug_variants(LIBXML2_LIBRARIES "${LIBXML2_LIBRARIES}" d)
-ENDIF()
+    # Open CASCADE
+    if("${OCC_INCLUDE_DIR}" STREQUAL "")
+        find_path(OCC_INCLUDE_DIR Standard_Version.hxx
+            PATHS
+                /usr/include/occt
+                /usr/include/oce
+                /usr/include/opencascade
+            REQUIRED
+        )
 
-if (WITH_OPENCASCADE)
-
-# Open CASCADE
-IF("${OCC_INCLUDE_DIR}" STREQUAL "")
-    FIND_PATH(OCC_INCLUDE_DIR Standard_Version.hxx
-        [PATHS
-            /usr/include/occt
-            /usr/include/oce
-            /usr/include/opencascade
-        ]
-        REQUIRED
-    )
-    IF(OCC_INCLUDE_DIR)
-        MESSAGE(STATUS "Found Open CASCADE include files in: ${OCC_INCLUDE_DIR}")
-    ELSE()
-        MESSAGE(FATAL_ERROR "Unable to find Open CASCADE include directory, specify OCC_INCLUDE_DIR manually.")
-    ENDIF()
-ELSE()
-    SET(OCC_INCLUDE_DIR ${OCC_INCLUDE_DIR} CACHE FILEPATH "Open CASCADE header files")
-    MESSAGE(STATUS "Looking for Open CASCADE include files in: ${OCC_INCLUDE_DIR}")
-ENDIF()
-
-SET(OPENCASCADE_LIBRARY_NAMES
-    TKernel TKMath TKBRep TKGeomBase TKGeomAlgo TKG3d TKG2d TKShHealing TKTopAlgo TKMesh TKPrim TKBool TKBO
-    TKFillet TKSTEP TKSTEPBase TKSTEPAttr TKXSBase TKSTEP209 TKIGES TKOffset TKHLR
-    
-    # @todo investigate the exact conditions when this is necessary
-    TKBin
-)
-
-IF("${OCC_LIBRARY_DIR}" STREQUAL "")
-    find_library(OCC_LIBRARY TKernel
-        [PATHS
-            /usr/lib
-        ]
-        REQUIRED
-    )
-    IF(OCC_LIBRARY)
-	GET_FILENAME_COMPONENT(OCC_LIBRARY_DIR ${OCC_LIBRARY} PATH)
-        MESSAGE(STATUS "Found Open CASCADE library files in: ${OCC_LIBRARY_DIR}")
-    ELSE()
-        MESSAGE(FATAL_ERROR "Unable find Open CASCADE library directory, specify OCC_LIBRARY_DIR manually.")
-    ENDIF()
-ELSE()
-    SET(OCC_LIBRARY_DIR ${OCC_LIBRARY_DIR} CACHE FILEPATH "Open CASCADE library files")
-    MESSAGE(STATUS "Looking for Open CASCADE library files in: ${OCC_LIBRARY_DIR}")
-ENDIF()
-
-FIND_LIBRARY(libTKernel NAMES TKernel TKerneld PATHS ${OCC_LIBRARY_DIR} NO_DEFAULT_PATH)
-IF(libTKernel)
-    MESSAGE(STATUS "Required Open Cascade Library files found")
-ELSE()
-    MESSAGE(FATAL_ERROR "Unable to find Open Cascade library files, aborting")
-ENDIF()
-
-# Use the found libTKernel as a template for all other OCC libraries
-# TODO Extract this into macro/function
-foreach(lib ${OPENCASCADE_LIBRARY_NAMES})
-    # Make sure we'll handle the Windows/MSVC debug postfix convention too.
-    string(REPLACE TKerneld "${lib}" lib_path "${libTKernel}")
-    string(REPLACE TKernel "${lib}" lib_path "${lib_path}")
-	list(APPEND OPENCASCADE_LIBRARIES "${lib_path}")
-endforeach()
-
-if(MSVC)
-    add_definitions(-DHAVE_NO_DLL)
-    add_debug_variants(OPENCASCADE_LIBRARIES "${OPENCASCADE_LIBRARIES}" d)
-endif()
-if (WIN32)
-    # OCC might require linking to Winsock depending on the version and build configuration
-    list(APPEND OPENCASCADE_LIBRARIES ws2_32.lib)
-endif()
-
-# Make sure cross-referenced symbols between static OCC libraries get
-# resolved. Also add thread and rt libraries.
-get_filename_component(libTKernelExt ${libTKernel} EXT)
-if("${libTKernelExt}" STREQUAL ".a")
-    set(OCCT_STATIC ON)
-endif()
-
-if(WASM_BUILD)
-    set(CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH_BACKUP}")
-endif()
-
-if(OCCT_STATIC)
-    find_package(Threads)
-    
-    if(WASM_BUILD)
-        set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+        if(OCC_INCLUDE_DIR)
+            message(STATUS "Found Open CASCADE include files in: ${OCC_INCLUDE_DIR}")
+        else()
+            message(FATAL_ERROR "Unable to find Open CASCADE include directory, specify OCC_INCLUDE_DIR manually.")
+        endif()
     else()
-        # OPENCASCADE_LIBRARIES repeated N times below in order to fix cyclic dependencies - use --start-group ... --end-group instead?
-        # tfk: --start-group ... --end-group didn't work on the apple linker when last tested
-	if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-		set(OPENCASCADE_LIBRARIES -Wl,--start-group ${OPENCASCADE_LIBRARIES} -Wl,--end-group)
-	else()
-	        set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-	endif()
+        set(OCC_INCLUDE_DIR ${OCC_INCLUDE_DIR} CACHE FILEPATH "Open CASCADE header files")
+        message(STATUS "Looking for Open CASCADE include files in: ${OCC_INCLUDE_DIR}")
     endif()
-    
-    if (NOT APPLE AND NOT WIN32)
-        set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} "rt")
-    endif()
-    if (NOT WIN32)
-        set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} "dl")
-    endif()
-endif()
 
-endif()
+    set(OPENCASCADE_LIBRARY_NAMES
+        TKernel TKMath TKBRep TKGeomBase TKGeomAlgo TKG3d TKG2d TKShHealing TKTopAlgo TKMesh TKPrim TKBool TKBO
+        TKFillet TKSTEP TKSTEPBase TKSTEPAttr TKXSBase TKSTEP209 TKIGES TKOffset TKHLR
+
+        # @todo investigate the exact conditions when this is necessary
+        TKBin
+    )
+
+    if("${OCC_LIBRARY_DIR}" STREQUAL "")
+        find_library(OCC_LIBRARY TKernel
+            PATHS
+                /usr/lib
+            REQUIRED
+        )
+
+        if(OCC_LIBRARY)
+            GET_FILENAME_COMPONENT(OCC_LIBRARY_DIR ${OCC_LIBRARY} PATH)
+            message(STATUS "Found Open CASCADE library files in: ${OCC_LIBRARY_DIR}")
+        else()
+            message(FATAL_ERROR "Unable find Open CASCADE library directory, specify OCC_LIBRARY_DIR manually.")
+        endif()
+    else()
+        set(OCC_LIBRARY_DIR ${OCC_LIBRARY_DIR} CACHE FILEPATH "Open CASCADE library files")
+        message(STATUS "Looking for Open CASCADE library files in: ${OCC_LIBRARY_DIR}")
+    endif()
+
+    find_library(libTKernel NAMES TKernel TKerneld PATHS ${OCC_LIBRARY_DIR} NO_DEFAULT_PATH)
+
+    if(libTKernel)
+        message(STATUS "Required Open Cascade Library files found")
+    else()
+        message(FATAL_ERROR "Unable to find Open Cascade library files, aborting")
+    endif()
+
+    # Use the found libTKernel as a template for all other OCC libraries
+    # TODO Extract this into macro/function
+    foreach(lib ${OPENCASCADE_LIBRARY_NAMES})
+        # Make sure we'll handle the Windows/MSVC debug postfix convention too.
+        string(REPLACE TKerneld "${lib}" lib_path "${libTKernel}")
+        string(REPLACE TKernel "${lib}" lib_path "${lib_path}")
+        list(APPEND OPENCASCADE_LIBRARIES "${lib_path}")
+    endforeach()
+
+    if(MSVC)
+        add_definitions(-DHAVE_NO_DLL)
+        add_debug_variants(OPENCASCADE_LIBRARIES "${OPENCASCADE_LIBRARIES}" d)
+    endif()
+
+    if(WIN32)
+        # OCC might require linking to Winsock depending on the version and build configuration
+        list(APPEND OPENCASCADE_LIBRARIES ws2_32.lib)
+    endif()
+
+    # Make sure cross-referenced symbols between static OCC libraries get
+    # resolved. Also add thread and rt libraries.
+    get_filename_component(libTKernelExt ${libTKernel} EXT)
+    if("${libTKernelExt}" STREQUAL ".a")
+        set(OCCT_STATIC ON)
+    endif()
+
+    if(OCCT_STATIC)
+        find_package(Threads)
+        
+        if(WASM_BUILD)
+            set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+        else()
+            # OPENCASCADE_LIBRARIES repeated N times below in order to fix cyclic dependencies - use --start-group ... --end-group instead?
+            # tfk: --start-group ... --end-group didn't work on the apple linker when last tested
+            set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+        endif()
+        
+        if (NOT APPLE AND NOT WIN32)
+            set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} "rt")
+        endif()
+        if (NOT WIN32)
+            set(OPENCASCADE_LIBRARIES ${OPENCASCADE_LIBRARIES} "dl")
+        endif()
+    endif()
 
 endif(BUILD_IFCGEOM)
 
-IF(NOT MINIMAL_BUILD AND COLLADA_SUPPORT)
-	# Find OpenCOLLADA
-	IF("${OPENCOLLADA_INCLUDE_DIR}" STREQUAL "")
-		MESSAGE(STATUS "No OpenCOLLADA include directory specified")
-		SET(OPENCOLLADA_INCLUDE_DIR "/usr/include/opencollada" CACHE FILEPATH "OpenCOLLADA header files")
-	ELSE()
-		SET(OPENCOLLADA_INCLUDE_DIR "${OPENCOLLADA_INCLUDE_DIR}" CACHE FILEPATH "OpenCOLLADA header files")
-	ENDIF()
+if(COLLADA_SUPPORT)
+    # Find OpenCOLLADA
+    if("${OPENCOLLADA_INCLUDE_DIR}" STREQUAL "")
+        message(STATUS "No OpenCOLLADA include directory specified")
+        set(OPENCOLLADA_INCLUDE_DIR "/usr/include/opencollada" CACHE FILEPATH "OpenCOLLADA header files")
+    else()
+        set(OPENCOLLADA_INCLUDE_DIR "${OPENCOLLADA_INCLUDE_DIR}" CACHE FILEPATH "OpenCOLLADA header files")
+    endif()
 
-	IF("${OPENCOLLADA_LIBRARY_DIR}" STREQUAL "")
-		MESSAGE(STATUS "No OpenCOLLADA library directory specified")
-		FIND_LIBRARY(OPENCOLLADA_FRAMEWORK_LIB NAMES OpenCOLLADAFramework
-			PATHS /usr/lib64/opencollada /usr/lib/opencollada /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib)
-		GET_FILENAME_COMPONENT(OPENCOLLADA_LIBRARY_DIR ${OPENCOLLADA_FRAMEWORK_LIB} PATH)
-	ENDIF()
+    if("${OPENCOLLADA_LIBRARY_DIR}" STREQUAL "")
+        message(STATUS "No OpenCOLLADA library directory specified")
+        find_library(OPENCOLLADA_FRAMEWORK_LIB NAMES OpenCOLLADAFramework
+            PATHS /usr/lib64/opencollada /usr/lib/opencollada /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib)
+        get_filename_component(OPENCOLLADA_LIBRARY_DIR ${OPENCOLLADA_FRAMEWORK_LIB} PATH)
+    endif()
 
-	FIND_LIBRARY(OpenCOLLADAFramework NAMES OpenCOLLADAFramework OpenCOLLADAFrameworkd PATHS ${OPENCOLLADA_LIBRARY_DIR} NO_DEFAULT_PATH)
-    if (OpenCOLLADAFramework)
+    find_library(OpenCOLLADAFramework NAMES OpenCOLLADAFramework OpenCOLLADAFrameworkd PATHS ${OPENCOLLADA_LIBRARY_DIR} NO_DEFAULT_PATH)
+
+    if(OpenCOLLADAFramework)
         message(STATUS "OpenCOLLADA library files found")
     else()
         message(FATAL_ERROR "COLLADA_SUPPORT enabled, but unable to find OpenCOLLADA libraries. "
             "Disable COLLADA_SUPPORT or fix OpenCOLLADA paths to proceed.")
     endif()
 
-	SET(OPENCOLLADA_LIBRARY_DIR "${OPENCOLLADA_LIBRARY_DIR}" CACHE FILEPATH "OpenCOLLADA library files")
+    set(OPENCOLLADA_LIBRARY_DIR "${OPENCOLLADA_LIBRARY_DIR}" CACHE FILEPATH "OpenCOLLADA library files")
 
-	SET(OPENCOLLADA_INCLUDE_DIRS "${OPENCOLLADA_INCLUDE_DIR}/COLLADABaseUtils" "${OPENCOLLADA_INCLUDE_DIR}/COLLADAStreamWriter")
+    set(OPENCOLLADA_INCLUDE_DIRS "${OPENCOLLADA_INCLUDE_DIR}/COLLADABaseUtils" "${OPENCOLLADA_INCLUDE_DIR}/COLLADAStreamWriter")
 
-	FIND_FILE(COLLADASWStreamWriter_h "COLLADASWStreamWriter.h" ${OPENCOLLADA_INCLUDE_DIRS})
-	IF(COLLADASWStreamWriter_h)
-		MESSAGE(STATUS "OpenCOLLADA header files found")
-		ADD_DEFINITIONS(-DWITH_OPENCOLLADA)
-		set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_OPENCOLLADA)
+    find_file(COLLADASWStreamWriter_h "COLLADASWStreamWriter.h" ${OPENCOLLADA_INCLUDE_DIRS})
 
-		SET(OPENCOLLADA_LIBRARY_NAMES
-			GeneratedSaxParser MathMLSolver OpenCOLLADABaseUtils OpenCOLLADAFramework OpenCOLLADASaxFrameworkLoader
-			OpenCOLLADAStreamWriter UTF buffer ftoa
-		)
+    if(COLLADASWStreamWriter_h)
+        message(STATUS "OpenCOLLADA header files found")
+        add_definitions(-DWITH_OPENCOLLADA)
+        set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_OPENCOLLADA)
 
-		# Use the found OpenCOLLADAFramework as a template for all other OpenCOLLADA libraries
-		foreach(lib ${OPENCOLLADA_LIBRARY_NAMES})
+        set(OPENCOLLADA_LIBRARY_NAMES
+            GeneratedSaxParser MathMLSolver OpenCOLLADABaseUtils OpenCOLLADAFramework OpenCOLLADASaxFrameworkLoader
+            OpenCOLLADAStreamWriter UTF buffer ftoa
+        )
+
+        # Use the found OpenCOLLADAFramework as a template for all other OpenCOLLADA libraries
+        foreach(lib ${OPENCOLLADA_LIBRARY_NAMES})
             # Make sure we'll handle the Windows/MSVC debug postfix convention too.
             string(REPLACE OpenCOLLADAFrameworkd "${lib}" lib_path "${OpenCOLLADAFramework}")
             string(REPLACE OpenCOLLADAFramework "${lib}" lib_path "${lib_path}")
- 			list(APPEND OPENCOLLADA_LIBRARIES "${lib_path}")
-		endforeach()
+            list(APPEND OPENCOLLADA_LIBRARIES "${lib_path}")
+        endforeach()
 
-		if("${PCRE_LIBRARY_DIR}" STREQUAL "")
+        if("${PCRE_LIBRARY_DIR}" STREQUAL "")
             if(WIN32)
                 find_library(pcre_library NAMES pcre pcred PATHS ${OPENCOLLADA_LIBRARY_DIR} NO_DEFAULT_PATH)
             else()
                 find_library(pcre_library NAMES pcre PATHS ${OPENCOLLADA_LIBRARY_DIR})
             endif()
-			GET_FILENAME_COMPONENT(PCRE_LIBRARY_DIR ${pcre_library} PATH)
-		else()
-			find_library(pcre_library NAMES pcre pcred PATHS ${PCRE_LIBRARY_DIR} NO_DEFAULT_PATH)
-		endif()
 
-		if (pcre_library)
-			SET(OPENCOLLADA_LIBRARY_DIR ${OPENCOLLADA_LIBRARY_DIR} ${PCRE_LIBRARY_DIR})
-            if (MSVC)
+            get_filename_component(PCRE_LIBRARY_DIR ${pcre_library} PATH)
+        else()
+            find_library(pcre_library NAMES pcre pcred PATHS ${PCRE_LIBRARY_DIR} NO_DEFAULT_PATH)
+        endif()
+
+        if(pcre_library)
+            set(OPENCOLLADA_LIBRARY_DIR ${OPENCOLLADA_LIBRARY_DIR} ${PCRE_LIBRARY_DIR})
+
+            if(MSVC)
                 # Add release lib regardless whether release or debug found. Debug version will be appended below.
                 list(APPEND OPENCOLLADA_LIBRARIES "${PCRE_LIBRARY_DIR}/pcre.lib")
             else()
@@ -495,61 +526,59 @@ IF(NOT MINIMAL_BUILD AND COLLADA_SUPPORT)
         else()
             message(FATAL_ERROR "COLLADA_SUPPORT enabled, but unable to find PCRE. "
                 "Disable COLLADA_SUPPORT or fix PCRE_LIBRARY_DIR path to proceed.")
-		endif()
+        endif()
 
-		IF(MSVC)
-			add_debug_variants(OPENCOLLADA_LIBRARIES "${OPENCOLLADA_LIBRARIES}" d)
-		ENDIF()
-	ELSE()
+        if(MSVC)
+            add_debug_variants(OPENCOLLADA_LIBRARIES "${OPENCOLLADA_LIBRARIES}" d)
+        endif()
+    else()
         message(FATAL_ERROR "COLLADA_SUPPORT enabled, but unable to find OpenCOLLADA headers. "
             "Disable COLLADA_SUPPORT or fix OpenCOLLADA paths to proceed.")
-	ENDIF()
-ENDIF()
+    endif()
+endif()
 
-if(NOT MINIMAL_BUILD AND HDF5_SUPPORT)
-    IF("${HDF5_INCLUDE_DIR}" STREQUAL "")
-		MESSAGE(STATUS "No HDF5 include directory specified")
-	ElSE()
-		SET(HDF5_INCLUDE_DIR "${HDF5_INCLUDE_DIR}" CACHE FILEPATH "HDF5 header files")
-	ENDIF()
-	
-    IF("${HDF5_LIBRARY_DIR}" STREQUAL "")
-		MESSAGE(STATUS "No HDF5 library directory specified")
-	ElSE()
-		SET(HDF5_LIBRARY_DIR "${HDF5_LIBRARY_DIR}" CACHE FILEPATH "HDF5 library files")
-	ENDIF()
+if(HDF5_SUPPORT)
+    if("${HDF5_INCLUDE_DIR}" STREQUAL "")
+        message(STATUS "No HDF5 include directory specified")
+    else()
+        set(HDF5_INCLUDE_DIR "${HDF5_INCLUDE_DIR}" CACHE FILEPATH "HDF5 header files")
+    endif()
 
-    if (HDF5_LIBRARY_DIR)
-    	# result of the HDF5 ctest package
+    if("${HDF5_LIBRARY_DIR}" STREQUAL "")
+        message(STATUS "No HDF5 library directory specified")
+    else()
+        set(HDF5_LIBRARY_DIR "${HDF5_LIBRARY_DIR}" CACHE FILEPATH "HDF5 library files")
+    endif()
+
+    if(HDF5_LIBRARY_DIR)
+        # result of the HDF5 ctest package
         # Find zlib using cmake find_library. How should this be implemented?
         # FIND_LIBRARY(NAMES z libz libz_debug PATHS ... NO_DEFAULT_PATH)
-
-
-        if ("$ENV{CONDA_BUILD}" STREQUAL "")
+        if("$ENV{CONDA_BUILD}" STREQUAL "")
             # result of the HDF5 ctest package
-
-            if (WIN32)
+            if(WIN32)
                 set(zlib_post lib)
                 set(lib_ext lib)
             else()
                 set(lib_ext a)
             endif()
 
-            if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+            if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
                 set(debug_postfix "_debug")
             endif()
 
-            SET(HDF5_LIBRARIES
-                    "${HDF5_LIBRARY_DIR}/libhdf5_cpp${debug_postfix}.${lib_ext}"
-                    "${HDF5_LIBRARY_DIR}/libhdf5${debug_postfix}.${lib_ext}"
-                    "${HDF5_LIBRARY_DIR}/libz${zlib_post}${debug_postfix}.${lib_ext}"
-                    "${HDF5_LIBRARY_DIR}/libsz${debug_postfix}.${lib_ext}"
-                    "${HDF5_LIBRARY_DIR}/libaec${debug_postfix}.${lib_ext}"
-                    )
+            set(HDF5_LIBRARIES
+                "${HDF5_LIBRARY_DIR}/libhdf5_cpp${debug_postfix}.${lib_ext}"
+                "${HDF5_LIBRARY_DIR}/libhdf5${debug_postfix}.${lib_ext}"
+                "${HDF5_LIBRARY_DIR}/libz${zlib_post}${debug_postfix}.${lib_ext}"
+                "${HDF5_LIBRARY_DIR}/libsz${debug_postfix}.${lib_ext}"
+                "${HDF5_LIBRARY_DIR}/libaec${debug_postfix}.${lib_ext}"
+            )
 
-        ELSE()
-            MESSAGE(STATUS "Packaging hdf5 and zlib for conda distribution")
-            if (WIN32)
+        else()
+            message(STATUS "Packaging hdf5 and zlib for conda distribution")
+
+            if(WIN32)
                 # Windows
                 set(zlib_post zlib)
                 set(lib_ext lib)
@@ -563,19 +592,17 @@ if(NOT MINIMAL_BUILD AND HDF5_SUPPORT)
                 set(lib_ext so)
             endif()
 
-            SET(HDF5_LIBRARIES
-                    "${HDF5_LIBRARY_DIR}/libhdf5_cpp.${lib_ext}"
-                    "${HDF5_LIBRARY_DIR}/libhdf5.${lib_ext}"
-                    "${HDF5_LIBRARY_DIR}/${zlib_post}.${lib_ext}"
-                    )
+            set(HDF5_LIBRARIES
+                "${HDF5_LIBRARY_DIR}/libhdf5_cpp.${lib_ext}"
+                "${HDF5_LIBRARY_DIR}/libhdf5.${lib_ext}"
+                "${HDF5_LIBRARY_DIR}/${zlib_post}.${lib_ext}"
+            )
         endif()
-
     endif()
 
-    if (NOT HDF5_LIBRARIES)
-    	# debian default
-
-        SET(HDF5_LIBRARIES
+    if(NOT HDF5_LIBRARIES)
+        # debian default
+        set(HDF5_LIBRARIES
             /usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5_cpp.so
             /usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so
             /usr/lib/x86_64-linux-gnu/libsz.so
@@ -583,100 +610,117 @@ if(NOT MINIMAL_BUILD AND HDF5_SUPPORT)
             z dl
         )
     endif()
-    
+
     add_definitions(-DWITH_HDF5)
-	set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_HDF5)
+    set(SWIG_DEFINES ${SWIG_DEFINES} -DWITH_HDF5)
+endif()
+
+if(WASM_BUILD)
+    # reset to use sysroot
+    set(CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH_BACKUP}")
 endif()
 
 if(ENABLE_BUILD_OPTIMIZATIONS)
-	if(MSVC)
+    if(MSVC)
         # NOTE: RelWithDebInfo and Release use O2 (= /Ox /Gl /Gy/ = Og /Oi /Ot /Oy /Ob2 /Gs /GF /Gy) by default,
         # with the exception with RelWithDebInfo has /Ob1 instead. /Ob2 has been observed to improve the performance
         # of IfcConvert significantly.
         # TODO Setting of /GL and /LTCG don't seem to apply for static libraries (IfcGeom, IfcParse)
-		# C++
-		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Ob2 /GL")
-		set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
-		# Linker
-		# /OPT:REF enables also /OPT:ICF and disables INCREMENTAL
-		set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /LTCG /OPT:REF")
-		# /OPT:NOICF is recommended when /DEBUG is used (http://msdn.microsoft.com/en-us/library/xe4t6fc1.aspx)
-		set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:NOICF")
-		set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG /OPT:REF")
-		set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:NOICF")
-	else()
+        # C++
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Ob2 /GL")
+        set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
+
+        # Linker
+        # /OPT:REF enables also /OPT:ICF and disables INCREMENTAL
+        set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /LTCG /OPT:REF")
+
+        # /OPT:NOICF is recommended when /DEBUG is used (http://msdn.microsoft.com/en-us/library/xe4t6fc1.aspx)
+        set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:NOICF")
+        set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG /OPT:REF")
+        set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /DEBUG /OPT:NOICF")
+    else()
         # GCC-like: Release should use O3 but RelWithDebInfo 02 so enforce 03. Anything other useful that could be added here?
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
         set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELEASE} -O3")
-	endif()
+    endif()
 endif()
 
-IF(MSVC)
-	# warning due to virtual inheritance
-	ADD_DEFINITIONS(-wd4250)
-	# warning due to select definitions in the schema being redundant
-	ADD_DEFINITIONS(-wd4584)
-	
-	# didn't work well on ifcopenbot, @todo make configurable
-	# add_definitions(/MP)
+if(MSVC)
+    # warning due to virtual inheritance
+    add_definitions(-wd4250)
+
+    # warning due to select definitions in the schema being redundant
+    add_definitions(-wd4584)
+
+    # didn't work well on ifcopenbot, @todo make configurable
+    # add_definitions(/MP)
 
     # Enable solution folders (free VS versions prior to 2012 don't support solution folders)
-    if (MSVC_VERSION GREATER 1600)
+    if(MSVC_VERSION GREATER 1600)
         set_property(GLOBAL PROPERTY USE_FOLDERS ON)
     endif()
 
-	IF(USE_VLD)
-		ADD_DEFINITIONS(-DUSE_VLD)
-	ENDIF()
-	# Enforce Unicode for CRT and Win32 API calls
-	ADD_DEFINITIONS(-D_UNICODE -DUNICODE)
-	# Disable warnings about unsafe C functions; we could use the safe C99 & C11 versions if we have no need for supporting old compilers.
-	ADD_DEFINITIONS(-D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS)
-	ADD_DEFINITIONS(-bigobj) # required for building the big ifcXXX.objs, https://msdn.microsoft.com/en-us/library/ms173499.aspx
-	# Bump up the warning level from the default 3 to 4.
-	ADD_DEFINITIONS(-W4)
-	IF(MSVC_VERSION GREATER 1800) # > 2013
-		# Disable overeager and false positives causing C4458 ("declaration of 'indentifier' hides class member"), at least for now.
-		ADD_DEFINITIONS(-wd4458)
-	ENDIF()
+    if(USE_VLD)
+        add_definitions(-DUSE_VLD)
+    endif()
+
+    # Enforce Unicode for CRT and Win32 API calls
+    add_definitions(-D_UNICODE -DUNICODE)
+
+    # Disable warnings about unsafe C functions; we could use the safe C99 & C11 versions if we have no need for supporting old compilers.
+    add_definitions(-D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(-bigobj) # required for building the big ifcXXX.objs, https://msdn.microsoft.com/en-us/library/ms173499.aspx
+
+    # Bump up the warning level from the default 3 to 4.
+    add_definitions(-W4)
+
+    if(MSVC_VERSION GREATER 1800) # > 2013
+        # Disable overeager and false positives causing C4458 ("declaration of 'indentifier' hides class member"), at least for now.
+        add_definitions(-wd4458)
+    endif()
+
     # Enforce standards-conformance on VS > 2015, older Boost versions fail to compile with this
-    if (MSVC_VERSION GREATER 1900 AND (Boost_MAJOR_VERSION GREATER 1 OR Boost_MINOR_VERSION GREATER 66))
+    if(MSVC_VERSION GREATER 1900 AND(Boost_MAJOR_VERSION GREATER 1 OR Boost_MINOR_VERSION GREATER 66))
         add_definitions(-permissive-)
     endif()
-	# Link against the static VC runtime
-    # TODO Make this configurable
-	# IF("$ENV{CONDA_BUILD}" STREQUAL "")
-	# FOREACH(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL
-			# CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-			# CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
-		# IF(${flag} MATCHES "/MD")
-			# STRING(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
-		# ENDIF()
-		# IF(${flag} MATCHES "/MDd")
-			# STRING(REGEX REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
-		# ENDIF()
-	# ENDFOREACH()
-	# ENDIF()
-ElSE()
+
+# Link against the static VC runtime
+# TODO Make this configurable
+# IF("$ENV{CONDA_BUILD}" STREQUAL "")
+# FOREACH(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL
+# CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+# CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+# IF(${flag} MATCHES "/MD")
+# STRING(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+# ENDIF()
+# IF(${flag} MATCHES "/MDd")
+# STRING(REGEX REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
+# ENDIF()
+# ENDFOREACH()
+# ENDIF()
+else()
     add_definitions(-Wall -Wextra)
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_definitions(-Wno-tautological-constant-out-of-range-compare)
     else()
         add_definitions(-Wno-maybe-uninitialized)
     endif()
-    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 9.0))
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 9.0))
         # OpenCascade spews a lot of deprecated-copy warnings
         add_definitions(-Wno-deprecated-copy)
     endif()
+
     # -fPIC is not relevant on Windows and creates pointless warnings
-    if (UNIX)
+    if(UNIX)
         add_definitions(-fPIC)
     endif()
-ENDIF()
+endif()
 
-INCLUDE_DIRECTORIES(${INCLUDE_DIRECTORIES} ${OCC_INCLUDE_DIR} ${OPENCOLLADA_INCLUDE_DIRS}
+include_directories(${INCLUDE_DIRECTORIES} ${OCC_INCLUDE_DIR} ${OPENCOLLADA_INCLUDE_DIRS}
 	${Boost_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIR} ${JSON_INCLUDE_DIR} ${HDF5_INCLUDE_DIR}
-    ${EIGEN_DIR} ${CGAL_INCLUDE_DIR} ${GMP_INCLUDE_DIR} ${MPFR_INCLUDE_DIR}
+    ${USD_INCLUDE_DIR}
 )
 
 function(files_for_ifc_version IFC_VERSION RESULT_NAME)
@@ -685,7 +729,7 @@ function(files_for_ifc_version IFC_VERSION RESULT_NAME)
         ${IFC_PARSE_DIR}/Ifc${IFC_VERSION}.h
         ${IFC_PARSE_DIR}/Ifc${IFC_VERSION}enum.h
         ${IFC_PARSE_DIR}/Ifc${IFC_VERSION}.cpp
-		PARENT_SCOPE
+        PARENT_SCOPE
     )
 endfunction()
 
@@ -698,39 +742,44 @@ if(NOT SCHEMA_VERSIONS)
     endif()
 endif()
 
-foreach(s ${SCHEMA_VERSIONS})
-	add_definitions(-DHAS_SCHEMA_${s})
+foreach(schema ${SCHEMA_VERSIONS})
+    add_definitions(-DHAS_SCHEMA_${schema})
 endforeach()
 
 string(REPLACE ";" ")(" schema_version_seq "(${SCHEMA_VERSIONS})")
-ADD_DEFINITIONS(-DSCHEMA_SEQ=${schema_version_seq})
+add_definitions(-DSCHEMA_SEQ=${schema_version_seq})
 
 if(COMPILE_SCHEMA)
-	# @todo, this appears to be untested at the moment
-
+    # @todo, this appears to be untested at the moment
     find_package(PythonInterp)
 
-    IF(NOT PYTHONINTERP_FOUND)
-        MESSAGE(FATAL_ERROR "A Python interpreter is necessary when COMPILE_SCHEMA is enabled. Disable COMPILE_SCHEMA or fix Python paths to proceed.")
-    ENDIF()
+    if(NOT PYTHONINTERP_FOUND)
+        message(FATAL_ERROR "A Python interpreter is necessary when COMPILE_SCHEMA is enabled. Disable COMPILE_SCHEMA or fix Python paths to proceed.")
+    endif()
 
     set(IFC_RELEASE_NOT_USED ${SCHEMA_VERSIONS})
 
     # Install pyparsing if necessary
     execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip freeze OUTPUT_VARIABLE PYTHON_PACKAGE_LIST)
-    if ("${PYTHON_PACKAGE_LIST}" STREQUAL "")
+
+    if("${PYTHON_PACKAGE_LIST}" STREQUAL "")
         execute_process(COMMAND pip freeze OUTPUT_VARIABLE PYTHON_PACKAGE_LIST)
-        if ("${PYTHON_PACKAGE_LIST}" STREQUAL "")
+
+        if("${PYTHON_PACKAGE_LIST}" STREQUAL "")
             message(WARNING "Failed to find pip. Pip is required to automatically install pyparsing")
         endif()
     endif()
+
     string(FIND "${PYTHON_PACKAGE_LIST}" pyparsing PYPARSING_FOUND)
-    if ("${PYPARSING_FOUND}" STREQUAL "-1")
+
+    if("${PYPARSING_FOUND}" STREQUAL "-1")
         message(STATUS "Installing pyparsing")
         execute_process(COMMAND ${PYTHON_EXECUTABLE} -m pip "install" --user pyparsing RESULT_VARIABLE SUCCESS)
-        if (NOT "${SUCCESS}" STREQUAL "0")
+
+        if(NOT "${SUCCESS}" STREQUAL "0")
             execute_process(COMMAND pip "install" --user pyparsing RESULT_VARIABLE SUCCESS)
-            if (NOT "${SUCCESS}" STREQUAL "0")
+
+            if(NOT "${SUCCESS}" STREQUAL "0")
                 message(WARNING "Failed to automatically install pyparsing. Please install manually")
             endif()
         endif()
@@ -745,8 +794,8 @@ if(COMPILE_SCHEMA)
         OUTPUT_FILE express_parser.py
         RESULT_VARIABLE SUCCESS)
 
-    if (NOT "${SUCCESS}" STREQUAL "0")
-        MESSAGE(FATAL_ERROR "Failed to bootstrap parser. Make sure pyparsing is installed")
+    if(NOT "${SUCCESS}" STREQUAL "0")
+        message(FATAL_ERROR "Failed to bootstrap parser. Make sure pyparsing is installed")
     endif()
 
     # Generate code
@@ -755,11 +804,11 @@ if(COMPILE_SCHEMA)
         OUTPUT_VARIABLE COMPILED_SCHEMA_NAME)
 
     # Prevent the schema that had just been compiled from being excluded
-	foreach(s ${SCHEMA_VERSIONS})
-		if("${COMPILED_SCHEMA_NAME}" STREQUAL "${s}")
-			list(REMOVE_ITEM IFC_RELEASE_NOT_USED "${s}")
-		endif()
-	endforeach()
+    foreach(schema ${SCHEMA_VERSIONS})
+        if("${COMPILED_SCHEMA_NAME}" STREQUAL "${schema}")
+            list(REMOVE_ITEM IFC_RELEASE_NOT_USED "${schema}")
+        endif()
+    endforeach()
 endif()
 
 # Boost >= 1.58 requires BOOST_OPTIONAL_USE_OLD_DEFINITION_OF_NONE to build on some Linux distros.
@@ -769,8 +818,8 @@ endif()
 
 set(IFCOPENSHELL_LIBRARIES IfcParse)
 if (BUILD_IFCGEOM)
-	foreach(s ${SCHEMA_VERSIONS})
-		set(IFCGEOM_SCHEMA_LIBRARIES ${IFCGEOM_SCHEMA_LIBRARIES} geometry_mapping_ifc${s})
+	foreach(schema ${SCHEMA_VERSIONS})
+		set(IFCGEOM_SCHEMA_LIBRARIES ${IFCGEOM_SCHEMA_LIBRARIES} IfcGeom_ifc${schema})
 	endforeach()
 	if (WASM_BUILD)
 	    set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} IfcGeom ${IFCGEOM_SCHEMA_LIBRARIES})
@@ -780,341 +829,275 @@ if (BUILD_IFCGEOM)
 endif()
 
 if (BUILD_CONVERT OR BUILD_IFCPYTHON)
-	foreach(s ${SCHEMA_VERSIONS})
-		set(SERIALIZER_SCHEMA_LIBRARIES ${SERIALIZER_SCHEMA_LIBRARIES} Serializers_ifc${s})
+	foreach(schema ${SCHEMA_VERSIONS})
+		set(SERIALIZER_SCHEMA_LIBRARIES ${SERIALIZER_SCHEMA_LIBRARIES} Serializers_ifc${schema})
 	endforeach()
 	set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} Serializers ${SERIALIZER_SCHEMA_LIBRARIES})
-
-	if (WITH_OPENCASCADE)
-		foreach(s ${SCHEMA_VERSIONS})
-			set(GEOM_SERIALIZER_SCHEMA_LIBRARIES ${GEOM_SERIALIZER_SCHEMA_LIBRARIES} GeometrySerializers_ifc${s})
-
-			add_library(geometry_serializer_ifc${s} STATIC ../src/ifcgeom/Serialization/schema/Serialization.cpp)
-			set_target_properties(geometry_serializer_ifc${s} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${s}")
-			list(APPEND geometry_serializer_libraries geometry_serializer_ifc${s})
-		endforeach()
-
-		add_library(geometry_serializer STATIC ../src/ifcgeom/Serialization/Serialization.cpp)
-		target_link_libraries(geometry_serializer ${geometry_serializer_libraries})
-		set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} geometry_serializer ${geometry_serializer_libraries})
-	endif()
 endif()
 
 # IfcParse
 file(GLOB IFCPARSE_H_FILES_ALL ../src/ifcparse/*.h)
 file(GLOB IFCPARSE_CPP_FILES_ALL ../src/ifcparse/*.cpp)
 
-foreach(s ${IFCPARSE_H_FILES_ALL})
-get_filename_component(p "${s}" NAME)
-if (NOT "${p}" MATCHES "[0-9]")
-list(APPEND IFCPARSE_H_FILES "${s}")
-endif()
+foreach(file ${IFCPARSE_H_FILES_ALL})
+    get_filename_component(filename "${file}" NAME)
+
+    if(NOT "${filename}" MATCHES "[0-9]")
+        list(APPEND IFCPARSE_H_FILES "${file}")
+    endif()
 endforeach()
 
-foreach(s ${IFCPARSE_CPP_FILES_ALL})
-get_filename_component(p "${s}" NAME)
-if (NOT "${p}" MATCHES "[0-9]")
-list(APPEND IFCPARSE_CPP_FILES "${s}")
-endif()
+foreach(file ${IFCPARSE_CPP_FILES_ALL})
+    get_filename_component(filename "${file}" NAME)
+
+    if(NOT "${filename}" MATCHES "[0-9]")
+        list(APPEND IFCPARSE_CPP_FILES "${file}")
+    endif()
 endforeach()
 
-foreach(s ${SCHEMA_VERSIONS})
-	list(APPEND IFCPARSE_H_FILES
-		../src/ifcparse/Ifc${s}.h
-		../src/ifcparse/Ifc${s}-definitions.h
-	)
-	list(APPEND IFCPARSE_CPP_FILES
-		../src/ifcparse/Ifc${s}.cpp
-		../src/ifcparse/Ifc${s}-schema.cpp
-	)
+foreach(schema ${SCHEMA_VERSIONS})
+    list(APPEND IFCPARSE_H_FILES
+        ../src/ifcparse/Ifc${schema}.h
+        ../src/ifcparse/Ifc${schema}-definitions.h
+    )
+    list(APPEND IFCPARSE_CPP_FILES
+        ../src/ifcparse/Ifc${schema}.cpp
+        ../src/ifcparse/Ifc${schema}-schema.cpp
+    )
 endforeach()
-
 
 set(IFCPARSE_FILES ${IFCPARSE_CPP_FILES} ${IFCPARSE_H_FILES})
 
 add_library(IfcParse ${IFCPARSE_FILES})
-set_target_properties(IfcParse PROPERTIES COMPILE_FLAGS -DIFC_PARSE_EXPORTS VERSION "0.8.0" SOVERSION "0.8")
+set_target_properties(IfcParse PROPERTIES COMPILE_FLAGS -DIFC_PARSE_EXPORTS VERSION "${PROJECT_VERSION}" SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
 if (WASM_BUILD)
-    TARGET_LINK_LIBRARIES(IfcParse ${BCRYPT_LIBRARIES} ${LIBXML2_LIBRARIES})
+    target_link_libraries(IfcParse ${BCRYPT_LIBRARIES} ${LIBXML2_LIBRARIES})
 else()
-    TARGET_LINK_LIBRARIES(IfcParse ${Boost_LIBRARIES} ${BCRYPT_LIBRARIES} ${LIBXML2_LIBRARIES})
+    target_link_libraries(IfcParse ${Boost_LIBRARIES} ${BCRYPT_LIBRARIES} ${LIBXML2_LIBRARIES})
 endif()
 
-if (BUILD_IFCGEOM)
+if(BUILD_IFCGEOM)
+    # IfcGeom
+    file(GLOB IFCGEOM_H_FILES ../src/ifcgeom/*.h ../src/ifcgeom/*.i)
+    file(GLOB IFCGEOM_CPP_FILES ../src/ifcgeom/*.cpp)
+    set(IFCGEOM_FILES ${IFCGEOM_CPP_FILES} ${IFCGEOM_H_FILES})
 
-if (WITH_CGAL)
+    foreach(schema ${SCHEMA_VERSIONS})
+        add_library(IfcGeom_ifc${schema} STATIC ${IFCGEOM_FILES})
+        set_target_properties(IfcGeom_ifc${schema} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${schema}")
+        if (NOT WASM_BUILD)
+            target_link_libraries(IfcGeom_ifc${schema} IfcParse ${OPENCASCADE_LIBRARIES})	    
+        endif()
+    endforeach()
 
-find_library(libGMP NAMES gmp mpir PATHS ${GMP_LIBRARY_DIR} NO_DEFAULT_PATH)
-find_library(libMPFR NAMES mpfr PATHS ${MPFR_LIBRARY_DIR} NO_DEFAULT_PATH)
-if(NOT libGMP)
-        message(FATAL_ERROR "Unable to find GMP library files, aborting")
-endif()
-if(NOT libMPFR)
-        message(FATAL_ERROR "Unable to find MPFR library files, aborting")
-endif()
+    # IfcGeom (schema agnostic)
+    file(GLOB SCHEMA_AGNOSTIC_H_FILES ../src/ifcgeom_schema_agnostic/*.h)
+    file(GLOB SCHEMA_AGNOSTIC_CPP_FILES ../src/ifcgeom_schema_agnostic/*.cpp)
+    set(SCHEMA_AGNOSTIC_FILES ${SCHEMA_AGNOSTIC_H_FILES} ${SCHEMA_AGNOSTIC_CPP_FILES})
 
-list(APPEND CGAL_LIBRARIES "${libMPFR}")
-list(APPEND CGAL_LIBRARIES "${libGMP}")
+    add_library(IfcGeom ${SCHEMA_AGNOSTIC_FILES})
+    set_target_properties(IfcGeom PROPERTIES COMPILE_FLAGS -DIFC_GEOM_EXPORTS VERSION "${PROJECT_VERSION}" SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
-endif()
+    if(UNIX)
+        find_package(Threads)
+    endif()
 
-foreach(kernel ${GEOMETRY_KERNELS})
-
-string(TOUPPER ${kernel} KERNEL_UPPER)
-file(GLOB IFCGEOM_H_FILES ../src/ifcgeom/kernels/${kernel}/*.h)
-file(GLOB IFCGEOM_CPP_FILES ../src/ifcgeom/kernels/${kernel}/*.cpp)
-set(IFCGEOM_FILES ${IFCGEOM_CPP_FILES} ${IFCGEOM_H_FILES})
-
-add_library(geometry_kernel_${kernel} ${IFCGEOM_FILES})
-set_target_properties(geometry_kernel_${kernel} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS")
-# needed?
-# if (NOT WASM_BUILD)
-# endif()
-target_link_libraries(geometry_kernel_${kernel} ${${KERNEL_UPPER}_LIBRARIES})
-list(APPEND kernel_libraries geometry_kernel_${kernel})
-
-if (${kernel} STREQUAL "cgal")
-add_library(geometry_kernel_${kernel}_simple ${IFCGEOM_FILES})
-set_target_properties(geometry_kernel_${kernel}_simple PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIFOPSH_SIMPLE_KERNEL")
-# needed?
-# if (NOT WASM_BUILD)
-# endif()
-target_link_libraries(geometry_kernel_${kernel}_simple ${${KERNEL_UPPER}_LIBRARIES})
-list(APPEND kernel_libraries geometry_kernel_${kernel}_simple)
-endif()
-
-endforeach()
-
-foreach(schema ${SCHEMA_VERSIONS})
-
-file(GLOB IFCGEOM_I_FILES ../src/ifcgeom/mapping/*.i)
-file(GLOB IFCGEOM_H_FILES ../src/ifcgeom/mapping/*.h)
-file(GLOB IFCGEOM_CPP_FILES ../src/ifcgeom/mapping/*.cpp)
-set(IFCGEOM_FILES ${IFCGEOM_CPP_FILES} ${IFCGEOM_H_FILES} ${IFCGEOM_I_FILES})
-
-add_library(geometry_mapping_ifc${schema} STATIC ${IFCGEOM_FILES})
-set_target_properties(geometry_mapping_ifc${schema} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${schema}")
-target_link_libraries(geometry_mapping_ifc${schema} IfcParse)
-list(APPEND mapping_libraries geometry_mapping_ifc${schema})
-
-endforeach()
-
-file(GLOB SCHEMA_AGNOSTIC_H_FILES ../src/ifcgeom/*.h)
-file(GLOB SCHEMA_AGNOSTIC_CPP_FILES ../src/ifcgeom/*.cpp)
-set(SCHEMA_AGNOSTIC_FILES ${SCHEMA_AGNOSTIC_H_FILES} ${SCHEMA_AGNOSTIC_CPP_FILES})
-
-add_library(IfcGeom ${SCHEMA_AGNOSTIC_FILES})
-set_target_properties(IfcGeom PROPERTIES COMPILE_FLAGS -DIFC_GEOM_EXPORTS VERSION "0.8.0" SOVERSION "0.8")
-
-if (UNIX)
-find_package(Threads)
-endif()
-
-# needed?
-# if (NOT WASM_BUILD)
-# endif()
-target_link_libraries(IfcGeom ${kernel_libraries} ${mapping_libraries} ${CMAKE_THREAD_LIBS_INIT})
+    if (WASM_BUILD)
+        target_link_libraries(IfcGeom ${IFCGEOM_SCHEMA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    else()
+        target_link_libraries(IfcGeom IfcParse ${IFCGEOM_SCHEMA_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    endif()
 
 endif(BUILD_IFCGEOM)
 
-if (BUILD_CONVERT OR BUILD_IFCPYTHON)
+if(BUILD_CONVERT OR BUILD_IFCPYTHON)
+    # Serializers
+    file(GLOB SERIALIZERS_H_FILES ../src/serializers/*.h)
+    file(GLOB SERIALIZERS_CPP_FILES ../src/serializers/*.cpp)
+    set(SERIALIZERS_FILES ${SERIALIZERS_H_FILES} ${SERIALIZERS_CPP_FILES})
+    file(GLOB SERIALIZERS_S_H_FILES ../src/serializers/schema_dependent/*.h)
+    file(GLOB SERIALIZERS_S_CPP_FILES ../src/serializers/schema_dependent/*.cpp)
+    set(SERIALIZERS_S_FILES ${SERIALIZERS_S_H_FILES} ${SERIALIZERS_S_CPP_FILES})
 
-# Serializers
-file(GLOB SERIALIZERS_H_FILES ../src/serializers/*.h)
-file(GLOB SERIALIZERS_CPP_FILES ../src/serializers/*.cpp)
-set(SERIALIZERS_FILES ${SERIALIZERS_H_FILES} ${SERIALIZERS_CPP_FILES})
-file(GLOB SERIALIZERS_S_H_FILES ../src/serializers/schema_dependent/*.h)
-file(GLOB SERIALIZERS_S_CPP_FILES ../src/serializers/schema_dependent/*.cpp)
-set(SERIALIZERS_S_FILES ${SERIALIZERS_S_H_FILES} ${SERIALIZERS_S_CPP_FILES})
+    foreach(schema ${SCHEMA_VERSIONS})
+        add_library(Serializers_ifc${schema} STATIC ${SERIALIZERS_S_FILES})
+        set_target_properties(Serializers_ifc${schema} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${schema}")
+        
+        if (WASM_BUILD)
+            target_link_libraries(Serializers_ifc${schema} ${HDF5_LIBRARIES})
+        else()
+            target_link_libraries(Serializers_ifc${schema} IfcGeom ${OPENCASCADE_LIBRARIES} ${HDF5_LIBRARIES})
+        endif()
+    endforeach()
 
-foreach(s ${SCHEMA_VERSIONS})
-	add_library(Serializers_ifc${s} STATIC ${SERIALIZERS_S_FILES})
-	set_target_properties(Serializers_ifc${s} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${s} ${CONVERT_PRECISION}")
-	
-	if (WASM_BUILD)
-	    TARGET_LINK_LIBRARIES(Serializers_ifc${s} ${HDF5_LIBRARIES})
-	else()
-	    TARGET_LINK_LIBRARIES(Serializers_ifc${s} IfcGeom ${OPENCASCADE_LIBRARIES} ${HDF5_LIBRARIES})
-	endif()
-endforeach()
+    add_library(Serializers ${SERIALIZERS_FILES})
+    set_target_properties(Serializers PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS" VERSION "${PROJECT_VERSION}" SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 
-add_library(Serializers ${SERIALIZERS_FILES})
-set_target_properties(Serializers PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS ${CONVERT_PRECISION}" VERSION "0.8.0" SOVERSION "0.8")
+    target_link_libraries(Serializers ${SERIALIZER_SCHEMA_LIBRARIES} ${OPENCOLLADA_LIBRARIES} ${USD_LIBRARIES})
 
-TARGET_LINK_LIBRARIES(Serializers ${SERIALIZER_SCHEMA_LIBRARIES} ${OPENCOLLADA_LIBRARIES})
+endif(BUILD_CONVERT OR BUILD_IFCPYTHON)
 
-endif()
+if(BUILD_CONVERT)
+    # IfcConvert
+    file(GLOB IFCCONVERT_CPP_FILES ../src/ifcconvert/*.cpp)
+    file(GLOB IFCCONVERT_H_FILES ../src/ifcconvert/*.h)
+    set(IFCCONVERT_FILES ${IFCCONVERT_CPP_FILES} ${IFCCONVERT_H_FILES})
+    add_executable(IfcConvert ${IFCCONVERT_FILES})
 
-if (BUILD_CONVERT)
+    target_link_libraries(IfcConvert ${IFCOPENSHELL_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${Boost_LIBRARIES} ${HDF5_LIBRARIES} ${USD_LIBRARIES})
 
-if (WITH_CGAL AND CITYJSON_SUPPORT)
-    message(STATUS "Building CityJSON support")
-set(CITYJSON_CONVERT_FILES
-	../src/ifcconvert/cityjson/geobim.cpp
-	../src/ifcconvert/cityjson/global_execution_context.cpp
-	../src/ifcconvert/cityjson/opening_collector.cpp
-	../src/ifcconvert/cityjson/processing.cpp
-	../src/ifcconvert/cityjson/radius_comparison.cpp
-	../src/ifcconvert/cityjson/radius_execution_context.cpp
-	../src/ifcconvert/cityjson/settings.cpp
-	../src/ifcconvert/cityjson/writer.cpp
-)
+    if((NOT WIN32) AND BUILD_SHARED_LIBS)
+        # Only set RPATHs when building shared libraries (i.e. IfcParse and
+        # IfcGeom are dynamically linked). Not necessarily a perfect solution
+        # but probably a good indication of whether RPATHs are necessary.
+        SET_INSTALL_RPATHS(IfcConvert "${IFCOPENSHELL_LIBRARY_DIR};${OCC_LIBRARY_DIR};${Boost_LIBRARY_DIRS};${OPENCOLLADA_LIBRARY_DIR}")
+    endif()
 
-add_library(cityjson_converter ${CITYJSON_CONVERT_FILES})
-target_include_directories(cityjson_converter PRIVATE ../src)
-set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} cityjson_converter)
-endif()
-
-# IfcConvert
-file(GLOB IFCCONVERT_CPP_FILES ../src/ifcconvert/*.cpp)
-file(GLOB IFCCONVERT_H_FILES ../src/ifcconvert/*.h)
-set(IFCCONVERT_FILES ${IFCCONVERT_CPP_FILES} ${IFCCONVERT_H_FILES})
-ADD_EXECUTABLE(IfcConvert ${IFCCONVERT_FILES})
-set_target_properties(IfcConvert PROPERTIES COMPILE_FLAGS "${CONVERT_PRECISION}")
-
-TARGET_LINK_LIBRARIES(IfcConvert ${IFCOPENSHELL_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${Boost_LIBRARIES} ${HDF5_LIBRARIES})
-
-if ((NOT WIN32) AND BUILD_SHARED_LIBS)
-    # Only set RPATHs when building shared libraries (i.e. IfcParse and
-    # IfcGeom are dynamically linked). Not necessarily a perfect solution
-    # but probably a good indication of whether RPATHs are necessary.
-    SET_INSTALL_RPATHS(IfcConvert "${IFCOPENSHELL_LIBRARY_DIR};${OCC_LIBRARY_DIR};${Boost_LIBRARY_DIRS};${OPENCOLLADA_LIBRARY_DIR}")
-endif()
-
-INSTALL(TARGETS IfcConvert
-    ARCHIVE DESTINATION ${LIBDIR}
-    LIBRARY DESTINATION ${LIBDIR}
-    RUNTIME DESTINATION ${BINDIR}
-)
-
+    install(TARGETS IfcConvert
+        ARCHIVE DESTINATION ${LIBDIR}
+        LIBRARY DESTINATION ${LIBDIR}
+        RUNTIME DESTINATION ${BINDIR}
+    )
 endif(BUILD_CONVERT)
 
 # IfcGeomServer
-if(NOT MINIMAL_BUILD AND BUILD_GEOMSERVER AND WITH_OPENCASCADE)
+if(BUILD_GEOMSERVER)
+    file(GLOB CPP_FILES ../src/ifcgeomserver/*.cpp)
+    file(GLOB H_FILES ../src/ifcgeomserver/*.h)
+    set(SOURCE_FILES ${CPP_FILES} ${H_FILES})
+    add_executable(IfcGeomServer ${SOURCE_FILES})
+    target_link_libraries(IfcGeomServer ${IFCOPENSHELL_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${Boost_LIBRARIES})
 
-file(GLOB CPP_FILES ../src/ifcgeomserver/*.cpp)
-file(GLOB H_FILES ../src/ifcgeomserver/*.h)
-set(SOURCE_FILES ${CPP_FILES} ${H_FILES})
-ADD_EXECUTABLE(IfcGeomServer ${SOURCE_FILES})
-TARGET_LINK_LIBRARIES(IfcGeomServer ${IFCOPENSHELL_LIBRARIES} ${OPENCASCADE_LIBRARIES} ${Boost_LIBRARIES})
+    if((NOT WIN32) AND BUILD_SHARED_LIBS)
+        SET_INSTALL_RPATHS(IfcGeomServer "${IFCOPENSHELL_LIBRARY_DIR};${OCC_LIBRARY_DIR};${Boost_LIBRARY_DIRS}")
+    endif()
 
-if ((NOT WIN32) AND BUILD_SHARED_LIBS)
-    SET_INSTALL_RPATHS(IfcGeomServer "${IFCOPENSHELL_LIBRARY_DIR};${OCC_LIBRARY_DIR};${Boost_LIBRARY_DIRS}")
+    install(TARGETS IfcGeomServer
+        ARCHIVE DESTINATION ${LIBDIR}
+        LIBRARY DESTINATION ${LIBDIR}
+        RUNTIME DESTINATION ${BINDIR}
+    )
 endif()
 
-INSTALL(TARGETS IfcGeomServer
-    ARCHIVE DESTINATION ${LIBDIR}
-    LIBRARY DESTINATION ${LIBDIR}
-    RUNTIME DESTINATION ${BINDIR}
-)
+if(ADD_COMMIT_SHA)
+    find_package(Git)
 
-endif()
+    if(GIT_FOUND)
+        message("git found: ${GIT_EXECUTABLE} with version ${GIT_VERSION_STRING}")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} branch -a --contains HEAD
+            OUTPUT_VARIABLE git_branches
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        string(REPLACE "\n" ";" git_branch_list "${git_branches}")
 
-if (ADD_COMMIT_SHA)
-find_package (Git)
-if (GIT_FOUND)
-	message("git found: ${GIT_EXECUTABLE} with version ${GIT_VERSION_STRING}")
-	execute_process(
-		COMMAND ${GIT_EXECUTABLE} branch --contains HEAD
-		OUTPUT_VARIABLE git_branches
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-	)
-	string(REPLACE "\n" ";" git_branch_list "${git_branches}")
-	foreach(git_branch_candidate IN ITEMS ${git_branch_list})
-		string(REPLACE "*" "" git_branch_candidate_temp "${git_branch_candidate}")
-		string(STRIP "${git_branch_candidate_temp}" git_branch_candidate_2)
-		if (NOT git_branch_candidate_2 MATCHES "^HEAD$")
-			set(git_branch ${git_branch_candidate_2})
-		endif()
-	endforeach()
-	execute_process(
-		COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
-		OUTPUT_VARIABLE git_sha
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-	)
-	message(STATUS "IfcOpenShell branch: \"${git_branch}\"")
-	message(STATUS "IfcOpenShell commit: \"${git_sha}\"")
-	add_definitions(-DIFCOPENSHELL_BRANCH=${git_branch})
-	add_definitions(-DIFCOPENSHELL_COMMIT=${git_sha})
-endif()
-endif()
+        foreach(git_branch_candidate IN ITEMS ${git_branch_list})
+		    string(REPLACE "*" "" git_branch_candidate_temp "${git_branch_candidate}")
+		    string(STRIP "${git_branch_candidate_temp}" git_branch_candidate_2)
+            if (NOT git_branch_candidate_2 MATCHES "^HEAD$")
+                string(REPLACE "/" ";" git_branch_candidate_2_list "${git_branch_candidate_2}")
+                list(GET git_branch_candidate_2_list -1 git_branch)
+            endif()
+        endforeach()
 
-if (MSVC)
-# @todo still needs to be understood better, but the cgal and cgal-simple kernel cause multiply defined boost lambda placeholders _1 ... _3
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /FORCE:MULTIPLE")
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /FORCE:MULTIPLE")
-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /FORCE:MULTIPLE")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+            OUTPUT_VARIABLE git_sha
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        message(STATUS "IfcOpenShell branch: \"${git_branch}\"")
+        message(STATUS "IfcOpenShell commit: \"${git_sha}\"")
+        add_definitions(-DIFCOPENSHELL_BRANCH=${git_branch})
+        add_definitions(-DIFCOPENSHELL_COMMIT=${git_sha})
+    endif()
 endif()
 
 # Documentation
-IF(BUILD_DOCUMENTATION)
-	set(CMAKE_MODULE_PATH "../docs/cmake")
-	ADD_SUBDIRECTORY(../docs docs)
-ENDIF()
-
-IF(NOT MINIMAL_BUILD AND BUILD_IFCPYTHON)
-	ADD_SUBDIRECTORY(../src/ifcwrap ifcwrap)
-ENDIF()
-
-IF(BUILD_EXAMPLES)
-	ADD_SUBDIRECTORY(../src/examples examples)
-ENDIF()
-
-IF(NOT MINIMAL_BUILD AND BUILD_IFCMAX)
-	ADD_SUBDIRECTORY(../src/ifcmax ifcmax)
-ENDIF()
-
-if (NOT MINIMAL_BUILD)
-if (WITH_CGAL)
-ADD_SUBDIRECTORY(../src/svgfill svgfill)
+if(BUILD_DOCUMENTATION)
+    set(CMAKE_MODULE_PATH "../docs/cmake")
+    add_subdirectory(../docs docs)
 endif()
+
+if(BUILD_IFCPYTHON)
+    add_subdirectory(../src/ifcwrap ifcwrap)
+endif()
+
+if(BUILD_EXAMPLES)
+    add_subdirectory(../src/examples examples)
+endif()
+
+if(BUILD_IFCMAX)
+    add_subdirectory(../src/ifcmax ifcmax)
+endif()
+
+if(NOT MINIMAL_BUILD)
+    add_subdirectory(../src/svgfill svgfill)
+endif()
+
+if(BUILD_QTVIEWER)
+    add_subdirectory(../src/qtviewer qtviewer)
 endif()
 
 # CMake installation targets
-INSTALL(FILES ${IFCPARSE_H_FILES}
+install(FILES ${IFCPARSE_H_FILES}
 	DESTINATION ${INCLUDEDIR}/ifcparse
 )
 
-INSTALL(TARGETS IfcParse
+install(TARGETS IfcParse
 	ARCHIVE DESTINATION ${LIBDIR}
 	LIBRARY DESTINATION ${LIBDIR}
 	RUNTIME DESTINATION ${BINDIR}
 )
 
 if(BUILD_IFCGEOM)
-INSTALL(FILES ${IFCGEOM_H_FILES}
-	DESTINATION ${INCLUDEDIR}/ifcgeom
-)
+    install(FILES ${IFCGEOM_H_FILES}
+        DESTINATION ${INCLUDEDIR}/ifcgeom
+    )
 
-INSTALL(TARGETS ${IFCGEOM_SCHEMA_LIBRARIES} IfcGeom
-	ARCHIVE DESTINATION ${LIBDIR}
-	LIBRARY DESTINATION ${LIBDIR}
-	RUNTIME DESTINATION ${BINDIR}
-)
+    install(FILES ${SCHEMA_AGNOSTIC_H_FILES}
+        DESTINATION ${INCLUDEDIR}/ifcgeom_schema_agnostic
+    )
+
+    install(TARGETS ${IFCGEOM_SCHEMA_LIBRARIES} IfcGeom
+        ARCHIVE DESTINATION ${LIBDIR}
+        LIBRARY DESTINATION ${LIBDIR}
+        RUNTIME DESTINATION ${BINDIR}
+    )
 endif()
 
 if(BUILD_CONVERT)
-INSTALL(TARGETS Serializers ${SERIALIZER_SCHEMA_LIBRARIES}
-	ARCHIVE DESTINATION ${LIBDIR}
-	LIBRARY DESTINATION ${LIBDIR}
-	RUNTIME DESTINATION ${BINDIR}
-)
+    install(TARGETS Serializers ${SERIALIZER_SCHEMA_LIBRARIES}
+        ARCHIVE DESTINATION ${LIBDIR}
+        LIBRARY DESTINATION ${LIBDIR}
+        RUNTIME DESTINATION ${BINDIR}
+    )
 
-INSTALL(FILES  ${SERIALIZERS_FILES}
-	DESTINATION ${INCLUDEDIR}/serializers/
-)
+    install(FILES ${SERIALIZERS_FILES}
+        DESTINATION ${INCLUDEDIR}/serializers/
+    )
+
+    install(FILES ${SERIALIZERS_S_FILES}
+        DESTINATION ${INCLUDEDIR}/serializers/schema_dependent
+    )
 endif()
 
-IF(BUILD_QTVIEWER)
-    ADD_SUBDIRECTORY(../src/qtviewer qtviewer)
+# Cmake uninstall target
+if(NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
+
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 endif()
 
+# Packaging
 list(APPEND CPACK_SOURCE_IGNORE_FILES
-  .git
-  .gitignore
-  )
-
+    .git
+    .gitignore
+)
 set(CPACK_PACKAGE_NAME "${PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}${EXTRA_VERSION}")
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}${EXTRA_VERSION}")
 SET(CPACK_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}${EXTRA_VERSION}-${CMAKE_SYSTEM_NAME}")
@@ -1127,11 +1110,10 @@ set(CPACK_PACKAGE_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
 set(CPACK_PACKAGE_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
 set(CPACK_PACKAGE_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
 
-
 set(CPACK_GENERATOR "TGZ;DEB")
 set(CPACK_SOURCE_GENERATOR "TGZ")
 
-FOREACH(COMPONENT IN ITEMS ${BOOST_COMPONENTS})
+foreach(COMPONENT IN ITEMS ${BOOST_COMPONENTS})
     string(REPLACE "_" "-" COMP ${COMPONENT})
     set(BOOST_DEPS "${BOOST_DEPS}, libboost-${COMP}-dev")
 endforeach(COMPONENT)
@@ -1145,6 +1127,6 @@ set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 set(CPACK_DEBIAN_PACKAGE_SECTION "science")
 set(CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}${EXTRA_VERSION}")
 set(CPACK_DEBIAN_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
-#set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/cmake/debian/postinst")
 
+# set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/cmake/debian/postinst")
 include(CPack)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -18,7 +18,7 @@
 ################################################################################
 
 cmake_minimum_required(VERSION 3.1.3)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON) # not necessary, but encouraged
 
 project(IfcOpenShell VERSION 0.8.0)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,43 @@
+################################################################################
+#                                                                              #
+# This file is part of IfcOpenShell.                                           #
+#                                                                              #
+# IfcOpenShell is free software: you can redistribute it and/or modify         #
+# it under the terms of the Lesser GNU General Public License as published by  #
+# the Free Software Foundation, either version 3.0 of the License, or          #
+# (at your option) any later version.                                          #
+#                                                                              #
+# IfcOpenShell is distributed in the hope that it will be useful,              #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of               #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 #
+# Lesser GNU General Public License for more details.                          #
+#                                                                              #
+# You should have received a copy of the Lesser GNU General Public License     #
+# along with this program. If not, see <http://www.gnu.org/licenses/>.         #
+#                                                                              #
+################################################################################
+
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+
+foreach(file ${files})
+    message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+
+    if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        exec_program(
+            "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+            OUTPUT_VARIABLE rm_out
+            RETURN_VALUE rm_retval
+        )
+
+        if(NOT "${rm_retval}" STREQUAL 0)
+            message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+        endif()
+    else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+        message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+    endif()
+endforeach()

--- a/src/ifcmax/CMakeLists.txt
+++ b/src/ifcmax/CMakeLists.txt
@@ -16,32 +16,72 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.         #
 #                                                                              #
 ################################################################################
+
+# check for 3ds Max SDK
 foreach(max_year RANGE 2014 2030)
+    set(max_sdk "$ENV{ADSK_3DSMAX_SDK_${max_year}}")
 
-set(max_sdk "$ENV{ADSK_3DSMAX_SDK_${max_year}}")
-if (NOT "${max_sdk}" STREQUAL "")
-
-INCLUDE_DIRECTORIES(${INCLUDE_DIRECTORIES} ${OCC_INCLUDE_DIR} ${OPENCOLLADA_INCLUDE_DIRS} ${ICU_INCLUDE_DIR}
-    ${Boost_INCLUDE_DIRS} ${max_sdk}/include
-)
-
-# All recent versions of 3ds Max (2014 and newer) are 64-bit only so assume lib/x64 directory
-LINK_DIRECTORIES(${LINK_DIRECTORIES} ${IfcOpenShell_BINARY_DIR} ${OCC_LIBRARY_DIR} ${OPENCOLLADA_LIBRARY_DIR}
-    ${ICU_LIBRARY_DIR} ${Boost_LIBRARY_DIRS} ${max_sdk}/lib/x64/Release
-)
-
-ADD_LIBRARY(IfcMax_${max_year} SHARED IfcMax.h IfcMax.cpp)
-
-# TODO: find the minimal subset of 3dsmax libraries to reference
-TARGET_LINK_LIBRARIES(IfcMax_${max_year} ${IFCOPENSHELL_LIBRARIES} Comctl32.lib zlibdll.lib bmm.lib core.lib CustDlg.lib edmodel.lib expr.lib
-    flt.lib geom.lib gfx.lib gup.lib imageViewers.lib ManipSys.lib maxnet.lib Maxscrpt.lib
-    maxutil.lib MenuMan.lib menus.lib mesh.lib MNMath.lib Paramblk2.lib particle.lib Poly.lib RenderUtil.lib
-    tessint.lib viewfile.lib ${OPENCASCADE_LIBRARIES}
-)
-
-SET_TARGET_PROPERTIES(IfcMax_${max_year} PROPERTIES SUFFIX ".dli")
-
-INSTALL(TARGETS IfcMax_${max_year} RUNTIME DESTINATION ${BINDIR})
-
-endif()
+    if(NOT "${max_sdk}" STREQUAL "")
+        message(STATUS "Autodesk 3ds Max SDK ${max_year} found at ${max_sdk}")
+        list(APPEND FOUND_MAX_YEARS ${max_year})
+        list(APPEND FOUND_MAX_SDKS ${max_sdk})
+        set(HAS_MAX TRUE)
+    endif()
 endforeach()
+
+if(HAS_MAX)
+    # build libraray for each found 3ds Max SDK
+    foreach(max_year max_sdk IN ZIP_LISTS FOUND_MAX_YEARS FOUND_MAX_SDKS)
+
+        message(STATUS "Building IFCMax library for Autodesk 3ds Max SDK ${max_year}")
+
+        include_directories(${INCLUDE_DIRECTORIES} ${OCC_INCLUDE_DIR} ${OPENCOLLADA_INCLUDE_DIRS} ${ICU_INCLUDE_DIR}
+            ${Boost_INCLUDE_DIRS} ${max_sdk}/include
+        )
+
+        # All recent versions of 3ds Max (2014 and newer) are 64-bit only so assume lib/x64 directory
+        link_directories(${LINK_DIRECTORIES} ${IfcOpenShell_BINARY_DIR} ${OCC_LIBRARY_DIR} ${OPENCOLLADA_LIBRARY_DIR}
+            ${ICU_LIBRARY_DIR} ${Boost_LIBRARY_DIRS} ${max_sdk}/lib/x64/Release
+        )
+
+        add_library(IfcMax_${max_year} SHARED IfcMax.h IfcMax.cpp)
+
+        # TODO: find the minimal subset of 3dsmax libraries to reference
+        target_link_libraries(IfcMax_${max_year} ${IFCOPENSHELL_LIBRARIES}
+            bmm.lib
+            Comctl32.lib
+            core.lib
+            CustDlg.lib
+            edmodel.lib
+            expr.lib
+            flt.lib
+            geom.lib
+            gfx.lib
+            gup.lib
+            imageViewers.lib
+            ManipSys.lib
+            maxnet.lib
+            Maxscrpt.lib
+            maxutil.lib
+            MenuMan.lib
+            menus.lib
+            mesh.lib
+            MNMath.lib
+            Paramblk2.lib
+            particle.lib
+            Poly.lib
+            RenderUtil.lib
+            tessint.lib
+            viewfile.lib
+            zlibdll.lib
+            ${OPENCASCADE_LIBRARIES}
+        )
+
+        set_target_properties(IfcMax_${max_year} PROPERTIES SUFFIX ".dli")
+
+        install(TARGETS IfcMax_${max_year} RUNTIME DESTINATION ${BINDIR})
+    endforeach()
+else()
+    message(STATUS "Autodesk 3ds Max SDK not found, is required to build IFCMax.")
+endif()
+


### PR DESCRIPTION
This PR merges the format and unify changes of the CMakeLists files from v0.7.0 to branch v0.8.0. The intermediate changes  regarding the use of CGAL are reapplied.