### PR TITLE
call update_thumbnail_for_element when the parametric door/window is finished for an elementType

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/door.py
+++ b/src/bonsai/bonsai/bim/module/model/door.py
@@ -616,6 +616,9 @@ class FinishEditingDoor(bpy.types.Operator, tool.Ifc.Operator):
         props.is_editing = False
 
         update_door_modifier_representation(obj)
+        element_type = ifcopenshell.util.element.get_type(element)
+        if element_type:
+            tool.Model.update_thumbnail_for_element(element_type, refresh=True)
 
         pset = tool.Pset.get_element_pset(element, "BBIM_Door")
         door_data = tool.Ifc.get().createIfcText(json.dumps(door_data, default=list))

--- a/src/bonsai/bonsai/bim/module/model/window.py
+++ b/src/bonsai/bonsai/bim/module/model/window.py
@@ -529,6 +529,9 @@ class FinishEditingWindow(bpy.types.Operator, tool.Ifc.Operator):
         props.is_editing = False
 
         update_window_modifier_representation(context)
+        element_type = ifcopenshell.util.element.get_type(element)
+        if element_type:
+            tool.Model.update_thumbnail_for_element(element_type, refresh=True)
 
         pset = tool.Pset.get_element_pset(element, "BBIM_Window")
         window_data = tool.Ifc.get().createIfcText(json.dumps(window_data, default=list))


### PR DESCRIPTION
This is a follow up of Added entry in type menu to call for a thumbnail refresh#6517 (https://github.com/IfcOpenShell/IfcOpenShell/pull/6517/).
It just call for the thumbnail update after finishing editing Door/window wiht the parametric tool.
Thanks!
