### PR TITLE
geometry iterator to reuse representations in more cases #4799

### DIFF
--- a/src/ifcgeom/IfcGeom.cpp
+++ b/src/ifcgeom/IfcGeom.cpp
@@ -579,7 +579,7 @@ namespace {
 #endif
 }
 
-const IfcSchema::IfcMaterial* IfcGeom::Kernel::get_single_material_association(const IfcSchema::IfcProduct* product) {
+const IfcSchema::IfcMaterial* IfcGeom::Kernel::get_single_material_association(const IfcSchema::IfcObjectDefinition* product) {
 	IfcSchema::IfcMaterial* single_material = 0;
 	IfcSchema::IfcRelAssociatesMaterial::list::ptr associated_materials = product->HasAssociations()->as<IfcSchema::IfcRelAssociatesMaterial>();
 	if (associated_materials->size() == 1) {
@@ -675,7 +675,7 @@ IfcGeom::BRepElement* IfcGeom::Kernel::create_brep_for_representation_and_produc
 
 	bool material_style_applied = false;
 
-	const IfcSchema::IfcMaterial* single_material = get_single_material_association(product);
+	const IfcSchema::IfcMaterial* single_material = get_single_material_association(product->as<IfcSchema::IfcObjectDefinition>());
 	if (single_material) {
 		auto s = get_style(single_material);
 		for (IfcGeom::IfcRepresentationShapeItems::iterator it = shapes.begin(); it != shapes.end(); ++it) {
@@ -1635,6 +1635,18 @@ IfcSchema::IfcRepresentation* IfcGeom::Kernel::find_representation(const IfcSche
 	IfcSchema::IfcRepresentation::list::ptr reps = prod_rep->Representations();
 	for (IfcSchema::IfcRepresentation::list::it it = reps->begin(); it != reps->end(); ++it) {
 		if ((**it).RepresentationIdentifier() && (*(**it).RepresentationIdentifier()) == identifier) {
+			return *it;
+		}
+	}
+	return 0;
+}
+
+IfcSchema::IfcRepresentation* IfcGeom::Kernel::find_representation(const IfcSchema::IfcProduct* product, const IfcSchema::IfcRepresentationContext* context) {
+	if (!product->Representation()) return 0;
+	IfcSchema::IfcProductRepresentation* prod_rep = product->Representation();
+	IfcSchema::IfcRepresentation::list::ptr reps = prod_rep->Representations();
+	for (IfcSchema::IfcRepresentation::list::it it = reps->begin(); it != reps->end(); ++it) {
+        if ((**it).ContextOfItems() == context) {
 			return *it;
 		}
 	}

--- a/src/ifcgeom/IfcGeom.h
+++ b/src/ifcgeom/IfcGeom.h
@@ -280,6 +280,7 @@ public:
 	IfcSchema::IfcRelVoidsElement::list::ptr find_openings(IfcSchema::IfcProduct* product);
 
 	IfcSchema::IfcRepresentation* find_representation(const IfcSchema::IfcProduct*, const std::string&);
+	IfcSchema::IfcRepresentation* find_representation(const IfcSchema::IfcProduct*, const IfcSchema::IfcRepresentationContext* context);
 
 	std::pair<std::string, double> initializeUnits(IfcSchema::IfcUnitAssignment*);
 
@@ -289,7 +290,7 @@ public:
     IfcGeom::BRepElement* create_brep_for_processed_representation(
         const IteratorSettings&, IfcSchema::IfcRepresentation*, IfcSchema::IfcProduct*, IfcGeom::BRepElement*);
 
-	const IfcSchema::IfcMaterial* get_single_material_association(const IfcSchema::IfcProduct*);
+	const IfcSchema::IfcMaterial* get_single_material_association(const IfcSchema::IfcObjectDefinition*);
 	IfcSchema::IfcRepresentation* representation_mapped_to(const IfcSchema::IfcRepresentation* representation);
 	IfcSchema::IfcProduct::list::ptr products_represented_by(const IfcSchema::IfcRepresentation*);
 	std::shared_ptr<const SurfaceStyle> get_style(const IfcSchema::IfcRepresentationItem*);


### PR DESCRIPTION
- get_next_task() changes

Previously: if type had n occurrences and only 1 of them was requiring to have their own representation (e.g. one of the occurrences had openings), then all the occurrences would have their own representations even though it wasn't necessary. Now get_next_task() is filter out products that should have their own representation and use a common representation of other occurrences. In the example above only this 1 product requiring unique representation will have it and all other n-1 will share type's representation.

To do so I've changed reuse_ok_() - now it's checking the condition for a single product instead of a list of them (previously we could only check whether all products in a list are okay to reuse type's representation or not).

Previously there was a check if provided products use multiple materials (I assumed it was to check whether they do have conflicting material styles). I've replaced it with check for whether current product has an overriding material style.

- removed ok_mapped_representations cache since it's no longer possible that we'll be checking reuse_ok_ for all products of a mapped representation multiple times
- get_single_material_association now is using IfcObjectDefinition to allow both IfcProducts and IfcTypeProducts
- find_representation now has another implementation that will search for representation with matching IfcRepresentationContext


Example python snippet (difference in output at the end, example ifc - [cube.ifc.txt](https://github.com/user-attachments/files/15731161/cube.ifc.txt)):
```python
import ifcopenshell
import ifcopenshell.api.geometry
import ifcopenshell.api.root
import ifcopenshell.geom
import ifcopenshell.api.void
import ifcopenshell.util.element
import multiprocessing
from pathlib import Path
import ifcopenshell.util.representation
from ifcopenshell.util.shape_builder import ShapeBuilder, V
from typing import Union

path = Path(r"cube.ifc")
ifc_file = ifcopenshell.open(path)
products = ifc_file.by_type("IfcActuator")
settings = ifcopenshell.geom.settings()
settings.set_deflection_tolerance(0.001)
settings.set_angular_tolerance(0.5)
settings.set(settings.STRICT_TOLERANCE, True)
settings.set(settings.INCLUDE_CURVES, True)
context = ifc_file.by_id(15)
settings.set_context_ids([context.id()])
filter_products = lambda: ifc_file.by_type("IfcActuator")

def print_reps():
    products = filter_products()
    def get_id(item):
        item_id = item.geometry.id
        if "-" in item_id:
            item_id = item_id.split("-")[0]
        return int(item_id)

    iterator = ifcopenshell.geom.iterator(settings, ifc_file, num_threads=multiprocessing.cpu_count(), include=products)
    for item in iterator:
        rep = ifc_file.by_id(get_id(item))
        print(rep, item.product_())


print("occurrences representations from iterator before adding an opening:")
# returns common IfcActuatorType representation
# 2324=IfcShapeRepresentation(# 15,'Body','Tessellation',(# 2323)) # 2251=IfcActuator('0$0Wsg5jP5Hu2QbwD1qGi$',$,'No Openings Occurrence',$,$,# 2419,# 2264,$,$)
# 2324=IfcShapeRepresentation(# 15,'Body','Tessellation',(# 2323)) # 2420=IfcActuator('1j1SEPWBXDJvDvSjKM2pKf',$,'Has Opening',$,$,# 2450,# 2433,$,$)
print_reps()

actuator = products[1]
builder = ShapeBuilder(ifc_file)
opening = ifcopenshell.api.root.create_entity(ifc_file, "IfcOpeningElement")
ifcopenshell.api.geometry.edit_object_placement(ifc_file, opening)
rectangle = builder.rectangle(V(1000, 1000))
extrusion = builder.extrude(rectangle, 1000)
rep_opening = builder.get_representation(context, extrusion)
ifcopenshell.api.geometry.assign_representation(ifc_file, opening, rep_opening)
ifcopenshell.api.void.add_opening(ifc_file, opening, actuator)

actuator = ifcopenshell.api.root.create_entity(ifc_file, "IfcActuator", name="new")
rep = ifcopenshell.util.element.copy_deep(ifc_file, rep_opening, exclude=["IfcRepresentationContext"])
ifcopenshell.api.geometry.assign_representation(ifc_file, actuator, rep)
opening = ifcopenshell.api.root.create_entity(ifc_file, "IfcOpeningElement")
ifcopenshell.api.geometry.edit_object_placement(ifc_file, opening)
rep = ifcopenshell.util.element.copy_deep(ifc_file, rep_opening, exclude=["IfcRepresentationContext"])
ifcopenshell.api.geometry.assign_representation(ifc_file, opening, rep_opening)
ifcopenshell.api.void.add_opening(ifc_file, opening, actuator)

ifc_file.write(path.with_stem("fixed"))

# import ifcopenshell.ifcopenshell_wrapper
# ifcopenshell.ifcopenshell_wrapper.turn_on_detailed_logging()

print("after adding an opening:")
# Before PR:
# 2271=IfcShapeRepresentation(# 15,'Body','MappedRepresentation',(# 2270)) # 2251=IfcActuator('0$0Wsg5jP5Hu2QbwD1qGi$',$,'No Openings Occurrence',$,$,# 2419,# 2264,$,$)
# 2432=IfcShapeRepresentation(# 15,'Body','MappedRepresentation',(# 2431)) # 2420=IfcActuator('1j1SEPWBXDJvDvSjKM2pKf',$,'Has Opening',$,$,# 2450,# 2433,$,$)
# 2475=IfcShapeRepresentation(# 15,'Body','SweptSolid',(# 2476)) # 2474=IfcActuator('0kFdxsNMb83vwdfgz3bjYG',$,'new',$,$,$,# 2485,$,$)

# After PR:
# 2324=IfcShapeRepresentation(# 15,'Body','Tessellation',(# 2323)) # 2251=IfcActuator('0$0Wsg5jP5Hu2QbwD1qGi$',$,'No Openings Occurrence',$,$,# 2419,# 2264,$,$)
# 2432=IfcShapeRepresentation(# 15,'Body','MappedRepresentation',(# 2431)) # 2420=IfcActuator('1j1SEPWBXDJvDvSjKM2pKf',$,'Has Opening',$,$,# 2450,# 2433,$,$)
# 2475=IfcShapeRepresentation(# 15,'Body','SweptSolid',(# 2476)) # 2474=IfcActuator('34Vv3wTtn9_ezlB5ZTZrCS',$,'new',$,$,$,# 2485,$,$)
print_reps()

print("finished")
```