### PR TITLE
Github Action build scripts!

### DIFF
--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout Build Repository
         uses: actions/checkout@v3
         with:
-          repository: aothms/build-outputs
+          repository: IfcOpenShell/build-outputs
           path: ./build
           ref: ${{ matrix.os }}-${{ matrix.arch }}
           lfs: true

--- a/.github/workflows/build_osx.yml
+++ b/.github/workflows/build_osx.yml
@@ -1,0 +1,130 @@
+name: Build IfcOpenShell OSX
+
+on:
+  push:
+    branches:
+      - v0.8.0
+  workflow_dispatch:
+
+jobs:
+  build_ifcopenshell:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos
+            runner: macos-13
+            arch: x64
+            oldarch: 
+          - os: macos
+            runner: macos-14
+            arch: arm64
+            oldarch: m1
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Checkout Build Repository
+        uses: actions/checkout@v3
+        with:
+          repository: aothms/build-outputs
+          path: ./build
+          ref: ${{ matrix.os }}-${{ matrix.arch }}
+          lfs: true
+          token: ${{ secrets.BUILD_REPO_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+        
+      - name: Install Dependencies
+        run: |
+          brew update
+          brew install git bison autoconf automake libffi cmake findutils
+          echo "$(brew --prefix findutils)/libexec/gnubin" >> $GITHUB_PATH
+        
+      - name: Unpack Dependencies
+        run: |
+          install_root=$(find ./build -maxdepth 4 -name install)
+          find "$install_root" -type f -name 'cache-*.tar.gz' -maxdepth 1 -exec tar -xzf {} -C "$install_root" \;
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ${GITHUB_WORKFLOW}-${{ matrix.os }}
+
+      - name: Run Build Script
+        run: |
+          if [ "${{ matrix.os }}" == "macos" ]; then
+            DARWIN_C_SOURCE=-D_DARWIN_C_SOURCE
+          fi
+          CXXFLAGS="-O3" CFLAGS="-O3 ${DARWIN_C_SOURCE}" ADD_COMMIT_SHA=1 BUILD_CFG=Release python3 ./nix/build-all.py --diskcleanup
+
+      - name: Pack Dependencies
+        run: |
+          cd build
+          for install_dir in $(find $(find . -maxdepth 4 -name install) -mindepth 1 -maxdepth 1 -type d); do
+            test -f $(dirname "$install_dir")/cache-$(basename "$install_dir").tar.gz || tar -czf $(dirname "$install_dir")/cache-$(basename "$install_dir").tar.gz -C $(dirname "$install_dir") $(basename "$install_dir");
+          done
+
+      - name: Commit and Push Changes to Build Repository
+        run: |
+          cd build
+          git config user.name "IfcOpenBot"
+          git config user.email "ifcopenbot@ifcopenshell.org"
+          git add "$(find . -maxdepth 4 -name install)/*.tar.gz"
+          git commit -m "Update build artifacts [skip ci]" || echo "No changes to commit"
+          git push || true
+
+      - name: Package .zip archives
+        run: |
+          VERSION=v`cat VERSION`
+          cd ./build/`uname`/*/10.9/install/ifcopenshell
+          mkdir ~/output
+
+          ls -d python-* | while read py_version; do
+              postfix=`echo ${py_version: -1} | sed s/[0-9]//`
+              numbers=`echo $py_version | grep -oE '[0-9]+\.[0-9]+' | tr -d '.'`
+              py_version_major=python-${numbers}$postfix
+              pushd . > /dev/null
+              cd $py_version
+              if [ ! -d ifcopenshell ]; then
+                  mkdir ../ifcopenshell_
+                  mv * ../ifcopenshell_
+                  mv ../ifcopenshell_ ifcopenshell
+              fi
+              [ -d ifcopenshell/__pycache__ ] && rm -rf ifcopenshell/__pycache__
+              find ifcopenshell -name "*.pyc" -delete
+              zip -r -qq ifcopenshell-${py_version_major}-${VERSION}-${GITHUB_SHA:0:7}-macos${{ matrix.oldarch }}64.zip ifcopenshell/*
+              mv *.zip ~/output
+              popd > /dev/null
+          done
+
+          cd bin
+          rm *.zip || true
+          ls | while read exe; do
+              zip -qq -r ${exe}-${VERSION}-${GITHUB_SHA:0:7}-macos${{ matrix.oldarch }}64.zip $exe
+          done
+          mv *.zip ~/output
+          cd ..
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_UPLOAD_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_UPLOAD_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Overwrite aws cli
+        run: |
+          # https://github.com/rust-lang/rustup/pull/3989/files
+          brew install --overwrite awscli
+
+      - name: Upload .zip archives to S3
+        run: |
+          aws s3 cp ~/output s3://ifcopenshell-builds/ --recursive

--- a/.github/workflows/build_rocky.yml
+++ b/.github/workflows/build_rocky.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout Build Repository
         uses: actions/checkout@v3
         with:
-          repository: aothms/build-outputs
+          repository: IfcOpenShell/build-outputs
           path: ./build
           ref: rockylinux8-x64
           lfs: true

--- a/.github/workflows/build_rocky.yml
+++ b/.github/workflows/build_rocky.yml
@@ -1,0 +1,118 @@
+name: Build IfcOpenShell Linux
+
+on:
+  push:
+    branches:
+      - v0.8.0
+  workflow_dispatch:
+
+jobs:
+  build_ifcopenshell:
+    runs-on: ubuntu-20.04
+    container: rockylinux:8
+
+    steps:
+      - name: Install Dependencies
+        run: |
+          yum update -y
+          yum install -y gcc gcc-c++ git autoconf automake bison make zip cmake python3  \
+                         bzip2 patch mesa-libGL-devel libffi-devel fontconfig-devel      \
+                         sqlite-devel bzip2-devel zlib-devel openssl-devel xz-devel      \
+                         readline-devel ncurses-devel libffi-devel libuuid-devel git-lfs \
+                         findutils
+
+      - name: Install aws cli
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          ./aws/install
+          rm -rf awscliv2.zip aws
+          aws --version
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Checkout Build Repository
+        uses: actions/checkout@v3
+        with:
+          repository: aothms/build-outputs
+          path: ./build
+          ref: rockylinux8-x64
+          lfs: true
+          token: ${{ secrets.BUILD_REPO_TOKEN }}
+
+      - name: Unpack Dependencies
+        run: |
+          install_root=$(find ./build -maxdepth 4 -name install)
+          find "$install_root" -type f -name 'cache-*.tar.gz' -maxdepth 1 -exec tar -xzf {} -C "$install_root" \;
+
+      # Not supported on docker
+      # - name: ccache
+      #   uses: hendrikmuhs/ccache-action@v1
+      #   with:
+      #     key: ${GITHUB_WORKFLOW}-rockylinux8-x64
+
+      - name: Run Build Script
+        run: |
+          CXXFLAGS="-O3" CFLAGS="-O3 ${DARWIN_C_SOURCE}" ADD_COMMIT_SHA=1 BUILD_CFG=Release python3 ./nix/build-all.py --diskcleanup
+
+      - name: Pack Dependencies
+        run: |
+          cd build
+          for install_dir in $(find $(find . -maxdepth 4 -name install) -mindepth 1 -maxdepth 1 -type d); do
+            test -f $(dirname "$install_dir")/cache-$(basename "$install_dir").tar.gz || tar -czf $(dirname "$install_dir")/cache-$(basename "$install_dir").tar.gz -C $(dirname "$install_dir") $(basename "$install_dir");
+          done
+
+      - name: Commit and Push Changes to Build Repository
+        run: |
+          cd build
+          git config user.name "IfcOpenBot"
+          git config user.email "ifcopenbot@ifcopenshell.org"
+          git add "$(find . -maxdepth 4 -name install)/*.tar.gz"
+          git commit -m "Update build artifacts [skip ci]" || echo "No changes to commit"
+          git push || true
+
+      - name: Package .zip archives
+        run: |
+          VERSION=v`cat VERSION`
+          cd ./build/`uname`/*/install/ifcopenshell
+          mkdir ~/output
+
+          ls -d python-* | while read py_version; do
+              postfix=`echo ${py_version: -1} | sed s/[0-9]//`
+              numbers=`echo $py_version | grep -oE '[0-9]+\.[0-9]+' | tr -d '.'`
+              py_version_major=python-${numbers}$postfix
+              pushd . > /dev/null
+              cd $py_version
+              if [ ! -d ifcopenshell ]; then
+                  mkdir ../ifcopenshell_
+                  mv * ../ifcopenshell_
+                  mv ../ifcopenshell_ ifcopenshell
+              fi
+              [ -d ifcopenshell/__pycache__ ] && rm -rf ifcopenshell/__pycache__
+              find ifcopenshell -name "*.pyc" -delete
+              zip -r -qq ifcopenshell-${py_version_major}-${VERSION}-${GITHUB_SHA:0:7}-linux64.zip ifcopenshell/*
+              mv *.zip ~/output
+              popd > /dev/null
+          done
+
+          cd bin
+          rm *.zip || true
+          ls | while read exe; do
+              zip -qq -r ${exe}-${VERSION}-${GITHUB_SHA:0:7}-linux64.zip $exe
+          done
+          mv *.zip ~/output
+          cd ..
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_UPLOAD_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_UPLOAD_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload .zip archives to S3
+        run: |
+          aws s3 cp ~/output s3://ifcopenshell-builds/ --recursive

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -1,0 +1,121 @@
+name: Build IfcOpenShell Windows
+
+on:
+  push:
+    branches:
+      - v0.8.0
+  workflow_dispatch:
+
+jobs:
+  build_ifcopenshell:
+    runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.9.11', '3.10.3', '3.11.8', '3.12.1', '3.13.0']
+        arch: ['x64']
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Checkout Build Repository
+        uses: actions/checkout@v3
+        with:
+          repository: aothms/build-outputs
+          path: _deps-vs2019-x64-installed
+          ref: windows-${{ matrix.arch }}
+          lfs: true
+          token: ${{ secrets.BUILD_REPO_TOKEN }}
+
+      - name: Install Dependencies
+        run: |
+          choco install -y sed 7zip.install awscli
+
+      - name: Install Python
+        run: |
+          $installer = "python-${{ matrix.python }}-amd64.exe"
+          $url = "https://www.python.org/ftp/python/${{ matrix.python }}/$installer"
+          Invoke-WebRequest -Uri $url -OutFile $installer
+          Start-Process -Wait -FilePath .\$installer -ArgumentList '/quiet InstallAllUsers=0 PrependPath=0 Include_test=0 TargetDir=C:\Python\${{ matrix.python }}'
+          Remove-Item .\$installer
+
+      - name: Unpack Dependencies
+        run: |
+          cd _deps-vs2019-x64-installed
+          Get-ChildItem -Path . -Filter 'cache-*.zip' | ForEach-Object {
+            7z x $_.FullName
+          }
+
+      - name: Run Build Script
+        shell: cmd
+        run: |
+          setlocal EnableDelayedExpansion
+          SET PYTHON_VERSION=${{ matrix.python }}
+          for /f "tokens=1,2,3 delims=." %%a in ("%PYTHON_VERSION%") do ( 
+              set PY_VER_MAJOR_MINOR=%%a%%b
+          )
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          SET IFCOS_INSTALL_PYTHON=FALSE
+          cd win
+          echo y | call build-deps.cmd vs2019-x64 Release
+          SET PYTHONHOME=C:\Python\${{ matrix.python }}
+          call run-cmake.bat vs2019-x64 -DENABLE_BUILD_OPTIMIZATIONS=On -DGLTF_SUPPORT=ON -DADD_COMMIT_SHA=ON -DVERSION_OVERRIDE=ON
+          call install-ifcopenshell.bat vs2019-x64 Release
+
+      - name: Pack Dependencies
+        run: |
+          cd _deps-vs2019-x64-installed
+          Get-ChildItem -Path . -Directory | ForEach-Object {
+            $cacheFile = "cache-$($_.Name).zip"
+            echo $cacheFile
+            if (!(Test-Path $cacheFile)) {
+              7z a $cacheFile $_.FullName
+            }
+          }
+
+      - name: Commit and Push Changes to Build Repository
+        run: |
+          cd _deps-vs2019-x64-installed
+          git config user.name "IfcOpenBot"
+          git config user.email "ifcopenbot@ifcopenshell.org"
+          git add *.zip
+          git commit -m "Update build artifacts [skip ci]" || echo "No changes to commit"
+          git push || echo "Push failed"
+
+      - name: Package .zip Archives
+        run: |
+          $VERSION = 'v' + ((Get-Content VERSION).Trim())
+          $SHA = ${env:GITHUB_SHA}.Substring(0, 7)
+          cd _installed-vs2019-x64/bin
+          Get-ChildItem -Path . | ForEach-Object {
+            echo $_
+            $exe = $_.Name
+            $baseName = $exe.Substring(0, $exe.Length - 4)
+            $zipName = "${baseName}-$VERSION-$SHA-win64.zip"
+            7z a $zipName $exe
+          }
+          $OUTPUT_DIR = "$env:USERPROFILE\output"
+          New-Item -ItemType Directory -Force -Path $OUTPUT_DIR
+          mv *.zip $OUTPUT_DIR
+
+          $version = "${{ matrix.python }}"
+          $pyVersionMajor = ($version -split '\.')[0..1] -join '.'
+          cd C:\Python\${{ matrix.python }}\Lib\site-packages
+          Remove-Item -Recurse -Force ifcopenshell\__pycache__ -ErrorAction SilentlyContinue
+          Get-ChildItem -Path ifcopenshell -Filter "*.pyc" -Recurse | Remove-Item -Force
+          $zipName = "ifcopenshell-$pyVersionMajor-$VERSION-$SHA-win64.zip"
+          7z a $zipName ifcopenshell
+          mv $zipName $OUTPUT_DIR
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_UPLOAD_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_UPLOAD_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload .zip Archives to S3
+        run: |
+          aws s3 cp $env:USERPROFILE\output s3://ifcopenshell-builds/ --recursive

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout Build Repository
         uses: actions/checkout@v3
         with:
-          repository: aothms/build-outputs
+          repository: IfcOpenShell/build-outputs
           path: _deps-vs2019-x64-installed
           ref: windows-${{ matrix.arch }}
           lfs: true


### PR DESCRIPTION
Previously IfcOpenBot was a collection of physical machines and SSH/ansible scripts that ran on Amazon EC3.

I've rewritten them to run on Github Actions instead, still levering mostly the same build scripts that have been aging rather well.

You can expect a speed especially on windows because we (a) no longer need to install MSVC on an otherwise empty AMI (b) cache the compiled dependencies using git lfs in a separate repo (you can checkout yourself as well for speedier builds) and (c) because we now compile the python versions in a parallel matrix.

We only still need to figure out a place where to post notifications when builds are complete.