### PR TITLE
Fix #5563 inconsistent behaviour of Status filter

### DIFF
--- a/src/bonsai/bonsai/bim/module/sequence/operator.py
+++ b/src/bonsai/bonsai/bim/module/sequence/operator.py
@@ -72,6 +72,28 @@ class DisableStatusFilters(bpy.types.Operator):
 
     def execute(self, context):
         props = context.scene.BIMStatusProperties
+
+        query = []
+        visible_statuses = {s.name for s in props.statuses}
+        for name in visible_statuses:
+            if name == "No Status":
+                q = f"IfcProduct, /Pset_.*Common/.Status=NULL, EPset_Status.Status=NULL"
+            else:
+                q = f"IfcProduct, /Pset_.*Common/.Status={name} + IfcProduct, EPset_Status.Status={name}"
+            query.append(q)
+        query = " + ".join(query)
+
+        if not query:
+            self.report({"INFO"}, "No statuses selected.")
+
+        visible_elements = ifcopenshell.util.selector.filter_elements(tool.Ifc.get(), query)
+
+        for obj in bpy.context.view_layer.objects:
+            element = tool.Ifc.get_entity(obj)
+            if not element or not element.is_a("IfcProduct"):
+                continue
+            obj.hide_set(element not in visible_elements)
+
         props.is_enabled = False
         return {"FINISHED"}
 
@@ -96,7 +118,6 @@ class ActivateStatusFilters(bpy.types.Operator):
 
         if not query:
             self.report({"INFO"}, "No statuses selected.")
-            return {"FINISHED"}
 
         visible_elements = ifcopenshell.util.selector.filter_elements(tool.Ifc.get(), query)
 

--- a/src/bonsai/bonsai/bim/module/sequence/operator.py
+++ b/src/bonsai/bonsai/bim/module/sequence/operator.py
@@ -43,17 +43,19 @@ class EnableStatusFilters(bpy.types.Operator):
     def execute(self, context):
         props = context.scene.BIMStatusProperties
         props.is_enabled = True
+        hidden_statuses = {s.name for s in props.statuses if not s.is_visible}
 
         props.statuses.clear()
 
         statuses = set()
         for element in tool.Ifc.get().by_type("IfcPropertyEnumeratedValue"):
             if element.Name == "Status":
-                pset = element.PartOfPset[0]
-                if pset.Name.startswith("Pset_") and pset.Name.endswith("Common"):
-                    statuses.update(element.EnumerationValues)
-                elif pset.Name == "EPset_Status":  # Our secret sauce
-                    statuses.update(element.EnumerationValues)
+                if element.PartOfPset and isinstance(element.EnumerationValues, tuple):
+                    pset = element.PartOfPset[0]
+                    if pset.Name.startswith("Pset_") and pset.Name.endswith("Common"):
+                        statuses.update(element.EnumerationValues)
+                    elif pset.Name == "EPset_Status":  # Our secret sauce
+                        statuses.update(element.EnumerationValues)
             elif element.Name == "UserDefinedStatus":
                 statuses.add(element.NominalValue)
 
@@ -62,6 +64,11 @@ class EnableStatusFilters(bpy.types.Operator):
         for status in statuses:
             new = props.statuses.add()
             new.name = status
+            if new.name in hidden_statuses:
+                new.is_visible = False
+
+        visible_statuses = {s.name for s in props.statuses} - hidden_statuses
+        tool.Sequence.set_visibility_by_status(visible_statuses)
         return {"FINISHED"}
 
 
@@ -73,27 +80,8 @@ class DisableStatusFilters(bpy.types.Operator):
     def execute(self, context):
         props = context.scene.BIMStatusProperties
 
-        query = []
         visible_statuses = {s.name for s in props.statuses}
-        for name in visible_statuses:
-            if name == "No Status":
-                q = f"IfcProduct, /Pset_.*Common/.Status=NULL, EPset_Status.Status=NULL"
-            else:
-                q = f"IfcProduct, /Pset_.*Common/.Status={name} + IfcProduct, EPset_Status.Status={name}"
-            query.append(q)
-        query = " + ".join(query)
-
-        if not query:
-            self.report({"INFO"}, "No statuses selected.")
-
-        visible_elements = ifcopenshell.util.selector.filter_elements(tool.Ifc.get(), query)
-
-        for obj in bpy.context.view_layer.objects:
-            element = tool.Ifc.get_entity(obj)
-            if not element or not element.is_a("IfcProduct"):
-                continue
-            obj.hide_set(element not in visible_elements)
-
+        tool.Sequence.set_visibility_by_status(visible_statuses)
         props.is_enabled = False
         return {"FINISHED"}
 
@@ -106,26 +94,8 @@ class ActivateStatusFilters(bpy.types.Operator):
     def execute(self, context):
         props = context.scene.BIMStatusProperties
 
-        query = []
         visible_statuses = {s.name for s in props.statuses if s.is_visible}
-        for name in visible_statuses:
-            if name == "No Status":
-                q = f"IfcProduct, /Pset_.*Common/.Status=NULL, EPset_Status.Status=NULL"
-            else:
-                q = f"IfcProduct, /Pset_.*Common/.Status={name} + IfcProduct, EPset_Status.Status={name}"
-            query.append(q)
-        query = " + ".join(query)
-
-        if not query:
-            self.report({"INFO"}, "No statuses selected.")
-
-        visible_elements = ifcopenshell.util.selector.filter_elements(tool.Ifc.get(), query)
-
-        for obj in bpy.context.view_layer.objects:
-            element = tool.Ifc.get_entity(obj)
-            if not element or not element.is_a("IfcProduct"):
-                continue
-            obj.hide_set(element not in visible_elements)
+        tool.Sequence.set_visibility_by_status(visible_statuses)
         return {"FINISHED"}
 
 

--- a/src/bonsai/bonsai/bim/module/sequence/operator.py
+++ b/src/bonsai/bonsai/bim/module/sequence/operator.py
@@ -67,7 +67,7 @@ class EnableStatusFilters(bpy.types.Operator):
             if new.name in hidden_statuses:
                 new.is_visible = False
 
-        visible_statuses = {s.name for s in props.statuses} - hidden_statuses
+        visible_statuses = {s.name for s in props.statuses if s.is_visible}
         tool.Sequence.set_visibility_by_status(visible_statuses)
         return {"FINISHED"}
 
@@ -80,8 +80,8 @@ class DisableStatusFilters(bpy.types.Operator):
     def execute(self, context):
         props = context.scene.BIMStatusProperties
 
-        visible_statuses = {s.name for s in props.statuses}
-        tool.Sequence.set_visibility_by_status(visible_statuses)
+        all_statuses = {s.name for s in props.statuses}
+        tool.Sequence.set_visibility_by_status(all_statuses)
         props.is_enabled = False
         return {"FINISHED"}
 

--- a/src/bonsai/bonsai/tool/sequence.py
+++ b/src/bonsai/bonsai/tool/sequence.py
@@ -1788,3 +1788,22 @@ class Sequence(bonsai.core.tool.Sequence):
         if include_time:
             return isodate.datetime_isoformat(datetime_)
         return isodate.date_isoformat(datetime_)
+
+    @classmethod
+    def set_visibility_by_status(cls, visible_statuses: list[str]) -> None:
+        query = []
+        for name in visible_statuses:
+            if name == "No Status":
+                q = f"IfcProduct, /Pset_.*Common/.Status=NULL, EPset_Status.Status=NULL"
+            else:
+                q = f"IfcProduct, /Pset_.*Common/.Status={name} + IfcProduct, EPset_Status.Status={name}"
+            query.append(q)
+        query = " + ".join(query)
+
+        visible_elements = ifcopenshell.util.selector.filter_elements(tool.Ifc.get(), query)
+
+        for obj in bpy.context.view_layer.objects:
+            element = tool.Ifc.get_entity(obj)
+            if not element or not element.is_a("IfcProduct"):
+                continue
+            obj.hide_set(element not in visible_elements)


### PR DESCRIPTION
Fixes for inconsistency as detailed in #5563
- Hiding last status hides last items in viewport,
- Disabling the status filter makes all status' visible again.