### PR TITLE
added 'product' parameter to a few usages of 'pset.remove_pset' after…

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/aggregate/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/aggregate/operator.py
@@ -100,7 +100,7 @@ class BIM_OT_aggregate_unassign_object(bpy.types.Operator, Operator):
                 pset = ifcopenshell.util.element.get_pset(element, 'BBIM_Linked_Aggregate')
                 if pset:
                     pset = tool.Ifc.get().by_id(pset["id"])
-                    ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), pset=pset)
+                    ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=element, pset=pset)
 
               
 class BIM_OT_enable_editing_aggregate(bpy.types.Operator, Operator):

--- a/src/blenderbim/blenderbim/bim/module/geometry/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/geometry/operator.py
@@ -938,7 +938,7 @@ class OverrideDuplicateMove(bpy.types.Operator):
             pset = ifcopenshell.util.element.get_pset(new[0], "BBIM_Linked_Aggregate")
             if pset:
                 pset = tool.Ifc.get().by_id(pset["id"])
-                ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), pset=pset)
+                ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=new[0],pset=pset)
 
             if new[0].is_a("IfcElementAssembly"):
                 linked_aggregate_group = [

--- a/src/blenderbim/blenderbim/bim/module/model/door.py
+++ b/src/blenderbim/blenderbim/bim/module/model/door.py
@@ -644,6 +644,6 @@ class RemoveDoor(bpy.types.Operator, tool.Ifc.Operator):
         obj.BIMDoorProperties.is_editing = False
 
         pset = tool.Pset.get_element_pset(element, "BBIM_Door")
-        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), pset=pset)
+        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=element, pset=pset)
 
         return {"FINISHED"}

--- a/src/blenderbim/blenderbim/bim/module/model/railing.py
+++ b/src/blenderbim/blenderbim/bim/module/model/railing.py
@@ -535,5 +535,5 @@ class RemoveRailing(bpy.types.Operator, tool.Ifc.Operator):
         obj.BIMRailingProperties.is_editing = False
 
         pset = tool.Pset.get_element_pset(element, "BBIM_Railing")
-        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), pset=pset)
+        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=element, pset=pset)
         return {"FINISHED"}

--- a/src/blenderbim/blenderbim/bim/module/model/roof.py
+++ b/src/blenderbim/blenderbim/bim/module/model/roof.py
@@ -757,7 +757,7 @@ class RemoveRoof(bpy.types.Operator, tool.Ifc.Operator):
         obj.BIMRoofProperties.is_editing = False
 
         pset = tool.Pset.get_element_pset(element, "BBIM_Roof")
-        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), pset=pset)
+        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=element, pset=pset)
         return {"FINISHED"}
 
 

--- a/src/blenderbim/blenderbim/bim/module/model/stair.py
+++ b/src/blenderbim/blenderbim/bim/module/model/stair.py
@@ -337,6 +337,6 @@ class RemoveStair(bpy.types.Operator, tool.Ifc.Operator):
         obj.BIMStairProperties.is_editing = False
 
         pset = tool.Pset.get_element_pset(element, "BBIM_Stair")
-        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), pset=pset)
+        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=element, pset=pset)
 
         return {"FINISHED"}

--- a/src/blenderbim/blenderbim/bim/module/model/window.py
+++ b/src/blenderbim/blenderbim/bim/module/model/window.py
@@ -590,6 +590,6 @@ class RemoveWindow(bpy.types.Operator, tool.Ifc.Operator):
         obj.BIMWindowProperties.is_editing = False
 
         pset = tool.Pset.get_element_pset(element, "BBIM_Window")
-        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), pset=pset)
+        ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=element, pset=pset)
 
         return {"FINISHED"}

--- a/src/blenderbim/blenderbim/tool/model.py
+++ b/src/blenderbim/blenderbim/tool/model.py
@@ -551,7 +551,7 @@ class Model(blenderbim.core.tool.Model):
             data = tool.Ifc.get().createIfcText(json.dumps(data))
             ifcopenshell.api.run("pset.edit_pset", tool.Ifc.get(), pset=pset, properties={"Data": data})
         else:
-            ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), pset=pset)
+            ifcopenshell.api.run("pset.remove_pset", tool.Ifc.get(), product=element, pset=pset)
 
     @classmethod
     def get_flow_segment_axis(cls, obj):


### PR DESCRIPTION
… ebd03e9

Hi  @Andrej730, maybe you've already planned this, but I saw that the `product` parameter is no longer optional for `remove_pset` and I was getting an error while using linked aggregates. So I spotted a few other places in the code where the `product` parameters were still missing and added them.