### PR TITLE
Scale placeangelunit unit type

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -566,7 +566,14 @@ def convert(value, from_prefix, from_unit, to_prefix, to_unit):
     return value
 
 
-def calculate_unit_scale(ifc_file):
+def do_try(fn, default=None):
+    try:
+        return fn()
+    except:
+        return default
+
+
+def calculate_unit_scale(ifc_file, unit_type='LENGTHUNIT'):
     """Returns a unit scale factor to convert to and from IFC project length units and SI meters
 
     Example:
@@ -578,6 +585,8 @@ def calculate_unit_scale(ifc_file):
 
     :param ifc_file: The IFC file.
     :type ifc_file: ifcopenshell.file.file
+    :param unit_type: The type of SI unit, defaults to "LENGTHUNIT"
+    :type unit_type: str
     :returns: The scale factor
     :rtype: float
     """
@@ -586,13 +595,17 @@ def calculate_unit_scale(ifc_file):
     units = ifc_file.by_type("IfcUnitAssignment")[0]
     unit_scale = 1
     for unit in units.Units:
-        if not hasattr(unit, "UnitType") or unit.UnitType != "LENGTHUNIT":
+        if not hasattr(unit, "UnitType") or unit.UnitType != unit_type:
             continue
         while unit.is_a("IfcConversionBasedUnit"):
             unit_scale *= unit.ConversionFactor.ValueComponent.wrappedValue
             unit = unit.ConversionFactor.UnitComponent
         if unit.is_a("IfcSIUnit"):
             unit_scale *= get_prefix_multiplier(unit.Prefix)
+            current_unit_type = getattr(unit, 'UnitType', None)
+            if unit_type == 'PLANEANGLEUNIT':
+                if current_unit_type == unit_type and (scale := do_try(lambda: si_conversions.get(getattr(unit, 'Name', None).lower()), False)):
+                    unit_scale = scale
     return unit_scale
 
 

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -203,6 +203,7 @@ si_conversions = {
     "gallon UK": 0.004546,
     "gallon US": 0.003785,
     "degree": pi / 180,
+    "radian": 180 / pi,
     "ounce": 0.02835,
     "pound": 0.454,
     "ton UK": 1016.0469088,

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -601,12 +601,8 @@ def calculate_unit_scale(ifc_file, unit_type='LENGTHUNIT'):
         while unit.is_a("IfcConversionBasedUnit"):
             unit_scale *= unit.ConversionFactor.ValueComponent.wrappedValue
             unit = unit.ConversionFactor.UnitComponent
-        if unit.is_a("IfcSIUnit"):
+        if unit.is_a("IfcSIUnit") and not unit_type=='PLANEANGLEUNIT':
             unit_scale *= get_prefix_multiplier(unit.Prefix)
-            current_unit_type = getattr(unit, 'UnitType', None)
-            if unit_type == 'PLANEANGLEUNIT':
-                if current_unit_type == unit_type and (scale := do_try(lambda: si_conversions.get(getattr(unit, 'Name', None).lower()), False)):
-                    unit_scale = scale
     return unit_scale
 
 

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -203,7 +203,6 @@ si_conversions = {
     "gallon UK": 0.004546,
     "gallon US": 0.003785,
     "degree": pi / 180,
-    "radian": 180 / pi,
     "ounce": 0.02835,
     "pound": 0.454,
     "ton UK": 1016.0469088,
@@ -567,13 +566,6 @@ def convert(value, from_prefix, from_unit, to_prefix, to_unit):
     return value
 
 
-def do_try(fn, default=None):
-    try:
-        return fn()
-    except:
-        return default
-
-
 def calculate_unit_scale(ifc_file, unit_type='LENGTHUNIT'):
     """Returns a unit scale factor to convert to and from IFC project length units and SI meters
 
@@ -601,7 +593,7 @@ def calculate_unit_scale(ifc_file, unit_type='LENGTHUNIT'):
         while unit.is_a("IfcConversionBasedUnit"):
             unit_scale *= unit.ConversionFactor.ValueComponent.wrappedValue
             unit = unit.ConversionFactor.UnitComponent
-        if unit.is_a("IfcSIUnit") and not unit_type=='PLANEANGLEUNIT':
+        if unit.is_a("IfcSIUnit")':
             unit_scale *= get_prefix_multiplier(unit.Prefix)
     return unit_scale
 


### PR DESCRIPTION
> add a default argument unit_type='LENGTHUNIT' and use that so that the calculate_unit_scale()  function in IfcOpenShell can also be adapted to PLANEANGLEUNIT

- Example1 : conversion unit present
```python
aim_value = 32.27
i = 35.27
file.by_type("IfcConversionBasedUnit")
[#49=IfcConversionBasedUnit(#47,.PLANEANGLEUNIT.,'DEGREE',#48)]
abs(aim_value - math.degrees(calculate_unit_scale(filel, unit_type='PLANEANGLEUNIT') * i))) < 1.e-2
True
```

- Example 2 : conversion unit not present
```python
aim_value = 32.27
i = 0.6155
file.by_type("IfcConversionBasedUnit")
[]
abs(aim_value - math.degrees(calculate_unit_scale(filel, unit_type='PLANEANGLEUNIT') * i))) < 1.e-2
True
```


ping @aothms 