### PR TITLE
Resolve memory leaks when using `create_shape()` in ifcopenshell-python

### DIFF
--- a/src/ifcgeom/AbstractKernel.cpp
+++ b/src/ifcgeom/AbstractKernel.cpp
@@ -206,6 +206,8 @@ ifcopenshell::geometry::kernels::AbstractKernel* ifcopenshell::geometry::kernels
 			}
 #endif
 			if (kernels.size() != n + 1) {
+                for (auto k : kernels)
+                    delete k;
 				throw IfcParse::IfcException("Invalid hybrid kernel " + geometry_library);
 			}
 		}

--- a/src/ifcgeom/AbstractKernel.cpp
+++ b/src/ifcgeom/AbstractKernel.cpp
@@ -206,8 +206,8 @@ ifcopenshell::geometry::kernels::AbstractKernel* ifcopenshell::geometry::kernels
 			}
 #endif
 			if (kernels.size() != n + 1) {
-                for (auto k : kernels)
-                    delete k;
+				for (auto k : kernels)
+					delete k;
 				throw IfcParse::IfcException("Invalid hybrid kernel " + geometry_library);
 			}
 		}

--- a/src/ifcgeom/Converter.cpp
+++ b/src/ifcgeom/Converter.cpp
@@ -13,6 +13,16 @@ ifcopenshell::geometry::Converter::Converter(const std::string& geometry_library
 	settings_ = mapping_->settings();
 }
 
+ifcopenshell::geometry::Converter::~Converter()
+{
+    if (kernel_ != nullptr) {
+        delete kernel_;
+    }
+    if (mapping_ != nullptr) {
+        delete mapping_;
+    }
+}
+
 namespace {
 	void substitute_with_box_based_on_density(IfcGeom::ConversionResults& items, double& density) {
 		int nv = 0;

--- a/src/ifcgeom/Converter.cpp
+++ b/src/ifcgeom/Converter.cpp
@@ -15,12 +15,12 @@ ifcopenshell::geometry::Converter::Converter(const std::string& geometry_library
 
 ifcopenshell::geometry::Converter::~Converter()
 {
-    if (kernel_ != nullptr) {
-        delete kernel_;
-    }
-    if (mapping_ != nullptr) {
-        delete mapping_;
-    }
+	if (kernel_ != nullptr) {
+		delete kernel_;
+	}
+	if (mapping_ != nullptr) {
+		delete mapping_;
+	}
 }
 
 namespace {

--- a/src/ifcgeom/Converter.h
+++ b/src/ifcgeom/Converter.h
@@ -28,7 +28,7 @@ namespace ifcopenshell { namespace geometry {
 
 		Converter(const std::string& geometry_library, IfcParse::IfcFile* file, ifcopenshell::geometry::Settings& settings);
 		
-		~Converter() {}
+		~Converter();
 
 		ifcopenshell::geometry::abstract_mapping* mapping() const { return mapping_; }
 

--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -978,7 +978,7 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 	if (b.Extent() == 0) {
 		Logger::Warning("No other operands remaining, using first operand");
 		result = a;
-        delete builder;
+		delete builder;
 		return true;
 	}
 
@@ -1131,7 +1131,7 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 						} else {
 							Logger::Notice("Processed fully in 2D");
 							result = mp.Shape();
-                            delete builder;
+							delete builder;
 							return true;
 						}
 					} else {

--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -978,6 +978,7 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 	if (b.Extent() == 0) {
 		Logger::Warning("No other operands remaining, using first operand");
 		result = a;
+        delete builder;
 		return true;
 	}
 
@@ -1130,6 +1131,7 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 						} else {
 							Logger::Notice("Processed fully in 2D");
 							result = mp.Shape();
+                            delete builder;
 							return true;
 						}
 					} else {


### PR DESCRIPTION
When calling the `create_shape(...)` function from the python wrapper, the kernel instance that lives in the templated helper function as a stack allocation seemed to have 100+ new leaking allocations per call according to heap profiling.

From my super basic testing script (see below) it looks like that fixed all of the leaking memory allocations, with any growth of total memory allocated stemming from just the logging buffer growing in size.

This is a very straight-forward and naive fix for the problem, as the Converter instance and the kernels that are created for **each** call of creating a shape reads to me like it should be something that's handled within the library as a singleton or static of some type, although I am very unfamiliar with the codebase as a whole so I've decided to keep it to a simple delete where it felt it makes most sense solution.

```python
import sys
import ifcopenshell
from ifcopenshell import geom
import psutil
import os
import gc

settings = geom.settings()
model = ifcopenshell.open("IfcOpenHouse.ifc")
entity = model.by_type("IfcWall")[0]

process = psutil.Process(os.getpid())
base_mem = process.memory_info().rss / 1024 / 1024
print(f"Baseline: {base_mem:.2f} MB")

for i in range(1000):
    shape = geom.create_shape(settings, entity)
    shape = None
    gc.collect() 
    mem = process.memory_info().rss / 1024 / 1024
    if i % 100 == 0:
        print(f"Iteration {i}: {mem:.2f} MB")

final_mem = process.memory_info().rss / 1024 / 1024
print(f"Final: {final_mem:.2f} MB")

input()
```

|before|after|
|-|-|
|![image](https://github.com/user-attachments/assets/b1c03f7c-3b59-498c-92a3-a9454e4237f0)|![image](https://github.com/user-attachments/assets/790e2704-0724-4e3a-a415-aec54dbff982)|