### PR TITLE
Patch API calls to ifcopenshell.api

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/file.py
+++ b/src/ifcopenshell-python/ifcopenshell/file.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import annotations
 
 import os
 import re
@@ -27,6 +28,12 @@ import numbers
 import zipfile
 import functools
 from pathlib import Path
+import importlib
+import inspect
+from types import ModuleType
+from typing import Any, DefaultDict
+from dataclasses import dataclass, field
+from collections import defaultdict
 
 import ifcopenshell.util.element
 import ifcopenshell.util.file
@@ -564,3 +571,72 @@ class file(object):
     @staticmethod
     def from_pointer(v):
         return file_dict.get(v)
+
+    def patch_api(self) -> None:
+        """Monkey-patches ifcopenshell.api.run calls as methods of a file instance"""
+
+        actions_to_exclude: list[str] = ["__init__", "settings"]
+
+        @dataclass
+        class ApiModule:
+            _module: str
+
+            def __post_init__(self):
+                self.__name__ = self._module
+                self.__qualname__ = self._module
+
+            def __repr__(self) -> str:
+                return f"<class 'ifcopenshell.file.{self._module}'> (patched)"
+
+        @dataclass(slots=True)
+        class ApiAction:
+            file: ifcopenshell.file
+            module: str
+            action: str
+            _file_as_arg: bool = field(init=False, default=True)
+            __name__: str = ""
+            __qualname__: str = ""
+            __signature__: inspect.Signature = field(init=False)
+
+            def __post_init__(self):
+                self.__name__ = self.action
+                self.__qualname__ = f"{self.module}.{self.action}"
+                self.update_signature()
+
+            def __repr__(self) -> str:
+                return f"<class 'ifcopenshell.file.{self.module}.{self.action}'> (patched)"
+
+            def __call__(self, *args, **kwargs) -> Any:
+                if self._file_as_arg:
+                    args = [self.file, *args]
+                return ifcopenshell.api.run(f"{self.module}.{self.action}", *args, **kwargs)
+
+            def update_signature(self) -> None:
+                python_module: ModuleType = importlib.import_module(f"ifcopenshell.api.{self.module}.{self.action}")
+                api_signature: inspect.Signature = inspect.signature(python_module.Usecase.__init__)
+                parameters: list[inspect.Parameter] = list(api_signature.parameters.values())
+                if parameters:
+                    parameters = parameters[1:]  # discarding self from the signature
+                if parameters and parameters[0].name == "file":
+                    parameters = parameters[1:]  # discarding file from the signature
+                else:
+                    self._file_as_arg = False
+                return_annotation: Any = api_signature.return_annotation
+                self.__signature__ = inspect.signature(self).replace(
+                    parameters=parameters, return_annotation=return_annotation
+                )
+
+        api_calls: DefaultDict[str, list[str]] = defaultdict(list)
+        ios_dir = Path(os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe()))))
+
+        for path in (ios_dir / "api").glob("*/*.py"):
+            if (action := path.stem) in actions_to_exclude:
+                continue
+            module = path.parent.name
+            api_calls[module].append(action)
+
+        for module, actions in api_calls.items():
+            action_functors: dict[str, ApiAction] = {
+                action: ApiAction(file=self, module=module, action=action) for action in actions
+            }
+            setattr(self, module, type(module, (ApiModule,), {"_module": module} | action_functors))

--- a/src/ifcopenshell-python/ifcopenshell/file.py
+++ b/src/ifcopenshell-python/ifcopenshell/file.py
@@ -22,6 +22,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import annotations
 
+import os
 import re
 import numbers
 import zipfile

--- a/src/ifcopenshell-python/ifcopenshell/file.py
+++ b/src/ifcopenshell-python/ifcopenshell/file.py
@@ -584,6 +584,7 @@ class file(object):
             def __post_init__(self):
                 self.__name__ = self._module
                 self.__qualname__ = self._module
+                self.__doc__ = f"IfcOpenShell API module {self._module}"
 
             def __repr__(self) -> str:
                 return f"<class 'ifcopenshell.file.{self._module}'> (patched)"
@@ -597,6 +598,7 @@ class file(object):
             __name__: str = ""
             __qualname__: str = ""
             __signature__: inspect.Signature = field(init=False)
+            __doc__: str = ""
 
             def __post_init__(self):
                 self.__name__ = self.action
@@ -617,6 +619,7 @@ class file(object):
                 except ModuleNotFoundError:
                     return
                 else:
+                    self.__doc__ = python_module.Usecase.__init__.__doc__
                     api_signature: inspect.Signature = inspect.signature(python_module.Usecase.__init__)
                     parameters: list[inspect.Parameter] = list(api_signature.parameters.values())
                     if parameters:

--- a/src/ifcopenshell-python/ifcopenshell/file.py
+++ b/src/ifcopenshell-python/ifcopenshell/file.py
@@ -643,4 +643,7 @@ class file(object):
             action_functors: dict[str, ApiAction] = {
                 action: ApiAction(file=self, module=module, action=action) for action in actions
             }
-            setattr(self, module, type(module, (ApiModule,), {"_module": module} | action_functors))
+            api_module = ApiModule(_module=module)
+            for action, functor in action_functors.items():
+                setattr(api_module, action, functor)
+            setattr(self, module, api_module)


### PR DESCRIPTION
This PR is related to https://github.com/IfcOpenShell/IfcOpenShell/issues/2693. It adds static type decorations without changing the underlying architecture of the Usecases and the centralized `run`. Or, more specifically, it grabs the signatures from the Usecases, so to take full advantage of the benefits of static typing in smart IDEs or Jupyter Notebooks, they'd also need to update its signature, as proposed in https://github.com/IfcOpenShell/IfcOpenShell/pull/3774 for the `geometry.add_wall_representation` case.

The proposal consists of the simple addition of `patch_api` method to IfcOpenShell files. For now, nothing happens if one doesn't explicitly call `file.patch_api()`, so it is safe to merge in case this strategy sounds good. If/when it is fully agreed, it can then be included to `file.__init__` and patch all new files by default at runtime. I guess it could also be added to the cmake in order to patch the file class at install time, by making it a classmethod, but I can't think of a straightforward way to reach the file instance in that case.

It is worth noting that there aren't as much API calls so as to add a very significant overhead. There's a glob over there to find the Usecase files, but a call to `patch_api` takes 100 ms on my system. I'd say it's acceptable.

With this design, one calls the API following the dot notation from a file:
![patch_api](https://github.com/IfcOpenShell/IfcOpenShell/assets/57069798/a6a1caaa-fa03-44b5-bfc5-2fbd1244950f)

I find it very user friendly, even better than what I was proposing before of `ios.root.create_entity(file, "IfcWall")`. It more or less follows the notation of the existing `file.create_entity`, and the dot notation, grouping by API module, makes the namespace not super polluted, at least in my view.

What do you think of an approach like this, @aothms @Moult and everyone interested?