### PR TITLE
Add Description-ContextMenu Entry to bSDD Properties

### DIFF
--- a/src/bonsai/bonsai/bim/module/bsdd/__init__.py
+++ b/src/bonsai/bonsai/bim/module/bsdd/__init__.py
@@ -25,6 +25,7 @@ classes = (
     operator.LoadBSDDDictionaries,
     operator.SearchBSDDClassifications,
     operator.SearchBSDDProperties,
+    operator.BIM_OT_show_bsdd_description,
     prop.BSDDDictionary,
     prop.BSDDClassification,
     prop.BSDDProperty,

--- a/src/bonsai/bonsai/bim/module/bsdd/operator.py
+++ b/src/bonsai/bonsai/bim/module/bsdd/operator.py
@@ -120,16 +120,19 @@ class BIM_OT_show_bsdd_description(bpy.types.Operator):
         return {"FINISHED"}
 
     def draw(self, context):
+        WIDTH = 80
         layout = self.layout
-        wrapper = textwrap.TextWrapper(width=80)
+        wrapper = textwrap.TextWrapper(width=WIDTH)
         result = tool.Bsdd.get_bsdd_property(self.url)
         description = result.get("description") or ""
         definition = result.get("definition") or ""
         if description != definition:
-            text = f"Description : {description}\n Definition : {definition}"
+            text = wrapper.wrap(f"Description : {description}")
+            text.append("-" * (WIDTH - 15))
+            text += wrapper.wrap(f"Definition : {definition}")
         else:
-            text = f"Description : {description}"
-        for line in wrapper.wrap(text):
+            text = wrapper.wrap(f"Description : {description}")
+        for line in text:
             layout.label(text=line)
         if self.url:
             url_op = layout.operator("bim.open_uri", icon="URL", text="Online bSDD Documentation")

--- a/src/bonsai/bonsai/bim/module/bsdd/operator.py
+++ b/src/bonsai/bonsai/bim/module/bsdd/operator.py
@@ -123,8 +123,6 @@ class BIM_OT_show_bsdd_description(bpy.types.Operator):
         layout = self.layout
         wrapper = textwrap.TextWrapper(width=80)
         result = tool.Bsdd.get_bsdd_property(self.url)
-        self.bl_label = result.get("name") or "undefined"
-        # pset_name = result.get("propertySet") or "undefined"
         description = result.get("description") or ""
         definition = result.get("definition") or ""
         if description != definition:

--- a/src/bonsai/bonsai/bim/module/bsdd/operator.py
+++ b/src/bonsai/bonsai/bim/module/bsdd/operator.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
-
+import textwrap
 import bpy
 import bsdd
 import bonsai.tool as tool
@@ -105,3 +105,34 @@ class AddBSDDProperties(bpy.types.Operator, tool.Ifc.Operator):
             else:
                 pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name=pset_name)
             ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties=properties)
+
+
+class BIM_OT_show_bsdd_description(bpy.types.Operator):
+    bl_idname = "bim.show_bsdd_description"
+    bl_label = "bSDD Description"
+    url: bpy.props.StringProperty()
+
+    def invoke(self, context, event):
+        wm = context.window_manager
+        return wm.invoke_props_dialog(self, width=450)
+
+    def execute(self, context):
+        return {"FINISHED"}
+
+    def draw(self, context):
+        layout = self.layout
+        wrapper = textwrap.TextWrapper(width=80)
+        result = tool.Bsdd.get_bsdd_property(self.url)
+        self.bl_label = result.get("name") or "undefined"
+        # pset_name = result.get("propertySet") or "undefined"
+        description = result.get("description") or ""
+        definition = result.get("definition") or ""
+        if description != definition:
+            text = f"Description : {description}\n Definition : {definition}"
+        else:
+            text = f"Description : {description}"
+        for line in wrapper.wrap(text):
+            layout.label(text=line)
+        if self.url:
+            url_op = layout.operator("bim.open_uri", icon="URL", text="Online bSDD Documentation")
+            url_op.uri = self.url

--- a/src/bonsai/bonsai/bim/module/bsdd/ui.py
+++ b/src/bonsai/bonsai/bim/module/bsdd/ui.py
@@ -147,6 +147,7 @@ class BIM_UL_bsdd_properties(UIList):
         active_propname,
     ) -> None:
         if item:
+            layout.context_pointer_set("active_bsdd_property", item)  # used for context menu
             row = layout.row(align=True)
             name = item.name
             if name != item.code:

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from bonsai.bim.prop import ObjProperty
     from bonsai.bim.module.project.prop import BIMProjectProperties
 
+
 class IFCFileSelector:
     layout: bpy.types.UILayout
 
@@ -1442,9 +1443,7 @@ def draw_custom_context_menu(self: bpy.types.Menu, context: bpy.types.Context) -
             op.text = attr_name
     elif isinstance(prop_struct, BIMBSDDProperties) and hasattr(context, "active_bsdd_property"):
         # Context Menu for bSDD Properties
-        op_description = layout.operator(
-            "bim.show_bsdd_description", text="bSDD Description", icon="INFO"
-        )
+        op_description = layout.operator("bim.show_bsdd_description", text="bSDD Description", icon="INFO")
         op_description.url = context.active_bsdd_property.uri
     else:
         # Basically context menu for any Blender property will end up here,

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -36,6 +36,7 @@ import bonsai.bim
 import bonsai.tool as tool
 from ifcopenshell.util.file import IfcHeaderExtractor
 from bonsai.bim.prop import Attribute
+from bonsai.bim.module.bsdd.prop import BIMBSDDProperties
 from typing import Optional, TYPE_CHECKING, Literal
 from natsort import natsorted
 
@@ -43,6 +44,7 @@ from natsort import natsorted
 if TYPE_CHECKING:
     from bonsai.bim.prop import ObjProperty
     from bonsai.bim.module.project.prop import BIMProjectProperties
+    from bonsai.bim.module.bsdd.operator import BIM_OT_show_bsdd_description
 
 
 class IFCFileSelector:
@@ -1440,6 +1442,13 @@ def draw_custom_context_menu(self: bpy.types.Menu, context: bpy.types.Context) -
         if attr_name:
             op = layout.operator("bim.copy_text_to_clipboard", text="Copy Attribute Name", icon="COPYDOWN")
             op.text = attr_name
+    elif isinstance(prop_struct, BIMBSDDProperties) and hasattr(context, "active_bsdd_property"):
+        # Context Menu for bSDD Properties
+        bsdd_property = context.active_bsdd_property
+        op_description: BIM_OT_show_bsdd_description = layout.operator(
+            "bim.show_bsdd_description", text="bSDD Description", icon="INFO"
+        )
+        op_description.url = bsdd_property.uri
     else:
         # Basically context menu for any Blender property will end up here,
         # and will check 3 types of docs.

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -44,8 +44,6 @@ from natsort import natsorted
 if TYPE_CHECKING:
     from bonsai.bim.prop import ObjProperty
     from bonsai.bim.module.project.prop import BIMProjectProperties
-    from bonsai.bim.module.bsdd.operator import BIM_OT_show_bsdd_description
-
 
 class IFCFileSelector:
     layout: bpy.types.UILayout
@@ -1444,11 +1442,10 @@ def draw_custom_context_menu(self: bpy.types.Menu, context: bpy.types.Context) -
             op.text = attr_name
     elif isinstance(prop_struct, BIMBSDDProperties) and hasattr(context, "active_bsdd_property"):
         # Context Menu for bSDD Properties
-        bsdd_property = context.active_bsdd_property
-        op_description: BIM_OT_show_bsdd_description = layout.operator(
+        op_description = layout.operator(
             "bim.show_bsdd_description", text="bSDD Description", icon="INFO"
         )
-        op_description.url = bsdd_property.uri
+        op_description.url = context.active_bsdd_property.uri
     else:
         # Basically context menu for any Blender property will end up here,
         # and will check 3 types of docs.

--- a/src/bonsai/bonsai/tool/bsdd.py
+++ b/src/bonsai/bonsai/tool/bsdd.py
@@ -200,6 +200,7 @@ class Bsdd(bonsai.core.tool.Bsdd):
             if cprops.classification_source == "BSDD"
             else [cprops.classification_source]
         )
+        total_results = 0
         for dictionary_uri in dictionary_uris:
             for related_ifc_entity in related_ifc_entities or [None]:
                 response = cls.client.get_classes(
@@ -220,7 +221,7 @@ class Bsdd(bonsai.core.tool.Bsdd):
                     prop.dictionary_name = dictionary_name
                     prop.dictionary_namespace_uri = dictionary_namespace_uri
 
-        total_results = response.get("count", response.get("classesCount"))
+        total_results = len(bprops.classifications)
         # For now, hard limit at 1000 results because any more and Blender
         # starts getting slow and they really should filter better
         if offset < 1000 and should_paginate and total_results == limit:

--- a/src/bonsai/bonsai/tool/bsdd.py
+++ b/src/bonsai/bonsai/tool/bsdd.py
@@ -200,7 +200,6 @@ class Bsdd(bonsai.core.tool.Bsdd):
             if cprops.classification_source == "BSDD"
             else [cprops.classification_source]
         )
-        total_results = 0
         for dictionary_uri in dictionary_uris:
             for related_ifc_entity in related_ifc_entities or [None]:
                 response = cls.client.get_classes(


### PR DESCRIPTION
I like the "IFC Description" Context Menu. So i added the same functionality for bSDD Properties.
<img width="457" height="583" alt="image" src="https://github.com/user-attachments/assets/c0fe6342-d6f6-4f57-b034-7da77e9e712b" />


<img width="721" height="309" alt="image" src="https://github.com/user-attachments/assets/57ab1e26-c051-4433-85d7-3b92b3466ef4" />
