### PR TITLE
fix: Remove the "ifc_patch_args" property

### DIFF
--- a/src/blenderbim/blenderbim/bim/module/patch/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/patch/operator.py
@@ -77,7 +77,7 @@ class ExecuteIfcPatch(bpy.types.Operator):
         props = context.scene.BIMPatchProperties
         arguments = []
         if props.ifc_patch_args_attr:
-           arguments = [arg.get_value() for arg in props.ifc_patch_args_attr]
+            arguments = [arg.get_value() for arg in props.ifc_patch_args_attr]
 
         if props.should_load_from_memory and tool.Ifc.get():
             input_file = props.ifc_patch_input

--- a/src/blenderbim/blenderbim/bim/module/patch/operator.py
+++ b/src/blenderbim/blenderbim/bim/module/patch/operator.py
@@ -67,7 +67,6 @@ class ExecuteIfcPatch(bpy.types.Operator):
     bl_idname = "bim.execute_ifc_patch"
     bl_label = "Execute IFCPatch"
     file_format: bpy.props.StringProperty()
-    use_json_for_args: bpy.props.BoolProperty()
 
     @classmethod
     def poll(cls, context):
@@ -76,10 +75,9 @@ class ExecuteIfcPatch(bpy.types.Operator):
 
     def execute(self, context):
         props = context.scene.BIMPatchProperties
-        if self.use_json_for_args or not props.ifc_patch_args_attr:
-            arguments = json.loads(props.ifc_patch_args or "[]")
-        else:
-            arguments = [arg.get_value() for arg in props.ifc_patch_args_attr]
+        arguments = []
+        if props.ifc_patch_args_attr:
+           arguments = [arg.get_value() for arg in props.ifc_patch_args_attr]
 
         if props.should_load_from_memory and tool.Ifc.get():
             input_file = props.ifc_patch_input

--- a/src/blenderbim/blenderbim/bim/module/patch/prop.py
+++ b/src/blenderbim/blenderbim/bim/module/patch/prop.py
@@ -65,6 +65,5 @@ class BIMPatchProperties(PropertyGroup):
     ifc_patch_recipes: EnumProperty(items=get_ifcpatch_recipes, name="Recipes", update=update_ifc_patch_recipe)
     ifc_patch_input: StringProperty(default="", name="IFC Patch Input IFC")
     ifc_patch_output: StringProperty(default="", name="IFC Patch Output IFC")
-    ifc_patch_args: StringProperty(default="", name="Arguments")
     ifc_patch_args_attr: CollectionProperty(type=Attribute, name="Arguments")
     should_load_from_memory: BoolProperty(default=False, name="Load from Memory")

--- a/src/blenderbim/blenderbim/bim/module/patch/ui.py
+++ b/src/blenderbim/blenderbim/bim/module/patch/ui.py
@@ -56,7 +56,4 @@ class BIM_PT_patch(bpy.types.Panel):
 
         if props.ifc_patch_args_attr:
             draw_attributes(props.ifc_patch_args_attr, layout)
-        else:
-            layout.row().prop(props, "ifc_patch_args")
         op = layout.operator("bim.execute_ifc_patch")
-        op.use_json_for_args = len(props.ifc_patch_args_attr) == 0

--- a/src/blenderbim/test/bim/feature/patch.feature
+++ b/src/blenderbim/test/bim/feature/patch.feature
@@ -6,8 +6,14 @@ Scenario: Execute IFC Patch - file in memory
     And I set "scene.BIMPatchProperties.ifc_patch_recipes" to "OffsetObjectPlacements"
     And I set "scene.BIMPatchProperties.should_load_from_memory" to "True"
     And I set "scene.BIMPatchProperties.ifc_patch_output" to "{cwd}/test/files/temp/basic-patched.ifc"
-    And I set "scene.BIMPatchProperties.ifc_patch_args" to "[123454321,0,0,0]"
-    When I press "bim.execute_ifc_patch(use_json_for_args=True)"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['X'].string_value" to "123454321"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Y'].string_value" to "0"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Z'].string_value" to "0"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Should Rotate First'].bool_value" to "True"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Ax'].string_value" to "0"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Ay'].string_value" to "0"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Az'].string_value" to "0"
+    When I press "bim.execute_ifc_patch()"
     Then the file "{cwd}/test/files/temp/basic-patched.ifc" should contain "123454321"
 
 Scenario: Execute IFC Patch - file from disk
@@ -15,8 +21,14 @@ Scenario: Execute IFC Patch - file from disk
     And I set "scene.BIMPatchProperties.ifc_patch_recipes" to "OffsetObjectPlacements"
     And I set "scene.BIMPatchProperties.ifc_patch_input" to "{cwd}/test/files/basic.ifc"
     And I set "scene.BIMPatchProperties.ifc_patch_output" to "{cwd}/test/files/temp/basic-patched.ifc"
-    And I set "scene.BIMPatchProperties.ifc_patch_args" to "[123454321,0,0,0]"
-    When I press "bim.execute_ifc_patch(use_json_for_args=True)"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['X'].string_value" to "123454321"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Y'].string_value" to "0"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Z'].string_value" to "0"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Should Rotate First'].bool_value" to "True"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Ax'].string_value" to "0"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Ay'].string_value" to "0"
+    And I set "scene.BIMPatchProperties.ifc_patch_args_attr['Az'].string_value" to "0"
+    When I press "bim.execute_ifc_patch()"
     Then the file "{cwd}/test/files/temp/basic-patched.ifc" should contain "123454321"
 
 Scenario: Run migrate patch


### PR DESCRIPTION
This property has been removed, because patch recipes with arguments other than the boilerplate arguments automatically display these arguments as properties, and patch recipes that don't allow more arguments than the boilerplate arguments fail, if "ifc_patch_args" is not None or "[]". The test cases have been adjusted accordingly.