### PR TITLE
[Bonsai] Fix #6364

### DIFF
--- a/src/bonsai/bonsai/bim/module/qto/calculator.py
+++ b/src/bonsai/bonsai/bim/module/qto/calculator.py
@@ -291,7 +291,7 @@ def get_space_net_perimeter(obj: bpy.types.Object) -> float:
 
 
 def get_rectangular_perimeter(obj: bpy.types.Object) -> float:
-    length = get_length(obj, main_axis="x")
+    length = get_length(obj)
     height = get_height(obj)
     return (length + height) * 2
 


### PR DESCRIPTION
`get_length` was being called with a `main_axis` parameter which doesn't exist; the method seems to deduce the main axis automatically with `get_object_main_axis`.

If this is not a typo, an optional `main_axis` parameter can be added to `get_length`.

Tested to fix #6364.