### PR TITLE
fix leaking ifcgeom as_compound() calls

### DIFF
--- a/src/ifcgeom/IfcGeomRepresentation.cpp
+++ b/src/ifcgeom/IfcGeomRepresentation.cpp
@@ -222,7 +222,7 @@ IfcGeom::ConversionResultShape* IfcGeom::Representation::BRep::as_compound(bool 
 		builder.Add(compound, moved_shape);
 	}
 
-	return new ifcopenshell::geometry::OpenCascadeShape(compound);
+	return new ifcopenshell::geometry::OpenCascadeShape(std::move(compound));
 #else
         throw std::runtime_error("Not available without Open Cascade");
 #endif

--- a/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
+++ b/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
@@ -1365,8 +1365,10 @@ namespace IfcGeom {
 			}
 
 			std::vector<T> select(const IfcGeom::BRepElement* elem, bool completely_within = false, double extend = -1.e-5) const {
-				auto shp = elem->geometry().as_compound();
-				auto compound = ((ifcopenshell::geometry::OpenCascadeShape*)shp)->shape();
+                auto shp = (ifcopenshell::geometry::OpenCascadeShape*)elem->geometry().as_compound();
+				TopoDS_Shape compound(std::move((ifcopenshell::geometry::OpenCascadeShape*)shp)->shape()));
+                delete shp;
+
 				const auto& m = elem->transformation().data()->ccomponents();
 				gp_Trsf tr;
 				tr.SetValues(
@@ -1956,8 +1958,9 @@ namespace IfcGeom {
 				return;
 			}
 
-			auto compound_generic = elem->geometry().as_compound();
-			auto compound = ((ifcopenshell::geometry::OpenCascadeShape*)compound_generic)->shape();
+			auto compound_generic = (ifcopenshell::geometry::OpenCascadeShape*)elem->geometry().as_compound();
+			TopoDS_Shape compound(std::move(compound_generic->shape()));
+            delete compound_generic;
 			
 			const auto& m = elem->transformation().data()->ccomponents();
 			gp_Trsf tr;

--- a/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
+++ b/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
@@ -1365,9 +1365,9 @@ namespace IfcGeom {
 			}
 
 			std::vector<T> select(const IfcGeom::BRepElement* elem, bool completely_within = false, double extend = -1.e-5) const {
-                auto shp = (ifcopenshell::geometry::OpenCascadeShape*)elem->geometry().as_compound();
-				TopoDS_Shape compound(std::move((ifcopenshell::geometry::OpenCascadeShape*)shp)->shape()));
-                delete shp;
+				auto shp = (ifcopenshell::geometry::OpenCascadeShape*)elem->geometry().as_compound();
+				TopoDS_Shape compound(std::move(((ifcopenshell::geometry::OpenCascadeShape*)shp)->shape()));
+				delete shp;
 
 				const auto& m = elem->transformation().data()->ccomponents();
 				gp_Trsf tr;

--- a/src/ifcgeom/kernels/opencascade/OpenCascadeConversionResult.h
+++ b/src/ifcgeom/kernels/opencascade/OpenCascadeConversionResult.h
@@ -46,6 +46,8 @@ namespace ifcopenshell {
 		public:
 			OpenCascadeShape(const TopoDS_Shape& shape)
 				: shape_(shape) {}
+			OpenCascadeShape(TopoDS_Shape&& shape)
+				: shape_(std::move(shape)) {}
 
 			const TopoDS_Shape& shape() const { return shape_; }
 			operator const TopoDS_Shape& () { return shape_; }


### PR DESCRIPTION
Hello again, I've managed to get more of my paid-for time in the office approved for looking at the source code for our python service, some more memory leaks seemed to be popping up during long-lived service and calculations and after throwing our worker and pytest through memray the `add_element` showed up as an obvious problem (up to 2.1gB of allocated memory from `add_element` python invocations for 170mB in-memory file data)

At first I thought `IfcFile::open(...)` was leaking but turns out it was just the static schema pointers being lazy initialized, instead some places that invoked as_compound() forgot to clean up the OpenCascadeShape after copying the `TopoDS_Shape`.

I'll be looking to throw up a CICD pipeline tomorrow to package and push my fork into our private infrastructure for now and trying to monitor if any more leaking memory seems to be showing up with the little time I've got left to dedicate on this, but I don't think I'll be able to do more dedicated contributions until the next round of corpo-approvals outside of my freetime.