### PR TITLE
Update style.py with StyleType for "Internal"

### DIFF
--- a/src/bonsai/bonsai/tool/style.py
+++ b/src/bonsai/bonsai/tool/style.py
@@ -51,7 +51,7 @@ STYLE_PROPS_MAP = {
 
 
 class Style(bonsai.core.tool.Style):
-    StyleType = Literal["Shading", "External"]
+    StyleType = Literal["Shading", "External", "Internal"]
 
     @classmethod
     def get_style_props(cls) -> BIMStylesProperties:


### PR DESCRIPTION
When  clicking BIMSolarProperties.shadow_mode if RENDERING or SHADING is selected. The update sets StyleType to "Internal" which is an enum not defined.