### PR TITLE
Make Door / Window Tool place doors on the correct side of a wall

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -40,7 +40,7 @@ import bonsai.core.geometry
 import bonsai.bim.import_ifc as import_ifc
 from collections import defaultdict
 from math import pi, radians
-from mathutils import Vector, Matrix
+from mathutils import Vector, Matrix, Euler
 from bpy.types import Operator
 from bpy.types import SpaceView3D
 from bpy.props import FloatProperty
@@ -92,11 +92,26 @@ class FilledOpeningGenerator:
             layers = tool.Model.get_material_layer_parameters(element)
             if layers["layer_set_direction"] == "AXIS2":
                 opening_thickness_si = layers["thickness"] * 2
-                axis = tool.Model.get_wall_axis(voided_obj, layers=layers)["base"]
+                axes = tool.Model.get_wall_axis(voided_obj, layers=layers)
+                axis_base = axes["base"]
+                axis_side = axes["side"]
                 new_matrix = voided_obj.matrix_world.copy()
-                point_on_axis = tool.Cad.point_on_edge(target, axis)
-                new_matrix.translation.x = point_on_axis.x
-                new_matrix.translation.y = point_on_axis.y
+                point_on_base_axis = tool.Cad.point_on_edge(target, axis_base)
+                point_on_side_axis = tool.Cad.point_on_edge(target, axis_side)
+                if (point_on_base_axis - target).length <= (point_on_side_axis - target).length:
+                    new_matrix.translation.x = point_on_base_axis.x
+                    new_matrix.translation.y = point_on_base_axis.y
+                else:
+                    filling_min_x = min([p[0] for p in filling_obj.bound_box])
+                    filling_max_x = max([p[0] for p in filling_obj.bound_box])
+
+                    # offset that results in the same x extents when the model is rotated 180 degrees
+                    filling_opposite_x = filling_max_x + filling_min_x
+
+                    offset_dir = voided_obj.matrix_world @ Vector((filling_opposite_x, 0, 0, 0))
+                    new_matrix.translation.x = point_on_side_axis.x + offset_dir.x
+                    new_matrix.translation.y = point_on_side_axis.y + offset_dir.y
+                    new_matrix = new_matrix @ Euler((0, 0, radians(180.0))).to_matrix().to_4x4()
 
                 if should_set_z_level:
                     if filling.is_a("IfcDoor"):

--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -448,7 +448,42 @@ class FlipFill(bpy.types.Operator, tool.Ifc.Operator):
             element = tool.Ifc.get_entity(obj)
             if not element or not element.FillsVoids:
                 continue
+
+            filled_opening = element.FillsVoids[0].RelatingOpeningElement
+            filled_element = filled_opening.VoidsElements[0].RelatingBuildingElement
+            filled_object = tool.Ifc.get_object(filled_element)
+
+            if filled_element.is_a() in [ "IfcWall", "IfcWallStandardCase" ]:
+                # if the filled element is a wall, move the filling in such a way
+                # that it will have the same relative position, but to the other
+                # side of the wall
+                #
+                # For example, if a door frame protudes 1cm out of the wall,
+                # it will produde 1cm out of the other side of the wall.
+
+                layers = tool.Model.get_material_layer_parameters(filled_element)
+                axes = tool.Model.get_wall_axis(filled_object, layers=layers)
+
+                center_axis = [ (axes["base"][0] + axes["side"][0]) * 0.5, (axes["base"][1] + axes["side"][1]) * 0.5 ]
+
+                original_pos = obj.matrix_world.translation
+                bb = tool.Blender.get_object_bounding_box(obj)
+                min_y = min(bb["min_y"], 0)
+                max_y = max(bb["max_y"], 0)
+
+                point_on_center_axis = tool.Cad.point_on_edge(original_pos, center_axis)
+                offset_to_center_axis = point_on_center_axis - original_pos
+                offset_to_center_axis.z = 0
+                depth_offset = max_y + min_y
+                depth_correction_vec = offset_to_center_axis.normalized() * depth_offset
+
+                mirrored_point = original_pos + offset_to_center_axis * 2.0 - depth_correction_vec
+
+                obj.matrix_world.translation = mirrored_point
+                bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
+            
             tool.Geometry.flip_object(obj, "XY")
+                
         return {"FINISHED"}
 
 

--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -104,7 +104,7 @@ class FilledOpeningGenerator:
                 else:
                     new_matrix.translation.x = point_on_side_axis.x
                     new_matrix.translation.y = point_on_side_axis.y
-                    new_matrix = new_matrix @ Euler((0, 0, radians(180.0))).to_matrix().to_4x4()
+                    new_matrix = new_matrix @ Matrix.Rotation(radians(180.0), 4, "Z")
 
                 if should_set_z_level:
                     if filling.is_a("IfcDoor"):
@@ -446,7 +446,7 @@ class FlipFill(bpy.types.Operator, tool.Ifc.Operator):
             filled_element = filled_opening.VoidsElements[0].RelatingBuildingElement
             filled_object = tool.Ifc.get_object(filled_element)
 
-            if filled_element.is_a() in [ "IfcWall", "IfcWallStandardCase" ]:
+            if filled_element.is_a() in ["IfcWall", "IfcWallStandardCase"]:
                 # if the filled element is a wall, move the filling in such a way
                 # that it will have the same relative position, but to the other
                 # side of the wall
@@ -457,7 +457,7 @@ class FlipFill(bpy.types.Operator, tool.Ifc.Operator):
                 layers = tool.Model.get_material_layer_parameters(filled_element)
                 axes = tool.Model.get_wall_axis(filled_object, layers=layers)
 
-                center_axis = [ (axes["base"][0] + axes["side"][0]) * 0.5, (axes["base"][1] + axes["side"][1]) * 0.5 ]
+                center_axis = [(axes["base"][0] + axes["side"][0]) * 0.5, (axes["base"][1] + axes["side"][1]) * 0.5]
 
                 original_pos = obj.matrix_world.translation
                 bb = tool.Blender.get_object_bounding_box(obj)
@@ -474,11 +474,11 @@ class FlipFill(bpy.types.Operator, tool.Ifc.Operator):
 
                 obj.matrix_world.translation = mirrored_point
                 bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
-            
+
             tool.Geometry.flip_object(obj, "XY")
             ifcopenshell.api.geometry.edit_object_placement(tool.Ifc.get(), filled_opening, obj.matrix_world)
             tool.Geometry.reload_representation(filled_object)
-                
+
         return {"FINISHED"}
 
 

--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -102,15 +102,8 @@ class FilledOpeningGenerator:
                     new_matrix.translation.x = point_on_base_axis.x
                     new_matrix.translation.y = point_on_base_axis.y
                 else:
-                    filling_min_x = min([p[0] for p in filling_obj.bound_box])
-                    filling_max_x = max([p[0] for p in filling_obj.bound_box])
-
-                    # offset that results in the same x extents when the model is rotated 180 degrees
-                    filling_opposite_x = filling_max_x + filling_min_x
-
-                    offset_dir = voided_obj.matrix_world @ Vector((filling_opposite_x, 0, 0, 0))
-                    new_matrix.translation.x = point_on_side_axis.x + offset_dir.x
-                    new_matrix.translation.y = point_on_side_axis.y + offset_dir.y
+                    new_matrix.translation.x = point_on_side_axis.x
+                    new_matrix.translation.y = point_on_side_axis.y
                     new_matrix = new_matrix @ Euler((0, 0, radians(180.0))).to_matrix().to_4x4()
 
                 if should_set_z_level:

--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -476,6 +476,8 @@ class FlipFill(bpy.types.Operator, tool.Ifc.Operator):
                 bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
             
             tool.Geometry.flip_object(obj, "XY")
+            ifcopenshell.api.geometry.edit_object_placement(tool.Ifc.get(), filled_opening, obj.matrix_world)
+            tool.Geometry.reload_representation(filled_object)
                 
         return {"FINISHED"}
 

--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -541,14 +541,35 @@ def get_generic_product_preview_data(context, relating_type):
     snap_obj = bpy.data.objects.get(snap_prop.snap_object)
     snap_element = tool.Ifc.get_entity(snap_obj)
     rot_mat = Quaternion()
-    if snap_element and snap_element.is_a("IfcWall"):
-        rot_mat = snap_obj.matrix_world.to_quaternion()
+    invert_x = False
+    if relating_type.is_a() in [ "IfcDoorType", "IfcWindowType" ] and snap_element and snap_element.is_a("IfcWall"):
+        layers = tool.Model.get_material_layer_parameters(snap_element)
+        axes = tool.Model.get_wall_axis(snap_obj, layers=layers)
+        axis_base = axes["base"]
+        axis_side = axes["side"]
+        point_on_base_axis = tool.Cad.point_on_edge(mouse_point, axis_base)
+        point_on_side_axis = tool.Cad.point_on_edge(mouse_point, axis_side)
+        if (point_on_base_axis - mouse_point).length_squared <= (point_on_side_axis - mouse_point).length_squared:
+            # mouse is snapped to the base axis, the preview looks exactly like the placed door / window
+            rot_mat = snap_obj.matrix_world.to_quaternion()
+        else:
+            # mouse is snapped to the side axis, the preview is inverted, rotate it now and correct x position later
+            rot_mat = snap_obj.matrix_world.to_quaternion() @ Quaternion(Vector((0, 0, 1)), radians(180))
+            invert_x = True
+
+        mouse_point.z = snap_obj.matrix_world.translation.z
 
     obj_type = tool.Ifc.get_object(relating_type)
     if obj_type.data:
         data = ItemDecorator.get_obj_data(obj_type)
         data["verts"] = [tuple(obj_type.matrix_world.inverted() @ Vector(v)) for v in data["verts"]]
-        data["verts"] = [tuple(rot_mat @ (Vector((v[0], v[1], (v[2] + rl)))) + mouse_point) for v in data["verts"]]
+        offset_x = 0
+        if invert_x:
+            # correct the x position so that the inverted object occupies the same x extents
+            min_x = min([p[0] for p in data["verts"]])
+            max_x = max([p[0] for p in data["verts"]])
+            offset_x = max_x + min_x
+        data["verts"] = [tuple(rot_mat @ (Vector((v[0], v[1], (v[2] + rl)))) + mouse_point - Vector((offset_x, 0, 0))) for v in data["verts"]]
 
         return data
 

--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -541,7 +541,7 @@ def get_generic_product_preview_data(context, relating_type):
     snap_obj = bpy.data.objects.get(snap_prop.snap_object)
     snap_element = tool.Ifc.get_entity(snap_obj)
     rot_mat = Quaternion()
-    if relating_type.is_a() in [ "IfcDoorType", "IfcWindowType" ] and snap_element and snap_element.is_a("IfcWall"):
+    if relating_type.is_a() in ["IfcDoorType", "IfcWindowType"] and snap_element and snap_element.is_a("IfcWall"):
         layers = tool.Model.get_material_layer_parameters(snap_element)
         axes = tool.Model.get_wall_axis(snap_obj, layers=layers)
         axis_base = axes["base"]

--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -541,7 +541,6 @@ def get_generic_product_preview_data(context, relating_type):
     snap_obj = bpy.data.objects.get(snap_prop.snap_object)
     snap_element = tool.Ifc.get_entity(snap_obj)
     rot_mat = Quaternion()
-    invert_x = False
     if relating_type.is_a() in [ "IfcDoorType", "IfcWindowType" ] and snap_element and snap_element.is_a("IfcWall"):
         layers = tool.Model.get_material_layer_parameters(snap_element)
         axes = tool.Model.get_wall_axis(snap_obj, layers=layers)
@@ -555,7 +554,6 @@ def get_generic_product_preview_data(context, relating_type):
         else:
             # mouse is snapped to the side axis, the preview is inverted, rotate it now and correct x position later
             rot_mat = snap_obj.matrix_world.to_quaternion() @ Quaternion(Vector((0, 0, 1)), radians(180))
-            invert_x = True
 
         mouse_point.z = snap_obj.matrix_world.translation.z
 
@@ -563,12 +561,6 @@ def get_generic_product_preview_data(context, relating_type):
     if obj_type.data:
         data = ItemDecorator.get_obj_data(obj_type)
         data["verts"] = [tuple(obj_type.matrix_world.inverted() @ Vector(v)) for v in data["verts"]]
-        if invert_x:
-            # correct the x position so that the inverted object occupies the same x extents
-            min_x = min([p[0] for p in data["verts"]])
-            max_x = max([p[0] for p in data["verts"]])
-            offset_x = max_x + min_x
-            data["verts"] = [tuple(Vector(v) - Vector((offset_x, 0, 0))) for v in data["verts"]]
         data["verts"] = [tuple(rot_mat @ (Vector((v[0], v[1], (v[2] + rl)))) + mouse_point) for v in data["verts"]]
 
         return data

--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -563,13 +563,13 @@ def get_generic_product_preview_data(context, relating_type):
     if obj_type.data:
         data = ItemDecorator.get_obj_data(obj_type)
         data["verts"] = [tuple(obj_type.matrix_world.inverted() @ Vector(v)) for v in data["verts"]]
-        offset_x = 0
         if invert_x:
             # correct the x position so that the inverted object occupies the same x extents
             min_x = min([p[0] for p in data["verts"]])
             max_x = max([p[0] for p in data["verts"]])
             offset_x = max_x + min_x
-        data["verts"] = [tuple(rot_mat @ (Vector((v[0], v[1], (v[2] + rl)))) + mouse_point - Vector((offset_x, 0, 0))) for v in data["verts"]]
+            data["verts"] = [tuple(Vector(v) - Vector((offset_x, 0, 0))) for v in data["verts"]]
+        data["verts"] = [tuple(rot_mat @ (Vector((v[0], v[1], (v[2] + rl)))) + mouse_point) for v in data["verts"]]
 
         return data
 


### PR DESCRIPTION
### Changes
This PR makes the door and window tools place objects on the side of a wall that was actually clicked on.
Previously, the door / window would always be placed on the baseline of the wall, which seems unintuitive to me.
The door/window will also be oriented in a way that always makes the same side protrude out of the wall side.

The flip tool (shift + f) now also moves doors and windows to the other side of a wall when flipping them. For example, if a door protudes 1cm out of the wall, flipping it will make it protude 1cm out of the other side of the wall, instead of flipping it in place.
This could also be split out into a new tool if the behavior of the flip tool should stay unchanged.

The occurrence preview was also updated to match the actual orientation of the created occurrence (at least for every edge case I could think of). This also applies to non-door/window elements.

### Door / Window Tool

| Before | <img alt="image" src="https://github.com/user-attachments/assets/3a5dfefb-4937-48ed-b80c-a148b35f60f6" />  | <img alt="image" src="https://github.com/user-attachments/assets/aefa2356-0505-4853-92d4-1e8d3b8b422f" /> The door is placed on the wrong side of the wall. The preview does not match the final positioning. |
|--------|--------|-------|
| After | <img width="893" height="845" alt="image" src="https://github.com/user-attachments/assets/49662a7e-c439-4953-a4c7-be115ce0f1f9" /> | <img width="784" height="812" alt="image" src="https://github.com/user-attachments/assets/abb62fe7-7902-4cae-afdf-abaf754bde47" /> The door is placed on the side of the wall that was actually clicked on. The preview matches the final positioning. |

### BuildingStorey display

This PR also fixes displaying the door/window on the default storey height, even if snapped to another storey.

| Before | <img width="869" height="1423" alt="image" src="https://github.com/user-attachments/assets/1e7c8399-e5ef-452e-b274-e21a2ba9f499" /> The door is shown on the default storey, which does not match its final location |
|---|---|
| After | <img width="1076" height="1517" alt="image" src="https://github.com/user-attachments/assets/1d702cef-1abf-4430-8b10-f0999e3cc2d6" /> The door is correctly shown on the storey of wall it is snapped to |

### Flip tool

| Before | <img width="1255" height="1346" alt="image" src="https://github.com/user-attachments/assets/5d015060-91e9-4ffb-8535-fc543a81c6aa" /> | <img width="1306" height="1522" alt="image" src="https://github.com/user-attachments/assets/8e4c36fc-9fd3-47fb-ac63-30e2d0520260" /> The door is flipped in place. The door would now open into the wall |
|---------|------|------|
| After | <img width="1203" height="1432" alt="image" src="https://github.com/user-attachments/assets/7b4f2a5b-05d0-4cff-9f17-e7bc9abc400a" /> | <img width="1536" height="1412" alt="image" src="https://github.com/user-attachments/assets/217188e3-2123-4470-8d15-adebf46438e8" /> The door is flipped and moved to the other side of the wall. The door still opens to the outside of the wall. |

