### PR TITLE
Update reference_structure.py

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/spatial/reference_structure.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/spatial/reference_structure.py
@@ -44,7 +44,7 @@ class Usecase:
         :param relating_structure: The IfcSpatialStructureElement element, such
             as IfcBuilding, IfcBuildingStorey, or IfcSpace that the element
             exists in.
-        :return: The IfcRelContainedInSpatialStructure relationship instance
+        :return: The IfcRelReferencedInSpatialStructure relationship instance
         :rtype: ifcopenshell.entity_instance.entity_instance
 
         Example:


### PR DESCRIPTION
A mistype in docs: should be IfcRelReferencedInSpatialStructure instead of IfcRelContainedInSpatialStructure