### PR TITLE
add cron job for trimming the number of conda daily package versions

### DIFF
--- a/.github/workflows/ci-ifcopenshell-conda-cleaner.yml
+++ b/.github/workflows/ci-ifcopenshell-conda-cleaner.yml
@@ -1,0 +1,98 @@
+name: ci-ifcopenshell-conda-daily-cleaner
+
+on:
+  workflow_dispatch:
+  schedule:
+  #         ┌───────────── minute (0 - 59)
+  #         │  ┌───────────── hour (0 - 23)
+  #         │  │ ┌───────────── day of the month (1 - 31)
+  #         │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+  #         │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+  #         *  * * * *
+  - cron: "00 23 * * *" # 11min before utc midnight every day
+
+env:
+  ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+  NUM_SUPPORTED_VERSIONS: 5
+
+jobs:
+  activate:
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'IfcOpenShell/IfcOpenShell'
+    steps:
+      - uses: mamba-org/setup-micromamba@v1 # https://github.com/mamba-org/setup-micromamba
+        with:
+          environment-name: test-env
+          create-args: >-
+            python=3.11
+            anaconda-client=1.12.3
+
+      - name: Run conda cleaner
+        run: |
+          python - << EOF
+          
+          import os
+          from datetime import datetime, timedelta
+          from binstar_client.utils import get_server_api
+          from binstar_client.errors import BinstarError
+          
+          # Configuration
+          api_token = os.environ.get('ANACONDA_TOKEN')
+          pkg_name = 'ifcopenshell'
+          channel_name = 'ifcopenshell'
+          
+          # Authenticate with Anaconda
+          aserver_api = get_server_api(token=api_token)
+          
+          
+          # Get the list of packages in the channel
+          def get_package(filter_package_name: str = None):
+              try:
+                  user_packages = aserver_api.user_packages(channel_name)
+                  if filter_package_name:
+                      user_packages = [pkg for pkg in user_packages if pkg['name'] == filter_package_name]
+                  if len(user_packages) == 0:
+                      print(f"No packages found for {filter_package_name}.")
+                  if len(user_packages) > 1:
+                      raise ValueError(f"Found {len(user_packages)} package for {filter_package_name}. Will only support 1 package.")
+          
+                  return user_packages[0]
+              except BinstarError as err:
+                  raise ValueError(f"Failed to fetch packages: {err}")
+          
+          
+          # Delete a package version
+          def delete_package(package_name, version):
+              try:
+                  aserver_api.remove_release(channel_name, package_name, version)
+                  print(f"Deleted {package_name} version {version}")
+              except BinstarError as err:
+                  print(f"Failed to delete {package_name} version {version}: {err}")
+          
+          
+          # Main logic
+          def main():
+              package = get_package(pkg_name)
+              if not package:
+                  print("No packages found.")
+                  return
+          
+              number_of_supported_versions = ${{ env.NUM_SUPPORTED_VERSIONS }}
+          
+              package_name = package['name']
+              versions = package["versions"]
+              if len(versions) <= number_of_supported_versions:
+                  print(f"Number of versions {len(versions)} is less than or equal to {number_of_supported_versions}.")
+                  return
+          
+              # sort the versions in descending order
+              versions = sorted(versions, reverse=True)
+              releases = versions[number_of_supported_versions:]
+          
+              for release in releases:
+                  delete_package(package_name, release)
+          
+          main()
+          
+          EOF


### PR DESCRIPTION
This will add a cron job for trimming the number of available daily conda packages of ifcopenshell-python. The default number of available versions is set to 5. The cron job runs 1 hour before building a new daily job, so the total number of available versions will in practice be 6