### PR TITLE
Fix issue with eliminate_touching_operands

### DIFF
--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -503,10 +503,10 @@ int IfcGeom::util::eliminate_touching_operands(double prec, const TopoDS_Shape &
 
 				double u0, u1, v0, v1;
 				prop_a.Bounds(u0, u1, v0, v1);
-				prop_a.Normal((u0 + u1) / 2., (u0 + u1) / 2., p_a, v_a);
+				prop_a.Normal((u0 + u1) / 2., (v0 + v1) / 2., p_a, v_a);
 
 				prop_b.Bounds(u0, u1, v0, v1);
-				prop_b.Normal((u0 + u1) / 2., (u0 + u1) / 2., p_b, v_b);
+				prop_b.Normal((u0 + u1) / 2., (v0 + v1) / 2., p_b, v_b);
 
 				bool all_vertices_behind_f_a = true;
 
@@ -531,7 +531,7 @@ int IfcGeom::util::eliminate_touching_operands(double prec, const TopoDS_Shape &
 				// Check if surface normals are opposite
 				if (v_a.IsOpposite(v_b, 1.e-5)) {
 					// Check if faces are co-planar
-					if ((p_b.XYZ() - p_a.XYZ()).Dot(v_a.XYZ()) <= prec) {
+					if (std::abs((p_b.XYZ() - p_a.XYZ()).Dot(v_a.XYZ())) <= prec) {
 
 						TopTools_IndexedMapOfShape f_b_vertices;
 						TopExp::MapShapes(f_b, TopAbs_VERTEX, f_b_vertices);


### PR DESCRIPTION
Hello
Yesterday I started using clipping on some of my walls and the rendering of the boolean substraction would not work for some of them in Bonsai. Since it worked fine in Solibri and Open IFC Viewer I thought it is probably a bug here. 

After a bit of investigation I think a found the bug. Looks like the coplanarity test was not restrictive enough.

![{80956786-4D7A-4FAE-B229-90421D6149DE}](https://github.com/user-attachments/assets/06c987fe-6eb3-4c67-9be5-7cf3617270dc)
![{465C0008-5CD2-499C-9054-8448C243D991}](https://github.com/user-attachments/assets/ed04af94-8e6c-4c46-8d6a-ceb9d2b14d74)
[clipping_issue.ifc.txt](https://github.com/user-attachments/files/18511513/clipping_issue.ifc.txt)

I didn't add a test case for this fix but I will be happy to add one if someone points me to where it should be placed.