### PR TITLE
First rough draft of alignment-based IfcFixedReferenceSweptAreaSolid

### DIFF
--- a/src/ifcgeom/kernels/opencascade/OpenCascadeKernel.h
+++ b/src/ifcgeom/kernels/opencascade/OpenCascadeKernel.h
@@ -133,6 +133,7 @@ public:
 	bool convert(const ifcopenshell::geometry::taxonomy::matrix4::ptr, gp_GTrsf&);
 	bool convert(const ifcopenshell::geometry::taxonomy::shell::ptr, TopoDS_Shape&);
 	bool convert(const ifcopenshell::geometry::taxonomy::solid::ptr, TopoDS_Shape&);
+	bool convert(const ifcopenshell::geometry::taxonomy::loft::ptr, TopoDS_Shape&);
 	bool convert(const ifcopenshell::geometry::taxonomy::bspline_surface::ptr bs, Handle(Geom_Surface) surf);
 
 	virtual bool convert_impl(const ifcopenshell::geometry::taxonomy::loop::ptr, IfcGeom::ConversionResults&);
@@ -141,6 +142,7 @@ public:
 	virtual bool convert_impl(const ifcopenshell::geometry::taxonomy::shell::ptr, IfcGeom::ConversionResults&);
 	virtual bool convert_impl(const ifcopenshell::geometry::taxonomy::extrusion::ptr, IfcGeom::ConversionResults&);
 	virtual bool convert_impl(const ifcopenshell::geometry::taxonomy::boolean_result::ptr, IfcGeom::ConversionResults&);
+	virtual bool convert_impl(const ifcopenshell::geometry::taxonomy::loft::ptr, IfcGeom::ConversionResults&);
 
 	virtual bool convert_openings(const IfcUtil::IfcBaseEntity* entity, const std::vector<std::pair<ifcopenshell::geometry::taxonomy::ptr, ifcopenshell::geometry::taxonomy::matrix4>>& openings,
 		const IfcGeom::ConversionResults& entity_shapes, const ifcopenshell::geometry::taxonomy::matrix4& entity_trsf, IfcGeom::ConversionResults& cut_shapes);

--- a/src/ifcgeom/kernels/opencascade/face.cpp
+++ b/src/ifcgeom/kernels/opencascade/face.cpp
@@ -41,6 +41,7 @@
 #include "OpenCascadeKernel.h"
 #include "face_definition.h"
 #include "wire_utils.h"
+#include "base_utils.h"
 
 using namespace ifcopenshell::geometry;
 using namespace ifcopenshell::geometry::kernels;
@@ -295,6 +296,10 @@ bool OpenCascadeKernel::convert(const taxonomy::face::ptr face, TopoDS_Shape& re
 		result = compound;
 	} else {
 		result = face_list.First();
+	}
+
+	if (face->matrix) {
+		result = apply_transformation(result, *face->matrix);
 	}
 
 	return true;

--- a/src/ifcgeom/kernels/opencascade/loft.cpp
+++ b/src/ifcgeom/kernels/opencascade/loft.cpp
@@ -1,0 +1,111 @@
+/********************************************************************************
+ *                                                                              *
+ * This file is part of IfcOpenShell.                                           *
+ *                                                                              *
+ * IfcOpenShell is free software: you can redistribute it and/or modify         *
+ * it under the terms of the Lesser GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3.0 of the License, or          *
+ * (at your option) any later version.                                          *
+ *                                                                              *
+ * IfcOpenShell is distributed in the hope that it will be useful,              *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 *
+ * Lesser GNU General Public License for more details.                          *
+ *                                                                              *
+ * You should have received a copy of the Lesser GNU General Public License     *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.         *
+ *                                                                              *
+ ********************************************************************************/
+
+#include "OpenCascadeKernel.h"
+#include "base_utils.h"
+
+#include <TopExp.hxx>
+#include <BRepFill_Filling.hxx>
+#include <BRepTools_WireExplorer.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+
+using namespace ifcopenshell::geometry;
+using namespace ifcopenshell::geometry::kernels;
+using namespace IfcGeom;
+using namespace IfcGeom::util;
+
+bool OpenCascadeKernel::convert(const taxonomy::loft::ptr loft, TopoDS_Shape& result) {
+	// @todo this approach based on BRepFill_Filling is both slow, as well as
+	// potentially incorrect as there is no guarantee that the wires for
+	// subsequently placed profiles are traversed from an equivalent start vertex.
+	
+	if (loft->children.size() < 2) {
+		return false;
+	}
+	
+	TopTools_ListOfShape faces;
+	TopoDS_Compound comp;
+	BRep_Builder BB;
+	BB.MakeCompound(comp);
+
+	for (auto it = loft->children.begin(); it < loft->children.end() - 1; ++it) {
+		auto jt = it + 1;
+		std::array<taxonomy::face::ptr, 2> fa = { *it, *jt };
+		std::array<TopoDS_Shape, 2> shps;
+		std::array<TopoDS_Wire, 2> ws;
+		for (int i = 0; i < 2; ++i) {
+			if (!convert(fa[i], shps[i])) {
+				return false;
+			}
+			if (shps[i].ShapeType() != TopAbs_FACE) {
+				return false;
+			}
+			ws[i] = BRepTools::OuterWire(TopoDS::Face(shps[i]));
+		}
+		if (it == loft->children.begin()) {
+			// faces.Append(shps[0]);
+			BB.Add(comp, shps[0]);
+		}
+		if (jt == loft->children.end() - 1) {
+			// faces.Append(shps[1]);
+			BB.Add(comp, shps[1]);
+		}
+		BRepTools_WireExplorer a(ws[0]);
+		BRepTools_WireExplorer b(ws[1]);
+		for (; a.More() && b.More(); a.Next(), b.Next()) {
+			BRepFill_Filling fill;
+			auto& e1 = a.Current();
+			auto e3 = TopoDS::Edge(b.Current().Reversed());
+			
+			// Documentation says unconnected edges are automatically connected, but this is not the case
+			TopoDS_Vertex e1a, e1b, e3a, e3b;
+			TopExp::Vertices(e1, e1a, e1b, true);
+			TopExp::Vertices(e3, e3a, e3b, true);
+			auto e2 = BRepBuilderAPI_MakeEdge(e1b, e3a).Edge();
+			auto e4 = BRepBuilderAPI_MakeEdge(e3b, e1a).Edge();
+			
+			fill.Add(e1, GeomAbs_C0);
+			fill.Add(e2, GeomAbs_C0);
+			fill.Add(e3, GeomAbs_C0);
+			fill.Add(e4, GeomAbs_C0);
+			fill.Build();
+			// faces.Append(fill.Face());
+			BB.Add(comp, fill.Face());
+		}
+	}
+
+	// create_solid_from_faces(faces, result, settings_.get<settings::Precision>().get());
+	result = comp;
+
+	return true;
+}
+
+bool OpenCascadeKernel::convert_impl(const taxonomy::loft::ptr loft, IfcGeom::ConversionResults& results) {
+	TopoDS_Shape shape;
+	if (!convert(loft, shape)) {
+		return false;
+	}
+	results.emplace_back(ConversionResult(
+		loft->instance->data().id(),
+		loft->matrix,
+		new OpenCascadeShape(shape),
+		loft->surface_style
+	));
+	return true;
+}

--- a/src/ifcgeom/mapping/IfcDerivedProfileDef.cpp
+++ b/src/ifcgeom/mapping/IfcDerivedProfileDef.cpp
@@ -24,6 +24,10 @@ using namespace ifcopenshell::geometry;
 taxonomy::ptr mapping::map_impl(const IfcSchema::IfcDerivedProfileDef* inst) {
 	auto it = map(inst->ParentProfile());
 	taxonomy::matrix4::ptr m = taxonomy::cast<taxonomy::matrix4>(map(inst->Operator()));
+	if (!taxonomy::cast<taxonomy::geom_item>(it)->matrix) {
+		// @todo should this not be initialized by default? matrix4 already has a 'lazy identity' mechanism.
+		taxonomy::cast<taxonomy::geom_item>(it)->matrix = taxonomy::make<taxonomy::matrix4>();
+	}
 	taxonomy::cast<taxonomy::geom_item>(it)->matrix->components() *= m->ccomponents();
 	return it;
 }

--- a/src/ifcgeom/mapping/IfcExtrudedAreaSolidTapered.cpp
+++ b/src/ifcgeom/mapping/IfcExtrudedAreaSolidTapered.cpp
@@ -36,6 +36,7 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcExtrudedAreaSolidTapered* in
 	Eigen::Matrix4d end_profile = af3d.matrix();
 
 	auto loft = taxonomy::make<taxonomy::loft>();
+	loft->axis = nullptr;
 	loft->children = {
 		taxonomy::cast<taxonomy::face>(map(inst->SweptArea())),
 		taxonomy::cast<taxonomy::face>(map(inst->EndSweptArea()))
@@ -45,97 +46,5 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcExtrudedAreaSolidTapered* in
 	loft->children.back()->matrix->components() = old * end_profile;
 
 	return loft;
-
-	/*
-	gp_Trsf trsf;
-	bool has_position = true;
-#ifdef SCHEMA_IfcSweptAreaSolid_Position_IS_OPTIONAL
-	has_position = inst->Position() != nullptr;
-#endif
-	if (has_position) {
-		IfcGeom::Kernel::convert(inst->Position(), trsf);
-	}
-
-	gp_Dir dir;
-	convert(inst->ExtrudedDirection(), dir);
-
-	gp_Trsf end_profile;
-	end_profile.SetTranslation(height * dir);
-
-	TopoDS_Edge spine_edge = BRepBuilderAPI_MakeEdge(gp_Pnt(), gp_Pnt((height * dir).XYZ())).Edge();
-	TopoDS_Wire wire = BRepBuilderAPI_MakeWire(spine_edge).Wire();
-
-	shape.Nullify();
-
-	TopExp_Explorer exp1(face1, TopAbs_WIRE);
-	TopExp_Explorer exp2(face2, TopAbs_WIRE);
-
-	TopoDS_Vertex v1, v2;
-	TopExp::Vertices(wire, v1, v2);
-
-	TopoDS_Shape shell;
-	TopoDS_Compound compound;
-	BRep_Builder compound_builder;
-
-	for (; exp1.More() && exp2.More(); exp1.Next(), exp2.Next()) {
-		const TopoDS_Wire& w1 = TopoDS::Wire(exp1.Current());
-		const TopoDS_Wire& w2 = TopoDS::Wire(exp2.Current());
-
-		BRepOffsetAPI_MakePipeShell builder(wire);
-		builder.Add(w1, v1);
-		builder.Add(w2.Moved(end_profile), v2);
-
-		TopoDS_Shape result = builder.Shape();
-
-		TopTools_ListOfShape li;
-		util::shape_to_face_list(result, li);
-		li.Append(BRepBuilderAPI_MakeFace(w1).Face().Reversed());
-		li.Append(BRepBuilderAPI_MakeFace(w2).Face().Moved(end_profile));
-		
-		util::create_solid_from_faces(li, result, true);
-
-		// @todo ugly hack
-
-		// The reason for this distinction is that at this point of the loop we're not sure anymore
-		// whether this was constructed from an inner or outer bound. So rather than iterating over
-		// wires of `face1` and `face2` we should iterate over the faces and then properly check with
-		// BRepTools::OuterBound().
-		// Currently this distinction happens based on profile type which is not robust and probably
-		// not complete.
-		if (shell.IsNull()) {
-			shell = result;
-		} else if (inst->SweptArea()->declaration().is(IfcSchema::IfcCircleHollowProfileDef::Class()) ||
-			inst->SweptArea()->declaration().is(IfcSchema::IfcRectangleHollowProfileDef::Class()) ||
-			inst->SweptArea()->declaration().is(IfcSchema::IfcArbitraryProfileDefWithVoids::Class()))
-		{
-			// @todo properly check for failure and all.
-			shell = BRepAlgoAPI_Cut(shell, result).Shape();
-		} else {
-			if (compound.IsNull()) {
-				compound_builder.MakeCompound(compound);
-				compound_builder.Add(compound, shell);
-			}
-			compound_builder.Add(compound, result);
-		}
-	}
-
-	if (!compound.IsNull()) {
-		shell = compound;
-	}
-
-	shape = shell;
-
-	if (exp1.More() != exp2.More()) {
-		Logger::Message(Logger::LOG_ERROR, "Inconsistent profiles encountered for:", l);
-	}
-
-	if (has_position && !shape.IsNull()) {
-		// IfcSweptAreaSolid.Position (trsf) is an IfcAxis2Placement3D
-		// and therefore has a unit scale factor
-		shape.Move(trsf);
-	}
-
-	return !shape.IsNull();
-	*/
 }
 #endif

--- a/src/ifcgeom/mapping/IfcFixedReferenceSweptAreaSolid.cpp
+++ b/src/ifcgeom/mapping/IfcFixedReferenceSweptAreaSolid.cpp
@@ -53,10 +53,19 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcFixedReferenceSweptAreaSolid
 			}
 		}
 #endif
-		auto len = end - start;
-		auto nsteps = (size_t)ceil(len);
-		for (size_t i = 0; i <= nsteps; ++i) {
-			auto m4 = pwf->evaluate(start + len / nsteps * i);
+		auto curve_length = end - start;
+		auto param_type = settings_.get<ifcopenshell::geometry::settings::PiecewiseStepType>().get();
+		auto param = settings_.get<ifcopenshell::geometry::settings::PiecewiseStepParam>().get();
+		size_t num_steps = 0;
+		if (param_type == ifcopenshell::geometry::settings::PiecewiseStepMethod::MAXSTEPSIZE) {
+			// parameter is max step size
+			num_steps = (size_t) std::ceil(curve_length / param);
+		} else {
+			// parameter is minimum number of steps
+			num_steps = (size_t) std::ceil(param);
+		}
+		for (size_t i = 0; i <= num_steps; ++i) {
+			auto m4 = pwf->evaluate(start + curve_length / num_steps * i);
 			
 			/*
 			std::stringstream ss;

--- a/src/ifcgeom/mapping/IfcFixedReferenceSweptAreaSolid.cpp
+++ b/src/ifcgeom/mapping/IfcFixedReferenceSweptAreaSolid.cpp
@@ -40,13 +40,13 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcFixedReferenceSweptAreaSolid
 		// IfcDirectrixCurveSweptAreaSolid introduced in 4.3 changed attribute type
 		// from optional IfcParamValue to optional IfcCurveMeasureSelect.
 		// Invocation of mapping on pre-4.3 models can never result in a piecewise_function.
-		if (inst->StartParam()) { // && inst->StartParam()->as<IfcSchema::IfcLengthMeasure>()) {
+		if (inst->StartParam() && inst->StartParam()->as<IfcSchema::IfcLengthMeasure>()) {
 			double s = *inst->StartParam()->as<IfcSchema::IfcLengthMeasure>();
 			if (s > start) {
 				start = s;
 			}
 		}
-		if (inst->EndParam()) { // && inst->EndParam()->as<IfcSchema::IfcLengthMeasure>()) {
+		if (inst->EndParam() && inst->EndParam()->as<IfcSchema::IfcLengthMeasure>()) {
 			double e = *inst->EndParam()->as<IfcSchema::IfcLengthMeasure>();
 			if (e < end) {
 				end = e;
@@ -57,10 +57,13 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcFixedReferenceSweptAreaSolid
 		auto nsteps = (size_t)ceil(len);
 		for (size_t i = 0; i <= nsteps; ++i) {
 			auto m4 = pwf->evaluate(start + len / nsteps * i);
+			
+			/*
 			std::stringstream ss;
 			ss << m4;
 			auto s = ss.str();
 			std::wcout << s.c_str() << std::endl;
+			*/
 
 			Eigen::Vector3d tangent = m4.col(0).head<3>().normalized();
 			Eigen::Vector3d proj = (ref->components() - tangent * tangent.dot(ref->components()));

--- a/src/ifcgeom/mapping/IfcFixedReferenceSweptAreaSolid.cpp
+++ b/src/ifcgeom/mapping/IfcFixedReferenceSweptAreaSolid.cpp
@@ -1,0 +1,87 @@
+/********************************************************************************
+ *                                                                              *
+ * This file is part of IfcOpenShell.                                           *
+ *                                                                              *
+ * IfcOpenShell is free software: you can redistribute it and/or modify         *
+ * it under the terms of the Lesser GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3.0 of the License, or          *
+ * (at your option) any later version.                                          *
+ *                                                                              *
+ * IfcOpenShell is distributed in the hope that it will be useful,              *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 *
+ * Lesser GNU General Public License for more details.                          *
+ *                                                                              *
+ * You should have received a copy of the Lesser GNU General Public License     *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.         *
+ *                                                                              *
+ ********************************************************************************/
+
+#include "mapping.h"
+#define mapping POSTFIX_SCHEMA(mapping)
+using namespace ifcopenshell::geometry;
+
+#ifdef SCHEMA_HAS_IfcFixedReferenceSweptAreaSolid
+
+taxonomy::ptr mapping::map_impl(const IfcSchema::IfcFixedReferenceSweptAreaSolid* inst) {
+	auto dir = map(inst->Directrix());
+	auto ref = taxonomy::cast<taxonomy::direction3>(map(inst->FixedReference()));
+	auto profile = taxonomy::cast<taxonomy::face>(map(inst->SweptArea()));
+
+	auto loft = taxonomy::make<taxonomy::loft>();
+	// @todo intialize as default
+	loft->axis = nullptr;
+
+	// @todo currently only the case is handled where directrix returns a piecewise_function
+	if (auto pwf = taxonomy::dcast<taxonomy::piecewise_function>(dir)) {
+		double start = 0;
+		double end = pwf->length();
+#ifdef SCHEMA_HAS_IfcDirectrixCurveSweptAreaSolid
+		// IfcDirectrixCurveSweptAreaSolid introduced in 4.3 changed attribute type
+		// from optional IfcParamValue to optional IfcCurveMeasureSelect.
+		// Invocation of mapping on pre-4.3 models can never result in a piecewise_function.
+		if (inst->StartParam()) { // && inst->StartParam()->as<IfcSchema::IfcLengthMeasure>()) {
+			double s = *inst->StartParam()->as<IfcSchema::IfcLengthMeasure>();
+			if (s > start) {
+				start = s;
+			}
+		}
+		if (inst->EndParam()) { // && inst->EndParam()->as<IfcSchema::IfcLengthMeasure>()) {
+			double e = *inst->EndParam()->as<IfcSchema::IfcLengthMeasure>();
+			if (e < end) {
+				end = e;
+			}
+		}
+#endif
+		auto len = end - start;
+		auto nsteps = (size_t)ceil(len);
+		for (size_t i = 0; i <= nsteps; ++i) {
+			auto m4 = pwf->evaluate(start + len / nsteps * i);
+			std::stringstream ss;
+			ss << m4;
+			auto s = ss.str();
+			std::wcout << s.c_str() << std::endl;
+
+			Eigen::Vector3d tangent = m4.col(0).head<3>().normalized();
+			Eigen::Vector3d proj = (ref->components() - tangent * tangent.dot(ref->components()));
+			proj.normalize();
+			auto ref = proj.cross(tangent);
+			auto pos = m4.col(3).head<3>();
+
+			Eigen::Matrix4d m4b = Eigen::Matrix4d::Identity();
+			m4b.col(0).head<3>() = ref;
+			m4b.col(1).head<3>() = proj;
+			m4b.col(2).head<3>() = tangent;
+			m4b.col(3).head<3>() = pos;
+
+			// @todo taxonomy::clone() does not actually clone. That's really confusing.
+			// loft->children.push_back(taxonomy::clone(profile));
+			loft->children.push_back(taxonomy::face::ptr(profile->clone_()));
+			loft->children.back()->matrix = taxonomy::make<taxonomy::matrix4>(m4b);
+		}
+	}
+
+	return loft;
+}
+
+#endif

--- a/src/ifcgeom/mapping/mapping.i
+++ b/src/ifcgeom/mapping/mapping.i
@@ -129,6 +129,10 @@ BIND(IfcArbitraryOpenProfileDef);
 BIND(IfcIndexedPolyCurve);
 #endif
 
+#ifdef SCHEMA_HAS_IfcFixedReferenceSweptAreaSolid
+BIND(IfcFixedReferenceSweptAreaSolid)
+#endif
+
 BIND(IfcCircle);
 BIND(IfcEllipse);
 BIND(IfcLine);


### PR DESCRIPTION
I've implemented a mapping from IfcFixedReferenceSweptAreaSolid to `loft` (sequence of `face`) and implemented `loft` in the occt kernel. The directrix/axis is used to transform the various repetitions of face, but is not actually passed on, because the segments are interpolated linearly. The results appear reasonably correct.

I'm really quite happy with how this went. Thanks for all the great work on the C++ impl @RickBrice. I took the first the wrong column from the evaluate() matrix output at first, but after that it was really a breeze.

![afbeelding](https://github.com/IfcOpenShell/IfcOpenShell/assets/1096535/6943db8e-cd94-42cd-b439-fc0f4d39c153)

RDF.bg

![afbeelding](https://github.com/IfcOpenShell/IfcOpenShell/assets/1096535/69de0d29-ca76-4621-8329-9408161b4a62)

ODA

![afbeelding](https://github.com/IfcOpenShell/IfcOpenShell/assets/1096535/9f3ce6f9-d5fb-416e-af2b-eb01317ab4c5)

![afbeelding](https://github.com/IfcOpenShell/IfcOpenShell/assets/1096535/4ec6a8a5-1b91-40e7-b6e0-1b43e692f26c)

Actually in ODA it becomes a flat surface.