### PR TITLE
Fix bug in activating drawing with exclude filter

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1875,7 +1875,6 @@ class Drawing(bonsai.core.tool.Drawing):
         cls.import_camera_props(drawing, camera.data)
 
         for obj in selected_objects_before:
-            obj.hide_set(False)
             obj.select_set(True)
 
     @classmethod


### PR DESCRIPTION
Activating a drawing view when an element included in exclude filter is selected results in the element not being excluded.