### PR TITLE
Csv cost doc reference

### DIFF
--- a/src/bonsai/bonsai/bim/module/cost/__init__.py
+++ b/src/bonsai/bonsai/bim/module/cost/__init__.py
@@ -84,7 +84,6 @@ classes = (
     prop.CostItem,
     prop.CostItemQuantity,
     prop.CostItemType,
-    prop.CostSchedulesMapping,
     prop.ScheduleColumn,
     prop.BIMCostProperties,
     ui.BIM_PT_cost_schedules,

--- a/src/bonsai/bonsai/bim/module/cost/data.py
+++ b/src/bonsai/bonsai/bim/module/cost/data.py
@@ -76,7 +76,7 @@ class CostSchedulesData:
                         filepaths[schedule_id] = reference.Location
                     except ValueError:
                         pass
-        
+
         return filepaths
 
     @classmethod

--- a/src/bonsai/bonsai/bim/module/cost/data.py
+++ b/src/bonsai/bonsai/bim/module/cost/data.py
@@ -56,8 +56,36 @@ class CostSchedulesData:
             "cost_values": cls.cost_values(),
             "quantity_types": cls.quantity_types(),
             "currency": cls.currency(),
+            "csv_filepaths": cls.get_csv_filepaths(),  # Add this line
         }
         cls.is_loaded = True
+
+    @classmethod
+    def get_csv_filepaths(cls) -> dict[int, str]:
+        """Get CSV filepaths for cost schedules from document references."""
+        filepaths = {}
+        ifc_file = tool.Ifc.get()
+        cost_docs_document = next(
+            (
+                document
+                for document in ifc_file.by_type("IfcDocumentInformation")
+                if document.Name == "BBIM_Cost_Documents"
+            ),
+            None,
+        )
+
+        if cost_docs_document:
+            references = tool.Document.get_document_references(cost_docs_document)
+            for reference in references:
+                if reference.Description and "Cost Schedule ID:" in reference.Description:
+                    schedule_id_str = reference.Description.split("Cost Schedule ID:")[1].strip()
+                    try:
+                        schedule_id = int(schedule_id_str)
+                        filepaths[schedule_id] = reference.Location
+                    except ValueError:
+                        pass
+        
+        return filepaths
 
     @classmethod
     def currency(cls) -> Union[Currency, None]:

--- a/src/bonsai/bonsai/bim/module/cost/data.py
+++ b/src/bonsai/bonsai/bim/module/cost/data.py
@@ -64,15 +64,7 @@ class CostSchedulesData:
     def get_csv_filepaths(cls) -> dict[int, str]:
         """Get CSV filepaths for cost schedules from document references."""
         filepaths = {}
-        ifc_file = tool.Ifc.get()
-        cost_docs_document = next(
-            (
-                document
-                for document in ifc_file.by_type("IfcDocumentInformation")
-                if document.Name == "BBIM_Cost_Documents"
-            ),
-            None,
-        )
+        cost_docs_document = tool.Cost.get_or_create_cost_documents()
 
         if cost_docs_document:
             references = tool.Document.get_document_references(cost_docs_document)

--- a/src/bonsai/bonsai/bim/module/cost/data.py
+++ b/src/bonsai/bonsai/bim/module/cost/data.py
@@ -56,7 +56,7 @@ class CostSchedulesData:
             "cost_values": cls.cost_values(),
             "quantity_types": cls.quantity_types(),
             "currency": cls.currency(),
-            "csv_filepaths": cls.get_csv_filepaths(),  # Add this line
+            "csv_filepaths": cls.get_csv_filepaths(),
         }
         cls.is_loaded = True
 
@@ -199,6 +199,7 @@ class CostSchedulesData:
         #         parametric_quantities.extend(quantities)
         data["TotalCostQuantity"] = ifcopenshell.util.cost.get_total_quantity(cost_item)
         data["UnitSymbol"] = "-"
+        data["QuantityType"] = None
         quantities: list[ifcopenshell.entity_instance] = cost_item.CostQuantities
         if quantities:
             quantity = quantities[0]

--- a/src/bonsai/bonsai/bim/module/cost/operator.py
+++ b/src/bonsai/bonsai/bim/module/cost/operator.py
@@ -25,6 +25,9 @@ import bonsai.tool as tool
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 import bonsai.tool as tool
 import bonsai.core.cost as core
+from bonsai.bim.module.cost.data import CostSchedulesData
+from pathlib import Path
+
 from typing import get_args, TYPE_CHECKING, Literal
 
 
@@ -100,6 +103,7 @@ class EnableEditingCostItems(bpy.types.Operator, tool.Ifc.Operator):
 
     def _execute(self, context):
         core.enable_editing_cost_items(tool.Cost, cost_schedule=tool.Ifc.get().by_id(self.cost_schedule))
+        CostSchedulesData.is_loaded = False
 
 
 class DisableEditingCostSchedule(bpy.types.Operator, tool.Ifc.Operator):
@@ -565,8 +569,6 @@ class ImportCostScheduleCsv(bpy.types.Operator, ImportHelper, tool.Ifc.Operator)
         return True
 
     def _execute(self, context):
-        from pathlib import Path
-        from bonsai.bim.module.cost.data import CostSchedulesData
         
         store_path = self.filepath
         if self.use_relative_path:
@@ -604,7 +606,7 @@ class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
             cls.poll_message_set("No active cost schedule")
             return False
             
-        file_path = tool.Cost.get_cost_schedule_csv_filepath(props.active_cost_schedule_id)
+        file_path = core.get_cost_schedule_csv_filepath(tool.Cost, props.active_cost_schedule_id)
         if not file_path:
             cls.poll_message_set("No CSV file associated with this cost schedule")
             return False
@@ -612,44 +614,14 @@ class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
         return True
 
     def _execute(self, context):
-        from pathlib import Path
-        from bonsai.bim.module.cost.data import CostSchedulesData
-        
-        props = tool.Cost.get_cost_props()
-        cost_schedule_id = props.active_cost_schedule_id
-        
-        file_path = tool.Cost.get_cost_schedule_csv_filepath(cost_schedule_id)
-        if not file_path:
-            self.report({"ERROR"}, "No CSV file associated with this cost schedule")
+        error_message = core.refresh_cost_schedule_csv(tool.Cost)
+        if error_message:
+            self.report({"ERROR"}, error_message)
             return {"CANCELLED"}
-            
-        resolved_path = Path(tool.Ifc.resolve_uri(file_path))
-        if not resolved_path.exists():
-            self.report({"ERROR"}, f"File does not exist: '{file_path}' (resolved to '{resolved_path}')")
-            return {"CANCELLED"}
-            
-        tool.Cost.delete_all_cost_items()
-        
-        cost_schedule = tool.Ifc.get_entity_by_id(cost_schedule_id)
-        is_schedule_of_rates = tool.Cost.is_schedule_of_rates_csv(cost_schedule_id)
+        CostSchedulesData.is_loaded = False
 
-        try:
-            from ifc5d.csv2ifc import Csv2Ifc
-            
-            csv2ifc = Csv2Ifc()
-            csv2ifc.csv = str(resolved_path)
-            csv2ifc.file = tool.Ifc.get()
-            csv2ifc.cost_schedule = cost_schedule
-            csv2ifc.is_schedule_of_rates = is_schedule_of_rates
-            csv2ifc.refresh()
-            
-            tool.Cost.load_cost_schedule_tree()
-            CostSchedulesData.is_loaded = False
-            
-            return {"FINISHED"}
-        except Exception as e:
-            self.report({"ERROR"}, f"Error refreshing CSV: {str(e)}")
-            return {"CANCELLED"}
+        return {"FINISHED"}
+
 
 class AddCostColumn(bpy.types.Operator):
     bl_idname = "bim.add_cost_column"

--- a/src/bonsai/bonsai/bim/module/cost/operator.py
+++ b/src/bonsai/bonsai/bim/module/cost/operator.py
@@ -566,28 +566,30 @@ class ImportCostScheduleCsv(bpy.types.Operator, ImportHelper, tool.Ifc.Operator)
 
     def _execute(self, context):
         from pathlib import Path
-
+        from bonsai.bim.module.cost.data import CostSchedulesData
+        
         store_path = self.filepath
         if self.use_relative_path:
             store_path = tool.Ifc.get_uri(self.filepath, use_relative_path=True)
-
+        
         resolved_path = Path(tool.Ifc.resolve_uri(self.filepath))
         if not resolved_path.exists():
             self.report({"ERROR"}, f"File does not exist: '{store_path}' (resolved to '{resolved_path}')")
             return {"CANCELLED"}
-
+            
         cost_schedule = core.import_cost_schedule_csv(tool.Cost, str(resolved_path), self.is_schedule_of_rates)
         if cost_schedule:
             core.add_csv_filepath(tool.Cost, store_path, self.is_schedule_of_rates, cost_schedule)
+            CostSchedulesData.is_loaded = False
+            
             return {"FINISHED"}
         return {"CANCELLED"}
-
+        
     def draw(self, context):
         row = self.layout.row()
         row.prop(self, "is_schedule_of_rates")
         row = self.layout.row()
         row.prop(self, "use_relative_path")
-
 
 class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.refresh_cost_schedule_csv"
@@ -601,41 +603,53 @@ class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
         if not props.active_cost_schedule_id:
             cls.poll_message_set("No active cost schedule")
             return False
+            
+        file_path = tool.Cost.get_cost_schedule_csv_filepath(props.active_cost_schedule_id)
+        if not file_path:
+            cls.poll_message_set("No CSV file associated with this cost schedule")
+            return False
+            
         return True
 
     def _execute(self, context):
         from pathlib import Path
-
+        from bonsai.bim.module.cost.data import CostSchedulesData
+        
         props = tool.Cost.get_cost_props()
         cost_schedule_id = props.active_cost_schedule_id
-
+        
         file_path = tool.Cost.get_cost_schedule_csv_filepath(cost_schedule_id)
+        if not file_path:
+            self.report({"ERROR"}, "No CSV file associated with this cost schedule")
+            return {"CANCELLED"}
+            
         resolved_path = Path(tool.Ifc.resolve_uri(file_path))
         if not resolved_path.exists():
             self.report({"ERROR"}, f"File does not exist: '{file_path}' (resolved to '{resolved_path}')")
             return {"CANCELLED"}
-
+            
         tool.Cost.delete_all_cost_items()
-
+        
         cost_schedule = tool.Ifc.get_entity_by_id(cost_schedule_id)
         is_schedule_of_rates = tool.Cost.is_schedule_of_rates_csv(cost_schedule_id)
 
         try:
             from ifc5d.csv2ifc import Csv2Ifc
-
+            
             csv2ifc = Csv2Ifc()
             csv2ifc.csv = str(resolved_path)
             csv2ifc.file = tool.Ifc.get()
             csv2ifc.cost_schedule = cost_schedule
             csv2ifc.is_schedule_of_rates = is_schedule_of_rates
             csv2ifc.refresh()
-
+            
             tool.Cost.load_cost_schedule_tree()
+            CostSchedulesData.is_loaded = False
+            
             return {"FINISHED"}
         except Exception as e:
             self.report({"ERROR"}, f"Error refreshing CSV: {str(e)}")
             return {"CANCELLED"}
-
 
 class AddCostColumn(bpy.types.Operator):
     bl_idname = "bim.add_cost_column"

--- a/src/bonsai/bonsai/bim/module/cost/operator.py
+++ b/src/bonsai/bonsai/bim/module/cost/operator.py
@@ -25,7 +25,6 @@ import bonsai.tool as tool
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 import bonsai.tool as tool
 import bonsai.core.cost as core
-from bonsai.bim.module.cost.data import CostSchedulesData
 from pathlib import Path
 
 from typing import get_args, TYPE_CHECKING, Literal
@@ -103,7 +102,6 @@ class EnableEditingCostItems(bpy.types.Operator, tool.Ifc.Operator):
 
     def _execute(self, context):
         core.enable_editing_cost_items(tool.Cost, cost_schedule=tool.Ifc.get().by_id(self.cost_schedule))
-        CostSchedulesData.is_loaded = False
 
 
 class DisableEditingCostSchedule(bpy.types.Operator, tool.Ifc.Operator):
@@ -569,29 +567,28 @@ class ImportCostScheduleCsv(bpy.types.Operator, ImportHelper, tool.Ifc.Operator)
         return True
 
     def _execute(self, context):
-        
+
         store_path = self.filepath
         if self.use_relative_path:
             store_path = tool.Ifc.get_uri(self.filepath, use_relative_path=True)
-        
+
         resolved_path = Path(tool.Ifc.resolve_uri(self.filepath))
         if not resolved_path.exists():
             self.report({"ERROR"}, f"File does not exist: '{store_path}' (resolved to '{resolved_path}')")
             return {"CANCELLED"}
-            
+
         cost_schedule = core.import_cost_schedule_csv(tool.Cost, str(resolved_path), self.is_schedule_of_rates)
         if cost_schedule:
             core.add_csv_filepath(tool.Cost, store_path, self.is_schedule_of_rates, cost_schedule)
-            CostSchedulesData.is_loaded = False
-            
             return {"FINISHED"}
         return {"CANCELLED"}
-        
+
     def draw(self, context):
         row = self.layout.row()
         row.prop(self, "is_schedule_of_rates")
         row = self.layout.row()
         row.prop(self, "use_relative_path")
+
 
 class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.refresh_cost_schedule_csv"
@@ -605,18 +602,16 @@ class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
         if not props.active_cost_schedule_id:
             cls.poll_message_set("No active cost schedule")
             return False
-            
+
         file_path = tool.Cost.get_cost_schedule_csv_filepath(props.active_cost_schedule_id)
         if not file_path:
             cls.poll_message_set("No CSV file associated with this cost schedule")
             return False
-            
+
         return True
 
     def _execute(self, context):
         core.refresh_cost_schedule_csv(tool.Cost)
-        CostSchedulesData.is_loaded = False
-
         return {"FINISHED"}
 
 

--- a/src/bonsai/bonsai/bim/module/cost/operator.py
+++ b/src/bonsai/bonsai/bim/module/cost/operator.py
@@ -606,7 +606,7 @@ class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
             cls.poll_message_set("No active cost schedule")
             return False
             
-        file_path = core.get_cost_schedule_csv_filepath(tool.Cost, props.active_cost_schedule_id)
+        file_path = tool.Cost.get_cost_schedule_csv_filepath(props.active_cost_schedule_id)
         if not file_path:
             cls.poll_message_set("No CSV file associated with this cost schedule")
             return False
@@ -614,10 +614,7 @@ class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
         return True
 
     def _execute(self, context):
-        error_message = core.refresh_cost_schedule_csv(tool.Cost)
-        if error_message:
-            self.report({"ERROR"}, error_message)
-            return {"CANCELLED"}
+        core.refresh_cost_schedule_csv(tool.Cost)
         CostSchedulesData.is_loaded = False
 
         return {"FINISHED"}

--- a/src/bonsai/bonsai/bim/module/cost/operator.py
+++ b/src/bonsai/bonsai/bim/module/cost/operator.py
@@ -541,11 +541,10 @@ class SelectCostScheduleProducts(bpy.types.Operator):
         )
         return {"FINISHED"}
 
-
 class ImportCostScheduleCsv(bpy.types.Operator, ImportHelper, tool.Ifc.Operator):
     bl_idname = "bim.import_cost_schedule_csv"
     bl_label = "Import Cost Schedule CSV"
-    bl_description = "Import cost schdule from the provided .csv file."
+    bl_description = "Import cost schedule from the provided .csv file."
     bl_options = {"REGISTER", "UNDO"}
     filename_ext = ".csv"
     filter_glob: bpy.props.StringProperty(default="*.csv", options={"HIDDEN"})
@@ -568,11 +567,27 @@ class ImportCostScheduleCsv(bpy.types.Operator, ImportHelper, tool.Ifc.Operator)
 class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.refresh_cost_schedule_csv"
     bl_label = "Refresh Cost Schedule CSV"
+    bl_description = "Refresh cost schedule data from the associated CSV file"
     bl_options = {"REGISTER", "UNDO"}
 
     @classmethod
+    def poll(cls, context):
+        props = tool.Cost.get_cost_props()
+        if not props.active_cost_schedule_id:
+            cls.poll_message_set("No active cost schedule")
+            return False
+        
+        filepath = tool.Cost.get_cost_schedule_csv_filepath(props.active_cost_schedule_id)
+        if not filepath:
+            cls.poll_message_set("No CSV file associated with this cost schedule")
+            return False
+            
+        return True
+
     def _execute(self, context):
-        core.refresh_cost_schedule_csv(tool.Ifc, tool.Cost)
+        tool.Cost.delete_all_cost_items()
+        tool.Cost.refresh_cost_schedule_csv()
+        tool.Cost.load_cost_schedule_tree()
         return {"FINISHED"}
 
 

--- a/src/bonsai/bonsai/bim/module/cost/operator.py
+++ b/src/bonsai/bonsai/bim/module/cost/operator.py
@@ -541,6 +541,7 @@ class SelectCostScheduleProducts(bpy.types.Operator):
         )
         return {"FINISHED"}
 
+
 class ImportCostScheduleCsv(bpy.types.Operator, ImportHelper, tool.Ifc.Operator):
     bl_idname = "bim.import_cost_schedule_csv"
     bl_label = "Import Cost Schedule CSV"
@@ -549,6 +550,11 @@ class ImportCostScheduleCsv(bpy.types.Operator, ImportHelper, tool.Ifc.Operator)
     filename_ext = ".csv"
     filter_glob: bpy.props.StringProperty(default="*.csv", options={"HIDDEN"})
     is_schedule_of_rates: bpy.props.BoolProperty(name="Is Schedule Of Rates", default=False)
+    use_relative_path: bpy.props.BoolProperty(
+        name="Use Relative Path",
+        description="Store the CSV filepath relative to the currently opened IFC file",
+        default=False,
+    )
 
     @classmethod
     def poll(cls, context):
@@ -559,9 +565,28 @@ class ImportCostScheduleCsv(bpy.types.Operator, ImportHelper, tool.Ifc.Operator)
         return True
 
     def _execute(self, context):
-        cost_schedule = core.import_cost_schedule_csv(tool.Cost, self.filepath, self.is_schedule_of_rates)
-        core.add_csv_filepath(tool.Cost, self.filepath, self.is_schedule_of_rates, cost_schedule)
-        return {"FINISHED"}
+        from pathlib import Path
+
+        store_path = self.filepath
+        if self.use_relative_path:
+            store_path = tool.Ifc.get_uri(self.filepath, use_relative_path=True)
+
+        resolved_path = Path(tool.Ifc.resolve_uri(self.filepath))
+        if not resolved_path.exists():
+            self.report({"ERROR"}, f"File does not exist: '{store_path}' (resolved to '{resolved_path}')")
+            return {"CANCELLED"}
+
+        cost_schedule = core.import_cost_schedule_csv(tool.Cost, str(resolved_path), self.is_schedule_of_rates)
+        if cost_schedule:
+            core.add_csv_filepath(tool.Cost, store_path, self.is_schedule_of_rates, cost_schedule)
+            return {"FINISHED"}
+        return {"CANCELLED"}
+
+    def draw(self, context):
+        row = self.layout.row()
+        row.prop(self, "is_schedule_of_rates")
+        row = self.layout.row()
+        row.prop(self, "use_relative_path")
 
 
 class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
@@ -576,19 +601,40 @@ class RefreshCostScheduleCsv(bpy.types.Operator, tool.Ifc.Operator):
         if not props.active_cost_schedule_id:
             cls.poll_message_set("No active cost schedule")
             return False
-        
-        filepath = tool.Cost.get_cost_schedule_csv_filepath(props.active_cost_schedule_id)
-        if not filepath:
-            cls.poll_message_set("No CSV file associated with this cost schedule")
-            return False
-            
         return True
 
     def _execute(self, context):
+        from pathlib import Path
+
+        props = tool.Cost.get_cost_props()
+        cost_schedule_id = props.active_cost_schedule_id
+
+        file_path = tool.Cost.get_cost_schedule_csv_filepath(cost_schedule_id)
+        resolved_path = Path(tool.Ifc.resolve_uri(file_path))
+        if not resolved_path.exists():
+            self.report({"ERROR"}, f"File does not exist: '{file_path}' (resolved to '{resolved_path}')")
+            return {"CANCELLED"}
+
         tool.Cost.delete_all_cost_items()
-        tool.Cost.refresh_cost_schedule_csv()
-        tool.Cost.load_cost_schedule_tree()
-        return {"FINISHED"}
+
+        cost_schedule = tool.Ifc.get_entity_by_id(cost_schedule_id)
+        is_schedule_of_rates = tool.Cost.is_schedule_of_rates_csv(cost_schedule_id)
+
+        try:
+            from ifc5d.csv2ifc import Csv2Ifc
+
+            csv2ifc = Csv2Ifc()
+            csv2ifc.csv = str(resolved_path)
+            csv2ifc.file = tool.Ifc.get()
+            csv2ifc.cost_schedule = cost_schedule
+            csv2ifc.is_schedule_of_rates = is_schedule_of_rates
+            csv2ifc.refresh()
+
+            tool.Cost.load_cost_schedule_tree()
+            return {"FINISHED"}
+        except Exception as e:
+            self.report({"ERROR"}, f"Error refreshing CSV: {str(e)}")
+            return {"CANCELLED"}
 
 
 class AddCostColumn(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/cost/prop.py
+++ b/src/bonsai/bonsai/bim/module/cost/prop.py
@@ -174,16 +174,6 @@ class CostItemQuantity(PropertyGroup):
         unit_symbol: str
         total_cost_quantity: float
 
-
-class CostSchedulesMapping(PropertyGroup):
-    cost_schedule_id: IntProperty(name="cost_schedule_id")
-    csv_filepath: StringProperty(name="filepath")
-
-    if TYPE_CHECKING:
-        cost_schedule_id: int
-        csv_filepath: str
-
-
 class CostItemType(PropertyGroup):
     name: StringProperty(name="Name")
     ifc_definition_id: IntProperty(name="IFC Definition ID")
@@ -289,7 +279,6 @@ class BIMCostProperties(PropertyGroup):
     custom_currency: StringProperty(
         name="Custom Currency", default="USD", description="Custom Currency in ISO 4217 format"
     )
-    cost_schedule_files: CollectionProperty(name="Cost Schedule Files", type=CostSchedulesMapping)
 
     if TYPE_CHECKING:
         cost_schedule_predefined_types: str
@@ -344,7 +333,6 @@ class BIMCostProperties(PropertyGroup):
         show_cost_item_operators: bool
         currency: str
         custom_currency: str
-        cost_schedule_files: bpy.types.bpy_prop_collection_idprop[CostSchedulesMapping]
 
     @property
     def active_cost_item(self) -> Union[CostItem, None]:

--- a/src/bonsai/bonsai/bim/module/cost/prop.py
+++ b/src/bonsai/bonsai/bim/module/cost/prop.py
@@ -174,6 +174,7 @@ class CostItemQuantity(PropertyGroup):
         unit_symbol: str
         total_cost_quantity: float
 
+
 class CostItemType(PropertyGroup):
     name: StringProperty(name="Name")
     ifc_definition_id: IntProperty(name="IFC Definition ID")

--- a/src/bonsai/bonsai/bim/module/cost/ui.py
+++ b/src/bonsai/bonsai/bim/module/cost/ui.py
@@ -76,10 +76,28 @@ class BIM_PT_cost_schedules(Panel):
             col = row0.column()
             col.label(text="Linked CSV:")
             row_1 = col.row(align=True)
-            
-            # Get filepath from document reference instead of props
-            file_path = tool.Cost.get_cost_schedule_csv_filepath(self.props.active_cost_schedule_id)
-            
+
+            ifc_file = tool.Ifc.get()
+            cost_docs_document = next(
+                (
+                    document
+                    for document in ifc_file.by_type("IfcDocumentInformation")
+                    if document.Name == "BBIM_Cost_Documents"
+                ),
+                None,
+            )
+
+            file_path = None
+            if cost_docs_document:
+                references = tool.Document.get_document_references(cost_docs_document)
+                for reference in references:
+                    if (
+                        reference.Description
+                        and f"Cost Schedule ID: {self.props.active_cost_schedule_id}" in reference.Description
+                    ):
+                        file_path = reference.Location
+                        break
+
             if file_path:
                 row_1.label(text=file_path)
                 row_1.operator("bim.refresh_cost_schedule_csv", icon="FILE_REFRESH", text="")

--- a/src/bonsai/bonsai/bim/module/cost/ui.py
+++ b/src/bonsai/bonsai/bim/module/cost/ui.py
@@ -76,16 +76,12 @@ class BIM_PT_cost_schedules(Panel):
             col = row0.column()
             col.label(text="Linked CSV:")
             row_1 = col.row(align=True)
-            if self.props.active_cost_schedule_id in [item.cost_schedule_id for item in self.props.cost_schedule_files]:
-                file = next(
-                    (
-                        item.csv_filepath
-                        for item in self.props.cost_schedule_files
-                        if item.cost_schedule_id == self.props.active_cost_schedule_id
-                    ),
-                    None,
-                )
-                row_1.label(text=file)
+            
+            # Get filepath from document reference instead of props
+            file_path = tool.Cost.get_cost_schedule_csv_filepath(self.props.active_cost_schedule_id)
+            
+            if file_path:
+                row_1.label(text=file_path)
                 row_1.operator("bim.refresh_cost_schedule_csv", icon="FILE_REFRESH", text="")
             else:
                 row_1.label(text="No CSV file found")

--- a/src/bonsai/bonsai/bim/module/cost/ui.py
+++ b/src/bonsai/bonsai/bim/module/cost/ui.py
@@ -222,7 +222,7 @@ class BIM_PT_cost_schedules(Panel):
         quantities = CostSchedulesData.data["cost_quantities"]
         row = self.layout.row(align=True)
         # In IFC, all quantities of IfcCostTime should have 1 type.
-        if quantities:
+        if quantities and cost_item.get("QuantityType"):
             quantity_class = cost_item["QuantityType"]
             row.label(text=quantity_class)
         else:

--- a/src/bonsai/bonsai/bim/module/cost/ui.py
+++ b/src/bonsai/bonsai/bim/module/cost/ui.py
@@ -76,10 +76,10 @@ class BIM_PT_cost_schedules(Panel):
             col = row0.column()
             col.label(text="Linked CSV:")
             row_1 = col.row(align=True)
-            
+
             csv_filepaths = CostSchedulesData.data["csv_filepaths"]
             file_path = csv_filepaths.get(self.props.active_cost_schedule_id)
-            
+
             if file_path:
                 row_1.label(text=file_path)
                 row_1.operator("bim.refresh_cost_schedule_csv", icon="FILE_REFRESH", text="")

--- a/src/bonsai/bonsai/bim/module/cost/ui.py
+++ b/src/bonsai/bonsai/bim/module/cost/ui.py
@@ -76,28 +76,10 @@ class BIM_PT_cost_schedules(Panel):
             col = row0.column()
             col.label(text="Linked CSV:")
             row_1 = col.row(align=True)
-
-            ifc_file = tool.Ifc.get()
-            cost_docs_document = next(
-                (
-                    document
-                    for document in ifc_file.by_type("IfcDocumentInformation")
-                    if document.Name == "BBIM_Cost_Documents"
-                ),
-                None,
-            )
-
-            file_path = None
-            if cost_docs_document:
-                references = tool.Document.get_document_references(cost_docs_document)
-                for reference in references:
-                    if (
-                        reference.Description
-                        and f"Cost Schedule ID: {self.props.active_cost_schedule_id}" in reference.Description
-                    ):
-                        file_path = reference.Location
-                        break
-
+            
+            csv_filepaths = CostSchedulesData.data["csv_filepaths"]
+            file_path = csv_filepaths.get(self.props.active_cost_schedule_id)
+            
             if file_path:
                 row_1.label(text=file_path)
                 row_1.operator("bim.refresh_cost_schedule_csv", icon="FILE_REFRESH", text="")

--- a/src/bonsai/bonsai/core/cost.py
+++ b/src/bonsai/bonsai/core/cost.py
@@ -349,7 +349,6 @@ def import_cost_schedule_csv(
 def add_csv_filepath(cost: type[tool.Cost], file_path: str, is_schedule_of_rates: bool, cost_schedule) -> None:
     cost.add_csv_filepath(file_path, is_schedule_of_rates, cost_schedule)
 
-
 def remove_csv_filepath(cost: type[tool.Cost], cost_schedule) -> None:
     cost.remove_csv_filepath(cost_schedule)
 

--- a/src/bonsai/bonsai/core/cost.py
+++ b/src/bonsai/bonsai/core/cost.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Union, Literal
-import bonsai.tool as tool
 import os
 from bonsai.bim.module.cost.data import CostSchedulesData
 
@@ -26,6 +25,7 @@ if TYPE_CHECKING:
     import bpy
     import ifcopenshell
     import ifcopenshell.util.cost
+    import bonsai.tool as tool
 
 
 def add_cost_schedule(ifc: type[tool.Ifc], name: str, predefined_type: str) -> None:
@@ -342,13 +342,9 @@ def select_cost_schedule_products(
 
 
 def import_cost_schedule_csv(
-    cost: type[tool.Cost], file_path: str, is_schedule_of_rates: bool
+    cost: type[tool.Cost], resolved_path: str, is_schedule_of_rates: bool
 ) -> ifcopenshell.entity_instance:
 
-    resolved_path = tool.Ifc.resolve_uri(file_path)
-    if not os.path.exists(resolved_path):
-        print(f"Error: Could not find CSV file at {file_path} (resolved to {resolved_path})")
-        return None
 
     cost_schedule = cost.import_cost_schedule_csv(resolved_path, is_schedule_of_rates)
     return cost_schedule
@@ -364,18 +360,7 @@ def remove_csv_filepath(cost: type[tool.Cost], cost_schedule) -> None:
 
 def refresh_cost_schedule_csv(cost: type[tool.Cost]) -> Optional[str]:
 
-    props = cost.get_cost_props()
-    cost_schedule_id = props.active_cost_schedule_id
-    file_path = cost.get_cost_schedule_csv_filepath(cost_schedule_id)
-
-    if not file_path:
-        return "No CSV file associated with this cost schedule"
-
-    resolved_path = tool.Ifc.resolve_uri(file_path)
-
-    if not os.path.exists(resolved_path):
-        return f"Could not find CSV file at {file_path} (resolved to {resolved_path})"
-
+    
     cost.delete_all_cost_items()
     cost.refresh_cost_schedule_csv()
     cost.load_cost_schedule_tree()
@@ -489,9 +474,7 @@ def generate_cost_schedule_browser(
     return cost.generate_cost_schedule_browser(cost_schedule)
 
 
-def get_cost_schedule_csv_filepath(cost: type[tool.Cost], cost_schedule_id: int) -> Optional[str]:
-    return cost.get_cost_schedule_csv_filepath(cost_schedule_id)
 
 
-def is_schedule_of_rates_csv(cost: type[tool.Cost], cost_schedule_id: int) -> bool:
-    return cost.is_schedule_of_rates_csv(cost_schedule_id)
+
+

--- a/src/bonsai/bonsai/core/cost.py
+++ b/src/bonsai/bonsai/core/cost.py
@@ -18,12 +18,14 @@
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Union, Literal
+import bonsai.tool as tool
+import os
+from bonsai.bim.module.cost.data import CostSchedulesData
 
 if TYPE_CHECKING:
     import bpy
     import ifcopenshell
     import ifcopenshell.util.cost
-    import bonsai.tool as tool
 
 
 def add_cost_schedule(ifc: type[tool.Ifc], name: str, predefined_type: str) -> None:
@@ -342,7 +344,13 @@ def select_cost_schedule_products(
 def import_cost_schedule_csv(
     cost: type[tool.Cost], file_path: str, is_schedule_of_rates: bool
 ) -> ifcopenshell.entity_instance:
-    cost_schedule = cost.import_cost_schedule_csv(file_path, is_schedule_of_rates)
+
+    resolved_path = tool.Ifc.resolve_uri(file_path)
+    if not os.path.exists(resolved_path):
+        print(f"Error: Could not find CSV file at {file_path} (resolved to {resolved_path})")
+        return None
+
+    cost_schedule = cost.import_cost_schedule_csv(resolved_path, is_schedule_of_rates)
     return cost_schedule
 
 
@@ -354,10 +362,27 @@ def remove_csv_filepath(cost: type[tool.Cost], cost_schedule) -> None:
     cost.remove_csv_filepath(cost_schedule)
 
 
-def refresh_cost_schedule_csv(ifc: type[tool.Ifc], cost: type[tool.Cost]) -> None:
+def refresh_cost_schedule_csv(cost: type[tool.Cost]) -> Optional[str]:
+
+    props = cost.get_cost_props()
+    cost_schedule_id = props.active_cost_schedule_id
+    file_path = cost.get_cost_schedule_csv_filepath(cost_schedule_id)
+
+    if not file_path:
+        return "No CSV file associated with this cost schedule"
+
+    resolved_path = tool.Ifc.resolve_uri(file_path)
+
+    if not os.path.exists(resolved_path):
+        return f"Could not find CSV file at {file_path} (resolved to {resolved_path})"
+
     cost.delete_all_cost_items()
     cost.refresh_cost_schedule_csv()
     cost.load_cost_schedule_tree()
+
+    CostSchedulesData.is_loaded = False
+
+    return None
 
 
 def add_cost_column(cost: type[tool.Cost], name: str) -> None:
@@ -462,3 +487,11 @@ def generate_cost_schedule_browser(
     cost: type[tool.Cost], cost_schedule: ifcopenshell.entity_instance
 ) -> bpy.types.Panel:
     return cost.generate_cost_schedule_browser(cost_schedule)
+
+
+def get_cost_schedule_csv_filepath(cost: type[tool.Cost], cost_schedule_id: int) -> Optional[str]:
+    return cost.get_cost_schedule_csv_filepath(cost_schedule_id)
+
+
+def is_schedule_of_rates_csv(cost: type[tool.Cost], cost_schedule_id: int) -> bool:
+    return cost.is_schedule_of_rates_csv(cost_schedule_id)

--- a/src/bonsai/bonsai/core/cost.py
+++ b/src/bonsai/bonsai/core/cost.py
@@ -18,8 +18,6 @@
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Union, Literal
-import os
-from bonsai.bim.module.cost.data import CostSchedulesData
 
 if TYPE_CHECKING:
     import bpy
@@ -345,7 +343,6 @@ def import_cost_schedule_csv(
     cost: type[tool.Cost], resolved_path: str, is_schedule_of_rates: bool
 ) -> ifcopenshell.entity_instance:
 
-
     cost_schedule = cost.import_cost_schedule_csv(resolved_path, is_schedule_of_rates)
     return cost_schedule
 
@@ -359,15 +356,9 @@ def remove_csv_filepath(cost: type[tool.Cost], cost_schedule) -> None:
 
 
 def refresh_cost_schedule_csv(cost: type[tool.Cost]) -> Optional[str]:
-
-    
     cost.delete_all_cost_items()
     cost.refresh_cost_schedule_csv()
     cost.load_cost_schedule_tree()
-
-    CostSchedulesData.is_loaded = False
-
-    return None
 
 
 def add_cost_column(cost: type[tool.Cost], name: str) -> None:
@@ -472,9 +463,3 @@ def generate_cost_schedule_browser(
     cost: type[tool.Cost], cost_schedule: ifcopenshell.entity_instance
 ) -> bpy.types.Panel:
     return cost.generate_cost_schedule_browser(cost_schedule)
-
-
-
-
-
-

--- a/src/bonsai/bonsai/core/cost.py
+++ b/src/bonsai/bonsai/core/cost.py
@@ -349,6 +349,7 @@ def import_cost_schedule_csv(
 def add_csv_filepath(cost: type[tool.Cost], file_path: str, is_schedule_of_rates: bool, cost_schedule) -> None:
     cost.add_csv_filepath(file_path, is_schedule_of_rates, cost_schedule)
 
+
 def remove_csv_filepath(cost: type[tool.Cost], cost_schedule) -> None:
     cost.remove_csv_filepath(cost_schedule)
 

--- a/src/bonsai/bonsai/tool/cost.py
+++ b/src/bonsai/bonsai/tool/cost.py
@@ -603,12 +603,12 @@ class Cost(bonsai.core.tool.Cost):
             ),
             None,
         )
-        
+
         if not cost_docs_document:
             cost_docs_document = ifcopenshell.api.document.add_information(ifc_file)
             cost_docs_document.Name = "BBIM_Cost_Documents"
             cost_docs_document.Description = "Bonsai internal document containing references to cost CSV files"
-        
+
         return cost_docs_document
 
     @classmethod
@@ -1097,6 +1097,3 @@ class Cost(bonsai.core.tool.Cost):
         if results["quantity_type"] == "IfcQuantityCount":
             results["unit_symbol"] = "U"
         return results
-
-
-

--- a/src/bonsai/bonsai/tool/cost.py
+++ b/src/bonsai/bonsai/tool/cost.py
@@ -590,38 +590,67 @@ class Cost(bonsai.core.tool.Cost):
         return csv2ifc.cost_schedule
 
     @classmethod
-    def add_csv_filepath(
-        cls,
-        file_path: Optional[str] = None,
-        is_schedule_of_rates: bool = False,
-        cost_schedule: ifcopenshell.entity_instance = None,
-    ) -> None:
-        if not file_path:
+    def add_csv_filepath(cls, file_path: str, is_schedule_of_rates: bool, cost_schedule) -> None:
+        """Store CSV filepath as a document reference in the IFC file."""
+        if not file_path or not cost_schedule:
             return
 
-        props = cls.get_cost_props()
-        if not props.active_cost_schedule_id in [item.cost_schedule_id for item in props.cost_schedule_files]:
-            item = props.cost_schedule_files.add()
-            item.cost_schedule_id = cost_schedule.id()
-            item.csv_filepath = file_path
+        ifc_file = tool.Ifc.get()
+        cost_docs_document = next(
+            (
+                document
+                for document in ifc_file.by_type("IfcDocumentInformation")
+                if document.Name == "BBIM_Cost_Documents"
+            ),
+            None,
+        )
+
+        if not cost_docs_document:
+            cost_docs_document = ifcopenshell.api.document.add_information(ifc_file)
+            cost_docs_document.Name = "BBIM_Cost_Documents"
+            cost_docs_document.Description = "Bonsai internal document containing references to cost CSV files"
+
+        # Create a reference with the filepath
+        reference = ifcopenshell.api.document.add_reference(ifc_file, cost_docs_document)
+        reference.Location = file_path
+        
+        # Store the cost schedule ID in the reference description
+        reference.Description = f"Cost Schedule ID: {cost_schedule.id()}"
+        
+        # If it's a schedule of rates, store that info too
+        if is_schedule_of_rates:
+            reference.Identification = "SCHEDULE_OF_RATES"
         else:
-            return
+            reference.Identification = "COST_SCHEDULE"
 
     @classmethod
     def remove_csv_filepath(cls, cost_schedule: ifcopenshell.entity_instance = None) -> None:
+        """Remove CSV filepath reference from IFC file."""
         if not cost_schedule:
             return
 
-        props = cls.get_cost_props()
-        cost_schedule_id = cost_schedule.id()
-        if cost_schedule_id in [item.cost_schedule_id for item in props.cost_schedule_files]:
-            for i, item in enumerate(props.cost_schedule_files):
-                if item.cost_schedule_id == cost_schedule_id:
-                    props.cost_schedule_files.remove(i)
-                    print(f"Cost schedule id={cost_schedule_id} csv filepath correctly removed")
-                    return
-        else:
+        ifc_file = tool.Ifc.get()
+        cost_docs_document = next(
+            (
+                document
+                for document in ifc_file.by_type("IfcDocumentInformation")
+                if document.Name == "BBIM_Cost_Documents"
+            ),
+            None,
+        )
+
+        if not cost_docs_document:
             return
+
+        cost_schedule_id = cost_schedule.id()
+        references = tool.Document.get_document_references(cost_docs_document)
+        
+        for reference in references:
+            # Check if this reference is for the given cost schedule
+            if reference.Description and f"Cost Schedule ID: {cost_schedule_id}" in reference.Description:
+                ifcopenshell.api.document.remove_reference(ifc_file, reference)
+                print(f"Cost schedule id={cost_schedule_id} csv filepath correctly removed")
+                return
 
     @classmethod
     def delete_all_cost_items(cls):
@@ -633,24 +662,74 @@ class Cost(bonsai.core.tool.Cost):
             tool.Cost.clean_up_cost_item_tree(cost_item_id)
 
     @classmethod
+    def is_schedule_of_rates_csv(cls, cost_schedule_id: int) -> bool:
+        """Check if a cost schedule is a schedule of rates based on document references."""
+        ifc_file = tool.Ifc.get()
+        cost_docs_document = next(
+            (
+                document
+                for document in ifc_file.by_type("IfcDocumentInformation")
+                if document.Name == "BBIM_Cost_Documents"
+            ),
+            None,
+        )
+
+        if not cost_docs_document:
+            return False
+
+        references = tool.Document.get_document_references(cost_docs_document)
+        
+        for reference in references:
+            if reference.Description and f"Cost Schedule ID: {cost_schedule_id}" in reference.Description:
+                return reference.Identification == "SCHEDULE_OF_RATES"
+                
+        return False
+
+    @classmethod
+    def get_cost_schedule_csv_filepath(cls, cost_schedule_id: int) -> Optional[str]:
+        """Get CSV filepath for a cost schedule from document references."""
+        ifc_file = tool.Ifc.get()
+        cost_docs_document = next(
+            (
+                document
+                for document in ifc_file.by_type("IfcDocumentInformation")
+                if document.Name == "BBIM_Cost_Documents"
+            ),
+            None,
+        )
+
+        if not cost_docs_document:
+            return None
+
+        references = tool.Document.get_document_references(cost_docs_document)
+        
+        for reference in references:
+            if reference.Description and f"Cost Schedule ID: {cost_schedule_id}" in reference.Description:
+                return reference.Location
+                
+        return None
+
+
+    @classmethod
     def refresh_cost_schedule_csv(cls):
+        """Refresh cost schedule from CSV file stored in document references."""
         from ifc5d.csv2ifc import Csv2Ifc
 
         props = cls.get_cost_props()
         cost_schedule_id = props.active_cost_schedule_id
-        file_path = next(
-            (item.csv_filepath for item in props.cost_schedule_files if item.cost_schedule_id == cost_schedule_id), None
-        )
+        file_path = cls.get_cost_schedule_csv_filepath(cost_schedule_id)
+        
         if not file_path:
             return
 
         cost_schedule = tool.Ifc.get_entity_by_id(cost_schedule_id)
+        is_schedule_of_rates = cls.is_schedule_of_rates_csv(cost_schedule_id)
 
         csv2ifc = Csv2Ifc()
         csv2ifc.csv = file_path
         csv2ifc.file = tool.Ifc.get()
         csv2ifc.cost_schedule = cost_schedule
-        csv2ifc.is_schedule_of_rates = False
+        csv2ifc.is_schedule_of_rates = is_schedule_of_rates
         csv2ifc.refresh()
 
         print("Csv file correctly refreshed")
@@ -1032,3 +1111,51 @@ class Cost(bonsai.core.tool.Cost):
         if results["quantity_type"] == "IfcQuantityCount":
             results["unit_symbol"] = "U"
         return results
+
+    @classmethod
+    def get_cost_schedule_documents(cls) -> Union[ifcopenshell.entity_instance, None]:
+        """Get the document information entity that stores CSV references."""
+        for document in tool.Ifc.get().by_type("IfcDocumentInformation"):
+            if document.Name == "BBIM_Cost_Documents":
+                return document
+        return None
+
+    @classmethod
+    def add_csv_filepath(
+        cls,
+        file_path: Optional[str] = None,
+        is_schedule_of_rates: bool = False,
+        cost_schedule: ifcopenshell.entity_instance = None,
+    ) -> None:
+        """Store CSV filepath as a document reference in the IFC file."""
+        if not file_path or not cost_schedule:
+            return
+
+        ifc_file = tool.Ifc.get()
+        cost_docs_document = next(
+            (
+                document
+                for document in ifc_file.by_type("IfcDocumentInformation")
+                if document.Name == "BBIM_Cost_Documents"
+            ),
+            None,
+        )
+
+        if not cost_docs_document:
+            cost_docs_document = ifcopenshell.api.document.add_information(ifc_file)
+            cost_docs_document.Name = "BBIM_Cost_Documents"
+            cost_docs_document.Description = "Bonsai internal document containing references to cost CSV files"
+
+        # Create a reference with the filepath
+        reference = ifcopenshell.api.document.add_reference(ifc_file, cost_docs_document)
+        reference.Location = file_path
+        
+        # Store the cost schedule ID in the reference description
+        reference.Description = f"Cost Schedule ID: {cost_schedule.id()}"
+        
+        # If it's a schedule of rates, store that info too
+        if is_schedule_of_rates:
+            reference.Identification = "SCHEDULE_OF_RATES"
+        else:
+            reference.Identification = "COST_SCHEDULE"
+

--- a/src/bonsai/bonsai/tool/cost.py
+++ b/src/bonsai/bonsai/tool/cost.py
@@ -593,10 +593,7 @@ class Cost(bonsai.core.tool.Cost):
         return csv2ifc.cost_schedule
 
     @classmethod
-    def add_csv_filepath(cls, file_path: str, is_schedule_of_rates: bool, cost_schedule) -> None:
-        if not file_path or not cost_schedule:
-            return
-
+    def get_or_create_cost_documents(cls) -> ifcopenshell.entity_instance:
         ifc_file = tool.Ifc.get()
         cost_docs_document = next(
             (
@@ -606,11 +603,26 @@ class Cost(bonsai.core.tool.Cost):
             ),
             None,
         )
-
+        
         if not cost_docs_document:
             cost_docs_document = ifcopenshell.api.document.add_information(ifc_file)
             cost_docs_document.Name = "BBIM_Cost_Documents"
             cost_docs_document.Description = "Bonsai internal document containing references to cost CSV files"
+        
+        return cost_docs_document
+
+    @classmethod
+    def add_csv_filepath(
+        cls,
+        file_path: Optional[str] = None,
+        is_schedule_of_rates: bool = False,
+        cost_schedule: ifcopenshell.entity_instance = None,
+    ) -> None:
+        if not file_path or not cost_schedule:
+            return
+
+        ifc_file = tool.Ifc.get()
+        cost_docs_document = cls.get_or_create_cost_documents()
 
         reference = ifcopenshell.api.document.add_reference(ifc_file, cost_docs_document)
         reference.Location = file_path
@@ -628,14 +640,7 @@ class Cost(bonsai.core.tool.Cost):
             return
 
         ifc_file = tool.Ifc.get()
-        cost_docs_document = next(
-            (
-                document
-                for document in ifc_file.by_type("IfcDocumentInformation")
-                if document.Name == "BBIM_Cost_Documents"
-            ),
-            None,
-        )
+        cost_docs_document = cls.get_or_create_cost_documents()
 
         if not cost_docs_document:
             return
@@ -646,7 +651,6 @@ class Cost(bonsai.core.tool.Cost):
         for reference in references:
             if reference.Description and f"Cost Schedule ID: {cost_schedule_id}" in reference.Description:
                 ifcopenshell.api.document.remove_reference(ifc_file, reference)
-                print(f"Cost schedule id={cost_schedule_id} csv filepath correctly removed")
                 return
 
     @classmethod
@@ -661,15 +665,7 @@ class Cost(bonsai.core.tool.Cost):
     @classmethod
     def is_schedule_of_rates_csv(cls, cost_schedule_id: int) -> bool:
         """Check if a cost schedule is a schedule of rates based on document references."""
-        ifc_file = tool.Ifc.get()
-        cost_docs_document = next(
-            (
-                document
-                for document in ifc_file.by_type("IfcDocumentInformation")
-                if document.Name == "BBIM_Cost_Documents"
-            ),
-            None,
-        )
+        cost_docs_document = cls.get_or_create_cost_documents()
 
         if not cost_docs_document:
             return False
@@ -684,15 +680,7 @@ class Cost(bonsai.core.tool.Cost):
 
     @classmethod
     def get_cost_schedule_csv_filepath(cls, cost_schedule_id: int) -> Optional[str]:
-        ifc_file = tool.Ifc.get()
-        cost_docs_document = next(
-            (
-                document
-                for document in ifc_file.by_type("IfcDocumentInformation")
-                if document.Name == "BBIM_Cost_Documents"
-            ),
-            None,
-        )
+        cost_docs_document = cls.get_or_create_cost_documents()
 
         if not cost_docs_document:
             return None
@@ -1110,12 +1098,5 @@ class Cost(bonsai.core.tool.Cost):
             results["unit_symbol"] = "U"
         return results
 
-    @classmethod
-    def get_cost_schedule_documents(cls) -> Union[ifcopenshell.entity_instance, None]:
-        """Get the document information entity that stores CSV references."""
-        for document in tool.Ifc.get().by_type("IfcDocumentInformation"):
-            if document.Name == "BBIM_Cost_Documents":
-                return document
-        return None
 
 

--- a/src/bonsai/bonsai/tool/cost.py
+++ b/src/bonsai/bonsai/tool/cost.py
@@ -584,14 +584,16 @@ class Cost(bonsai.core.tool.Cost):
         import time
 
         start = time.time()
-        csv2ifc = Csv2Ifc(file_path, tool.Ifc.get(), is_schedule_of_rates=is_schedule_of_rates)
+
+        resolved_path = tool.Ifc.resolve_uri(file_path)
+
+        csv2ifc = Csv2Ifc(resolved_path, tool.Ifc.get(), is_schedule_of_rates=is_schedule_of_rates)
         csv2ifc.execute()
         print("Import finished in {:.2f} seconds".format(time.time() - start))
         return csv2ifc.cost_schedule
 
     @classmethod
     def add_csv_filepath(cls, file_path: str, is_schedule_of_rates: bool, cost_schedule) -> None:
-        """Store CSV filepath as a document reference in the IFC file."""
         if not file_path or not cost_schedule:
             return
 
@@ -610,14 +612,11 @@ class Cost(bonsai.core.tool.Cost):
             cost_docs_document.Name = "BBIM_Cost_Documents"
             cost_docs_document.Description = "Bonsai internal document containing references to cost CSV files"
 
-        # Create a reference with the filepath
         reference = ifcopenshell.api.document.add_reference(ifc_file, cost_docs_document)
         reference.Location = file_path
-        
-        # Store the cost schedule ID in the reference description
+
         reference.Description = f"Cost Schedule ID: {cost_schedule.id()}"
-        
-        # If it's a schedule of rates, store that info too
+
         if is_schedule_of_rates:
             reference.Identification = "SCHEDULE_OF_RATES"
         else:
@@ -625,7 +624,6 @@ class Cost(bonsai.core.tool.Cost):
 
     @classmethod
     def remove_csv_filepath(cls, cost_schedule: ifcopenshell.entity_instance = None) -> None:
-        """Remove CSV filepath reference from IFC file."""
         if not cost_schedule:
             return
 
@@ -644,9 +642,8 @@ class Cost(bonsai.core.tool.Cost):
 
         cost_schedule_id = cost_schedule.id()
         references = tool.Document.get_document_references(cost_docs_document)
-        
+
         for reference in references:
-            # Check if this reference is for the given cost schedule
             if reference.Description and f"Cost Schedule ID: {cost_schedule_id}" in reference.Description:
                 ifcopenshell.api.document.remove_reference(ifc_file, reference)
                 print(f"Cost schedule id={cost_schedule_id} csv filepath correctly removed")
@@ -678,16 +675,15 @@ class Cost(bonsai.core.tool.Cost):
             return False
 
         references = tool.Document.get_document_references(cost_docs_document)
-        
+
         for reference in references:
             if reference.Description and f"Cost Schedule ID: {cost_schedule_id}" in reference.Description:
                 return reference.Identification == "SCHEDULE_OF_RATES"
-                
+
         return False
 
     @classmethod
     def get_cost_schedule_csv_filepath(cls, cost_schedule_id: int) -> Optional[str]:
-        """Get CSV filepath for a cost schedule from document references."""
         ifc_file = tool.Ifc.get()
         cost_docs_document = next(
             (
@@ -702,31 +698,33 @@ class Cost(bonsai.core.tool.Cost):
             return None
 
         references = tool.Document.get_document_references(cost_docs_document)
-        
+
         for reference in references:
             if reference.Description and f"Cost Schedule ID: {cost_schedule_id}" in reference.Description:
                 return reference.Location
-                
-        return None
 
+        return None
 
     @classmethod
     def refresh_cost_schedule_csv(cls):
         """Refresh cost schedule from CSV file stored in document references."""
         from ifc5d.csv2ifc import Csv2Ifc
+        import os
 
         props = cls.get_cost_props()
         cost_schedule_id = props.active_cost_schedule_id
         file_path = cls.get_cost_schedule_csv_filepath(cost_schedule_id)
-        
+
         if not file_path:
             return
+
+        resolved_path = tool.Ifc.resolve_uri(file_path)
 
         cost_schedule = tool.Ifc.get_entity_by_id(cost_schedule_id)
         is_schedule_of_rates = cls.is_schedule_of_rates_csv(cost_schedule_id)
 
         csv2ifc = Csv2Ifc()
-        csv2ifc.csv = file_path
+        csv2ifc.csv = resolved_path
         csv2ifc.file = tool.Ifc.get()
         csv2ifc.cost_schedule = cost_schedule
         csv2ifc.is_schedule_of_rates = is_schedule_of_rates
@@ -1120,42 +1118,4 @@ class Cost(bonsai.core.tool.Cost):
                 return document
         return None
 
-    @classmethod
-    def add_csv_filepath(
-        cls,
-        file_path: Optional[str] = None,
-        is_schedule_of_rates: bool = False,
-        cost_schedule: ifcopenshell.entity_instance = None,
-    ) -> None:
-        """Store CSV filepath as a document reference in the IFC file."""
-        if not file_path or not cost_schedule:
-            return
-
-        ifc_file = tool.Ifc.get()
-        cost_docs_document = next(
-            (
-                document
-                for document in ifc_file.by_type("IfcDocumentInformation")
-                if document.Name == "BBIM_Cost_Documents"
-            ),
-            None,
-        )
-
-        if not cost_docs_document:
-            cost_docs_document = ifcopenshell.api.document.add_information(ifc_file)
-            cost_docs_document.Name = "BBIM_Cost_Documents"
-            cost_docs_document.Description = "Bonsai internal document containing references to cost CSV files"
-
-        # Create a reference with the filepath
-        reference = ifcopenshell.api.document.add_reference(ifc_file, cost_docs_document)
-        reference.Location = file_path
-        
-        # Store the cost schedule ID in the reference description
-        reference.Description = f"Cost Schedule ID: {cost_schedule.id()}"
-        
-        # If it's a schedule of rates, store that info too
-        if is_schedule_of_rates:
-            reference.Identification = "SCHEDULE_OF_RATES"
-        else:
-            reference.Identification = "COST_SCHEDULE"
 


### PR DESCRIPTION
This is a proposal for https://github.com/IfcOpenShell/IfcOpenShell/issues/6570#issuecomment-2994413876 item:
link an external .csv with the imported IfcCostSchedule and store the filepath in order to be able to refresh it "on the fly" (create a new refresh button) (testing) (store the .csv file as a document)

Cheers!
