### PR TITLE
Extending Distance Limit on IFC Import 

### DIFF
--- a/src/blenderbim/blenderbim/bim/import_ifc.py
+++ b/src/blenderbim/blenderbim/bim/import_ifc.py
@@ -2063,7 +2063,7 @@ class IfcImportSettings:
         self.deflection_tolerance = 0.001
         self.angular_tolerance = 0.5
         self.void_limit = 30
-        self.distance_limit = 1000
+        self.distance_limit = 10000
         self.false_origin = None
         self.element_offset = 0
         self.element_limit = 30000


### PR DESCRIPTION
Hello!

I know this is a pretty minor change, but I was having a use case where the model I wanted to load was rather off center, and I didn't really want to push my users into using the advanced menu, when I believe the purpose of having the limit was to allow users to only load in some of the model, in cases where the model was large. 

Can we just bump this a little for now? 

I think the best case scenario would be to not have the default behavior filter by distance at all, and try to load in everything it can, then allow a way for them to filter by distance. 

Probably by re-working:
https://github.com/IfcOpenShell/IfcOpenShell/blob/bc72c927c1d6737730a2db1391e5b4a9e4de21d3/src/blenderbim/blenderbim/bim/import_ifc.py#L314

To return False if that distance limit is set to None? or inf? I'm not sure. 