### PR TITLE
mistype-fix:Aggregate class assign_object

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/aggregate/assign_object.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/aggregate/assign_object.py
@@ -47,7 +47,7 @@ class Usecase:
         flight, a landing, a railing and so on. Or a wall might be made out of
         stud members, and coverings.
 
-        As a product may only have a single locaion in the "spatial
+        As a product may only have a single location in the "spatial
         decomposition" tree, assigning an aggregate relationship will remove any
         previous aggregation, containment, or nesting relationships it may have.
 


### PR DESCRIPTION
Small PR for a mistype inside Aggregate - assign_object.py related to #4064 