### PR TITLE
Small change of ifcwrap pythoninterpreter function

### DIFF
--- a/src/ifcwrap/CMakeLists.txt
+++ b/src/ifcwrap/CMakeLists.txt
@@ -78,7 +78,7 @@ IF((PYTHONINTERP_FOUND AND NOT "${PYTHON_EXECUTABLE}" STREQUAL "") OR PYTHON_MOD
             )
         ELSE ()
             EXECUTE_PROCESS(
-                COMMAND ${PYTHON_EXECUTABLE} -c "import sys; from distutils.sysconfig import get_python_lib; sys.stdout.write(get_python_lib(1))"
+                COMMAND ${PYTHON_EXECUTABLE} -c "import sys; import sysconfig; sys.stdout.write(sysconfig.get_path('platlib'))"
                 OUTPUT_VARIABLE python_package_dir
             )
         ENDIF()


### PR DESCRIPTION
Hey,

to no rely on distutil (which is deprecated in python 3.12) here is a suggested change to the cmakelists.txt in the IfcWrap module.

Conda-forge appears to have in place a rather strict no-tolerance for distutils for python 3.12, so all tests concerning python 3.12 were failing -> https://github.com/conda-forge/ifcopenshell-feedstock/pull/44. 

As shown below this should perform the same task.
```
Python 3.10.12 | packaged by conda-forge | (main, Jun 23 2023, 22:40:32) [GCC 12.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys; from distutils.sysconfig import get_python_lib; sys.stdout.write(get_python_lib(1))
/home/krande/miniforge3/lib/python3.10/site-packages52
>>> import sys; import sysconfig; sys.stdout.write(sysconfig.get_path('platlib'))
/home/krande/miniforge3/lib/python3.10/site-packages52
```

@aothms, @Moult. I could commit this directly to the branch given its such a small change, but I feel like any changes to the cmakelists.txt files should be vetted in a PR. 

Let me know what you guys think?
