### PR TITLE
Fixing the error when activating a BCF viewpoint from a topic comment

### DIFF
--- a/src/bonsai/bonsai/bim/module/bcf/operator.py
+++ b/src/bonsai/bonsai/bim/module/bcf/operator.py
@@ -1215,7 +1215,7 @@ class ActivateBcfViewpoint(bpy.types.Operator):
         assert blender_topic
         topic = bcfxml.topics[blender_topic.name]
         if self.viewpoint_guid:
-            viewpoint_guid = self.viewpoint_guid
+            viewpoint_guid = self.viewpoint_guid + ".bcfv"
             if viewpoint_guid not in topic.viewpoints:
                 self.report({"ERROR"}, f"No such viewpoint in the active topic: '{viewpoint_guid}'.")
                 return {"CANCELLED"}


### PR DESCRIPTION
A error occurred when trying to activate a BCF viewpoint from a comment in the Bonsai interface. The error source was  https://github.com/IfcOpenShell/IfcOpenShell/blob/f5220fba56761a7dad71e9eb3d1c372b9fdf885f/src/bonsai/bonsai/bim/module/bcf/operator.py#L1217-L1221

I tried editing the error message to print `topic.viewpoints` value. The result was:

<img width="890" height="151" alt="Image" src="https://github.com/user-attachments/assets/59227bb6-7b4c-469f-922f-468f644d1b30" />

The viewpoint GUID was being compared directly with the viewpoint filename, including its extension, which always lead to this error.  To fix the comparison, the viewpoint file extension was added to the viewpoint GUID variable being compared.
