### PR TITLE
when `bim.select_aggregate` is run, it deselects the initial object

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/aggregate/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/aggregate/operator.py
@@ -209,6 +209,7 @@ class BIM_OT_select_aggregate(bpy.types.Operator):
         aggregate_obj = tool.Ifc.get_object(aggregate)
         if aggregate_obj in context.selectable_objects:
             aggregate_obj.select_set(True)
+            obj.select_set(False)
             bpy.context.view_layer.objects.active = aggregate_obj
         return {"FINISHED"}
 


### PR DESCRIPTION
ping @brunoperdigao 

After `bim.select_aggregate`, i often reassign the aggregate to another parent aggregate. 

The PR just streamlines things, as I don't have to deselect the initial object, before assigning the aggregate. 