### PR TITLE
Plan view fixes

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -240,6 +240,7 @@ class DecoratorData:
         cls.is_loaded = True
         cls.cut_cache = {}
         cls.layerset_cache = {}
+        cls.fill_cache = {}
 
         text = {}
         dimension = {}

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -469,6 +469,14 @@ class DocProperties(PropertyGroup):
         if drawing_id == 0:
             return None
         return tool.Ifc.get().by_id(drawing_id)
+    
+    def get_active_target_view(self) -> Union[str, None]:
+        active_drawing = self.get_active_drawing()
+        if not active_drawing:
+            return None
+        return tool.Drawing.get_drawing_target_view(active_drawing)
+        
+        
 
 
 def update_width_height(self: "BIMCameraProperties", context: bpy.types.Context) -> None:

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -469,14 +469,12 @@ class DocProperties(PropertyGroup):
         if drawing_id == 0:
             return None
         return tool.Ifc.get().by_id(drawing_id)
-    
+
     def get_active_target_view(self) -> Union[str, None]:
         active_drawing = self.get_active_drawing()
         if not active_drawing:
             return None
         return tool.Drawing.get_drawing_target_view(active_drawing)
-        
-        
 
 
 def update_width_height(self: "BIMCameraProperties", context: bpy.types.Context) -> None:

--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -549,6 +549,31 @@ def get_generic_product_preview_data(context, relating_type):
         mouse_point.z = container_obj.location.z
 
     obj_type = tool.Ifc.get_object(relating_type)
+
+    subcontexts = tool.Drawing.get_active_drawing_subcontexts()
+    if not subcontexts:
+        subcontexts = [("Model", "Body", "MODEL_VIEW")]
+
+    active_context = tool.Geometry.get_active_representation_context(obj_type)
+    active_context_params = tool.Geometry.get_subcontext_parameters(active_context)
+    for subcontext in subcontexts:
+        if subcontext == active_context_params:
+            break
+
+        representation = ifcopenshell.util.representation.get_representation(relating_type, *subcontext)
+        if representation:
+            bonsai.core.geometry.switch_representation(
+                tool.Ifc,
+                tool.Geometry,
+                obj_type,
+                representation,
+                should_reload=True,
+                is_global=False,
+                should_sync_changes_first=False,
+            )
+            context.view_layer.update()
+            break
+
     if obj_type.data:
         data = ItemDecorator.get_obj_data(obj_type)
         data["verts"] = [tuple(obj_type.matrix_world.inverted() @ Vector(v)) for v in data["verts"]]

--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -544,6 +544,10 @@ def get_generic_product_preview_data(context, relating_type):
     if snap_element and snap_element.is_a("IfcWall"):
         rot_mat = snap_obj.matrix_world.to_quaternion()
 
+    if snap_element and (container := ifcopenshell.util.element.get_container(snap_element)):
+        container_obj = tool.Ifc.get_object(container)
+        mouse_point.z = container_obj.location.z
+
     obj_type = tool.Ifc.get_object(relating_type)
     if obj_type.data:
         data = ItemDecorator.get_obj_data(obj_type)

--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -334,7 +334,11 @@ class AddOccurrence(bpy.types.Operator, tool.Ifc.Operator):
 
         self.container = None
         self.container_obj = None
-        if building_obj and building_element and (container := ifcopenshell.util.element.get_container(building_element)):
+        if (
+            building_obj
+            and building_element
+            and (container := ifcopenshell.util.element.get_container(building_element))
+        ):
             self.container = container
             self.container_obj = tool.Ifc.get_object(container)
         elif container := tool.Root.get_default_container():

--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -327,9 +327,17 @@ class AddOccurrence(bpy.types.Operator, tool.Ifc.Operator):
         if self.from_invoke and str(self.relating_type_id) in AuthoringData.data["relating_type_id"]:
             props.relating_type_id = str(self.relating_type_id)
 
+        building_obj = None
+        if len(context.selected_objects) == 1 and context.active_object:
+            building_obj = context.active_object
+            building_element = tool.Ifc.get_entity(building_obj)
+
         self.container = None
         self.container_obj = None
-        if container := tool.Root.get_default_container():
+        if building_obj and building_element and (container := ifcopenshell.util.element.get_container(building_element)):
+            self.container = container
+            self.container_obj = tool.Ifc.get_object(container)
+        elif container := tool.Root.get_default_container():
             self.container = container
             self.container_obj = tool.Ifc.get_object(container)
 
@@ -416,11 +424,6 @@ class AddOccurrence(bpy.types.Operator, tool.Ifc.Operator):
                 )
             return
 
-        building_obj = None
-        if len(context.selected_objects) == 1 and context.active_object:
-            building_obj = context.active_object
-            building_element = tool.Ifc.get_entity(building_obj)
-
         mesh = bpy.data.meshes.new(name="Instance")
         obj = bpy.data.objects.new(tool.Model.generate_occurrence_name(relating_type, instance_class), mesh)
 
@@ -487,12 +490,15 @@ class AddOccurrence(bpy.types.Operator, tool.Ifc.Operator):
             building_obj
             and building_element
             and building_element.is_a() in ["IfcWall", "IfcWallStandardCase", "IfcCovering", "IfcElementAssembly"]
+            and instance_class in ["IfcWindow", "IfcDoor"]
         ):
-            if instance_class in ["IfcWindow", "IfcDoor"]:
-                # TODO For now we are hardcoding windows and doors as a prototype
-                tool.Model.add_filled_opening(building_obj, obj)
+            # TODO For now we are hardcoding windows and doors as a prototype
+            tool.Model.add_filled_opening(building_obj, obj)
         else:
             if self.container_obj:
+                bonsai.core.spatial.assign_container(
+                    tool.Ifc, tool.Collector, tool.Spatial, container=self.container, element_obj=obj
+                )
                 if props.rl_mode == "BOTTOM":
                     obj.location.z = self.container_obj.location.z - tool.Blender.get_object_bounding_box(obj)["min_z"]
                 elif props.rl_mode == "CONTAINER":

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2114,22 +2114,9 @@ class Drawing(bonsai.core.tool.Drawing):
                         layer_collection2.hide_viewport = False
 
     @classmethod
-    def activate_drawing(cls, camera: bpy.types.Object) -> None:
-        selected_objects_before = bpy.context.selected_objects
-        non_ifc_objects_hide = {o: o.hide_get() for o in bpy.context.view_layer.objects if not tool.Ifc.get_entity(o)}
-
-        # Sync viewport objects visibility with selectors from EPset_Drawing/Include and /Exclude
-        drawing = tool.Ifc.get_entity(camera)
-        assert drawing and isinstance(camera.data, bpy.types.Camera)
-
-        filtered_elements = cls.get_drawing_elements(drawing) | cls.get_drawing_spaces(drawing)
-        filtered_elements.add(drawing)
-
-        subcontexts: list[ifcopenshell.entity_instance] = []
-        target_view = cls.get_drawing_target_view(drawing)
-
+    def get_drawing_context_filters(cls, target_view: str) -> list[tuple[str, str, str]]:
         if target_view in ("PLAN_VIEW", "REFLECTED_PLAN_VIEW"):
-            context_filters = [
+            return [
                 ("Plan", "Body", target_view),
                 ("Plan", "Body", "MODEL_VIEW"),
                 ("Plan", "Facetation", target_view),
@@ -2144,7 +2131,7 @@ class Drawing(bonsai.core.tool.Drawing):
                 ("Model", "Annotation", "MODEL_VIEW"),
             ]
         else:
-            context_filters = [
+            return [
                 ("Model", "Body", target_view),
                 ("Model", "Body", "MODEL_VIEW"),
                 ("Model", "Facetation", target_view),
@@ -2152,11 +2139,42 @@ class Drawing(bonsai.core.tool.Drawing):
                 ("Model", "Annotation", target_view),
                 ("Model", "Annotation", "MODEL_VIEW"),
             ]
+        
+    @classmethod
+    def get_drawing_subcontexts(cls, target_view: str) -> list[tuple[str, str, str]]:
+        context_filters = cls.get_drawing_context_filters(target_view)
+        subcontexts = []
 
         for context_filter in context_filters:
             subcontext = ifcopenshell.util.representation.get_context(tool.Ifc.get(), *context_filter)
             if subcontext:
                 subcontexts.append(context_filter)
+
+        return subcontexts
+    
+    @classmethod
+    def get_active_drawing_subcontexts(cls) -> list[tuple[str, str, str]] | None:
+        props = cls.get_document_props()
+        target_view = props.get_active_target_view()
+        if not target_view:
+            return None
+        
+        return cls.get_drawing_subcontexts(target_view)
+
+    @classmethod
+    def activate_drawing(cls, camera: bpy.types.Object) -> None:
+        selected_objects_before = bpy.context.selected_objects
+        non_ifc_objects_hide = {o: o.hide_get() for o in bpy.context.view_layer.objects if not tool.Ifc.get_entity(o)}
+
+        # Sync viewport objects visibility with selectors from EPset_Drawing/Include and /Exclude
+        drawing = tool.Ifc.get_entity(camera)
+        assert drawing and isinstance(camera.data, bpy.types.Camera)
+
+        filtered_elements = cls.get_drawing_elements(drawing) | cls.get_drawing_spaces(drawing)
+        filtered_elements.add(drawing)
+
+        target_view = cls.get_drawing_target_view(drawing)
+        subcontexts = cls.get_drawing_subcontexts(target_view)
 
         # Hide everything first, then selectively show. This is significantly faster.
         with bpy.context.temp_override(**tool.Blender.get_viewport_context()):

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2139,7 +2139,7 @@ class Drawing(bonsai.core.tool.Drawing):
                 ("Model", "Annotation", target_view),
                 ("Model", "Annotation", "MODEL_VIEW"),
             ]
-        
+
     @classmethod
     def get_drawing_subcontexts(cls, target_view: str) -> list[tuple[str, str, str]]:
         context_filters = cls.get_drawing_context_filters(target_view)
@@ -2151,14 +2151,14 @@ class Drawing(bonsai.core.tool.Drawing):
                 subcontexts.append(context_filter)
 
         return subcontexts
-    
+
     @classmethod
     def get_active_drawing_subcontexts(cls) -> list[tuple[str, str, str]] | None:
         props = cls.get_document_props()
         target_view = props.get_active_target_view()
         if not target_view:
             return None
-        
+
         return cls.get_drawing_subcontexts(target_view)
 
     @classmethod

--- a/src/bonsai/bonsai/tool/snap.py
+++ b/src/bonsai/bonsai/tool/snap.py
@@ -17,10 +17,13 @@
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
+import bmesh
 import ifcopenshell
 import ifcopenshell.util.unit
 import bonsai.core.tool
 import bonsai.tool as tool
+from bonsai.bim.module.drawing.data import DecoratorData
+from bonsai.bim.module.drawing.decoration import CutDecorator
 from bonsai.bim.module.model.decorator import PolylineDecorator
 import math
 import mathutils
@@ -413,6 +416,51 @@ class Snap(bonsai.core.tool.Snap):
                         for point in snap_points:
                             point["group"] = "Object"
                             detected_snaps.append(point)
+
+        # snap to cut geometry (e.g. in plan view)
+        if CutDecorator.installed:
+            cut_snaps = []
+
+            model_props = tool.Model.get_model_props()
+
+            for obj in [o for o in context.visible_objects if o.type == "MESH"]:
+                if not (element := tool.Ifc.get_entity(obj)):
+                    continue
+
+                if model_props.show_cut_decorator and element.id() in DecoratorData.cut_cache:
+                    verts, edges = DecoratorData.cut_cache[element.id()]
+                    if not verts or not edges:
+                        continue
+
+                    bm = bmesh.new()
+                    bverts = [bm.verts.new(pos) for pos in verts]
+                    for edge in edges:
+                        bm.edges.new([bverts[vi] for vi in edge])
+
+                    snap_points = tool.Raycast.ray_cast_by_proximity(context, event, None, None, bm)
+                    if snap_points:
+                        for p in snap_points:
+                            p["group"] = "Object"
+                            p["object"] = obj
+                            cut_snaps.append(p)
+
+                if model_props.show_cut_decorator_fill and element.id() in DecoratorData.fill_cache:
+                    bm = bmesh.new()
+                    for color, verts_and_tris in DecoratorData.fill_cache[element.id()].items():
+                        for verts, tris in verts_and_tris:
+                            bverts = [bm.verts.new(pos) for pos in verts]
+                            for tri in tris:
+                                bm.faces.new([bverts[vi] for vi in tri])
+
+                    snap_points = tool.Raycast.ray_cast_by_proximity(context, event, None, None, bm)
+                    if snap_points:
+                        for p in snap_points:
+                            p["group"] = "Object"
+                            p["object"] = obj
+                            cut_snaps.append(p)
+
+            if len(cut_snaps) > 0:
+                detected_snaps = cut_snaps
 
         # Axis and Plane
         if tool.Ifc.get():

--- a/src/bonsai/bonsai/tool/snap.py
+++ b/src/bonsai/bonsai/tool/snap.py
@@ -450,7 +450,9 @@ class Snap(bonsai.core.tool.Snap):
                         for verts, tris in verts_and_tris:
                             bverts = [bm.verts.new(pos) for pos in verts]
                             for tri in tris:
-                                bm.faces.new([bverts[vi] for vi in tri])
+                                verts = [bverts[vi] for vi in tri]
+                                if not bm.faces.get(verts):
+                                    bm.faces.new(verts)
 
                     snap_points = tool.Raycast.ray_cast_by_proximity(context, event, None, None, bm)
                     if snap_points:


### PR DESCRIPTION
This PR addresses a few issues with the plan view.

Together with #6986 and #7003, plan view is much easier to work with.

### Cut geometry not updating properly
Previously, placing a door / window into a wall resulted in the "fill" geometry not updating correctly, while the "cut" geometry updated normally. This is now fixed.

| Before | After |
|---|---|
| <img width="2168" height="1789" alt="image" src="https://github.com/user-attachments/assets/681d77fe-df78-4239-bc99-244f7d0c48f4" /> | <img width="2069" height="1648" alt="image" src="https://github.com/user-attachments/assets/bc57bc12-fa18-4c56-a416-4ea5231cbf57" /> |

### Snapping to cut geometry
Previously, it was very hard to place doors / windows into a wall, as snapping seemed to prefer the floor slab. This was somewhat fixed by adding logic to snap to the "cut" and "fill" geometry in plan mode. Additionally, if any viable snap point is found on this geometry, all other snap points are ignored.

### Placing objects into the intended container
Previously, generic objects like furniture were always placed into the default container. This is especially frustrating in plan view, as only one storey will be visible most of the time.
With this PR, generic objects will be placed into the container of the object that is snapped to. The preview was also updated to accomodate this. The default container will only be used if no object was snapped to or the snapped object does not have a container.

| Before | After |
|---|---|
| <img width="1536" height="1347" alt="image" src="https://github.com/user-attachments/assets/7749d3b3-b23d-4b38-ba9f-4c63dda65490" /> | <img width="1216" height="1245" alt="image" src="https://github.com/user-attachments/assets/8456d3db-fe04-46e6-8fa5-2c016540b2e4" /> |

(Images taken in model view to better visualize what is happening)

This incidentally also fixes window / door previews (they were already placed in the snapped container, but the preview was not reflecting this), but this is explicitly fixed in #6986.

### Using the appropriate representation for placement preview
Previously, when placing an object (e.g. a door), the current representation of the type object would be used. This would be the wrong preview if the type was last seen in a different mode (e.g. plan view). The preview now switches to the appropriate representation.
