### PR TITLE
Delete unused import

### DIFF
--- a/src/bonsai/bonsai/bim/__init__.py
+++ b/src/bonsai/bonsai/bim/__init__.py
@@ -20,8 +20,7 @@ import os
 import bpy
 import bpy.utils.previews
 import importlib
-from pathlib import Path
-from . import handler, ui, prop, operator, helper
+from . import handler, ui, prop, operator
 from typing import Callable, Union
 
 try:

--- a/src/bonsai/bonsai/bim/export_ifc.py
+++ b/src/bonsai/bonsai/bim/export_ifc.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import os
 import bpy
 import json
-import numpy as np
 import datetime
 import zipfile
 import tempfile

--- a/src/bonsai/bonsai/bim/helper.py
+++ b/src/bonsai/bonsai/bim/helper.py
@@ -20,15 +20,12 @@ from __future__ import annotations
 import importlib
 import bpy
 import json
-import math
 import ifcopenshell
 import ifcopenshell.ifcopenshell_wrapper as W
 import ifcopenshell.util.attribute
 import ifcopenshell.util.element
 import ifcopenshell.util.unit
 from ifcopenshell.util.doc import get_attribute_doc, get_predefined_type_doc, get_property_doc
-from mathutils import geometry
-from mathutils import Vector
 import bonsai.tool as tool
 from bonsai.bim.ifc import IfcStore
 from typing import Optional, Callable, Any, Union, Iterable, TYPE_CHECKING

--- a/src/bonsai/bonsai/bim/operator.py
+++ b/src/bonsai/bonsai/bim/operator.py
@@ -19,7 +19,6 @@
 import os
 import bpy
 import bmesh
-import json
 import time
 import logging
 import textwrap
@@ -32,11 +31,10 @@ import ifcopenshell
 import bonsai.bim
 import bonsai.tool as tool
 from bonsai.bim import import_ifc
-from bonsai.bim.ifc import IfcStore
 from bonsai.bim.prop import StrProperty
 from bonsai.bim.ui import IFCFileSelector
 from bonsai.bim.helper import get_enum_items
-from mathutils import Vector, Matrix, Euler
+from mathutils import Vector, Euler
 from math import radians
 from pathlib import Path
 from collections import namedtuple

--- a/src/bonsai/bonsai/bim/prop.py
+++ b/src/bonsai/bonsai/bim/prop.py
@@ -16,11 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
-from pathlib import Path
 import os
 import bpy
 import json
-import importlib
 import platformdirs
 import ifcopenshell
 import ifcopenshell.util.pset
@@ -36,7 +34,6 @@ import bonsai.bim
 import bonsai.bim.schema
 import bonsai.bim.handler
 import bonsai.tool as tool
-from collections import defaultdict
 from bpy.types import PropertyGroup
 from bpy.props import (
     PointerProperty,


### PR DESCRIPTION
I delete unused Python imports on Python files in `/src/bonsai/bonsai`. I think there are many unused Python imports in other files but this is my first contribution so I can do it later just in case what I do is wrong.