### PR TITLE
Guid-Standards ---> v0.8.0

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/guid.py
+++ b/src/ifcopenshell-python/ifcopenshell/guid.py
@@ -72,7 +72,7 @@ def compress(
 
     # remove possible separators
     uuid = uuid.lower()
-    uuid = re.sub(pattern=r"\W", repl="", string=uuid);
+    uuid = re.sub(pattern=r"\W", repl="", string=uuid)
 
     # left-pad uuid with 0s
     n = len(uuid)
@@ -121,13 +121,15 @@ def split(uuid: str, /) -> str:
     xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     ```
     """
-    return "-".join([
-        uuid[:8],
-        uuid[8:][:4],
-        uuid[12:][:4],
-        uuid[16:][:4],
-        uuid[20:],
-    ])
+    return "-".join(
+        [
+            uuid[:8],
+            uuid[8:][:4],
+            uuid[12:][:4],
+            uuid[16:][:4],
+            uuid[20:],
+        ]
+    )
 
 
 def new() -> str:


### PR DESCRIPTION
IfcOpenShell uses a non-standard order of alphanumerical characters for their Base64<->Hex encoding of UUIDs/GUIDs.

- The Base64 standard is
    ```txt
    ABCD...Z abcd...z 01...9 +/
    ```
    and right-padding with `=`-symbols (so that the length is 0 mod 4).

    See

    - <https://base64.guru/learn/base64-characters>;
    - p. 5 in <https://www.rfc-editor.org/rfc/rfc4648.txt>.

- IfcOpenShell by contrast uses
    ```txt
    01...9 ABCD...Z abcd...z _$
    ```
    
    and no padding.

    See

    - <https://technical.buildingsmart.org/resources/ifcimplementationguidance/ifc-guid>.

Now, the final characters can be arbitrarily set and the use of padding is neither here nor there. However, what is a serious problem is the order of the alphanumerical symbols. This makes the base64 GUIDs from IfcOpenShell incompatible with other systems.

The present PR corrects proposes a change to align IfcOpenShell with other systems. In the process the methods

- `src/ifcopenshell-python/ifcopenshell/guid.py` > compress
- `src/ifcopenshell-python/ifcopenshell/guid.py` > expand

are dramatically simplified, as we can now use standard python libraries.

> [!NOTE]
> This PR does not change the underlying C-code. If accepted, then another PR will be required that corrects the handling of UUIDs/GUIDs in the wrapper. The documentation on IfcOpenShell's website <https://technical.buildingsmart.org/resources/ifcimplementationguidance/ifc-guid> would also need to be amended.
