### PR TITLE
Fix #4588 fix broken rev cloud styles in sheets.

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/sheeter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/sheeter.py
@@ -374,6 +374,8 @@ class SheetBuilder:
             if "filter" in attrib:
                 # example use "#fill-background" filter
                 attrib["filter"] = replace_urls(attrib["filter"])
+            if "style" in attrib:
+                attrib["style"] = replace_urls(attrib["style"])
             if svg_element.tag == f"{SVG}use":
                 href_attrib = f"{XLINK}href"
                 if href_attrib in attrib:


### PR DESCRIPTION
Beware... I have only lightly tested this on my simple test case.

It is possible that a better fix is to style the rev cloud with the embedded stylesheet, but at the moment the svg tags forming the rev cloud seem to be directly styled with a style attribute, resulting in broken clouds in sheets.