### PR TITLE
fix git clone depth

### DIFF
--- a/.github/workflows/ci-blenderbim-choco.yml
+++ b/.github/workflows/ci-blenderbim-choco.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-python@v5 # https://github.com/actions/setup-python
         with:
           python-version: '3.12.4' # Version range or exact version of a Python version to use, using SemVer's version range syntax


### PR DESCRIPTION
@Moult : ok from the debug info it shows, I was on right right track. 
but now it needs to pull the git repo not only with the latest commit, 
but with depth=0 to also show the git commit from the day before. 🙂 
