### PR TITLE
Fix HDF5 conditional inclusion in GeomTree

### DIFF
--- a/src/ifcgeom_schema_agnostic/IfcGeomTree.h
+++ b/src/ifcgeom_schema_agnostic/IfcGeomTree.h
@@ -62,7 +62,9 @@
 #include <STEPConstruct_PointHasher.hxx>
 #include "clash_utils.h"
 
+#ifdef WITH_HDF5
 #include "H5Cpp.h"
+#endif
 
 
 namespace IfcGeom {
@@ -1504,6 +1506,7 @@ namespace IfcGeom {
 			}
 		}
 
+#ifdef WITH_HDF5
         void write_h5() {
             H5::H5File file("filename.h5", H5F_ACC_TRUNC);
             H5::Group shapes = file.createGroup("/shapes");
@@ -1714,6 +1717,7 @@ namespace IfcGeom {
                 colours_dataset.write(flat_colours.data(), H5::PredType::NATIVE_FLOAT);
             }
         }
+#endif
 
         template <typename T>
         void apply_matrix_to_flat_verts(const std::vector<T>& flat_list, const std::vector<T>& matrix, std::vector<T>& result) {


### PR DESCRIPTION
IfcGeomTree uses HDF5, but this is an optional module, so we have to wrap it with #ifdef WITH_HDF5