### PR TITLE
If local view is toggled, that it turns off grid decorations. #6257

### DIFF
--- a/src/bonsai/bonsai/bim/__init__.py
+++ b/src/bonsai/bonsai/bim/__init__.py
@@ -269,6 +269,24 @@ def register():
     # RestrictedContext doesn't allow accessing scene attribute, postpone it for a bit.
     bpy.app.timers.register(tool.Blender.setup_user_data_dir, first_interval=0.1)
 
+<<<<<<< HEAD
+    from .operator import VIEW3D_OT_localview_custom
+    bpy.utils.register_class(VIEW3D_OT_localview_custom)
+    print("Bonsai VIEW3D_OT_localview_custom registered")
+    # Replace the default Local View keybinding (NUMPAD /)
+    kc = bpy.context.window_manager.keyconfigs.addon
+    if kc:
+        km = kc.keymaps.get("3D View", None)
+        if km:
+            # Remove existing Local View keybinding
+            for kmi in km.keymap_items:
+                if kmi.idname == "view3d.localview":
+                    km.keymap_items.remove(kmi)
+            # Add new keybinding for the custom operator
+            km.keymap_items.new("view3d.localview_custom", 'NUMPAD_SLASH', 'PRESS')
+            print("Local View with BIM Grid Toggle keybinding added")
+=======
+>>>>>>> 41188e26e1fba582e63b4acac22b5ed625db0fa8
 
 def unregister():
     global icons
@@ -311,3 +329,10 @@ def unregister():
         tool.Blender.remove_scene_panel_override(panel)
 
     bpy.app.translations.unregister("bonsai")
+<<<<<<< HEAD
+
+    from .operator import VIEW3D_OT_localview_custom
+    bpy.utils.unregister_class(VIEW3D_OT_localview_custom)
+    print("Bonsai VIEW3D_OT_localview_custom unregistered")
+=======
+>>>>>>> 41188e26e1fba582e63b4acac22b5ed625db0fa8

--- a/src/bonsai/bonsai/bim/operator.py
+++ b/src/bonsai/bonsai/bim/operator.py
@@ -1203,3 +1203,25 @@ class CopyTextToClipboard(bpy.types.Operator):
     def execute(self, context):
         context.window_manager.clipboard = self.text
         return {"FINISHED"}
+<<<<<<< HEAD
+
+class VIEW3D_OT_localview_custom(bpy.types.Operator):
+    """Toggle Local View and BIM Grid Visibility"""
+    bl_idname = "view3d.localview_custom"
+    bl_label = "Local View with BIM Grid Toggle"
+
+    def execute(self, context):
+        # Call the original Local View operator
+        bpy.ops.view3d.localview()
+
+        # Toggle the BIMGridProperties.is_visible property
+        scene = context.scene
+        if hasattr(scene, "BIMGridProperties"):
+            scene.BIMGridProperties.is_visible = not scene.BIMGridProperties.is_visible
+        else:
+            print("BIMGridProperties not found in scene.")
+
+        return {'FINISHED'}
+
+=======
+>>>>>>> 41188e26e1fba582e63b4acac22b5ed625db0fa8

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -1307,3 +1307,10 @@ class BIM_PT_snappping(Panel):
         row.prop(groups, "object", toggle=True)
         row.prop(groups, "polyline", toggle=True)
         row.prop(groups, "measure", toggle=True)
+<<<<<<< HEAD
+        row = layout.row(align=True)
+        row.label(text="Bonsai Custom Operators")
+        row = layout.row(align=True)
+        row.operator("view3d.localview_custom", text="Toggle Local View (Custom)")
+=======
+>>>>>>> 41188e26e1fba582e63b4acac22b5ed625db0fa8


### PR DESCRIPTION
This PR addresses the issue  #6257.
Please see the discussion in https://community.osarch.org/discussion/2815/can-a-blender-addon-intercept-a-blender-function