### PR TITLE
Fix: add missing typename

### DIFF
--- a/src/ifcparse/IfcHierarchyHelper.h
+++ b/src/ifcparse/IfcHierarchyHelper.h
@@ -436,7 +436,7 @@ public:
 			{ IfcWrite::IfcWriteArgument* attr = new IfcWrite::IfcWriteArgument(); attr->set<std::string>(IfcParse::IfcGlobalId()); data->setArgument(0, attr); }
 			{ IfcWrite::IfcWriteArgument* attr = new IfcWrite::IfcWriteArgument(); attr->set(owner_hist); data->setArgument(1, attr); }
 			int relating_index = 4, related_index = 5;
-			if (T::Class().name() == "IfcRelContainedInSpatialStructure" || std::is_base_of<Schema::IfcRelDefines, T>::value) {
+			if (T::Class().name() == "IfcRelContainedInSpatialStructure" || std::is_base_of<typename Schema::IfcRelDefines, T>::value) {
 				// some classes have attributes reversed.
 				std::swap(relating_index, related_index);
 			}


### PR DESCRIPTION
Hey @aothms, the failing daily conda builds are complaining about a missing typename in the hierarchy helper header file. This fixes it. 