### PR TITLE
Skip non MESH and CURVE object listing elements for coloring

### DIFF
--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -276,6 +276,8 @@ class ColourByProperty(Operator):
             colourscheme = {cs.name: {"colour": cs.colour[0:3], "total": 0} for cs in props.colourscheme}
 
         for obj in context.visible_objects:
+            if obj.type != "MESH" and obj.type != "CURVE":
+                continue
             element = tool.Ifc.get_entity(obj)
             if not element:
                 continue


### PR DESCRIPTION
So non MESH or CURVE objects are not listed in the Colour by property.