### PR TITLE
bbim tomllib fixes

### DIFF
--- a/src/blenderbim/Makefile
+++ b/src/blenderbim/Makefile
@@ -189,6 +189,10 @@ else ifeq ($(PLATFORM), macos)
 else
 	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download pyradiance $(PYPI_PLATFORM) --python-version $(PYPI_VERSION) --implementation $(PYPI_IMP) --only-binary=:all: --dest=./wheels
 endif
+	# tomllib replacement for < Python 3.11, used to parse blender_manifest
+ifeq ($(PYVERSION), py310)
+	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download tomli --dest=./wheels
+endif
 
 	# Provides jsgantt-improved supports for web-based construction sequencing gantt charts
 	cd build/blenderbim/bim/data/gantt/ && wget https://raw.githubusercontent.com/jsGanttImproved/jsgantt-improved/master/dist/jsgantt.js

--- a/src/blenderbim/blenderbim/__init__.py
+++ b/src/blenderbim/blenderbim/__init__.py
@@ -68,11 +68,14 @@ def initialize_bbim_semver():
     in `addon_utils.modules()->bl_info['version']`,
     therefore we just parse it from .toml.
     """
-    import tomllib
+    if sys.version_info >= (3, 11):
+        import tomllib as toml
+    else:
+        import tomli as toml
 
     toml_path = Path(__file__).parent / "blender_manifest.toml"
     with open(toml_path, "rb") as f:
-        manifest = tomllib.load(f)
+        manifest = toml.load(f)
     semver_pattern = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
     version_str = manifest["version"]
     re_version = re.match(semver_pattern, version_str)

--- a/src/blenderbim/blenderbim/__init__.py
+++ b/src/blenderbim/blenderbim/__init__.py
@@ -82,9 +82,6 @@ def initialize_bbim_semver():
     bbim_semver["version"] = version_str
 
 
-initialize_bbim_semver()
-
-
 def get_debug_info():
     bbim_version = bbim_semver["version"]
 
@@ -177,6 +174,7 @@ def clean_up_dlls_safe_links() -> None:
 
 
 if IN_BLENDER:
+    initialize_bbim_semver()
 
     def get_binary_info() -> dict[str, Any]:
         info = {}


### PR DESCRIPTION
- prevent issues importing blenderbim for core test
- initialize_bbim_semver was possible breaking on running core tests if system python was missing tomllib