### PR TITLE
Fix bug: Add type instance button duplicated

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -811,9 +811,7 @@ class BimToolUI:
             else:
                 text = ""
             if not AuthoringData.data["ifc_element_type"]:
-
                 prop_with_search(row, cls.props, "ifc_class", text="")
-                row.operator("bim.add_constr_type_instance", text=text, icon_value=custom_icon_previews["ADD"].icon_id)
 
             row = cls.layout.row(align=True)
             if AuthoringData.data["relating_type_id"]:


### PR DESCRIPTION
Add type instance button was duplicated after both `Construction Class` and `Relating Type` drop downs.

Before:
![Screenshot from 2024-09-02 14-41-35](https://github.com/user-attachments/assets/b18d249f-dda9-4363-aef4-85f87ccd881d)

After:
![Screenshot from 2024-09-02 15-04-43](https://github.com/user-attachments/assets/7c1a6ce2-e3c4-4b57-baa3-a7124dffd12b)
![Screenshot from 2024-09-02 15-05-01](https://github.com/user-attachments/assets/1ea95b7a-6895-4f1a-996d-129f21c64d4a)
