### PR TITLE
Fixes #4261

### DIFF
--- a/src/ifcwrap/utils/type_conversion.i
+++ b/src/ifcwrap/utils/type_conversion.i
@@ -72,9 +72,16 @@
 
 	template <>
 	std::string cast_pyobject(PyObject* element) {
+	#if SWIG_VERSION >= 0x040200
+	    PyObject *pbytes = NULL;
+	    const char* str_data = SWIG_PyUnicode_AsUTF8AndSize(element, NULL, &pbytes);
+		std::string str = str_data;
+		Py_XDECREF(pbytes);
+	#else
 		char* str_data = SWIG_Python_str_AsChar(element);
 		std::string str = str_data;
 		SWIG_Python_str_DelForPy3(str_data);
+	#endif
 		return str;
 	}
 


### PR DESCRIPTION
SWIG_Python_str_AsChar and SWIG_Python_str_DelForPy3 are no longer available in swig 4.2 (see : https://github.com/swig/swig/commit/f89dd59d4b82ece899087682fdb86e94d2611513 ), this commit fixes the build for swig versions > 4.2.

