### PR TITLE
Update profile.py to add MEPGenerator().setup_ports when the profile has only one segment (no DumbProfileJoiner called)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -1148,6 +1148,14 @@ class DrawPolylineProfile(bpy.types.Operator, PolylineOperator, tool.Ifc.Operato
                 for profile1, profile2 in zip(profiles, profiles[1:] + [profiles[0]]):
                     DumbProfileJoiner().join_V(profile2["obj"], profile1["obj"])
             else:
+                if len(profiles) == 1:
+                    profile1 = profiles[0]
+                    element1 = tool.Ifc.get_entity(profile1["obj"])
+                    if element1.is_a("IfcFlowSegment") or element1.is_a("IfcFlowFitting"):
+                        # lazy import to avoid circular import errors
+                        from bonsai.bim.module.model.mep import MEPGenerator
+                        MEPGenerator().setup_ports(profile1["obj"])
+                else:                
                 for profile1, profile2 in zip(profiles[:-1], profiles[1:]):
                     DumbProfileJoiner().join_V(profile2["obj"], profile1["obj"])
 


### PR DESCRIPTION
When adding a single duct in MEP no ports where attached. 
The function create_profiles_from_polyline does not call DumbProfileJoiner (which eventually calls MEPGenerator().setup_ports). I have added a check so if there is only one segment, the MEPGenerator().setup_ports is called explicitly.
