### PR TITLE
IfcCostSchedule PDF Export: Add Analysis of Rates

### DIFF
--- a/src/bonsai/bonsai/bim/module/cost/operator.py
+++ b/src/bonsai/bonsai/bim/module/cost/operator.py
@@ -936,7 +936,7 @@ class ExportCostSchedulesToPDF(bpy.types.Operator, ExportHelper):
     )
     should_print_analysis_of_rates: bpy.props.BoolProperty(
         name="Analysis of rates",
-        description="Print Analysis of Rates at the\n end of the document",
+        description="If printing a Schedule of Rates, display\nthe Analysis of Rates for each\nitem that has more than one Cost Value.",
         default=True,
     )
     force_schedule_type: bpy.props.EnumProperty(

--- a/src/bonsai/bonsai/bim/module/cost/operator.py
+++ b/src/bonsai/bonsai/bim/module/cost/operator.py
@@ -940,12 +940,12 @@ class ExportCostSchedulesToPDF(bpy.types.Operator, ExportHelper):
         default=True,
     )
     force_schedule_type: bpy.props.EnumProperty(
-        name="Force output type",
-        description="Force the output to this type\nalso if it is not coincident with the cost schedule Predefined Type",
+        name="Output type",
+        description='Force the output to this type.\n"Auto" defaults to selected cost schedule Predefined Type',
         items=[
             (
-                "OFF",
-                "Off",
+                "AUTO",
+                "By PredefinedType",
                 "Uses Cost Schedule Predefined Type",
             ),
             (
@@ -959,7 +959,7 @@ class ExportCostSchedulesToPDF(bpy.types.Operator, ExportHelper):
                 "Forces the output as a schedule of rates",
             ),
         ],
-        default="OFF",
+        default="AUTO",
     )
 
     def draw(self, context):

--- a/src/bonsai/bonsai/bim/module/cost/operator.py
+++ b/src/bonsai/bonsai/bim/module/cost/operator.py
@@ -924,11 +924,6 @@ class ExportCostSchedulesToPDF(bpy.types.Operator, ExportHelper):
         description="Export the full list of quantities",
         default=False,
     )
-    should_print_each_cost_value: bpy.props.BoolProperty(
-        name="Show each cost value",
-        description="Export the full list of cost values\nassociated with each cost item\nin the schedule of rates",
-        default=False,
-    )
     should_print_rates: bpy.props.BoolProperty(
         name="Rates and totals",
         description="Print rates and totals for each voice",
@@ -937,6 +932,11 @@ class ExportCostSchedulesToPDF(bpy.types.Operator, ExportHelper):
     should_print_summary: bpy.props.BoolProperty(
         name="Final Summary",
         description="Print summary at the end of the document",
+        default=True,
+    )
+    should_print_analysis_of_rates: bpy.props.BoolProperty(
+        name="Analysis of rates",
+        description="Print Analysis of Rates at the\n end of the document",
         default=True,
     )
     force_schedule_type: bpy.props.EnumProperty(
@@ -967,6 +967,7 @@ class ExportCostSchedulesToPDF(bpy.types.Operator, ExportHelper):
         box = layout.box()
         box.label(text="Select Ifc Cost Schedule:")
         box.prop(self, "cost_schedules_enum", text="")
+        box.prop(self, "force_schedule_type")
         layout.separator()
         box = layout.box()
         box.label(text="Nested cost structure:")
@@ -980,7 +981,7 @@ class ExportCostSchedulesToPDF(bpy.types.Operator, ExportHelper):
         box.prop(self, "should_print_each_quantity")
         box.prop(self, "should_print_rates")
         box.prop(self, "should_print_summary")
-        box.prop(self, "force_schedule_type")
+        box.prop(self, "should_print_analysis_of_rates")
 
     @classmethod
     def poll(cls, context):
@@ -1023,7 +1024,7 @@ class ExportCostSchedulesToPDF(bpy.types.Operator, ExportHelper):
             "should_print_cost_ids": self.should_print_cost_ids,
             "should_print_description": self.should_print_description,
             "should_print_each_quantity": self.should_print_each_quantity,
-            "should_print_each_cost_value": self.should_print_each_cost_value,
+            "should_print_analysis_of_rates": self.should_print_analysis_of_rates,
             "should_print_rates": self.should_print_rates,
             "should_print_summary": self.should_print_summary,
         }

--- a/src/ifc5d/ifc5d/ifc5Dspreadsheet.py
+++ b/src/ifc5d/ifc5d/ifc5Dspreadsheet.py
@@ -44,6 +44,7 @@ class CostItem(TypedDict):
     Unit: str
     Quantities: str
     Quantity: Union[float, None]
+    CostValues: str
     RateSubtotal: float
     TotalPrice: float
 
@@ -157,6 +158,7 @@ class IfcDataGetter:
             "Unit": unit,
             "Quantities": IfcDataGetter.serialise_cost_quantities(file, cost_item),
             "Quantity": quantity_data["quantity"],
+            "CostValues": IfcDataGetter.serialise_cost_values(file, cost_item),
             "RateSubtotal": rate_subtotal,
             "TotalPrice": total_price,
             "cost_categories": cost_categories,
@@ -247,6 +249,32 @@ class IfcDataGetter:
             "quantity": total_cost_quantity,
             "unit": unit,
         }
+
+
+    @staticmethod
+    def serialise_cost_values(file: ifcopenshell.file, cost_item: ifcopenshell.entity_instance) -> str:
+        if not cost_item.is_a("IfcCostItem"):
+            return ""
+        if cost_item.CostValues is None:
+            return ""
+        if IfcDataGetter.cost_item_is_a_sum(cost_item):
+            return ""
+        string = '['
+        for cost_value in cost_item.CostValues:
+            cost_value_name = cost_value.Name or "Unnamed"
+            cost_value_description = cost_value.Description or ""
+            cost_value_category = cost_value.Category or "Not categorized"
+            applied_value = getattr(cost_value, "AppliedValue") 
+            if applied_value:
+                value = getattr(applied_value, "wrappedValue", 0.0)
+            string += '{"Category": "' + cost_value_category + '",'
+            string += '"Name": "' + cost_value_name + '",'
+            string += '"Description": "' + cost_value_description + '",'
+            string += '"Value": ' + str(value) + "},"
+        string = string.removesuffix(",")
+        string += ']'
+        return string
+    
 
     @staticmethod
     def serialise_cost_quantities(file: ifcopenshell.file, cost_item: ifcopenshell.entity_instance) -> str:
@@ -351,6 +379,7 @@ class Ifc5Dwriter:
             if cost_schedule.PredefinedType != "SCHEDULEOFRATES":
                 headers.insert(-1, "Quantities")
                 headers.insert(-1, "Quantity")
+            headers.extend(["CostValues"])
             headers.extend(["RateSubtotal", "TotalPrice"])
 
             # Handle cost categories.
@@ -604,9 +633,9 @@ class Ifc5DPdfWriter(Ifc5Dwriter):
             "should_print_cost_ids": True,
             "should_print_description": False,
             "should_print_each_quantity": True,
-            "should_print_each_cost_value": False,
             "should_print_rates": True,
             "should_print_summary": True,
+            "should_print_analysis_of_rates": True
         }
 
         HANDLED_COST_SCHEDULE_TYPES = (

--- a/src/ifc5d/ifc5d/ifc5Dspreadsheet.py
+++ b/src/ifc5d/ifc5d/ifc5Dspreadsheet.py
@@ -655,13 +655,13 @@ class Ifc5DPdfWriter(Ifc5Dwriter):
             cost_schedule_name = self.cost_schedule.Name or "Unnamed"
             if self.force_schedule_type in ("PRICEDBILLOFQUANTITIES", "SCHEDULEOFRATES"):
                 schedule_type = self.force_schedule_type
-            elif self.force_schedule_type is None or self.force_schedule_type == "OFF":
+            elif self.force_schedule_type is None or self.force_schedule_type == "AUTO":
                 schedule_type = self.cost_schedule.PredefinedType
                 if schedule_type not in HANDLED_COST_SCHEDULE_TYPES:
                     schedule_type = "PRICEDBILLOFQUANTITIES"
             else:
                 raise ValueError(
-                    "force_schedule_type can be set to OFF, PRICEDBILLOFQUANTITIES, SCHEDULEOFRATES values only."
+                    "force_schedule_type can be set to AUTO, PRICEDBILLOFQUANTITIES, SCHEDULEOFRATES values only."
                 )
             project_monetary_unit = self.file.by_type("IfcMonetaryUnit")
             if project_monetary_unit:

--- a/src/ifc5d/ifc5d/typst_template_ifc_cost_schedule.typ
+++ b/src/ifc5d/ifc5d/typst_template_ifc_cost_schedule.typ
@@ -3,9 +3,9 @@
 // year: 2025
 
 
-// custom cell styles
-#let total-cell-style = (stroke: (top: 0.25pt + gray))
-
+#let total-cell-style = (
+  stroke: (top: 0.25pt + gray)
+)
 
 
 #let root-cost-cell-style = (
@@ -15,9 +15,9 @@
 )
 
 
-
-#let template_fonts = ("Liberation Sans", "Roboto", "Arial", "Calibri")
-
+#let template_fonts = (
+  "Liberation Sans", "Roboto", "Arial", "Calibri"
+)
 
 
 #let euro(num) = {
@@ -25,35 +25,32 @@
 }
 
 
-
 #let bill_of_quantities_table = table(
   columns: (18mm,54mm, 12mm,12mm,12mm,12mm, 20mm, 20mm, 25mm),
-    rows: (6mm, 248mm),
-    align: (center, left, center, center, center, center, center, center, center),
-    stroke: (x, y) => (
-      left: if x == 0 { 1pt } else { 0.25pt },
-      right: 1pt,
-      top: 1pt,
-      bottom: 1pt
-    ),
-    [Hierarchy], [Description], [n°],[l],[w],[h/w], [Quantity], [Rate], [Total]
-  )
-
+  rows: (6mm, 248mm),
+  align: (center, left, center, center, center, center, center, center, center),
+  stroke: (x, y) => (
+    left: if x == 0 { 1pt } else { 0.25pt },
+    right: 1pt,
+    top: 1pt,
+    bottom: 1pt
+  ),
+  [Hierarchy], [Description], [n°],[l],[w],[h/w], [Quantity], [Rate], [Total]
+)
 
 
 #let schedule_of_rates_table = table(
   columns: (30mm,130mm, 25mm),
-    rows: (6mm, 248mm),
-    align: (center, left, center),
-    stroke: (x, y) => (
-      left: if x == 0 { 1pt } else { 0.25pt },
-      right: 1pt,
-      top: 1pt,
-      bottom: 1pt
-    ),
-    [Identification], [Description], [Rate]
-  )
-
+  rows: (6mm, 248mm),
+  align: (center, left, center),
+  stroke: (x, y) => (
+    left: if x == 0 { 1pt } else { 0.25pt },
+    right: 1pt,
+    top: 1pt,
+    bottom: 1pt
+  ),
+  [Identification], [Description], [Rate]
+)
 
   
 #let summary_table = table(
@@ -73,14 +70,12 @@
 )
 
 
-
 #let analysis_of_raters_table = table(
   columns: (185mm),
   rows: (254mm),
   stroke: 1pt,
   text(size: 8pt)[]
 )
-
 
 
 #let format_table = (
@@ -90,7 +85,6 @@
   "SUMMARY" : summary_table,
   "ANALYSISOFRATES": analysis_of_raters_table,
 )
-
 
 
 #let unit_map = (
@@ -106,16 +100,13 @@
 )
 
 
-
 #let format-decimal(num, places: 2) = {
   let rounded = calc.round(num, digits: places)
   let str-num = str(rounded)
-  
   // Split into integer and decimal parts
   let parts = str-num.split(".")
   let integer-part = parts.at(0)
   let decimal-part = parts.at(1, default: "")
-  
   // Add thousand separators to integer part
   let formatted-integer = ""
   let chars = integer-part.clusters().rev()
@@ -125,7 +116,6 @@
     }
     formatted-integer = char + formatted-integer
   }
-  
   // Ensure decimal part has correct number of places
   decimal-part = decimal-part + "0" * (places - decimal-part.len())
   
@@ -133,42 +123,45 @@
 }
 
 
-
-#let arrange_summary_row(row, options) = {
-  let name = strong(upper(row.at("Name")))
-  let description = [#par(justify: true, text(8pt, row.at("Description", default: "")))]
-  let total = if row.at("RateSubtotal") == "" {0.0} else {float(row.at("RateSubtotal"))}
-  if row.at("ItemIsASum") == "True" {   
-    if row.at("Index") == "1" {
-      // ROOT COST
-      (
-        strong[#row.at("Hierarchy")],
-        name,
-        [],
-        if options.at("should_print_rates") {
-          strong[#format-decimal(float(row.at("TotalPrice")), places: 2)]
-        } else {
-        }
-      )
-    } else {
-      // SUB-SECTION
-      ( 
-        row.at("Hierarchy"),
-        table.cell(inset: (left: int(row.at("Index"))*2.5mm))[#upper(row.at("Name"))],
-        if options.at("should_print_rates") {
-          format-decimal(float(row.at("TotalPrice")), places: 2)
-        } else {
-          []
-        }
-          ,
-        [],
-      )
-    }
-  } else {
-    ()
-  }
+#let create-cover(
+  title,
+  schedule_name,
+  schedule_description,
+  schedule_type,    
+) = {
+  set page(
+    numbering: none,
+    margin: (top: 35mm, left: 20mm, right: 10mm),
+    background: place( top + left, dx: 15mm, dy: 25mm,
+      table(
+        columns: 185mm,
+        rows: 254mm,
+        align: (center, left, center),
+        stroke: 1pt        
+      ) 
+    ),
+    footer: [
+    #set text(size: 7pt, fill: gray)
+    #align(right)[#linebreak()powered by IfcOpenShell]
+    ]
+  )
+  set text(font: template_fonts, size: 12pt)
+  place( bottom + left, dx: 0mm, dy: -10mm,
+    grid(
+      columns: (30mm, 135mm),
+      gutter: 2em,
+      align: top + left,
+      [Title:], [*#title*],
+      [Schedule:],[*#schedule_name*],
+      [Schedule Type:], [#schedule_type],
+      if schedule_description != "" {[Description:]},
+      if schedule_description != "" {[#schedule_description]},
+      [],[],
+      [#datetime.today().display("[day]/[month]/[year]")],[Signed],
+      [],[.................................],
+    )
+  )
 }
-
 
 
 #let arrange_bill_of_quantity_row(row, options) = {
@@ -286,6 +279,132 @@
 }
 
 
+#let arrange_schedule_of_rates_row(row, options) = {
+  let name = strong(upper(row.at("Name")))
+  let description = [#par(justify: true, text(8pt, row.at("Description", default: "")))]
+  let unit = table.cell(align: right)[#unit_map.at(row.at("Unit"), default: "")]
+  let rate = if row.at("RateSubtotal") == "" {0.0} else {
+      format-decimal(float(row.at("RateSubtotal")))}
+  if row.at("ItemIsASum") == "True" {return ()} //skip sections in schedule of rates
+  (
+    row.at("Identification"),
+    if row.at("Identification") == "" {name + linebreak() + description} else {name + linebreak() + description},
+    []
+  )
+  (
+    [],
+    table.cell(align: right+bottom)[#unit],
+    table.cell(align: right+bottom)[#rate],
+  )
+  (
+    [],[],[],
+  )
+}
+
+
+#let create-schedule(
+    path, 
+    delimiter: ",", 
+    type: "PRICEDBILLOFQUANTITIES",    
+    options: ()
+  ) = {
+  if type == "PRICEDBILLOFQUANTITIES" or type == "UNPRICEDBILLOFQUANTITIES"{
+    let data = csv(path, delimiter: delimiter, row-type: dictionary)
+    let new_rows = data.map(item => arrange_bill_of_quantity_row(item, options))
+    table(
+      columns: (18mm,1fr, 12mm,12mm,12mm,12mm, 20mm, 20mm, 25mm),
+      align: (center, left, center, center, center, center, right, right, right),
+      stroke: none,
+      ..new_rows.flatten()
+    )
+  } else if type == "SCHEDULEOFRATES" {
+    // REMEMBER TO CHECK IF THE ROW IS UNIQUE
+    let data = csv(path, delimiter: delimiter, row-type: dictionary)
+    let new_rows = data.map(item => arrange_schedule_of_rates_row(item, options))
+    table(
+      columns: (30mm,130mm, 25mm),
+      align: (center, left, right),
+      stroke: none,
+      ..new_rows.flatten()
+    )
+  }
+}
+
+
+#let arrange_summary_row(row, options) = {
+  let name = strong(upper(row.at("Name")))
+  let description = [#par(justify: true, text(8pt, row.at("Description", default: "")))]
+  let total = if row.at("RateSubtotal") == "" {0.0} else {float(row.at("RateSubtotal"))}
+  if row.at("ItemIsASum") == "True" {   
+    if row.at("Index") == "1" {
+      // ROOT COST
+      (
+        strong[#row.at("Hierarchy")],
+        name,
+        [],
+        if options.at("should_print_rates") {
+          strong[#format-decimal(float(row.at("TotalPrice")), places: 2)]
+        } else {
+        }
+      )
+    } else {
+      // SUB-SECTION
+      ( 
+        row.at("Hierarchy"),
+        table.cell(inset: (left: int(row.at("Index"))*2.5mm))[#upper(row.at("Name"))],
+        if options.at("should_print_rates") {
+          format-decimal(float(row.at("TotalPrice")), places: 2)
+        } else {
+          []
+        }
+          ,
+        [],
+      )
+    }
+  } else {
+    ()
+  }
+}
+
+
+#let create-summary(
+    path, 
+    delimiter: ",",
+    options
+  ) = {
+  let data = csv(path, delimiter: delimiter, row-type: dictionary)
+  let new_rows = data.map(item => arrange_summary_row(item, options))
+  let general_total = data.filter(row => row.at("Index") == "1") 
+   .map(row => float(row.at("TotalPrice")))
+   .sum(default: 0.00)
+  set text(size: 10pt)
+  pad(left: 2cm, top:5mm)[SUMMARY:]
+  set text(size: 8pt)
+  table(
+    columns: (18mm,107mm, 30mm, 30mm),
+    align: (center, left, right, right),
+    stroke: (x, y) => (
+      left: none,
+      right: none,
+      top: (thickness: 0.4pt, dash: "dotted"),
+      bottom:  (thickness: 0.4pt, dash: "dotted")
+    ),
+    ..new_rows.flatten()
+  )
+  set text(size: 10pt)
+  grid(
+  columns: (18mm,107mm, 30mm, 30mm),
+  align: (center, right, center, right),
+  inset: 1mm,
+  fill: gray.transparentize(70%),
+  [], strong[GENERAL TOTAL:], [],
+  if options.at("should_print_rates"){[#strong(format-decimal(general_total, places: 2))]
+  } else {
+    []
+  }
+)
+}
+
 
 #let arrange_analysis_row(row, options) = {
   if row.at("CostValues") == "" {
@@ -384,105 +503,6 @@
 }
 
 
-
-#let arrange_schedule_of_rates_row(row, options) = {
-  let name = strong(upper(row.at("Name")))
-  let description = [#par(justify: true, text(8pt, row.at("Description", default: "")))]
-  let unit = table.cell(align: right)[#unit_map.at(row.at("Unit"), default: "")]
-  let rate = if row.at("RateSubtotal") == "" {0.0} else {
-      format-decimal(float(row.at("RateSubtotal")))}
-  if row.at("ItemIsASum") == "True" {return ()} //skip sections in schedule of rates
-  (
-    row.at("Identification"),
-    if row.at("Identification") == "" {name + linebreak() + description} else {name + linebreak() + description},
-    []
-  )
-  (
-    [],
-    table.cell(align: right+bottom)[#unit],
-    table.cell(align: right+bottom)[#rate],
-  )
-  (
-    [],[],[],
-  )
-}
-
-
-
-#let create-schedule(
-    path, 
-    delimiter: ",", 
-    type: "PRICEDBILLOFQUANTITIES",    
-    options: ()
-  ) = {
-  if type == "PRICEDBILLOFQUANTITIES" or type == "UNPRICEDBILLOFQUANTITIES"{
-    let data = csv(path, delimiter: delimiter, row-type: dictionary)
-    let new_rows = data.map(item => arrange_bill_of_quantity_row(item, options))
-   
-    table(
-      columns: (18mm,1fr, 12mm,12mm,12mm,12mm, 20mm, 20mm, 25mm),
-      align: (center, left, center, center, center, center, right, right, right),
-      stroke: none,
-      ..new_rows.flatten()
-    )
-
-  } else if type == "SCHEDULEOFRATES" {
-    // REMEMBER TO CHECK IF THE ROW IS UNIQUE
-    let data = csv(path, delimiter: delimiter, row-type: dictionary)
-    let new_rows = data.map(item => arrange_schedule_of_rates_row(item, options))
-   
-    table(
-      columns: (30mm,130mm, 25mm),
-      align: (center, left, right),
-      stroke: none,
-      ..new_rows.flatten()
-    )
-  }
-}
-
-
-
-#let create-summary(
-    path, 
-    delimiter: ",",
-    options
-  ) = {
-  let data = csv(path, delimiter: delimiter, row-type: dictionary)
-  let new_rows = data.map(item => arrange_summary_row(item, options))
-  let general_total = data.filter(row => row.at("Index") == "1") 
-   .map(row => float(row.at("TotalPrice")))
-   .sum(default: 0.00)
-  
-  set text(size: 10pt)
-  pad(left: 2cm, top:5mm)[SUMMARY:]
-  
-  set text(size: 8pt)
-  table(
-    columns: (18mm,107mm, 30mm, 30mm),
-    align: (center, left, right, right),
-    stroke: (x, y) => (
-      left: none,
-      right: none,
-      top: (thickness: 0.4pt, dash: "dotted"),
-      bottom:  (thickness: 0.4pt, dash: "dotted")
-    ),
-    ..new_rows.flatten()
-  )
-  
-  set text(size: 10pt)
-  grid(
-  columns: (18mm,107mm, 30mm, 30mm),
-  align: (center, right, center, right),
-  inset: 1mm,
-  fill: gray.transparentize(70%),
-  [], strong[GENERAL TOTAL:], [],
-  if options.at("should_print_rates"){[#strong(format-decimal(general_total, places: 2))]
-  } else {
-    []
-  }
-)
-}
-
 #let create-analysis-of-rates(
     path: str, 
     delimiter: ",",
@@ -507,56 +527,11 @@
       pagebreak()
     }
   }
-
-}
-
-
-#let create-cover(
-  title,
-  schedule_name,
-  schedule_description,
-  schedule_type,    
-) = {
-  set page(
-    numbering: none,
-    margin: (top: 35mm, left: 20mm, right: 10mm),
-    background: place( top + left, dx: 15mm, dy: 25mm,
-      table(
-        columns: 185mm,
-        rows: 254mm,
-        align: (center, left, center),
-        stroke: 1pt        
-      ) 
-    ),
-    footer: [
-    #set text(size: 7pt, fill: gray)
-    #align(right)[#linebreak()powered by IfcOpenShell]
-    ]
-  )
-  set text(font: template_fonts, size: 12pt)
-  place( bottom + left, dx: 0mm, dy: -10mm,
-    grid(
-      columns: (30mm, 135mm),
-      gutter: 2em,
-      align: top + left,
-      [Title:], [*#title*],
-      [Schedule:],[*#schedule_name*],
-      [Schedule Type:], [#schedule_type],
-      if schedule_description != "" {[Description:]},
-      if schedule_description != "" {[#schedule_description]},
-      [],[],
-      [#datetime.today().display("[day]/[month]/[year]")],[Signed],
-      [],[.................................],
-    )
-  )
-  
-    
 }
 
 
 
 #let project(
-  
   schedule_path: "",
   title: "", 
   schedule_name: "",
@@ -574,7 +549,6 @@
   should_print_summary: bool,
   should_print_analysis_of_rates: bool,
   body) = {   
-  
   if should_print_cover {
     create-cover(
       title,
@@ -585,7 +559,6 @@
     pagebreak()
     counter(page).update(n => n - 1)
   }
-  
   set page(
     margin: (left: 15mm, right: 10mm, top: 31mm, bottom: 20mm),
     numbering: "1/1",
@@ -614,9 +587,7 @@
       format_table.at(schedule_type, default: bill_of_quantities_table)
     )
   )
-  
   set text(font: template_fonts, size: 8pt, lang: "en");
-
   let options = (
     "nested_structure_depth": nested_structure_depth,
     "parent_to_new_page_up_to_depth": parent_to_new_page_up_to_depth,
@@ -627,7 +598,6 @@
     "should_print_rates": should_print_rates,
     "should_print_analysis_of_rates": should_print_analysis_of_rates,
   )
-  
   if schedule_type == "UNPRICEDBILLOFQUANTITIES" {
     create-schedule(
       schedule_path, 
@@ -647,7 +617,6 @@
       options: options
     )
   }
-    
   if should_print_summary and schedule_type != "SCHEDULEOFRATES"{
     pagebreak()
     set text(font: template_fonts, size: 8pt, lang: "en");
@@ -659,7 +628,6 @@
   )
     create-summary(schedule_path, options)
   }
-
   if should_print_analysis_of_rates == true and schedule_type == "SCHEDULEOFRATES" {
     pagebreak()
     set page(

--- a/src/ifc5d/ifc5d/typst_template_ifc_cost_schedule.typ
+++ b/src/ifc5d/ifc5d/typst_template_ifc_cost_schedule.typ
@@ -74,12 +74,21 @@
 
 
 
-  
+#let analysis_of_raters_table = table(
+  columns: (185mm),
+  rows: (254mm),
+  stroke: 1pt,
+  text(size: 8pt)[]
+)
+
+
+
 #let format_table = (
   "SCHEDULEOFRATES": schedule_of_rates_table,
   "PRICEDBILLOFQUANTITIES" : bill_of_quantities_table,
   "UNPRICEDBILLOFQUANTITIES" : bill_of_quantities_table,
-  "SUMMARY" : summary_table
+  "SUMMARY" : summary_table,
+  "ANALYSISOFRATES": analysis_of_raters_table,
 )
 
 
@@ -92,6 +101,7 @@
   "m3": "m³",
   "VOLUMEUNIT / CUBIC_METRE": "m³",
   "KILOGRAM": "kg",
+  "": "",
   // add more mappings as needed
 )
 
@@ -277,6 +287,103 @@
 
 
 
+#let arrange_analysis_row(row, options) = {
+  if row.at("CostValues") == "" {
+    return none
+  }
+  let json_str = row.at("CostValues")
+  let cost_values = json.decode(json_str)
+  if cost_values.len() > 1 { 
+  //More than one value is present, item need analysis
+    // Create analysis header
+    (
+      table.cell(
+        stroke: (bottom: (thickness: 1pt),
+          top: (thickness: 1pt)
+        ), 
+        fill: gray.transparentize(90%),
+        align: bottom
+      )[#row.at("Identification")],
+      table.cell(
+        stroke: (bottom: (thickness: 1pt),
+          top: (thickness: 1pt)), 
+        fill: gray.transparentize(90%),
+        align: bottom
+      )[#row.at("Name")],
+      table.cell(
+        stroke: (bottom: (thickness: 1pt),
+          top: (thickness: 1pt)), 
+        fill: gray.transparentize(90%),
+        align: bottom
+      )[],
+    )
+    (
+      [],
+      table.cell(
+        colspan: 2,
+        stroke: (bottom: (thickness: 0.5pt))
+      )[#row.at("Description")],
+    )
+    (
+      [],[],[]
+    )
+    (
+      [],[Cost Values:],[]
+    )
+    // Arrange Cost Values table
+    let categories = ()
+    for cost_value in cost_values {
+      if not cost_value.at("Category") in categories {
+        categories.push(cost_value.at("Category"))
+      }
+    } 
+    for category in categories {
+      (
+        [],
+        table.cell(..root-cost-cell-style)[#category],
+        table.cell(..root-cost-cell-style)[],
+      )
+      let category_total = 0.0
+      for cost_value in cost_values {
+        if cost_value.at("Category") == category {
+          (
+            [],
+            cost_value.at("Name"),
+            format-decimal(cost_value.at("Value")),
+          )
+          category_total += cost_value.at("Value")
+        }
+      }
+      (
+        [],
+        table.cell(stroke: (top: (thickness: 0.5pt, dash: "dotted")), align: right)[Sum #category],
+        table.cell(stroke: (top: (thickness: 0.5pt, dash: "dotted")))[*#format-decimal(category_total)*],
+      )
+      (
+        [],[],[]
+      )
+    }
+    // Create cost value analysis final row
+    (
+      [],[],[]
+    )
+    (
+      [],
+      table.cell(
+        stroke: (top: (thickness: 0.5pt)),
+        align: right
+      )[Total rate value: #row.at("Name") #unit_map.at(row.at("Unit"), default: "")],
+      table.cell(
+        stroke: (top: (thickness: 0.5pt))
+      )[*#format-decimal(float(row.at("RateSubtotal", default: 0.0)))*]
+    )
+    (
+      [PAGEBREAK],
+    )
+  }
+}
+
+
 
 #let arrange_schedule_of_rates_row(row, options) = {
   let name = strong(upper(row.at("Name")))
@@ -347,7 +454,7 @@
    .sum(default: 0.00)
   
   set text(size: 10pt)
-  pad(left: 2cm)[SUMMARY:]
+  pad(left: 2cm, top:5mm)[SUMMARY:]
   
   set text(size: 8pt)
   table(
@@ -376,6 +483,32 @@
 )
 }
 
+#let create-analysis-of-rates(
+    path: str, 
+    delimiter: ",",
+    options: (),
+) = {
+  let data = csv(path, delimiter: delimiter, row-type: dictionary)
+  let new_rows = data.map(item => arrange_analysis_row(item, options))
+  let flattened_data = new_rows.flatten()
+  let cleaned_flattened_data = flattened_data.filter(item => item != none)
+  let splitted_data = cleaned_flattened_data.split([PAGEBREAK])
+  for (index, analysis) in splitted_data.slice(0,-1).enumerate(){
+    // Removed last item because it's none due to array splitting
+    set align(center)
+    [*ANALYSIS OF RATES*]
+    table(
+      columns: (30mm,130mm, 25mm),
+      align: (center, left, right),
+      stroke: none,
+      ..analysis
+    )
+    if index < splitted_data.slice(0,-2).len(){
+      pagebreak()
+    }
+  }
+
+}
 
 
 #let create-cover(
@@ -437,10 +570,9 @@
   should_print_cost_ids: bool,
   should_print_description: bool,
   should_print_each_quantity: bool,
-  should_print_each_cost_value: bool,
   should_print_rates: bool,
   should_print_summary: bool,
-  
+  should_print_analysis_of_rates: bool,
   body) = {   
   
   if should_print_cover {
@@ -455,7 +587,7 @@
   }
   
   set page(
-    margin: (left: 15mm, right: 10mm, top: 35mm, bottom: 20mm),
+    margin: (left: 15mm, right: 10mm, top: 31mm, bottom: 20mm),
     numbering: "1/1",
     number-align: end,
     header:[
@@ -465,7 +597,7 @@
         rows: 10mm,
         stroke: none,
         inset: 0mm,
-        align:(top+left, top+right),
+        align:(left+horizon, right+horizon),
         [#title], [#schedule_name]
       )
     ],
@@ -492,8 +624,8 @@
     "should_print_cost_ids": should_print_cost_ids,
     "should_print_description": should_print_description,
     "should_print_each_quantity": should_print_each_quantity,
-    "should_print_each_cost_value": should_print_each_cost_value,
     "should_print_rates": should_print_rates,
+    "should_print_analysis_of_rates": should_print_analysis_of_rates,
   )
   
   if schedule_type == "UNPRICEDBILLOFQUANTITIES" {
@@ -526,5 +658,21 @@
     )
   )
     create-summary(schedule_path, options)
+  }
+
+  if should_print_analysis_of_rates == true and schedule_type == "SCHEDULEOFRATES" {
+    pagebreak()
+    set page(
+      margin: (top: 31mm),
+      background: 
+      place( top + left, dx: 15mm, dy: 25mm,
+        format_table.at("ANALYSISOFRATES"),
+      )
+    )
+    create-analysis-of-rates(
+    path: schedule_path, 
+    delimiter: ",",
+    options: options
+    )
   }
 }


### PR DESCRIPTION
Add support for Analysis of Rates.
Analysis of rates can be created when printing a Schedule of Rates and is displayed at the end of the document.
Each CostItem with more than one CostValue is analyzed.

<img width="661" height="938" alt="immagine" src="https://github.com/user-attachments/assets/a885981e-b38e-4442-bca7-55eb83811ed5" />
