### PR TITLE
Limit clipping plane euler rotation angles to <= 360 degrees

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -2486,6 +2486,7 @@ class FlipClippingPlane(bpy.types.Operator):
         obj = context.active_object
         if obj in tool.Project.get_project_props().clipping_planes_objs:
             obj.rotation_euler[0] += radians(180)
+            obj.rotation_euler[0] %= radians(360)
             context.view_layer.update()
         return {"FINISHED"}
 


### PR DESCRIPTION
The "Flip Clipping Plane" operator adds 180 degrees to the angle's value, meaning the angle will keep increasing with each press.