### PR TITLE
Changed unescaped ; with , as in #4456

### DIFF
--- a/src/blenderbim/blenderbim/bim/data/assets/sample.css
+++ b/src/blenderbim/blenderbim/bim/data/assets/sample.css
@@ -10,7 +10,7 @@
  * (at your option) any later version.
  *
  * BlenderBIM Add-on is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *


### PR DESCRIPTION
Changed unescaped `;` with `,` because it may cause problems if the style is included in svg.

It's the same as in #4456 for `default.css` but I only realised now that `sample.css` could lead to the same problem.