### PR TITLE
Color Failed Entities on Specification Level

### DIFF
--- a/src/bonsai/bonsai/bim/module/tester/__init__.py
+++ b/src/bonsai/bonsai/bim/module/tester/__init__.py
@@ -25,6 +25,7 @@ classes = (
     operator.StopIfcTesterWebapp,
     operator.OpenIfcTesterWebapp,
     operator.SelectRequirement,
+    operator.ColorSpecefication,
     operator.SelectFailedEntities,
     operator.ExportBcf,
     prop.FailedEntities,

--- a/src/bonsai/bonsai/bim/module/tester/operator.py
+++ b/src/bonsai/bonsai/bim/module/tester/operator.py
@@ -520,8 +520,10 @@ class SelectFailedEntities(bpy.types.Operator):
         self.report({"INFO"}, f"{len(failed_ids)} failed entities found, {len(context.selected_objects)} selected.")
         return {"FINISHED"}
 
+
 class ColorSpecefication(bpy.types.Operator):
     """Colors all entities red that failed each test and color all entities yellow that failed some tests"""
+
     bl_idname = "bim.color_specification"
     bl_label = "Color Failed Entities"
     bl_options = {"REGISTER", "UNDO"}
@@ -531,9 +533,11 @@ class ColorSpecefication(bpy.types.Operator):
         props = context.scene.IfcTesterProperties
         report = tool.Tester.report
 
-        failures = [{e["id"] for e in requirement["failed_entities"]} for requirement in report[self.spec_index]["requirements"]]
+        failures = [
+            {e["id"] for e in requirement["failed_entities"]} for requirement in report[self.spec_index]["requirements"]
+        ]
         failed_all_ids = set.intersection(*failures)
-        failed_some_ids =  set.union(*failures)-failed_all_ids
+        failed_some_ids = set.union(*failures) - failed_all_ids
         if props.flag:
             area = next(area for area in context.screen.areas if area.type == "VIEW_3D")
             area.spaces[0].shading.color_type = "OBJECT"

--- a/src/bonsai/bonsai/bim/module/tester/operator.py
+++ b/src/bonsai/bonsai/bim/module/tester/operator.py
@@ -520,6 +520,35 @@ class SelectFailedEntities(bpy.types.Operator):
         self.report({"INFO"}, f"{len(failed_ids)} failed entities found, {len(context.selected_objects)} selected.")
         return {"FINISHED"}
 
+class ColorSpecefication(bpy.types.Operator):
+    """Colors all entities red that failed each test and color all entities yellow that failed some tests"""
+    bl_idname = "bim.color_specification"
+    bl_label = "Color Failed Entities"
+    bl_options = {"REGISTER", "UNDO"}
+    spec_index: bpy.props.IntProperty()
+
+    def execute(self, context):
+        props = context.scene.IfcTesterProperties
+        report = tool.Tester.report
+
+        failures = [{e["id"] for e in requirement["failed_entities"]} for requirement in report[self.spec_index]["requirements"]]
+        failed_all_ids = set.intersection(*failures)
+        failed_some_ids =  set.union(*failures)-failed_all_ids
+        if props.flag:
+            area = next(area for area in context.screen.areas if area.type == "VIEW_3D")
+            area.spaces[0].shading.color_type = "OBJECT"
+            area.spaces[0].shading.show_xray = True
+            for obj in context.scene.objects:
+                ifc_id = tool.Blender.get_ifc_definition_id(obj)
+                if ifc_id in failed_all_ids:
+                    obj.color = (1, 0, 0, 1)
+                elif ifc_id in failed_some_ids:
+                    obj.color = (1, 1, 0, 1)
+                else:
+                    obj.color = (1, 1, 1, 1)
+
+        return {"FINISHED"}
+
 
 class ExportBcf(bpy.types.Operator, ExportHelper):
     bl_idname = "bim.export_bcf"

--- a/src/bonsai/bonsai/bim/module/tester/ui.py
+++ b/src/bonsai/bonsai/bim/module/tester/ui.py
@@ -112,6 +112,9 @@ class BIM_PT_tester(Panel):
         )
         row = self.layout.row()
         row.label(text=f"Requirements ({n_requirements}):")
+        if props.flag:
+            op = row.operator("bim.color_specification", text="", icon="COLOR")
+            op.spec_index = props.active_specification_index
         box = self.layout.box()
         for i, requirement in enumerate(specification["requirements"]):
             row = box.row(align=True)


### PR DESCRIPTION
Adds Button to the IFC-Tester that allowes to Flag Failed Entities for A full Specification not just 1 Requirement:
<img width="1399" height="591" alt="image" src="https://github.com/user-attachments/assets/fbf69c2f-0442-4dae-8c34-29fa0a596116" />

It colors all entities that failed each requirement red and all entities that failed some requirements yellow
The button is hidden if Flag Failed Entities is disabled

I think i generally might be a good idea to add a "reset view" button but i don't know how to implement this