### PR TITLE
Hide Quick Create tools in IFC2X3

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -580,7 +580,7 @@ class CreateObjectUI:
             row = box.row(align=True)
             row.alignment = "CENTER"
             row.template_icon(icon_value=0, scale=3.5)
-        elif AuthoringData.data["ifc_element_type"]:
+        elif AuthoringData.data["ifc_element_type"] and tool.Ifc.get().schema != "IFC2X3":
             row = cls.layout.row(align=True)
             op = row.operator(
                 "bim.add_default_type",


### PR DESCRIPTION
When testing Tool functions on IFC2X3, all quick create functions crash Blender.