### PR TITLE
Fix "gtlf" typo, use "gltf" instead

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/main.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/main.py
@@ -313,7 +313,7 @@ class serializers:
     buffer = ifcopenshell_wrapper.buffer
     # gltf and hdf5 availability depend on IfcOpenShell configuration settings
     try:
-        gtlf = ifcopenshell_wrapper.GltfSerializer
+        gltf = ifcopenshell_wrapper.GltfSerializer
     except:
         pass
     try:


### PR DESCRIPTION
This pull request fixes issue #4535 