### PR TITLE
Partial fix for #6906 - Improve Merge/Mirror error messages to reduce confusion.

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -1303,6 +1303,20 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
         if not bpy.context.selected_objects:
             return
         if self.active_material_usage == "LAYER2":
+            if len(bpy.context.selected_objects) != 2:
+                self.report(
+                    {"ERROR"},
+                    "Exactly two LAYER2 items (walls, railings, etc) must be selected to perform a merge.",
+                )
+                return
+            for item in bpy.context.selected_objects:
+                element = tool.Ifc.get_entity(item)
+                if tool.Model.get_usage_type(element) != "LAYER2":
+                    self.report(
+                        {"ERROR"},
+                        "Both selected items must be LAYER2 (walls, railings, etc) to perform a merge.",
+                    )
+                    return
             bpy.ops.bim.merge_wall()
         else:
             if len(bpy.context.selected_objects) == 1:


### PR DESCRIPTION
Partial fix for #6906 - Improves the pop-up messages when people try use the Mirror/Merge buttons with incorrect sets of objects.

Couple of questions still to be answered:
1. Should these error messages be push out of the hotkey_S_M function to the respective bim.merge_wall and bim.mirror_elements operators.
2. The Mirror/Merge both call the same function, and the action taken is dependent on what the active object is. This is really confusing, and should probably be properly separated.