### PR TITLE
Don't mark function that throws exception noexcept

### DIFF
--- a/src/ifcparse/variantarray.h
+++ b/src/ifcparse/variantarray.h
@@ -193,7 +193,7 @@ public:
         free_();
     }
 
-    std::size_t index(std::size_t index) const noexcept {
+    std::size_t index(std::size_t index) const {
         if (index >= size()) {
             throw IfcParse::IfcException(
                 "Index " + std::to_string(index) + " is out of range for variant of size " + std::to_string(size())


### PR DESCRIPTION
Fixes annoying warning in MSVC builds:

```
src\ifcparse\variantarray.h(198): warning C4297: 'VariantArray<Blank,Derived,int,bool,boost::logic::tribool,double,std::string,boost::dynamic_bitset<unsigned long,std::allocator<Block>>,EnumerationReference,IfcUtil::IfcBaseClass *,empty_aggregate_t,std::vector<int,std::allocator<int>>,std::vector<double,std::allocator<double>>,std::vector<std::string,std::allocator<std::string>>,std::vector<boost::dynamic_bitset<Block,std::allocator<Block>>,std::allocator<boost::dynamic_bitset<Block,std::allocator<Block>>>>,aggregate_of_instance::ptr,empty_aggregate_of_aggregate_t,std::vector<std::vector<int,std::allocator<int>>,std::allocator<std::vector<int,std::allocator<int>>>>,std::vector<std::vector<double,std::allocator<double>>,std::allocator<std::vector<double,std::allocator<double>>>>,aggregate_of_aggregate_of_instance::ptr>::index': function assumed not to throw an exception but does
        with
        [
            Block=unsigned long
        ]
src\ifcparse\variantarray.h(198): note: __declspec(nothrow), throw(), noexcept(true), or noexcept was specified on the function
```