### PR TITLE
Fix default container label #5817

### DIFF
--- a/src/bonsai/bonsai/bim/module/spatial/ui.py
+++ b/src/bonsai/bonsai/bim/module/spatial/ui.py
@@ -119,7 +119,7 @@ class BIM_PT_spatial_decomposition(Panel):
         if SpatialDecompositionData.data["default_container"]:
             row = self.layout.row(align=True)
             row.label(
-                text=f"Default: {SpatialDecompositionData.data['default_container']}",
+                text=f"Default: {SpatialDecompositionData.default_container()}",
                 icon="OUTLINER_COLLECTION",
             )
         else:


### PR DESCRIPTION
Not sure if this is the "right way" to fix this, but it is simple and it works. There is effectively a get'er function  that works, and a stored value that never updates when you change the default container. The label was using the stored value. So perhaps the better fix is to update the stored value on change of def. cont. rather than calling the default_container() function every poll of the UI. I was struggling a bit to follow the path through the set_default_container functions. Seemed to bounce around a bit. So I picked the easy way.