### PR TITLE
fix choco release using release tag for url

### DIFF
--- a/.github/workflows/ci-blenderbim-choco.yml
+++ b/.github/workflows/ci-blenderbim-choco.yml
@@ -43,30 +43,32 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2 # https://github.com/actions/setup-python
         with:
-          python-version: '3.10.9' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          python-version: '3.11.7' # Version range or exact version of a Python version to use, using SemVer's version range syntax
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
       - run: echo ${{ env.DATE }}
 
-      - name: Check in published releases if we should do a choco release
+      - name: Check in release tags if we should do a choco release
         id: do_choco
         run: |
-          echo "::set-output name=choco_release::$(python3 /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/check_repo_infos.py --do_choco_release?)"
+          cd /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/ &&
+          echo "::set-output name=choco_release::$(python3 check_release_needed.py)"
 
       - name: Fill chocolatey scripts on win with latest blender python
         if: ${{steps.do_choco.outputs.choco_release}} == 'do_choco_release'
         run: |
+          cd /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/ &&
           yesterday_non_iso="$(date  --date='yesterday' +'%y%m%d' | tr -d '\n')" &&
           target_os=${{ matrix.config.short_name }} &&
-          latest_blender_python_version_maj_min=$(python3 /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/check_repo_infos.py --latest_blender_python_version_maj_min?) &&
+          latest_blender_python_version_maj_min=$(python3 check_repo_infos.py --latest_blender_python_version_maj_min?) &&
           echo "latest_blender_python_version_maj_min?: $latest_blender_python_version_maj_min" &&
           pyver=$(python3 /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/check_repo_infos.py --pyver?) &&
-          export latest_blender_version_maj_min=$(python3 /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/check_repo_infos.py --latest_blender_release_maj_min?) &&
-          export latest_blender_version_maj_min_pat=$(python3 /home/runner/work/IfcOpenShell/IfcOpenShell/choco/blenderbim/check_repo_infos.py --latest_blender_release_maj_min_pat?) &&
+          export latest_blender_version_maj_min=$(python3 check_repo_infos.py --latest_blender_release_maj_min?) &&
+          export latest_blender_version_maj_min_pat=$(python3 check_repo_infos.py --latest_blender_release_maj_min_pat?) &&
           echo   latest_blender_version_maj_min_pat?: $latest_blender_version_maj_min_pat &&
           export blenderbim_build_version="${{ env.major }}.${{ env.minor }}.$yesterday_non_iso" &&
-          export url_blenderbim_py310_win_zip="https://github.com/IfcOpenShell/IfcOpenShell/releases/download/blenderbim-$yesterday_non_iso/blenderbim-$yesterday_non_iso-$pyver-$target_os.zip" &&
-          wget $url_blenderbim_py310_win_zip --no-verbose &&
-          export sha256sum_blenderbim_py310_win_zip=$( sha256sum blenderbim-$yesterday_non_iso-$pyver-$target_os.zip  --tag | cut -d ' ' -f 4  | tr -d '\n') &&
+          export url_blenderbim_py3x_win_zip="https://github.com/IfcOpenShell/IfcOpenShell/releases/download/blenderbim-$yesterday_non_iso/$target_release_tag-$pyver-$target_os.zip" &&
+          wget $url_blenderbim_py3x_win_zip --no-verbose &&
+          export sha256sum_blenderbim_py310_win_zip=$( sha256sum $target_release_tag-$pyver-$target_os.zip  --tag | cut -d ' ' -f 4  | tr -d '\n') &&
           echo   sha256sum_blenderbim_py310_win_zip: $sha256sum_blenderbim_py310_win_zip &&
           python3 choco/blenderbim/fill_dynamic_parameters.py &&
           echo __build choco with mono &&
@@ -89,4 +91,3 @@ jobs:
         if: ${{steps.do_choco.outputs.choco_release}} != 'do_choco_release'
         run: |
           echo "no releases found today ${{ env.DATE }}, therefore choco packaging is skipped."
-

--- a/choco/blenderbim/check_release_needed.py
+++ b/choco/blenderbim/check_release_needed.py
@@ -1,0 +1,23 @@
+import datetime
+import os
+
+
+def get_repo_tag_names():
+    git_return = os.popen("git tag -l").read()
+    return [tag_name for tag_name in git_return.split("\n") if tag_name]
+
+
+def set_github_env_var(key: str, value: str):
+    env_file_path = os.getenv('GITHUB_ENV')
+    with open(env_file_path, "a") as env_file:
+        _ = env_file.write(f"{key}={value}" + "\n")
+
+
+blenderbim_date_yesterday = (datetime.datetime.now() - datetime.timedelta(days=1)).strftime("%y%m%d")
+
+for tag_name in get_repo_tag_names():
+    if blenderbim_date_yesterday in tag_name:
+        set_github_env_var(key="choco_release", value="do_choco_release")
+        set_github_env_var(key="target_release_tag", value=tag_name)
+        print("do_choco_release", end="")
+        break

--- a/choco/blenderbim/check_repo_infos.py
+++ b/choco/blenderbim/check_repo_infos.py
@@ -1,4 +1,4 @@
-import datetime
+import os
 import re
 import sys
 from urllib import request
@@ -24,24 +24,14 @@ def get_latest_blender_version() -> list:
     return re.findall(RE_BLENDER_VERSION_MIN_MAJ_PAT, html_txt)
 
 
-URL_IFCOS_RELEASES = "https://github.com/IfcOpenShell/IfcOpenShell/releases"
 URL_CHOCO_PACKAGE  = "https://community.chocolatey.org/packages/blender"
 URL_BLENDER_CMAKE  = "https://raw.githubusercontent.com/blender/blender/{}/build_files/cmake/Modules/FindPythonLibsUnix.cmake"
 RE_BLENDER_VERSION_MIN_MAJ        = r"Latest Version.+<span>Blender (\d+\.\d+)\..+</span>"
 RE_BLENDER_VERSION_MIN_MAJ_PAT    = r"Latest Version.+<span>Blender (\d+\.\d+\.\d+)</span>"
-RE_BLENDER_PYTHON_VERSION_MAJ_MIN = r"(?:set|SET)\(_PYTHON_VERSION_SUPPORTED (\d+\.\d+)\)"
+RE_BLENDER_PYTHON_VERSION_MAJ_MIN = r"SET\(_PYTHON_VERSION_SUPPORTED (\d+\.\d+)\)"
 
 
-if sys.argv[1] == "--do_choco_release?":
-    now = datetime.datetime.now()
-    blenderbim_date = (now - datetime.timedelta(days=1)).strftime("%y%m%d")
-    resp = request_repo_info(URL_IFCOS_RELEASES)
-    text = str(resp.read())
-    if blenderbim_date in text:
-        print("do_choco_release", end="")
-
-
-elif sys.argv[1] == "--latest_blender_release_maj_min_pat?":
+if   sys.argv[1] == "--latest_blender_release_maj_min_pat?":
     latest_blender_version = get_latest_blender_version()
     if latest_blender_version:
         print(latest_blender_version[0], end="")
@@ -86,4 +76,3 @@ elif sys.argv[1] == "--pyver?":
         else:
             print("[ERROR] could not determine pyver")
             quit(1)
-


### PR DESCRIPTION
for now this should only fix using the release tag for the download zip url, 
to get choco releases up and running again. 🤞 
once that is running, I will look into simplifying it and pull logic from the 
action yaml into into python code in a separate PR. 🙂 