### PR TITLE
validate ifcopenshell.simple_spf.file

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -570,7 +570,7 @@ def to_string_header_entity(header_entity):
     # Prefer native .toString() if available (native IfcOpenShell wrapper)
     if isinstance(header_entity, W.HeaderEntity):
         return header_entity.toString()
-    elif isinstance(header_entity, tuple):
+    elif hasattr(header_entity, '_fields'):
         values = [repr(getattr(header_entity, f)) for f in header_entity._fields]
         return f"{type(header_entity).__name__.upper()}({','.join(values)})"
     else:

--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -568,9 +568,9 @@ def to_string_header_entity(header_entity):
     """Recreate IFC header string representation, like FILE_NAME(...)"""
     
     # Prefer native .toString() if available (native IfcOpenShell wrapper)
-    if hasattr(header_entity, 'toString'):
+    if isinstance(header_entity, W.HeaderEntity):
         return header_entity.toString()
-    elif hasattr(header_entity, '_fields'):
+    elif isinstance(header_entity, tuple):
         values = [repr(getattr(header_entity, f)) for f in header_entity._fields]
         return f"{type(header_entity).__name__.upper()}({','.join(values)})"
     else:
@@ -581,7 +581,7 @@ def validate_ifc_header(f: Union[ifcopenshell.file, ifcopenshell.simple_spf.file
     AGGREGATE_TYPE = "LIST [ 1 : ? ] OF STRING (256)"
     STRING_TYPE = "STRING (256)"
 
-    def log_error(header_entity: W.HeaderEntity, name: str, index: int, expected_type: str, provided_type: str) -> None:
+    def log_error(header_entity: Union[W.HeaderEntity, tuple], name: str, index: int, expected_type: str, provided_type: str) -> None:
         logger.error(
             (
                 "For instance:\n    %s\n    %s\n"

--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -43,6 +43,7 @@ from typing import Union, Iterator, Any, Optional
 from logging import Logger, Handler
 
 import ifcopenshell
+import ifcopenshell.simple_spf
 import ifcopenshell.ifcopenshell_wrapper
 import ifcopenshell.ifcopenshell_wrapper as W
 import ifcopenshell.express.rule_executor
@@ -564,8 +565,11 @@ def validate_guid(guid: str) -> Union[str, None]:
     return None
 
 
-def validate_ifc_header(f: ifcopenshell.file, logger: Logger) -> None:
-    header: W.IfcSpfHeader = f.wrapped_data.header
+def validate_ifc_header(f: Union[ifcopenshell.file, ifcopenshell.simple_spf.file], logger: Logger) -> None:
+    if type(f) is ifcopenshell.file:
+        header: W.IfcSpfHeader = f.wrapped_data.header
+    else:
+        header: types.SimpleNamespace = f.header
     AGGREGATE_TYPE = "LIST [ 1 : ? ] OF STRING (256)"
     STRING_TYPE = "STRING (256)"
 

--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -566,29 +566,21 @@ def validate_guid(guid: str) -> Union[str, None]:
 
 def to_string_header_entity(header_entity):
     """Recreate IFC header string representation, like FILE_NAME(...)"""
-    def format_value(val):
-        if isinstance(val, str):
-            return f"'{val}'"
-        elif isinstance(val, tuple):
-            return "(" + ",".join(format_value(v) for v in val) + ")"
-        return str(val)
-
+    
     # Prefer native .toString() if available (native IfcOpenShell wrapper)
     if hasattr(header_entity, 'toString'):
         return header_entity.toString()
 
-    if hasattr(header_entity, '_fields'):
-        values = [format_value(getattr(header_entity, f)) for f in header_entity._fields]
+    if hasattr(header_entity, 'toString'):
+        return header_entity.toString()
+    elif hasattr(header_entity, '_fields'):
+        values = [repr(getattr(header_entity, f)) for f in header_entity._fields]
+        return f"{type(header_entity).__name__.upper()}({','.join(values)})"
     else:
         raise TypeError(f"Cannot stringify header_entity of type {type(header_entity)}")
 
-    return f"{type(header_entity).__name__.upper()}({','.join(values)})"
-
 def validate_ifc_header(f: Union[ifcopenshell.file, ifcopenshell.simple_spf.file], logger: Logger) -> None:
-    if type(f) is ifcopenshell.file:
-        header: W.IfcSpfHeader = f.wrapped_data.header
-    else:
-        header: types.SimpleNamespace = f.header
+    header: Union[W.IfcSpfHeader, types.SimpleNamespace] = f.header
     AGGREGATE_TYPE = "LIST [ 1 : ? ] OF STRING (256)"
     STRING_TYPE = "STRING (256)"
 

--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -564,6 +564,25 @@ def validate_guid(guid: str) -> Union[str, None]:
         return "Couldn't decompress guid, it's not base64 encoded."
     return None
 
+def to_string_header_entity(header_entity):
+    """Recreate IFC header string representation, like FILE_NAME(...)"""
+    def format_value(val):
+        if isinstance(val, str):
+            return f"'{val}'"
+        elif isinstance(val, tuple):
+            return "(" + ",".join(format_value(v) for v in val) + ")"
+        return str(val)
+
+    # Prefer native .toString() if available (native IfcOpenShell wrapper)
+    if hasattr(header_entity, 'toString'):
+        return header_entity.toString()
+
+    if hasattr(header_entity, '_fields'):
+        values = [format_value(getattr(header_entity, f)) for f in header_entity._fields]
+    else:
+        raise TypeError(f"Cannot stringify header_entity of type {type(header_entity)}")
+
+    return f"{type(header_entity).__name__.upper()}({','.join(values)})"
 
 def validate_ifc_header(f: Union[ifcopenshell.file, ifcopenshell.simple_spf.file], logger: Logger) -> None:
     if type(f) is ifcopenshell.file:
@@ -580,7 +599,7 @@ def validate_ifc_header(f: Union[ifcopenshell.file, ifcopenshell.simple_spf.file
                 "Attribute '%s' has invalid type:\n"
                 "    Expected: %s\n    Current value type: %s\n"
             ),
-            (s := header_entity.toString()),
+            (s := to_string_header_entity(header_entity)),
             annotate_inst_attr_pos(header_entity, index, s),
             name,
             expected_type,

--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -570,9 +570,6 @@ def to_string_header_entity(header_entity):
     # Prefer native .toString() if available (native IfcOpenShell wrapper)
     if hasattr(header_entity, 'toString'):
         return header_entity.toString()
-
-    if hasattr(header_entity, 'toString'):
-        return header_entity.toString()
     elif hasattr(header_entity, '_fields'):
         values = [repr(getattr(header_entity, f)) for f in header_entity._fields]
         return f"{type(header_entity).__name__.upper()}({','.join(values)})"


### PR DESCRIPTION
In the validation service, we're currently using` ifcopenshell.validate` to [pre-validate IFC headers](https://github.com/buildingSMART/validate/blob/9bed38ff2a82b4ff9d070c8170ae8492200975b9/backend/apps/ifc_validation/checks/header_policy/validate_header.py#L31). However, since we're transitioning away from wrapping the entire IFC file for this task and instead adopting the lightweight `simple_spf `parser, the validate_ifc_header function should also support this new file type.

For reference, see the parse-only API introduced in [this commit](https://github.com/IfcOpenShell/step-file-parser/pull/13/commits/211a3055f437206ddcbcdaf401658b37bd170d71).