### PR TITLE
set active flag for mapped representations

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/data.py
+++ b/src/bonsai/bonsai/bim/module/geometry/data.py
@@ -118,14 +118,13 @@ class RepresentationsData:
         for representation in tool.Geometry.get_representations_iter(element):
             representation_type = representation.RepresentationType
             mapped_rep_id = None
-            
+
             if representation_type == "MappedRepresentation":
                 mapped_rep = representation.Items[0].MappingSource.MappedRepresentation
                 mapped_rep_id = mapped_rep.id()
                 representation_type = mapped_rep.RepresentationType + "*"
-            
-            is_active = (representation.id() == active_representation_id or 
-                        mapped_rep_id == active_representation_id)
+
+            is_active = representation.id() == active_representation_id or mapped_rep_id == active_representation_id
 
             data = {
                 "id": representation.id(),

--- a/src/bonsai/bonsai/bim/module/geometry/data.py
+++ b/src/bonsai/bonsai/bim/module/geometry/data.py
@@ -117,14 +117,13 @@ class RepresentationsData:
 
         for representation in tool.Geometry.get_representations_iter(element):
             representation_type = representation.RepresentationType
-            mapped_rep_id = None
+            resolved_representation = ifcopenshell.util.representation.resolve_representation(representation)
+            
+            if resolved_representation != representation:
+                representation_type = resolved_representation.RepresentationType + "*"
 
-            if representation_type == "MappedRepresentation":
-                mapped_rep = representation.Items[0].MappingSource.MappedRepresentation
-                mapped_rep_id = mapped_rep.id()
-                representation_type = mapped_rep.RepresentationType + "*"
-
-            is_active = representation.id() == active_representation_id or mapped_rep_id == active_representation_id
+            is_active = (representation.id() == active_representation_id or 
+                        resolved_representation.id() == active_representation_id)
 
             data = {
                 "id": representation.id(),

--- a/src/bonsai/bonsai/bim/module/geometry/data.py
+++ b/src/bonsai/bonsai/bim/module/geometry/data.py
@@ -118,12 +118,14 @@ class RepresentationsData:
         for representation in tool.Geometry.get_representations_iter(element):
             representation_type = representation.RepresentationType
             resolved_representation = ifcopenshell.util.representation.resolve_representation(representation)
-            
+
             if resolved_representation != representation:
                 representation_type = resolved_representation.RepresentationType + "*"
 
-            is_active = (representation.id() == active_representation_id or 
-                        resolved_representation.id() == active_representation_id)
+            is_active = (
+                representation.id() == active_representation_id
+                or resolved_representation.id() == active_representation_id
+            )
 
             data = {
                 "id": representation.id(),

--- a/src/bonsai/bonsai/bim/module/geometry/data.py
+++ b/src/bonsai/bonsai/bim/module/geometry/data.py
@@ -117,16 +117,23 @@ class RepresentationsData:
 
         for representation in tool.Geometry.get_representations_iter(element):
             representation_type = representation.RepresentationType
+            mapped_rep_id = None
+            
             if representation_type == "MappedRepresentation":
-                representation_type = representation.Items[0].MappingSource.MappedRepresentation.RepresentationType
-                representation_type += "*"
+                mapped_rep = representation.Items[0].MappingSource.MappedRepresentation
+                mapped_rep_id = mapped_rep.id()
+                representation_type = mapped_rep.RepresentationType + "*"
+            
+            is_active = (representation.id() == active_representation_id or 
+                        mapped_rep_id == active_representation_id)
+
             data = {
                 "id": representation.id(),
                 "ContextType": representation.ContextOfItems.ContextType or "",
                 "ContextIdentifier": "",
                 "TargetView": "",
                 "RepresentationType": representation_type or "",
-                "is_active": representation.id() == active_representation_id,
+                "is_active": is_active,
             }
             if representation.ContextOfItems.is_a("IfcGeometricRepresentationSubContext"):
                 data["ContextIdentifier"] = representation.ContextOfItems.ContextIdentifier or ""


### PR DESCRIPTION
This was sparked by https://github.com/IfcOpenShell/IfcOpenShell/issues/5776
The code currently is much more robust than when the issue was raised and it will not break if one removed some representation. It will switch to the next one available. If there is only one representation for the object and it is removed, the object is still defined (the empty remains) without geometry.
However i have seen that for windows/doors the active representation was missing and all the representations had the "is_active" flag set to false.
Here is a proposal to update the "active_flag" in the case of Mapped Representations.

https://github.com/user-attachments/assets/2db1c93a-e117-43ce-90f3-8a916e7d71f0

Cheers!
