### PR TITLE
Fix transform matrix computation in Axis2Placement3D

### DIFF
--- a/src/ifcgeom/taxonomy.h
+++ b/src/ifcgeom/taxonomy.h
@@ -267,9 +267,9 @@ typedef item const* ptr;
 			struct matrix4 : public item, public eigen_base<Eigen::Matrix4d> {
 			private:
 				void init(const Eigen::Vector3d& o, const Eigen::Vector3d& z, const Eigen::Vector3d& x) {
-					auto X = x.normalized();
-					auto Y = z.cross(x).normalized();
 					auto Z = z.normalized();
+					auto Y = Z.cross(x).normalized();
+					auto X = Y.cross(Z);
 					components_ = new Eigen::Matrix4d;
 					(*components_) <<
 						X(0), Y(0), Z(0), o(0),


### PR DESCRIPTION
Hello,
I believe there was a mistake in the computation of the transform matrix to resolve the placements of the entities. I used [this](https://github.com/g-truc/glm/blob/69b130c162e6266e07392741bd04feacc55dcda2/glm/ext/matrix_transform.inl#L178) implementation as a reference.

I stumbled upon the issue when trying to place the roof in my model (blender + bonsai on windows):
![{1A4F45D9-E8D6-4BCF-8C7C-B906289921B0}](https://github.com/user-attachments/assets/bff2df19-a474-4536-a574-e532c6815ebb)
![{14B7942D-954A-43A1-A9BD-35DACDF39CCE}](https://github.com/user-attachments/assets/7a5a69e5-0a54-45e8-8286-b8a121bf6d94)

When transforming the ifc to obj in linux through python I had this output:
![{89962E85-0733-40C0-8DEF-7752D80F9B5C}](https://github.com/user-attachments/assets/968813d4-b36e-46dd-b6cd-f6f32eb9963a)
I have no explanation as to why it does not orient at all.

After the fix, the ifc to obj starts working fine on linux:
![{727344B4-A4F8-4BCA-B417-ACC5244175B0}](https://github.com/user-attachments/assets/783481a6-1a5b-483a-94b9-eea6e116bf3c)

I have no way of testing this in blender + bonsai on windows because I don't want to install MSVC but I assume it also fixes my original issue.
I also didn't run any tests so I don't know if the change has side effects that result in the need for some adaptations.