### PR TITLE
fix: bug in initialization of gltf serialiser fixed (documentation)

### DIFF
--- a/src/ifcopenshell-python/docs/ifcopenshell-python/geometry_processing.rst
+++ b/src/ifcopenshell-python/docs/ifcopenshell-python/geometry_processing.rst
@@ -306,39 +306,43 @@ In addition to geometry settings, serialisation has its own set of
 
 .. code-block:: python
 
-    import ifcopenshell
-    import ifcopenshell.geom
-    import multiprocessing
-
-    settings = ifcopenshell.geom.settings()
-
-    # Settings for glTF / glb
-    settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
-    # Note that applying default materials is required in glTF serialisation.
-    settings.set("apply-default-materials", True)
-
-    # Settings for obj
-    # settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
-    # settings.set("apply-default-materials", True)
-    # settings.set("use-world-coords", True)
-
-    # Serialise to glTF / glb
-    serialiser = ifcopenshell.geom.serializers.gltf("output.glb", settings)
-    self.serialiser_settings = ifcopenshell.geom.serializer_settings()
-    # Setting element GUIDs is optional, but useful to uniquely identify objects in non-semantic formats.
-    serialiser_settings.set("use-element-guids", True)
-
-    # Serialise to obj
-    # serialiser = ifcopenshell.geom.serializers.obj('output.obj', 'output.mtl', settings, serialiser_settings)
-
-    serialiser.setFile(self.file)
-    serialiser.setUnitNameAndMagnitude("METER", 1.0)
-    serialiser.writeHeader()
-
-    iterator = ifcopenshell.geom.iterator(settings, self.file, multiprocessing.cpu_count())
-    if iterator.initialize():
-        while True:
-            serialiser.write(iterator.get())
-            if not iterator.next():
-                break
-    serialiser.finalize()
+   import multiprocessing
+   
+   import ifcopenshell
+   import ifcopenshell.geom
+   
+   ifc_file = ifcopenshell.open("model.ifc")
+   
+   settings = ifcopenshell.geom.settings()
+   
+   # Settings for glTF / glb
+   settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
+   # Note that applying default materials is required in glTF serialisation.
+   settings.set("apply-default-materials", True)
+   
+   # Settings for obj
+   # settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
+   # settings.set("apply-default-materials", True)
+   # settings.set("use-world-coords", True)
+   
+   serialiser_settings = ifcopenshell.geom.serializer_settings()
+   # Setting element GUIDs is optional, but useful to uniquely identify objects in non-semantic formats.
+   serialiser_settings.set("use-element-guids", True)
+   
+   # Serialise to glTF / glb
+   serialiser = ifcopenshell.geom.serializers.gltf("output.glb", settings, serialiser_settings)
+   
+   # Serialise to obj
+   # serialiser = ifcopenshell.geom.serializers.obj('output.obj', 'output.mtl', settings, serialiser_settings)
+   
+   serialiser.setFile(ifc_file)
+   serialiser.setUnitNameAndMagnitude("METER", 1.0)
+   serialiser.writeHeader()
+   
+   iterator = ifcopenshell.geom.iterator(settings, ifc_file, multiprocessing.cpu_count())
+   if iterator.initialize():
+       while True:
+           serialiser.write(iterator.get())
+           if not iterator.next():
+               break
+   serialiser.finalize()


### PR DESCRIPTION
The `GltfSerializer` requires 3 parameters, but the example script in the documentation just uses two. This results into an error.

```py
class GltfSerializer(WriteOnlyGeometrySerializer):
    r"""Proxy of C++ GltfSerializer class."""

    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
    __repr__ = _swig_repr

    def __init__(self, filename, geometry_settings, settings):
        r"""__init__(GltfSerializer self, std::string const & filename, Settings geometry_settings, SerializerSettings settings) -> GltfSerializer"""
        _ifcopenshell_wrapper.GltfSerializer_swiginit(self, _ifcopenshell_wrapper.new_GltfSerializer(filename, geometry_settings, settings))
    __swig_destroy__ = _ifcopenshell_wrapper.delete_GltfSerializer
```

I've fixed it.