### PR TITLE
Update highlight of block code

### DIFF
--- a/src/ifcopenshell-python/docs/ifcpatch.rst
+++ b/src/ifcopenshell-python/docs/ifcpatch.rst
@@ -101,6 +101,7 @@ that allows seeing available arguments, their descriptions, types, default value
     patcher.patch()
     ifcpatch.write(patcher.get_output(), "output.ifc")
 
+
 Patch recipes
 -------------
 

--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -25,20 +25,21 @@ Can be used to run validation on IFC file from the command line:
 
     python -m ifcopenshell.validate /path/to/model.ifc --rules
 
-```
-$ python -m ifcopenshell.validate -h
-usage: validate.py [-h] [--rules] [--json] [--fields] [--spf] files [files ...]
+.. code-block:: console
 
-positional arguments:
-  files       The IFC file to validate.
+    python -m ifcopenshell.validate -h
+    
+    usage: validate.py [-h] [--rules] [--json] [--fields] [--spf] files [files ...]
 
-options:
-  -h, --help  show this help message and exit
-  --rules     Run express rules.
-  --json      Output in JSON format.
-  --fields    Output more detailed information about failed entities (only with --json).
-  --spf       Output entities in SPF format (only with --json).
-```
+    positional arguments:
+      files       The IFC file to validate.
+
+    options:
+      -h, --help  show this help message and exit
+      --rules     Run express rules.
+      --json      Output in JSON format.
+      --fields    Output more detailed information about failed entities (only with --json).
+      --spf       Output entities in SPF format (only with --json).
 
 """
 


### PR DESCRIPTION
From:
<img width="860" height="545" alt="image" src="https://github.com/user-attachments/assets/73288e19-ea8b-4cb1-8364-17efbe0f9d26" />



To:

<img width="860" height="545" alt="image" src="https://github.com/user-attachments/assets/b62dd9d8-778f-47ee-aa2b-0b29ba914ac5" />

Same style like found in https://docs.ifcopenshell.org/ifcclash.html


<img width="855" height="379" alt="image" src="https://github.com/user-attachments/assets/e2a7ac34-9b5c-4fec-a138-cb23149873a5" />




And same to https://docs.ifcopenshell.org/ifcpatch.html:

<img width="855" height="329" alt="image" src="https://github.com/user-attachments/assets/70834a63-5d04-44b9-a1f4-e72662aad52a" />


Change to:

<img width="855" height="329" alt="image" src="https://github.com/user-attachments/assets/acbd2792-b824-44d6-bf61-0d82014a8705" />
