### PR TITLE
Fix for issue in code_examples.rst

### DIFF
--- a/src/ifcopenshell-python/docs/ifcopenshell-python/code_examples.rst
+++ b/src/ifcopenshell-python/docs/ifcopenshell-python/code_examples.rst
@@ -263,7 +263,7 @@ Create a simple model from scratch
     ifcopenshell.api.geometry.assign_representation(model, product=wall, representation=representation)
 
     # Place our wall in the ground floor
-    ifcopenshell.api.spatial.assign_container(model, relating_structure=storey, product=wall)
+    ifcopenshell.api.spatial.assign_container(model, relating_structure=storey, products=[wall])
 
     # Write out to a file
     model.write("/home/dion/model.ifc")


### PR DESCRIPTION
I've replaced "product=wall" with "products=[wall]" in:

Place our wall in the ground floor
ifcopenshell.api.spatial.assign_container(model, relating_structure=storey, products=[wall]) 

The example code fails otherwise per "TypeError: Incorrect function arguments provided for spatial.assign_container".

This is my first pull request on github so let me know if there's anything procedural I've missed.