### PR TITLE
Improve bim.activate_model speed ~10x when exiting a drawing #5696

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2204,6 +2204,7 @@ class ActivateModel(bpy.types.Operator):
                         is_global=True,
                         should_sync_changes_first=True,
                     )
+        tool.Geometry.clear_skip_list()
 
         # restore visibility after hide_view_clear()
         for obj, hide_status in visibility_status.items():

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2186,9 +2186,10 @@ class ActivateModel(bpy.types.Operator):
                 bpy.ops.object.hide_view_clear()
                 bpy.ops.bim.activate_status_filters(only_if_enabled=True)
 
+        tool.Geometry.clear_skip_list()
         for obj in context.visible_objects:
             element = tool.Ifc.get_entity(obj)
-            if not element:
+            if not element or element in tool.Geometry.skip_list:
                 continue
             model = ifcopenshell.util.representation.get_representation(element, "Model", "Body", "MODEL_VIEW")
             if model:

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -78,6 +78,8 @@ if TYPE_CHECKING:
 
 
 class Geometry(bonsai.core.tool.Geometry):
+    skip_list = set()
+
     @classmethod
     def get_geometry_props(cls) -> BIMGeometryProperties:
         return bpy.context.scene.BIMGeometryProperties
@@ -779,6 +781,12 @@ class Geometry(bonsai.core.tool.Geometry):
         return False
 
     @classmethod
+    def clear_skip_list(
+        cls
+    ):
+        cls.skip_list = set()
+
+    @classmethod
     def reimport_element_representations(
         cls, obj: bpy.types.Object, representation: ifcopenshell.entity_instance, apply_openings: bool = True
     ) -> None:
@@ -880,6 +888,7 @@ class Geometry(bonsai.core.tool.Geometry):
             while True:
                 shape = iterator.get()
                 element = tool.Ifc.get().by_id(shape.id)
+                cls.skip_list.add(element)
                 if obj := tool.Ifc.get_object(element):
                     # It's possible that there will be multiple shapes for the same context,
                     # Unfortunately, iterator still processes them all and


### PR DESCRIPTION
Putting this forward as much to spur discussion, rather than in an attempt to get it merged.

Heavy files that use lots of instances of types can take a long time to exit a drawing with the bim.activate_model operator. I tracked it down to iterating over every instance, and while processing *that* instance, processing every sibling. i.e. 10 instances would result in 100 change_data calls. This dumb hack appears to work with no negative side effects in ~1/10 th the time.

A test of theoryshaw's Highland Haven torture test in #5696 on my laptop went from ~351 secs to ~36 secs.