### PR TITLE
[BBIM docs] change color of ui breadcrumb on dark background

### DIFF
--- a/src/blenderbim/docs/_static/custom.css
+++ b/src/blenderbim/docs/_static/custom.css
@@ -63,7 +63,7 @@ section img {
     background-color: var(--color-admonition-title-background);
     border-radius: 5px;
     font-style: italic;
-    color: var(--color-content-foreground);
+    color: var(--color-admonition-text);
 }
 img.icon {
     width: auto;

--- a/src/blenderbim/docs/_static/custom.css
+++ b/src/blenderbim/docs/_static/custom.css
@@ -63,7 +63,7 @@ section img {
     background-color: var(--color-admonition-title-background);
     border-radius: 5px;
     font-style: italic;
-    color: var(--color-admonition-title);
+    color: var(--color-content-foreground);
 }
 img.icon {
     width: auto;

--- a/src/blenderbim/docs/conf.py
+++ b/src/blenderbim/docs/conf.py
@@ -99,6 +99,7 @@ html_theme_options = {
         "color-link--visited": "#39b54a",
         "color-link--hover": "#d98014",
         "color-link--visited--hover": "#d98014",
+        "color-admonition-text": "#651fff",
         "font-stack": "Nunito, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji"
     },
     "dark_css_variables": {
@@ -113,6 +114,7 @@ html_theme_options = {
         "color-link--visited": "#39b54a",
         "color-link--hover": "#d98014",
         "color-link--visited--hover": "#d98014",
+        "color-admonition-text": "#EEEEEC",        
         "font-stack": "Nunito, -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji"
     },
 


### PR DESCRIPTION
Make the breadcrumb text better readable on dark background.
ToDo: find a way to change the color of the SVG symbols as well.

Before:
![BlenderBIM-docs_breadcrumb_before](https://github.com/IfcOpenShell/IfcOpenShell/assets/3765119/11337537-c378-4a5c-8509-623ba4034ece)

After commit:
![BlenderBIM-docs_breadcrumb_after](https://github.com/IfcOpenShell/IfcOpenShell/assets/3765119/21f5f2a0-ab3e-4f0a-9ada-eaa0bedb0f1f)
