### PR TITLE
Fix relative header include paths

### DIFF
--- a/src/ifcgeom/AbstractKernel.cpp
+++ b/src/ifcgeom/AbstractKernel.cpp
@@ -1,21 +1,21 @@
 #include "AbstractKernel.h"
 
-#include "../ifcgeom/IfcGeomElement.h"
-#include "../ifcgeom/ConversionSettings.h"
-#include "../ifcgeom/abstract_mapping.h"
-#include "../ifcgeom/piecewise_function_evaluator.h"
+#include "IfcGeomElement.h"
+#include "ConversionSettings.h"
+#include "abstract_mapping.h"
+#include "piecewise_function_evaluator.h"
 
 #ifdef IFOPSH_WITH_OPENCASCADE
-#include "../ifcgeom/kernels/opencascade/OpenCascadeKernel.h"
+#include "kernels/opencascade/OpenCascadeKernel.h"
 #undef Handle
 #endif
 
 #ifdef IFOPSH_WITH_CGAL
-#include "../ifcgeom/kernels/cgal/CgalKernel.h"
+#include "kernels/cgal/CgalKernel.h"
 #undef CGAL_KERNEL_H
 #undef CGALCONVERSIONRESULT_H
 #define IFOPSH_SIMPLE_KERNEL
-#include "../ifcgeom/kernels/cgal/CgalKernel.h"
+#include "kernels/cgal/CgalKernel.h"
 #undef CgalKernel
 #endif
 

--- a/src/ifcgeom/AbstractKernel.h
+++ b/src/ifcgeom/AbstractKernel.h
@@ -3,10 +3,10 @@
 
 #include "../ifcparse/macros.h"
 #include "../ifcparse/IfcLogger.h"
-#include "../ifcgeom/ifc_geom_api.h"
-#include "../ifcgeom/IfcGeomRepresentation.h"
-#include "../ifcgeom/taxonomy.h"
-#include "../ifcgeom/ConversionSettings.h"
+#include "ifc_geom_api.h"
+#include "IfcGeomRepresentation.h"
+#include "taxonomy.h"
+#include "ConversionSettings.h"
 
 static const double ALMOST_ZERO = 1.e-9;
 

--- a/src/ifcgeom/ConversionResult.h
+++ b/src/ifcgeom/ConversionResult.h
@@ -20,9 +20,9 @@
 #ifndef CONVERSIONRESULT_H
 #define CONVERSIONRESULT_H
 
-#include "../ifcgeom/IfcGeomRenderStyles.h"
-#include "../ifcgeom/ConversionSettings.h"
-#include "../ifcgeom/taxonomy.h"
+#include "IfcGeomRenderStyles.h"
+#include "ConversionSettings.h"
+#include "taxonomy.h"
 
 #include <memory>
 #include <vector>

--- a/src/ifcgeom/Converter.cpp
+++ b/src/ifcgeom/Converter.cpp
@@ -1,6 +1,6 @@
 #include "Converter.h"
 
-#include "../ifcgeom/IfcGeomElement.h"
+#include "IfcGeomElement.h"
 
 using namespace ifcopenshell::geometry;
 
@@ -406,7 +406,7 @@ IfcGeom::ConversionResults ifcopenshell::geometry::Converter::convert(IfcUtil::I
 //#include "../../ifcparse/Ifc4.h"
 //
 //// @todo remove
-//#include "../../ifcgeom/schema_agnostic/opencascade/OpenCascadeConversionResult.h"
+//#include "kernels/opencascade/OpenCascadeConversionResult.h"
 //
 //#include <TopExp.hxx>
 //#include <TopTools_ListOfShape.hxx>

--- a/src/ifcgeom/Converter.h
+++ b/src/ifcgeom/Converter.h
@@ -2,12 +2,12 @@
 #define ITERATOR_KERNEL_H
 
 #include "../ifcparse/IfcFile.h"
-#include "../ifcgeom/ConversionSettings.h"
-#include "../ifcgeom/ConversionResult.h"
-#include "../ifcgeom/abstract_mapping.h"
-#include "../ifcgeom/ConversionSettings.h"
-#include "../ifcgeom/AbstractKernel.h"
-#include "../ifcgeom/IfcGeomElement.h"
+#include "ConversionSettings.h"
+#include "ConversionResult.h"
+#include "abstract_mapping.h"
+#include "ConversionSettings.h"
+#include "AbstractKernel.h"
+#include "IfcGeomElement.h"
 
 #include <boost/function.hpp>
 

--- a/src/ifcgeom/GeometrySerializer.h
+++ b/src/ifcgeom/GeometrySerializer.h
@@ -20,8 +20,8 @@
 #ifndef GEOMETRYSERIALIZER_H
 #define GEOMETRYSERIALIZER_H
 
-#include "../ifcgeom/Serializer.h"
-#include "../ifcgeom/IfcGeomElement.h"
+#include "Serializer.h"
+#include "IfcGeomElement.h"
 #include <fstream>
 
 namespace ifcopenshell {

--- a/src/ifcgeom/IfcGeomElement.h
+++ b/src/ifcgeom/IfcGeomElement.h
@@ -27,9 +27,9 @@
 #include "../ifcparse/IfcGlobalId.h"
 #include "../ifcparse/IfcLogger.h"
 
-#include "../ifcgeom/IfcGeomRepresentation.h"
-#include "../ifcgeom/IteratorSettings.h"
-#include "../ifcgeom/ifc_geom_api.h"
+#include "IfcGeomRepresentation.h"
+#include "IteratorSettings.h"
+#include "ifc_geom_api.h"
 
 namespace IfcGeom {
 

--- a/src/ifcgeom/IfcGeomFilter.h
+++ b/src/ifcgeom/IfcGeomFilter.h
@@ -28,9 +28,9 @@
 #define BOOST_REGEX_NO_W32
 #endif
 
-#include "../ifcgeom/AbstractKernel.h"
+#include "AbstractKernel.h"
 #include "../ifcparse/IfcFile.h"
-#include "../ifcgeom/abstract_mapping.h"
+#include "abstract_mapping.h"
 
 #include <boost/foreach.hpp>
 #include <boost/function.hpp>

--- a/src/ifcgeom/IfcGeomRenderStyles.h
+++ b/src/ifcgeom/IfcGeomRenderStyles.h
@@ -20,8 +20,8 @@
 #ifndef IFCGEOMRENDERSTYLES_H
 #define IFCGEOMRENDERSTYLES_H
 
-#include "../ifcgeom/ifc_geom_api.h"
-#include "../ifcgeom/taxonomy.h"
+#include "ifc_geom_api.h"
+#include "taxonomy.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/replace.hpp>

--- a/src/ifcgeom/IfcGeomRepresentation.cpp
+++ b/src/ifcgeom/IfcGeomRepresentation.cpp
@@ -21,8 +21,8 @@
 
 #ifdef IFOPSH_WITH_OPENCASCADE
 #include "../ifcparse/IfcLogger.h"
-#include "../ifcgeom/kernels/opencascade/OpenCascadeConversionResult.h"
-#include "../ifcgeom/kernels/opencascade/base_utils.h"
+#include "kernels/opencascade/OpenCascadeConversionResult.h"
+#include "kernels/opencascade/base_utils.h"
 
 #include <BRep_Tool.hxx>
 #include <BRepTools.hxx>

--- a/src/ifcgeom/IfcGeomRepresentation.h
+++ b/src/ifcgeom/IfcGeomRepresentation.h
@@ -20,8 +20,8 @@
 #ifndef IFCGEOMREPRESENTATION_H
 #define IFCGEOMREPRESENTATION_H
 
-#include "../ifcgeom/ConversionSettings.h"
-#include "../ifcgeom/ConversionResult.h"
+#include "ConversionSettings.h"
+#include "ConversionResult.h"
 
 #include <map>
 

--- a/src/ifcgeom/Iterator.h
+++ b/src/ifcgeom/Iterator.h
@@ -60,14 +60,14 @@
 
 #include "../ifcparse/IfcFile.h"
 
-#include "../ifcgeom/IfcGeomElement.h"
-#include "../ifcgeom/IteratorSettings.h"
-#include "../ifcgeom/ConversionResult.h"
-#include "../ifcgeom/IfcGeomFilter.h"
-#include "../ifcgeom/taxonomy.h"
-#include "../ifcgeom/Converter.h"
-#include "../ifcgeom/abstract_mapping.h"
-#include "../ifcgeom/GeometrySerializer.h"
+#include "IfcGeomElement.h"
+#include "IteratorSettings.h"
+#include "ConversionResult.h"
+#include "IfcGeomFilter.h"
+#include "taxonomy.h"
+#include "Converter.h"
+#include "abstract_mapping.h"
+#include "GeometrySerializer.h"
 
 #ifdef IFOPSH_WITH_OPENCASCADE
 #include <Standard_Failure.hxx>

--- a/src/ifcgeom/Serialization/Serialization.h
+++ b/src/ifcgeom/Serialization/Serialization.h
@@ -1,6 +1,6 @@
 #include "../../ifcparse/IfcBaseClass.h"
 
-#include "../../ifcgeom/ifc_geom_api.h"
+#include "../ifc_geom_api.h"
 
 #include <TopoDS_Shape.hxx>
 

--- a/src/ifcgeom/SurfaceStyle.cpp
+++ b/src/ifcgeom/SurfaceStyle.cpp
@@ -1,4 +1,4 @@
-#include "../ifcgeom/IfcGeomRenderStyles.h"
+#include "IfcGeomRenderStyles.h"
 
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/src/ifcgeom/abstract_mapping.h
+++ b/src/ifcgeom/abstract_mapping.h
@@ -3,9 +3,9 @@
 
 #include "../ifcparse/IfcBaseClass.h"
 #include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcgeom/taxonomy.h"
-#include "../ifcgeom/IteratorSettings.h"
-#include "../ifcgeom/ConversionSettings.h"
+#include "taxonomy.h"
+#include "IteratorSettings.h"
+#include "ConversionSettings.h"
 
 #include <boost/function.hpp>
 

--- a/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
@@ -5,7 +5,7 @@
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
 
 #include "../../../ifcparse/IfcLogger.h"
-#include "../../../ifcgeom/IfcGeomRepresentation.h"
+#include "../../IfcGeomRepresentation.h"
 
 using IfcGeom::OpaqueNumber;
 using IfcGeom::OpaqueCoordinate;

--- a/src/ifcgeom/kernels/cgal/CgalConversionResult.h
+++ b/src/ifcgeom/kernels/cgal/CgalConversionResult.h
@@ -20,11 +20,11 @@
 #ifndef CGALCONVERSIONRESULT_H
 #define CGALCONVERSIONRESULT_H
 
-#include "../../../ifcgeom/IfcGeomElement.h"
+#include "../../IfcGeomElement.h"
 
 #undef Handle
 
-#include "../../../ifcgeom/kernels/cgal/nef_to_halfspace_tree.h"
+#include "../../kernels/cgal/nef_to_halfspace_tree.h"
 
 #define CGAL_NO_DEPRECATED_CODE
 
@@ -84,7 +84,7 @@ typedef CGAL::Polyhedron_3<Kernel_> cgal_shape_t;
 typedef boost::graph_traits<CGAL::Polyhedron_3<Kernel_>>::vertex_descriptor cgal_vertex_descriptor_t;
 typedef boost::graph_traits<CGAL::Polyhedron_3<Kernel_>>::face_descriptor cgal_face_descriptor_t;
 
-#include "../../../ifcgeom/ConversionResult.h"
+#include "../../ConversionResult.h"
 
 namespace ifcopenshell { namespace geometry {
 

--- a/src/ifcgeom/kernels/cgal/CgalKernel.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalKernel.cpp
@@ -22,7 +22,7 @@
 #include "CgalKernel.h"
 
 #include "../../../ifcparse/IfcLogger.h"
-#include "../../../ifcgeom/kernels/cgal/CgalConversionResult.h"
+#include "../../kernels/cgal/CgalConversionResult.h"
 
 #include <CGAL/minkowski_sum_3.h>
 #include <CGAL/exceptions.h>

--- a/src/ifcgeom/kernels/cgal/CgalKernel.h
+++ b/src/ifcgeom/kernels/cgal/CgalKernel.h
@@ -43,10 +43,10 @@ if ( it != cache.T.end() ) { e = it->second; return true; }
 
 #include "../../../ifcparse/macros.h"
 
-#include "../../../ifcgeom/AbstractKernel.h"
+#include "../../AbstractKernel.h"
 
-#include "../../../ifcgeom/IfcGeomElement.h"
-#include "../../../ifcgeom/kernels/cgal/CgalConversionResult.h"
+#include "../../IfcGeomElement.h"
+#include "../../kernels/cgal/CgalConversionResult.h"
 
 #include <CGAL/Polygon_2.h>
 

--- a/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
+++ b/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
@@ -22,8 +22,8 @@
 
 #include "../../../ifcparse/IfcFile.h"
 
-#include "../../../ifcgeom/IfcGeomElement.h"
-#include "../../../ifcgeom/Iterator.h"
+#include "../../IfcGeomElement.h"
+#include "../../Iterator.h"
 #include "OpenCascadeConversionResult.h"
 #include "base_utils.h"
 

--- a/src/ifcgeom/kernels/opencascade/OpenCascadeConversionResult.cpp
+++ b/src/ifcgeom/kernels/opencascade/OpenCascadeConversionResult.cpp
@@ -11,7 +11,7 @@
 #include "OpenCascadeConversionResult.h"
 
 #include "../../../ifcparse/IfcLogger.h"
-#include "../../../ifcgeom/IfcGeomRepresentation.h"
+#include "../../IfcGeomRepresentation.h"
 #include "base_utils.h"
 #include "boolean_utils.h"
 

--- a/src/ifcgeom/kernels/opencascade/OpenCascadeConversionResult.h
+++ b/src/ifcgeom/kernels/opencascade/OpenCascadeConversionResult.h
@@ -34,7 +34,7 @@
 #include <BRepAdaptor_Curve.hxx>
 #include <GCPnts_QuasiUniformDeflection.hxx>
 
-#include "../../../ifcgeom/ConversionResult.h"
+#include "../../ConversionResult.h"
 
 namespace ifcopenshell {
 	namespace geometry {

--- a/src/ifcgeom/kernels/opencascade/OpenCascadeKernel.h
+++ b/src/ifcgeom/kernels/opencascade/OpenCascadeKernel.h
@@ -43,18 +43,18 @@
 #include <BRep_Builder.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 
-#include "../../../ifcgeom/AbstractKernel.h" 
+#include "../../AbstractKernel.h" 
 
-#include "../../../ifcgeom/IfcGeomElement.h" 
-#include "../../../ifcgeom/IfcGeomRepresentation.h" 
-#include "../../../ifcgeom/ConversionResult.h"
+#include "../../IfcGeomElement.h" 
+#include "../../IfcGeomRepresentation.h" 
+#include "../../ConversionResult.h"
 
-#include "../../../ifcgeom/kernels/opencascade/OpenCascadeConversionResult.h"
+#include "../../kernels/opencascade/OpenCascadeConversionResult.h"
 
-#include "../../../ifcgeom/ifc_geom_api.h"
+#include "../../ifc_geom_api.h"
 
-#include "../../../ifcgeom/taxonomy.h"
-#include "../../../ifcgeom/ConversionSettings.h"
+#include "../../taxonomy.h"
+#include "../../ConversionSettings.h"
 
 namespace IfcGeom {
 

--- a/src/ifcgeom/kernels/opencascade/base_utils.h
+++ b/src/ifcgeom/kernels/opencascade/base_utils.h
@@ -1,7 +1,7 @@
 #ifndef BASE_UTILS_H
 #define BASE_UTILS_H
 
-#include "../../../ifcgeom/ConversionResult.h"
+#include "../../ConversionResult.h"
 
 #include <gp_Pln.hxx>
 #include <gp_Pnt.hxx>

--- a/src/ifcgeom/kernels/opencascade/wire_builder.cpp
+++ b/src/ifcgeom/kernels/opencascade/wire_builder.cpp
@@ -1,7 +1,7 @@
 #include "wire_builder.h"
 
 #include "../../../ifcparse/IfcLogger.h"
-#include "../../../ifcgeom/ConversionSettings.h"
+#include "../../ConversionSettings.h"
 
 #include <TopExp.hxx>
 #include <TopoDS.hxx>

--- a/src/ifcgeom/kernels/opencascade/wire_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/wire_utils.cpp
@@ -1,7 +1,7 @@
 #include "wire_utils.h"
 
 #include "../../../ifcparse/IfcLogger.h"
-#include "../../../ifcgeom/ConversionSettings.h"
+#include "../../ConversionSettings.h"
 
 #include "base_utils.h"
 #include "boolean_utils.h"

--- a/src/ifcgeom/mapping/IfcSectionedSolidHorizontal.cpp
+++ b/src/ifcgeom/mapping/IfcSectionedSolidHorizontal.cpp
@@ -21,8 +21,8 @@
 #define mapping POSTFIX_SCHEMA(mapping)
 using namespace ifcopenshell::geometry;
 
-#include "../../ifcgeom/profile_helper.h"
-#include "../../ifcgeom/infra_sweep_helper.h"
+#include "../profile_helper.h"
+#include "../infra_sweep_helper.h"
 
 #ifdef SCHEMA_HAS_IfcSectionedSolidHorizontal
 

--- a/src/ifcgeom/mapping/IfcSectionedSurface.cpp
+++ b/src/ifcgeom/mapping/IfcSectionedSurface.cpp
@@ -21,8 +21,8 @@
 #define mapping POSTFIX_SCHEMA(mapping)
 using namespace ifcopenshell::geometry;
 
-#include "../../ifcgeom/profile_helper.h"
-#include "../../ifcgeom/infra_sweep_helper.h"
+#include "../profile_helper.h"
+#include "../infra_sweep_helper.h"
 
 #ifdef SCHEMA_HAS_IfcSectionedSurface
 

--- a/src/ifcgeom/piecewise_function_evaluator.h
+++ b/src/ifcgeom/piecewise_function_evaluator.h
@@ -1,7 +1,7 @@
 #ifndef ITERATOR_PWF_EVALUATOR_H
 #define ITERATOR_PWF_EVALUATOR_H
 
-#include "../ifcgeom/taxonomy.h"
+#include "taxonomy.h"
 
 #include <boost/function.hpp>
 

--- a/src/ifcparse/Ifc2x3-schema.cpp
+++ b/src/ifcparse/Ifc2x3-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc2x3.h"
+#include "IfcSchema.h"
+#include "Ifc2x3.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc2x3.cpp
+++ b/src/ifcparse/Ifc2x3.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc2x3.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc2x3.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc2x3.h
+++ b/src/ifcparse/Ifc2x3.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc2x3 {
 

--- a/src/ifcparse/Ifc4-schema.cpp
+++ b/src/ifcparse/Ifc4-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4.h"
+#include "IfcSchema.h"
+#include "Ifc4.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4.cpp
+++ b/src/ifcparse/Ifc4.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4.h
+++ b/src/ifcparse/Ifc4.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4 {
 

--- a/src/ifcparse/Ifc4x1-schema.cpp
+++ b/src/ifcparse/Ifc4x1-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x1.h"
+#include "IfcSchema.h"
+#include "Ifc4x1.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x1.cpp
+++ b/src/ifcparse/Ifc4x1.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x1.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x1.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x1.h
+++ b/src/ifcparse/Ifc4x1.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x1 {
 

--- a/src/ifcparse/Ifc4x2-schema.cpp
+++ b/src/ifcparse/Ifc4x2-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x2.h"
+#include "IfcSchema.h"
+#include "Ifc4x2.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x2.cpp
+++ b/src/ifcparse/Ifc4x2.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x2.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x2.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x2.h
+++ b/src/ifcparse/Ifc4x2.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x2 {
 

--- a/src/ifcparse/Ifc4x3-schema.cpp
+++ b/src/ifcparse/Ifc4x3-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x3.h"
+#include "IfcSchema.h"
+#include "Ifc4x3.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x3.cpp
+++ b/src/ifcparse/Ifc4x3.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x3.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x3.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x3.h
+++ b/src/ifcparse/Ifc4x3.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x3 {
 

--- a/src/ifcparse/Ifc4x3_add1-schema.cpp
+++ b/src/ifcparse/Ifc4x3_add1-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x3_add1.h"
+#include "IfcSchema.h"
+#include "Ifc4x3_add1.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x3_add1.cpp
+++ b/src/ifcparse/Ifc4x3_add1.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x3_add1.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x3_add1.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x3_add1.h
+++ b/src/ifcparse/Ifc4x3_add1.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x3_add1 {
 

--- a/src/ifcparse/Ifc4x3_add2-schema.cpp
+++ b/src/ifcparse/Ifc4x3_add2-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x3_add2.h"
+#include "IfcSchema.h"
+#include "Ifc4x3_add2.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x3_add2.cpp
+++ b/src/ifcparse/Ifc4x3_add2.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x3_add2.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x3_add2.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x3_add2.h
+++ b/src/ifcparse/Ifc4x3_add2.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x3_add2 {
 

--- a/src/ifcparse/Ifc4x3_rc1-schema.cpp
+++ b/src/ifcparse/Ifc4x3_rc1-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x3_rc1.h"
+#include "IfcSchema.h"
+#include "Ifc4x3_rc1.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x3_rc1.cpp
+++ b/src/ifcparse/Ifc4x3_rc1.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x3_rc1.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x3_rc1.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x3_rc1.h
+++ b/src/ifcparse/Ifc4x3_rc1.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x3_rc1 {
 

--- a/src/ifcparse/Ifc4x3_rc2-schema.cpp
+++ b/src/ifcparse/Ifc4x3_rc2-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x3_rc2.h"
+#include "IfcSchema.h"
+#include "Ifc4x3_rc2.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x3_rc2.cpp
+++ b/src/ifcparse/Ifc4x3_rc2.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x3_rc2.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x3_rc2.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x3_rc2.h
+++ b/src/ifcparse/Ifc4x3_rc2.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x3_rc2 {
 

--- a/src/ifcparse/Ifc4x3_rc3-schema.cpp
+++ b/src/ifcparse/Ifc4x3_rc3-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x3_rc3.h"
+#include "IfcSchema.h"
+#include "Ifc4x3_rc3.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x3_rc3.cpp
+++ b/src/ifcparse/Ifc4x3_rc3.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x3_rc3.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x3_rc3.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x3_rc3.h
+++ b/src/ifcparse/Ifc4x3_rc3.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x3_rc3 {
 

--- a/src/ifcparse/Ifc4x3_rc4-schema.cpp
+++ b/src/ifcparse/Ifc4x3_rc4-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x3_rc4.h"
+#include "IfcSchema.h"
+#include "Ifc4x3_rc4.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x3_rc4.cpp
+++ b/src/ifcparse/Ifc4x3_rc4.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x3_rc4.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x3_rc4.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x3_rc4.h
+++ b/src/ifcparse/Ifc4x3_rc4.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x3_rc4 {
 

--- a/src/ifcparse/Ifc4x3_tc1-schema.cpp
+++ b/src/ifcparse/Ifc4x3_tc1-schema.cpp
@@ -24,8 +24,8 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/Ifc4x3_tc1.h"
+#include "IfcSchema.h"
+#include "Ifc4x3_tc1.h"
 #include <string>
 
 using namespace std::string_literals;

--- a/src/ifcparse/Ifc4x3_tc1.cpp
+++ b/src/ifcparse/Ifc4x3_tc1.cpp
@@ -24,10 +24,10 @@
  *                                                                              *
  ********************************************************************************/
 
-#include "../ifcparse/Ifc4x3_tc1.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/IfcFile.h"
+#include "Ifc4x3_tc1.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "IfcFile.h"
 
 #include <map>
 

--- a/src/ifcparse/Ifc4x3_tc1.h
+++ b/src/ifcparse/Ifc4x3_tc1.h
@@ -32,13 +32,13 @@
 
 #include <boost/optional.hpp>
 
-#include "../ifcparse/ifc_parse_api.h"
+#include "ifc_parse_api.h"
 
-#include "../ifcparse/aggregate_of_instance.h"
-#include "../ifcparse/IfcBaseClass.h"
-#include "../ifcparse/IfcSchema.h"
-#include "../ifcparse/IfcException.h"
-#include "../ifcparse/Argument.h"
+#include "aggregate_of_instance.h"
+#include "IfcBaseClass.h"
+#include "IfcSchema.h"
+#include "IfcException.h"
+#include "Argument.h"
 
 struct Ifc4x3_tc1 {
 

--- a/src/serializers/ColladaSerializer.h
+++ b/src/serializers/ColladaSerializer.h
@@ -43,7 +43,7 @@
 
 #include "../ifcgeom/Iterator.h"
 
-#include "../serializers/serializers_api.h"
+#include "serializers_api.h"
 #include "../ifcgeom/GeometrySerializer.h"
 
 #include <boost/numeric/ublas/matrix.hpp>

--- a/src/serializers/GltfSerializer.h
+++ b/src/serializers/GltfSerializer.h
@@ -22,7 +22,7 @@
 
 #ifdef WITH_GLTF
 
-#include "../serializers/serializers_api.h"
+#include "serializers_api.h"
 #include "../ifcgeom/GeometrySerializer.h"
 
 #include <nlohmann/json.hpp>

--- a/src/serializers/HdfSerializer.h
+++ b/src/serializers/HdfSerializer.h
@@ -28,7 +28,7 @@
 
 #include "H5Cpp.h"
 
-#include "../serializers/serializers_api.h"
+#include "serializers_api.h"
 #include "../ifcgeom/GeometrySerializer.h"
 
 #define USE_BINARY

--- a/src/serializers/OpenCascadeBasedSerializer.h
+++ b/src/serializers/OpenCascadeBasedSerializer.h
@@ -22,7 +22,7 @@
 #ifndef OPENCASCADEBASEDSERIALIZER_H
 #define OPENCASCADEBASEDSERIALIZER_H
 
-#include "../serializers/serializers_api.h"
+#include "serializers_api.h"
 #include "../ifcgeom/Iterator.h"
 
 #include "../ifcgeom/GeometrySerializer.h"

--- a/src/serializers/StepSerializer.h
+++ b/src/serializers/StepSerializer.h
@@ -27,7 +27,7 @@
 
 #include "../ifcgeom/Iterator.h"
 
-#include "../serializers/OpenCascadeBasedSerializer.h"
+#include "OpenCascadeBasedSerializer.h"
 
 class StepSerializer : public OpenCascadeBasedSerializer
 {

--- a/src/serializers/SvgSerializer.h
+++ b/src/serializers/SvgSerializer.h
@@ -26,8 +26,8 @@
 
 #include "../ifcgeom/GeometrySerializer.h"
 #include "../ifcgeom/kernels/opencascade/base_utils.h"
-#include "../serializers/serializers_api.h"
-#include "../serializers/util.h"
+#include "serializers_api.h"
+#include "util.h"
 
 #include "../ifcparse/utils.h"
 

--- a/src/serializers/TtlWktSerializer.h
+++ b/src/serializers/TtlWktSerializer.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <fstream>
 
-#include "../serializers/serializers_api.h"
+#include "serializers_api.h"
 #include "../ifcgeom/GeometrySerializer.h"
 
  // http://people.sc.fsu.edu/~jburkardt/txt/obj_format.txt

--- a/src/serializers/USDSerializer.h
+++ b/src/serializers/USDSerializer.h
@@ -25,7 +25,7 @@
 #define __TBB_NO_IMPLICIT_LINKAGE 1
 #define __TBB_LIB_NAME bier
 
-#include "../serializers/serializers_api.h"
+#include "serializers_api.h"
 #include "../ifcgeom/GeometrySerializer.h"
 #include "../ifcparse/utils.h"
 

--- a/src/serializers/WavefrontObjSerializer.h
+++ b/src/serializers/WavefrontObjSerializer.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <fstream>
 
-#include "../serializers/serializers_api.h"
+#include "serializers_api.h"
 #include "../ifcgeom/GeometrySerializer.h"
 
 // http://people.sc.fsu.edu/~jburkardt/txt/obj_format.txt

--- a/src/serializers/XmlSerializer.h
+++ b/src/serializers/XmlSerializer.h
@@ -1,6 +1,6 @@
 #define SCHEMA_METHOD
 
-#include "../serializers/serializers_api.h"
+#include "serializers_api.h"
 #include "../ifcgeom/Serializer.h"
 #include "../ifcparse/IfcFile.h"
 

--- a/src/serializers/schema_dependent/XmlSerializer.h
+++ b/src/serializers/schema_dependent/XmlSerializer.h
@@ -22,7 +22,7 @@
 
 #include "../../ifcgeom/abstract_mapping.h"
 #include "../../ifcparse/macros.h"
-#include "../../serializers/XmlSerializer.h"
+#include "../XmlSerializer.h"
 
 #define INCLUDE_PARENT_PARENT_DIR(x) STRINGIFY(../../ifcparse/x.h)
 #include INCLUDE_PARENT_PARENT_DIR(IfcSchema)

--- a/src/serializers/util.cpp
+++ b/src/serializers/util.cpp
@@ -20,7 +20,7 @@
 #include <set>
 #include <iostream>
 
-#include "../serializers/util.h"
+#include "util.h"
 
 using namespace util;
 


### PR DESCRIPTION
> For example, if /usr/include/sys/stat.h contains #include "types.h", GCC looks for types.h first in /usr/include/sys, then in its usual search path. 

https://gcc.gnu.org/onlinedocs/cpp/Search-Path.html

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-incform

Is there a reason why it is the way it is?
