### PR TITLE
[Bonsai] Add proper rounding of float attributes by model precision

### DIFF
--- a/src/bonsai/bonsai/bim/helper.py
+++ b/src/bonsai/bonsai/bim/helper.py
@@ -278,9 +278,9 @@ def get_display_value(value: str, float_decimal_precision: int = 6) -> str:
     """
     try:
         digits = len(value.split(".")[1])
-        value = float(value)
-        if digits > 6:  # Maximal decimal float precision
-            value = round(value, float_decimal_precision)
+        fvalue = float(value)
+        if digits > float_decimal_precision:  # Maximal decimal float precision
+            value = round(fvalue, float_decimal_precision)
     except (ValueError, IndexError):  # Not castable to a float or no decimal places (eg integer)
         pass
     return str(value)

--- a/src/bonsai/bonsai/bim/helper.py
+++ b/src/bonsai/bonsai/bim/helper.py
@@ -276,14 +276,15 @@ def get_display_value(value: str, float_decimal_precision: int = 6) -> str:
     """
     This will get rid of the floating point precision artifacts in float values stored as a string
     """
+    fvalue = value
     try:
         digits = len(value.split(".")[1])
         fvalue = float(value)
         if digits > float_decimal_precision:  # Maximal decimal float precision
-            value = round(fvalue, float_decimal_precision)
+            fvalue = round(fvalue, float_decimal_precision)
     except (ValueError, IndexError):  # Not castable to a float or no decimal places (eg integer)
         pass
-    return str(value)
+    return str(fvalue)
 
 
 def prop_with_search(

--- a/src/bonsai/bonsai/bim/prop.py
+++ b/src/bonsai/bonsai/bim/prop.py
@@ -288,7 +288,7 @@ AttributeSpecialType = Literal["", "DATE", "DATETIME", "LENGTH", "AREA", "VOLUME
 class Attribute(PropertyGroup):
     tooltip = "`Right Click > IFC Description` to read the attribute description and online documentation"
     name: StringProperty(name="Name")  # type: ignore [reportRedeclaration]
-    display_name: StringProperty(name="Display Name", get=get_display_name)
+    display_name: StringProperty(name="Display Name", get=get_display_name) # type: ignore [reportRedeclaration]
     description: StringProperty(name="Description")  # type: ignore [reportRedeclaration]
     ifc_class: StringProperty(name="Ifc Class")  # type: ignore [reportRedeclaration]
     data_type: EnumProperty(  # type: ignore [reportRedeclaration]
@@ -366,7 +366,32 @@ class Attribute(PropertyGroup):
             return self.string_value.replace("\\n", "\n")
         if self.data_type == "file":
             return [f.name for f in self.filepath_value.file_list]
+            
         value = getattr(self, str(self.get_value_name()), None)
+        
+        if self.data_type == "float":
+            import math
+
+            # Handle float precision based on model settings
+            precision = 1e-6  # Default precision
+            model_context = None
+            try:
+                import ifcopenshell.util.representation
+                import ifcopenshell.util.unit
+
+                ifc_file = tool.Ifc.get()
+                model_context = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+                unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
+
+                if model_context and model_context.Precision is not None:
+                    precision = model_context.Precision * unit_scale
+                else:
+                    precision = precision * unit_scale
+            except (ImportError, AttributeError):
+                pass
+            if value is not None:
+                return round(value, -int(math.log10(precision)))
+        
         if self.special_type == "LOGICAL" and value != "UNKNOWN":
             # IfcOpenShell expects bool if IfcLogical is True/False.
             value = value == "TRUE"


### PR DESCRIPTION
In the `Attribute` class, `get_value` method was not properly handling `float` value attributes and simply passing them as-is, which can trigger some surprising float representation issues in Python (since it tries to represent each `float` in the highest precision).

The correct behaviour should be to round off float attributes up to the specified model precision ([documentation](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcGeometricRepresentationContext.htm)), or default to `1e-6` precision.