### PR TITLE
[IfcConvert] IfcBoundingBox conversion exclusion

### DIFF
--- a/src/ifcgeom/IfcRepresentation.cpp
+++ b/src/ifcgeom/IfcRepresentation.cpp
@@ -27,6 +27,12 @@ bool IfcGeom::Kernel::convert(const IfcSchema::IfcRepresentation* l, IfcRepresen
 	if ( items->size() ) {
 		for ( IfcSchema::IfcRepresentationItem::list::it it = items->begin(); it != items->end(); ++ it ) {
 			IfcSchema::IfcRepresentationItem* representation_item = *it;
+
+			if(/*TODO: settings.get(CONVERT_IFC_BOUNDING_BOXES) && */representation_item->data().type() == &IfcSchema::IfcBoundingBox::Class()) {
+				part_succes |= true;
+				continue;
+			}
+
 			if ( shape_type(representation_item) == ST_SHAPELIST ) {
 				part_succes |= convert_shapes(*it, shapes);
 			} else {


### PR DESCRIPTION
Hi, I am not sure if this is the best place to put the code. Also there is missing the command line to be able to convert the IfcBoundingBox, but I don't know how to retrieve the settings from the IfcRepresentation class.

The change will fix #2044 and all the duplicates.