### PR TITLE
fix to default directory on dev_environment.bat 

### DIFF
--- a/src/bonsai/docs/guides/development/installation.rst
+++ b/src/bonsai/docs/guides/development/installation.rst
@@ -158,8 +158,11 @@ For Linux or Mac:
    :language: bash
    :caption: dev_environment.sh
 
-For Windows, run this batch script as an administrator. Before running it
-follow the instructions described in the `rem` tags.
+For Windows, run this batch script as an administrator. Make sure to 
+run the script with blender closed. By default the script assumes its 
+in the root directory of the IFCOpenShell repository. If you want to run
+it from another directory, set the environment variables described in the
+`rem` tags.
 
 .. literalinclude:: ../../../scripts/installation/dev_environment.bat
    :language: bat

--- a/src/bonsai/scripts/installation/dev_environment.bat
+++ b/src/bonsai/scripts/installation/dev_environment.bat
@@ -8,7 +8,7 @@ rem Otherwise by default it is assumed script is executed from IfcOpenShell dire
 rem SET REPO_PATH=%HOMEDRIVE%\Users\%USERNAME%\Where\Your\Git\Repository\Is\Cloned\IfcOpenShell
 SET BLENDER_PATH=%HOMEDRIVE%\Users\%USERNAME%\AppData\Roaming\Blender Foundation\Blender\4.4
 SET PACKAGE_PATH=%BLENDER_PATH%\extensions\.local\lib\python3.11\site-packages
-SET BONSAI_PATH=%BLENDER_PATH%\extensions\user_default\bonsai
+SET BONSAI_PATH=%BLENDER_PATH%\extensions\raw_githubusercontent_com\bonsai
 
 
 echo SETUP BONSAI ADD-ON LIVE DEVELOPMENT ENVIRONMENT


### PR DESCRIPTION
Default directory for the bonsai path assumed you had a fixed build, and didn't use the which is contradictory.

This fixes that, and updates the docs to make it clear to run the setup .bat script when blender is closed. Because otherwise it will deny permission to some dependency files and break your bonsai installation. 