### PR TITLE
 dms2dd and dd2dms functions to use microseconds and handle negative degrees

### DIFF
--- a/src/ifcbimtester/bimtester/features/steps/geolocation/en.py
+++ b/src/ifcbimtester/bimtester/features/steps/geolocation/en.py
@@ -234,7 +234,7 @@ def step_impl(context, guid, number):
     site = util.assert_guid(IfcStore.file, guid)
     util.assert_type(site, "IfcSite")
     ref = util.assert_attribute(site, "RefLongitude")
-    number = ifcopenshell.util.geolocation.dd2dms(number, use_ms=(len(ref) == 4))
+    number = ifcopenshell.util.geolocation.dd2dms(number, use_us=(len(ref) == 4))
     util.assert_attribute(site, "RefLongitude", number)
 
 
@@ -244,7 +244,7 @@ def step_impl(context, guid, number):
     site = util.assert_guid(IfcStore.file, guid)
     util.assert_type(site, "IfcSite")
     ref = util.assert_attribute(site, "RefLatitude")
-    number = ifcopenshell.util.geolocation.dd2dms(number, use_ms=(len(ref) == 4))
+    number = ifcopenshell.util.geolocation.dd2dms(number, use_us=(len(ref) == 4))
     util.assert_attribute(site, "RefLatitude", number)
 
 

--- a/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
@@ -42,6 +42,7 @@ class HelmertTransformation(NamedTuple):
 
 def dms2dd(degrees: int, minutes: int, seconds: int, us: int = 0) -> float:
     """Convert degrees, minutes, and (micro)seconds to decimal degrees
+    All components must be either positive or negative.
 
     :param degrees: The degrees component
     :param minutes: The minutes component
@@ -49,22 +50,9 @@ def dms2dd(degrees: int, minutes: int, seconds: int, us: int = 0) -> float:
     :param us: The microseconds component
     :return: The angle in decimal degrees.
     """
-    sign = -1 if degrees < 0 or minutes < 0 or seconds < 0 or us < 0 else 1
-    
-    degrees_decimal = Decimal(str(abs(degrees)))
-    minutes_decimal = Decimal(str(abs(minutes)))
-    seconds_decimal = Decimal(str(abs(seconds)))
-    us_decimal = Decimal(str(abs(us)))
-    
-    dd_decimal = (
-        degrees_decimal + 
-        minutes_decimal / Decimal('60') + 
-        seconds_decimal / Decimal('3600') + 
-        us_decimal / Decimal('3600000000')
-    )
-    
-    result = sign * dd_decimal
-    return float(result)
+    assert abs(degrees + minutes + seconds + us) == abs(degrees) + abs(minutes) + abs(seconds) + abs(us)
+
+    return degrees + minutes / 60.0 + seconds / 3600.0 + us / 3600000000.0
 
 
 def dd2dms(dd: float, use_us: bool = False) -> Union[tuple[int, int, int, int], tuple[int, int, float]]:
@@ -75,32 +63,33 @@ def dd2dms(dd: float, use_us: bool = False) -> Union[tuple[int, int, int, int], 
     :return: The angle in a tuple of either 3 or 4 values,
         4 values: integer number of degrees, integer number of minutes, integer number of seconds and integer number of microseconds
         3 values: integer number of degrees, integer number of minutes, and a float number for seconds
-    :note: the tuple follows the format of IfcCompoundPlaneAngleMeasure. Namely all of its are either positive or negative.
+    :note: the tuple follows the format of IfcCompoundPlaneAngleMeasure. Namely all of its components are either positive or negative.
     """
     sign = -1 if dd < 0 else 1
-    
+
     dd_decimal = Decimal(str(abs(dd)))
-    
+
     degrees = int(dd_decimal)
-    degrees_decimal = Decimal(str(degrees))
-    
+    degrees_decimal = Decimal(degrees)
+
     fractional_part = dd_decimal - degrees_decimal
-    
-    minutes_decimal = fractional_part * Decimal('60')
+
+    minutes_decimal = fractional_part * Decimal("60")
     minutes = int(minutes_decimal)
-    minutes_decimal_int = Decimal(str(minutes))
-    
-    seconds_decimal = (minutes_decimal - minutes_decimal_int) * Decimal('60')
+    minutes_decimal_int = Decimal(minutes)
+
+    seconds_decimal = (minutes_decimal - minutes_decimal_int) * Decimal("60")
 
     if use_us:
         seconds = int(seconds_decimal)
-        seconds_decimal_int = Decimal(str(seconds))
-        microseconds_decimal = (seconds_decimal - seconds_decimal_int) * Decimal('1000000')
-        microseconds = int(microseconds_decimal.quantize(Decimal('1'), rounding=ROUND_HALF_UP))
+        seconds_decimal_int = Decimal(seconds)
+        microseconds_decimal = (seconds_decimal - seconds_decimal_int) * Decimal("1000000")
+        microseconds = int(microseconds_decimal.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
         return (sign * degrees, sign * minutes, sign * seconds, sign * microseconds)
     else:
         seconds_float = float(seconds_decimal)
         return (sign * degrees, sign * minutes, sign * seconds_float)
+
 
 def xyz2enh(
     x: float,

--- a/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
@@ -50,8 +50,9 @@ def dms2dd(degrees: int, minutes: int, seconds: int, us: int = 0) -> float:
     :param us: The microseconds component
     :return: The angle in decimal degrees.
     """
-    assert abs(degrees + minutes + seconds + us) == abs(degrees) + abs(minutes) + abs(seconds) + abs(us)
-
+    all_positive_or_zero = degrees >= 0 and minutes >= 0 and seconds >= 0 and us >= 0
+    all_negative_or_zero = degrees <= 0 and minutes <= 0 and seconds <= 0 and us <= 0
+    assert all_positive_or_zero or all_negative_or_zero
     return degrees + minutes / 60.0 + seconds / 3600.0 + us / 3600000000.0
 
 
@@ -65,30 +66,28 @@ def dd2dms(dd: float, use_us: bool = False) -> Union[tuple[int, int, int, int], 
         3 values: integer number of degrees, integer number of minutes, and a float number for seconds
     :note: the tuple follows the format of IfcCompoundPlaneAngleMeasure. Namely all of its components are either positive or negative.
     """
-    sign = -1 if dd < 0 else 1
-
-    dd_decimal = Decimal(str(abs(dd)))
+    dd_decimal = Decimal(str(dd))
 
     degrees = int(dd_decimal)
     degrees_decimal = Decimal(degrees)
 
     fractional_part = dd_decimal - degrees_decimal
 
-    minutes_decimal = fractional_part * Decimal("60")
+    minutes_decimal = fractional_part * Decimal(60)
     minutes = int(minutes_decimal)
     minutes_decimal_int = Decimal(minutes)
 
-    seconds_decimal = (minutes_decimal - minutes_decimal_int) * Decimal("60")
+    seconds_decimal = (minutes_decimal - minutes_decimal_int) * Decimal(60)
 
     if use_us:
         seconds = int(seconds_decimal)
         seconds_decimal_int = Decimal(seconds)
-        microseconds_decimal = (seconds_decimal - seconds_decimal_int) * Decimal("1000000")
-        microseconds = int(microseconds_decimal.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
-        return (sign * degrees, sign * minutes, sign * seconds, sign * microseconds)
+        microseconds_decimal = (seconds_decimal - seconds_decimal_int) * Decimal(1000000)
+        microseconds = int(microseconds_decimal.quantize(Decimal(1), rounding=ROUND_HALF_UP))
+        return (degrees, minutes, seconds, microseconds)
     else:
         seconds_float = float(seconds_decimal)
-        return (sign * degrees, sign * minutes, sign * seconds_float)
+        return (degrees, minutes, seconds_float)
 
 
 def xyz2enh(

--- a/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
@@ -40,38 +40,44 @@ class HelmertTransformation(NamedTuple):
 
 
 def dms2dd(degrees: int, minutes: int, seconds: int, ms: int = 0) -> float:
-    """Convert degrees, minutes, and (milli)seconds to decimal degrees
+    """Convert degrees, minutes, and (micro)seconds to decimal degrees
 
     :param degrees: The degrees component
     :param minutes: The minutes component
     :param seconds: The seconds component
-    :param ms: The milliseconds component
+    :param ms: The microseconds component
     :return: The angle in decimal degrees.
     """
-    dd = float(degrees) + float(minutes) / 60.0 + float(seconds) / (3600.0) + float(ms / 3600000000.0)
-    return dd
+    sign = -1 if degrees < 0 else 1
+    dd = abs(float(degrees)) + float(minutes) / 60.0 + float(seconds) / 3600.0 + float(ms) / 3600000000.0
+    return sign * dd
 
 
 def dd2dms(dd: float, use_ms: bool = False) -> Union[tuple[float, float, float, float], tuple[float, float, float]]:
-    """Convert decimal degrees to degrees, minutes, and (milli)seconds format
+    """Convert decimal degrees to degrees, minutes, and (micro)seconds format
 
     :param dd: The decimal degrees
-    :param use_ms: True if to include milliseconds and false otherwise. Defaults to false.
-    :return: The angle in a tuple of either 3 or 4 values, being degrees,
-        minutes, seconds, and optionally milliseconds.
+    :param use_ms: True if to include microseconds and false otherwise. Defaults to false.
+    :return: The angle in a tuple of either 3 or 4 values,
+        4 values: integer number of degrees, integer number of minutes, integer number of seconds and integer number of microseconds
+        3 values: integer number of degrees, integer number of minutes, and a float number for seconds
     """
-    dd = float(dd)
-    sign = 1 if dd >= 0 else -1
+    sign = -1 if dd < 0 else 1
     dd = abs(dd)
+
+    degrees = int(dd)
+    minutes_float = (dd - degrees) * 60
+    minutes = int(minutes_float)
+    seconds_float = (minutes_float - minutes) * 60
+
     if use_ms:
-        seconds, ms = divmod(dd * 60 * 60 * 1000000, 1000000)
-    minutes, seconds = divmod(dd * 60 * 60, 60)
-    degrees, minutes = divmod(minutes, 60)
-    if dd < 0:
-        degrees = -degrees
-    if use_ms:
-        return (int(degrees) * sign, int(minutes) * sign, int(seconds) * sign, int(ms) * sign)
-    return (int(degrees) * sign, int(minutes) * sign, int(seconds) * sign)
+        seconds = int(seconds_float)
+        microseconds = int(round((seconds_float - seconds) * 1_000_000))
+        result = (sign * degrees, minutes, seconds, microseconds)
+    else:
+        result = (sign * degrees, minutes, seconds_float)
+
+    return result
 
 
 def xyz2enh(

--- a/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
@@ -39,28 +39,29 @@ class HelmertTransformation(NamedTuple):
     factor_z: float
 
 
-def dms2dd(degrees: int, minutes: int, seconds: int, ms: int = 0) -> float:
+def dms2dd(degrees: int, minutes: int, seconds: int, us: int = 0) -> float:
     """Convert degrees, minutes, and (micro)seconds to decimal degrees
 
     :param degrees: The degrees component
     :param minutes: The minutes component
     :param seconds: The seconds component
-    :param ms: The microseconds component
+    :param us: The microseconds component
     :return: The angle in decimal degrees.
     """
     sign = -1 if degrees < 0 else 1
-    dd = abs(float(degrees)) + float(minutes) / 60.0 + float(seconds) / 3600.0 + float(ms) / 3600000000.0
+    dd = abs(float(degrees)) + float(minutes) / 60.0 + float(seconds) / 3600.0 + float(us) / 3600000000.0
     return sign * dd
 
 
-def dd2dms(dd: float, use_ms: bool = False) -> Union[tuple[float, float, float, float], tuple[float, float, float]]:
+def dd2dms(dd: float, use_us: bool = False) -> Union[tuple[float, float, float, float], tuple[float, float, float]]:
     """Convert decimal degrees to degrees, minutes, and (micro)seconds format
 
     :param dd: The decimal degrees
-    :param use_ms: True if to include microseconds and false otherwise. Defaults to false.
+    :param use_us: True if to include microseconds and false otherwise. Defaults to false.
     :return: The angle in a tuple of either 3 or 4 values,
         4 values: integer number of degrees, integer number of minutes, integer number of seconds and integer number of microseconds
         3 values: integer number of degrees, integer number of minutes, and a float number for seconds
+    :note: the tuple follows the format of IfcCompoundPlaneAngleMeasure. Namely all of its are either positive or negative.
     """
     sign = -1 if dd < 0 else 1
     dd = abs(dd)
@@ -70,12 +71,12 @@ def dd2dms(dd: float, use_ms: bool = False) -> Union[tuple[float, float, float, 
     minutes = int(minutes_float)
     seconds_float = (minutes_float - minutes) * 60
 
-    if use_ms:
+    if use_us:
         seconds = int(seconds_float)
         microseconds = int(round((seconds_float - seconds) * 1_000_000))
-        result = (sign * degrees, minutes, seconds, microseconds)
+        result = sign * (degrees, minutes, seconds, microseconds)
     else:
-        result = (sign * degrees, minutes, seconds_float)
+        result = sign * (degrees, minutes, seconds_float)
 
     return result
 

--- a/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
@@ -23,6 +23,7 @@ import ifcopenshell.util.unit
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
 from typing import NamedTuple, Optional, Union
+from decimal import Decimal, ROUND_HALF_UP
 
 MatrixType = ifcopenshell.util.placement.MatrixType
 
@@ -48,12 +49,25 @@ def dms2dd(degrees: int, minutes: int, seconds: int, us: int = 0) -> float:
     :param us: The microseconds component
     :return: The angle in decimal degrees.
     """
-    sign = -1 if degrees < 0 else 1
-    dd = abs(float(degrees)) + float(minutes) / 60.0 + float(seconds) / 3600.0 + float(us) / 3600000000.0
-    return sign * dd
+    sign = -1 if degrees < 0 or minutes < 0 or seconds < 0 or us < 0 else 1
+    
+    degrees_decimal = Decimal(str(abs(degrees)))
+    minutes_decimal = Decimal(str(abs(minutes)))
+    seconds_decimal = Decimal(str(abs(seconds)))
+    us_decimal = Decimal(str(abs(us)))
+    
+    dd_decimal = (
+        degrees_decimal + 
+        minutes_decimal / Decimal('60') + 
+        seconds_decimal / Decimal('3600') + 
+        us_decimal / Decimal('3600000000')
+    )
+    
+    result = sign * dd_decimal
+    return float(result)
 
 
-def dd2dms(dd: float, use_us: bool = False) -> Union[tuple[float, float, float, float], tuple[float, float, float]]:
+def dd2dms(dd: float, use_us: bool = False) -> Union[tuple[int, int, int, int], tuple[int, int, float]]:
     """Convert decimal degrees to degrees, minutes, and (micro)seconds format
 
     :param dd: The decimal degrees
@@ -64,22 +78,29 @@ def dd2dms(dd: float, use_us: bool = False) -> Union[tuple[float, float, float, 
     :note: the tuple follows the format of IfcCompoundPlaneAngleMeasure. Namely all of its are either positive or negative.
     """
     sign = -1 if dd < 0 else 1
-    dd = abs(dd)
-
-    degrees = int(dd)
-    minutes_float = (dd - degrees) * 60
-    minutes = int(minutes_float)
-    seconds_float = (minutes_float - minutes) * 60
+    
+    dd_decimal = Decimal(str(abs(dd)))
+    
+    degrees = int(dd_decimal)
+    degrees_decimal = Decimal(str(degrees))
+    
+    fractional_part = dd_decimal - degrees_decimal
+    
+    minutes_decimal = fractional_part * Decimal('60')
+    minutes = int(minutes_decimal)
+    minutes_decimal_int = Decimal(str(minutes))
+    
+    seconds_decimal = (minutes_decimal - minutes_decimal_int) * Decimal('60')
 
     if use_us:
-        seconds = int(seconds_float)
-        microseconds = int(round((seconds_float - seconds) * 1_000_000))
-        result = sign * (degrees, minutes, seconds, microseconds)
+        seconds = int(seconds_decimal)
+        seconds_decimal_int = Decimal(str(seconds))
+        microseconds_decimal = (seconds_decimal - seconds_decimal_int) * Decimal('1000000')
+        microseconds = int(microseconds_decimal.quantize(Decimal('1'), rounding=ROUND_HALF_UP))
+        return (sign * degrees, sign * minutes, sign * seconds, sign * microseconds)
     else:
-        result = sign * (degrees, minutes, seconds_float)
-
-    return result
-
+        seconds_float = float(seconds_decimal)
+        return (sign * degrees, sign * minutes, sign * seconds_float)
 
 def xyz2enh(
     x: float,

--- a/src/ifcopenshell-python/test/util/test_geolocation.py
+++ b/src/ifcopenshell-python/test/util/test_geolocation.py
@@ -468,3 +468,29 @@ class TestAngle2YAxis(test.bootstrap.IFC4):
         assert np.allclose(subject.angle2yaxis(45), (-a, a))
         assert np.allclose(subject.angle2yaxis(-135), (a, -a))
         assert np.allclose(subject.angle2yaxis(135), (-a, -a))
+
+
+class TestDMS2DDandDD2DMS(test.bootstrap.IFC4):
+    def test_dms2dd_and_dd2dms(self):
+        test_cases_3tuple = [
+            (35.41, (35, 24, 36)),
+            (-116.89, (-116, -53, -24)),
+        ]
+        test_cases_4tuple = [
+            (40.431389, (40, 25, 53, 400)),
+            (-4.248056, (-4, -14, -53, -1600)),
+            (-35.401389, (-35, -24, -5, -400)),
+            (148.981667, (148, 58, 54, 1200)),
+        ]
+
+        for dd, dms in test_cases_3tuple:
+            d, m, s = subject.dd2dms(dd)
+            assert (int(d), int(m), float(s)) == dms
+            dd_converted = subject.dms2dd(dms[0], dms[1], dms[2])
+            assert abs(dd_converted - dd) < 1e-9
+
+        for dd, dms in test_cases_4tuple:
+            d, m, s, us = subject.dd2dms(dd, use_us=True)
+            assert (int(d), int(m), int(s), int(us)) == dms
+            dd_converted = subject.dms2dd(dms[0], dms[1], dms[2], dms[3])
+            assert abs(dd_converted - dd) < 1e-9

--- a/src/ifcopenshell-python/test/util/test_geolocation.py
+++ b/src/ifcopenshell-python/test/util/test_geolocation.py
@@ -473,8 +473,8 @@ class TestAngle2YAxis(test.bootstrap.IFC4):
 class TestDMS2DDandDD2DMS(test.bootstrap.IFC4):
     def test_dms2dd_and_dd2dms(self):
         test_cases_3tuple = [
-            (35.41, (35, 24, 36)),
-            (-116.89, (-116, -53, -24)),
+            (35.41, (35, 24, 36.0)),
+            (-116.89, (-116, -53, -24.0)),
         ]
         test_cases_4tuple = [
             (40.431389, (40, 25, 53, 400)),
@@ -485,12 +485,12 @@ class TestDMS2DDandDD2DMS(test.bootstrap.IFC4):
 
         for dd, dms in test_cases_3tuple:
             d, m, s = subject.dd2dms(dd)
-            assert (int(d), int(m), float(s)) == dms
+            assert (d, m, s) == dms
             dd_converted = subject.dms2dd(dms[0], dms[1], dms[2])
-            assert abs(dd_converted - dd) < 1e-9
+            assert dd_converted == dd
 
         for dd, dms in test_cases_4tuple:
             d, m, s, us = subject.dd2dms(dd, use_us=True)
-            assert (int(d), int(m), int(s), int(us)) == dms
+            assert (d, m, s, us) == dms
             dd_converted = subject.dms2dd(dms[0], dms[1], dms[2], dms[3])
-            assert abs(dd_converted - dd) < 1e-9
+            assert dd_converted == dd


### PR DESCRIPTION
Based on https://standards.buildingsmart.org/IFC/RELEASE/IFC4/ADD2_TC1/HTML/schema/ifcproductextension/lexical/ifcsite.htm

I think the functions need to be updated to handle microsencods instead of miliseconds for refLatitude and refLongitude

Also negative values affect the degree number only.
