### PR TITLE
Graceful handling of instance deletion in python

### DIFF
--- a/src/ifcparse/parse_ifcxml.cpp
+++ b/src/ifcparse/parse_ifcxml.cpp
@@ -480,7 +480,7 @@ static void start_element(void* user, const xmlChar* tag, const xmlChar** attrs)
             if (state->dialect == ifcxml_dialect_ifc4) {
                 // In IFC2X3 not added directly because attrs such as GlobalId are in
                 // subsequent child nodes
-                newinst = state->file->addEntity(newinst);
+                newinst = &*state->file->addEntity(newinst);
                 if (id) {
                     state->idmap[*id] = newinst->data().id();
                 }

--- a/src/serializers/GltfSerializer.cpp
+++ b/src/serializers/GltfSerializer.cpp
@@ -443,14 +443,14 @@ void GltfSerializer::setFile(IfcParse::IfcFile* f) {
 	boost::optional<std::array<double, 3>> crs_x_axis;
 	boost::optional<std::array<double, 3>> eastings_northings_elevation;
 
-	aggregate_of_instance::ptr coordops;
+	IfcParse::IfcFile::type_iterator_range_t coordops;
 	try {
 		coordops = f->instances_by_type("IfcCoordinateOperation");
 	} catch (IfcParse::IfcException&) {
 		// Ignored. Schema likely doesn't support IfcCoordinateOperation.
 	}
-	if (coordops) {
-		for (auto& coordop : *coordops) {
+	if (std::distance(coordops.first, coordops.second)) {
+		for (auto& coordop : boost::make_iterator_range(coordops)) {
 			IfcUtil::IfcBaseClass* source_crs = *coordop->as<IfcUtil::IfcBaseEntity>()->get("SourceCRS");
 			if (source_crs->declaration().is("IfcGeometricRepresentationContext")) {
 				IfcUtil::IfcBaseClass* target_crs = *coordop->as<IfcUtil::IfcBaseEntity>()->get("TargetCRS");
@@ -486,9 +486,9 @@ void GltfSerializer::setFile(IfcParse::IfcFile* f) {
 	if (!crs_epsg) {
 		auto sites = f->instances_by_type("IfcSite");
 
-		if (sites && sites->size() == 1) {
-			auto lat_attr = (*sites->begin())->as<IfcUtil::IfcBaseEntity>()->get("RefLatitude");
-			auto lon_attr = (*sites->begin())->as<IfcUtil::IfcBaseEntity>()->get("RefLongitude");
+		if (std::distance(sites.first, sites.second)) {
+			auto lat_attr = (*sites.first)->as<IfcUtil::IfcBaseEntity>()->get("RefLatitude");
+			auto lon_attr = (*sites.first)->as<IfcUtil::IfcBaseEntity>()->get("RefLongitude");
 
 			if (!lat_attr->isNull() && !lon_attr->isNull()) {
 				std::vector<int> lat_dms = *lat_attr;
@@ -521,8 +521,8 @@ void GltfSerializer::setFile(IfcParse::IfcFile* f) {
 
 	auto contexts = f->instances_by_type_excl_subtypes("IfcGeometricRepresentationContext");
 
-	if (contexts && contexts->size() > 0) {
-		auto context = (*contexts->begin())->as<IfcUtil::IfcBaseEntity>();
+	if (std::distance(contexts.first, contexts.second)) {
+		auto context = (*contexts.first)->as<IfcUtil::IfcBaseEntity>();
 		auto north_attr = context->get("TrueNorth");
 		if (!north_attr->isNull()) {
 			IfcUtil::IfcBaseClass* north = *north_attr;


### PR DESCRIPTION
Accessing an instance that got deleted now raises a catchable exception. Still need to let this percolate a bit in order to make this a bit more backwards compatible on the C++ side of things.

```
>>> import ifcopenshell
>>> f = ifcopenshell.file()
>>> inst = f.createIfcWall('a')
>>> inst2 = f.by_guid('a')
>>> f.remove(inst)
>>> inst2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\tkrij\miniconda3\envs\ifopsh08\lib\site-packages\ifcopenshell\entity_instance.py", line 307, in __repr__
    return repr(self.wrapped_data)
  File "C:\Users\tkrij\miniconda3\envs\ifopsh08\lib\site-packages\ifcopenshell\ifcopenshell_wrapper.py", line 8045, in __repr__
    return _ifcopenshell_wrapper.entity_instance___repr__(self)
RuntimeError: No longer availabe
```