### PR TITLE
Update operator.py so argv parameters in Windows are correctly parsed

### DIFF
--- a/src/bonsai/bonsai/bim/module/debug/operator.py
+++ b/src/bonsai/bonsai/bim/module/debug/operator.py
@@ -23,6 +23,7 @@ import time
 import random
 import logging
 import subprocess
+import platform
 import ifcopenshell
 import ifcopenshell.api
 import ifcopenshell.geom
@@ -960,7 +961,12 @@ class RestartBlender(bpy.types.Operator):
         ms_store_app_id = tool.Blender.get_microsoft_store_app_id()
         if not ms_store_app_id:
             path = bpy.app.binary_path
-            os.execv(path, sys.argv)
+            if platform.system() == "Windows":
+                args = sys.argv[1:] 
+                command_line = subprocess.list2cmdline([path] + args)
+                os.execv(path, [command_line])
+            else:
+                os.execv(path, sys.argv)
         else:
             # Microsoft apps do not allow launching blender.exe directly
             # since Blender folder is kind of private.


### PR DESCRIPTION
Currently the parameters that have spaces are not properly parsed when invoking os.execv.

Ej:
We start blender with some parameters and then invoke bim.restart_blender: C:\Users\falke>c:\Users\falke\Documents\blender-4.2.8-windows-x64\blender.exe --debug --python-expr "import bpy; bpy.ops.bim.load_project(filepath='C:/Users/falke/Documents/bonsaiDevel/Testing.ifc', should_start_fresh_session=True, use_detailed_tooltip=True)" TBBmalloc: skip allocation functions replacement in ucrtbase.dll: unknown prologue for function _msize Switching to fully guarded memory allocator.
Blender 4.2.8 LTS
Build: 2025-03-18 01:34:37 Windows Release
argv[0] = c:\Users\falke\Documents\blender-4.2.8-windows-x64\blender.exe argv[1] = --debug
argv[2] = --python-expr
argv[3] = import bpy; bpy.ops.bim.load_project(filepath='C:/Users/falke/Documents/bonsaiDevel/Testing.ifc', should_start_fresh_session=True, use_detailed_tooltip=True) Starting import process :: 0.00
Loading file :: 0.00
Calculate unit scale :: 0.00
Process context filter :: 0.01
Calculate model offset :: 0.00
Set units :: 0.00
Create project :: 0.00
Process element filter :: 0.00
Create styles :: 0.00
Parsing native elements :: 0.00
Done creating geometry
Create native elements :: 0.00
Done creating geometry
Create elements :: 0.03
Create annotations :: 0.00
Create positioning elements :: 0.00
0 / 3 elements processed ...
Create spatial elements :: 0.00
Create structural items :: 0.00
Create element types :: 0.00
Place objects in collections :: 0.00
Setup arrays :: 0.00
Load linked models :: 0.00
Add project to scene :: 0.00
Setting default context :: 0.01
Import finished in 0.06 seconds
No MySQL support
Writing userprefs: "C:\Users\falke\AppData\Roaming\Blender Foundation\Blender\4.2\config\userpref.blend" ok Info: Preferences saved
TBBmalloc: skip allocation functions replacement in ucrtbase.dll: unknown prologue for function _msize Switching to fully guarded memory allocator.
Blender 4.2.8 LTS
Build: 2025-03-18 01:34:37 Windows Release
argv[0] = c:\Users\falke\Documents\blender-4.2.8-windows-x64\blender.exe argv[1] = --debug
argv[2] = --python-expr
argv[3] = import
argv[4] = bpy;
argv[5] = bpy.ops.bim.load_project(filepath='C:/Users/falke/Documents/bonsaiDevel/Testing.ifc', argv[6] = should_start_fresh_session=True,
argv[7] = use_detailed_tooltip=True)

C:\Users\falke>  File "<string>", line 1
    import
          ^
SyntaxError: invalid syntax
Error: Cannot read file "C:\Users\falke\bpy;": No such file or directory Error: argument has no '.blend' file extension, not using as new file, exiting! C:\Users\falke\bpy;

Blender quit

By adding the proposed list2cmdline based solution, the commandline is properly formated before invoking os.execv

Thanks!