### PR TITLE
Update unit.py - convert function, case issue

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -506,8 +506,8 @@ def convert(value, from_prefix, from_unit, to_prefix, to_unit):
     :return: The converted value.
     :rtype: float
     """
-    if from_unit in si_conversions:
-        value *= si_conversions[from_unit]
+    if from_unit.lower() in si_conversions:
+        value *= si_conversions[from_unit.lower()]
     elif from_prefix:
         value *= get_prefix_multiplier(from_prefix)
         if "SQUARE" in from_unit:
@@ -515,8 +515,8 @@ def convert(value, from_prefix, from_unit, to_prefix, to_unit):
         elif "CUBIC" in from_unit:
             value *= get_prefix_multiplier(from_prefix)
             value *= get_prefix_multiplier(from_prefix)
-    if to_unit in si_conversions:
-        return value * (1 / si_conversions[to_unit])
+    if to_unit.lower() in si_conversions:
+        return value * (1 / si_conversions[to_unit.lower()])
     elif to_prefix:
         value *= 1 / get_prefix_multiplier(to_prefix)
         if "SQUARE" in from_unit:


### PR DESCRIPTION
Hi,
I noticed an issue and suggest a fix:
Unit names from <si_conversions> are all lowercase, whereas project units extracted from the IFC files with <get_project_unit(...).Name> are uppercase. So the convert function didn't seem to work properly. Hope this helps!

(it's my first time contributing to an open-source GitHub project, I hope I didn't mess anything up, please tell me if this is the case!)