### PR TITLE
Don't unlink ifc elements from vanilla collections on assign

### DIFF
--- a/src/blenderbim/blenderbim/tool/blender.py
+++ b/src/blenderbim/blenderbim/tool/blender.py
@@ -551,6 +551,18 @@ class Blender(blenderbim.core.tool.Blender):
             for axis_idx in range(3):
                 attr[axis_idx] = lock_state
 
+    class Collection:
+        @classmethod
+        def get_ifc_collections(cls):
+            ifc_collections = []
+            project_collection = next(col for col in bpy.data.collections if col.name.startswith("IfcProject/"))
+            collections = [project_collection]
+            while collections:
+                ifc_collection = collections.pop(0)
+                ifc_collections.append(ifc_collection)
+                collections.extend(ifc_collection.children)
+            return ifc_collections
+
     class Modifier:
         @classmethod
         def is_eligible_for_railing_modifier(cls, obj):

--- a/src/blenderbim/blenderbim/tool/collector.py
+++ b/src/blenderbim/blenderbim/tool/collector.py
@@ -93,9 +93,11 @@ class Collector(blenderbim.core.tool.Collector):
         else:
             object_collection = cls._get_collection(element, obj)
 
+        ifc_collections = tool.Blender.Collection.get_ifc_collections()
         if obj.users_collection != (object_collection,):
             for collection in obj.users_collection:
-                collection.objects.unlink(obj)
+                if collection in ifc_collections or collection == bpy.context.scene.collection:
+                    collection.objects.unlink(obj)
             if object_collection is not None:
                 object_collection.objects.link(obj)
 


### PR DESCRIPTION
I think this is not reallly ready to merge as-is but I would like to tackle a problem I have with the BlenderBIM addon automatically unlinking ifc objects from vanilla Blender collections on assign / save.

I consider this a semi-advanced feature because it takes the risk of associating the contents of the Blender file to the workflow of the BlenderBIM addon. Which in the past was extremely unstable but I must say nowadays I rarely encounter any bug regarding this workflow.

As you may know in Blender an object can be linked to any number of collections. This can be used to effectively visually filter certain elements. The current implementation prevents the user from using this feature because IFC elements are forced to be part of one and only one collection. 

eg I may want a collection with only the beams in my project, or a collection with only my flow systems, or only the geographical elements. Currently it is possible to do it with the group and filter system but I think the workflow is a bit too much abstracted from Blender's systems and the query syntax forces the user to be intimate with the IFC terminology which is not always straightforward.

This PR only unlinks elements from collections which are part of the ifc project, effectively leaving vanilla collections untouched on save. This may unlock some new workflows like discussed over [the OSArch forum](https://community.osarch.org/discussion/comment/18777#Comment_18777).

I think eventually it would be nice to couple the collection feature with the systems feature to allow visual grouping of objects by linking to actual Blender collection. 
![image](https://github.com/IfcOpenShell/IfcOpenShell/assets/25156105/ddef82ed-e4cc-4a76-9c61-31b7f387b841)

**I have not run the test suite to check if this ruins everything.**

Please advise if you have any commentary. Cheers
