### PR TITLE
Fixing Dimension Mismatch in Matrix Multiplication

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/shape.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/shape.py
@@ -247,7 +247,7 @@ def get_shape_vertices(shape, geometry):
     """
     verts = get_vertices(geometry)
     mat = get_shape_matrix(shape)
-    return np.array([mat @ np.array([verts[i], verts[i + 1], verts[i + 2]]) for i in range(0, len(verts), 3)])
+    return np.delete((mat @ np.hstack((verts, np.ones((len(verts), 1)))).T).T, -1, axis=1)
 
 
 def get_element_vertices(element, geometry):
@@ -269,7 +269,7 @@ def get_element_vertices(element, geometry):
     if not element.ObjectPlacement or not element.ObjectPlacement.is_a("IfcLocalPlacement"):
         return verts
     mat = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement)
-    return np.array([mat @ np.array([verts[i], verts[i + 1], verts[i + 2]]) for i in range(0, len(verts), 3)])
+    return np.delete((mat @ np.hstack((verts, np.ones((len(verts), 1)))).T).T, -1, axis=1)
 
 
 def get_bottom_elevation(geometry):


### PR DESCRIPTION
Description
This pull request addresses a dimension mismatch issue in matrix multiplication. The original code attempts to multiply a 4x4 transformation matrix (mat) by a 3-element vertex array (verts), resulting in an invalid operation. The proposed fix involves ensuring that the vertex array has a fourth element representing the homogeneous coordinate before performing the matrix multiplication.

Changes Made
The original code: np.array([mat @ np.array([verts[i], verts[i + 1], verts[i + 2]]) for i in range(0, len(verts), 3)])

the updated code: np.delete((mat @ np.hstack((verts, np.ones((len(verts), 1)))).T).T, -1, axis=1)

Explanation
To resolve the dimension mismatch, a modification has been made to ensure that each vertex array has a fourth element (homogeneous coordinate) before the matrix multiplication. This is achieved by appending a column of ones to the verts array.

1. np.ones((len(verts), 1)): This creates a column vector of ones with a length equal to the number of rows in the verts array. This is done to represent the homogeneous coordinates

2. np.hstack((verts, np.ones((len(verts), 1)))): This horizontally stacks the verts array with the column vector of ones. This is essentially adding an extra column to verts to represent homogeneous coordinates.

3. (mat @ np.hstack((verts, np.ones((len(verts), 1)))).T: The .T transposes the vertecies to match the dimension of the transformation matrix and perform a valid multiplication

4. mat @ np.hstack((verts, np.ones((len(verts), 1)))): This performs matrix multiplication between the matrix mat and the stacked array

5. (mat @ np.hstack((verts, np.ones((len(verts), 1)))).T).T: The second .T transposes the matrix back to its original form.

6. np.delete(..., -1, axis=1): This deletes the last column from the result of the matrix multiplication.

Example

mat [
    [ 0.0, -1.0,  0.0,  0.0],
    [ 1.0,  0.0,  0.0, -0.175],
    [ 0.0,  0.0,  1.0,  0.0],
    [ 0.0,  0.0,  0.0,  1.0]
]

verts [    [ 8.35,   0.175,  0.   ],
    [ 8.35,   0.175,  5.638],
    [ 0.   ,  0.175,  5.638],
    [ 0.   ,  0.175,  0.   ],
    [ 0.   , -0.175,  5.638],
    [ 0.   , -0.175,  0.   ],
    [ 8.35,  -0.175,  5.638],
    [ 8.35,  -0.175,  0.   ]
]

result [    [-0.175,  8.175,  0.   ],
    [-0.175,  8.175,  5.638],
    [-0.175, -0.175,  5.638],
    [-0.175, -0.175,  0.   ],
    [ 0.175, -0.175,  5.638],
    [ 0.175, -0.175,  0.   ],
    [ 0.175,  8.175,  5.638],
    [ 0.175,  8.175,  0.   ]
]

Testing
The fix has been tested with various vertex arrays and transformation matrices to ensure correct behavior.

Code compiles successfully

Tests pass

Documentation updating, not necessary

Other ways to solve the problem:
(mat @ np.hstack((verts, np.ones((len(verts), 1)))).T)[:3, :].T
(mat @ np.hstack((verts, np.ones((len(verts), 1)))).T).T[:, :-1]
(mat @ np.column_stack((verts, np.ones(verts.shape[0]))).T).T[:, :-1]