### PR TITLE
feat: add comparison property to ifc_filter for type "query"

### DIFF
--- a/src/bonsai/bonsai/bim/helper.py
+++ b/src/bonsai/bonsai/bim/helper.py
@@ -550,6 +550,7 @@ def draw_filter(
             elif ifc_filter.type == "query":
                 row = box.row(align=True)
                 row.prop(ifc_filter, "name", text="", icon="POINTCLOUD_DATA")
+                row.prop(ifc_filter, "comparison", text="")
                 row.prop(ifc_filter, "value", text="")
             elif ifc_filter.type == "instance":
                 row = box.row(align=True)

--- a/src/bonsai/bonsai/tool/search.py
+++ b/src/bonsai/bonsai/tool/search.py
@@ -121,7 +121,8 @@ class Search(bonsai.core.tool.Search):
                     filter_group_query.append(f"parent{comparison}{value}")
                 elif ifc_filter.type == "query":
                     keys = cls.wrap_value(ifc_filter, ifc_filter.name)
-                    comparison, value = cls.get_comparison_and_value(ifc_filter)
+                    comparison = ifc_filter.comparison or "="
+                    value = cls.wrap_value(ifc_filter, ifc_filter.value)
                     filter_group_query.append(f"query:{keys}{comparison}{value}")
             query.append(", ".join(filter_group_query))
         return " + ".join(query)


### PR DESCRIPTION
This is to address discussion https://community.osarch.org/discussion/3102/creating-a-query-for-search-group-qto
Currently the "query" type only allows to provide the = and the != operators within the value field.
<img width="1703" height="1578" alt="image" src="https://github.com/user-attachments/assets/18f2bbdc-6de2-4941-b825-b38a45b3a6e9" />

This is a proposal to split and add the comparison field like for the "property" type
<img width="3073" height="2046" alt="image" src="https://github.com/user-attachments/assets/329f432b-8f72-4ae1-a9d9-36cbe02ea6ee" />


Cheers!
