### PR TITLE
Organize drawings under a parent called DRAWINGS in ifc groups and ifc documents

### DIFF
--- a/src/bonsai/bonsai/core/drawing.py
+++ b/src/bonsai/bonsai/core/drawing.py
@@ -302,9 +302,23 @@ def add_drawing(
         context=drawing.get_body_context(),
         ifc_representation_class=None,
     )
+    
+    drawings_parent_group = None
+    for group in ifc.get().by_type("IfcGroup"):
+        if group.Name == "DRAWINGS" and group.ObjectType == "DRAWINGS":
+            drawings_parent_group = group
+            break
+    
+    if not drawings_parent_group:
+        drawings_parent_group = ifc.run("group.add_group")
+        ifc.run("group.edit_group", group=drawings_parent_group, attributes={"Name": "DRAWINGS", "ObjectType": "DRAWINGS"})
+    
     group = ifc.run("group.add_group")
     ifc.run("group.edit_group", group=group, attributes={"Name": drawing_name, "ObjectType": "DRAWING"})
     ifc.run("group.assign_group", group=group, products=[element])
+    
+    ifc.run("group.assign_group", group=drawings_parent_group, products=[group])
+    
     collector.assign(camera)
     pset = ifc.run("pset.add_pset", product=element, name="EPset_Drawing")
     if drawing.get_unit_system() == "METRIC":
@@ -335,7 +349,22 @@ def add_drawing(
         },
     )
     drawing.setup_shading_styles_path(shading_styles_path)
-    information = ifc.run("document.add_information")
+
+    drawings_parent_document = None
+    for document in ifc.get().by_type("IfcDocumentInformation"):
+        if document.Name == "DRAWINGS" and document.Scope == "DRAWINGS":
+            drawings_parent_document = document
+            break
+    
+    if not drawings_parent_document:
+        drawings_parent_document = ifc.run("document.add_information")
+        if ifc.get_schema() == "IFC2X3":
+            attributes = {"DocumentId": "DRAWINGS", "Name": "DRAWINGS", "Scope": "DRAWINGS"}
+        else:
+            attributes = {"Identification": "DRAWINGS", "Name": "DRAWINGS", "Scope": "DRAWINGS"}
+        ifc.run("document.edit_information", information=drawings_parent_document, attributes=attributes)
+    
+    information = ifc.run("document.add_information", parent=drawings_parent_document)
     uri = drawing.get_default_drawing_path(drawing_name)
     reference = ifc.run("document.add_reference", information=information)
     if ifc.get_schema() == "IFC2X3":
@@ -363,9 +392,21 @@ def duplicate_drawing(
     drawing_tool.set_name(new_drawing, drawing_name)
     group = drawing_tool.get_drawing_group(new_drawing)
     ifc.run("group.unassign_group", group=group, products=[new_drawing])
+    
+    drawings_parent_group = None
+    for parent_group in ifc.get().by_type("IfcGroup"):
+        if parent_group.Name == "DRAWINGS" and parent_group.ObjectType == "DRAWINGS":
+            drawings_parent_group = parent_group
+            break
+    
+    if not drawings_parent_group:
+        drawings_parent_group = ifc.run("group.add_group")
+        ifc.run("group.edit_group", group=drawings_parent_group, attributes={"Name": "DRAWINGS", "ObjectType": "DRAWINGS"})
+    
     new_group = ifc.run("group.add_group")
     ifc.run("group.edit_group", group=new_group, attributes={"Name": drawing_name, "ObjectType": "DRAWING"})
     ifc.run("group.assign_group", group=new_group, products=[new_drawing])
+    ifc.run("group.assign_group", group=drawings_parent_group, products=[new_group])
     if should_duplicate_annotations:
         new_annotations: list[ifcopenshell.entity_instance] = []
         annotation_objs = [ifc.get_object(a) for a in drawing_tool.get_group_elements(group) if a != drawing]
@@ -381,7 +422,21 @@ def duplicate_drawing(
     old_reference = drawing_tool.get_drawing_document(new_drawing)
     ifc.run("document.unassign_document", products=[new_drawing], document=old_reference)
 
-    information = ifc.run("document.add_information")
+    drawings_parent_document = None
+    for document in ifc.get().by_type("IfcDocumentInformation"):
+        if document.Name == "DRAWINGS" and document.Scope == "DRAWINGS":
+            drawings_parent_document = document
+            break
+    
+    if not drawings_parent_document:
+        drawings_parent_document = ifc.run("document.add_information")
+        if ifc.get_schema() == "IFC2X3":
+            attributes = {"DocumentId": "DRAWINGS", "Name": "DRAWINGS", "Scope": "DRAWINGS"}
+        else:
+            attributes = {"Identification": "DRAWINGS", "Name": "DRAWINGS", "Scope": "DRAWINGS"}
+        ifc.run("document.edit_information", information=drawings_parent_document, attributes=attributes)
+
+    information = ifc.run("document.add_information", parent=drawings_parent_document)
     uri = drawing_tool.get_default_drawing_path(drawing_name)
     reference = ifc.run("document.add_reference", information=information)
     if ifc.get_schema() == "IFC2X3":


### PR DESCRIPTION
This is a proposal to have a common parent called DRAWINGS for the ifc groups and ifc documents generated by Bonsai when dealing with drawings.
<img width="3715" height="1992" alt="image" src="https://github.com/user-attachments/assets/f0dd5bc5-2d39-48bd-99ae-401f83550897" />

Cheers!
