### PR TITLE
Use tool.Blender.get_view3d_area() to allow the use of separate windows

### DIFF
--- a/src/bonsai/bonsai/tool/clash.py
+++ b/src/bonsai/bonsai/tool/clash.py
@@ -112,7 +112,7 @@ class Clash(bonsai.core.tool.Clash):
     @classmethod
     def look_at(cls, target: Vector, location: Vector) -> None:
         camera_location = location
-        area = next(area for area in bpy.context.screen.areas if area.type == "VIEW_3D")
+        area = tool.Blender.get_view3d_area()
         region = next(region for region in area.regions if region.type == "WINDOW")
         space = next(space for space in area.spaces if space.type == "VIEW_3D")
         override = {"area": area, "region": region, "space_data": space}

--- a/src/bonsai/bonsai/tool/ifcgit.py
+++ b/src/bonsai/bonsai/tool/ifcgit.py
@@ -404,7 +404,7 @@ class IfcGit:
 
     @classmethod
     def colourise(cls, step_ids: STEP_IDS) -> None:
-        area = next(area for area in bpy.context.screen.areas if area.type == "VIEW_3D")
+        area = tool.Blender.get_view3d_area()
         area.spaces[0].shading.color_type = "OBJECT"
         bpy.ops.object.select_all(action="DESELECT")
 
@@ -426,7 +426,7 @@ class IfcGit:
 
     @classmethod
     def decolourise(cls) -> None:
-        area = next(area for area in bpy.context.screen.areas if area.type == "VIEW_3D")
+        area = tool.Blender.get_view3d_area()
         area.spaces[0].shading.color_type = "MATERIAL"
 
     @classmethod

--- a/src/bonsai/bonsai/tool/sequence.py
+++ b/src/bonsai/bonsai/tool/sequence.py
@@ -1229,7 +1229,7 @@ class Sequence(bonsai.core.tool.Sequence):
 
     @classmethod
     def set_object_shading(cls):
-        area = next(area for area in bpy.context.screen.areas if area.type == "VIEW_3D")
+        area = tool.Blender.get_view3d_area()
         area.spaces[0].shading.color_type = "OBJECT"
 
     @classmethod
@@ -1368,7 +1368,7 @@ class Sequence(bonsai.core.tool.Sequence):
                     cls.animate_input(obj, settings["start_frame"], product_frame, animation_type)
                 elif product_frame["relationship"] == "output":
                     cls.animate_output(obj, settings["start_frame"], product_frame, animation_type)
-        area = next(area for area in bpy.context.screen.areas if area.type == "VIEW_3D")
+        area = tool.Blender.get_view3d_area()
         area.spaces[0].shading.color_type = "OBJECT"
         bpy.context.scene.frame_start = settings["start_frame"]
         bpy.context.scene.frame_end = int(settings["start_frame"] + settings["total_frames"] + 1)


### PR DESCRIPTION
I replaced
next(area for area in bpy.context.screen.areas if area.type == "VIEW_3D")
with
tool.Blender.get_view3d_area()

Since the function had already been created and allows the use of separate windows.