### PR TITLE
Update operator.py so relative link to ifc file works

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1303,7 +1303,7 @@ class LoadLink(bpy.types.Operator):
     filepath_: Path
 
     def execute(self, context):
-        filepath = Path(tool.Ifc.resolve_uri(self.filepath))
+        filepath = Path(tool.Ifc.resolve_uri(tool.Ifc.get_uri(self.filepath, use_relative_path=False)))
         if not filepath.exists():
             self.report({"ERROR"}, f"File does not exist: '{filepath}'")
             return {"CANCELLED"}


### PR DESCRIPTION
This is a hack for 
https://github.com/IfcOpenShell/IfcOpenShell/issues/6337 If relative path is used the operator fails. By claculating the correspodning absolute path the issue is solved.