### PR TITLE
Added entry in type menu to call for a thumbnail refresh

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/ui.py
+++ b/src/bonsai/bonsai/bim/module/model/ui.py
@@ -70,7 +70,6 @@ class BIM_MT_type_menu(bpy.types.Menu):
         op.element = props.menu_relating_type_id
 
 
-
 class LaunchTypeMenu(bpy.types.Operator):
     bl_idname = "bim.launch_type_menu"
     bl_label = "Launch Type Menu"

--- a/src/bonsai/bonsai/bim/module/model/ui.py
+++ b/src/bonsai/bonsai/bim/module/model/ui.py
@@ -65,6 +65,10 @@ class BIM_MT_type_menu(bpy.types.Menu):
         layout.separator()
         op = layout.operator("bim.remove_type", icon="X")
         op.element = props.menu_relating_type_id
+        layout.separator()
+        op = layout.operator("bim.refresh_thumbnail", icon="FILE_REFRESH")
+        op.element = props.menu_relating_type_id
+
 
 
 class LaunchTypeMenu(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/type/__init__.py
+++ b/src/bonsai/bonsai/bim/module/type/__init__.py
@@ -26,6 +26,7 @@ classes = (
     operator.DuplicateType,
     operator.EnableEditingType,
     operator.RemoveType,
+    operator.RefreshTumbnail,
     operator.RenameType,
     operator.SelectSimilarType,
     operator.SelectType,

--- a/src/bonsai/bonsai/bim/module/type/operator.py
+++ b/src/bonsai/bonsai/bim/module/type/operator.py
@@ -271,6 +271,7 @@ class RemoveType(bpy.types.Operator, tool.Ifc.Operator):
         obj = tool.Ifc.get_object(element)
         tool.Geometry.delete_ifc_object(obj)
 
+
 class RefreshTumbnail(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.refresh_thumbnail"
     bl_label = "Refresh Thumbnail"

--- a/src/bonsai/bonsai/bim/module/type/operator.py
+++ b/src/bonsai/bonsai/bim/module/type/operator.py
@@ -271,6 +271,16 @@ class RemoveType(bpy.types.Operator, tool.Ifc.Operator):
         obj = tool.Ifc.get_object(element)
         tool.Geometry.delete_ifc_object(obj)
 
+class RefreshTumbnail(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.refresh_thumbnail"
+    bl_label = "Refresh Thumbnail"
+    bl_options = {"REGISTER", "UNDO"}
+    element: bpy.props.IntProperty()
+
+    def _execute(self, context):
+        element = tool.Ifc.get().by_id(self.element)
+        tool.Model.update_thumbnail_for_element(element, refresh=True)
+
 
 class RenameType(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.rename_type"


### PR DESCRIPTION
Sometimes the thumbnails are not refreshed (for example when changing the geometry in the door/window parametric too). This adds an entry to call to the refresh_thumbnail function.
