### PR TITLE
[Bonsai] Fix #6350: error when placing temporary section

### DIFF
--- a/src/bonsai/bonsai/bim/operator.py
+++ b/src/bonsai/bonsai/bim/operator.py
@@ -677,13 +677,13 @@ class BIM_OT_add_section_plane(bpy.types.Operator):
             if material.node_tree.nodes.get("Section Override"):
                 continue
             # In EEVEE rendering engine, `blend_mode` is deprecated and replaced by `surface_render_method`
+            # https://developer.blender.org/docs/release_notes/4.2/eevee_migration/#materials
             if (hasattr(material, "surface_render_method")):
                 material.surface_render_method = "DITHERED"
             else:
                 material.blend_method = "HASHED"
             
-            # https://developer.blender.org/docs/release_notes/4.2/eevee_migration/#materials
-            # TODO: Find an alternative for EEVEE engine
+            # TODO: Find an alternative to `shadow_method` for EEVEE engine
             if (hasattr(material, "shadow_method")):
                 material.shadow_method = "HASHED"
 

--- a/src/bonsai/bonsai/bim/operator.py
+++ b/src/bonsai/bonsai/bim/operator.py
@@ -676,8 +676,17 @@ class BIM_OT_add_section_plane(bpy.types.Operator):
             material.use_nodes = True
             if material.node_tree.nodes.get("Section Override"):
                 continue
-            material.blend_method = "HASHED"
-            material.shadow_method = "HASHED"
+            # In EEVEE rendering engine, `blend_mode` is deprecated and replaced by `surface_render_method`
+            if (hasattr(material, "surface_render_method")):
+                material.surface_render_method = "DITHERED"
+            else:
+                material.blend_method = "HASHED"
+            
+            # https://developer.blender.org/docs/release_notes/4.2/eevee_migration/#materials
+            # TODO: Find an alternative for EEVEE engine
+            if (hasattr(material, "shadow_method")):
+                material.shadow_method = "HASHED"
+
             material_output = tool.Blender.get_material_node(material, "OUTPUT_MATERIAL", {"is_active_output": True})
             if not material_output:
                 continue


### PR DESCRIPTION
The `override_materials` method was setting the `shadow_method` attribute for each material. However, in recent versions of Blender (with EEVEE rendering engine), this option has been completely removed ([migration guide](https://developer.blender.org/docs/release_notes/4.2/eevee_migration/#materials)). Moreover, the `blend_method` attribute has been deprecated in favor of `surface_render_method`.

This PR uses the new `surface_render_method` when available, and avoids the error in linked issue by simply not setting `shadow_method` when it isn't available. This might be wrong, and we probably need to find an alternative to `shadow_method` that works in newer Blender versions.

Tested to fix the error in #6350.