### PR TITLE
fix(bcf): Create directory entries in the zip file's central directory

### DIFF
--- a/src/bcf/bcf/v2/topic.py
+++ b/src/bcf/bcf/v2/topic.py
@@ -192,6 +192,8 @@ class TopicHandler:
             bcf_zip: The BCF zip file to save to.
         """
         topic_dir = self.guid
+        # simulating directory creation (ZipFile in python < 3.11 doesn't have mkdir)
+        destination_zip.writestr(f"{topic_dir}/", "")
         self._save_xml(destination_zip, self._markup, "markup.bcf")
         self._save_viewpoints(destination_zip, topic_dir)
         self._save_bim_snippet(destination_zip)

--- a/src/bcf/bcf/v3/topic.py
+++ b/src/bcf/bcf/v3/topic.py
@@ -179,6 +179,8 @@ class TopicHandler:
             bcf_zip: The BCF zip file to save to.
         """
         topic_dir = self.guid
+        # simulating directory creation (ZipFile in python < 3.11 doesn't have mkdir)
+        destination_zip.writestr(f"{topic_dir}/", "")
         self._save_xml(destination_zip, self._markup, "markup.bcf")
         self._save_viewpoints(destination_zip, topic_dir)
         self._save_bim_snippet(destination_zip)


### PR DESCRIPTION
This is done to comply with the [Implementation Agreements ](https://github.com/buildingSMART/BCF-XML/tree/release_3_0/Documentation#create-directory-folder-entries-in-the-zip-files-central-directory)

Doesn't solve the BCF compatibility issue I'm facing with BimCollab, but at least we ruled it out.