### PR TITLE
v0.8.0 - fix clang-tidy warnings

### DIFF
--- a/src/examples/IfcAlignment.cpp
+++ b/src/examples/IfcAlignment.cpp
@@ -25,12 +25,13 @@
 // Sections and page number for this document are cited in the code comments.
 
 // Disable warnings coming from IfcOpenShell
-#pragma warning(disable:4018 4267 4250 4984 4985)
+#pragma warning(disable : 4018 4267 4250 4984 4985)
 
-#include "../ifcparse/IfcHierarchyHelper.h"
 #include "../ifcparse/Ifc4x3_add2.h"
+#include "../ifcparse/IfcHierarchyHelper.h"
 
 #include <boost/math/constants/constants.hpp>
+#include <fstream>
 
 const double PI = boost::math::constants::pi<double>();
 double to_radian(double deg) { return PI * deg / 180; }

--- a/src/examples/IfcParseExamples.cpp
+++ b/src/examples/IfcParseExamples.cpp
@@ -20,8 +20,9 @@
 // TODO: Multiple schemas
 #define IfcSchema Ifc2x3
 
-#include "../ifcparse/IfcFile.h"
 #include "../ifcparse/Ifc2x3.h"
+#include "../ifcparse/IfcFile.h"
+#include "../ifcparse/IfcLogger.h"
 
 #if USE_VLD
 #include <vld.h>
@@ -29,54 +30,52 @@
 
 int main(int argc, char** argv) {
 
-	if ( argc != 2 ) {
-		std::cout << "usage: IfcParseExamples <filename.ifc>" << std::endl;
-		return 1;
-	}
+    if (argc != 2) {
+        std::cout << "usage: IfcParseExamples <filename.ifc>" << std::endl;
+        return 1;
+    }
 
-	// Redirect the output (both progress and log) to stdout
-	Logger::SetOutput(&std::cout,&std::cout);
+    // Redirect the output (both progress and log) to stdout
+    Logger::SetOutput(&std::cout, &std::cout);
 
-	// Parse the IFC file provided in argv[1]
-	IfcParse::IfcFile file(argv[1]);
-	if (!file.good()) {
-		std::cout << "Unable to parse .ifc file" << std::endl;
-		return 1;
-	}
+    // Parse the IFC file provided in argv[1]
+    IfcParse::IfcFile file(argv[1]);
+    if (!file.good()) {
+        std::cout << "Unable to parse .ifc file" << std::endl;
+        return 1;
+    }
 
-	// Lets get a list of IfcBuildingElements, this is the parent
-	// type of things like walls, windows and doors.
-	// entitiesByType is a templated function and returns a
-	// templated class that behaves like a std::vector.
-	// Note that the return types are all typedef'ed as members of
-	// the generated classes, ::list for the templated vector class,
-	// ::ptr for a shared pointer and ::it for an iterator.
-	// We will simply iterate over the vector and print a string
-	// representation of the entity to stdout.
-	//
-	// Secondly, lets find out which of them are IfcWindows. 
-	// In order to access the additional properties that windows 
-	// have on top af the properties of building elements, 
-	// we need to cast them to IfcWindows. Since these properties 
-	// are optional we need to make sure the properties are 
-	// defined for the window in question before accessing them.
-	IfcSchema::IfcBuildingElement::list::ptr elements = file.instances_by_type<IfcSchema::IfcBuildingElement>();
+    // Lets get a list of IfcBuildingElements, this is the parent
+    // type of things like walls, windows and doors.
+    // entitiesByType is a templated function and returns a
+    // templated class that behaves like a std::vector.
+    // Note that the return types are all typedef'ed as members of
+    // the generated classes, ::list for the templated vector class,
+    // ::ptr for a shared pointer and ::it for an iterator.
+    // We will simply iterate over the vector and print a string
+    // representation of the entity to stdout.
+    //
+    // Secondly, lets find out which of them are IfcWindows.
+    // In order to access the additional properties that windows
+    // have on top af the properties of building elements,
+    // we need to cast them to IfcWindows. Since these properties
+    // are optional we need to make sure the properties are
+    // defined for the window in question before accessing them.
+    IfcSchema::IfcBuildingElement::list::ptr elements = file.instances_by_type<IfcSchema::IfcBuildingElement>();
 
-	std::cout << "Found " << elements->size() << " elements in " << argv[1] << ":" << std::endl;
-	
-	for (IfcSchema::IfcBuildingElement::list::it it = elements->begin(); it != elements->end(); ++it) {
-		
-		const IfcSchema::IfcBuildingElement* element = *it;
-		std::cout << element->data().toString() << std::endl;
-		
-		const IfcSchema::IfcWindow* window;
-		if ((window = element->as<IfcSchema::IfcWindow>()) != 0) {
-			if (window->OverallWidth() && window->OverallHeight()) {
-				const double area = *window->OverallWidth() * *window->OverallHeight();
-				std::cout << "The area of this window is " << area << std::endl;
-			}
-		}
+    std::cout << "Found " << elements->size() << " elements in " << argv[1] << ":" << std::endl;
 
-	}
+    for (IfcSchema::IfcBuildingElement::list::it it = elements->begin(); it != elements->end(); ++it) {
 
+        const IfcSchema::IfcBuildingElement* element = *it;
+        std::cout << element->data().toString() << std::endl;
+
+        const IfcSchema::IfcWindow* window;
+        if ((window = element->as<IfcSchema::IfcWindow>()) != 0) {
+            if (window->OverallWidth() && window->OverallHeight()) {
+                const double area = *window->OverallWidth() * *window->OverallHeight();
+                std::cout << "The area of this window is " << area << std::endl;
+            }
+        }
+    }
 }

--- a/src/ifcgeom/GeometrySerializer.h
+++ b/src/ifcgeom/GeometrySerializer.h
@@ -22,6 +22,7 @@
 
 #include "../ifcgeom/Serializer.h"
 #include "../ifcgeom/IfcGeomElement.h"
+#include <fstream>
 
 namespace ifcopenshell {
 namespace geometry {

--- a/src/ifcgeom/mapping/mapping.h
+++ b/src/ifcgeom/mapping/mapping.h
@@ -4,6 +4,7 @@
 #include "../abstract_mapping.h"
 #include "../../ifcparse/macros.h"
 #include "../../ifcparse/IfcFile.h"
+#include "../../ifcparse/IfcLogger.h"
 
 #define INCLUDE_SCHEMA(x) STRINGIFY(../../ifcparse/x.h)
 #include INCLUDE_SCHEMA(IfcSchema)

--- a/src/ifcparse/Argument.h
+++ b/src/ifcparse/Argument.h
@@ -23,12 +23,9 @@
 #include "ArgumentType.h"
 #include "ifc_parse_api.h"
 
-#include <algorithm>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/logic/tribool.hpp>
 #include <boost/shared_ptr.hpp>
-#include <set>
-#include <sstream>
 #include <string>
 #include <vector>
 

--- a/src/ifcparse/Argument.h
+++ b/src/ifcparse/Argument.h
@@ -38,7 +38,7 @@ class IfcBaseClass;
 IFC_PARSE_API const char* ArgumentTypeToString(ArgumentType argument_type);
 
 /// Returns false when the string `s` contains character outside of {'0', '1'}
-IFC_PARSE_API bool valid_binary_string(const std::string& s);
+IFC_PARSE_API bool valid_binary_string(const std::string& string);
 } // namespace IfcUtil
 
 class IFC_PARSE_API Argument {
@@ -65,7 +65,7 @@ class IFC_PARSE_API Argument {
     virtual unsigned int size() const = 0;
 
     virtual IfcUtil::ArgumentType type() const = 0;
-    virtual Argument* operator[](unsigned int i) const = 0;
+    virtual Argument* operator[](unsigned int index) const = 0;
     virtual std::string toString(bool upper = false) const = 0;
 
     virtual ~Argument(){};

--- a/src/ifcparse/IfcBaseClass.h
+++ b/src/ifcparse/IfcBaseClass.h
@@ -37,7 +37,7 @@ namespace IfcUtil {
 class IFC_PARSE_API IfcBaseInterface {
   protected:
     static bool is_null(const IfcBaseInterface* not_this) {
-        return !not_this;
+        return not_this == nullptr;
     }
 
     template <typename T>
@@ -90,7 +90,7 @@ class IFC_PARSE_API IfcBaseClass : public virtual IfcBaseInterface {
     IfcEntityInstanceData* data_;
 
     static bool is_null(const IfcBaseClass* not_this) {
-        return !not_this;
+        return not_this == nullptr;
     }
 
   public:

--- a/src/ifcparse/IfcBaseClass.h
+++ b/src/ifcparse/IfcBaseClass.h
@@ -61,11 +61,11 @@ class IFC_PARSE_API IfcBaseInterface {
         if (is_null(this)) {
             return static_cast<T*>(0);
         }
-        auto t = dynamic_cast<T*>(this);
-        if (do_throw && !t) {
+        auto type = dynamic_cast<T*>(this);
+        if (do_throw && !type) {
             raise_error_on_concrete_class<T>();
         }
-        return t;
+        return type;
     }
 
     template <class T>
@@ -73,11 +73,11 @@ class IFC_PARSE_API IfcBaseInterface {
         if (is_null(this)) {
             return static_cast<const T*>(0);
         }
-        auto t = dynamic_cast<const T*>(this);
-        if (do_throw && !t) {
+        auto type = dynamic_cast<const T*>(this);
+        if (do_throw && !type) {
             raise_error_on_concrete_class<T>();
         }
-        return t;
+        return type;
     }
 };
 
@@ -96,13 +96,13 @@ class IFC_PARSE_API IfcBaseClass : public virtual IfcBaseInterface {
   public:
     IfcBaseClass() : identity_(counter_++),
                      data_(0) {}
-    IfcBaseClass(IfcEntityInstanceData* d) : identity_(counter_++),
-                                             data_(d) {}
+    IfcBaseClass(IfcEntityInstanceData* data) : identity_(counter_++),
+                                                data_(data) {}
     virtual ~IfcBaseClass() { delete data_; }
 
     const IfcEntityInstanceData& data() const { return *data_; }
     IfcEntityInstanceData& data() { return *data_; }
-    void data(IfcEntityInstanceData* d);
+    void data(IfcEntityInstanceData* data);
 
     virtual const IfcParse::declaration& declaration() const = 0;
 
@@ -125,7 +125,7 @@ class IFC_PARSE_API IfcLateBoundEntity : public IfcBaseClass {
 class IFC_PARSE_API IfcBaseEntity : public IfcBaseClass {
   public:
     IfcBaseEntity() : IfcBaseClass() {}
-    IfcBaseEntity(IfcEntityInstanceData* d) : IfcBaseClass(d) {}
+    IfcBaseEntity(IfcEntityInstanceData* data) : IfcBaseClass(data) {}
 
     virtual const IfcParse::entity& declaration() const = 0;
 
@@ -137,14 +137,14 @@ class IFC_PARSE_API IfcBaseEntity : public IfcBaseClass {
     template <typename T>
     T get_value(const std::string& name, const T& default_value) const;
 
-    boost::shared_ptr<aggregate_of_instance> get_inverse(const std::string& a) const;
+    boost::shared_ptr<aggregate_of_instance> get_inverse(const std::string& name) const;
 };
 
 // TODO: Investigate whether these should be template classes instead
 class IFC_PARSE_API IfcBaseType : public IfcBaseClass {
   public:
     IfcBaseType() : IfcBaseClass() {}
-    IfcBaseType(IfcEntityInstanceData* d) : IfcBaseClass(d) {}
+    IfcBaseType(IfcEntityInstanceData* data) : IfcBaseClass(data) {}
 
     virtual const IfcParse::declaration& declaration() const = 0;
 };

--- a/src/ifcparse/IfcBaseClass.h
+++ b/src/ifcparse/IfcBaseClass.h
@@ -154,13 +154,13 @@ class IFC_PARSE_API IfcBaseType : public IfcBaseClass {
 namespace IfcUtil {
 template <typename T>
 T IfcBaseEntity::get_value(const std::string& name) const {
-    auto attr = get(name);
+    auto* attr = get(name);
     return (T)*attr;
 }
 
 template <typename T>
 T IfcBaseEntity::get_value(const std::string& name, const T& default_value) const {
-    auto attr = get(name);
+    auto* attr = get(name);
     if (attr->isNull()) {
         return default_value;
     }

--- a/src/ifcparse/IfcCharacterDecoder.cpp
+++ b/src/ifcparse/IfcCharacterDecoder.cpp
@@ -92,17 +92,15 @@ class pure_impure_helper {
     char peek() {
         if (pure_) {
             return stream_->peek_at(pointer_);
-        } else {
-            return stream_->Peek();
         }
+        return stream_->Peek();
     }
 
     unsigned int tell() {
         if (pure_) {
             return pointer_;
-        } else {
-            return stream_->Tell();
         }
+        return stream_->Tell();
     }
 
     void increment() {
@@ -206,27 +204,26 @@ class pure_impure_helper {
             if (builder_.empty()) {
                 static std::string empty;
                 return empty;
-            } else {
-                auto it = std::max_element(builder_.begin(), builder_.end());
-                if (*it <= 0x7e) {
-                    std::string r(builder_.begin(), builder_.end());
-                    return r;
-                } else {
-                    return IfcUtil::convert_utf8(builder_);
-                }
             }
-        } else if (mode == IfcParse::IfcCharacterDecoder::SUBSTITUTE) {
+            auto it = std::max_element(builder_.begin(), builder_.end());
+            if (*it <= 0x7e) {
+                std::string r(builder_.begin(), builder_.end());
+                return r;
+            }
+            return IfcUtil::convert_utf8(builder_);
+        }
+        if (mode == IfcParse::IfcCharacterDecoder::SUBSTITUTE) {
             std::string r;
             r.reserve(builder_.size());
             std::transform(builder_.begin(), builder_.end(), std::back_inserter(r), [&substitution_character](wchar_t c) {
                 if (c >= 0x20 && c <= 0x7e) {
                     return (char)c;
-                } else {
-                    return substitution_character;
                 }
+                return substitution_character;
             });
             return r;
-        } else if (mode == IfcParse::IfcCharacterDecoder::ESCAPE) {
+        }
+        if (mode == IfcParse::IfcCharacterDecoder::ESCAPE) {
             std::stringstream str;
             str << std::hex << std::setw(4) << std::setfill('0');
             std::for_each(builder_.begin(), builder_.end(), [&str](wchar_t c) {
@@ -237,9 +234,8 @@ class pure_impure_helper {
                 }
             });
             return str.str();
-        } else {
-            throw IfcParse::IfcException("Invalid conversion mode");
         }
+        throw IfcParse::IfcException("Invalid conversion mode");
     }
 };
 } // namespace

--- a/src/ifcparse/IfcCharacterDecoder.cpp
+++ b/src/ifcparse/IfcCharacterDecoder.cpp
@@ -135,16 +135,16 @@ class pure_impure_helper {
             if (EXPECTS_CHARACTER(parse_state)) {
                 builder_.push_back(IfcUtil::convert_codepage(codepage, current_char + 0x80));
                 parse_state = 0;
-            } else if (current_char == '\'' && !parse_state) {
+            } else if (current_char == '\'' && (parse_state == 0U)) {
                 parse_state = APOSTROPHE;
-            } else if (current_char == '\\' && !parse_state) {
+            } else if (current_char == '\\' && (parse_state == 0U)) {
                 parse_state = FIRST_SOLIDUS;
             } else if (current_char == '\\' && EXPECTS_SOLIDUS(parse_state)) {
-                if (parse_state & ALPHABET_DEFINITION ||
-                    parse_state & IGNORED_DIRECTIVE ||
-                    parse_state & ENDEXTENDED_0) {
+                if (((parse_state & ALPHABET_DEFINITION) != 0U) ||
+                    ((parse_state & IGNORED_DIRECTIVE) != 0U) ||
+                    ((parse_state & ENDEXTENDED_0) != 0U)) {
                     parse_state = hex = hex_count = 0;
-                } else if (parse_state & ENCOUNTERED_HEX) {
+                } else if ((parse_state & ENCOUNTERED_HEX) != 0U) {
                     parse_state += THIRD_SOLIDUS;
                     parse_state -= ENCOUNTERED_HEX;
                 } else {
@@ -173,8 +173,8 @@ class pure_impure_helper {
                 hex <<= 4;
                 parse_state += HEX((++hex_count));
                 hex += HEX_TO_INT(current_char);
-                if ((hex_count == 2 && !(parse_state & EXTENDED2)) ||
-                    (hex_count == 4 && !(parse_state & EXTENDED4)) ||
+                if ((hex_count == 2 && ((parse_state & EXTENDED2) == 0U)) ||
+                    (hex_count == 4 && ((parse_state & EXTENDED4) == 0U)) ||
                     (hex_count == 8)) {
                     builder_.push_back(hex);
                     if (hex_count == 2) {
@@ -185,9 +185,9 @@ class pure_impure_helper {
                     }
                     hex = hex_count = 0;
                 }
-            } else if (parse_state && !(
-                                          (current_char == '\\' && parse_state == FIRST_SOLIDUS) ||
-                                          (current_char == '\'' && parse_state == APOSTROPHE))) {
+            } else if ((parse_state != 0U) && !(
+                                                  (current_char == '\\' && parse_state == FIRST_SOLIDUS) ||
+                                                  (current_char == '\'' && parse_state == APOSTROPHE))) {
                 if (parse_state == APOSTROPHE && current_char != '\'') {
                     break;
                 }
@@ -255,16 +255,16 @@ void IfcCharacterDecoder::skip() {
     while ((current_char = file->Peek()) != 0) {
         if (EXPECTS_CHARACTER(parse_state)) {
             parse_state = 0;
-        } else if (current_char == '\'' && !parse_state) {
+        } else if (current_char == '\'' && (parse_state == 0U)) {
             parse_state = APOSTROPHE;
-        } else if (current_char == '\\' && !parse_state) {
+        } else if (current_char == '\\' && (parse_state == 0U)) {
             parse_state = FIRST_SOLIDUS;
         } else if (current_char == '\\' && EXPECTS_SOLIDUS(parse_state)) {
-            if (parse_state & ALPHABET_DEFINITION ||
-                parse_state & IGNORED_DIRECTIVE ||
-                parse_state & ENDEXTENDED_0) {
+            if (((parse_state & ALPHABET_DEFINITION) != 0U) ||
+                ((parse_state & IGNORED_DIRECTIVE) != 0U) ||
+                ((parse_state & ENDEXTENDED_0) != 0U)) {
                 parse_state = hex_count = 0;
-            } else if (parse_state & ENCOUNTERED_HEX) {
+            } else if ((parse_state & ENCOUNTERED_HEX) != 0U) {
                 parse_state += THIRD_SOLIDUS;
                 parse_state -= ENCOUNTERED_HEX;
             } else {
@@ -290,8 +290,8 @@ void IfcCharacterDecoder::skip() {
             parse_state += PAGE;
         } else if (IS_HEXADECIMAL(current_char) && EXPECTS_HEX(parse_state)) {
             parse_state += HEX((++hex_count));
-            if ((hex_count == 2 && !(parse_state & EXTENDED2)) ||
-                (hex_count == 4 && !(parse_state & EXTENDED4)) ||
+            if ((hex_count == 2 && ((parse_state & EXTENDED2) == 0U)) ||
+                (hex_count == 4 && ((parse_state & EXTENDED4) == 0U)) ||
                 (hex_count == 8)) {
                 if (hex_count == 2) {
                     parse_state = 0;
@@ -301,9 +301,9 @@ void IfcCharacterDecoder::skip() {
                 }
                 hex_count = 0;
             }
-        } else if (parse_state && !(
-                                      (current_char == '\\' && parse_state == FIRST_SOLIDUS) ||
-                                      (current_char == '\'' && parse_state == APOSTROPHE))) {
+        } else if ((parse_state != 0U) && !(
+                                              (current_char == '\\' && parse_state == FIRST_SOLIDUS) ||
+                                              (current_char == '\'' && parse_state == APOSTROPHE))) {
             if (parse_state == APOSTROPHE && current_char != '\'') {
                 break;
             }

--- a/src/ifcparse/IfcCharacterDecoder.h
+++ b/src/ifcparse/IfcCharacterDecoder.h
@@ -29,7 +29,6 @@
 
 #include "IfcSpfStream.h"
 
-#include <sstream>
 #include <string>
 
 namespace IfcUtil {

--- a/src/ifcparse/IfcCharacterDecoder.h
+++ b/src/ifcparse/IfcCharacterDecoder.h
@@ -32,10 +32,10 @@
 #include <string>
 
 namespace IfcUtil {
-std::wstring::value_type convert_codepage(int codepage, int c);
-std::string convert_utf8(const std::wstring& s);
-std::wstring convert_utf8(const std::string& s);
-std::u32string convert_utf8_to_utf32(const std::string& s);
+std::wstring::value_type convert_codepage(int codepage, int index);
+std::string convert_utf8(const std::wstring& string);
+std::wstring convert_utf8(const std::string& string);
+std::u32string convert_utf8_to_utf32(const std::string& string);
 } // namespace IfcUtil
 
 namespace IfcParse {
@@ -53,7 +53,7 @@ class IFC_PARSE_API IfcCharacterDecoder {
     };
     static ConversionMode mode;
     static char substitution_character;
-    IfcCharacterDecoder(IfcParse::IfcSpfStream* file);
+    IfcCharacterDecoder(IfcParse::IfcSpfStream* stream);
     ~IfcCharacterDecoder();
     // Only advances the underlying token stream read pointer
     // to the next token.

--- a/src/ifcparse/IfcCharacterDecoder.h
+++ b/src/ifcparse/IfcCharacterDecoder.h
@@ -42,7 +42,7 @@ namespace IfcParse {
 
 class IFC_PARSE_API IfcCharacterDecoder {
   private:
-    IfcParse::IfcSpfStream* file;
+    IfcParse::IfcSpfStream* stream_;
     int codepage_;
 
   public:
@@ -72,7 +72,7 @@ namespace IfcWrite {
 
 class IFC_PARSE_API IfcCharacterEncoder {
   private:
-    std::u32string str;
+    std::u32string str_;
 
   public:
     IfcCharacterEncoder(const std::string& input);

--- a/src/ifcparse/IfcEntityInstanceData.h
+++ b/src/ifcparse/IfcEntityInstanceData.h
@@ -24,7 +24,6 @@
 
 #include <boost/optional.hpp>
 #include <boost/shared_ptr.hpp>
-#include <vector>
 
 class Argument;
 class aggregate_of_instance;

--- a/src/ifcparse/IfcEntityInstanceData.h
+++ b/src/ifcparse/IfcEntityInstanceData.h
@@ -84,7 +84,7 @@ class IFC_PARSE_API IfcEntityInstanceData {
         if (type_ == 0) {
             return 0;
         }
-        if (type_->as_entity()) {
+        if (type_->as_entity() != nullptr) {
             return type_->as_entity()->attribute_count();
         }
         return 1;

--- a/src/ifcparse/IfcEntityInstanceData.h
+++ b/src/ifcparse/IfcEntityInstanceData.h
@@ -44,10 +44,10 @@ class IFC_PARSE_API IfcEntityInstanceData {
 
   public:
     IfcEntityInstanceData(const IfcParse::declaration* type,
-                          IfcParse::IfcFile* file_,
+                          IfcParse::IfcFile* file,
                           unsigned id = 0,
                           unsigned offset_in_file = 0)
-        : file(file_),
+        : file(file),
           id_(id),
           type_(type),
           attributes_(0),
@@ -69,16 +69,16 @@ class IFC_PARSE_API IfcEntityInstanceData {
 
     void load() const;
 
-    IfcEntityInstanceData(const IfcEntityInstanceData& e);
+    IfcEntityInstanceData(const IfcEntityInstanceData& data);
 
     virtual ~IfcEntityInstanceData();
 
     boost::shared_ptr<aggregate_of_instance> getInverse(const IfcParse::declaration* type, int attribute_index) const;
 
-    Argument* getArgument(size_t i) const;
+    Argument* getArgument(size_t index) const;
 
     // NB: This makes a copy of the argument if make_copy is set
-    void setArgument(size_t i, Argument* a, IfcUtil::ArgumentType attr_type = IfcUtil::Argument_UNKNOWN, bool make_copy = false);
+    void setArgument(size_t ibdex, Argument* argument, IfcUtil::ArgumentType attr_type = IfcUtil::Argument_UNKNOWN, bool make_copy = false);
 
     virtual size_t getArgumentCount() const {
         if (type_ == 0) {
@@ -104,7 +104,7 @@ class IFC_PARSE_API IfcEntityInstanceData {
     // NB: const ommitted for lazy loading
     Argument**& attributes() const { return attributes_; }
 
-    unsigned set_id(boost::optional<unsigned> i = boost::none);
+    unsigned set_id(boost::optional<unsigned> id = boost::none);
 };
 
 #endif

--- a/src/ifcparse/IfcEntityInstanceData.h
+++ b/src/ifcparse/IfcEntityInstanceData.h
@@ -86,9 +86,8 @@ class IFC_PARSE_API IfcEntityInstanceData {
         }
         if (type_->as_entity()) {
             return type_->as_entity()->attribute_count();
-        } else {
-            return 1;
         }
+        return 1;
     }
 
     void clearArguments();

--- a/src/ifcparse/IfcException.h
+++ b/src/ifcparse/IfcException.h
@@ -39,8 +39,8 @@ class IFC_PARSE_API IfcException : public std::exception {
     std::string message_;
 
   public:
-    IfcException(const std::string& m)
-        : message_(m) {}
+    IfcException(const std::string& message)
+        : message_(message) {}
     virtual ~IfcException() throw() {}
     virtual const char* what() const throw() {
         return message_.c_str();
@@ -49,8 +49,8 @@ class IFC_PARSE_API IfcException : public std::exception {
 
 class IFC_PARSE_API IfcAttributeOutOfRangeException : public IfcException {
   public:
-    IfcAttributeOutOfRangeException(const std::string& e)
-        : IfcException(e) {}
+    IfcAttributeOutOfRangeException(const std::string& exception)
+        : IfcException(exception) {}
     ~IfcAttributeOutOfRangeException() throw() {}
 };
 
@@ -66,9 +66,9 @@ class IFC_PARSE_API IfcInvalidTokenException : public IfcException {
               " invalid " + expected_type) {}
     IfcInvalidTokenException(
         int token_start,
-        char c)
+        char character)
         : IfcException(
-              std::string("Unexpected '") + std::string(1, c) + "' at offset " +
+              std::string("Unexpected '") + std::string(1, character) + "' at offset " +
               boost::lexical_cast<std::string>(token_start)) {}
     ~IfcInvalidTokenException() throw() {}
 };

--- a/src/ifcparse/IfcException.h
+++ b/src/ifcparse/IfcException.h
@@ -36,14 +36,14 @@
 namespace IfcParse {
 class IFC_PARSE_API IfcException : public std::exception {
   private:
-    std::string message;
+    std::string message_;
 
   public:
     IfcException(const std::string& m)
-        : message(m) {}
+        : message_(m) {}
     virtual ~IfcException() throw() {}
     virtual const char* what() const throw() {
-        return message.c_str();
+        return message_.c_str();
     }
 };
 

--- a/src/ifcparse/IfcFile.h
+++ b/src/ifcparse/IfcFile.h
@@ -206,9 +206,8 @@ class IFC_PARSE_API IfcFile {
         aggregate_of_instance::ptr untyped_list = instances_by_type(&T::Class());
         if (untyped_list) {
             return untyped_list->as<T>();
-        } else {
-            return typename T::list::ptr(new typename T::list);
         }
+        return typename T::list::ptr(new typename T::list);
     }
 
     template <class T>
@@ -216,9 +215,8 @@ class IFC_PARSE_API IfcFile {
         aggregate_of_instance::ptr untyped_list = instances_by_type_excl_subtypes(&T::Class());
         if (untyped_list) {
             return untyped_list->as<T>();
-        } else {
-            return typename T::list::ptr(new typename T::list);
         }
+        return typename T::list::ptr(new typename T::list);
     }
 
     /// Returns all entities in the file that match the positional argument.

--- a/src/ifcparse/IfcFile.h
+++ b/src/ifcparse/IfcFile.h
@@ -32,7 +32,6 @@
 #include <boost/unordered_map.hpp>
 #include <iterator>
 #include <map>
-#include <set>
 
 namespace IfcParse {
 

--- a/src/ifcparse/IfcFile.h
+++ b/src/ifcparse/IfcFile.h
@@ -87,8 +87,8 @@ class IFC_PARSE_API IfcFile {
       public:
         type_iterator() : entities_by_type_t::const_iterator(){};
 
-        type_iterator(const entities_by_type_t::const_iterator& it)
-            : entities_by_type_t::const_iterator(it){};
+        type_iterator(const entities_by_type_t::const_iterator& iter)
+            : entities_by_type_t::const_iterator(iter){};
 
         entities_by_type_t::key_type const* operator->() const {
             return &entities_by_type_t::const_iterator::operator->()->first;
@@ -151,7 +151,7 @@ class IFC_PARSE_API IfcFile {
 
     void setDefaultHeaderValues();
 
-    void initialize_(IfcParse::IfcSpfStream* f);
+    void initialize_(IfcParse::IfcSpfStream* stream);
 
     void build_inverses_(IfcUtil::IfcBaseClass*);
 
@@ -171,13 +171,13 @@ class IFC_PARSE_API IfcFile {
     IfcParse::IfcSpfStream* stream;
 
 #ifdef USE_MMAP
-    IfcFile(const std::string& fn, bool mmap = false);
+    IfcFile(const std::string& path, bool mmap = false);
 #else
-    IfcFile(const std::string& fn);
+    IfcFile(const std::string& path);
 #endif
-    IfcFile(std::istream& fn, int len);
-    IfcFile(void* data, int len);
-    IfcFile(IfcParse::IfcSpfStream* f);
+    IfcFile(std::istream& stream, int length);
+    IfcFile(void* data, int length);
+    IfcFile(IfcParse::IfcSpfStream* stream);
     IfcFile(const IfcParse::schema_definition* schema = IfcParse::schema_by_name("IFC4"));
 
     /// Deleting the file will also delete all new instances that were added to the file (via memory allocation)
@@ -230,10 +230,10 @@ class IFC_PARSE_API IfcFile {
     /// Returns all entities in the file that match the positional argument.
     /// NOTE: This also returns subtypes of the requested type, for example:
     /// IfcWall will also return IfcWallStandardCase entities
-    aggregate_of_instance::ptr instances_by_type(const std::string& t);
+    aggregate_of_instance::ptr instances_by_type(const std::string& type);
 
     /// Returns all entities in the file that match the positional argument.
-    aggregate_of_instance::ptr instances_by_type_excl_subtypes(const std::string& t);
+    aggregate_of_instance::ptr instances_by_type_excl_subtypes(const std::string& type);
 
     /// Returns all entities in the file that reference the id
     aggregate_of_instance::ptr instances_by_reference(int id);
@@ -275,7 +275,7 @@ class IFC_PARSE_API IfcFile {
     void recalculate_id_counter();
 
     IfcUtil::IfcBaseClass* addEntity(IfcUtil::IfcBaseClass* entity, int id = -1);
-    void addEntities(aggregate_of_instance::ptr es);
+    void addEntities(aggregate_of_instance::ptr entities);
 
     void batch() { batch_mode_ = true; }
     void unbatch() {

--- a/src/ifcparse/IfcFile.h
+++ b/src/ifcparse/IfcFile.h
@@ -135,15 +135,15 @@ class IFC_PARSE_API IfcFile {
 
     std::vector<Argument*> internal_attribute_vector_, internal_attribute_vector_simple_type_;
 
-    entity_by_id_t byid;
+    entity_by_id_t byid_;
     // this is for simple types
-    entity_by_iden_t byidentity;
-    entities_by_type_t bytype;
-    entities_by_type_t bytype_excl;
-    entities_by_ref_t byref;
-    entities_by_ref_excl_t byref_excl;
-    entity_by_guid_t byguid;
-    entity_entity_map_t entity_file_map;
+    entity_by_iden_t byidentity_;
+    entities_by_type_t bytype_;
+    entities_by_type_t bytype_excl_;
+    entities_by_ref_t byref_;
+    entities_by_ref_excl_t byref_excl_;
+    entity_by_guid_t byguid_;
+    entity_entity_map_t entity_file_map_;
 
     unsigned int MaxId;
 
@@ -316,7 +316,7 @@ class IFC_PARSE_API IfcFile {
 
     void build_inverses();
 
-    entity_by_guid_t& internal_guid_map() { return byguid; };
+    entity_by_guid_t& internal_guid_map() { return byguid_; };
 };
 
 #ifdef WITH_IFCXML

--- a/src/ifcparse/IfcGlobalId.cpp
+++ b/src/ifcparse/IfcGlobalId.cpp
@@ -35,7 +35,7 @@ static const char* chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnop
 std::string base64(unsigned v, int l) {
     std::string r;
     r.reserve(l);
-    while (v) {
+    while (v != 0U) {
         r.push_back(chars[v % 64]);
         v /= 64;
     }
@@ -54,7 +54,7 @@ unsigned from_base64(const std::string& s) {
         for (std::string::const_iterator i = s.begin() + zeros; i != s.end(); ++i) {
             r *= 64;
             const char* c = strchr(chars, *i);
-            if (!c) {
+            if (c == nullptr) {
                 throw IfcParse::IfcException("Failed to decode GlobalId");
             }
             r += (unsigned)(c - chars);

--- a/src/ifcparse/IfcGlobalId.cpp
+++ b/src/ifcparse/IfcGlobalId.cpp
@@ -32,46 +32,47 @@
 static const char* chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$";
 
 // Converts an unsigned integer into a base64 string of length l
-std::string base64(unsigned v, int l) {
-    std::string r;
-    r.reserve(l);
-    while (v != 0U) {
-        r.push_back(chars[v % 64]);
-        v /= 64;
+std::string base64(unsigned value, int length) {
+    const int BASE64 = 64;
+    std::string result;
+    result.reserve(length);
+    while (value != 0U) {
+        result.push_back(chars[value % BASE64]);
+        value /= BASE64;
     }
-    while ((int)r.size() != l) {
-        r.push_back('0');
+    while ((int)result.size() != length) {
+        result.push_back('0');
     }
-    std::reverse(r.begin(), r.end());
-    return r;
+    std::reverse(result.begin(), result.end());
+    return result;
 }
 
 // Converts a base64 string into an unsigned integer
-unsigned from_base64(const std::string& s) {
-    std::string::size_type zeros = s.find_first_not_of('0');
-    unsigned r = 0;
+unsigned from_base64(const std::string& string) {
+    std::string::size_type zeros = string.find_first_not_of('0');
+    unsigned result = 0;
     if (zeros != std::string::npos) {
-        for (std::string::const_iterator i = s.begin() + zeros; i != s.end(); ++i) {
-            r *= 64;
-            const char* c = strchr(chars, *i);
-            if (c == nullptr) {
+        for (std::string::const_iterator i = string.begin() + zeros; i != string.end(); ++i) {
+            result *= 64;
+            const char* character = strchr(chars, *i);
+            if (character == nullptr) {
                 throw IfcParse::IfcException("Failed to decode GlobalId");
             }
-            r += (unsigned)(c - chars);
+            result += (unsigned)(character - chars);
         }
     }
-    return r;
+    return result;
 }
 
 // Compresses the UUID byte array into a base64 representation
-std::string compress(unsigned char* v) {
-    std::string r;
-    r.reserve(22);
-    r += base64(v[0], 2);
+std::string compress(unsigned char* value) {
+    std::string result;
+    result.reserve(22);
+    result += base64(value[0], 2);
     for (unsigned i = 1; i < 16; i += 3) {
-        r += base64((v[i] << 16) + (v[i + 1] << 8) + v[i + 2], 4);
+        result += base64((value[i] << 16) + (value[i + 1] << 8) + value[i + 2], 4);
     }
-    return r;
+    return result;
 }
 
 // Expands the base64 representation into a UUID byte array
@@ -110,20 +111,20 @@ IfcParse::IfcGlobalId::IfcGlobalId() {
 #endif
 }
 
-IfcParse::IfcGlobalId::IfcGlobalId(const std::string& s)
-    : string_data_(s) {
-    std::vector<unsigned char> v;
-    expand(string_data_, v);
-    std::copy(v.begin(), v.end(), uuid_data_.begin());
+IfcParse::IfcGlobalId::IfcGlobalId(const std::string& string)
+    : string_data_(string) {
+    std::vector<unsigned char> result;
+    expand(string_data_, result);
+    std::copy(result.begin(), result.end(), uuid_data_.begin());
 #if BOOST_VERSION < 104400
-    formatted_string = boost::lexical_cast<std::string>(uuid_data);
+    formatted_string_ = boost::lexical_cast<std::string>(uuid_data_);
 #else
     formatted_string_ = boost::uuids::to_string(uuid_data_);
 #endif
 
 #ifndef NDEBUG
-    const std::string test_string = compress(&uuid_data.data[0]);
-    if (string_data != test_string) {
+    const std::string test_string = compress(&uuid_data_.data[0]);
+    if (string_data_ != test_string) {
         Logger::Message(Logger::LOG_ERROR, "Internal error generating GlobalId");
     }
 #endif

--- a/src/ifcparse/IfcGlobalId.cpp
+++ b/src/ifcparse/IfcGlobalId.cpp
@@ -89,14 +89,14 @@ void expand(const std::string& s, std::vector<unsigned char>& v) {
 static boost::uuids::basic_random_generator<boost::mt19937> gen;
 
 IfcParse::IfcGlobalId::IfcGlobalId() {
-    uuid_data = gen();
-    std::vector<unsigned char> v(uuid_data.size());
-    std::copy(uuid_data.begin(), uuid_data.end(), v.begin());
-    string_data = compress(&v[0]);
+    uuid_data_ = gen();
+    std::vector<unsigned char> v(uuid_data_.size());
+    std::copy(uuid_data_.begin(), uuid_data_.end(), v.begin());
+    string_data_ = compress(&v[0]);
 #if BOOST_VERSION < 104400
     formatted_string = boost::lexical_cast<std::string>(uuid_data);
 #else
-    formatted_string = boost::uuids::to_string(uuid_data);
+    formatted_string_ = boost::uuids::to_string(uuid_data_);
 #endif
 
 #ifndef NDEBUG
@@ -111,14 +111,14 @@ IfcParse::IfcGlobalId::IfcGlobalId() {
 }
 
 IfcParse::IfcGlobalId::IfcGlobalId(const std::string& s)
-    : string_data(s) {
+    : string_data_(s) {
     std::vector<unsigned char> v;
-    expand(string_data, v);
-    std::copy(v.begin(), v.end(), uuid_data.begin());
+    expand(string_data_, v);
+    std::copy(v.begin(), v.end(), uuid_data_.begin());
 #if BOOST_VERSION < 104400
     formatted_string = boost::lexical_cast<std::string>(uuid_data);
 #else
-    formatted_string = boost::uuids::to_string(uuid_data);
+    formatted_string_ = boost::uuids::to_string(uuid_data_);
 #endif
 
 #ifndef NDEBUG
@@ -130,13 +130,13 @@ IfcParse::IfcGlobalId::IfcGlobalId(const std::string& s)
 }
 
 IfcParse::IfcGlobalId::operator const std::string&() const {
-    return string_data;
+    return string_data_;
 }
 
 IfcParse::IfcGlobalId::operator const boost::uuids::uuid&() const {
-    return uuid_data;
+    return uuid_data_;
 }
 
 const std::string& IfcParse::IfcGlobalId::formatted() const {
-    return formatted_string;
+    return formatted_string_;
 }

--- a/src/ifcparse/IfcGlobalId.cpp
+++ b/src/ifcparse/IfcGlobalId.cpp
@@ -20,6 +20,7 @@
 #include "IfcGlobalId.h"
 
 #include "IfcException.h"
+#include "IfcLogger.h"
 
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
@@ -102,10 +103,10 @@ IfcParse::IfcGlobalId::IfcGlobalId() {
 
 #ifndef NDEBUG
     std::vector<unsigned char> test_vector;
-    expand(string_data, test_vector);
+    expand(string_data_, test_vector);
     boost::uuids::uuid test_uuid;
     std::copy(test_vector.begin(), test_vector.end(), test_uuid.begin());
-    if (uuid_data != test_uuid) {
+    if (uuid_data_ != test_uuid) {
         Logger::Message(Logger::LOG_ERROR, "Internal error generating GlobalId");
     }
 #endif

--- a/src/ifcparse/IfcGlobalId.cpp
+++ b/src/ifcparse/IfcGlobalId.cpp
@@ -19,9 +19,7 @@
 
 #include "IfcGlobalId.h"
 
-#include "IfcBaseClass.h"
 #include "IfcException.h"
-#include "IfcLogger.h"
 
 #include <algorithm>
 #include <boost/lexical_cast.hpp>

--- a/src/ifcparse/IfcGlobalId.h
+++ b/src/ifcparse/IfcGlobalId.h
@@ -30,8 +30,9 @@ namespace IfcParse {
 /// A helper class for the creation of IFC GlobalIds.
 class IFC_PARSE_API IfcGlobalId {
   private:
-    std::string string_data, formatted_string;
-    boost::uuids::uuid uuid_data;
+    std::string string_data_;
+    std::string formatted_string_;
+    boost::uuids::uuid uuid_data_;
 
   public:
     static const unsigned int length = 22;

--- a/src/ifcparse/IfcHierarchyHelper.cpp
+++ b/src/ifcparse/IfcHierarchyHelper.cpp
@@ -63,11 +63,11 @@ typename Schema::IfcLocalPlacement* IfcHierarchyHelper<Schema>::addLocalPlacemen
                                                                                   double xx,
                                                                                   double xy,
                                                                                   double xz) {
-    typename Schema::IfcLocalPlacement* lp = new typename Schema::IfcLocalPlacement(parent,
-                                                                                    addPlacement3d(ox, oy, oz, zx, zy, zz, xx, xy, xz));
+    typename Schema::IfcLocalPlacement* local_placement = new typename Schema::IfcLocalPlacement(parent,
+                                                                                                 addPlacement3d(ox, oy, oz, zx, zy, zz, xx, xy, xz));
 
-    addEntity(lp);
-    return lp;
+    addEntity(local_placement);
+    return local_placement;
 }
 
 template <typename Schema>
@@ -995,9 +995,9 @@ void push_back_to_maybe_optional(boost::optional<boost::shared_ptr<T>>& t, U* u)
 
 template <typename Schema>
 typename Schema::IfcGeometricRepresentationContext* IfcHierarchyHelper<Schema>::getRepresentationContext(const std::string& s) {
-    typename std::map<std::string, typename Schema::IfcGeometricRepresentationContext*>::const_iterator it = contexts_.find(s);
-    if (it != contexts_.end()) {
-        return it->second;
+    typename std::map<std::string, typename Schema::IfcGeometricRepresentationContext*>::const_iterator iter = contexts_.find(s);
+    if (iter != contexts_.end()) {
+        return iter->second;
     }
     typename Schema::IfcProject* project = getSingle<typename Schema::IfcProject>();
     if (!project) {

--- a/src/ifcparse/IfcHierarchyHelper.cpp
+++ b/src/ifcparse/IfcHierarchyHelper.cpp
@@ -995,8 +995,8 @@ void push_back_to_maybe_optional(boost::optional<boost::shared_ptr<T>>& t, U* u)
 
 template <typename Schema>
 typename Schema::IfcGeometricRepresentationContext* IfcHierarchyHelper<Schema>::getRepresentationContext(const std::string& s) {
-    typename std::map<std::string, typename Schema::IfcGeometricRepresentationContext*>::const_iterator it = contexts.find(s);
-    if (it != contexts.end()) {
+    typename std::map<std::string, typename Schema::IfcGeometricRepresentationContext*>::const_iterator it = contexts_.find(s);
+    if (it != contexts_.end()) {
         return it->second;
     }
     typename Schema::IfcProject* project = getSingle<typename Schema::IfcProject>();
@@ -1010,7 +1010,7 @@ typename Schema::IfcGeometricRepresentationContext* IfcHierarchyHelper<Schema>::
     push_back_to_maybe_optional(project_contexts, context);
 
     project->setRepresentationContexts(project_contexts);
-    return contexts[s] = context;
+    return contexts_[s] = context;
 }
 
 #ifdef HAS_SCHEMA_2x3

--- a/src/ifcparse/IfcHierarchyHelper.cpp
+++ b/src/ifcparse/IfcHierarchyHelper.cpp
@@ -998,20 +998,19 @@ typename Schema::IfcGeometricRepresentationContext* IfcHierarchyHelper<Schema>::
     typename std::map<std::string, typename Schema::IfcGeometricRepresentationContext*>::const_iterator it = contexts.find(s);
     if (it != contexts.end()) {
         return it->second;
-    } else {
-        typename Schema::IfcProject* project = getSingle<typename Schema::IfcProject>();
-        if (!project) {
-            project = addProject();
-        }
-        auto project_contexts = project->RepresentationContexts();
-        typename Schema::IfcGeometricRepresentationContext* context = new typename Schema::IfcGeometricRepresentationContext(
-            boost::none, s, 3, 1e-5, addPlacement3d(), addDoublet<typename Schema::IfcDirection>(0, 1));
-        addEntity(context);
-        push_back_to_maybe_optional(project_contexts, context);
-
-        project->setRepresentationContexts(project_contexts);
-        return contexts[s] = context;
     }
+    typename Schema::IfcProject* project = getSingle<typename Schema::IfcProject>();
+    if (!project) {
+        project = addProject();
+    }
+    auto project_contexts = project->RepresentationContexts();
+    typename Schema::IfcGeometricRepresentationContext* context = new typename Schema::IfcGeometricRepresentationContext(
+        boost::none, s, 3, 1e-5, addPlacement3d(), addDoublet<typename Schema::IfcDirection>(0, 1));
+    addEntity(context);
+    push_back_to_maybe_optional(project_contexts, context);
+
+    project->setRepresentationContexts(project_contexts);
+    return contexts[s] = context;
 }
 
 #ifdef HAS_SCHEMA_2x3

--- a/src/ifcparse/IfcHierarchyHelper.h
+++ b/src/ifcparse/IfcHierarchyHelper.h
@@ -29,6 +29,7 @@
 #define IFCHIERARCHYHELPER_H
 
 #include "ifc_parse_api.h"
+#include "IfcLogger.h"
 
 #include <map>
 

--- a/src/ifcparse/IfcHierarchyHelper.h
+++ b/src/ifcparse/IfcHierarchyHelper.h
@@ -517,7 +517,7 @@ class IFC_PARSE_API IfcHierarchyHelper : public IfcParse::IfcFile {
     typename Schema::IfcGeometricRepresentationContext* getRepresentationContext(const std::string&);
 
   private:
-    std::map<std::string, typename Schema::IfcGeometricRepresentationContext*> contexts;
+    std::map<std::string, typename Schema::IfcGeometricRepresentationContext*> contexts_;
 };
 
 #ifdef HAS_SCHEMA_2x3

--- a/src/ifcparse/IfcHierarchyHelper.h
+++ b/src/ifcparse/IfcHierarchyHelper.h
@@ -451,7 +451,8 @@ class IFC_PARSE_API IfcHierarchyHelper : public IfcParse::IfcFile {
                 attr->set(owner_hist);
                 data->setArgument(1, attr);
             }
-            int relating_index = 4, related_index = 5;
+            int relating_index = 4;
+            int related_index = 5;
             if (T::Class().name() == "IfcRelContainedInSpatialStructure") {
                 // IfcRelContainedInSpatialStructure has attributes reversed.
                 std::swap(relating_index, related_index);

--- a/src/ifcparse/IfcLogger.cpp
+++ b/src/ifcparse/IfcLogger.cpp
@@ -61,7 +61,7 @@ template <>
 const std::array<std::basic_string<wchar_t>, 5> severity_strings<wchar_t>::value = {L"Performance", L"Debug", L"Notice", L"Warning", L"Error"};
 
 template <typename T>
-void plain_text_message(T& out, const boost::optional<IfcUtil::IfcBaseClass*>& current_product, Logger::Severity type, const std::string& message, const IfcUtil::IfcBaseInterface* instance) {
+void plain_text_message(T& out, const boost::optional<const IfcUtil::IfcBaseClass*>& current_product, Logger::Severity type, const std::string& message, const IfcUtil::IfcBaseInterface* instance) {
     out << "[" << severity_strings<typename T::char_type>::value[type] << "] ";
     out << "[" << get_time(type <= Logger::LOG_PERF).c_str() << "] ";
     if (current_product) {
@@ -86,7 +86,7 @@ std::basic_string<T> string_as(const std::string& string) {
 }
 
 template <typename T>
-void json_message(T& out, const boost::optional<IfcUtil::IfcBaseClass*>& current_product, Logger::Severity type, const std::string& message, const IfcUtil::IfcBaseInterface* instance) {
+void json_message(T& out, const boost::optional<const IfcUtil::IfcBaseClass*>& current_product, Logger::Severity type, const std::string& message, const IfcUtil::IfcBaseInterface* instance) {
     boost::property_tree::basic_ptree<std::basic_string<typename T::char_type>, std::basic_string<typename T::char_type>> property_tree;
 
     // @todo this is crazy
@@ -245,7 +245,7 @@ std::stringstream Logger::log_stream_;
 Logger::Severity Logger::verbosity_ = Logger::LOG_NOTICE;
 Logger::Severity Logger::max_severity_ = Logger::LOG_NOTICE;
 Logger::Format Logger::format_ = Logger::FMT_PLAIN;
-boost::optional<IfcUtil::IfcBaseClass*> Logger::current_product_;
+boost::optional<const IfcUtil::IfcBaseClass*> Logger::current_product_;
 boost::optional<long long> Logger::first_timepoint_;
 std::map<std::string, double> Logger::performance_statistics_;
 std::map<std::string, double> Logger::performance_signal_start_;

--- a/src/ifcparse/IfcLogger.cpp
+++ b/src/ifcparse/IfcLogger.cpp
@@ -20,7 +20,6 @@
 #include "IfcLogger.h"
 
 #include "Argument.h"
-#include "IfcException.h"
 
 #include <algorithm>
 #include <boost/algorithm/string/replace.hpp>

--- a/src/ifcparse/IfcLogger.cpp
+++ b/src/ifcparse/IfcLogger.cpp
@@ -126,7 +126,7 @@ void Logger::SetOutput(std::ostream* l1, std::ostream* l2) {
     wlog1 = wlog2 = 0;
     log1 = l1;
     log2 = l2;
-    if (!log2) {
+    if (log2 == nullptr) {
         log2 = &log_stream;
     }
 }
@@ -135,7 +135,7 @@ void Logger::SetOutput(std::wostream* l1, std::wostream* l2) {
     log1 = log2 = 0;
     wlog1 = l1;
     wlog2 = l2;
-    if (!wlog2) {
+    if (wlog2 == nullptr) {
         log2 = &log_stream;
     }
 }
@@ -160,17 +160,17 @@ void Logger::Message(Logger::Severity type, const std::string& message, const If
     if (type > max_severity) {
         max_severity = type;
     }
-    if ((log2 || wlog2) && type >= verbosity) {
+    if (((log2 != nullptr) || (wlog2 != nullptr)) && type >= verbosity) {
         if (format == FMT_PLAIN) {
-            if (log2) {
+            if (log2 != nullptr) {
                 plain_text_message(*log2, current_product, type, message, instance);
-            } else if (wlog2) {
+            } else if (wlog2 != nullptr) {
                 plain_text_message(*wlog2, current_product, type, message, instance);
             }
         } else if (format == FMT_JSON) {
-            if (log2) {
+            if (log2 != nullptr) {
                 json_message(*log2, current_product, type, message, instance);
-            } else if (wlog2) {
+            } else if (wlog2 != nullptr) {
                 json_message(*wlog2, current_product, type, message, instance);
             }
         }
@@ -192,9 +192,9 @@ void status(T& log1, const std::string& message, bool new_line) {
 }
 
 void Logger::Status(const std::string& message, bool new_line) {
-    if (log1) {
+    if (log1 != nullptr) {
         status(*log1, message, new_line);
-    } else if (wlog1) {
+    } else if (wlog1 != nullptr) {
         status(*wlog1, message, new_line);
     }
 }

--- a/src/ifcparse/IfcLogger.h
+++ b/src/ifcparse/IfcLogger.h
@@ -57,7 +57,7 @@ class IFC_PARSE_API Logger {
 
     static Severity verbosity_;
     static Format format_;
-    static boost::optional<IfcUtil::IfcBaseClass*> current_product_;
+    static boost::optional<const IfcUtil::IfcBaseClass*> current_product_;
     static Severity max_severity_;
 
     static boost::optional<long long> first_timepoint_;

--- a/src/ifcparse/IfcLogger.h
+++ b/src/ifcparse/IfcLogger.h
@@ -70,23 +70,23 @@ class IFC_PARSE_API Logger {
     static void SetProduct(boost::optional<const IfcUtil::IfcBaseClass*> product);
 
     /// Determines to what stream respectively progress and errors are logged
-    static void SetOutput(std::wostream* l1, std::wostream* l2);
+    static void SetOutput(std::wostream* stream1, std::wostream* stream2);
 
     /// Determines to what stream respectively progress and errors are logged
-    static void SetOutput(std::ostream* l1, std::ostream* l2);
+    static void SetOutput(std::ostream* stream1, std::ostream* stream2);
 
     /// Determines the types of log messages to get logged
-    static void Verbosity(Severity v);
+    static void Verbosity(Severity severity);
     static Severity Verbosity();
     static Severity MaxSeverity();
 
     /// Determines output format: plain text or sequence of JSON objects
-    static void OutputFormat(Format f);
+    static void OutputFormat(Format format);
     static Format OutputFormat();
 
     /// Log a message to the output stream
     static void Message(Severity type, const std::string& message, const IfcUtil::IfcBaseInterface* instance = 0);
-    static void Message(Severity type, const std::exception& message, const IfcUtil::IfcBaseInterface* instance = 0);
+    static void Message(Severity type, const std::exception& exception, const IfcUtil::IfcBaseInterface* instance = 0);
 
     static void Notice(const std::string& message, const IfcUtil::IfcBaseInterface* instance = 0) { Message(LOG_NOTICE, message, instance); }
     static void Warning(const std::string& message, const IfcUtil::IfcBaseInterface* instance = 0) { Message(LOG_WARNING, message, instance); }

--- a/src/ifcparse/IfcLogger.h
+++ b/src/ifcparse/IfcLogger.h
@@ -47,24 +47,24 @@ class IFC_PARSE_API Logger {
   private:
     // To both stream variants need to exist at runtime or should this be a
     // template argument of Logger or controlled using preprocessor directives?
-    static std::ostream* log1;
-    static std::ostream* log2;
+    static std::ostream* log1_;
+    static std::ostream* log2_;
 
-    static std::wostream* wlog1;
-    static std::wostream* wlog2;
+    static std::wostream* wlog1_;
+    static std::wostream* wlog2_;
 
-    static std::stringstream log_stream;
+    static std::stringstream log_stream_;
 
-    static Severity verbosity;
-    static Format format;
-    static boost::optional<const IfcUtil::IfcBaseClass*> current_product;
-    static Severity max_severity;
+    static Severity verbosity_;
+    static Format format_;
+    static boost::optional<IfcUtil::IfcBaseClass*> current_product_;
+    static Severity max_severity_;
 
-    static boost::optional<long long> first_timepoint;
-    static std::map<std::string, double> performance_statistics;
-    static std::map<std::string, double> performance_signal_start;
+    static boost::optional<long long> first_timepoint_;
+    static std::map<std::string, double> performance_statistics_;
+    static std::map<std::string, double> performance_signal_start_;
 
-    static bool print_perf_stats_on_element;
+    static bool print_perf_stats_on_element_;
 
   public:
     static void SetProduct(boost::optional<const IfcUtil::IfcBaseClass*> product);
@@ -101,7 +101,7 @@ class IFC_PARSE_API Logger {
     static void ProgressBar(int progress);
     static std::string GetLog();
     static void PrintPerformanceStats();
-    static void PrintPerformanceStatsOnElement(bool b) { print_perf_stats_on_element = b; }
+    static void PrintPerformanceStatsOnElement(bool b) { print_perf_stats_on_element_ = b; }
 };
 
 #define PERF(x)                                                      \

--- a/src/ifcparse/IfcLogger.h
+++ b/src/ifcparse/IfcLogger.h
@@ -23,15 +23,12 @@
 #include "ifc_parse_api.h"
 #include "IfcBaseClass.h"
 
-#include <algorithm>
 #include <boost/optional.hpp>
 #include <boost/scope_exit.hpp>
 #include <exception>
 #include <map>
-#include <set>
 #include <sstream>
 #include <string>
-#include <vector>
 
 class IFC_PARSE_API Logger {
   public:

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -23,6 +23,7 @@
 #include "IfcCharacterDecoder.h"
 #include "IfcException.h"
 #include "IfcFile.h"
+#include "IfcLogger.h"
 #include "IfcSchema.h"
 #include "IfcSIPrefix.h"
 #include "IfcSpfStream.h"

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -355,9 +355,8 @@ Token IfcSpfLexer::Next() {
     }
     if (len) {
         return GeneralTokenPtr(this, pos, stream->Tell());
-    } else {
-        return NoneTokenPtr();
     }
+    return NoneTokenPtr();
 }
 
 bool IfcSpfStream::is_eof_at(unsigned int local_ptr) {
@@ -392,13 +391,13 @@ void IfcSpfLexer::TokenString(unsigned int offset, std::string& buffer) {
         stream->increment_at(offset);
         if (c == ' ' || c == '\r' || c == '\n' || c == '\t') {
             continue;
-        } else if (c == '\'') {
+        }
+        if (c == '\'') {
             // todo, make decoder use local offset ptr
             buffer = decoder->get(offset);
             break;
-        } else {
-            buffer.push_back(c);
         }
+        buffer.push_back(c);
     }
 }
 
@@ -574,14 +573,13 @@ boost::logic::tribool TokenFunc::asLogical(const Token& t) {
     if (t.type != Token_BOOL) {
         throw IfcInvalidTokenException(t.startPos, toString(t), "boolean");
     }
-
     if (t.value_int == 0) {
         return false;
-    } else if (t.value_int == 1) {
-        return true;
-    } else {
-        return boost::logic::indeterminate;
     }
+    if (t.value_int == 1) {
+        return true;
+    }
+    return boost::logic::indeterminate;
 }
 
 double TokenFunc::asFloat(const Token& t) {
@@ -589,13 +587,12 @@ double TokenFunc::asFloat(const Token& t) {
     if (t.type == Token_INT) {
         /// NB: We are being more permissive here then allowed by the standard
         return t.value_int;
-    } else // ----> continues beyond preprocessor directive
+    } // ----> continues beyond preprocessor directive
 #endif
-        if (t.type == Token_FLOAT) {
+    if (t.type == Token_FLOAT) {
         return t.value_double;
-    } else {
-        throw IfcInvalidTokenException(t.startPos, toString(t), "real");
     }
+    throw IfcInvalidTokenException(t.startPos, toString(t), "real");
 }
 
 const std::string& TokenFunc::asStringRef(const Token& t) {
@@ -615,9 +612,8 @@ const std::string& TokenFunc::asStringRef(const Token& t) {
 std::string TokenFunc::asString(const Token& t) {
     if (isString(t) || isEnumeration(t) || isBinary(t)) {
         return asStringRef(t);
-    } else {
-        throw IfcInvalidTokenException(t.startPos, toString(t), "string");
     }
+    throw IfcInvalidTokenException(t.startPos, toString(t), "string");
 }
 
 boost::dynamic_bitset<> TokenFunc::asBinary(const Token& t) {
@@ -703,9 +699,8 @@ class vector_or_array {
     size_t index() const {
         if (vector_) {
             return vector_->size();
-        } else {
-            return index_;
         }
+        return index_;
     }
 };
 } // namespace
@@ -935,27 +930,35 @@ ArgumentList::~ArgumentList() {
 IfcUtil::ArgumentType TokenArgument::type() const {
     if (TokenFunc::isInt(token)) {
         return IfcUtil::Argument_INT;
-    } else if (TokenFunc::isBool(token)) {
-        return IfcUtil::Argument_BOOL;
-    } else if (TokenFunc::isLogical(token)) {
-        return IfcUtil::Argument_LOGICAL;
-    } else if (TokenFunc::isFloat(token)) {
-        return IfcUtil::Argument_DOUBLE;
-    } else if (TokenFunc::isString(token)) {
-        return IfcUtil::Argument_STRING;
-    } else if (TokenFunc::isEnumeration(token)) {
-        return IfcUtil::Argument_ENUMERATION;
-    } else if (TokenFunc::isIdentifier(token)) {
-        return IfcUtil::Argument_ENTITY_INSTANCE;
-    } else if (TokenFunc::isBinary(token)) {
-        return IfcUtil::Argument_BINARY;
-    } else if (TokenFunc::isOperator(token, '$')) {
-        return IfcUtil::Argument_NULL;
-    } else if (TokenFunc::isOperator(token, '*')) {
-        return IfcUtil::Argument_DERIVED;
-    } else {
-        return IfcUtil::Argument_UNKNOWN;
     }
+    if (TokenFunc::isBool(token)) {
+        return IfcUtil::Argument_BOOL;
+    }
+    if (TokenFunc::isLogical(token)) {
+        return IfcUtil::Argument_LOGICAL;
+    }
+    if (TokenFunc::isFloat(token)) {
+        return IfcUtil::Argument_DOUBLE;
+    }
+    if (TokenFunc::isString(token)) {
+        return IfcUtil::Argument_STRING;
+    }
+    if (TokenFunc::isEnumeration(token)) {
+        return IfcUtil::Argument_ENUMERATION;
+    }
+    if (TokenFunc::isIdentifier(token)) {
+        return IfcUtil::Argument_ENTITY_INSTANCE;
+    }
+    if (TokenFunc::isBinary(token)) {
+        return IfcUtil::Argument_BINARY;
+    }
+    if (TokenFunc::isOperator(token, '$')) {
+        return IfcUtil::Argument_NULL;
+    }
+    if (TokenFunc::isOperator(token, '*')) {
+        return IfcUtil::Argument_DERIVED;
+    }
+    return IfcUtil::Argument_UNKNOWN;
 }
 
 //
@@ -973,9 +976,8 @@ Argument* TokenArgument::operator[](unsigned int /*i*/) const { throw IfcExcepti
 std::string TokenArgument::toString(bool upper) const {
     if (upper && TokenFunc::isString(token)) {
         return IfcWrite::IfcCharacterEncoder(TokenFunc::asString(token));
-    } else {
-        return TokenFunc::toString(token);
     }
+    return TokenFunc::toString(token);
 }
 bool TokenArgument::isNull() const { return TokenFunc::isOperator(token, '$'); }
 
@@ -1148,9 +1150,8 @@ IfcEntityInstanceData::~IfcEntityInstanceData() {
 unsigned IfcEntityInstanceData::set_id(boost::optional<unsigned> i) {
     if (i) {
         return id_ = *i;
-    } else {
-        return id_ = file->FreshId();
     }
+    return id_ = file->FreshId();
 }
 
 //
@@ -1215,9 +1216,8 @@ IfcUtil::ArgumentType get_argument_type(const IfcParse::declaration* decl, size_
 
     if (pt == 0) {
         return IfcUtil::Argument_UNKNOWN;
-    } else {
-        return IfcUtil::from_parameter_type(pt);
     }
+    return IfcUtil::from_parameter_type(pt);
 }
 } // namespace
 
@@ -1246,12 +1246,10 @@ Argument* IfcEntityInstanceData::getArgument(size_t i) const {
     if (i < getArgumentCount()) {
         if (attributes_[i] == nullptr) {
             return &static_null_attribute;
-        } else {
-            return attributes_[i];
         }
-    } else {
-        throw IfcParse::IfcException("Attribute index out of range");
+        return attributes_[i];
     }
+    throw IfcParse::IfcException("Attribute index out of range");
 }
 
 class unregister_inverse_visitor {
@@ -1799,13 +1797,12 @@ class traversal_recorder {
     aggregate_of_instance::ptr get_list() const {
         if (mode_ == 0) {
             return list_;
-        } else {
-            aggregate_of_instance::ptr l(new aggregate_of_instance);
-            for (auto& p : instances_by_level_) {
-                l->push(p.second);
-            }
-            return l;
         }
+        aggregate_of_instance::ptr l(new aggregate_of_instance);
+        for (auto& p : instances_by_level_) {
+            l->push(p.second);
+        }
+        return l;
     }
 };
 
@@ -2415,9 +2412,8 @@ IfcUtil::IfcBaseClass* IfcFile::instance_by_guid(const std::string& guid) {
     entity_by_guid_t::const_iterator it = byguid.find(guid);
     if (it == byguid.end()) {
         throw IfcException("Instance with GlobalId '" + guid + "' not found");
-    } else {
-        return it->second;
     }
+    return it->second;
 }
 
 // FIXME: Test destructor to delete entity and arg allocations

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -755,7 +755,7 @@ size_t IfcParse::IfcFile::load(unsigned entity_instance_name, const IfcParse::en
 
             if (TokenFunc::isKeyword(next)) {
                 try {
-                    auto ea = new EntityArgument(next);
+                    auto* ea = new EntityArgument(next);
                     addEntity(((IfcUtil::IfcBaseClass*)*ea));
                     filler.push_back(ea);
                 } catch (IfcException& e) {
@@ -873,7 +873,7 @@ ArgumentList::operator aggregate_of_aggregate_of_instance::ptr() const {
             aggregate_of_instance::ptr e = *arg_list;
             l->push(e);
         } else {
-            auto token = dynamic_cast<const TokenArgument*>(arg);
+            const auto* token = dynamic_cast<const TokenArgument*>(arg);
             int startpos = token != nullptr ? token->token.startPos : 0;
             std::string string_rep = this->toString();
             throw IfcInvalidTokenException(startpos, string_rep, "nested aggregate");
@@ -1051,7 +1051,7 @@ void IfcParse::IfcFile::try_read_semicolon() {
 
 void IfcParse::IfcFile::register_inverse(unsigned id_from, const IfcParse::entity* from_entity, Token t, int attribute_index) {
     // Assume a check on token type has already been performed
-    auto e = from_entity;
+    const auto* e = from_entity;
     byref_excl[t.value_int].push_back(id_from);
     while (e != nullptr) {
         byref[{t.value_int, e->index_in_schema(), attribute_index}].push_back(id_from);
@@ -1060,7 +1060,7 @@ void IfcParse::IfcFile::register_inverse(unsigned id_from, const IfcParse::entit
 }
 
 void IfcParse::IfcFile::register_inverse(unsigned id_from, const IfcParse::entity* from_entity, IfcUtil::IfcBaseClass* inst, int attribute_index) {
-    auto e = from_entity;
+    const auto* e = from_entity;
     byref_excl[inst->data().id()].push_back(id_from);
     while (e != nullptr) {
         byref[{inst->data().id(), e->index_in_schema(), attribute_index}].push_back(id_from);
@@ -1069,7 +1069,7 @@ void IfcParse::IfcFile::register_inverse(unsigned id_from, const IfcParse::entit
 }
 
 void IfcParse::IfcFile::unregister_inverse(unsigned id_from, const IfcParse::entity* from_entity, IfcUtil::IfcBaseClass* inst, int attribute_index) {
-    auto e = from_entity;
+    const auto* e = from_entity;
     while (e != nullptr) {
         std::vector<int>& ids = byref[{inst->data().id(), e->index_in_schema(), attribute_index}];
         std::vector<int>::iterator it = std::find(ids.begin(), ids.end(), id_from);
@@ -1799,7 +1799,7 @@ class traversal_recorder {
             return list_;
         }
         aggregate_of_instance::ptr l(new aggregate_of_instance);
-        for (auto& p : instances_by_level_) {
+        for (const auto& p : instances_by_level_) {
             l->push(p.second);
         }
         return l;
@@ -2174,8 +2174,8 @@ void IfcFile::removeEntity(IfcUtil::IfcBaseClass* entity) {
 
 void IfcFile::process_deletion_() {
 
-    for (auto& id : batch_deletion_ids_.get<0>()) {
-        auto entity = instance_by_id(id);
+    for (const auto& id : batch_deletion_ids_.get<0>()) {
+        auto* entity = instance_by_id(id);
 
         aggregate_of_instance::ptr references = instances_by_reference(id);
 
@@ -2425,7 +2425,7 @@ IfcFile::~IfcFile() {
     for (const auto& pair : byidentity) {
         entities_to_delete.insert(pair.second);
     }
-    for (auto entity : entities_to_delete) {
+    for (auto* entity : entities_to_delete) {
         delete entity;
     }
     delete stream;
@@ -2521,7 +2521,7 @@ std::vector<int> IfcFile::get_inverse_indices(int instance_id) {
 
     auto refs = instances_by_reference(instance_id);
 
-    for (auto& r : *refs) {
+    for (const auto& r : *refs) {
         auto it = mapping.find(r->data().id());
         if (it == mapping.end() || it->second.empty()) {
             throw IfcException("Internal error");
@@ -2667,7 +2667,7 @@ void IfcParse::IfcFile::build_inverses_(IfcUtil::IfcBaseClass* inst) {
     std::function<void(IfcUtil::IfcBaseClass*, int)> fn = [this, inst](IfcUtil::IfcBaseClass* attr, int idx) {
         if (attr->declaration().as_entity() != nullptr) {
             unsigned entity_attribute_id = attr->data().id();
-            auto decl = inst->declaration().as_entity();
+            const auto* decl = inst->declaration().as_entity();
             byref_excl[entity_attribute_id].push_back(inst->data().id());
             while (decl != nullptr) {
                 byref[{entity_attribute_id, decl->index_in_schema(), idx}].push_back(inst->data().id());
@@ -2680,7 +2680,7 @@ void IfcParse::IfcFile::build_inverses_(IfcUtil::IfcBaseClass* inst) {
 }
 
 void IfcParse::IfcFile::build_inverses() {
-    for (auto& pair : *this) {
+    for (const auto& pair : *this) {
         build_inverses_(pair.second);
     }
 }

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -210,7 +210,7 @@ void IfcSpfStream::Close() {
     }
 #endif
     delete[] buffer;
-    if (stream) {
+    if (stream != nullptr) {
         fclose(stream);
     }
 }
@@ -320,7 +320,7 @@ Token IfcSpfLexer::Next() {
         return NoneTokenPtr();
     }
 
-    while (skipWhitespace() || skipComment()) {
+    while ((skipWhitespace() != 0U) || (skipComment() != 0U)) {
     }
 
     if (stream->eof) {
@@ -342,7 +342,7 @@ Token IfcSpfLexer::Next() {
 
         // Read character and increment pointer if not starting a new token
         c = stream->Peek();
-        if (len && (c == '(' || c == ')' || c == '=' || c == ',' || c == ';' || c == '/')) {
+        if ((len != 0) && (c == '(' || c == ')' || c == '=' || c == ',' || c == ';' || c == '/')) {
             break;
         }
         stream->Inc();
@@ -353,7 +353,7 @@ Token IfcSpfLexer::Next() {
             decoder->skip();
         }
     }
-    if (len) {
+    if (len != 0) {
         return GeneralTokenPtr(this, pos, stream->Tell());
     }
     return NoneTokenPtr();
@@ -385,7 +385,7 @@ void IfcSpfLexer::TokenString(unsigned int offset, std::string& buffer) {
     buffer.clear();
     while (!stream->is_eof_at(offset)) {
         char c = stream->peek_at(offset);
-        if (buffer.size() && (c == '(' || c == ')' || c == '=' || c == ',' || c == ';' || c == '/')) {
+        if (!buffer.empty() && (c == '(' || c == ')' || c == '=' || c == ',' || c == ';' || c == '/')) {
             break;
         }
         stream->increment_at(offset);
@@ -639,7 +639,7 @@ boost::dynamic_bitset<> TokenFunc::asBinary(const Token& t) {
             if (i-- == 0) {
                 break;
             }
-            if (value & (1 << (3 - j))) {
+            if ((value & (1 << (3 - j))) != 0) {
                 bitset.set(i);
             }
         }
@@ -719,7 +719,7 @@ size_t IfcParse::IfcFile::load(unsigned entity_instance_name, const IfcParse::en
             // If num_attributes is zero we know this is a top-level entity instance (or header entity) being parsed.
             // There can only be parsed one of these at a time, so we can reuse the vector we have defined at the file
             // scope.
-            if (entity) {
+            if (entity != nullptr) {
                 vector = &internal_attribute_vector_;
             } else {
                 vector = &internal_attribute_vector_simple_type_;
@@ -733,7 +733,7 @@ size_t IfcParse::IfcFile::load(unsigned entity_instance_name, const IfcParse::en
 
     size_t return_value = 0;
 
-    while (next.startPos || next.lexer) {
+    while ((next.startPos != 0U) || (next.lexer != nullptr)) {
         if (TokenFunc::isOperator(next, ',')) {
             // do nothing
         } else if (TokenFunc::isOperator(next, ')')) {
@@ -768,9 +768,9 @@ size_t IfcParse::IfcFile::load(unsigned entity_instance_name, const IfcParse::en
         next = tokens->Next();
     }
 
-    if (vector) {
+    if (vector != nullptr) {
         // Obviously don't try and create a 0-length array.
-        if (num_attributes || vector->size()) {
+        if ((num_attributes != 0U) || !vector->empty()) {
             // @todo figure out whether all this logic is still necessary, since we know the
             // expected amount of attributes and shouldn't be able to access more than allowed
             // by the schema.
@@ -874,7 +874,7 @@ ArgumentList::operator aggregate_of_aggregate_of_instance::ptr() const {
             l->push(e);
         } else {
             auto token = dynamic_cast<const TokenArgument*>(arg);
-            int startpos = token ? token->token.startPos : 0;
+            int startpos = token != nullptr ? token->token.startPos : 0;
             std::string string_rep = this->toString();
             throw IfcInvalidTokenException(startpos, string_rep, "nested aggregate");
         }
@@ -1053,7 +1053,7 @@ void IfcParse::IfcFile::register_inverse(unsigned id_from, const IfcParse::entit
     // Assume a check on token type has already been performed
     auto e = from_entity;
     byref_excl[t.value_int].push_back(id_from);
-    while (e) {
+    while (e != nullptr) {
         byref[{t.value_int, e->index_in_schema(), attribute_index}].push_back(id_from);
         e = e->supertype();
     }
@@ -1062,7 +1062,7 @@ void IfcParse::IfcFile::register_inverse(unsigned id_from, const IfcParse::entit
 void IfcParse::IfcFile::register_inverse(unsigned id_from, const IfcParse::entity* from_entity, IfcUtil::IfcBaseClass* inst, int attribute_index) {
     auto e = from_entity;
     byref_excl[inst->data().id()].push_back(id_from);
-    while (e) {
+    while (e != nullptr) {
         byref[{inst->data().id(), e->index_in_schema(), attribute_index}].push_back(id_from);
         e = e->supertype();
     }
@@ -1070,7 +1070,7 @@ void IfcParse::IfcFile::register_inverse(unsigned id_from, const IfcParse::entit
 
 void IfcParse::IfcFile::unregister_inverse(unsigned id_from, const IfcParse::entity* from_entity, IfcUtil::IfcBaseClass* inst, int attribute_index) {
     auto e = from_entity;
-    while (e) {
+    while (e != nullptr) {
         std::vector<int>& ids = byref[{inst->data().id(), e->index_in_schema(), attribute_index}];
         std::vector<int>::iterator it = std::find(ids.begin(), ids.end(), id_from);
         if (it == ids.end()) {
@@ -1105,13 +1105,13 @@ std::string IfcEntityInstanceData::toString(bool upper) const {
     ss.imbue(std::locale::classic());
 
     std::string dt;
-    if (type_) {
+    if (type_ != nullptr) {
         dt = type()->name();
         if (upper) {
             boost::to_upper(dt);
         }
 
-        if (type()->as_entity() || id_ != 0) {
+        if ((type()->as_entity() != nullptr) || id_ != 0) {
             ss << "#" << id_ << "=";
         }
     }
@@ -1182,7 +1182,7 @@ void IfcEntityInstanceData::load() const {
     // type_ is 0 for header entities which have their size predetermined in code
     // in that we have attributes_ pre-constructed to the correct size in the constructor
     // in the other case load() will use a vector internally to grow to the size found in the file
-    size_t n = file->load(id(), type_ ? type_->as_entity() : nullptr, type_ ? tmp_data : attributes_, getArgumentCount());
+    size_t n = file->load(id(), type_ != nullptr ? type_->as_entity() : nullptr, type_ != nullptr ? tmp_data : attributes_, getArgumentCount());
     if (n != getArgumentCount()) {
         Logger::Error("Wrong number of attributes on instance with id #" + std::to_string(id_) +
                       " at offset " + std::to_string(this->offset_in_file()) +
@@ -1193,7 +1193,7 @@ void IfcEntityInstanceData::load() const {
     file->try_read_semicolon();
 
     // @todo does this need to be atomic somehow?
-    if (tmp_data) {
+    if (tmp_data != nullptr) {
         attributes_ = tmp_data;
     }
 }
@@ -1203,14 +1203,14 @@ namespace {
 // different handling of enumerations)
 IfcUtil::ArgumentType get_argument_type(const IfcParse::declaration* decl, size_t i) {
     const IfcParse::parameter_type* pt = 0;
-    if (decl->as_entity()) {
+    if (decl->as_entity() != nullptr) {
         pt = decl->as_entity()->attribute_by_index(i)->type_of_attribute();
         if (decl->as_entity()->derived()[i]) {
             return IfcUtil::Argument_DERIVED;
         }
-    } else if (decl->as_type_declaration() && i == 0) {
+    } else if ((decl->as_type_declaration() != nullptr) && i == 0) {
         pt = decl->as_type_declaration()->declared_type();
-    } else if (decl->as_enumeration_type() && i == 0) {
+    } else if ((decl->as_enumeration_type() != nullptr) && i == 0) {
         return IfcUtil::Argument_ENUMERATION;
     }
 
@@ -1416,7 +1416,7 @@ void IfcEntityInstanceData::setArgument(size_t i, Argument* a, IfcUtil::Argument
             // Remove leading and trailing '.'
             enum_literal = enum_literal.substr(1, enum_literal.size() - 2);
 
-            const IfcParse::enumeration_type* enum_type = type()->as_enumeration_type()
+            const IfcParse::enumeration_type* enum_type = type()->as_enumeration_type() != nullptr
                                                               ? type()->as_enumeration_type()
                                                               : type()->as_entity()->attribute_by_index(i)->type_of_attribute()->as_named_type()->declared_type()->as_enumeration_type();
 
@@ -1483,7 +1483,7 @@ void IfcEntityInstanceData::setArgument(size_t i, Argument* a, IfcUtil::Argument
             break;
         }
 
-        if (!copy) {
+        if (copy == nullptr) {
             return;
         }
 
@@ -1492,10 +1492,10 @@ void IfcEntityInstanceData::setArgument(size_t i, Argument* a, IfcUtil::Argument
 
     if (attributes_[i] != 0) {
         Argument* current_attribute = attributes_[i];
-        if (this->file) {
+        if (this->file != nullptr) {
 
             // Deregister old attribute guid in file guid map.
-            if (i == 0 && this->type() && this->file->ifcroot_type() && this->type()->is(*this->file->ifcroot_type())) {
+            if (i == 0 && (this->type() != nullptr) && (this->file->ifcroot_type() != nullptr) && this->type()->is(*this->file->ifcroot_type())) {
                 try {
                     auto guid = (std::string)*current_attribute;
                     auto it = this->file->internal_guid_map().find(guid);
@@ -1514,7 +1514,7 @@ void IfcEntityInstanceData::setArgument(size_t i, Argument* a, IfcUtil::Argument
         delete attributes_[i];
     }
 
-    if (this->file) {
+    if (this->file != nullptr) {
         // Register inverse indices in file
         register_inverse_visitor visitor(*this->file, *this);
         apply_individual_instance_visitor(new_attribute, i).apply(visitor);
@@ -1523,8 +1523,8 @@ void IfcEntityInstanceData::setArgument(size_t i, Argument* a, IfcUtil::Argument
     attributes_[i] = new_attribute;
 
     // Register new attribute guid in guid map
-    if (this->file) {
-        if (i == 0 && this->type() && this->file->ifcroot_type() && this->type()->is(*this->file->ifcroot_type())) {
+    if (this->file != nullptr) {
+        if (i == 0 && (this->type() != nullptr) && (this->file->ifcroot_type() != nullptr) && this->type()->is(*this->file->ifcroot_type())) {
             try {
                 auto guid = (std::string)*new_attribute;
                 auto it = this->file->internal_guid_map().find(guid);
@@ -1662,7 +1662,7 @@ void IfcFile::initialize_(IfcParse::IfcSpfStream* s) {
 
             /// @todo Printing to stdout in a library class feels weird. Maybe move the progress prints to the client code?
             // Update the status after every 1000 instances parsed
-            if (!((++progress) % 1000)) {
+            if (((++progress) % 1000) == 0) {
                 std::stringstream ss;
                 ss << "\r#" << current_id;
                 Logger::Status(ss.str(), false);
@@ -1708,7 +1708,7 @@ void IfcFile::initialize_(IfcParse::IfcSpfStream* s) {
                 }
                 insts->push(instance);
                 const IfcParse::declaration* pt = ty->as_entity()->supertype();
-                if (pt) {
+                if (pt != nullptr) {
                     ty = pt;
                 } else {
                     break;
@@ -1723,7 +1723,7 @@ void IfcFile::initialize_(IfcParse::IfcSpfStream* s) {
             byid[current_id] = instance;
 
             MaxId = (std::max)(MaxId, current_id);
-        } else if (token_stream[0].type == IfcParse::Token_IDENTIFIER && instance) {
+        } else if (token_stream[0].type == IfcParse::Token_IDENTIFIER && (instance != nullptr)) {
             register_inverse(current_id, instance->declaration().as_entity(), token_stream[0], attribute_index);
         } else if (token_stream[0].type == IfcParse::Token_OPERATOR && token_stream[0].value_char == '(') {
             paren_stack_depth++;
@@ -1913,7 +1913,7 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
     // See whether the instance is already part of a file
     if (entity->data().file != 0) {
         if (entity->data().file == this) {
-            if (!entity->declaration().as_entity()) {
+            if (entity->declaration().as_entity() == nullptr) {
                 // While not a mapping that can be queried, we do need to free the instance later on
                 byidentity[new_entity->identity()] = new_entity;
             }
@@ -1939,13 +1939,13 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
             IfcUtil::ArgumentType attr_type = attr->type();
 
             IfcParse::declaration* decl = 0;
-            if (entity->declaration().as_entity()) {
+            if (entity->declaration().as_entity() != nullptr) {
                 decl = 0;
                 const parameter_type* pt = entity->declaration().as_entity()->attribute_by_index(i)->type_of_attribute();
-                while (pt->as_aggregation_type()) {
+                while (pt->as_aggregation_type() != nullptr) {
                     pt = pt->as_aggregation_type()->type_of_element();
                 }
-                if (pt->as_named_type()) {
+                if (pt->as_named_type() != nullptr) {
                     decl = pt->as_named_type()->declared_type();
                 }
             }
@@ -1991,7 +1991,7 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
                 IfcWrite::IfcWriteArgument* copy = new IfcWrite::IfcWriteArgument();
                 copy->set(new_instances);
                 we->setArgument(i, copy);
-            } else if (decl && decl->is(*schema()->declaration_by_name("IfcLengthMeasure"))) {
+            } else if ((decl != nullptr) && decl->is(*schema()->declaration_by_name("IfcLengthMeasure"))) {
                 if (boost::math::isnan(conversion_factor)) {
                     std::pair<IfcUtil::IfcBaseClass*, double> this_file_unit = {nullptr, 1.0};
                     std::pair<IfcUtil::IfcBaseClass*, double> other_file_unit = {nullptr, 1.0};
@@ -2000,7 +2000,7 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
                         other_file_unit = other_file->getUnit("LENGTHUNIT");
                     } catch (IfcParse::IfcException&) {
                     }
-                    if (this_file_unit.first && other_file_unit.first) {
+                    if ((this_file_unit.first != nullptr) && (other_file_unit.first != nullptr)) {
                         conversion_factor = other_file_unit.second / this_file_unit.second;
                     } else {
                         conversion_factor = 1.;
@@ -2041,7 +2041,7 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
         // A new entity instance name is generated and
         // the instance is pointed to this file.
         we->file = this;
-        if (we->type()->as_entity()) {
+        if (we->type()->as_entity() != nullptr) {
             if (id == -1) {
                 we->set_id(FreshId());
             } else {
@@ -2073,7 +2073,7 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
     // The mapping by entity type is updated.
     const IfcParse::declaration* ty = &new_entity->declaration();
 
-    if (ty->as_entity()) {
+    if (ty->as_entity() != nullptr) {
         aggregate_of_instance::ptr insts = instances_by_type_excl_subtypes(ty);
         if (!insts) {
             insts = aggregate_of_instance::ptr(new aggregate_of_instance());
@@ -2082,7 +2082,7 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
         insts->push(new_entity);
     }
 
-    for (; ty->as_entity();) {
+    for (; ty->as_entity() != nullptr;) {
         aggregate_of_instance::ptr insts = instances_by_type(ty);
         if (!insts) {
             insts = aggregate_of_instance::ptr(new aggregate_of_instance());
@@ -2091,16 +2091,16 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
         insts->push(new_entity);
 
         const IfcParse::declaration* pt = ty->as_entity()->supertype();
-        if (pt) {
+        if (pt != nullptr) {
             ty = pt;
         } else {
             break;
         }
     }
 
-    if (ty->as_entity()) {
+    if (ty->as_entity() != nullptr) {
         int new_id = -1;
-        if (!new_entity->data().file) {
+        if (new_entity->data().file == nullptr) {
             // For newly created entities ensure a valid ENTITY_INSTANCE_NAME is set
             new_entity->data().file = this;
             boost::optional<unsigned> id_value;
@@ -2124,7 +2124,7 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
 
         // The mapping by entity instance name is updated.
         byid[new_id] = new_entity;
-    } else if (!new_entity->data().file) {
+    } else if (new_entity->data().file == nullptr) {
         // For non-entity instances, no mappings are updated, but the file
         // pointer has to be set, so that actual copies are created in subsequent
         // times.
@@ -2134,7 +2134,7 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
         byidentity[new_entity->identity()] = new_entity;
     }
 
-    if (parsing_complete_ && ty->as_entity()) {
+    if (parsing_complete_ && (ty->as_entity() != nullptr)) {
         build_inverses_(new_entity);
     }
 
@@ -2213,7 +2213,7 @@ void IfcFile::process_deletion_() {
                         if (instance_list->contains(entity)) {
                             IfcWrite::IfcWriteArgument* copy = new IfcWrite::IfcWriteArgument();
                             instance_list->remove(entity);
-                            if (!instance_list->size() && related_instance->declaration().as_entity()->attribute_by_index(i)->optional()) {
+                            if ((instance_list->size() == 0U) && related_instance->declaration().as_entity()->attribute_by_index(i)->optional()) {
                                 // @todo we can also check the lower bound of the attribute type before setting to null.
                                 copy->set(boost::blank());
                             } else {
@@ -2317,7 +2317,7 @@ void IfcFile::process_deletion_() {
             }
 
             const IfcParse::declaration* pt = ty->as_entity()->supertype();
-            if (pt) {
+            if (pt != nullptr) {
                 ty = pt;
             } else {
                 break;
@@ -2473,7 +2473,7 @@ std::ostream& operator<<(std::ostream& os, const IfcParse::IfcFile& f) {
 
     for (vector_t::const_iterator it = sorted.begin(); it != sorted.end(); ++it) {
         const IfcUtil::IfcBaseClass* e = it->second;
-        if (e->declaration().as_entity()) {
+        if (e->declaration().as_entity() != nullptr) {
             os << e->data().toString(true) << ";" << std::endl;
         }
     }
@@ -2493,7 +2493,7 @@ std::string IfcFile::createTimestamp() const {
     struct tm* ti = localtime(&t);
 
     std::string result = "";
-    if (strftime(buf, 255, "%Y-%m-%dT%H:%M:%S", ti)) {
+    if (strftime(buf, 255, "%Y-%m-%dT%H:%M:%S", ti) != 0U) {
         result = std::string(buf);
     }
 
@@ -2578,7 +2578,7 @@ void IfcFile::setDefaultHeaderValues() {
     std::vector<std::string> file_description, schema_identifiers, empty_vector;
 
     file_description.push_back("ViewDefinition [CoordinationView]");
-    if (schema()) {
+    if (schema() != nullptr) {
         schema_identifiers.push_back(schema()->name());
     }
 
@@ -2648,7 +2648,7 @@ std::pair<IfcUtil::IfcBaseClass*, double> IfcFile::getUnit(const std::string& un
                     return_value.first = siunit = unit;
                 }
 
-                if (siunit) {
+                if (siunit != nullptr) {
                     Argument* prefix = siunit->data().getArgument(
                         siunit->declaration().as_entity()->attribute_index("Prefix"));
 
@@ -2665,11 +2665,11 @@ std::pair<IfcUtil::IfcBaseClass*, double> IfcFile::getUnit(const std::string& un
 
 void IfcParse::IfcFile::build_inverses_(IfcUtil::IfcBaseClass* inst) {
     std::function<void(IfcUtil::IfcBaseClass*, int)> fn = [this, inst](IfcUtil::IfcBaseClass* attr, int idx) {
-        if (attr->declaration().as_entity()) {
+        if (attr->declaration().as_entity() != nullptr) {
             unsigned entity_attribute_id = attr->data().id();
             auto decl = inst->declaration().as_entity();
             byref_excl[entity_attribute_id].push_back(inst->data().id());
-            while (decl) {
+            while (decl != nullptr) {
                 byref[{entity_attribute_id, decl->index_in_schema(), idx}].push_back(inst->data().id());
                 decl = decl->supertype();
             }

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -88,51 +88,51 @@ struct Token {
 /// Tokens are merely offsets to where they can be read in the file
 class IFC_PARSE_API TokenFunc {
   private:
-    static bool startsWith(const Token& t, char c);
+    static bool startsWith(const Token& token, char character);
 
   public:
     /// Returns the offset at which the token is read from the file
     // static unsigned int Offset(const Token& t);
     /// Returns whether the token can be interpreted as a string
-    static bool isString(const Token& t);
+    static bool isString(const Token& token);
     /// Returns whether the token can be interpreted as an identifier
-    static bool isIdentifier(const Token& t);
+    static bool isIdentifier(const Token& token);
     /// Returns whether the token can be interpreted as a syntactical operator
-    static bool isOperator(const Token& t);
+    static bool isOperator(const Token& token);
     /// Returns whether the token is a given operator
-    static bool isOperator(const Token& t, char op);
+    static bool isOperator(const Token& token, char character);
     /// Returns whether the token can be interpreted as an enumerated value
-    static bool isEnumeration(const Token& t);
+    static bool isEnumeration(const Token& token);
     /// Returns whether the token can be interpreted as a datatype name
-    static bool isKeyword(const Token& t);
+    static bool isKeyword(const Token& token);
     /// Returns whether the token can be interpreted as an integer
-    static bool isInt(const Token& t);
+    static bool isInt(const Token& token);
     /// Returns whether the token can be interpreted as a boolean
-    static bool isBool(const Token& t);
+    static bool isBool(const Token& token);
     /// Returns whether the token can be interpreted as a logical
-    static bool isLogical(const Token& t);
+    static bool isLogical(const Token& token);
     /// Returns whether the token can be interpreted as a floating point number
-    static bool isFloat(const Token& t);
+    static bool isFloat(const Token& token);
     /// Returns whether the token can be interpreted as a binary type
-    static bool isBinary(const Token& t);
+    static bool isBinary(const Token& token);
     /// Returns the token interpreted as an integer
-    static int asInt(const Token& t);
+    static int asInt(const Token& token);
     /// Returns the token interpreted as an identifier
-    static int asIdentifier(const Token& t);
+    static int asIdentifier(const Token& token);
     /// Returns the token interpreted as an boolean (.T. or .F.)
-    static bool asBool(const Token& t);
+    static bool asBool(const Token& token);
     /// Returns the token interpreted as an logical (.T. or .F. or .U.)
-    static boost::logic::tribool asLogical(const Token& t);
+    static boost::logic::tribool asLogical(const Token& token);
     /// Returns the token as a floating point number
-    static double asFloat(const Token& t);
+    static double asFloat(const Token& token);
     /// Returns the token as a string (without the dot or apostrophe)
-    static std::string asString(const Token& t);
+    static std::string asString(const Token& token);
     /// Returns the token as a string in internal buffer (for optimization purposes)
-    static const std::string& asStringRef(const Token& t);
+    static const std::string& asStringRef(const Token& token);
     /// Returns the token as a string (without the dot or apostrophe)
-    static boost::dynamic_bitset<> asBinary(const Token& t);
+    static boost::dynamic_bitset<> asBinary(const Token& token);
     /// Returns a string representation of the token (including the dot or apostrophe)
-    static std::string toString(const Token& t);
+    static std::string toString(const Token& token);
 };
 
 //
@@ -152,12 +152,12 @@ class IFC_PARSE_API IfcSpfLexer {
 
   public:
     std::string& GetTempString() const {
-        static my_thread_local std::string s;
-        return s;
+        static my_thread_local std::string string;
+        return string;
     }
     IfcSpfStream* stream;
     IfcFile* file;
-    IfcSpfLexer(IfcSpfStream* s, IfcFile* f);
+    IfcSpfLexer(IfcSpfStream* stream, IfcFile* file);
     Token Next();
     ~IfcSpfLexer();
     void TokenString(unsigned int offset, std::string& result);
@@ -178,7 +178,7 @@ class IFC_PARSE_API ArgumentList : public Argument {
                              list_(new Argument* [size_] { 0 }) {}
     ~ArgumentList();
 
-    void read(IfcSpfLexer* t, std::vector<unsigned int>& ids);
+    void read(IfcSpfLexer* lexer, std::vector<unsigned int>& ids);
 
     IfcUtil::ArgumentType type() const;
 
@@ -195,7 +195,7 @@ class IFC_PARSE_API ArgumentList : public Argument {
     bool isNull() const;
     unsigned int size() const;
 
-    Argument* operator[](unsigned int i) const;
+    Argument* operator[](unsigned int index) const;
 
     std::string toString(bool upper = false) const;
 
@@ -221,7 +221,7 @@ class IFC_PARSE_API NullArgument : public Argument {
 class IFC_PARSE_API TokenArgument : public Argument {
   public:
     Token token;
-    TokenArgument(const Token& t);
+    TokenArgument(const Token& token);
 
     IfcUtil::ArgumentType type() const;
 
@@ -236,7 +236,7 @@ class IFC_PARSE_API TokenArgument : public Argument {
     bool isNull() const;
     unsigned int size() const;
 
-    Argument* operator[](unsigned int i) const;
+    Argument* operator[](unsigned int index) const;
     std::string toString(bool upper = false) const;
 };
 
@@ -248,7 +248,7 @@ class IFC_PARSE_API EntityArgument : public Argument {
     IfcUtil::IfcBaseClass* entity_;
 
   public:
-    EntityArgument(const Token& t);
+    EntityArgument(const Token& token);
     ~EntityArgument();
 
     IfcUtil::ArgumentType type() const;
@@ -258,17 +258,17 @@ class IFC_PARSE_API EntityArgument : public Argument {
     bool isNull() const;
     unsigned int size() const;
 
-    Argument* operator[](unsigned int i) const;
+    Argument* operator[](unsigned int index) const;
     std::string toString(bool upper = false) const;
 };
 
-IFC_PARSE_API IfcEntityInstanceData* read(unsigned int i, IfcFile* t, boost::optional<unsigned> offset = boost::none);
+IFC_PARSE_API IfcEntityInstanceData* read(unsigned int index, IfcFile* file, boost::optional<unsigned> offset = boost::none);
 
 IFC_PARSE_API aggregate_of_instance::ptr traverse(IfcUtil::IfcBaseClass* instance, int max_level = -1);
 
 IFC_PARSE_API aggregate_of_instance::ptr traverse_breadth_first(IfcUtil::IfcBaseClass* instance, int max_level = -1);
 } // namespace IfcParse
 
-IFC_PARSE_API std::ostream& operator<<(std::ostream& os, const IfcParse::IfcFile& f);
+IFC_PARSE_API std::ostream& operator<<(std::ostream& out, const IfcParse::IfcFile& file);
 
 #endif

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -38,17 +38,12 @@
 #include "ifc_parse_api.h"
 #include "IfcBaseClass.h"
 #include "IfcCharacterDecoder.h"
-#include "IfcLogger.h"
 #include "IfcSpfStream.h"
-#include "macros.h"
 
 #include <boost/dynamic_bitset.hpp>
 #include <boost/shared_ptr.hpp>
 #include <cstring>
-#include <fstream>
 #include <iostream>
-#include <map>
-#include <sstream>
 #include <string>
 #include <vector>
 

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -146,7 +146,7 @@ Token NoneTokenPtr();
 /// A stream of tokens to be read from a IfcSpfStream.
 class IFC_PARSE_API IfcSpfLexer {
   private:
-    IfcCharacterDecoder* decoder;
+    IfcCharacterDecoder* decoder_;
     unsigned int skipWhitespace();
     unsigned int skipComment();
 
@@ -219,7 +219,6 @@ class IFC_PARSE_API NullArgument : public Argument {
 /// #1=IfcVector(#2,1.0);
 ///              == ===
 class IFC_PARSE_API TokenArgument : public Argument {
-  private:
   public:
     Token token;
     TokenArgument(const Token& t);
@@ -246,7 +245,7 @@ class IFC_PARSE_API TokenArgument : public Argument {
 ///                        =====================   =====================
 class IFC_PARSE_API EntityArgument : public Argument {
   private:
-    IfcUtil::IfcBaseClass* entity;
+    IfcUtil::IfcBaseClass* entity_;
 
   public:
     EntityArgument(const Token& t);

--- a/src/ifcparse/IfcSIPrefix.cpp
+++ b/src/ifcparse/IfcSIPrefix.cpp
@@ -56,53 +56,53 @@
 #include "Ifc4x3_add2.h"
 #endif
 
-double IfcParse::IfcSIPrefixToValue(const std::string& v) {
-    if (v == "EXA") {
+double IfcParse::IfcSIPrefixToValue(const std::string& prefix) {
+    if (prefix == "EXA") {
         return 1.e18;
     }
-    if (v == "PETA") {
+    if (prefix == "PETA") {
         return 1.e15;
     }
-    if (v == "TERA") {
+    if (prefix == "TERA") {
         return 1.e12;
     }
-    if (v == "GIGA") {
+    if (prefix == "GIGA") {
         return 1.e9;
     }
-    if (v == "MEGA") {
+    if (prefix == "MEGA") {
         return 1.e6;
     }
-    if (v == "KILO") {
+    if (prefix == "KILO") {
         return 1.e3;
     }
-    if (v == "HECTO") {
+    if (prefix == "HECTO") {
         return 1.e2;
     }
-    if (v == "DECA") {
+    if (prefix == "DECA") {
         return 1.e1;
     }
-    if (v == "DECI") {
+    if (prefix == "DECI") {
         return 1.e-1;
     }
-    if (v == "CENTI") {
+    if (prefix == "CENTI") {
         return 1.e-2;
     }
-    if (v == "MILLI") {
+    if (prefix == "MILLI") {
         return 1.e-3;
     }
-    if (v == "MICRO") {
+    if (prefix == "MICRO") {
         return 1.e-6;
     }
-    if (v == "NANO") {
+    if (prefix == "NANO") {
         return 1.e-9;
     }
-    if (v == "PICO") {
+    if (prefix == "PICO") {
         return 1.e-12;
     }
-    if (v == "FEMTO") {
+    if (prefix == "FEMTO") {
         return 1.e-15;
     }
-    if (v == "ATTO") {
+    if (prefix == "ATTO") {
         return 1.e-18;
     }
     return 1.;
@@ -119,8 +119,8 @@ double IfcParse::get_SI_equivalent(typename Schema::IfcNamedUnit* named_unit) {
         typename Schema::IfcUnit* component = factor->UnitComponent();
         if (component->declaration().is(Schema::IfcSIUnit::Class())) {
             si_unit = component->template as<typename Schema::IfcSIUnit>();
-            typename Schema::IfcValue* v = factor->ValueComponent();
-            scale = *v->data().getArgument(0);
+            typename Schema::IfcValue* value = factor->ValueComponent();
+            scale = *value->data().getArgument(0);
         }
     } else if (named_unit->declaration().is(Schema::IfcSIUnit::Class())) {
         si_unit = named_unit->template as<typename Schema::IfcSIUnit>();

--- a/src/ifcparse/IfcSIPrefix.cpp
+++ b/src/ifcparse/IfcSIPrefix.cpp
@@ -59,39 +59,53 @@
 double IfcParse::IfcSIPrefixToValue(const std::string& v) {
     if (v == "EXA") {
         return 1.e18;
-    } else if (v == "PETA") {
-        return 1.e15;
-    } else if (v == "TERA") {
-        return 1.e12;
-    } else if (v == "GIGA") {
-        return 1.e9;
-    } else if (v == "MEGA") {
-        return 1.e6;
-    } else if (v == "KILO") {
-        return 1.e3;
-    } else if (v == "HECTO") {
-        return 1.e2;
-    } else if (v == "DECA") {
-        return 1.e1;
-    } else if (v == "DECI") {
-        return 1.e-1;
-    } else if (v == "CENTI") {
-        return 1.e-2;
-    } else if (v == "MILLI") {
-        return 1.e-3;
-    } else if (v == "MICRO") {
-        return 1.e-6;
-    } else if (v == "NANO") {
-        return 1.e-9;
-    } else if (v == "PICO") {
-        return 1.e-12;
-    } else if (v == "FEMTO") {
-        return 1.e-15;
-    } else if (v == "ATTO") {
-        return 1.e-18;
-    } else {
-        return 1.;
     }
+    if (v == "PETA") {
+        return 1.e15;
+    }
+    if (v == "TERA") {
+        return 1.e12;
+    }
+    if (v == "GIGA") {
+        return 1.e9;
+    }
+    if (v == "MEGA") {
+        return 1.e6;
+    }
+    if (v == "KILO") {
+        return 1.e3;
+    }
+    if (v == "HECTO") {
+        return 1.e2;
+    }
+    if (v == "DECA") {
+        return 1.e1;
+    }
+    if (v == "DECI") {
+        return 1.e-1;
+    }
+    if (v == "CENTI") {
+        return 1.e-2;
+    }
+    if (v == "MILLI") {
+        return 1.e-3;
+    }
+    if (v == "MICRO") {
+        return 1.e-6;
+    }
+    if (v == "NANO") {
+        return 1.e-9;
+    }
+    if (v == "PICO") {
+        return 1.e-12;
+    }
+    if (v == "FEMTO") {
+        return 1.e-15;
+    }
+    if (v == "ATTO") {
+        return 1.e-18;
+    }
+    return 1.;
 }
 
 template <typename Schema>

--- a/src/ifcparse/IfcSIPrefix.h
+++ b/src/ifcparse/IfcSIPrefix.h
@@ -21,7 +21,8 @@
 #define IFCSIPREFIX
 
 #include "ifc_parse_api.h"
-#include "IfcParse.h"
+
+#include <string>
 
 namespace IfcParse {
 IFC_PARSE_API double IfcSIPrefixToValue(const std::string& prefix);

--- a/src/ifcparse/IfcSchema.cpp
+++ b/src/ifcparse/IfcSchema.cpp
@@ -21,6 +21,8 @@
 
 #include "IfcBaseClass.h"
 
+#include <map>
+
 #ifdef HAS_SCHEMA_2x3
 #include "Ifc2x3.h"
 #endif
@@ -57,8 +59,6 @@
 #ifdef HAS_SCHEMA_4x3_add2
 #include "Ifc4x3_add2.h"
 #endif
-
-#include <map>
 
 bool IfcParse::declaration::is(const std::string& name) const {
     const std::string* name_ptr = &name;

--- a/src/ifcparse/IfcSchema.cpp
+++ b/src/ifcparse/IfcSchema.cpp
@@ -74,7 +74,8 @@ bool IfcParse::declaration::is(const std::string& name) const {
 
     if (this->as_entity() && this->as_entity()->supertype()) {
         return this->as_entity()->supertype()->is(name);
-    } else if (this->as_type_declaration()) {
+    }
+    if (this->as_type_declaration()) {
         const IfcParse::named_type* nt = this->as_type_declaration()->declared_type()->as_named_type();
         if (nt) {
             return nt->is(name);
@@ -91,7 +92,8 @@ bool IfcParse::declaration::is(const IfcParse::declaration& decl) const {
 
     if (this->as_entity() && this->as_entity()->supertype()) {
         return this->as_entity()->supertype()->is(decl);
-    } else if (this->as_type_declaration()) {
+    }
+    if (this->as_type_declaration()) {
         const IfcParse::named_type* nt = this->as_type_declaration()->declared_type()->as_named_type();
         if (nt) {
             return nt->is(decl);
@@ -153,9 +155,8 @@ IfcParse::schema_definition::~schema_definition() {
 IfcUtil::IfcBaseClass* IfcParse::schema_definition::instantiate(IfcEntityInstanceData* data) const {
     if (factory_) {
         return (*factory_)(data);
-    } else {
-        return new IfcUtil::IfcLateBoundEntity(data->type(), data);
     }
+    return new IfcUtil::IfcLateBoundEntity(data->type(), data);
 }
 
 void IfcParse::register_schema(schema_definition* s) {

--- a/src/ifcparse/IfcSchema.cpp
+++ b/src/ifcparse/IfcSchema.cpp
@@ -112,10 +112,10 @@ bool IfcParse::named_type::is(const IfcParse::declaration& decl) const {
 }
 
 IfcParse::entity::~entity() {
-    for (auto attribute : attributes_) {
+    for (const auto* attribute : attributes_) {
         delete attribute;
     }
-    for (auto inverse_attribute : inverse_attributes_) {
+    for (const auto* inverse_attribute : inverse_attributes_) {
         delete inverse_attribute;
     }
 }

--- a/src/ifcparse/IfcSchema.cpp
+++ b/src/ifcparse/IfcSchema.cpp
@@ -62,7 +62,7 @@
 
 bool IfcParse::declaration::is(const std::string& name) const {
     const std::string* name_ptr = &name;
-    if (std::any_of(name.begin(), name.end(), [](char c) { return std::islower(c); })) {
+    if (std::any_of(name.begin(), name.end(), [](char character) { return std::islower(character); })) {
         temp_string_() = name;
         boost::to_upper(temp_string_());
         name_ptr = &temp_string_();
@@ -76,9 +76,9 @@ bool IfcParse::declaration::is(const std::string& name) const {
         return this->as_entity()->supertype()->is(name);
     }
     if (this->as_type_declaration() != nullptr) {
-        const IfcParse::named_type* nt = this->as_type_declaration()->declared_type()->as_named_type();
-        if (nt != nullptr) {
-            return nt->is(name);
+        const IfcParse::named_type* named_type = this->as_type_declaration()->declared_type()->as_named_type();
+        if (named_type != nullptr) {
+            return named_type->is(name);
         }
     }
 
@@ -94,9 +94,9 @@ bool IfcParse::declaration::is(const IfcParse::declaration& decl) const {
         return this->as_entity()->supertype()->is(decl);
     }
     if (this->as_type_declaration() != nullptr) {
-        const IfcParse::named_type* nt = this->as_type_declaration()->declared_type()->as_named_type();
-        if (nt != nullptr) {
-            return nt->is(decl);
+        const IfcParse::named_type* named_type = this->as_type_declaration()->declared_type()->as_named_type();
+        if (named_type != nullptr) {
+            return named_type->is(decl);
         }
     }
 
@@ -159,8 +159,8 @@ IfcUtil::IfcBaseClass* IfcParse::schema_definition::instantiate(IfcEntityInstanc
     return new IfcUtil::IfcLateBoundEntity(data->type(), data);
 }
 
-void IfcParse::register_schema(schema_definition* s) {
-    schemas.insert({boost::to_upper_copy(s->name()), s});
+void IfcParse::register_schema(schema_definition* schema) {
+    schemas.insert({boost::to_upper_copy(schema->name()), schema});
 }
 
 const IfcParse::schema_definition* IfcParse::schema_by_name(const std::string& name) {
@@ -202,11 +202,11 @@ const IfcParse::schema_definition* IfcParse::schema_by_name(const std::string& n
     Ifc4x3_add2::get_schema();
 #endif
 
-    std::map<std::string, const IfcParse::schema_definition*>::const_iterator it = schemas.find(boost::to_upper_copy(name));
-    if (it == schemas.end()) {
+    std::map<std::string, const IfcParse::schema_definition*>::const_iterator iter = schemas.find(boost::to_upper_copy(name));
+    if (iter == schemas.end()) {
         throw IfcParse::IfcException("No schema named " + name);
     }
-    return it->second;
+    return iter->second;
 }
 
 std::vector<std::string> IfcParse::schema_names() {

--- a/src/ifcparse/IfcSchema.cpp
+++ b/src/ifcparse/IfcSchema.cpp
@@ -72,12 +72,12 @@ bool IfcParse::declaration::is(const std::string& name) const {
         return true;
     }
 
-    if (this->as_entity() && this->as_entity()->supertype()) {
+    if ((this->as_entity() != nullptr) && (this->as_entity()->supertype() != nullptr)) {
         return this->as_entity()->supertype()->is(name);
     }
-    if (this->as_type_declaration()) {
+    if (this->as_type_declaration() != nullptr) {
         const IfcParse::named_type* nt = this->as_type_declaration()->declared_type()->as_named_type();
-        if (nt) {
+        if (nt != nullptr) {
             return nt->is(name);
         }
     }
@@ -90,12 +90,12 @@ bool IfcParse::declaration::is(const IfcParse::declaration& decl) const {
         return true;
     }
 
-    if (this->as_entity() && this->as_entity()->supertype()) {
+    if ((this->as_entity() != nullptr) && (this->as_entity()->supertype() != nullptr)) {
         return this->as_entity()->supertype()->is(decl);
     }
-    if (this->as_type_declaration()) {
+    if (this->as_type_declaration() != nullptr) {
         const IfcParse::named_type* nt = this->as_type_declaration()->declared_type()->as_named_type();
-        if (nt) {
+        if (nt != nullptr) {
             return nt->is(decl);
         }
     }
@@ -129,16 +129,16 @@ IfcParse::schema_definition::schema_definition(const std::string& name, const st
     for (std::vector<const declaration*>::iterator it = declarations_.begin(); it != declarations_.end(); ++it) {
         (**it).schema_ = this;
 
-        if ((**it).as_type_declaration()) {
+        if ((**it).as_type_declaration() != nullptr) {
             type_declarations_.push_back((**it).as_type_declaration());
         }
-        if ((**it).as_select_type()) {
+        if ((**it).as_select_type() != nullptr) {
             select_types_.push_back((**it).as_select_type());
         }
-        if ((**it).as_enumeration_type()) {
+        if ((**it).as_enumeration_type() != nullptr) {
             enumeration_types_.push_back((**it).as_enumeration_type());
         }
-        if ((**it).as_entity()) {
+        if ((**it).as_entity() != nullptr) {
             entities_.push_back((**it).as_entity());
         }
     }
@@ -153,7 +153,7 @@ IfcParse::schema_definition::~schema_definition() {
 }
 
 IfcUtil::IfcBaseClass* IfcParse::schema_definition::instantiate(IfcEntityInstanceData* data) const {
-    if (factory_) {
+    if (factory_ != nullptr) {
         return (*factory_)(data);
     }
     return new IfcUtil::IfcLateBoundEntity(data->type(), data);

--- a/src/ifcparse/IfcSchema.h
+++ b/src/ifcparse/IfcSchema.h
@@ -489,9 +489,8 @@ class IFC_PARSE_API schema_definition {
         std::vector<const declaration*>::const_iterator it = std::lower_bound(declarations_.begin(), declarations_.end(), *name_ptr, declaration_by_name_cmp());
         if (it == declarations_.end() || (**it).name_uc() != *name_ptr) {
             throw IfcParse::IfcException("Entity with name '" + name + "' not found in schema '" + name_ + "'");
-        } else {
-            return *it;
         }
+        return *it;
     }
 
     const declaration* declaration_by_name(int name) const {

--- a/src/ifcparse/IfcSchema.h
+++ b/src/ifcparse/IfcSchema.h
@@ -117,7 +117,8 @@ class IFC_PARSE_API aggregation_type : public parameter_type {
 
   protected:
     aggregate_type type_of_aggregation_;
-    int bound1_, bound2_;
+    int bound1_;
+    int bound2_;
     parameter_type* type_of_element_;
 
   public:
@@ -268,7 +269,8 @@ class IFC_PARSE_API inverse_attribute {
   protected:
     std::string name_;
     aggregate_type type_of_aggregation_;
-    int bound1_, bound2_;
+    int bound1_;
+    int bound2_;
     const entity* entity_reference_;
     const attribute* attribute_reference_;
 

--- a/src/ifcparse/IfcSchema.h
+++ b/src/ifcparse/IfcSchema.h
@@ -319,7 +319,7 @@ class IFC_PARSE_API entity : public declaration {
 
     const attribute* attribute_by_index_(size_t& index) const {
         const attribute* attr = 0;
-        if (supertype_) {
+        if (supertype_ != nullptr) {
             attr = supertype_->attribute_by_index_(index);
         }
         if (attr == 0) {
@@ -361,7 +361,7 @@ class IFC_PARSE_API entity : public declaration {
     const std::vector<const attribute*> all_attributes() const {
         std::vector<const attribute*> attrs;
         attrs.reserve(derived_.size());
-        if (supertype_) {
+        if (supertype_ != nullptr) {
             const std::vector<const attribute*> supertype_attrs = supertype_->all_attributes();
             std::copy(supertype_attrs.begin(), supertype_attrs.end(), std::back_inserter(attrs));
         }
@@ -371,7 +371,7 @@ class IFC_PARSE_API entity : public declaration {
 
     const std::vector<const inverse_attribute*> all_inverse_attributes() const {
         std::vector<const inverse_attribute*> attrs;
-        if (supertype_) {
+        if (supertype_ != nullptr) {
             const std::vector<const inverse_attribute*> supertype_inv_attrs = supertype_->all_inverse_attributes();
             std::copy(supertype_inv_attrs.begin(), supertype_inv_attrs.end(), std::back_inserter(attrs));
         }
@@ -389,7 +389,7 @@ class IFC_PARSE_API entity : public declaration {
 
     size_t attribute_count() const {
         size_t super_count = 0;
-        if (supertype_) {
+        if (supertype_ != nullptr) {
             super_count = supertype_->attribute_count();
         }
         return super_count + attributes_.size();

--- a/src/ifcparse/IfcSchema.h
+++ b/src/ifcparse/IfcSchema.h
@@ -147,8 +147,8 @@ class IFC_PARSE_API declaration {
     mutable const schema_definition* schema_;
 
     std::string& temp_string_() const {
-        static my_thread_local std::string s;
-        return s;
+        static my_thread_local std::string string;
+        return string;
     }
 
   public:
@@ -226,14 +226,14 @@ class IFC_PARSE_API enumeration_type : public declaration {
         return enumeration_items_[i].c_str();
     }
 
-    size_t lookup_enum_offset(const std::string& s) const {
-        size_t i = 0;
-        for (auto it = enumeration_items_.begin(); it != enumeration_items_.end(); ++it, ++i) {
-            if (s == *it) {
-                return i;
+    size_t lookup_enum_offset(const std::string& string) const {
+        size_t index = 0;
+        for (auto it = enumeration_items_.begin(); it != enumeration_items_.end(); ++it, ++index) {
+            if (string == *it) {
+                return index;
             }
         }
-        throw IfcParse::IfcException("Unable to find keyword in schema: " + s);
+        throw IfcParse::IfcException("Unable to find keyword in schema: " + string);
     }
 
     virtual const enumeration_type* as_enumeration_type() const { return this; }
@@ -404,10 +404,10 @@ class IFC_PARSE_API entity : public declaration {
             if (index > -1) {
                 index += current->attributes().size();
             } else {
-                std::vector<const attribute*>::const_iterator it;
-                it = std::find(current->attributes().begin(), current->attributes().end(), attr);
-                if (it != current->attributes().end()) {
-                    index = std::distance(current->attributes().begin(), it);
+                std::vector<const attribute*>::const_iterator iter;
+                iter = std::find(current->attributes().begin(), current->attributes().end(), attr);
+                if (iter != current->attributes().end()) {
+                    index = std::distance(current->attributes().begin(), iter);
                 }
             }
         } while ((current = current->supertype_) != 0);
@@ -422,10 +422,10 @@ class IFC_PARSE_API entity : public declaration {
             if (index > -1) {
                 index += current->attributes().size();
             } else {
-                std::vector<const attribute*>::const_iterator it;
-                it = std::find_if(current->attributes().begin(), current->attributes().end(), cmp);
-                if (it != current->attributes().end()) {
-                    index = std::distance(current->attributes().begin(), it);
+                std::vector<const attribute*>::const_iterator iter;
+                iter = std::find_if(current->attributes().begin(), current->attributes().end(), cmp);
+                if (iter != current->attributes().end()) {
+                    index = std::distance(current->attributes().begin(), iter);
                 }
             }
         } while ((current = current->supertype_) != 0);
@@ -464,16 +464,16 @@ class IFC_PARSE_API schema_definition {
 
     class declaration_by_index_sort {
       public:
-        bool operator()(const declaration* a, const declaration* b) {
-            return a->index_in_schema() < b->index_in_schema();
+        bool operator()(const declaration* lhs, const declaration* rhs) {
+            return lhs->index_in_schema() < rhs->index_in_schema();
         }
     };
 
     instance_factory* factory_;
 
     std::string& temp_string_() const {
-        static my_thread_local std::string s;
-        return s;
+        static my_thread_local std::string string;
+        return string;
     }
 
   public:
@@ -483,16 +483,16 @@ class IFC_PARSE_API schema_definition {
 
     const declaration* declaration_by_name(const std::string& name) const {
         const std::string* name_ptr = &name;
-        if (std::any_of(name.begin(), name.end(), [](char c) { return std::islower(c); })) {
+        if (std::any_of(name.begin(), name.end(), [](char character) { return std::islower(character); })) {
             temp_string_() = name;
             boost::to_upper(temp_string_());
             name_ptr = &temp_string_();
         }
-        std::vector<const declaration*>::const_iterator it = std::lower_bound(declarations_.begin(), declarations_.end(), *name_ptr, declaration_by_name_cmp());
-        if (it == declarations_.end() || (**it).name_uc() != *name_ptr) {
+        std::vector<const declaration*>::const_iterator iter = std::lower_bound(declarations_.begin(), declarations_.end(), *name_ptr, declaration_by_name_cmp());
+        if (iter == declarations_.end() || (**iter).name_uc() != *name_ptr) {
             throw IfcParse::IfcException("Entity with name '" + name + "' not found in schema '" + name_ + "'");
         }
-        return *it;
+        return *iter;
     }
 
     const declaration* declaration_by_name(int name) const {

--- a/src/ifcparse/IfcSpfHeader.cpp
+++ b/src/ifcparse/IfcSpfHeader.cpp
@@ -113,21 +113,21 @@ bool IfcSpfHeader::tryRead() {
     }
 }
 
-void IfcSpfHeader::write(std::ostream& os) const {
-    os << ISO_10303_21 << ";"
-       << "\n";
-    os << HEADER << ";"
-       << "\n";
-    os << file_description().toString(true) << ";"
-       << "\n";
-    os << file_name().toString(true) << ";"
-       << "\n";
-    os << file_schema().toString(true) << ";"
-       << "\n";
-    os << ENDSEC << ";"
-       << "\n";
-    os << DATA << ";"
-       << "\n";
+void IfcSpfHeader::write(std::ostream& out) const {
+    out << ISO_10303_21 << ";"
+        << "\n";
+    out << HEADER << ";"
+        << "\n";
+    out << file_description().toString(true) << ";"
+        << "\n";
+    out << file_name().toString(true) << ";"
+        << "\n";
+    out << file_schema().toString(true) << ";"
+        << "\n";
+    out << ENDSEC << ";"
+        << "\n";
+    out << DATA << ";"
+        << "\n";
 }
 
 const FileDescription& IfcSpfHeader::file_description() const {

--- a/src/ifcparse/IfcSpfHeader.cpp
+++ b/src/ifcparse/IfcSpfHeader.cpp
@@ -20,6 +20,7 @@
 #include "IfcSpfHeader.h"
 
 #include "IfcFile.h"
+#include "IfcLogger.h"
 
 static const char* const ISO_10303_21 = "ISO-10303-21";
 static const char* const HEADER = "HEADER";

--- a/src/ifcparse/IfcSpfHeader.cpp
+++ b/src/ifcparse/IfcSpfHeader.cpp
@@ -133,49 +133,43 @@ void IfcSpfHeader::write(std::ostream& os) const {
 const FileDescription& IfcSpfHeader::file_description() const {
     if (_file_description) {
         return *_file_description;
-    } else {
-        throw IfcException("File description not set");
     }
+    throw IfcException("File description not set");
 }
 
 const FileName& IfcSpfHeader::file_name() const {
     if (_file_name) {
         return *_file_name;
-    } else {
-        throw IfcException("File name not set");
     }
+    throw IfcException("File name not set");
 }
 
 const FileSchema& IfcSpfHeader::file_schema() const {
     if (_file_schema) {
         return *_file_schema;
-    } else {
-        throw IfcException("File schema not set");
     }
+    throw IfcException("File schema not set");
 }
 
 FileDescription& IfcSpfHeader::file_description() {
     if (_file_description) {
         return *_file_description;
-    } else {
-        throw IfcException("File description not set");
     }
+    throw IfcException("File description not set");
 }
 
 FileName& IfcSpfHeader::file_name() {
     if (_file_name) {
         return *_file_name;
-    } else {
-        throw IfcException("File name not set");
     }
+    throw IfcException("File name not set");
 }
 
 FileSchema& IfcSpfHeader::file_schema() {
     if (_file_schema) {
         return *_file_schema;
-    } else {
-        throw IfcException("File schema not set");
     }
+    throw IfcException("File schema not set");
 }
 
 FileDescription::FileDescription(IfcFile* file) : HeaderEntity(FILE_DESCRIPTION, 2, file) {}

--- a/src/ifcparse/IfcSpfHeader.cpp
+++ b/src/ifcparse/IfcSpfHeader.cpp
@@ -38,7 +38,7 @@ using namespace IfcParse;
 
 HeaderEntity::HeaderEntity(const char* const datatype, size_t size, IfcFile* file)
     : IfcEntityInstanceData(file, size),
-      _datatype(datatype),
+      datatype_(datatype),
       size_(size) {
     if (file != nullptr) {
         offset_in_file_ = file->stream->Tell();
@@ -88,18 +88,18 @@ void IfcSpfHeader::read() {
     // ISO 10303-21 Second edition 2002-01-15 p. 16
 
     readTerminal(FILE_DESCRIPTION, NONE);
-    delete _file_description;
-    _file_description = new FileDescription(file_);
+    delete file_description_;
+    file_description_ = new FileDescription(file_);
     // readSemicolon();
 
     readTerminal(FILE_NAME, NONE);
-    delete _file_name;
-    _file_name = new FileName(file_);
+    delete file_name_;
+    file_name_ = new FileName(file_);
     // readSemicolon();
 
     readTerminal(FILE_SCHEMA, NONE);
-    delete _file_schema;
-    _file_schema = new FileSchema(file_);
+    delete file_schema_;
+    file_schema_ = new FileSchema(file_);
     // readSemicolon();
 }
 
@@ -131,45 +131,45 @@ void IfcSpfHeader::write(std::ostream& os) const {
 }
 
 const FileDescription& IfcSpfHeader::file_description() const {
-    if (_file_description == nullptr) {
+    if (file_description_ == nullptr) {
         throw IfcException("File description not set");
     }
-    return *_file_description;
+    return *file_description_;
 }
 
 const FileName& IfcSpfHeader::file_name() const {
-    if (_file_name == nullptr) {
+    if (file_name_ == nullptr) {
         throw IfcException("File name not set");
     }
-    return *_file_name;
+    return *file_name_;
 }
 
 const FileSchema& IfcSpfHeader::file_schema() const {
-    if (_file_schema == nullptr) {
+    if (file_schema_ == nullptr) {
         throw IfcException("File schema not set");
     }
-    return *_file_schema;
+    return *file_schema_;
 }
 
 FileDescription& IfcSpfHeader::file_description() {
-    if (_file_description == nullptr) {
+    if (file_description_ == nullptr) {
         throw IfcException("File description not set");
     }
-    return *_file_description;
+    return *file_description_;
 }
 
 FileName& IfcSpfHeader::file_name() {
-    if (_file_name == nullptr) {
+    if (file_name_ == nullptr) {
         throw IfcException("File name not set");
     }
-    return *_file_name;
+    return *file_name_;
 }
 
 FileSchema& IfcSpfHeader::file_schema() {
-    if (_file_schema == nullptr) {
+    if (file_schema_ == nullptr) {
         throw IfcException("File schema not set");
     }
-    return *_file_schema;
+    return *file_schema_;
 }
 
 FileDescription::FileDescription(IfcFile* file) : HeaderEntity(FILE_DESCRIPTION, 2, file) {}

--- a/src/ifcparse/IfcSpfHeader.cpp
+++ b/src/ifcparse/IfcSpfHeader.cpp
@@ -40,7 +40,7 @@ HeaderEntity::HeaderEntity(const char* const datatype, size_t size, IfcFile* fil
     : IfcEntityInstanceData(file, size),
       _datatype(datatype),
       size_(size) {
-    if (file) {
+    if (file != nullptr) {
         offset_in_file_ = file->stream->Tell();
         load();
     }
@@ -131,45 +131,45 @@ void IfcSpfHeader::write(std::ostream& os) const {
 }
 
 const FileDescription& IfcSpfHeader::file_description() const {
-    if (_file_description) {
-        return *_file_description;
+    if (_file_description == nullptr) {
+        throw IfcException("File description not set");
     }
-    throw IfcException("File description not set");
+    return *_file_description;
 }
 
 const FileName& IfcSpfHeader::file_name() const {
-    if (_file_name) {
-        return *_file_name;
+    if (_file_name == nullptr) {
+        throw IfcException("File name not set");
     }
-    throw IfcException("File name not set");
+    return *_file_name;
 }
 
 const FileSchema& IfcSpfHeader::file_schema() const {
-    if (_file_schema) {
-        return *_file_schema;
+    if (_file_schema == nullptr) {
+        throw IfcException("File schema not set");
     }
-    throw IfcException("File schema not set");
+    return *_file_schema;
 }
 
 FileDescription& IfcSpfHeader::file_description() {
-    if (_file_description) {
-        return *_file_description;
+    if (_file_description == nullptr) {
+        throw IfcException("File description not set");
     }
-    throw IfcException("File description not set");
+    return *_file_description;
 }
 
 FileName& IfcSpfHeader::file_name() {
-    if (_file_name) {
-        return *_file_name;
+    if (_file_name == nullptr) {
+        throw IfcException("File name not set");
     }
-    throw IfcException("File name not set");
+    return *_file_name;
 }
 
 FileSchema& IfcSpfHeader::file_schema() {
-    if (_file_schema) {
-        return *_file_schema;
+    if (_file_schema == nullptr) {
+        throw IfcException("File schema not set");
     }
-    throw IfcException("File schema not set");
+    return *_file_schema;
 }
 
 FileDescription::FileDescription(IfcFile* file) : HeaderEntity(FILE_DESCRIPTION, 2, file) {}

--- a/src/ifcparse/IfcSpfHeader.h
+++ b/src/ifcparse/IfcSpfHeader.h
@@ -21,7 +21,6 @@
 #define IFCSPFHEADER_H
 
 #include "ifc_parse_api.h"
-#include "IfcSpfStream.h"
 #include "IfcWrite.h"
 
 namespace IfcParse {

--- a/src/ifcparse/IfcSpfHeader.h
+++ b/src/ifcparse/IfcSpfHeader.h
@@ -27,7 +27,7 @@ namespace IfcParse {
 
 class IFC_PARSE_API HeaderEntity : public IfcEntityInstanceData {
   private:
-    const char* const _datatype;
+    const char* const datatype_;
     size_t size_;
 
     HeaderEntity(const HeaderEntity&);            //N/A
@@ -55,7 +55,7 @@ class IFC_PARSE_API HeaderEntity : public IfcEntityInstanceData {
 
     std::string toString(bool upper = false) const {
         std::stringstream ss;
-        ss << _datatype << IfcEntityInstanceData::toString(upper);
+        ss << datatype_ << IfcEntityInstanceData::toString(upper);
         return ss.str();
     }
 };
@@ -104,9 +104,9 @@ class IFC_PARSE_API FileSchema : public HeaderEntity {
 class IFC_PARSE_API IfcSpfHeader {
   private:
     IfcFile* file_;
-    FileDescription* _file_description;
-    FileName* _file_name;
-    FileSchema* _file_schema;
+    FileDescription* file_description_;
+    FileName* file_name_;
+    FileSchema* file_schema_;
     void readParen();
     void readSemicolon();
     enum Trail {
@@ -119,18 +119,18 @@ class IFC_PARSE_API IfcSpfHeader {
   public:
     explicit IfcSpfHeader(IfcParse::IfcFile* file = 0)
         : file_(file),
-          _file_description(0),
-          _file_name(0),
-          _file_schema(0) {
-        _file_description = new FileDescription(file_);
-        _file_name = new FileName(file_);
-        _file_schema = new FileSchema(file_);
+          file_description_(0),
+          file_name_(0),
+          file_schema_(0) {
+        file_description_ = new FileDescription(file_);
+        file_name_ = new FileName(file_);
+        file_schema_ = new FileSchema(file_);
     }
 
     ~IfcSpfHeader() {
-        delete _file_schema;
-        delete _file_name;
-        delete _file_description;
+        delete file_schema_;
+        delete file_name_;
+        delete file_description_;
     }
 
     IfcParse::IfcFile* file() { return file_; }

--- a/src/ifcparse/IfcSpfHeader.h
+++ b/src/ifcparse/IfcSpfHeader.h
@@ -36,16 +36,16 @@ class IFC_PARSE_API HeaderEntity : public IfcEntityInstanceData {
     HeaderEntity(const char* const datatype, size_t size, IfcParse::IfcFile* file);
     virtual ~HeaderEntity();
 
-    void setValue(unsigned int i, const std::string& s) {
+    void setValue(unsigned int index, const std::string& string) {
         IfcWrite::IfcWriteArgument* argument = new IfcWrite::IfcWriteArgument;
-        argument->set(s);
-        setArgument(i, argument);
+        argument->set(string);
+        setArgument(index, argument);
     }
 
-    void setValue(unsigned int i, const std::vector<std::string>& s) {
+    void setValue(unsigned int index, const std::vector<std::string>& strings) {
         IfcWrite::IfcWriteArgument* argument = new IfcWrite::IfcWriteArgument;
-        argument->set(s);
-        setArgument(i, argument);
+        argument->set(strings);
+        setArgument(index, argument);
     }
 
   public:
@@ -54,9 +54,9 @@ class IFC_PARSE_API HeaderEntity : public IfcEntityInstanceData {
     }
 
     std::string toString(bool upper = false) const {
-        std::stringstream ss;
-        ss << datatype_ << IfcEntityInstanceData::toString(upper);
-        return ss.str();
+        std::stringstream stream;
+        stream << datatype_ << IfcEntityInstanceData::toString(upper);
+        return stream.str();
     }
 };
 
@@ -139,7 +139,7 @@ class IFC_PARSE_API IfcSpfHeader {
     void read();
     bool tryRead();
 
-    void write(std::ostream& os) const;
+    void write(std::ostream& out) const;
 
     const FileDescription& file_description() const;
     const FileName& file_name() const;

--- a/src/ifcparse/IfcSpfStream.h
+++ b/src/ifcparse/IfcSpfStream.h
@@ -44,10 +44,10 @@ class IFC_PARSE_API IfcSpfStream {
 #ifdef USE_MMAP
     boost::iostreams::mapped_file_source mfs;
 #endif
-    FILE* stream;
-    const char* buffer;
-    unsigned int ptr;
-    unsigned int len;
+    FILE* stream_;
+    const char* buffer_;
+    unsigned int ptr_;
+    unsigned int len_;
 
   public:
     bool valid;

--- a/src/ifcparse/IfcSpfStream.h
+++ b/src/ifcparse/IfcSpfStream.h
@@ -54,12 +54,12 @@ class IFC_PARSE_API IfcSpfStream {
     bool eof;
     unsigned int size;
 #ifdef USE_MMAP
-    IfcSpfStream(const std::string& fn, bool mmap = false);
+    IfcSpfStream(const std::string& path, bool mmap = false);
 #else
-    IfcSpfStream(const std::string& fn);
+    IfcSpfStream(const std::string& path);
 #endif
-    IfcSpfStream(std::istream& f, int len);
-    IfcSpfStream(void* data, int len);
+    IfcSpfStream(std::istream& stream, int length);
+    IfcSpfStream(void* data, int length);
     ~IfcSpfStream();
     /// Returns the character at the cursor
     char Peek();

--- a/src/ifcparse/IfcSpfStream.h
+++ b/src/ifcparse/IfcSpfStream.h
@@ -29,7 +29,6 @@
 
 #include "ifc_parse_api.h"
 
-#include <fstream>
 #include <string>
 
 #ifdef USE_MMAP

--- a/src/ifcparse/IfcUtil.cpp
+++ b/src/ifcparse/IfcUtil.cpp
@@ -62,14 +62,14 @@
 #include <boost/optional.hpp>
 
 void aggregate_of_instance::push(IfcUtil::IfcBaseClass* l) {
-    if (l) {
+    if (l != nullptr) {
         ls.push_back(l);
     }
 }
 void aggregate_of_instance::push(const aggregate_of_instance::ptr& l) {
     if (l) {
         for (it i = l->begin(); i != l->end(); ++i) {
-            if (*i) {
+            if (*i != nullptr) {
                 ls.push_back(*i);
             }
         }
@@ -253,23 +253,23 @@ IfcUtil::ArgumentType IfcUtil::from_parameter_type(const IfcParse::parameter_typ
     const IfcParse::named_type* nt = pt->as_named_type();
     const IfcParse::simple_type* st = pt->as_simple_type();
 
-    if (at) {
+    if (at != nullptr) {
         return make_aggregate(from_parameter_type(at->type_of_element()));
     }
-    if (nt) {
-        if (nt->declared_type()->as_entity()) {
+    if (nt != nullptr) {
+        if (nt->declared_type()->as_entity() != nullptr) {
             return IfcUtil::Argument_ENTITY_INSTANCE;
         }
-        if (nt->declared_type()->as_enumeration_type()) {
+        if (nt->declared_type()->as_enumeration_type() != nullptr) {
             return IfcUtil::Argument_ENUMERATION;
         }
-        if (nt->declared_type()->as_select_type()) {
+        if (nt->declared_type()->as_select_type() != nullptr) {
             return IfcUtil::Argument_ENTITY_INSTANCE;
         }
-        if (nt->declared_type()->as_type_declaration()) {
+        if (nt->declared_type()->as_type_declaration() != nullptr) {
             return from_parameter_type(nt->declared_type()->as_type_declaration()->declared_type());
         }
-    } else if (st) {
+    } else if (st != nullptr) {
         switch (st->declared_type()) {
         case IfcParse::simple_type::binary_type:
             return IfcUtil::Argument_BINARY;
@@ -336,7 +336,7 @@ IFC_PARSE_API bool IfcUtil::path::rename_file(const std::string& old_filename, c
 }
 
 IFC_PARSE_API bool IfcUtil::path::delete_file(const std::string& filename) {
-    return std::remove(filename.c_str());
+    return std::remove(filename.c_str()) != 0;
 }
 
 #endif

--- a/src/ifcparse/IfcUtil.cpp
+++ b/src/ifcparse/IfcUtil.cpp
@@ -60,7 +60,6 @@
 #include <algorithm>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/optional.hpp>
-#include <iostream>
 
 void aggregate_of_instance::push(IfcUtil::IfcBaseClass* l) {
     if (l) {

--- a/src/ifcparse/IfcUtil.cpp
+++ b/src/ifcparse/IfcUtil.cpp
@@ -63,32 +63,32 @@
 
 void aggregate_of_instance::push(IfcUtil::IfcBaseClass* l) {
     if (l != nullptr) {
-        ls.push_back(l);
+        list_.push_back(l);
     }
 }
 void aggregate_of_instance::push(const aggregate_of_instance::ptr& l) {
     if (l) {
         for (it i = l->begin(); i != l->end(); ++i) {
             if (*i != nullptr) {
-                ls.push_back(*i);
+                list_.push_back(*i);
             }
         }
     }
 }
-unsigned int aggregate_of_instance::size() const { return (unsigned int)ls.size(); }
-void aggregate_of_instance::reserve(unsigned capacity) { ls.reserve((size_t)capacity); }
-aggregate_of_instance::it aggregate_of_instance::begin() { return ls.begin(); }
-aggregate_of_instance::it aggregate_of_instance::end() { return ls.end(); }
+unsigned int aggregate_of_instance::size() const { return (unsigned int)list_.size(); }
+void aggregate_of_instance::reserve(unsigned capacity) { list_.reserve((size_t)capacity); }
+aggregate_of_instance::it aggregate_of_instance::begin() { return list_.begin(); }
+aggregate_of_instance::it aggregate_of_instance::end() { return list_.end(); }
 IfcUtil::IfcBaseClass* aggregate_of_instance::operator[](int i) {
-    return ls[i];
+    return list_[i];
 }
 bool aggregate_of_instance::contains(IfcUtil::IfcBaseClass* instance) const {
-    return std::find(ls.begin(), ls.end(), instance) != ls.end();
+    return std::find(list_.begin(), list_.end(), instance) != list_.end();
 }
 void aggregate_of_instance::remove(IfcUtil::IfcBaseClass* instance) {
     std::vector<IfcUtil::IfcBaseClass*>::iterator it;
-    while ((it = std::find(ls.begin(), ls.end(), instance)) != ls.end()) {
-        ls.erase(it);
+    while ((it = std::find(list_.begin(), list_.end(), instance)) != list_.end()) {
+        list_.erase(it);
     }
 }
 

--- a/src/ifcparse/IfcUtil.cpp
+++ b/src/ifcparse/IfcUtil.cpp
@@ -61,14 +61,14 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/optional.hpp>
 
-void aggregate_of_instance::push(IfcUtil::IfcBaseClass* l) {
-    if (l != nullptr) {
-        list_.push_back(l);
+void aggregate_of_instance::push(IfcUtil::IfcBaseClass* instance) {
+    if (instance != nullptr) {
+        list_.push_back(instance);
     }
 }
-void aggregate_of_instance::push(const aggregate_of_instance::ptr& l) {
-    if (l) {
-        for (it i = l->begin(); i != l->end(); ++i) {
+void aggregate_of_instance::push(const aggregate_of_instance::ptr& instance) {
+    if (instance) {
+        for (it i = instance->begin(); i != instance->end(); ++i) {
             if (*i != nullptr) {
                 list_.push_back(*i);
             }
@@ -86,9 +86,9 @@ bool aggregate_of_instance::contains(IfcUtil::IfcBaseClass* instance) const {
     return std::find(list_.begin(), list_.end(), instance) != list_.end();
 }
 void aggregate_of_instance::remove(IfcUtil::IfcBaseClass* instance) {
-    std::vector<IfcUtil::IfcBaseClass*>::iterator it;
-    while ((it = std::find(list_.begin(), list_.end(), instance)) != list_.end()) {
-        list_.erase(it);
+    std::vector<IfcUtil::IfcBaseClass*>::iterator iter;
+    while ((iter = std::find(list_.begin(), list_.end(), instance)) != list_.end()) {
+        list_.erase(iter);
     }
 }
 
@@ -168,8 +168,8 @@ const char* IfcUtil::ArgumentTypeToString(ArgumentType argument_type) {
     return argument_type_string[static_cast<int>(argument_type)];
 }
 
-bool IfcUtil::valid_binary_string(const std::string& s) {
-    for (std::string::const_iterator it = s.begin(); it != s.end(); ++it) {
+bool IfcUtil::valid_binary_string(const std::string& str) {
+    for (std::string::const_iterator it = str.begin(); it != str.end(); ++it) {
         if (*it != '0' && *it != '1') {
             return false;
         }
@@ -205,20 +205,20 @@ Argument* IfcUtil::IfcBaseEntity::get(const std::string& name) const {
 
 aggregate_of_instance::ptr IfcUtil::IfcBaseEntity::get_inverse(const std::string& name) const {
     const std::vector<const IfcParse::inverse_attribute*> attrs = declaration().as_entity()->all_inverse_attributes();
-    std::vector<const IfcParse::inverse_attribute*>::const_iterator it = attrs.begin();
-    for (; it != attrs.end(); ++it) {
-        if ((*it)->name() == name) {
+    std::vector<const IfcParse::inverse_attribute*>::const_iterator iter = attrs.begin();
+    for (; iter != attrs.end(); ++iter) {
+        if ((*iter)->name() == name) {
             return data().getInverse(
-                (*it)->entity_reference(),
-                (int)(*it)->entity_reference()->attribute_index((*it)->attribute_reference()));
+                (*iter)->entity_reference(),
+                (int)(*iter)->entity_reference()->attribute_index((*iter)->attribute_reference()));
         }
     }
     throw IfcParse::IfcException(name + " not found on " + declaration().name());
 }
 
-void IfcUtil::IfcBaseClass::data(IfcEntityInstanceData* d) {
+void IfcUtil::IfcBaseClass::data(IfcEntityInstanceData* data) {
     delete data_;
-    data_ = d;
+    data_ = data;
 }
 
 IfcUtil::ArgumentType IfcUtil::make_aggregate(IfcUtil::ArgumentType elem_type) {

--- a/src/ifcparse/IfcUtil.cpp
+++ b/src/ifcparse/IfcUtil.cpp
@@ -222,25 +222,26 @@ void IfcUtil::IfcBaseClass::data(IfcEntityInstanceData* d) {
 }
 
 IfcUtil::ArgumentType IfcUtil::make_aggregate(IfcUtil::ArgumentType elem_type) {
-    if (elem_type == IfcUtil::Argument_INT) {
+    switch (elem_type) {
+    case IfcUtil::Argument_INT:
         return IfcUtil::Argument_AGGREGATE_OF_INT;
-    } else if (elem_type == IfcUtil::Argument_DOUBLE) {
+    case IfcUtil::Argument_DOUBLE:
         return IfcUtil::Argument_AGGREGATE_OF_DOUBLE;
-    } else if (elem_type == IfcUtil::Argument_STRING) {
+    case IfcUtil::Argument_STRING:
         return IfcUtil::Argument_AGGREGATE_OF_STRING;
-    } else if (elem_type == IfcUtil::Argument_BINARY) {
+    case IfcUtil::Argument_BINARY:
         return IfcUtil::Argument_AGGREGATE_OF_BINARY;
-    } else if (elem_type == IfcUtil::Argument_ENTITY_INSTANCE) {
+    case IfcUtil::Argument_ENTITY_INSTANCE:
         return IfcUtil::Argument_AGGREGATE_OF_ENTITY_INSTANCE;
-    } else if (elem_type == IfcUtil::Argument_AGGREGATE_OF_INT) {
+    case IfcUtil::Argument_AGGREGATE_OF_INT:
         return IfcUtil::Argument_AGGREGATE_OF_AGGREGATE_OF_INT;
-    } else if (elem_type == IfcUtil::Argument_AGGREGATE_OF_DOUBLE) {
+    case IfcUtil::Argument_AGGREGATE_OF_DOUBLE:
         return IfcUtil::Argument_AGGREGATE_OF_AGGREGATE_OF_DOUBLE;
-    } else if (elem_type == IfcUtil::Argument_AGGREGATE_OF_ENTITY_INSTANCE) {
+    case IfcUtil::Argument_AGGREGATE_OF_ENTITY_INSTANCE:
         return IfcUtil::Argument_AGGREGATE_OF_AGGREGATE_OF_ENTITY_INSTANCE;
-    } else if (elem_type == IfcUtil::Argument_EMPTY_AGGREGATE) {
+    case IfcUtil::Argument_EMPTY_AGGREGATE:
         return IfcUtil::Argument_AGGREGATE_OF_EMPTY_AGGREGATE;
-    } else {
+    default:
         return IfcUtil::Argument_UNKNOWN;
     }
 }
@@ -254,14 +255,18 @@ IfcUtil::ArgumentType IfcUtil::from_parameter_type(const IfcParse::parameter_typ
 
     if (at) {
         return make_aggregate(from_parameter_type(at->type_of_element()));
-    } else if (nt) {
+    }
+    if (nt) {
         if (nt->declared_type()->as_entity()) {
             return IfcUtil::Argument_ENTITY_INSTANCE;
-        } else if (nt->declared_type()->as_enumeration_type()) {
+        }
+        if (nt->declared_type()->as_enumeration_type()) {
             return IfcUtil::Argument_ENUMERATION;
-        } else if (nt->declared_type()->as_select_type()) {
+        }
+        if (nt->declared_type()->as_select_type()) {
             return IfcUtil::Argument_ENTITY_INSTANCE;
-        } else if (nt->declared_type()->as_type_declaration()) {
+        }
+        if (nt->declared_type()->as_type_declaration()) {
             return from_parameter_type(nt->declared_type()->as_type_declaration()->declared_type());
         }
     } else if (st) {

--- a/src/ifcparse/IfcWrite.cpp
+++ b/src/ifcparse/IfcWrite.cpp
@@ -281,9 +281,8 @@ unsigned int IfcWriteArgument::size() const {
     const int size = container.apply_visitor(v);
     if (size == -1) {
         throw IfcParse::IfcException("Invalid cast");
-    } else {
-        return size;
     }
+    return size;
 }
 
 IfcUtil::ArgumentType IfcWriteArgument::type() const {

--- a/src/ifcparse/IfcWrite.cpp
+++ b/src/ifcparse/IfcWrite.cpp
@@ -20,8 +20,6 @@
 #include "IfcWrite.h"
 
 #include "IfcCharacterDecoder.h"
-#include "IfcFile.h"
-#include "IfcParse.h"
 
 #include <boost/algorithm/string.hpp>
 #include <iomanip>

--- a/src/ifcparse/IfcWrite.cpp
+++ b/src/ifcparse/IfcWrite.cpp
@@ -273,12 +273,12 @@ std::string IfcWriteArgument::toString(bool upper) const {
     std::ostringstream str;
     str.imbue(std::locale::classic());
     StringBuilderVisitor v(str, upper);
-    container.apply_visitor(v);
+    container_.apply_visitor(v);
     return v;
 }
 unsigned int IfcWriteArgument::size() const {
     SizeVisitor v;
-    const int size = container.apply_visitor(v);
+    const int size = container_.apply_visitor(v);
     if (size == -1) {
         throw IfcParse::IfcException("Invalid cast");
     }
@@ -286,32 +286,32 @@ unsigned int IfcWriteArgument::size() const {
 }
 
 IfcUtil::ArgumentType IfcWriteArgument::type() const {
-    return static_cast<IfcUtil::ArgumentType>(container.which());
+    return static_cast<IfcUtil::ArgumentType>(container_.which());
 }
 
 // Overload to detect null values
 void IfcWriteArgument::set(const aggregate_of_instance::ptr& v) {
     if (v) {
-        container = v;
+        container_ = v;
     } else {
-        container = boost::blank();
+        container_ = boost::blank();
     }
 }
 
 // Overload to detect null values
 void IfcWriteArgument::set(const aggregate_of_aggregate_of_instance::ptr& v) {
     if (v) {
-        container = v;
+        container_ = v;
     } else {
-        container = boost::blank();
+        container_ = boost::blank();
     }
 }
 
 // Overload to detect null values
 void IfcWriteArgument::set(IfcUtil::IfcBaseInterface* const& v) {
     if (v != nullptr) {
-        container = v->as<IfcUtil::IfcBaseClass>();
+        container_ = v->as<IfcUtil::IfcBaseClass>();
     } else {
-        container = boost::blank();
+        container_ = boost::blank();
     }
 }

--- a/src/ifcparse/IfcWrite.cpp
+++ b/src/ifcparse/IfcWrite.cpp
@@ -145,7 +145,7 @@ class StringBuilderVisitor : public boost::static_visitor<void> {
     }
     void operator()(const IfcUtil::IfcBaseClass* const& i) {
         const IfcEntityInstanceData& e = i->data();
-        if (!e.type()->as_entity()) {
+        if (e.type()->as_entity() == nullptr) {
             data << e.toString(upper);
         } else {
             data << "#" << e.id();
@@ -309,7 +309,7 @@ void IfcWriteArgument::set(const aggregate_of_aggregate_of_instance::ptr& v) {
 
 // Overload to detect null values
 void IfcWriteArgument::set(IfcUtil::IfcBaseInterface* const& v) {
-    if (v) {
+    if (v != nullptr) {
         container = v->as<IfcUtil::IfcBaseClass>();
     } else {
         container = boost::blank();

--- a/src/ifcparse/IfcWrite.h
+++ b/src/ifcparse/IfcWrite.h
@@ -122,9 +122,8 @@ class IFC_PARSE_API IfcWriteArgument : public Argument {
     const T& as() const {
         if (const T* val = boost::get<T>(&container)) {
             return *val;
-        } else {
-            throw IfcParse::IfcException("Invalid cast");
         }
+        throw IfcParse::IfcException("Invalid cast");
     }
 
     template <typename T>

--- a/src/ifcparse/IfcWrite.h
+++ b/src/ifcparse/IfcWrite.h
@@ -128,18 +128,18 @@ class IFC_PARSE_API IfcWriteArgument : public Argument {
 
     template <typename T>
     typename boost::disable_if<boost::is_base_of<IfcUtil::IfcBaseInterface, typename boost::remove_pointer<T>::type>, void>::type
-    set(const T& t) {
-        container_ = t;
+    set(const T& type) {
+        container_ = type;
     }
 
     // Overload to detect null values
-    void set(const aggregate_of_instance::ptr& v);
+    void set(const aggregate_of_instance::ptr& value);
 
     // Overload to detect null values
-    void set(const aggregate_of_aggregate_of_instance::ptr& v);
+    void set(const aggregate_of_aggregate_of_instance::ptr& value);
 
     // Overload to detect null values
-    void set(IfcUtil::IfcBaseInterface* const& v);
+    void set(IfcUtil::IfcBaseInterface* const& value);
 
     operator int() const;
     operator bool() const;
@@ -161,7 +161,7 @@ class IFC_PARSE_API IfcWriteArgument : public Argument {
     operator aggregate_of_aggregate_of_instance::ptr() const;
 
     bool isNull() const;
-    Argument* operator[](unsigned int i) const;
+    Argument* operator[](unsigned int index) const;
     std::string toString(bool upper = false) const;
     unsigned int size() const;
     IfcUtil::ArgumentType type() const;

--- a/src/ifcparse/IfcWrite.h
+++ b/src/ifcparse/IfcWrite.h
@@ -115,12 +115,12 @@ class IFC_PARSE_API IfcWriteArgument : public Argument {
         std::vector<std::vector<double>>,
         // An aggregate of an aggregate of entities. E.g. ((#1, #2), (#3))
         aggregate_of_aggregate_of_instance::ptr>
-        container;
+        container_;
 
   public:
     template <typename T>
     const T& as() const {
-        if (const T* val = boost::get<T>(&container)) {
+        if (const T* val = boost::get<T>(&container_)) {
             return *val;
         }
         throw IfcParse::IfcException("Invalid cast");
@@ -129,7 +129,7 @@ class IFC_PARSE_API IfcWriteArgument : public Argument {
     template <typename T>
     typename boost::disable_if<boost::is_base_of<IfcUtil::IfcBaseInterface, typename boost::remove_pointer<T>::type>, void>::type
     set(const T& t) {
-        container = t;
+        container_ = t;
     }
 
     // Overload to detect null values

--- a/src/ifcparse/IfcWrite.h
+++ b/src/ifcparse/IfcWrite.h
@@ -28,9 +28,9 @@
 #ifndef IFCWRITE_H
 #define IFCWRITE_H
 
+#include "aggregate_of_instance.h"
 #include "ifc_parse_api.h"
 #include "IfcBaseClass.h"
-#include "IfcParse.h"
 
 #include <boost/dynamic_bitset.hpp>
 #include <boost/optional.hpp>
@@ -38,7 +38,6 @@
 #include <boost/type_traits/remove_pointer.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/variant.hpp>
-// #include <boost/logic/tribool.hpp>
 
 namespace IfcWrite {
 

--- a/src/ifcparse/aggregate_of_instance.h
+++ b/src/ifcparse/aggregate_of_instance.h
@@ -29,7 +29,7 @@ template <class T>
 class aggregate_of;
 
 class IFC_PARSE_API aggregate_of_instance {
-    std::vector<IfcUtil::IfcBaseClass*> ls;
+    std::vector<IfcUtil::IfcBaseClass*> list_;
 
   public:
     typedef boost::shared_ptr<aggregate_of_instance> ptr;
@@ -59,14 +59,14 @@ class IFC_PARSE_API aggregate_of_instance {
 
 template <class T>
 class aggregate_of {
-    std::vector<T*> ls;
+    std::vector<T*> list_;
 
   public:
     typedef boost::shared_ptr<aggregate_of<T>> ptr;
     typedef typename std::vector<T*>::const_iterator it;
     void push(T* t) {
         if (t) {
-            ls.push_back(t);
+            list_.push_back(t);
         }
     }
     void push(ptr t) {
@@ -76,9 +76,9 @@ class aggregate_of {
             }
         }
     }
-    it begin() { return ls.begin(); }
-    it end() { return ls.end(); }
-    unsigned int size() const { return (unsigned int)ls.size(); }
+    it begin() { return list_.begin(); }
+    it end() { return list_.end(); }
+    unsigned int size() const { return (unsigned int)list_.size(); }
     aggregate_of_instance::ptr generalize() {
         aggregate_of_instance::ptr r(new aggregate_of_instance());
         for (it i = begin(); i != end(); ++i) {
@@ -86,7 +86,7 @@ class aggregate_of {
         }
         return r;
     }
-    bool contains(T* t) const { return std::find(ls.begin(), ls.end(), t) != ls.end(); }
+    bool contains(T* t) const { return std::find(list_.begin(), list_.end(), t) != list_.end(); }
     template <class U>
     typename U::list::ptr as() {
         typename U::list::ptr r(new typename U::list);
@@ -100,8 +100,8 @@ class aggregate_of {
     }
     void remove(T* t) {
         typename std::vector<T*>::iterator it;
-        while ((it = std::find(ls.begin(), ls.end(), t)) != ls.end()) {
-            ls.erase(it);
+        while ((it = std::find(list_.begin(), list_.end(), t)) != list_.end()) {
+            list_.erase(it);
         }
     }
 };
@@ -110,14 +110,14 @@ template <class T>
 class aggregate_of_aggregate_of;
 
 class IFC_PARSE_API aggregate_of_aggregate_of_instance {
-    std::vector<std::vector<IfcUtil::IfcBaseClass*>> ls;
+    std::vector<std::vector<IfcUtil::IfcBaseClass*>> list_;
 
   public:
     typedef boost::shared_ptr<aggregate_of_aggregate_of_instance> ptr;
     typedef std::vector<std::vector<IfcUtil::IfcBaseClass*>>::const_iterator outer_it;
     typedef std::vector<IfcUtil::IfcBaseClass*>::const_iterator inner_it;
     void push(const std::vector<IfcUtil::IfcBaseClass*>& l) {
-        ls.push_back(l);
+        list_.push_back(l);
     }
     void push(const aggregate_of_instance::ptr& l) {
         if (l) {
@@ -128,9 +128,9 @@ class IFC_PARSE_API aggregate_of_aggregate_of_instance {
             push(li);
         }
     }
-    outer_it begin() const { return ls.begin(); }
-    outer_it end() const { return ls.end(); }
-    int size() const { return (int)ls.size(); }
+    outer_it begin() const { return list_.begin(); }
+    outer_it end() const { return list_.end(); }
+    int size() const { return (int)list_.size(); }
     int totalSize() const {
         int accum = 0;
         for (outer_it it = begin(); it != end(); ++it) {
@@ -167,16 +167,16 @@ class IFC_PARSE_API aggregate_of_aggregate_of_instance {
 
 template <class T>
 class aggregate_of_aggregate_of {
-    std::vector<std::vector<T*>> ls;
+    std::vector<std::vector<T*>> list_;
 
   public:
     typedef typename boost::shared_ptr<aggregate_of_aggregate_of<T>> ptr;
     typedef typename std::vector<std::vector<T*>>::const_iterator outer_it;
     typedef typename std::vector<T*>::const_iterator inner_it;
-    void push(const std::vector<T*>& t) { ls.push_back(t); }
-    outer_it begin() { return ls.begin(); }
-    outer_it end() { return ls.end(); }
-    int size() const { return (int)ls.size(); }
+    void push(const std::vector<T*>& t) { list_.push_back(t); }
+    outer_it begin() { return list_.begin(); }
+    outer_it end() { return list_.end(); }
+    int size() const { return (int)list_.size(); }
     int totalSize() const {
         int accum = 0;
         for (outer_it it = begin(); it != end(); ++it) {

--- a/src/ifcparse/aggregate_of_instance.h
+++ b/src/ifcparse/aggregate_of_instance.h
@@ -34,23 +34,23 @@ class IFC_PARSE_API aggregate_of_instance {
   public:
     typedef boost::shared_ptr<aggregate_of_instance> ptr;
     typedef std::vector<IfcUtil::IfcBaseClass*>::const_iterator it;
-    void push(IfcUtil::IfcBaseClass* l);
-    void push(const ptr& l);
+    void push(IfcUtil::IfcBaseClass* instance);
+    void push(const ptr& instance);
     it begin();
     it end();
-    IfcUtil::IfcBaseClass* operator[](int i);
+    IfcUtil::IfcBaseClass* operator[](int index);
     unsigned int size() const;
     void reserve(unsigned capacity);
     bool contains(IfcUtil::IfcBaseClass*) const;
     template <class U>
     typename U::list::ptr as() {
-        typename U::list::ptr r(new typename U::list);
+        typename U::list::ptr result(new typename U::list);
         for (it i = begin(); i != end(); ++i) {
             if ((*i)->as<U>()) {
-                r->push((*i)->as<U>());
+                result->push((*i)->as<U>());
             }
         }
-        return r;
+        return result;
     }
     void remove(IfcUtil::IfcBaseClass*);
     aggregate_of_instance::ptr filtered(const std::set<const IfcParse::declaration*>& entities);
@@ -64,14 +64,14 @@ class aggregate_of {
   public:
     typedef boost::shared_ptr<aggregate_of<T>> ptr;
     typedef typename std::vector<T*>::const_iterator it;
-    void push(T* t) {
-        if (t) {
-            list_.push_back(t);
+    void push(T* type) {
+        if (type) {
+            list_.push_back(type);
         }
     }
-    void push(ptr t) {
-        if (t) {
-            for (typename T::list::it it = t->begin(); it != t->end(); ++it) {
+    void push(ptr instance) {
+        if (instance) {
+            for (typename T::list::it it = instance->begin(); it != instance->end(); ++it) {
                 push(*it);
             }
         }
@@ -80,28 +80,28 @@ class aggregate_of {
     it end() { return list_.end(); }
     unsigned int size() const { return (unsigned int)list_.size(); }
     aggregate_of_instance::ptr generalize() {
-        aggregate_of_instance::ptr r(new aggregate_of_instance());
+        aggregate_of_instance::ptr result(new aggregate_of_instance());
         for (it i = begin(); i != end(); ++i) {
-            r->push((*i)->template as<IfcUtil::IfcBaseClass>());
+            result->push((*i)->template as<IfcUtil::IfcBaseClass>());
         }
-        return r;
+        return result;
     }
-    bool contains(T* t) const { return std::find(list_.begin(), list_.end(), t) != list_.end(); }
+    bool contains(T* type) const { return std::find(list_.begin(), list_.end(), type) != list_.end(); }
     template <class U>
     typename U::list::ptr as() {
-        typename U::list::ptr r(new typename U::list);
+        typename U::list::ptr result(new typename U::list);
         const bool all = !U::Class().as_entity();
         for (it i = begin(); i != end(); ++i) {
             if (all || (*i)->declaration().is(U::Class())) {
-                r->push((U*)*i);
+                result->push((U*)*i);
             }
         }
-        return r;
+        return result;
     }
-    void remove(T* t) {
-        typename std::vector<T*>::iterator it;
-        while ((it = std::find(list_.begin(), list_.end(), t)) != list_.end()) {
-            list_.erase(it);
+    void remove(T* type) {
+        typename std::vector<T*>::iterator iter;
+        while ((iter = std::find(list_.begin(), list_.end(), type)) != list_.end()) {
+            list_.erase(iter);
         }
     }
 };
@@ -116,16 +116,16 @@ class IFC_PARSE_API aggregate_of_aggregate_of_instance {
     typedef boost::shared_ptr<aggregate_of_aggregate_of_instance> ptr;
     typedef std::vector<std::vector<IfcUtil::IfcBaseClass*>>::const_iterator outer_it;
     typedef std::vector<IfcUtil::IfcBaseClass*>::const_iterator inner_it;
-    void push(const std::vector<IfcUtil::IfcBaseClass*>& l) {
-        list_.push_back(l);
+    void push(const std::vector<IfcUtil::IfcBaseClass*>& instance) {
+        list_.push_back(instance);
     }
-    void push(const aggregate_of_instance::ptr& l) {
-        if (l) {
-            std::vector<IfcUtil::IfcBaseClass*> li;
-            for (std::vector<IfcUtil::IfcBaseClass*>::const_iterator jt = l->begin(); jt != l->end(); ++jt) {
-                li.push_back(*jt);
+    void push(const aggregate_of_instance::ptr& instance) {
+        if (instance) {
+            std::vector<IfcUtil::IfcBaseClass*> list;
+            for (std::vector<IfcUtil::IfcBaseClass*>::const_iterator iter = instance->begin(); iter != instance->end(); ++iter) {
+                list.push_back(*iter);
             }
-            push(li);
+            push(list);
         }
     }
     outer_it begin() const { return list_.begin(); }
@@ -149,7 +149,7 @@ class IFC_PARSE_API aggregate_of_aggregate_of_instance {
     }
     template <class U>
     typename aggregate_of_aggregate_of<U>::ptr as() {
-        typename aggregate_of_aggregate_of<U>::ptr r(new aggregate_of_aggregate_of<U>);
+        typename aggregate_of_aggregate_of<U>::ptr result(new aggregate_of_aggregate_of<U>);
         const bool all = !U::Class().as_entity();
         for (outer_it outer = begin(); outer != end(); ++outer) {
             const std::vector<IfcUtil::IfcBaseClass*>& from = *outer;
@@ -159,9 +159,9 @@ class IFC_PARSE_API aggregate_of_aggregate_of_instance {
                     to.push_back((U*)*inner);
                 }
             }
-            r->push(to);
+            result->push(to);
         }
-        return r;
+        return result;
     }
 };
 
@@ -173,7 +173,7 @@ class aggregate_of_aggregate_of {
     typedef typename boost::shared_ptr<aggregate_of_aggregate_of<T>> ptr;
     typedef typename std::vector<std::vector<T*>>::const_iterator outer_it;
     typedef typename std::vector<T*>::const_iterator inner_it;
-    void push(const std::vector<T*>& t) { list_.push_back(t); }
+    void push(const std::vector<T*>& type) { list_.push_back(type); }
     outer_it begin() { return list_.begin(); }
     outer_it end() { return list_.end(); }
     int size() const { return (int)list_.size(); }
@@ -184,26 +184,26 @@ class aggregate_of_aggregate_of {
         }
         return accum;
     }
-    bool contains(T* t) const {
-        for (outer_it it = begin(); it != end(); ++it) {
-            const std::vector<T*>& inner = *it;
-            if (std::find(inner.begin(), inner.end(), t) != inner.end()) {
+    bool contains(T* type) const {
+        for (outer_it iter = begin(); iter != end(); ++iter) {
+            const std::vector<T*>& inner = *iter;
+            if (std::find(inner.begin(), inner.end(), type) != inner.end()) {
                 return true;
             }
         }
         return false;
     }
     aggregate_of_aggregate_of_instance::ptr generalize() {
-        aggregate_of_aggregate_of_instance::ptr r(new aggregate_of_aggregate_of_instance());
+        aggregate_of_aggregate_of_instance::ptr result(new aggregate_of_aggregate_of_instance());
         for (outer_it outer = begin(); outer != end(); ++outer) {
             const std::vector<T*>& from = *outer;
             std::vector<IfcUtil::IfcBaseClass*> to;
             for (inner_it inner = from.begin(); inner != from.end(); ++inner) {
                 to.push_back(*inner);
             }
-            r->push(to);
+            result->push(to);
         }
-        return r;
+        return result;
     }
 };
 

--- a/src/ifcparse/parse_ifcxml.cpp
+++ b/src/ifcparse/parse_ifcxml.cpp
@@ -22,6 +22,7 @@
 #ifdef WITH_IFCXML
 
 #include "IfcFile.h"
+#include "IfcLogger.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/range/adaptor/transformed.hpp>

--- a/src/ifcparse/parse_ifcxml.cpp
+++ b/src/ifcparse/parse_ifcxml.cpp
@@ -91,64 +91,64 @@ class stack_node {
 
   public:
     static stack_node instance(const std::string& id_in_file, IfcUtil::IfcBaseClass* inst) {
-        stack_node n;
-        n.type_ = node_instance;
-        n.inst_ = inst;
-        n.id_in_file_ = id_in_file;
-        return n;
+        stack_node node;
+        node.type_ = node_instance;
+        node.inst_ = inst;
+        node.id_in_file_ = id_in_file;
+        return node;
     }
 
     static stack_node instance_attribute(IfcUtil::IfcBaseClass* inst, int idx) {
-        stack_node n;
-        n.type_ = node_instance_attribute;
-        n.inst_ = inst;
-        n.idx_ = idx;
-        return n;
+        stack_node node;
+        node.type_ = node_instance_attribute;
+        node.inst_ = inst;
+        node.idx_ = idx;
+        return node;
     }
 
     static stack_node aggregate(IfcUtil::IfcBaseClass* inst, int idx) {
-        stack_node n;
-        n.type_ = node_aggregate;
-        n.inst_ = inst;
-        n.idx_ = idx;
-        return n;
+        stack_node node;
+        node.type_ = node_aggregate;
+        node.inst_ = inst;
+        node.idx_ = idx;
+        return node;
     }
 
     static stack_node aggregate_element(const IfcParse::parameter_type* aggregate_elem_type, int idx) {
-        stack_node n;
-        n.type_ = node_aggregate_element;
-        n.idx_ = idx;
-        n.aggregate_elem_type_ = aggregate_elem_type;
-        return n;
+        stack_node node;
+        node.type_ = node_aggregate_element;
+        node.idx_ = idx;
+        node.aggregate_elem_type_ = aggregate_elem_type;
+        return node;
     }
 
     static stack_node inverse(IfcUtil::IfcBaseClass* inst, const IfcParse::inverse_attribute* inv) {
-        stack_node n;
-        n.type_ = node_inverse;
-        n.inst_ = inst;
-        n.inv_ = inv;
-        return n;
+        stack_node node;
+        node.type_ = node_inverse;
+        node.inst_ = inst;
+        node.inv_ = inv;
+        return node;
     }
 
     static stack_node select(IfcUtil::IfcBaseClass* inst, int idx) {
-        stack_node n;
-        n.type_ = node_select;
-        n.inst_ = inst;
-        n.idx_ = idx;
-        return n;
+        stack_node node;
+        node.type_ = node_select;
+        node.inst_ = inst;
+        node.idx_ = idx;
+        return node;
     }
 
     static stack_node header() {
-        stack_node n;
-        n.type_ = node_header;
-        return n;
+        stack_node node;
+        node.type_ = node_header;
+        return node;
     };
 
     static stack_node header_entry(const std::string& tagname) {
-        stack_node n;
-        n.type_ = node_header_entry;
-        n.tagname_ = tagname;
-        return n;
+        stack_node node;
+        node.type_ = node_header_entry;
+        node.tagname_ = tagname;
+        return node;
     };
 
     node_type ntype() const { return type_; }
@@ -161,19 +161,19 @@ class stack_node {
     const IfcParse::parameter_type* aggregate_elem_type() const { return aggregate_elem_type_; }
 
     std::string repr() const {
-        std::stringstream ss;
+        std::stringstream stream;
         static const char* const node_type_names[] = {"empty", "inst", "attr", "aggr", "agelem", "inv", "sel", "head", "hdentry"};
-        ss << "[" << node_type_names[type_] << "] ";
+        stream << "[" << node_type_names[type_] << "] ";
         if (inst_ != nullptr) {
-            ss << inst_->declaration().name() << " ";
+            stream << inst_->declaration().name() << " ";
         }
         if (type_ == node_aggregate) {
-            ss << "{" << aggregate_elements.size() << " elems} ";
+            stream << "{" << aggregate_elements.size() << " elems} ";
         }
         if (idx_ != -1) {
-            ss << idx_ << " ";
+            stream << idx_ << " ";
         }
-        return ss.str();
+        return stream.str();
     }
 };
 
@@ -190,7 +190,7 @@ template <typename T>
 std::vector<T> split(const std::string& value) {
     std::vector<std::string> strs;
     boost::split(
-        strs, value, [](char c) { return c == ' '; }, boost::token_compress_on);
+        strs, value, [](char character) { return character == ' '; }, boost::token_compress_on);
     std::vector<T> r(strs.size());
     boost::copy(strs | boost::adaptors::transformed([](const std::string& s) {
                     return boost::lexical_cast<T>(s);
@@ -209,13 +209,13 @@ Argument* parse_attribute_value(const IfcParse::parameter_type* ty, const std::s
     } else if (cpp_type == IfcUtil::Argument_ENUMERATION) {
         const auto* enum_type = ty->as_named_type()->declared_type()->as_enumeration_type();
 
-        std::vector<std::string>::const_iterator it = std::find(
+        std::vector<std::string>::const_iterator iter = std::find(
             enum_type->enumeration_items().begin(),
             enum_type->enumeration_items().end(),
             boost::to_upper_copy(value));
 
-        if (it != enum_type->enumeration_items().end()) {
-            v->set(IfcWrite::IfcWriteArgument::EnumerationReference(it - enum_type->enumeration_items().begin(), it->c_str()));
+        if (iter != enum_type->enumeration_items().end()) {
+            v->set(IfcWrite::IfcWriteArgument::EnumerationReference(iter - enum_type->enumeration_items().begin(), iter->c_str()));
         }
     } else if (cpp_type == IfcUtil::Argument_INT) {
         v->set(boost::lexical_cast<int>(value));
@@ -248,12 +248,12 @@ static void end_element(void* user, const xmlChar* tag) {
     if (!state->stack.empty() && state->stack.back().ntype() == stack_node::node_aggregate) {
         const auto& back = state->stack.back();
         auto& elems = state->stack.back().aggregate_elements;
-        auto* li = new IfcParse::ArgumentList(elems.size());
+        auto* list = new IfcParse::ArgumentList(elems.size());
         size_t i = 0;
         for (auto& elem : elems) {
-            li->arguments()[i++] = elem;
+            list->arguments()[i++] = elem;
         }
-        back.inst()->data().attributes()[back.idx()] = li;
+        back.inst()->data().attributes()[back.idx()] = list;
     }
 
     if (state->dialect == ifcxml_dialect_ifc2x3 && state->stack.back().ntype() == stack_node::node_instance) {
@@ -274,14 +274,14 @@ static void end_element(void* user, const xmlChar* tag) {
     }
 }
 
-static void process_characters(void* user, const xmlChar* ch, int len) {
+static void process_characters(void* user, const xmlChar* character, int len) {
     ifcxml_parse_state* state = (ifcxml_parse_state*)user;
 
     if (state->file == nullptr) {
         return;
     }
 
-    std::string txt((char*)ch, len);
+    std::string txt((char*)character, len);
 
     stack_node::node_type state_type = stack_node::stack_empty;
     if (!state->stack.empty()) {
@@ -348,8 +348,8 @@ static void start_element(void* user, const xmlChar* tag, const xmlChar** attrs)
     std::cout << "stack:" << std::endl;
     {
         int i = 1;
-        for (auto& n : state->stack) {
-            std::cout << "  " << (i++) << ":" << n.repr() << std::endl;
+        for (auto& node : state->stack) {
+            std::cout << "  " << (i++) << ":" << node.repr() << std::endl;
         }
     }
     std::cout << std::string(state->stack.size(), ' ') << "<" << tagname << ">";

--- a/src/serializers/schema_dependent/XmlSerializer.cpp
+++ b/src/serializers/schema_dependent/XmlSerializer.cpp
@@ -28,6 +28,7 @@
 
 #include "../../ifcparse/IfcSIPrefix.h"
 #include "../../ifcparse/utils.h"
+#include "../../ifcparse/IfcLogger.h"
 
 using boost::property_tree::ptree;
 


### PR DESCRIPTION
This PR is a working progress to start fixing clang-tidy warnings. Each warning type gets a dedicated commit across all files in `src/ifcparse`, except the generated schema files by `src/ifcopenshell-python/ifcopenshell/express/express_parser`. these should be fixed by refactoring the `express_parser`.

Some more rewrites within this PR:
- unify private member variable names to use trailing underscore

