### PR TITLE
Fix issue building IfcOpenHouse for IFC4

### DIFF
--- a/src/examples/IfcOpenHouse.cpp
+++ b/src/examples/IfcOpenHouse.cpp
@@ -341,7 +341,7 @@ int main() {
 		null, 
 		null,
 #ifdef USE_IFC4
-		file.instances_by_type<IfcSchema::IfcWallStandardCase>()->generalize(),
+		file.instances_by_type<IfcSchema::IfcWallStandardCase>()->as<IfcSchema::IfcDefinitionSelect>(),
 #else
 		file.instances_by_type<IfcSchema::IfcWallStandardCase>()->as<IfcSchema::IfcRoot>(),
 #endif


### PR DESCRIPTION
Currently https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.7.0/src/examples/IfcOpenHouse.cpp with `#define USE_IFC4` it fails on the lines:
```cpp
	IfcSchema::IfcRelAssociatesMaterial* associates_material = new IfcSchema::IfcRelAssociatesMaterial(
		guid(),
		file.getSingle<IfcSchema::IfcOwnerHistory>(), 
		null,
		null,
#ifdef USE_IFC4
		file.instances_by_type<IfcSchema::IfcWallStandardCase>()->generalize(),
#else
		file.instances_by_type<IfcSchema::IfcWallStandardCase>()->as<IfcSchema::IfcRoot>(),
#endif
		layer_usage);
```

with an error:
```
\IfcOpenHouse.cpp(340,100): error C2665: 'Ifc4::IfcRelAssociatesMaterial::IfcRelAssociatesMaterial': no overloaded function could convert all the argument types [\_build-vs2022-x64\examples\IfcOpenHouse.vcxproj]

\../ifcparse/Ifc4.h(22945,5): message : could be 'Ifc4::IfcRelAssociatesMaterial::IfcRelAssociatesMaterial(std::string,Ifc4::IfcOwnerHistory *,boost::optional<std::string>,boost::optional<std::string>,boost::shared_ptr<aggregate_of<Ifc4::IfcDefinitionSelect>>,Ifc4::IfcMaterialSelect *)' [\_build-vs2022-x64\examples\IfcOpenHouse.vcxproj]

\IfcOpenHouse.cpp(340,100): message : 'Ifc4::IfcRelAssociatesMaterial::IfcRelAssociatesMaterial(std::string,Ifc4::IfcOwnerHistory *,boost::optional<std::string>,
boost::optional<std::string>,boost::shared_ptr<aggregate_of<Ifc4::IfcDefinitionSelect>>,Ifc4::IfcMaterialSelect *)': cannot convert argument 5 from 'aggregate_of_instance::ptr' to 'boost::shared_ptr<aggregate_of<Ifc4::IfcDefinitionSelect>>' [\_build-vs2022-x64\examples\IfcOpenHouse.vcxproj]

\IfcOpenHouse.cpp(346,71): message : No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called [\_build-vs2022-x64\examples\IfcOpenHouse.vcxproj]

\IfcOpenHouse.cpp(340,100): message : while trying to match the argument list '(guid, T *, const boost::none_t, const boost::none_t, aggregate_of_instance::ptr,Ifc4::IfcMaterialLayerSetUsage *)' [\_build-vs2022-x64\examples\IfcOpenHouse.vcxproj]
```


IfcRelAssociatesMaterial constructor for reference:
```cpp
IfcRelAssociatesMaterial(
    std::string v1_GlobalId,
    ::Ifc4::IfcOwnerHistory* v2_OwnerHistory,
    boost::optional<std::string> v3_Name,
    boost::optional<std::string> v4_Description,
    aggregate_of<::Ifc4::IfcDefinitionSelect>::ptr v5_RelatedObjects,
    ::Ifc4::IfcMaterialSelect* v6_RelatingMaterial
);
```

So it fails to match `v5_RelatedObjects` argument - it's expected to be `boost::shared_ptr<aggregate_of<Ifc4::IfcDefinitionSelect>>` but in IfcOpenHouse it's `aggregate_of_instance::ptr`. I've tried to remove `->generalize()` and it became `boost::shared_ptr<aggregate_of<Ifc4::IfcWallStandardCase>>` but it still fails to match which is a bit weird since `IfcWallStandardCase` is subclass of `IfcObjectDefinition` (atleast in IFC).

As a workaround I've specified `->as<IfcSchema::IfcDefinitionSelect>()` directly and it works but now sure how correct it is since there may be some deeper code generation issue at play.