### PR TITLE
Automatic build and deploy bonsai docs on push

### DIFF
--- a/.github/workflows/docs-deployment-unstable.yml
+++ b/.github/workflows/docs-deployment-unstable.yml
@@ -1,0 +1,38 @@
+name: Build and Deploy Unstable Documentation
+
+on:
+  push:
+    branches:
+      - main  # Trigger the workflow on pushes to the main branch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install sphinx
+
+      - name: Build documentation
+        run: |
+          cd src/bonsai/docs
+          make html
+
+      - name: Deploy to GitHub Pages (Unstable)
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: IfcOpenShell/bonsaibim_org_docs_unstable
+          publish_branch: main
+          cname: docs-unstable.bonsaibim.org
+          publish_dir: src/bonsai/docs/_build/html

--- a/.github/workflows/docs-deployment-unstable.yml
+++ b/.github/workflows/docs-deployment-unstable.yml
@@ -20,19 +20,19 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install sphinx
+          cd src/bonsai/docs  # Navigate to the docs directory
+          pip install -r requirements.txt  # Install dependencies from requirements.txt
 
       - name: Build documentation
         run: |
-          cd src/bonsai/docs
-          make html
+          cd src/bonsai/docs  # Navigate to the docs directory
+          make html  # Build the documentation
 
       - name: Deploy to GitHub Pages (Unstable)
         uses: peaceiris/actions-gh-pages@v4
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          external_repository: IfcOpenShell/bonsaibim_org_docs_unstable
-          publish_branch: main
-          cname: docs-unstable.bonsaibim.org
-          publish_dir: src/bonsai/docs/_build/html
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}  # SSH key for deployment
+          external_repository: IfcOpenShell/bonsaibim_org_docs_unstable  # Target repository
+          publish_branch: main  # Branch to deploy to
+          cname: docs-unstable.bonsaibim.org  # Custom domain for unstable docs
+          publish_dir: src/bonsai/docs/_build/html  # Directory containing built docs

--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -1,0 +1,37 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main  # Trigger the workflow on pushes to the main branch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install sphinx
+
+      - name: Build documentation
+        run: |
+          cd src/bonsai/docs
+          make html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          external_repository: IfcOpenShell/bonsaibim_org_docs
+          publish_branch: main
+          publish_dir: src/bonsai/docs/_build/html

--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -1,9 +1,7 @@
-name: Build and Deploy Documentation
+name: Build and Deploy Stable Documentation
 
 on:
-  push:
-    branches:
-      - main  # Trigger the workflow on pushes to the main branch
+  workflow_dispatch:  # Manual trigger
 
 jobs:
   build:
@@ -28,7 +26,7 @@ jobs:
           cd src/bonsai/docs
           make html
 
-      - name: Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages (Stable)
         uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -34,4 +34,5 @@ jobs:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: IfcOpenShell/bonsaibim_org_docs
           publish_branch: main
+          cname: docs.bonsaibim.org
           publish_dir: src/bonsai/docs/_build/html

--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install sphinx
+          cd src/bonsai/docs
+          pip install -r requirements.txt  # Run pip install from the docs directory
 
       - name: Build documentation
         run: |

--- a/src/bonsai/docs/requirements.txt
+++ b/src/bonsai/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+furo
+sphinx-autoapi
+sphinx-copybutton


### PR DESCRIPTION
Currently, the documentation is pushed manually by IfcOpenBot, with the CNAME created manually afterward. This pull request introduces a workflow that automates the process of building the documentation and deploying it to the `main` branch of the `IfcOpenShell/bonsaibim_org_docs` repository.

### Changes:
- Added a new workflow file: `.github/workflows/docs-deployment.yml`
- The workflow includes steps to:
  - Set up the Python environment.
  - Install necessary dependencies.
  - Build the documentation using Sphinx.
  - Deploy the built documentation to the `main` branch of `IfcOpenShell/bonsaibim_org_docs`.

### Workflow Details:
- The workflow uses the `peaceiris/actions-gh-pages@v4` action for deployment.
- The deployment is authenticated using a deploy key stored as a secret (`ACTIONS_DEPLOY_KEY`).

### Instructions:
For this workflow to work, you need to create the deploy key by following the instructions here: [Create SSH Deploy Key](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-create-ssh-deploy-key).
- Name the deploy key: `ACTIONS_DEPLOY_KEY`.
- This SSH key should have write access to the `IfcOpenShell/bonsaibim_org_docs` repository.

### Motivation:
This workflow automates the process of building and deploying the documentation, ensuring that the latest changes are always reflected in the `bonsaibim_org_docs` repository and thus on https://docs.bonsaibim.org/.

### Additional Notes:
- Ensure that the `ACTIONS_DEPLOY_KEY` secret is configured correctly in the repository settings.
- The deploy key should have write access to the `IfcOpenShell/bonsaibim_org_docs` repository.
