### PR TITLE
Update ui.py So clicking the gear also updates the thumbnai

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/ui.py
+++ b/src/bonsai/bonsai/bim/module/model/ui.py
@@ -65,7 +65,8 @@ class BIM_MT_type_menu(bpy.types.Menu):
         layout.separator()
         op = layout.operator("bim.remove_type", icon="X")
         op.element = props.menu_relating_type_id
-
+        element = tool.Ifc.get().by_id(props.menu_relating_type_id)
+        tool.Model.update_thumbnail_for_element(element, refresh=True)
 
 class LaunchTypeMenu(bpy.types.Operator):
     bl_idname = "bim.launch_type_menu"


### PR DESCRIPTION
In some circunstances the thumbnail of namely doors/windows are not updated when we update teh parametric information of the type. This provides a way to get the thumbnail update triggered by the user.