### PR TITLE
Right click on material to run `bim.material_ui_select`

### DIFF
--- a/src/bonsai/bonsai/bim/module/material/__init__.py
+++ b/src/bonsai/bonsai/bim/module/material/__init__.py
@@ -66,6 +66,7 @@ classes = (
     ui.BIM_PT_materials,
     ui.BIM_PT_object_material,
     ui.BIM_UL_materials,
+    ui.BIM_MT_material_context_menu
 )
 
 

--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -62,6 +62,14 @@ class SelectByMaterial(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
     material: bpy.props.IntProperty()
 
+    def invoke(self, context, event):
+        if event.type == 'RIGHTMOUSE':  
+            if not hasattr(context.scene, "select_by_material_id"):
+                context.scene["select_by_material_id"] = self.material
+            bpy.ops.wm.call_menu(name="BIM_MT_material_context_menu")
+            return {"CANCELLED"}  # Don't run execute()
+        return self.execute(context)
+
     def execute(self, context):
         material = tool.Ifc.get().by_id(self.material)
         core.select_by_material(tool.Material, tool.Spatial, material=material)

--- a/src/bonsai/bonsai/bim/module/material/ui.py
+++ b/src/bonsai/bonsai/bim/module/material/ui.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import bonsai.bim.helper
 import bonsai.tool as tool
 import bpy
-from bpy.types import Panel, UIList
+from bpy.types import Panel, UIList, Operator, Menu
 from bonsai.bim.helper import draw_attributes
 from bonsai.bim.helper import prop_with_search
 from bonsai.bim.module.material.data import MaterialsData, ObjectMaterialData
@@ -374,6 +374,9 @@ class BIM_PT_object_material(Panel):
 
         self.layerset_bounds(box, active_object, location="Bottom_Exterior")
 
+
+    
+
     def layerset_bounds(self, layout, obj, location="Top_Interior"):
         set_usage = ObjectMaterialData.data.get("set_usage", {})
         layer_set_direction = set_usage.get("layer_set_direction")
@@ -437,3 +440,18 @@ class BIM_UL_materials(UIList):
                 if item.has_style:
                     row2.label(text="", icon="SHADING_RENDERED")
                 row2.label(text=str(item.total_elements))
+
+
+
+
+
+class BIM_MT_material_context_menu(bpy.types.Menu):
+    bl_label = "Material Context Menu"
+
+    def draw(self, context):
+        layout = self.layout
+        op = layout.operator("bim.material_ui_select", text="Select by Material", icon="RESTRICT_SELECT_OFF")
+        op.material = context.scene.select_by_material_id  # Use stored material
+
+
+


### PR DESCRIPTION
this correctly doesn't work. 
my debugger is [not working](https://github.com/JacquesLucke/blender_vscode/issues/217#issuecomment-2708860309). 

...
Wanted to ask though, on a high level UI approach, is it okay to start using 'right click' on operators?  Would seem like it would open a lot of possibilities, but it looks like we don't use them yet for some reason.