### PR TITLE
Small doc change to direct readers to advanced mode

### DIFF
--- a/src/blenderbim/docs/users/dealing_with_large_models.rst
+++ b/src/blenderbim/docs/users/dealing_with_large_models.rst
@@ -61,8 +61,8 @@ include:
 Filtered model loading
 ----------------------
 
-You may filter elements and only load a portion of the model. Click on **Enable
-Advanced Mode** when loading a model.
+You may filter elements and only load a portion of the model. Click on 
+:ref:`users/general_usage/ifc_project:Advanced mode` when loading a model.
 
 .. image:: images/advanced-mode.png
 

--- a/src/blenderbim/docs/users/general_usage/ifc_project.rst
+++ b/src/blenderbim/docs/users/general_usage/ifc_project.rst
@@ -102,6 +102,9 @@ with basic features to save and unload the project.
 Advanced mode
 -------------
 
+The advanced mode will not load the model right away, but preload it and
+provide additional loading possibilities like :ref:`users/dealing_with_large_models:Filtered model loading`.
+
 .. image:: images/ifc-project-load.png
 
 .. |FILE| image:: /images/icon-FILE.svg


### PR DESCRIPTION
I had more changes in mind, which went away when going through the whole thing.
Maybe more to come, starting tiny 😸 .

The docs built fine locally so I hope it works.