### PR TITLE
ifc5d.quantify: lookup entity names directly; index into dict rather than iterate in simple cases

### DIFF
--- a/src/ifc5d/ifc5d/qto.py
+++ b/src/ifc5d/ifc5d/qto.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Ifc5D.  If not, see <http://www.gnu.org/licenses/>.
 
+import functools
+import itertools
 import os
 import types
 import json
@@ -58,6 +60,23 @@ for name in get_args(RULE_SET):
         rules[name] = json.load(f)
 
 
+@functools.cache
+def lower_case_entity_names(schema_iden: str):
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_iden)
+    return set(n.name().lower() for n in schema.entities())
+
+
+@functools.cache
+def entity_supertypes(schema_iden: str, entity_name: str):
+    def visit(decl):
+        yield decl.name().lower()
+        if ty := decl.supertype():
+            yield from visit(ty)
+
+    decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_iden).declaration_by_name(entity_name)
+    return list(visit(decl))
+
+
 def quantify(ifc_file: ifcopenshell.file, elements: set[ifcopenshell.entity_instance], rules: dict) -> ResultsDict:
     """Quantify elements from a rules using preset quantification rules
 
@@ -73,8 +92,22 @@ def quantify(ifc_file: ifcopenshell.file, elements: set[ifcopenshell.entity_inst
 
     for calculator, queries in rules["calculators"].items():
         calculator = calculators[calculator]
+        if not set(m.lower() for m in queries.keys()) - lower_case_entity_names(ifc_file.schema_identifier):
+            # all defined queries are actually simple entity names: instead of looping over all
+            # calculators we loop over the entity types so that we don't have to repeatedly query
+            # the model, especially when the set of elements is small.
+            casenorm = {k.lower(): k for k in queries.keys()}
+            pred = lambda inst: inst.is_a().lower()
+            for ty, elements in itertools.groupby(sorted(elements, key=pred), key=pred):
+                for sty in entity_supertypes(ifc_file.schema_identifier, ty):
+                    if qtos := queries.get(casenorm.get(sty)):
+                        calculator.calculate(ifc_file, list(elements), qtos, results)
         for query, qtos in queries.items():
-            filtered_elements = ifcopenshell.util.selector.filter_elements(ifc_file, query, elements)
+            if query.lower() in lower_case_entity_names(ifc_file.schema_identifier):
+                # by_type is faster than selector parsing
+                filtered_elements = ifc_file.by_type(query)
+            else:
+                filtered_elements = ifcopenshell.util.selector.filter_elements(ifc_file, query, elements)
             if filtered_elements:
                 calculator.calculate(ifc_file, filtered_elements, qtos, results)
     return results


### PR DESCRIPTION
See here my call tree (from pyinstrument). A lot of time being spent in `selector.py` so I looked for some ways to reduce time spent there:

1. use by_type in simple entity type names
2. use type of elements as an index into the list (especially useful when list of elements is tiny).

```
4.186 _run_module_code  runpy.py:89
└─ 4.186 _run_code  runpy.py:63
   └─ 4.186 <module>  primitive_objects.py:1
      └─ 4.138 Element.build  primitive_objects.py:106
         └─ 4.138 Element._build  primitive_objects.py:327
            ├─ 3.805 <listcomp>  primitive_objects.py:346
            │  ├─ 2.904 Translate.build  primitive_objects.py:390
            │  │  ├─ 2.435 Boolean.build  primitive_objects.py:490
            │  │  │  ├─ 1.849 <listcomp>  primitive_objects.py:492
            │  │  │  │  ├─ 1.289 Translate.build  primitive_objects.py:390
            │  │  │  │  │  └─ 1.279 Element.build  primitive_objects.py:106
            │  │  │  │  │     └─ 1.278 Element._build  primitive_objects.py:327
            │  │  │  │  │        └─ 1.263 quantify  ifc5d\qto.py:61
            │  │  │  │  │           ├─ 1.107 filter_elements  ifcopenshell\util\selector.py:425
            │  │  │  │  │           │     [19 frames hidden]  lark
            │  │  │  │  │           └─ 0.152 IfcOpenShell.calculate  ifc5d\qto.py:259
            │  │  │  │  │              └─ 0.149 iterator.initialize  ifcopenshell\ifcopenshell_wrapper.py:1097
            │  │  │  │  │                 └─ 0.149 Iterator_initialize  <built-in>
            │  │  │  │  └─ 0.560 Element.build  primitive_objects.py:106
            │  │  │  │     └─ 0.560 Element._build  primitive_objects.py:327
            │  │  │  │        └─ 0.551 quantify  ifc5d\qto.py:61
            │  │  │  │           ├─ 0.455 filter_elements  ifcopenshell\util\selector.py:425
            │  │  │  │           │     [6 frames hidden]  lark
            │  │  │  │           └─ 0.095 IfcOpenShell.calculate  ifc5d\qto.py:259
            │  │  │  │              └─ 0.093 iterator.initialize  ifcopenshell\ifcopenshell_wrapper.py:1097
            │  │  │  │                 └─ 0.093 Iterator_initialize  <built-in>
            │  │  │  └─ 0.575 quantify  ifc5d\qto.py:61
            │  │  │     ├─ 0.452 filter_elements  ifcopenshell\util\selector.py:425
            │  │  │     │     [6 frames hidden]  lark
            │  │  │     └─ 0.123 IfcOpenShell.calculate  ifc5d\qto.py:259
            │  │  │        └─ 0.121 iterator.initialize  ifcopenshell\ifcopenshell_wrapper.py:1097
            │  │  │           └─ 0.121 Iterator_initialize  <built-in>
            │  │  └─ 0.386 Element.build  primitive_objects.py:106
            │  │     └─ 0.386 Element._build  primitive_objects.py:327
            │  │        └─ 0.381 quantify  ifc5d\qto.py:61
            │  │           ├─ 0.305 filter_elements  ifcopenshell\util\selector.py:425
            │  │           │     [5 frames hidden]  lark
            │  │           └─ 0.075 IfcOpenShell.calculate  ifc5d\qto.py:259
            │  │              └─ 0.075 iterator.initialize  ifcopenshell\ifcopenshell_wrapper.py:1097
            │  │                 └─ 0.075 Iterator_initialize  <built-in>
            │  └─ 0.901 Element.build  primitive_objects.py:106
            │     └─ 0.901 Element._build  primitive_objects.py:327
            │        ├─ 0.532 quantify  ifc5d\qto.py:61
            │        │  ├─ 0.455 filter_elements  ifcopenshell\util\selector.py:425
            │        │  │     [7 frames hidden]  lark
            │        │  └─ 0.076 IfcOpenShell.calculate  ifc5d\qto.py:259
            │        │     └─ 0.073 iterator.initialize  ifcopenshell\ifcopenshell_wrapper.py:1097
            │        │        └─ 0.073 Iterator_initialize  <built-in>
            │        └─ 0.351 <listcomp>  primitive_objects.py:346
            │           └─ 0.351 Element.build  primitive_objects.py:106
            │              └─ 0.351 Element._build  primitive_objects.py:327
            │                          │        [5 frames hidden]  lark
            │                          └─ 0.153 edit_qtos  ifc5d\qto.py:83
            │                             └─ 0.152 wrapper  ifcopenshell\api\__init__.py:261
            │                                   [8 frames hidden]  ifcopenshell, <built-in>
            ├─ 0.173 wrapper  ifcopenshell\api\__init__.py:261
            │     [3 frames hidden]  ifcopenshell
            └─ 0.158 <listcomp>  primitive_objects.py:363
               └─ 0.158 Element.build  primitive_objects.py:106
                  └─ 0.158 Element._build  primitive_objects.py:327
                     └─ 0.154 quantify  ifc5d\qto.py:61
                        └─ 0.154 filter_elements  ifcopenshell\util\selector.py:425
                              [5 frames hidden]  lark
```