### PR TITLE
Partially fix an issue with BIMModelProperties ifc_class enum.

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/data.py
+++ b/src/bonsai/bonsai/bim/module/model/data.py
@@ -58,6 +58,7 @@ class AuthoringData:
         cls.data["ifc_classes"] = cls.ifc_classes()
         cls.data["ifc_class_current"] = cls.ifc_class_current()
         cls.data["relating_type_id"] = cls.relating_type_id()  # only after .ifc_classes()
+        cls.data["relating_type_id_current"] = cls.relating_type_id_current()  # only after .ifc_classes()
         cls.data["relating_type_name"] = cls.relating_type_name()  # only after .relating_type_id()
         cls.data["relating_type_description"] = cls.relating_type_description()  # only after .relating_type_id()
         cls.data["predefined_type"] = cls.predefined_type()  # only after .relating_type_id()
@@ -247,18 +248,22 @@ class AuthoringData:
             return [(str(e.id()), e.Name or "Unnamed", e.Description or "") for e in results]
         return []
 
-    @classmethod
-    def relating_type_name(cls):
+    @classmethod 
+    def relating_type_id_current(cls):
         relating_type_id = tool.Blender.get_enum_safe(cls.props, "relating_type_id")
         relating_type_id_data = cls.data["relating_type_id"]
         if not relating_type_id and relating_type_id_data:
             relating_type_id = relating_type_id_data[0][0]
-        if relating_type_id:
+        return relating_type_id
+
+    @classmethod
+    def relating_type_name(cls):
+        if relating_type_id := cls.data["relating_type_id_current"]:
             return tool.Ifc.get().by_id(int(relating_type_id)).Name or "Unnamed"
 
     @classmethod
     def relating_type_description(cls):
-        if relating_type_id := cls.props.relating_type_id:
+        if relating_type_id := cls.data["relating_type_id_current"]:
             return tool.Ifc.get().by_id(int(relating_type_id)).Description or "No description"
 
     @classmethod

--- a/src/bonsai/bonsai/bim/module/model/data.py
+++ b/src/bonsai/bonsai/bim/module/model/data.py
@@ -56,6 +56,7 @@ class AuthoringData:
         cls.data["default_container"] = cls.default_container()
         cls.data["ifc_element_type"] = cls.ifc_element_type
         cls.data["ifc_classes"] = cls.ifc_classes()
+        cls.data["ifc_class_current"] = cls.ifc_class_current()
         cls.data["relating_type_id"] = cls.relating_type_id()  # only after .ifc_classes()
         cls.data["relating_type_name"] = cls.relating_type_name()  # only after .relating_type_id()
         cls.data["relating_type_description"] = cls.relating_type_description()  # only after .relating_type_id()
@@ -108,12 +109,12 @@ class AuthoringData:
 
     @classmethod
     def total_types(cls):
-        ifc_class = cls.props.ifc_class
+        ifc_class = cls.data["ifc_class_current"]
         return len(tool.Ifc.get().by_type(ifc_class)) if ifc_class else 0
 
     @classmethod
     def total_pages(cls):
-        ifc_class = cls.props.ifc_class
+        ifc_class = cls.data["ifc_class_current"]
         total_types = len(tool.Ifc.get().by_type(ifc_class)) if ifc_class else 0
         return math.ceil(total_types / cls.types_per_page)
 
@@ -129,7 +130,7 @@ class AuthoringData:
 
     @classmethod
     def paginated_relating_types(cls):
-        ifc_class = cls.props.ifc_class
+        ifc_class = cls.data["ifc_class_current"]
         if not ifc_class:
             return []
         results = []
@@ -226,15 +227,20 @@ class AuthoringData:
         results.extend([(c, c, "") for c in sorted(classes)])
         return results
 
-    @classmethod
-    def relating_type_id(cls):
+    @classmethod 
+    def ifc_class_current(cls):
         ifc_classes = cls.data["ifc_classes"]
         if not ifc_classes:
             return []
-        results = []
         ifc_class = tool.Blender.get_enum_safe(cls.props, "ifc_class")
         if not ifc_class and ifc_classes:
             ifc_class = ifc_classes[0][0]
+        return ifc_class
+
+    @classmethod
+    def relating_type_id(cls):
+        results = []
+        ifc_class = cls.data["ifc_class_current"]
         if ifc_class:
             elements = natsorted(tool.Ifc.get().by_type(ifc_class), key=lambda s: (s.Name or "Unnamed").lower())
             results.extend(elements)

--- a/src/bonsai/bonsai/bim/module/model/ui.py
+++ b/src/bonsai/bonsai/bim/module/model/ui.py
@@ -94,7 +94,7 @@ class LaunchTypeManager(bpy.types.Operator):
         props = context.scene.BIMModelProperties
         props.type_page = 1
         if get_ifc_class(None, context):
-            ifc_class = props.ifc_class or AuthoringData.data["ifc_element_type"]
+            ifc_class = AuthoringData.data["ifc_class_current"] or AuthoringData.data["ifc_element_type"]
         else:
             ifc_class = AuthoringData.data["ifc_element_type"]
 
@@ -167,7 +167,7 @@ class LaunchTypeManager(bpy.types.Operator):
             else:
                 row = box.row()
                 op = box.operator("bim.load_type_thumbnails", text="", icon="FILE_REFRESH", emboss=False)
-                op.ifc_class = props.ifc_class
+                op.ifc_class = AuthoringData.data["ifc_class_current"]
 
             row = box.row()
             row.alignment = "CENTER"

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -433,30 +433,33 @@ class CreateObjectUI:
         if not AuthoringData.data["relating_type_id"]:
             return
 
-        if cls.props.ifc_class == "IfcWallType":
+        ifc_class = tool.Blender.get_enum_safe(cls.props, "ifc_class")
+        if not ifc_class:
+            ifc_class = AuthoringData.data["ifc_classes"][0][0]
+        if ifc_class == "IfcWallType":
             row.prop(data=cls.props, property="rl1", text="Relative Level" if ui_context != "TOOL_HEADER" else "RL")
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
             row.prop(data=cls.props, property="extrusion_depth", text="Height" if ui_context != "TOOL_HEADER" else "H")
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
             row.prop(data=cls.props, property="x_angle", text="Slope") if ui_context != "TOOL_HEADER" else "A"
 
-        elif cls.props.ifc_class in ("IfcSlabType", "IfcRampType", "IfcRoofType"):
+        elif ifc_class in ("IfcSlabType", "IfcRampType", "IfcRoofType"):
             row.prop(
                 data=cls.props, property="x_angle", text="Slope" if ui_context != "TOOL_HEADER" else "A", icon="FILE_3D"
             )
 
-        elif cls.props.ifc_class in ("IfcColumnType", "IfcMemberType"):
+        elif ifc_class in ("IfcColumnType", "IfcMemberType"):
             row.prop(data=cls.props, property="cardinal_point", text="Axis")
             row.prop(data=cls.props, property="extrusion_depth", text="Height" if ui_context != "TOOL_HEADER" else "H")
 
-        elif cls.props.ifc_class in ("IfcBeamType"):
+        elif ifc_class in ("IfcBeamType"):
             row.prop(data=cls.props, property="cardinal_point", text="Axis")
             row.prop(data=cls.props, property="extrusion_depth", text="Length" if ui_context != "TOOL_HEADER" else "L")
 
-        elif cls.props.ifc_class in ("IfcDoorType", "IfcDoorStyle"):
+        elif ifc_class in ("IfcDoorType", "IfcDoorStyle"):
             row.prop(data=cls.props, property="rl1", text="Relative Level" if ui_context != "TOOL_HEADER" else "RL")
 
-        elif cls.props.ifc_class in (
+        elif ifc_class in (
             "IfcWindowType",
             "IfcWindowStyle",
             "IfcDoorType",
@@ -471,7 +474,7 @@ class CreateObjectUI:
             )
 
         ### this neeeds to move
-        elif cls.props.ifc_class in ("IfcSpaceType"):
+        elif ifc_class in ("IfcSpaceType"):
             add_layout_hotkey_operator(cls.layout, "Generate", "S_G", bpy.ops.bim.generate_space.__doc__, ui_context)
         ###
         else:
@@ -485,7 +488,10 @@ class CreateObjectUI:
         if not AuthoringData.data["ifc_element_type"]:
             prop_with_search(row, cls.props, "ifc_class", text="Type Class" if ui_context != "TOOL_HEADER" else "")
         if AuthoringData.data["ifc_classes"]:
-            if cls.props.ifc_class:
+            ifc_class = tool.Blender.get_enum_safe(cls.props, "ifc_class")
+            if not ifc_class:
+                ifc_class = AuthoringData.data["ifc_classes"][0][0]
+            if ifc_class:
                 box = cls.layout.box()
                 row = box.row(align=True)
                 if AuthoringData.data["type_thumbnail"] and ui_context == "TOOL_HEADER":
@@ -530,7 +536,7 @@ class CreateObjectUI:
                             icon="FILE_REFRESH",
                             emboss=False,
                         )
-                        op.ifc_class = cls.props.ifc_class
+                        op.ifc_class = ifc_class
 
                     row = box.row(align=True)
                     row.alignment = "CENTER"

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -433,9 +433,7 @@ class CreateObjectUI:
         if not AuthoringData.data["relating_type_id"]:
             return
 
-        ifc_class = tool.Blender.get_enum_safe(cls.props, "ifc_class")
-        if not ifc_class:
-            ifc_class = AuthoringData.data["ifc_classes"][0][0]
+        ifc_class = AuthoringData.data["ifc_class_current"]
         if ifc_class == "IfcWallType":
             row.prop(data=cls.props, property="rl1", text="Relative Level" if ui_context != "TOOL_HEADER" else "RL")
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
@@ -488,9 +486,7 @@ class CreateObjectUI:
         if not AuthoringData.data["ifc_element_type"]:
             prop_with_search(row, cls.props, "ifc_class", text="Type Class" if ui_context != "TOOL_HEADER" else "")
         if AuthoringData.data["ifc_classes"]:
-            ifc_class = tool.Blender.get_enum_safe(cls.props, "ifc_class")
-            if not ifc_class:
-                ifc_class = AuthoringData.data["ifc_classes"][0][0]
+            ifc_class = AuthoringData.data["ifc_class_current"]
             if ifc_class:
                 box = cls.layout.box()
                 row = box.row(align=True)
@@ -916,7 +912,7 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
 
         if get_ifc_class(None, None):
             try:
-                self.has_ifc_class = bool(self.props.ifc_class)
+                self.has_ifc_class = bool(tool.Blender.get_enum_safe(self.props, "ifc_class"))
             except:
                 pass
         getattr(self, f"hotkey_{self.hotkey}")()

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -936,18 +936,18 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
 
     def hotkey_S_A(self):
         props = bpy.context.scene.BIMModelProperties
+        relating_type_id = AuthoringData.data["relating_type_id_current"]
+        props.relating_type_id = relating_type_id
         if bpy.context.scene.BIMGeometryProperties.mode == "ITEM":
             bpy.ops.wm.call_menu(name="BIM_MT_add_representation_item")
         else:
             for obj in tool.Blender.get_selected_objects():
                 obj.select_set(False)
-            if (
-                relating_type_id := tool.Blender.get_enum_safe(props, "relating_type_id")
-            ) and tool.Model.get_usage_type(tool.Ifc.get().by_id(int(relating_type_id))) == "LAYER2":
+            if relating_type_id and tool.Model.get_usage_type(tool.Ifc.get().by_id(int(relating_type_id))) == "LAYER2":
                 bpy.ops.bim.draw_polyline_wall("INVOKE_DEFAULT")
             elif (
-                relating_type_id := tool.Blender.get_enum_safe(props, "relating_type_id")
-            ) and tool.Model.get_usage_type(tool.Ifc.get().by_id(int(relating_type_id))) == "LAYER3":
+                relating_type_id and tool.Model.get_usage_type(tool.Ifc.get().by_id(int(relating_type_id))) == "LAYER3"
+            ):
                 bpy.ops.bim.draw_polyline_slab("INVOKE_DEFAULT")
             else:
                 bpy.ops.bim.add_occurrence("INVOKE_DEFAULT")


### PR DESCRIPTION
The issue can be reproduced as follow:
- Select the Multi Object Tool and change the ifc class to anything other than the first option.
- Now select other tool, e.g. wall tool, and the menu is not correct.

![blender_SVUDEIfaCd](https://github.com/user-attachments/assets/a954e6ce-2003-4441-830a-7ce7df1962ce)


This PR proposes a partial solution. It solves the issue with the menu, but it's still getting this error:
` WARN (bpy.rna): C:\Users\blender\git\blender-v420\blender.git\source\blender\python\intern\bpy_rna.cc:1366 pyrna_enum_to_py: current value '8' matches no enum in 'BIMModelProperties', '', 'ifc_class' `