### PR TITLE
Added new button to SOLAR ANALYSIS tool. It provides a SUN object and toggles to EEVEES to have light traverse transparent materials and cast shadows

### DIFF
--- a/src/bonsai/bonsai/bim/module/light/ui.py
+++ b/src/bonsai/bonsai/bim/module/light/ui.py
@@ -240,4 +240,10 @@ class BIM_PT_solar(bpy.types.Panel):
         row.prop(context.scene.display.shading, "shadow_intensity", text="Shadow Intensity")
 
         row = self.layout.row(align=True)
+        row.prop(props, "traverse_transparent", icon="SHADING_RENDERED")
+        if props.traverse_transparent:
+            row = self.layout.row(align=True)
+            row.prop(context.scene.sun_pos_properties.sun_object.data , "energy", text="Sun Intensity")
+
+        row = self.layout.row(align=True)
         row.operator("bim.view_from_sun", icon="LIGHT_HEMI")


### PR DESCRIPTION
I have added a button in the "Solar Analysis" Tool. This one creates a sun object if it does not exist. It also provides the energy property of the sun light to adjust the strength of the light. It switeches to EEVEES rendering engine
<img width="319" alt="image" src="https://github.com/user-attachments/assets/f5816739-ab4e-4e2b-bbfe-f057a37ed67a" />

This is related to discussion:
https://community.osarch.org/discussion/2702/solar-analysis-and-windows

It is by no means a serious radiance analysis but it copes the "Standard analysis" from that discussion.
When this button  "Enable Sun..."  is enables, the button "Display shadows" is disabled and viceversa.

Thanks!
