### PR TITLE
updated restriction types

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -999,7 +999,8 @@ class Restriction:
         for constraint, value in self.options.items():
             value = [value] if not isinstance(value, list) else value
             for v in value:
-                if constraint in ["length", "minLength", "maxLength"]:
+                if constraint in ["length", "minLength", "maxLength", "maxExclusive", "maxInclusive",
+                                  "minExclusive", "minInclusive", "totalDigits", "fractionDigits"]:
                     value_dict = {"@value": v}
                 else:
                     value_dict = {"@value": str(v)}


### PR DESCRIPTION
Could not create valid xml if one of "maxExclusive", "maxInclusive","minExclusive", "minInclusive", "totalDigits", "fractionDigits" occured in a restriction inside the ids data. Because these are floating values and can not handled, if they are of type string. They should handled the same way as "length", "minLength", "maxLength", right?