### PR TITLE
add favicon to ifcopenshell-python and bonsaibim docs

### DIFF
--- a/src/blenderbim/docs/conf.py
+++ b/src/blenderbim/docs/conf.py
@@ -81,6 +81,7 @@ html_css_files = ["custom.css"]
 pygments_style = "one-dark"
 pygments_dark_style = "one-dark"
 
+html_favicon = "https://blenderbim.org/assets/images/blender/blender-logo.png"
 html_logo = "https://blenderbim.org/assets/images/blender/blender-logo.png"
 html_theme_options = {
     "source_repository": "https://github.com/IfcOpenShell/IfcOpenShell/",

--- a/src/ifcopenshell-python/docs/conf.py
+++ b/src/ifcopenshell-python/docs/conf.py
@@ -116,6 +116,7 @@ html_css_files = ["custom.css"]
 pygments_style = "one-dark"
 pygments_dark_style = "one-dark"
 
+html_favicon = "https://ifcopenshell.org/assets/images/logo.png"
 html_logo = "https://ifcopenshell.org/assets/images/logo.png"
 html_theme_options = {
     "source_repository": "https://github.com/IfcOpenShell/IfcOpenShell/",


### PR DESCRIPTION
Self explanatory. With collaped tabs it is easier to identify between those to documentation tabs in browsers.
