### PR TITLE
Skip IfcRelAggregates entities with missing RelatingObject

### DIFF
--- a/src/blenderbim/blenderbim/bim/import_ifc.py
+++ b/src/blenderbim/blenderbim/bim/import_ifc.py
@@ -1562,16 +1562,24 @@ class IfcImporter:
                 elif element.Nests:
                     rel_aggregates.add(element.Nests[0])
         else:
-            rel_aggregates = [
-                r
-                for r in self.file.by_type("IfcRelAggregates")
-                if r.RelatingObject.is_a("IfcElement") or r.RelatingObject.is_a("IfcElementType")
-            ] + [
-                r
-                for r in self.file.by_type("IfcRelNests")
-                if (r.RelatingObject.is_a("IfcElement") or r.RelatingObject.is_a("IfcElementType"))
-                and [e for e in r.RelatedObjects if not e.is_a("IfcPort")]
-            ]
+            def check_relation(r) -> bool:
+                return bool(r.RelatingObject.is_a("IfcElement") or r.RelatingObject.is_a("IfcElementType"))
+
+            rel_aggregates = list()
+
+            for relation in self.file.by_type("IfcRelAggregates"):
+                if relation.RelatingObject is None:
+                    print(f"Skipping '{relation.GlobalId}' because 'RelatingObject' needs to exist.")
+                    continue
+                if check_relation(relation):
+                    rel_aggregates.append(rel_aggregates)
+
+            for relation in self.file.by_type("IfcRelNests"):
+                if relation.RelatingObject is None:
+                    print(f"Skipping '{relation.GlobalId}' because 'RelatingObject' needs to exist.")
+                    continue
+                if check_relation(relation) and [e for e in relation.RelatedObjects if not e.is_a("IfcPort")]:
+                    rel_aggregates.append(rel_aggregates)
 
         if len(rel_aggregates) > 10000:
             # More than 10,000 collections makes Blender unhappy

--- a/src/blenderbim/blenderbim/bim/import_ifc.py
+++ b/src/blenderbim/blenderbim/bim/import_ifc.py
@@ -1572,14 +1572,13 @@ class IfcImporter:
                     print(f"Skipping '{relation.GlobalId}' because 'RelatingObject' needs to exist.")
                     continue
                 if check_relation(relation):
-                    rel_aggregates.append(rel_aggregates)
-
+                    rel_aggregates.append(relation)
             for relation in self.file.by_type("IfcRelNests"):
                 if relation.RelatingObject is None:
                     print(f"Skipping '{relation.GlobalId}' because 'RelatingObject' needs to exist.")
                     continue
                 if check_relation(relation) and [e for e in relation.RelatedObjects if not e.is_a("IfcPort")]:
-                    rel_aggregates.append(rel_aggregates)
+                    rel_aggregates.append(relation)
 
         if len(rel_aggregates) > 10000:
             # More than 10,000 collections makes Blender unhappy


### PR DESCRIPTION
when importing a specific ifc file I was getting this error:
```bash
  File "C:\Users\xxx\AppData\Roaming\Blender Foundation\Blender\4.0\scripts\addons\blenderbim\bim\module\project\operator.py", line 734, in execute
    ifc_importer.execute()
  File "C:\Users\xxx\AppData\Roaming\Blender Foundation\Blender\4.0\scripts\addons\blenderbim\bim\import_ifc.py", line 240, in execute
    self.create_collections()
  File "C:\Users\xxx\AppData\Roaming\Blender Foundation\Blender\4.0\scripts\addons\blenderbim\bim\import_ifc.py", line 1515, in create_collections
    self.create_aggregate_and_nest_collections()
  File "C:\Users\xxx\AppData\Roaming\Blender Foundation\Blender\4.0\scripts\addons\blenderbim\bim\import_ifc.py", line 1565, in create_aggregate_and_nest_collections
    rel_aggregates = [
  File "C:\Users\xxx\AppData\Roaming\Blender Foundation\Blender\4.0\scripts\addons\blenderbim\bim\import_ifc.py", line 1568, in <listcomp>
    if r.RelatingObject.is_a("IfcElement") or r.RelatingObject.is_a("IfcElementType")
```
and the import stopped.

After further investigation i found out, that my ifc file is a bit faulty because some IfcRelAggregates entities are missing their RelatingObject.

Now the importer throws an **error message and skips** the corresponding entity instead of breaking entirely.