### PR TITLE
Add functionality to deselect objects not intersected by the active camera view when annotation TEXT

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/__init__.py
+++ b/src/bonsai/bonsai/bim/module/drawing/__init__.py
@@ -89,6 +89,7 @@ classes = (
     operator.SelectAssignedProduct,
     operator.ToggleTargetView,
     operator.OpenDocumentationWebUi,
+    operator.SelectObjectsIntersectedByCamera,
     prop.Variable,
     prop.Drawing,
     prop.Document,

--- a/src/bonsai/bonsai/bim/module/drawing/__init__.py
+++ b/src/bonsai/bonsai/bim/module/drawing/__init__.py
@@ -89,7 +89,7 @@ classes = (
     operator.SelectAssignedProduct,
     operator.ToggleTargetView,
     operator.OpenDocumentationWebUi,
-    operator.SelectObjectsIntersectedByCamera,
+    operator.FilterSelectedObjectsIfIntersectedByCamera,
     prop.Variable,
     prop.Drawing,
     prop.Document,

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3785,3 +3785,60 @@ class ExcludeAnnotation(bpy.types.Operator, tool.Ifc.Operator):
                 if (referenced_element := tool.Drawing.get_annotation_element(element)):
                     tool.Drawing.exclude_annotation_from_drawing(referenced_element, drawing)
         core.sync_references(tool.Ifc, tool.Collector, tool.Drawing, drawing=drawing)
+
+
+class SelectObjectsIntersectedByCamera(bpy.types.Operator):
+    bl_idname = "bim.select_objects_intersected_by_camera"
+    bl_label = "Select Objects Intersected by Camera"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Select all objects that are intersected by the active camera view"
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.camera is not None
+
+    def execute(self, context):
+        self.select_objects_intersected_by_camera(context)
+        return {"FINISHED"}
+
+    def select_objects_intersected_by_camera(self, context: bpy.types.Context) -> None:
+        camera_obj = context.scene.camera
+        if not camera_obj:
+            return
+            
+        camera = camera_obj.data
+        if not isinstance(camera, bpy.types.Camera):
+            return
+
+        cam_matrix = camera_obj.matrix_world
+        cam_origin = cam_matrix.translation
+        cam_direction = cam_matrix.to_quaternion() @ Vector((0.0, 0.0, -1.0))
+        plane_normal = cam_direction.normalized()
+        plane_point = cam_origin
+
+        def point_plane_distance(point):
+            return (point - plane_point).dot(plane_normal)
+
+        bpy.ops.object.select_all(action='SELECT')
+        
+        deselected = 0
+        for obj in context.selected_objects:
+            if obj == camera_obj:
+                obj.select_set(False)
+                continue
+
+
+            bbox_world = [obj.matrix_world @ Vector(corner) for corner in obj.bound_box]
+            distances = [point_plane_distance(p) for p in bbox_world]
+            min_d = min(distances)
+            max_d = max(distances)
+
+            intersects = (min_d <= 0.0 <= max_d) or (max_d <= 0.0 <= min_d)
+            
+            if not intersects:
+                obj.select_set(False)
+                deselected += 1
+
+        selected_count = len([obj for obj in context.selected_objects if obj != camera_obj])
+        self.report({'INFO'}, f"Selected {selected_count} object(s) intersecting camera plane")
+    

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3794,21 +3794,21 @@ class ExcludeAnnotation(bpy.types.Operator, tool.Ifc.Operator):
         core.sync_references(tool.Ifc, tool.Collector, tool.Drawing, drawing=drawing)
 
 
-class SelectObjectsIntersectedByCamera(bpy.types.Operator):
-    bl_idname = "bim.select_objects_intersected_by_camera"
-    bl_label = "Select Objects Intersected by Camera"
+class FilterSelectedObjectsIfIntersectedByCamera(bpy.types.Operator):
+    bl_idname = "bim.filter_selected_objects_if_intersected_by_camera"
+    bl_label = "Filter Selected Objects If Intersected by Camera"
     bl_options = {"REGISTER", "UNDO"}
-    bl_description = "Select all objects that are intersected by the active camera view"
+    bl_description = "Deselect objects that are not intersected by the active camera view"
 
     @classmethod
     def poll(cls, context):
-        return context.scene.camera is not None
+        return context.scene.camera is not None and len(context.selected_objects) > 0
 
     def execute(self, context):
-        self.select_objects_intersected_by_camera(context)
+        self.filter_selected_objects_if_intersected_by_camera(context)
         return {"FINISHED"}
 
-    def select_objects_intersected_by_camera(self, context: bpy.types.Context) -> None:
+    def filter_selected_objects_if_intersected_by_camera(self, context: bpy.types.Context) -> None:
         camera_obj = context.scene.camera
         if not camera_obj:
             return
@@ -3826,14 +3826,10 @@ class SelectObjectsIntersectedByCamera(bpy.types.Operator):
         def point_plane_distance(point):
             return (point - plane_point).dot(plane_normal)
 
-        bpy.ops.object.select_all(action="SELECT")
-
+        selected_objects = [obj for obj in context.selected_objects if obj != camera_obj]
+        
         deselected = 0
-        for obj in context.selected_objects:
-            if obj == camera_obj:
-                obj.select_set(False)
-                continue
-
+        for obj in selected_objects:
             bbox_world = [obj.matrix_world @ Vector(corner) for corner in obj.bound_box]
             distances = [point_plane_distance(p) for p in bbox_world]
             min_d = min(distances)
@@ -3845,5 +3841,5 @@ class SelectObjectsIntersectedByCamera(bpy.types.Operator):
                 obj.select_set(False)
                 deselected += 1
 
-        selected_count = len([obj for obj in context.selected_objects if obj != camera_obj])
-        self.report({"INFO"}, f"Selected {selected_count} object(s) intersecting camera plane")
+        remaining_selected = len([obj for obj in context.selected_objects if obj != camera_obj])
+        self.report({"INFO"}, f"Filtered to {remaining_selected} object(s) intersecting camera plane (deselected {deselected})")

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1290,8 +1290,7 @@ class CreateDrawing(bpy.types.Operator):
             value = ifcopenshell.util.selector.get_element_value(element, key)
             if value:
                 classes.append(
-                    tool.Drawing.canonicalise_class_name(key) + "-" +
-                    tool.Drawing.canonicalise_class_name(str(value))
+                    tool.Drawing.canonicalise_class_name(key) + "-" + tool.Drawing.canonicalise_class_name(str(value))
                 )
 
         # ─── Target View ───────────────────────────────────────────
@@ -1300,7 +1299,6 @@ class CreateDrawing(bpy.types.Operator):
             classes.append(f"target-view-{target_view_class}")
 
         return classes
-
 
     def is_manifold(self, obj) -> bool:
         result = self.is_manifold_cache.get(obj.data.name, None)
@@ -1366,7 +1364,13 @@ class CreateDrawing(bpy.types.Operator):
             join_criteria = join_criteria.split(",")
         else:
             # Drawing convention states that same objects classes with the same material are merged when cut.
-            join_criteria = ["class", "material.Name", "/Pset_.*Common/.Status", "EPset_Status.Status", "EPset_Status.UserDefinedStatus"]
+            join_criteria = [
+                "class",
+                "material.Name",
+                "/Pset_.*Common/.Status",
+                "EPset_Status.Status",
+                "EPset_Status.UserDefinedStatus",
+            ]
 
         group = root.find("{http://www.w3.org/2000/svg}g")
         joined_paths = {}
@@ -2355,7 +2359,10 @@ class ActivateDrawingBase(tool.Ifc.Operator):
         camera_element = tool.Ifc.get_entity(camera)
         is_reflected = False
         if camera_element:
-            is_reflected = ifcopenshell.util.element.get_pset(camera_element, "EPset_Drawing", "TargetView") == "REFLECTED_PLAN_VIEW"
+            is_reflected = (
+                ifcopenshell.util.element.get_pset(camera_element, "EPset_Drawing", "TargetView")
+                == "REFLECTED_PLAN_VIEW"
+            )
             if is_reflected and camera.scale != (-1, -1, -1):
                 camera.scale = (-1, -1, -1)
                 camera.rotation_euler = (0.0, 0.0, radians(180))
@@ -3782,7 +3789,7 @@ class ExcludeAnnotation(bpy.types.Operator, tool.Ifc.Operator):
             return
         for obj in tool.Blender.get_selected_objects(include_active=False):
             if (element := tool.Ifc.get_entity(obj)) and tool.Drawing.is_auto_annotation(element):
-                if (referenced_element := tool.Drawing.get_annotation_element(element)):
+                if referenced_element := tool.Drawing.get_annotation_element(element):
                     tool.Drawing.exclude_annotation_from_drawing(referenced_element, drawing)
         core.sync_references(tool.Ifc, tool.Collector, tool.Drawing, drawing=drawing)
 
@@ -3805,7 +3812,7 @@ class SelectObjectsIntersectedByCamera(bpy.types.Operator):
         camera_obj = context.scene.camera
         if not camera_obj:
             return
-            
+
         camera = camera_obj.data
         if not isinstance(camera, bpy.types.Camera):
             return
@@ -3819,14 +3826,13 @@ class SelectObjectsIntersectedByCamera(bpy.types.Operator):
         def point_plane_distance(point):
             return (point - plane_point).dot(plane_normal)
 
-        bpy.ops.object.select_all(action='SELECT')
-        
+        bpy.ops.object.select_all(action="SELECT")
+
         deselected = 0
         for obj in context.selected_objects:
             if obj == camera_obj:
                 obj.select_set(False)
                 continue
-
 
             bbox_world = [obj.matrix_world @ Vector(corner) for corner in obj.bound_box]
             distances = [point_plane_distance(p) for p in bbox_world]
@@ -3834,11 +3840,10 @@ class SelectObjectsIntersectedByCamera(bpy.types.Operator):
             max_d = max(distances)
 
             intersects = (min_d <= 0.0 <= max_d) or (max_d <= 0.0 <= min_d)
-            
+
             if not intersects:
                 obj.select_set(False)
                 deselected += 1
 
         selected_count = len([obj for obj in context.selected_objects if obj != camera_obj])
-        self.report({'INFO'}, f"Selected {selected_count} object(s) intersecting camera plane")
-    
+        self.report({"INFO"}, f"Selected {selected_count} object(s) intersecting camera plane")

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -390,6 +390,13 @@ class RasterStyleProperty(enum.Enum):
 
 RASTER_STYLE_PROPERTIES_EXCLUDE = ("scene.render.filepath",)
 
+def update_should_select_intersected_by_camera(self, context: bpy.types.Context) -> None:
+    if self.should_select_intersected_by_camera:
+        if context.scene.camera:
+            bpy.ops.bim.select_objects_intersected_by_camera()
+    else:
+        bpy.ops.object.select_all(action='DESELECT')
+
 
 class DocProperties(PropertyGroup):
     # Note that options are global in descriptions to prevent confusion,
@@ -433,6 +440,12 @@ class DocProperties(PropertyGroup):
     active_sheet_index: IntProperty(name="Active Sheet Index")
     drawing_styles: CollectionProperty(name="Drawing Styles", type=DrawingStyle)
     should_draw_decorations: BoolProperty(name="Should Draw Decorations", update=update_should_draw_decorations)
+    should_select_intersected_by_camera: BoolProperty(
+        name="Intersected by Camera", 
+        description="Select all objects intersected by the active camera view",
+        default=False,
+        update=update_should_select_intersected_by_camera
+    )
 
     if TYPE_CHECKING:
         should_use_underlay_cache: bool
@@ -458,6 +471,7 @@ class DocProperties(PropertyGroup):
         active_sheet_index: int
         drawing_styles: bpy.types.bpy_prop_collection_idprop[DrawingStyle]
         should_draw_decorations: bool
+        should_select_intersected_by_camera: bool
 
     def get_active_drawing(self) -> Union[ifcopenshell.entity_instance, None]:
         drawing_id = self.active_drawing_id

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -391,14 +391,6 @@ class RasterStyleProperty(enum.Enum):
 RASTER_STYLE_PROPERTIES_EXCLUDE = ("scene.render.filepath",)
 
 
-def update_should_select_intersected_by_camera(self, context: bpy.types.Context) -> None:
-    if self.should_select_intersected_by_camera:
-        if context.scene.camera:
-            bpy.ops.bim.select_objects_intersected_by_camera()
-    else:
-        bpy.ops.object.select_all(action="DESELECT")
-
-
 class DocProperties(PropertyGroup):
     # Note that options are global in descriptions to prevent confusion,
     # as options are available through Active Drawing UI, but they're actually global.
@@ -441,12 +433,6 @@ class DocProperties(PropertyGroup):
     active_sheet_index: IntProperty(name="Active Sheet Index")
     drawing_styles: CollectionProperty(name="Drawing Styles", type=DrawingStyle)
     should_draw_decorations: BoolProperty(name="Should Draw Decorations", update=update_should_draw_decorations)
-    should_select_intersected_by_camera: BoolProperty(
-        name="Intersected by Camera",
-        description="Select all objects intersected by the active camera view",
-        default=False,
-        update=update_should_select_intersected_by_camera,
-    )
 
     if TYPE_CHECKING:
         should_use_underlay_cache: bool
@@ -472,7 +458,6 @@ class DocProperties(PropertyGroup):
         active_sheet_index: int
         drawing_styles: bpy.types.bpy_prop_collection_idprop[DrawingStyle]
         should_draw_decorations: bool
-        should_select_intersected_by_camera: bool
 
     def get_active_drawing(self) -> Union[ifcopenshell.entity_instance, None]:
         drawing_id = self.active_drawing_id

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -390,12 +390,13 @@ class RasterStyleProperty(enum.Enum):
 
 RASTER_STYLE_PROPERTIES_EXCLUDE = ("scene.render.filepath",)
 
+
 def update_should_select_intersected_by_camera(self, context: bpy.types.Context) -> None:
     if self.should_select_intersected_by_camera:
         if context.scene.camera:
             bpy.ops.bim.select_objects_intersected_by_camera()
     else:
-        bpy.ops.object.select_all(action='DESELECT')
+        bpy.ops.object.select_all(action="DESELECT")
 
 
 class DocProperties(PropertyGroup):
@@ -441,10 +442,10 @@ class DocProperties(PropertyGroup):
     drawing_styles: CollectionProperty(name="Drawing Styles", type=DrawingStyle)
     should_draw_decorations: BoolProperty(name="Should Draw Decorations", update=update_should_draw_decorations)
     should_select_intersected_by_camera: BoolProperty(
-        name="Intersected by Camera", 
+        name="Intersected by Camera",
         description="Select all objects intersected by the active camera view",
         default=False,
-        update=update_should_select_intersected_by_camera
+        update=update_should_select_intersected_by_camera,
     )
 
     if TYPE_CHECKING:
@@ -513,9 +514,7 @@ class BIMCameraProperties(PropertyGroup):
         update=get_update_layer_callback("linework_mode", "LineworkMode"),
     )
     generate_material_layers: bpy.props.BoolProperty(
-        name="Generate Material Layers",
-        description="Generate material layer linework in drawings",
-        default=True
+        name="Generate Material Layers", description="Generate material layer linework in drawings", default=True
     )
     fill_mode: EnumProperty(
         items=[

--- a/src/bonsai/bonsai/bim/module/drawing/workspace.py
+++ b/src/bonsai/bonsai/bim/module/drawing/workspace.py
@@ -259,6 +259,9 @@ class AnnotationToolUI:
             add_layout_hotkey_operator(
                 cls.layout, "Readjust", "S_G", "Readjust tags based on the products they are assigned to"
             )
+            row = cls.layout.row(align=True)
+            props = tool.Drawing.get_document_props()
+            row.prop(props, "should_select_intersected_by_camera", text="Intersected by Camera")
 
 
 class Hotkey(bpy.types.Operator, tool.Ifc.Operator):

--- a/src/bonsai/bonsai/bim/module/drawing/workspace.py
+++ b/src/bonsai/bonsai/bim/module/drawing/workspace.py
@@ -261,7 +261,7 @@ class AnnotationToolUI:
             )
             row = cls.layout.row(align=True)
             props = tool.Drawing.get_document_props()
-            row.prop(props, "should_select_intersected_by_camera", text="Intersected by Camera")
+            row.operator("bim.filter_selected_objects_if_intersected_by_camera", text="Filter by Camera")
 
 
 class Hotkey(bpy.types.Operator, tool.Ifc.Operator):


### PR DESCRIPTION
This is a PR to address the discussion in https://community.osarch.org/discussion/3180/deselect-non-intersecting-objects-with-camera


https://github.com/user-attachments/assets/851c9b73-685b-4d52-b8cb-359b0febb956



Cheers!
