### PR TITLE
Update IfcGlobalId.cpp to support boost 1.86

### DIFF
--- a/src/ifcparse/IfcGlobalId.cpp
+++ b/src/ifcparse/IfcGlobalId.cpp
@@ -87,8 +87,12 @@ void expand(const std::string& s, std::vector<unsigned char>& v) {
     }
 }
 
-// A random number generator for the UUID
-static boost::uuids::basic_random_generator<std::mt19937> gen;
+// Define the macro to handle different Boost versions
+#if BOOST_VERSION >= 108600
+    static boost::uuids::basic_random_generator<std::mt19937> gen;
+#else
+    static boost::uuids::basic_random_generator<boost::mt19937> gen;
+#endif
 
 IfcParse::IfcGlobalId::IfcGlobalId() {
     uuid_data_ = gen();

--- a/src/ifcparse/IfcGlobalId.cpp
+++ b/src/ifcparse/IfcGlobalId.cpp
@@ -88,7 +88,7 @@ void expand(const std::string& s, std::vector<unsigned char>& v) {
 }
 
 // A random number generator for the UUID
-static boost::uuids::basic_random_generator<boost::mt19937> gen;
+static boost::uuids::basic_random_generator<std::mt19937> gen;
 
 IfcParse::IfcGlobalId::IfcGlobalId() {
     uuid_data_ = gen();


### PR DESCRIPTION
It looks like mt19937 is no longer a member of boost in boost 1.86. I propose we use to std::mt19937 (which is already how it is used by svgfill.cpp)

see failure log from conda forge libboost 1.86 test here: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1008654&view=logs&j=4f922444-fdfe-5dcf-b824-02f86439ef14&t=b2a8456a-fb11-5506-ca32-5ccd32538dc0&l=880