### PR TITLE
Fix warning C4275

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -151,11 +151,6 @@ if(MSVC AND MSVC_PARALLEL_BUILD)
     add_definitions("/MP")
 endif()
 
-if (MSVC AND BUILD_SHARED_LIBS)
-    # @todo how do projects normally deal with this regarding classes derived from std::exception?
-    add_compile_options(/wd4275)
-endif()
-
 if(NO_WARN)
     if(MSVC)
         add_compile_options("/w")

--- a/src/ifcgeom/AbstractKernel.cpp
+++ b/src/ifcgeom/AbstractKernel.cpp
@@ -7,6 +7,14 @@
 
 using namespace ifcopenshell::geometry;
 
+const char* ifcopenshell::not_implemented_error::what() const noexcept {
+	return "Not implemented.";
+}
+
+const char* ifcopenshell::not_supported_error::what() const noexcept {
+	return "Not supported.";
+}
+
 bool ifcopenshell::geometry::kernels::AbstractKernel::convert(const taxonomy::ptr item, IfcGeom::ConversionResults& results) {
 	if (settings_.get<settings::CacheShapes>().get()) {
 		auto it = cache_.find(item);

--- a/src/ifcgeom/AbstractKernel.h
+++ b/src/ifcgeom/AbstractKernel.h
@@ -36,21 +36,26 @@ inline static bool ALMOST_THE_SAME(const T& a, const T& b, double tolerance = AL
 }
 
 namespace ifcopenshell { 
-	
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4275)
+#endif
+
 	class IFC_GEOM_API not_implemented_error : public std::exception {
 	public:
-		const char* what() const noexcept override {
-			return "Not implemented.";
-		}
+		const char* what() const noexcept override;
 	};
 
 	class IFC_GEOM_API not_supported_error : public std::exception {
 	public:
-		const char* what() const noexcept override {
-			return "Not supported.";
-		}
+		const char* what() const noexcept override;
 	};
-	
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 	namespace geometry { namespace kernels {
 
 	class IFC_GEOM_API AbstractKernel {

--- a/src/ifcgeom/ConversionSettings.cpp
+++ b/src/ifcgeom/ConversionSettings.cpp
@@ -94,3 +94,7 @@ std::istream& ifcopenshell::geometry::settings::operator>>(std::istream& in, Tri
 	}
 	return in;
 }
+
+IfcGeom::geometry_exception::~geometry_exception() = default;
+
+IfcGeom::too_many_faces_exception::~too_many_faces_exception() = default;

--- a/src/ifcgeom/ConversionSettings.h
+++ b/src/ifcgeom/ConversionSettings.h
@@ -655,6 +655,12 @@ namespace ifcopenshell {
 
 // @todo find a place
 namespace IfcGeom {
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4275)
+#endif
+
 	class IFC_GEOM_API geometry_exception : public std::runtime_error {
 	protected:
 		std::string message;
@@ -662,12 +668,19 @@ namespace IfcGeom {
 		geometry_exception(const std::string& m)
 			: std::runtime_error(m)
 		{}
+		~geometry_exception() override;
 	};
 
 	class IFC_GEOM_API too_many_faces_exception : public geometry_exception {
 	public:
 		too_many_faces_exception()
 			: geometry_exception("Too many faces for operation") {}
+		~too_many_faces_exception() override;
 	};
 }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
 #endif

--- a/src/ifcgeom/taxonomy.cpp
+++ b/src/ifcgeom/taxonomy.cpp
@@ -223,6 +223,8 @@ namespace {
 	};
 }
 
+ifcopenshell::geometry::taxonomy::topology_error::~topology_error() = default;
+
 bool ifcopenshell::geometry::taxonomy::less(item::const_ptr a, item::const_ptr b) {
 	if (a == b) {
 		return false;

--- a/src/ifcgeom/taxonomy.h
+++ b/src/ifcgeom/taxonomy.h
@@ -87,11 +87,21 @@ typedef item* ptr; \
 typedef item const* ptr;
 #endif
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4275)
+#endif
+
 			class IFC_GEOM_API topology_error : public std::runtime_error {
 			public:
 				topology_error() : std::runtime_error("Generic topology error") {}
 				topology_error(const char* const s) : std::runtime_error(s) {}
+				~topology_error() override;
 			};
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 			// Implementer note: If you add a new item type, be sure to do the following
 			// 1) Add a new kind to this list

--- a/src/ifcparse/IfcException.cpp
+++ b/src/ifcparse/IfcException.cpp
@@ -1,0 +1,7 @@
+#include "IfcException.h"
+
+IfcParse::IfcException::~IfcException() = default;
+
+IfcParse::IfcAttributeOutOfRangeException::~IfcAttributeOutOfRangeException() = default;
+
+IfcParse::IfcInvalidTokenException::~IfcInvalidTokenException() = default;

--- a/src/ifcparse/IfcException.h
+++ b/src/ifcparse/IfcException.h
@@ -41,8 +41,8 @@ class IFC_PARSE_API IfcException : public std::exception {
   public:
     IfcException(const std::string& message)
         : message_(message) {}
-    virtual ~IfcException() throw() {}
-    virtual const char* what() const throw() {
+    ~IfcException() override;
+    const char* what() const noexcept override {
         return message_.c_str();
     }
 };
@@ -51,7 +51,7 @@ class IFC_PARSE_API IfcAttributeOutOfRangeException : public IfcException {
   public:
     IfcAttributeOutOfRangeException(const std::string& exception)
         : IfcException(exception) {}
-    ~IfcAttributeOutOfRangeException() throw() {}
+    ~IfcAttributeOutOfRangeException() override;
 };
 
 class IFC_PARSE_API IfcInvalidTokenException : public IfcException {
@@ -70,7 +70,7 @@ class IFC_PARSE_API IfcInvalidTokenException : public IfcException {
         : IfcException(
               std::string("Unexpected '") + std::string(1, character) + "' at offset " +
               boost::lexical_cast<std::string>(token_start)) {}
-    ~IfcInvalidTokenException() throw() {}
+    ~IfcInvalidTokenException() override;
 };
 
 } // namespace IfcParse


### PR DESCRIPTION
It's not enough to disable this warning by adding /wd4257 at build time because it's triggered when the library is consumed.

Also move key functions to cpp.
https://lld.llvm.org/missingkeyfunction.html
https://releases.llvm.org/20.1.0/tools/clang/docs/DiagnosticsReference.html#wweak-vtables