### PR TITLE
Icon dark/light mode function

### DIFF
--- a/src/bonsai/bonsai/bim/module/cad/workspace.py
+++ b/src/bonsai/bonsai/bim/module/cad/workspace.py
@@ -29,7 +29,7 @@ from typing import Union
 def load_custom_icons():
     global custom_icon_previews, display_mode
     if display_mode is None:
-        display_mode = tool.Blender.detect_icon_color_mode("ToolText")
+        display_mode = tool.Blender.detect_icon_color_mode("user_interface.wcol_tool.text")
 
     icons_dir = os.path.join(os.path.dirname(__file__), "..", "..", "data", "icons")
     custom_icon_previews = bpy.utils.previews.new()

--- a/src/bonsai/bonsai/bim/module/cad/workspace.py
+++ b/src/bonsai/bonsai/bim/module/cad/workspace.py
@@ -26,24 +26,10 @@ from bonsai.bim.module.model.data import AuthoringData, RailingData, RoofData
 from typing import Union
 
 
-# TODO duplicate code in cad/workspace and model/workspace
-def check_display_mode():
-    global display_mode
-    try:
-        theme = bpy.context.preferences.themes["Default"]
-        text_color = theme.user_interface.wcol_menu_item.text
-        if sum(text_color) < 2.6:
-            display_mode = "lm"
-        else:
-            display_mode = "dm"
-    except:
-        display_mode = "dm"
-
-
 def load_custom_icons():
-    global custom_icon_previews
+    global custom_icon_previews, display_mode
     if display_mode is None:
-        check_display_mode()
+        display_mode = tool.Blender.detect_icon_color_mode("ToolText")
 
     icons_dir = os.path.join(os.path.dirname(__file__), "..", "..", "data", "icons")
     custom_icon_previews = bpy.utils.previews.new()

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -32,24 +32,10 @@ from bonsai.bim.module.model.prop import get_ifc_class
 from typing import Optional, Union
 
 
-# TODO duplicate code in cad/workspace and model/workspace
-def check_display_mode():
-    global display_mode
-    try:
-        theme = bpy.context.preferences.themes["Default"]
-        text_color = theme.user_interface.wcol_menu_item.text
-        if sum(text_color) < 2.6:
-            display_mode = "lm"
-        else:
-            display_mode = "dm"
-    except:
-        display_mode = "dm"
-
-
 def load_custom_icons():
-    global custom_icon_previews
+    global custom_icon_previews, display_mode
     if display_mode is None:
-        check_display_mode()
+        display_mode = tool.Blender.detect_icon_color_mode("ToolText")
 
     icons_dir = os.path.join(os.path.dirname(__file__), "..", "..", "data", "icons")
     custom_icon_previews = bpy.utils.previews.new()

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -35,7 +35,7 @@ from typing import Optional, Union
 def load_custom_icons():
     global custom_icon_previews, display_mode
     if display_mode is None:
-        display_mode = tool.Blender.detect_icon_color_mode("ToolText")
+        display_mode = tool.Blender.detect_icon_color_mode("user_interface.wcol_tool.text")
 
     icons_dir = os.path.join(os.path.dirname(__file__), "..", "..", "data", "icons")
     custom_icon_previews = bpy.utils.previews.new()

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1423,3 +1423,29 @@ class Blender(bonsai.core.tool.Blender):
     def V_(cls, *args: float) -> Vector:
         """Just a shortcut for creating mathutils Vector."""
         return Vector(args)
+
+    @classmethod
+    def detect_icon_color_mode(cls, key="RegularText", threshold=1.671):
+        """
+        Uses the color of text to determin if custom icons should be dark mode (dm) or light mode (mode).
+
+        Args:
+            key (str): The key representing the UI element (e.g., "RegularText").
+            threshold (float, optional): The RGB sum threshold for determining dark mode. Default is 1.671.
+
+        Returns:
+            str: 'dm' (dark mode) if the RGB sum is > threshold, otherwise 'lm' (light mode).
+        """
+        theme = bpy.context.preferences.themes[0]
+        ui_colors = {
+            "RegularText": theme.user_interface.wcol_regular.text[:3],  # User Interface - Regular - Text
+            "ToolText": theme.user_interface.wcol_tool.text[:3],  # User Interface - Tool - Text
+            "MenuBackgroundText": theme.user_interface.wcol_menu_back.text[
+                :3
+            ],  # User Interface - Menu Background - Text
+            "MenuText": theme.user_interface.wcol_menu.text[:3],  # User Interface - Menu - Text
+            "MenuTextSelected": theme.user_interface.wcol_menu.text_sel[:3],  # User Interface - Menu - Selected
+        }
+        color = ui_colors.get(key, (0.0, 0.0, 0.0))
+        rgb_sum = sum(color[:3])
+        return "dm" if rgb_sum > threshold else "lm"

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1425,27 +1425,29 @@ class Blender(bonsai.core.tool.Blender):
         return Vector(args)
 
     @classmethod
-    def detect_icon_color_mode(cls, key="RegularText", threshold=1.671):
+    def detect_icon_color_mode(cls, color_path="user_interface.wcol_regular.text", threshold=1.671):
         """
-        Uses the color of text to determine if custom icons should be dark mode (dm) or light mode (mode).
+        Uses the text color of a given Blender UI property to determine if custom icons should be dark mode (dm) or light mode (lm).
+
+        Common Blender UI text color paths:
+            - "user_interface.wcol_regular.text"  (Regular Text)
+            - "user_interface.wcol_tool.text"  (Tool Text)
+            - "user_interface.wcol_menu_back.text"  (Menu Background Text)
+            - "user_interface.wcol_menu.text"  (Menu Text)
+            - "user_interface.wcol_menu.text_sel"  (Menu Text Selected)
 
         Args:
-            key (str): The key representing the UI element (e.g., "RegularText").
+            color_path (str, optional): The attribute path relative to bpy.context.preferences.themes[0].
             threshold (float, optional): The RGB sum threshold for determining dark mode. Default is 1.671.
 
         Returns:
             str: 'dm' (dark mode) if the RGB sum is > threshold, otherwise 'lm' (light mode).
         """
-        theme = bpy.context.preferences.themes[0]
-        ui_colors = {
-            "RegularText": theme.user_interface.wcol_regular.text[:3],  # User Interface - Regular - Text
-            "ToolText": theme.user_interface.wcol_tool.text[:3],  # User Interface - Tool - Text
-            "MenuBackgroundText": theme.user_interface.wcol_menu_back.text[
-                :3
-            ],  # User Interface - Menu Background - Text
-            "MenuText": theme.user_interface.wcol_menu.text[:3],  # User Interface - Menu - Text
-            "MenuTextSelected": theme.user_interface.wcol_menu.text_sel[:3],  # User Interface - Menu - Selected
-        }
-        color = ui_colors.get(key, (0.0, 0.0, 0.0))
-        rgb_sum = sum(color[:3])
-        return "dm" if rgb_sum > threshold else "lm"
+        full_path = f"bpy.context.preferences.themes[0].{color_path}"
+
+        try:
+            color = eval(full_path)[:3]  # Dynamically evaluate and extract RGB values
+            rgb_sum = sum(color)
+            return "dm" if rgb_sum > threshold else "lm"
+        except Exception:
+            return "dm"  # Default to dark mode if an error occurs

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1427,7 +1427,7 @@ class Blender(bonsai.core.tool.Blender):
     @classmethod
     def detect_icon_color_mode(cls, key="RegularText", threshold=1.671):
         """
-        Uses the color of text to determin if custom icons should be dark mode (dm) or light mode (mode).
+        Uses the color of text to determine if custom icons should be dark mode (dm) or light mode (mode).
 
         Args:
             key (str): The key representing the UI element (e.g., "RegularText").


### PR DESCRIPTION
New function that uses the color of text to determine if custom icons should be dark mode (dm) or light mode (mode). Applied to model and cad workspaces.
