### PR TITLE
handle numeric simpleValue

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -149,8 +149,8 @@ class Facet:
         return "This facet cannot be interpreted"
 
     def to_ids_value(self, parameter: Union[str, Restriction, list]) -> dict[str, Any]:
-        if isinstance(parameter, str):
-            parameter_dict = {"simpleValue": parameter}
+        if isinstance(parameter, (int, float, str)):
+            parameter_dict = {"simpleValue": str(parameter)}
         elif isinstance(parameter, Restriction):
             parameter_dict = {"xs:restriction": [parameter.asdict()]}
         elif isinstance(parameter, list):


### PR DESCRIPTION
The input value can be a string or number, but 1.0 schema only accepts strings. The processing of int and float was missing. The casting to a string might no longer be needed in IDS 1.1. https://github.com/buildingSMART/IDS/issues/342