### PR TITLE
ISSUE #6340 check if material is null before trying to get id

### DIFF
--- a/src/serializers/HdfSerializer.cpp
+++ b/src/serializers/HdfSerializer.cpp
@@ -544,7 +544,8 @@ void HdfSerializer::write_style(surface_style_serialization& data, const ifcopen
 	data.name = s.name.c_str();
 	// @todo
 	data.original_name = s.name.c_str();
-	data.id = s.instance->as<IfcUtil::IfcBaseClass>()->id();
+	auto instance = s.instance->as<IfcUtil::IfcBaseClass>();
+	data.id = instance ? instance->id() : 0;
 	if (s.diffuse) {
 		data.diffuse[0] = s.diffuse.ccomponents()(0);
 		data.diffuse[1] = s.diffuse.ccomponents()(1);


### PR DESCRIPTION
This PR checks if the conversion to IfcUtil::IfcBaseClass is successful before trying to assign the id when serialising a style to HDF5.

The style instance may be null if the material is a default material.

Discussion and test case are in the issue: https://github.com/IfcOpenShell/IfcOpenShell/issues/6340