### PR TITLE
python: Fix ifcopenshell.guid.new()

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/__init__.py
@@ -86,6 +86,7 @@ except Exception:
     raise ImportError("IfcOpenShell not built for '%s'" % python_distribution)
 
 from .file import file
+from . import guid
 from .entity_instance import entity_instance, register_schema_attributes
 from .sql import sqlite, sqlite_entity
 
@@ -94,6 +95,7 @@ from .sql import sqlite, sqlite_entity
 __all__ = [
     "ifcopenshell_wrapper",
     "file",
+    "guid",
     "entity_instance",
     "sqlite",
     "sqlite_entity",


### PR DESCRIPTION
pyException:

<class 'AttributeError'>: module 'ifcopenshell' has no attribute 'guid'

---

This is having instaled IfcOpenShell using cmake.

Else you have to `import ifcopenshell.guid` and the docs don't suggest that is necessary:
https://docs.ifcopenshell.org/ifcopenshell-python/hello_world.html
