### PR TITLE
Minor-Fixes ---> v0.8.0

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -217,7 +217,6 @@ class DumbSlabPlaner:
 
         self.change_thickness(element, total_thickness)
 
-
     def regenerate_from_layer(self, usecase_path, ifc_file, settings):
         self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
 
@@ -316,7 +315,7 @@ class DumbSlabPlaner:
                 elif layer_params["direction_sense"] == "NEGATIVE":
                     y = -abs(y) if existing_x_angle > 0 else abs(y)
                     z = -abs(z)
-                    offset_vector = -offset_vector 
+                    offset_vector = -offset_vector
                 extrusion.ExtrudedDirection.DirectionRatios = (x, y, z)
                 extrusion.Depth = thickness
 
@@ -328,7 +327,6 @@ class DumbSlabPlaner:
                     rot_matrix = Matrix.Rotation(existing_x_angle, 4, "X")
                     rot_offset = offset_vector @ rot_matrix
                     extrusion.Position.Location.Coordinates = tuple(rot_offset)
-
 
             else:
                 props = bpy.context.scene.BIMModelProperties
@@ -378,7 +376,6 @@ class DumbSlabPlaner:
             is_global=True,
             should_sync_changes_first=False,
         )
-
 
 
 class EnableEditingSketchExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -244,10 +244,14 @@ class ChangeExtrusionXAngle(bpy.types.Operator, tool.Ifc.Operator):
             else:
                 if tool.Model.get_usage_type(element) == "LAYER3":
                     # Reset the transformation and returns to the original points with 0 degrees
-                    extrusion.SweptArea.OuterCurve.Points.CoordList = [(p[0], p[1] * (cos(existing_x_angle))) for p in extrusion.SweptArea.OuterCurve.Points.CoordList]
-                
+                    extrusion.SweptArea.OuterCurve.Points.CoordList = [
+                        (p[0], p[1] * (cos(existing_x_angle))) for p in extrusion.SweptArea.OuterCurve.Points.CoordList
+                    ]
+
                     # Apply the transformation for the new x_angle
-                    extrusion.SweptArea.OuterCurve.Points.CoordList = [(p[0], p[1] * (1 / cos(x_angle))) for p in extrusion.SweptArea.OuterCurve.Points.CoordList]
+                    extrusion.SweptArea.OuterCurve.Points.CoordList = [
+                        (p[0], p[1] * (1 / cos(x_angle))) for p in extrusion.SweptArea.OuterCurve.Points.CoordList
+                    ]
 
                     # The extrusion direction calculated previously default to the positive direction
                     # Here we set the extrusion direction to negative it that's the case
@@ -271,7 +275,6 @@ class ChangeExtrusionXAngle(bpy.types.Operator, tool.Ifc.Operator):
                         rot_offset = offset_vector @ rot_matrix
                         extrusion.Position.Location.Coordinates = tuple(rot_offset)
 
-
                 bonsai.core.geometry.switch_representation(
                     tool.Ifc,
                     tool.Geometry,
@@ -284,7 +287,7 @@ class ChangeExtrusionXAngle(bpy.types.Operator, tool.Ifc.Operator):
 
                 # Object rotation
                 local_rot_mat = obj.rotation_euler.to_matrix()
-                rot_mat = mathutils.Matrix.Rotation(x_angle - existing_x_angle, 4, 'X')
+                rot_mat = mathutils.Matrix.Rotation(x_angle - existing_x_angle, 4, "X")
                 new_rot_mat = local_rot_mat.to_4x4() @ rot_mat
                 new_rot_euler = new_rot_mat.to_euler()
                 obj.rotation_euler = new_rot_euler

--- a/src/bonsai/bonsai/bim/prop.py
+++ b/src/bonsai/bonsai/bim/prop.py
@@ -586,11 +586,13 @@ class BIMFacet(PropertyGroup):
 class BIMFilterGroup(PropertyGroup):
     filters: CollectionProperty(type=BIMFacet, name="filters")
 
+
 class BIMSnapGroups(PropertyGroup):
     object: BoolProperty(name="Object")
     polyline: BoolProperty(name="Polyline")
     measure: BoolProperty(name="Measure")
-    
+
+
 class BIMSnapProperties(PropertyGroup):
     vertex: BoolProperty(name="Vertex")
     edge: BoolProperty(name="Edge")

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2063,12 +2063,7 @@ class Model(bonsai.core.tool.Model):
         # The existing angle result can change when the direction sense in Negative because the DirectionRatios may have negative y and z.
         # For instance, a 30 degree angled slab, with negative direction will show as -150 degrees. To prevent that we do the following transformations
         existing_x_angle = Vector((0, 1)).angle_signed(Vector((y, z)))
-        existing_x_angle = (
-            existing_x_angle + radians(180) if existing_x_angle < -radians(90) else existing_x_angle
-        )
-        existing_x_angle = (
-            existing_x_angle - radians(180) if existing_x_angle > radians(90) else existing_x_angle
-        )
+        existing_x_angle = existing_x_angle + radians(180) if existing_x_angle < -radians(90) else existing_x_angle
+        existing_x_angle = existing_x_angle - radians(180) if existing_x_angle > radians(90) else existing_x_angle
 
         return existing_x_angle
-

--- a/src/bonsai/bonsai/tool/snap.py
+++ b/src/bonsai/bonsai/tool/snap.py
@@ -514,7 +514,7 @@ class Snap(bonsai.core.tool.Snap):
                     options.append(props.rna_type.properties[prop].name)
             filtered_groups = [group for group in detected_snaps if group["group"] in options]
             return filtered_groups
-            
+
         filtered_snaps = filter_snapping_groups_based_on_settings(detected_snaps)
         snapping_points = []
         edges = []  # Get edges to create edge-intersection snap
@@ -571,7 +571,7 @@ class Snap(bonsai.core.tool.Snap):
                         snapping_points.insert(0, (intersection[1], "Edge Intersection", None))
 
         filtered_snapping_points = filter_snapping_points_based_on_settings(snapping_points)
-        
+
         # Make Axis first priority
         if tool_state.lock_axis or tool_state.axis_method in {"X", "Y", "Z"}:
             cls.update_snapping_ref(filtered_snapping_points[0][0], filtered_snapping_points[0][1])
@@ -586,7 +586,9 @@ class Snap(bonsai.core.tool.Snap):
                     cls.update_snapping_point(point[0], point[1])
                     return filtered_snapping_points
 
-        cls.update_snapping_point(filtered_snapping_points[0][0], filtered_snapping_points[0][1], filtered_snapping_points[0][2])
+        cls.update_snapping_point(
+            filtered_snapping_points[0][0], filtered_snapping_points[0][1], filtered_snapping_points[0][2]
+        )
         return filtered_snapping_points
 
     @classmethod

--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/add_slab_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/add_slab_representation.py
@@ -84,7 +84,10 @@ class Usecase:
         size = self.convert_si_to_unit(1)
         points = ((0.0, 0.0), (size, 0.0), (size, size), (0.0, size), (0.0, 0.0))
         if self.settings["polyline"]:
-            points = [(self.convert_si_to_unit(p[0]), self.convert_si_to_unit(p[1] * (1 / cos(self.settings["x_angle"])))) for p in self.settings["polyline"]]
+            points = [
+                (self.convert_si_to_unit(p[0]), self.convert_si_to_unit(p[1] * (1 / cos(self.settings["x_angle"]))))
+                for p in self.settings["polyline"]
+            ]
         if self.file.schema == "IFC2X3":
             curve = self.file.createIfcPolyline([self.file.createIfcCartesianPoint(p) for p in points])
         else:

--- a/src/ifcopenshell-python/ifcopenshell/api/material/add_layer.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/material/add_layer.py
@@ -84,7 +84,9 @@ def add_layer(
     settings = {"layer_set": layer_set, "material": material}
 
     layers = list(settings["layer_set"].MaterialLayers or [])
-    layer = file.create_entity("IfcMaterialLayer", **{"Material": settings["material"], "LayerThickness": 0.1 / unit_scale})
+    layer = file.create_entity(
+        "IfcMaterialLayer", **{"Material": settings["material"], "LayerThickness": 0.1 / unit_scale}
+    )
     layers.append(layer)
     settings["layer_set"].MaterialLayers = layers
     return layer


### PR DESCRIPTION
It appears that files have been pushed to the branch without being linted causing the workflow `ci-black-formatting / lint-formatting` to consistently fail.

This PR attempts to fix this.

> [!NOTE]
> What would be even better would be the introduction of githooks that forcibly run the linter before pushing to remote.
