### PR TITLE
Remove mathutils import from shape_builder.py

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/shape_builder.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/shape_builder.py
@@ -30,7 +30,6 @@ import ifcopenshell.util.unit
 from math import cos, sin, pi, tan, radians, degrees, atan, sqrt
 from typing import Union, Optional, Literal, Any, Sequence, TYPE_CHECKING
 from itertools import chain
-from mathutils import Vector
 
 PRECISION = 1.0e-5
 


### PR DESCRIPTION
It's imported below in the type_checking conditional, can it be removed from the top-level imports?