### PR TITLE
Fix #2783 exception.

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/date.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/date.py
@@ -75,7 +75,7 @@ def ifc2datetime(element):
 
 def get_isosplit(s, split):
     if split in s:
-        n, s = s.split(split)
+        n, s = s.split(split, 1)
     else:
         n = 0
     return n, s


### PR DESCRIPTION
Limit split to 1, because M char is used twice in the parsed string.