### PR TITLE
Bug fix in editing material set item profile

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/material/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/material/operator.py
@@ -562,6 +562,7 @@ class EnableEditingMaterialSetItemProfile(bpy.types.Operator):
     def execute(self, context):
         obj = bpy.data.objects.get(self.obj) if self.obj else context.active_object
         self.props = obj.BIMObjectMaterialProperties
+        self.props.active_material_set_item_id = self.material_set_item
         self.props.material_set_item_profile_attributes.clear()
         profile = tool.Ifc.get().by_id(self.material_set_item).Profile
         blenderbim.bim.helper.import_attributes2(profile, self.props.material_set_item_profile_attributes)
@@ -577,6 +578,7 @@ class DisableEditingMaterialSetItemProfile(bpy.types.Operator):
     def execute(self, context):
         obj = bpy.data.objects.get(self.obj) if self.obj else context.active_object
         self.props = obj.BIMObjectMaterialProperties
+        self.props.active_material_set_item_id = 0
         self.props.material_set_item_profile_attributes.clear()
         return {"FINISHED"}
 

--- a/src/blenderbim/blenderbim/bim/module/material/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/material/ui.py
@@ -228,7 +228,7 @@ class BIM_PT_object_material(Panel):
 
         total_items = len(ObjectMaterialData.data["set_items"])
         for index, set_item in enumerate(ObjectMaterialData.data["set_items"]):
-            if len(self.props.material_set_item_profile_attributes):
+            if len(self.props.material_set_item_profile_attributes) and self.props.active_material_set_item_id == set_item["id"]:
                 self.draw_editable_set_item_profile_ui(set_item)
             elif self.props.active_material_set_item_id == set_item["id"]:
                 self.draw_editable_set_item_ui(set_item)


### PR DESCRIPTION
Fixes bug: Editing a profile under MaterialProfileSetUsage opened dialog boxes under all profiles.

See following screencasts.

Before:
[before.webm](https://github.com/IfcOpenShell/IfcOpenShell/assets/4415312/037b734a-935f-4ab7-b133-406ab5efcdfc)

After:
[after.webm](https://github.com/IfcOpenShell/IfcOpenShell/assets/4415312/c63f1e82-9e78-494e-811a-5ac02619f4ce)
