### PR TITLE
Derive docker tags from git refs

### DIFF
--- a/.github/workflows/ci-ifcopenshell-docker.yml
+++ b/.github/workflows/ci-ifcopenshell-docker.yml
@@ -116,6 +116,8 @@ jobs:
       with: 
         context: artifacts
         repository: aecgeeks/ifcopenshell
-        tags: aecgeeks/ifcopenshell:latest
+        # Since the dispatch is set to `tag`, `github.ref_name` should evaluate to the pushed tag
+        # On a workflow dispatch, `ref_name` will take on the value from the dispatch payload
+        tags: aecgeeks/ifcopenshell:${{ github.ref_name }}${{ github.ref_name == github.event.repository.default_branch && ',aecgeeks/ifcopenshell:latest' }}
         file: ./Dockerfile
         push: true


### PR DESCRIPTION
## Summary
- Update docker workflow to use [`github.ref_name`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context) for docker tags

## Description
See discussion in 
- #5168

The change here aligns the docker tag to the git tag, which seems to be aligned with the direction from #3927. 

The only tag that is available for `aecgeeks/ifcopenshell` on the Docker registry [is `:latest`](https://hub.docker.com/r/aecgeeks/ifcopenshell/tags). Because of the `on:` value of this workflow file, this means that either
- the last pushed tag
- the last manual dispatch

of this workflow will end up as the `:latest` tag. This is _strictly_ correct (i.e. `latest` means "it happened most recently"). But, it means that breaking changes like the issues from #5168 are hard to ameliorate.

In order to keep the `latest` tag aligned with the repository, I added the condition that the `latest` tag should only be applied when the git ref is the default branch (using the [`CSV` syntax from `docker-build-push@v2`](https://github.com/docker/build-push-action/tree/releases/v2?tab=readme-ov-file#inputs)). That seems to be the case with `v0.8.0`. Let me know if this is wrong. In order for this to work, I think that future release would need to:
- push the tag
- push a branch with the same name as the tag
- update the "default branch" in the repo settings
- re-run the workflow that was started from the tag event
  - the second time the workflow runs, the second expression should evaluate to `true` and append the second tag

Note that I can't test this and it relies on stringly-typed github workflow expressions. But I'm _pretty sure_ it will work 😬 .