### PR TITLE
[IfcSverchok] Add failsafe so nodes without input don't show error when added to tree

### DIFF
--- a/src/ifcsverchok/nodes/ifc/add.py
+++ b/src/ifcsverchok/nodes/ifc/add.py
@@ -55,6 +55,9 @@ class SvIfcAdd(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.SvIfcCor
         )
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
         self.sv_input_names = ["file", "entity"]
         self.file_out: list[ifcopenshell.file] = []
         self.entity_out: list[ifcopenshell.entity_instance] = []

--- a/src/ifcsverchok/nodes/ifc/create_entity.py
+++ b/src/ifcsverchok/nodes/ifc/create_entity.py
@@ -93,6 +93,9 @@ class SvIfcCreateEntity(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper
         row.prop(self, "refresh_local", icon="FILE_REFRESH")
 
     def process(self):
+         if not any(socket.is_linked for socket in self.outputs):
+            return
+
         self.names = flatten_data(self.inputs["Names"].sv_get(), target_level=1)
         self.descriptions = flatten_data(self.inputs["Descriptions"].sv_get(), target_level=1)
         self.ifc_class = flatten_data(self.inputs["IfcClass"].sv_get(), target_level=1)[0]

--- a/src/ifcsverchok/nodes/ifc/create_entity.py
+++ b/src/ifcsverchok/nodes/ifc/create_entity.py
@@ -93,7 +93,7 @@ class SvIfcCreateEntity(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper
         row.prop(self, "refresh_local", icon="FILE_REFRESH")
 
     def process(self):
-         if not any(socket.is_linked for socket in self.outputs):
+        if not any(socket.is_linked for socket in self.outputs):
             return
 
         self.names = flatten_data(self.inputs["Names"].sv_get(), target_level=1)

--- a/src/ifcsverchok/nodes/ifc/create_project.py
+++ b/src/ifcsverchok/nodes/ifc/create_project.py
@@ -46,6 +46,9 @@ class SvIfcCreateProject(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helpe
         )
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
         # file
         file = self.inputs["file"].sv_get()[0][0]
         if file:

--- a/src/ifcsverchok/nodes/ifc/quick_project_setup.py
+++ b/src/ifcsverchok/nodes/ifc/quick_project_setup.py
@@ -73,6 +73,9 @@ class SvIfcQuickProjectSetup(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.h
         )
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
         self.sv_input_names = [i.name for i in self.inputs]
         super().process()
 

--- a/src/ifcsverchok/nodes/ifc/read_file.py
+++ b/src/ifcsverchok/nodes/ifc/read_file.py
@@ -41,6 +41,9 @@ class SvIfcReadFile(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.SvI
         )
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
         self.sv_input_names = ["path"]
         super().process()
 

--- a/src/ifcsverchok/nodes/ifc/remove.py
+++ b/src/ifcsverchok/nodes/ifc/remove.py
@@ -55,6 +55,9 @@ class SvIfcRemove(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.SvIfc
         )
 
     def process(self):
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
         file: ifcopenshell.file
         file = self.inputs["file"].sv_get()[0][0]
         self.new_file = ifcopenshell.file.from_string(file.wrapped_data.to_string())

--- a/src/ifcsverchok/nodes/ifc/select_blender_objects.py
+++ b/src/ifcsverchok/nodes/ifc/select_blender_objects.py
@@ -65,6 +65,9 @@ class SvIfcSelectBlenderObjects(bpy.types.Node, SverchCustomTreeNode, ifcsvercho
         )
 
     def process(self) -> None:
+        if not any(socket.is_linked for socket in self.outputs):
+            return
+
         self.sv_input_names = ["entities"]
         self.guids: list[str] = []
         super().process()


### PR DESCRIPTION
Some IfcSverchok nodes with required inputs and no default values show errors (as per image) when added to the node tree, this changes makes it so the errors are only shown when someone tries to access the nodes outputs.

![Captura de tela de 2025-04-03 01-33-17](https://github.com/user-attachments/assets/b02bbce9-ba5d-490d-8068-e44b8a7a1f85)
