### PR TITLE
Put Bonsai webui PID file in a writable location

### DIFF
--- a/src/bonsai/bonsai/bim/data/webui/sioserver.py
+++ b/src/bonsai/bonsai/bim/data/webui/sioserver.py
@@ -15,6 +15,8 @@ import pystache
 import json
 import base64
 import xml.etree.ElementTree as ET
+import platformdirs
+from pathlib import Path
 
 sio_port = 8080  # default port
 
@@ -233,10 +235,17 @@ async def demo(request):
     return web.Response(text=html_content, content_type="text/html")
 
 
-async def on_startup(app):
-    pid_file = "running_pid.json"
+def get_pid_file_path():
+    """Get the path to the PID file in the user's cache directory."""
+    cache_dir = Path(platformdirs.user_cache_dir("bonsai"))
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / "running_pid.json"
 
-    if os.path.exists(pid_file):
+
+async def on_startup(app):
+    pid_file = get_pid_file_path()
+
+    if pid_file.exists():
         with open(pid_file, "r") as f:
             pids = json.load(f)
     else:

--- a/src/bonsai/bonsai/tool/web.py
+++ b/src/bonsai/bonsai/tool/web.py
@@ -41,6 +41,7 @@ import socketio
 import threading
 import queue
 import json
+import platformdirs
 from time import sleep
 from pathlib import Path
 import bonsai.core.sequence
@@ -63,6 +64,13 @@ IFC_TASK_ATTRIBUTE_MAP = {
     "pEnd": "ScheduleFinish",
     "pName": "Name",
 }
+
+
+def get_pid_file_path():
+    """Get the path to the PID file in the user's cache directory."""
+    cache_dir = Path(platformdirs.user_cache_dir("bonsai"))
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir / "running_pid.json"
 
 
 class Web(bonsai.core.tool.Web):
@@ -213,7 +221,7 @@ class Web(bonsai.core.tool.Web):
             cls.disconnect_websocket_server()
 
         # sleep(0.5)
-        pid_file = tool.Blender.get_data_dir_path("webui") / "running_pid.json"
+        pid_file = get_pid_file_path()
         with open(pid_file, "r") as f:
             pids = json.load(f)
 
@@ -250,7 +258,7 @@ class Web(bonsai.core.tool.Web):
         while True:
             if time.time() - start > max_time:
                 return False
-            pid_file = tool.Blender.get_data_dir_path("webui") / "running_pid.json"
+            pid_file = get_pid_file_path()
             try:
                 with open(pid_file, "r") as f:
                     data = json.load(f)


### PR DESCRIPTION
Currently a file called running_pid.json is written in the same folder as sioserver.py which is icky. It also doesn't work on a system where bonsai is read-only. This fix puts this file in a platform-suitable location:

  Linux: ~/.cache/bonsai/running_pid.json
  Windows: %LOCALAPPDATA%\bonsai\Cache\running_pid.json
  macOS: ~/Library/Caches/bonsai/running_pid.json

I'm adding this as a pull-request because I have other problems with the webui (Connected Blenders: 0), but I suspect this is some other issue.