### PR TITLE
Create ifcopenshell_wrapper.pyi

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/ifcopenshell_wrapper.pyi
+++ b/src/ifcopenshell-python/ifcopenshell/ifcopenshell_wrapper.pyi
@@ -1,0 +1,21 @@
+# ifcopenshell_wrapper.pyi
+
+class FileDescription:
+    description: tuple[str, ...]
+    implementation_level: str
+
+class FileName:
+    name: str
+    time_stamp: str
+    author: tuple[str, ...]
+    organization: tuple[str, ...]
+    preprocessor_version: str
+    originating_system: str
+    authorization: str
+
+class IfcSpfHeader:
+    @property
+    def file_description(self) -> FileDescription: ...
+    
+    @property
+    def file_name(self) -> FileName: ...


### PR DESCRIPTION
minimal stub file for swig-generated ifcopenshell_wrapper python file

https://github.com/IfcOpenShell/IfcOpenShell/issues/6684#issuecomment-2904402618

Attention: When one provides a stub file (a .pyi file) for a module or a part of a module, that stub file completely replaces the type information for that module for type checking purposes. Mypy will only use the definitions in the stub file and ignore the inline type annotations (if any) in the original .py file. See https://github.com/python/mypy/issues/7225