### PR TITLE
Fix: Add virtual destructor to AbstractKernel base class

### DIFF
--- a/src/ifcgeom/AbstractKernel.h
+++ b/src/ifcgeom/AbstractKernel.h
@@ -44,6 +44,8 @@ namespace ifcopenshell {
 			: geometry_library_(geometry_library)
 			, settings_(settings) {}
 
+		virtual ~AbstractKernel() = default;
+
 		virtual bool convert(const taxonomy::ptr, IfcGeom::ConversionResults&);
 		const Settings& settings() const;
 		const std::string& geometry_library() const {


### PR DESCRIPTION
This fixes a `SIGTRAP` when destructing an `IfcGeom::Iterator`, as that calls `delete` in `ifcopenshell::geometry::Converter::~Converter()` on the field `ifcopenshell::geometry::kernels::AbstractKernel* kernel_;`. This results in UB in C++. 

Adding a virtual destructor to the base class `AbstractKernel` fixes this issue. 