### PR TITLE
changed comparison for type relationships

### DIFF
--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -280,7 +280,7 @@ class IfcDiff:
                 old_type = ifcopenshell.util.element.get_type(old)
                 new_type = ifcopenshell.util.element.get_type(new)
                 if old_type is not None and new_type is not None:
-                    if old_type.get_info() != new_type.get_info():
+                    if old_type.GlobalId != new_type.GlobalId:
                         self.change_register.setdefault(new.GlobalId, {}).update({"type_changed": True})
                         return True
                 elif old_type != new_type:

--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -277,7 +277,14 @@ class IfcDiff:
             return
         for relationship in self.relationships:
             if relationship == "type":
-                if ifcopenshell.util.element.get_type(old) != ifcopenshell.util.element.get_type(new):
+                old_type = ifcopenshell.util.element.get_type(old)
+                new_type = ifcopenshell.util.element.get_type(new)
+                if old_type is not None and new_type is not None:
+                    if old_type.get_info() != new_type.get_info():
+                        self.change_register.setdefault(new.GlobalId, {}).update({"type_changed": True})
+                        return True
+                elif old_type != new_type:
+                    # one of the types is None while the other is not None
                     self.change_register.setdefault(new.GlobalId, {}).update({"type_changed": True})
                     return True
             elif relationship == "property":


### PR DESCRIPTION
The original code compares the type objects returned by get_type(). I am not 100% sure if this is the cause, but the __eq__ method of entity_instance compares the file_pointer. Since the types come from different files they will never be equal.

This proposal compares the result of get_info() on the types instead.

fixes #4402
