### PR TITLE
First attempt at taxonomy::implicit_item

### DIFF
--- a/src/ifcgeom/AbstractKernel.h
+++ b/src/ifcgeom/AbstractKernel.h
@@ -54,6 +54,8 @@ namespace ifcopenshell { namespace geometry { namespace kernels {
 		virtual bool convert_impl(const taxonomy::surface_curve_sweep::ptr, IfcGeom::ConversionResults&) { throw std::runtime_error("Not implemented"); }
 		virtual bool convert_impl(const taxonomy::loft::ptr, IfcGeom::ConversionResults&) { throw std::runtime_error("Not implemented"); }
 		virtual bool convert_impl(const taxonomy::collection::ptr, IfcGeom::ConversionResults&);
+		virtual bool convert_impl(const taxonomy::piecewise_function::ptr item, IfcGeom::ConversionResults& cs) { return convert(item->evaluate(), cs); }
+
 
 		/*
 		virtual void set_offset(const std::array<double, 3> &p_offset);

--- a/src/ifcgeom/mapping/IfcGradientCurve.cpp
+++ b/src/ifcgeom/mapping/IfcGradientCurve.cpp
@@ -1,0 +1,76 @@
+/********************************************************************************
+ *                                                                              *
+ * This file is part of IfcOpenShell.                                           *
+ *                                                                              *
+ * IfcOpenShell is free software: you can redistribute it and/or modify         *
+ * it under the terms of the Lesser GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3.0 of the License, or          *
+ * (at your option) any later version.                                          *
+ *                                                                              *
+ * IfcOpenShell is distributed in the hope that it will be useful,              *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 *
+ * Lesser GNU General Public License for more details.                          *
+ *                                                                              *
+ * You should have received a copy of the Lesser GNU General Public License     *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.         *
+ *                                                                              *
+ ********************************************************************************/
+
+#include "mapping.h"
+#define mapping POSTFIX_SCHEMA(mapping)
+using namespace ifcopenshell::geometry;
+
+#ifdef SCHEMA_HAS_IfcGradientCurve
+
+taxonomy::ptr mapping::map_impl(const IfcSchema::IfcGradientCurve* inst) {
+	auto horizontal = taxonomy::cast<taxonomy::piecewise_function>(map(inst->BaseCurve()));
+	auto vertical = taxonomy::make<taxonomy::piecewise_function>();
+
+	auto segments = inst->Segments();
+
+	for (auto& segment : *segments) {
+		if (segment->as<IfcSchema::IfcCurveSegment>()) {
+			// @todo check that we don't get a mixture of implicit and explicit definitions
+			auto crv = map(segment->as<IfcSchema::IfcCurveSegment>());
+			if (crv->kind() == taxonomy::PIECEWISE_FUNCTION) {
+				auto seg = taxonomy::cast<taxonomy::piecewise_function>(crv);
+				vertical->spans.insert(vertical->spans.end(), seg->spans.begin(), seg->spans.end());
+			} else {
+				Logger::Error("Unsupported");
+				return nullptr;
+			}
+		} else {
+			Logger::Error("Unsupported");
+			return nullptr;
+		}
+	}
+
+	// @todo does this really make sense?
+	auto composition = [horizontal, vertical](double u) {
+		auto xy = horizontal->evaluate(u);
+		auto z = vertical->evaluate(u);
+		Eigen::VectorXd vec(3);
+		vec << xy(0), xy(1), z(0);
+		return vec;
+	};
+
+	// @todo where do we get the startdistalong from @civilx64's code?
+	std::array<taxonomy::piecewise_function::ptr, 2> both = { horizontal , vertical };
+	double min_length = std::numeric_limits<double>::infinity();
+	for (auto i = 0; i < 2; ++i) {
+		double l = 0;
+		for (auto& s : both[i]->spans) {
+			l += s.first;
+		}
+		if (l < min_length) {
+			min_length = l;
+		}
+	}
+
+	auto pwf = taxonomy::make<taxonomy::piecewise_function>();
+	pwf->spans.push_back({ min_length, composition });
+	return pwf;
+}
+
+#endif

--- a/src/ifcgeom/mapping/mapping.i
+++ b/src/ifcgeom/mapping/mapping.i
@@ -113,6 +113,9 @@ BIND(IfcEdge);
 BIND(IfcEdgeLoop);
 BIND(IfcPolyline);
 BIND(IfcPolyLoop);
+#ifdef SCHEMA_HAS_IfcGradientCurve
+BIND(IfcGradientCurve);
+#endif
 BIND(IfcCompositeCurve);
 BIND(IfcTrimmedCurve);
 BIND(IfcArbitraryOpenProfileDef);

--- a/src/ifcgeom/taxonomy.cpp
+++ b/src/ifcgeom/taxonomy.cpp
@@ -1,4 +1,5 @@
 #include "taxonomy.h"
+#include "profile_helper.h"
 
 using namespace ifcopenshell::geometry::taxonomy;
 
@@ -142,6 +143,10 @@ namespace {
 	}
 
 	bool compare(const surface_curve_sweep&, const surface_curve_sweep&) {
+		throw std::runtime_error("not implemented");
+	}
+
+	bool compare(const piecewise_function&, const piecewise_function&) {
 		throw std::runtime_error("not implemented");
 	}
 	
@@ -434,6 +439,25 @@ ifcopenshell::geometry::taxonomy::solid::ptr ifcopenshell::geometry::create_box(
 	return solid;
 }
 
+ifcopenshell::geometry::taxonomy::item::ptr ifcopenshell::geometry::taxonomy::piecewise_function::evaluate() const {
+	// @todo configure resolution
+	double length = 0.;
+	static const double resolution = 0.5;
+	for (auto& s : spans) {
+		length += s.first;
+	}
+	std::vector<taxonomy::point3::ptr> polygon;
+
+	int num_steps = std::ceil(length / resolution);
+	for (int i = 0; i < num_steps; ++i) {
+		auto u = resolution * i;
+		auto p = evaluate(u);
+		polygon.push_back(taxonomy::make<taxonomy::point3>(p(0), p(1), p(2)));
+	}
+
+	return polygon_from_points(polygon);
+}
+
 ifcopenshell::geometry::taxonomy::collection::ptr ifcopenshell::geometry::flatten(taxonomy::collection::ptr deep) {
 	auto flat = make<taxonomy::collection>();
 	ifcopenshell::geometry::visit<taxonomy::collection>(deep, [&flat](taxonomy::ptr i) {
@@ -446,7 +470,7 @@ const std::string& ifcopenshell::geometry::taxonomy::kind_to_string(kinds k) {
 	using namespace std::string_literals;
 
 	static std::string values[] = {
-		"matrix4"s, "point3"s, "direction3"s, "line"s, "circle"s, "ellipse"s, "bspline_curve"s, "offset_curve"s, "plane"s, "cylinder"s, "bspline_surface"s, "edge"s, "loop"s, "face"s, "shell"s, "solid"s, "loft"s, "extrusion"s, "revolve"s, "surface_curve_sweep"s, "node"s, "collection"s, "boolean_result"s
+		"matrix4"s, "point3"s, "direction3"s, "line"s, "circle"s, "ellipse"s, "bspline_curve"s, "offset_curve"s, "plane"s, "cylinder"s, "bspline_surface"s, "edge"s, "loop"s, "face"s, "shell"s, "solid"s, "loft"s, "extrusion"s, "revolve"s, "surface_curve_sweep"s, "node"s, "collection"s, "boolean_result"s, "piecewise_function"s, "colour"s, "style"s,
 	};
 
 	return values[k];

--- a/src/ifcgeom/taxonomy.h
+++ b/src/ifcgeom/taxonomy.h
@@ -86,7 +86,7 @@ public:
 	topology_error(const char* const s) : std::runtime_error(s) {}
 };
 
-enum kinds { MATRIX4, POINT3, DIRECTION3, LINE, CIRCLE, ELLIPSE, BSPLINE_CURVE, OFFSET_CURVE, PLANE, CYLINDER, BSPLINE_SURFACE, EDGE, LOOP, FACE, SHELL, SOLID, LOFT, EXTRUSION, REVOLVE, SURFACE_CURVE_SWEEP, NODE, COLLECTION, BOOLEAN_RESULT, COLOUR, STYLE };
+enum kinds { MATRIX4, POINT3, DIRECTION3, LINE, CIRCLE, ELLIPSE, BSPLINE_CURVE, OFFSET_CURVE, PLANE, CYLINDER, BSPLINE_SURFACE, EDGE, LOOP, FACE, SHELL, SOLID, LOFT, EXTRUSION, REVOLVE, SURFACE_CURVE_SWEEP, NODE, COLLECTION, BOOLEAN_RESULT, PIECEWISE_FUNCTION, COLOUR, STYLE};
 
 const std::string& kind_to_string(kinds k);
 
@@ -125,6 +125,41 @@ public:
 	uint32_t identity() const { return identity_; }
 };
 
+struct implicit_item : public item {
+	DECLARE_PTR(implicit_item)
+	
+	virtual item::ptr evaluate() const = 0;
+};
+
+struct piecewise_function : public item {
+	DECLARE_PTR(piecewise_function)
+
+	std::vector<std::pair<double, std::function<Eigen::VectorXd(double u)>>> spans;
+
+	void print(std::ostream& o, int indent = 0) const {
+		o << "piecewise_function" << std::endl;
+	}
+
+	virtual piecewise_function* clone_() const { return new piecewise_function(*this); }
+	virtual kinds kind() const { return PIECEWISE_FUNCTION; }
+
+	virtual size_t calc_hash() const {
+		auto v = std::make_tuple(static_cast<size_t>(PIECEWISE_FUNCTION), 0);
+		return boost::hash<decltype(v)>{}(v);
+	}
+
+	virtual item::ptr evaluate() const;
+
+	Eigen::VectorXd evaluate(double u) const {
+		// @todo optimize, assume monotonic evaluation and store last evaluated segment?
+		for (auto& s : spans) {
+			if (u < s.first) {
+				return s.second(u);
+			}
+			u -= s.first;
+		}
+	}
+};
 
 #ifdef TAXONOMY_USE_SHARED_PTR
 typedef std::shared_ptr<item> ptr;
@@ -983,7 +1018,7 @@ struct boolean_result : public collection_base<geom_item> {
 };
 
 namespace impl {
-	typedef std::tuple<matrix4, point3, direction3, line, circle, ellipse, bspline_curve, offset_curve, plane, cylinder, bspline_surface, edge, loop, face, shell, solid, loft, extrusion, revolve, surface_curve_sweep, node, collection, boolean_result> KindsTuple;
+	typedef std::tuple<matrix4, point3, direction3, line, circle, ellipse, bspline_curve, offset_curve, plane, cylinder, bspline_surface, edge, loop, face, shell, solid, loft, extrusion, revolve, surface_curve_sweep, node, collection, boolean_result, piecewise_function> KindsTuple;
 	typedef std::tuple<line, circle, ellipse, bspline_curve, offset_curve, loop, edge> CurvesTuple;
 	typedef std::tuple<plane, cylinder, bspline_surface> SurfacesTuple;
 }


### PR DESCRIPTION
I've tried to create a prototype of this ``implicit_item'' idea I was describing. I've never seen such an amount of composition of lambdas in C++ code base. I'm not sure about it. Also, having to reverse engineer whether a curvesegment is part of a horizontal/vertical/cant and choose the appropriate return type deep down in this functor is probably less than ideal, but keeps the amount of code minimal. Curious to hear your feedback. I also took the liberty to replace integrate() with something from boost.math.

Added you as a member @RickBrice in order to assign you as a reviewer.