### PR TITLE
Fix #4807: invisible title after searching in docs

### DIFF
--- a/src/ifcopenshell-python/docs/_static/custom.css
+++ b/src/ifcopenshell-python/docs/_static/custom.css
@@ -82,3 +82,8 @@ dl.py.property, dl.py.attribute, dl.py.method, dl.py.function {
     color: var(--color-brand-content);
     font-style: italic;
 }
+
+/* Workaround for highlighting issue in Furo */
+[role=main] .highlighted {
+    -webkit-text-fill-color: initial !important;
+}


### PR DESCRIPTION
The `.highlighted` class in Furo added a background color, but heading titles had the `-webkit-text-fill-color` set to transparent which was causing the text to appear invisible.
Now, the `.highlighted` class forces texts to not have transparent fill color.

Fixes #4807.