### PR TITLE
Add Extras in addon preferences to conditionally add functionality. One extra added from commit from sjb007

### DIFF
--- a/src/bonsai/bonsai/bim/module/spatial/__init__.py
+++ b/src/bonsai/bonsai/bim/module/spatial/__init__.py
@@ -38,6 +38,7 @@ classes = (
     operator.SelectDecomposedElements,
     operator.SelectProduct,
     operator.SelectSimilarContainer,
+    operator.SetContainerVisibility,
     operator.SetDefaultContainer,
     operator.SetElementVisibility,
     operator.ToggleContainerElement,

--- a/src/bonsai/bonsai/bim/module/spatial/operator.py
+++ b/src/bonsai/bonsai/bim/module/spatial/operator.py
@@ -507,6 +507,7 @@ class SetDefaultContainer(bpy.types.Operator):
         core.set_orientation_slot(tool.Spatial, container=tool.Ifc.get().by_id(self.container))
         return {"FINISHED"}
 
+
 class SetContainerVisibility(bpy.types.Operator):
     bl_idname = "bim.set_container_visibility"
     bl_label = "Set Container Visibility"
@@ -553,6 +554,7 @@ class SetContainerVisibility(bpy.types.Operator):
             if self.should_include_children:
                 queue.extend(ifcopenshell.util.element.get_parts(container))
         return {"FINISHED"}
+
 
 class SetElementVisibility(bpy.types.Operator):
     bl_idname = "bim.set_element_visibility"

--- a/src/bonsai/bonsai/bim/module/spatial/operator.py
+++ b/src/bonsai/bonsai/bim/module/spatial/operator.py
@@ -507,6 +507,52 @@ class SetDefaultContainer(bpy.types.Operator):
         core.set_orientation_slot(tool.Spatial, container=tool.Ifc.get().by_id(self.container))
         return {"FINISHED"}
 
+class SetContainerVisibility(bpy.types.Operator):
+    bl_idname = "bim.set_container_visibility"
+    bl_label = "Set Container Visibility"
+    bl_options = {"REGISTER", "UNDO"}
+    container: bpy.props.IntProperty()
+    should_include_children: bpy.props.BoolProperty(name="Should Include Children", default=True, options={"SKIP_SAVE"})
+    mode: bpy.props.StringProperty(name="Mode")
+
+    @classmethod
+    def description(cls, context, operator):
+        if operator.mode == "HIDE":
+            return "Hides the selected container and all children.\n" + "ALT+CLICK to ignore children"
+        elif operator.mode == "SHOW":
+            return "Shows the selected container and all children.\n" + "ALT+CLICK to ignore children"
+        return "Isolate the selected container and all children.\n" + "ALT+CLICK to ignore children"
+
+    def invoke(self, context, event):
+        if event.type == "LEFTMOUSE" and event.alt:
+            self.should_include_children = False
+        return self.execute(context)
+
+    def execute(self, context):
+        if self.mode == "ISOLATE":
+            if tool.Ifc.get_schema() == "IFC2X3":
+                containers = tool.Ifc.get().by_type("IfcSpatialStructureElement")
+            elif tool.Ifc.get_schema() != "IFC2X3":
+                containers = set(tool.Ifc.get().by_type("IfcSpatialElement"))
+                containers -= set(tool.Ifc.get().by_type("IfcSpatialZone"))
+            for container in containers:
+                if obj := tool.Ifc.get_object(container):
+                    if collection := obj.BIMObjectProperties.collection:
+                        collection.hide_viewport = True
+            should_hide = False
+        else:
+            should_hide = self.mode == "HIDE"
+
+        container = tool.Ifc.get().by_id(self.container)
+        queue = [container]
+        while queue:
+            container = queue.pop()
+            if obj := tool.Ifc.get_object(container):
+                if collection := obj.BIMObjectProperties.collection:
+                    collection.hide_viewport = should_hide
+            if self.should_include_children:
+                queue.extend(ifcopenshell.util.element.get_parts(container))
+        return {"FINISHED"}
 
 class SetElementVisibility(bpy.types.Operator):
     bl_idname = "bim.set_element_visibility"

--- a/src/bonsai/bonsai/bim/module/spatial/ui.py
+++ b/src/bonsai/bonsai/bim/module/spatial/ui.py
@@ -132,23 +132,16 @@ class BIM_PT_spatial_decomposition(Panel):
             op = col.operator("bim.set_default_container", icon="OUTLINER_COLLECTION", text="Set Default")
             op.container = ifc_definition_id
 
-            # Only show container visibility operators if the preference is enabled
-            from bonsai.bim.ui import BIM_ADDON_preferences
-
-            addon = BIM_ADDON_preferences.get_addon_instance()
-            if addon and getattr(addon, "preferences", None):
-                prefs = addon.preferences
-                value = getattr(prefs, "container_hide_show_isolate", None)
-                if value:
-                    op = row.operator("bim.set_container_visibility", icon="FULLSCREEN_EXIT", text="")
-                    op.mode = "ISOLATE"
-                    op.container = ifc_definition_id
-                    op = row.operator("bim.set_container_visibility", icon="HIDE_OFF", text="")
-                    op.mode = "SHOW"
-                    op.container = ifc_definition_id
-                    op = row.operator("bim.set_container_visibility", icon="HIDE_ON", text="")
-                    op.mode = "HIDE"
-                    op.container = ifc_definition_id
+            if tool.Blender.get_addon_preferences().container_hide_show_isolate:
+                op = row.operator("bim.set_container_visibility", icon="FULLSCREEN_EXIT", text="")
+                op.mode = "ISOLATE"
+                op.container = ifc_definition_id
+                op = row.operator("bim.set_container_visibility", icon="HIDE_OFF", text="")
+                op.mode = "SHOW"
+                op.container = ifc_definition_id
+                op = row.operator("bim.set_container_visibility", icon="HIDE_ON", text="")
+                op.mode = "HIDE"
+                op.container = ifc_definition_id
 
             # The only operator that's enabled for IfcProject.
             col = row.column(align=True)

--- a/src/bonsai/bonsai/bim/module/spatial/ui.py
+++ b/src/bonsai/bonsai/bim/module/spatial/ui.py
@@ -132,6 +132,23 @@ class BIM_PT_spatial_decomposition(Panel):
             op = col.operator("bim.set_default_container", icon="OUTLINER_COLLECTION", text="Set Default")
             op.container = ifc_definition_id
 
+            # Only show container visibility operators if the preference is enabled
+            from bonsai.bim.ui import BIM_ADDON_preferences
+            addon = BIM_ADDON_preferences.get_addon_instance()
+            if addon and getattr(addon, "preferences", None):
+                prefs = addon.preferences
+                value = getattr(prefs, "container_hide_show_isolate", None)
+                if value:
+                    op = row.operator("bim.set_container_visibility", icon="FULLSCREEN_EXIT", text="")
+                    op.mode = "ISOLATE"
+                    op.container = ifc_definition_id
+                    op = row.operator("bim.set_container_visibility", icon="HIDE_OFF", text="")
+                    op.mode = "SHOW"
+                    op.container = ifc_definition_id
+                    op = row.operator("bim.set_container_visibility", icon="HIDE_ON", text="")
+                    op.mode = "HIDE"
+                    op.container = ifc_definition_id
+
             # The only operator that's enabled for IfcProject.
             col = row.column(align=True)
             col.operator("bim.select_container", icon="OBJECT_DATA", text="").container = ifc_definition_id

--- a/src/bonsai/bonsai/bim/module/spatial/ui.py
+++ b/src/bonsai/bonsai/bim/module/spatial/ui.py
@@ -134,6 +134,7 @@ class BIM_PT_spatial_decomposition(Panel):
 
             # Only show container visibility operators if the preference is enabled
             from bonsai.bim.ui import BIM_ADDON_preferences
+
             addon = BIM_ADDON_preferences.get_addon_instance()
             if addon and getattr(addon, "preferences", None):
                 prefs = addon.preferences

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -678,6 +678,12 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         description="Default parameters for BIM elements",
     )
 
+    container_hide_show_isolate: BoolProperty(
+        name="Container hide/show/isolate",
+        description="Enable container hide/show/isolate feature in the UI",
+        default=False,
+    )
+
     if TYPE_CHECKING:
         svg2pdf_command: str
         svg2dxf_command: str
@@ -713,6 +719,7 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         pset_dir: str
         doc: DocPreferences
         default_parameters: DefaultParameters
+        container_hide_show_isolate: bool
 
     def draw(self, context: bpy.types.Context) -> None:
         layout = self.layout
@@ -892,15 +899,8 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         layout.prop(self, "bsdd_load_inactive_dictionaries")
         layout.prop(self, "bsdd_load_test_dictionaries")
 
-
     def draw_extras_settings(self, layout: bpy.types.UILayout, context: bpy.types.Context) -> None:
         layout.prop(self, "container_hide_show_isolate")
-
-    container_hide_show_isolate: BoolProperty(
-        name="Container hide/show/isolate",
-        description="Enable container hide/show/isolate feature in the UI",
-        default=False,
-    )
 
 
 # Scene panel groups

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -678,34 +678,6 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         description="Default parameters for BIM elements",
     )
 
-    addon_instance = None
-
-    @classmethod
-    def set_addon_instance(cls):
-        import bpy
-
-        instance = None
-        for key in bpy.context.preferences.addons.keys():
-            if ".bonsai" in key:
-                instance = bpy.context.preferences.addons.get(key)
-                break
-        cls.addon_instance = instance
-
-    @classmethod
-    def get_addon_instance(cls):
-        if cls.addon_instance is None:
-            cls.set_addon_instance()
-        return cls.addon_instance
-
-    def draw_extras_settings(self, layout: bpy.types.UILayout, context: bpy.types.Context) -> None:
-        layout.prop(self, "container_hide_show_isolate")
-
-    container_hide_show_isolate: BoolProperty(
-        name="Container hide/show/isolate",
-        description="Enable container hide/show/isolate feature in the UI",
-        default=False,
-    )
-
     if TYPE_CHECKING:
         svg2pdf_command: str
         svg2dxf_command: str
@@ -919,6 +891,16 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         layout.prop(self, "bsdd_load_preview_dictionaries")
         layout.prop(self, "bsdd_load_inactive_dictionaries")
         layout.prop(self, "bsdd_load_test_dictionaries")
+
+
+    def draw_extras_settings(self, layout: bpy.types.UILayout, context: bpy.types.Context) -> None:
+        layout.prop(self, "container_hide_show_isolate")
+
+    container_hide_show_isolate: BoolProperty(
+        name="Container hide/show/isolate",
+        description="Enable container hide/show/isolate feature in the UI",
+        default=False,
+    )
 
 
 # Scene panel groups

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -679,9 +679,11 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
     )
 
     addon_instance = None
+
     @classmethod
     def set_addon_instance(cls):
         import bpy
+
         instance = None
         for key in bpy.context.preferences.addons.keys():
             if ".bonsai" in key:

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -678,6 +678,32 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         description="Default parameters for BIM elements",
     )
 
+    addon_instance = None
+    @classmethod
+    def set_addon_instance(cls):
+        import bpy
+        instance = None
+        for key in bpy.context.preferences.addons.keys():
+            if ".bonsai" in key:
+                instance = bpy.context.preferences.addons.get(key)
+                break
+        cls.addon_instance = instance
+
+    @classmethod
+    def get_addon_instance(cls):
+        if cls.addon_instance is None:
+            cls.set_addon_instance()
+        return cls.addon_instance
+
+    def draw_extras_settings(self, layout: bpy.types.UILayout, context: bpy.types.Context) -> None:
+        layout.prop(self, "container_hide_show_isolate")
+
+    container_hide_show_isolate: BoolProperty(
+        name="Container hide/show/isolate",
+        description="Enable container hide/show/isolate feature in the UI",
+        default=False,
+    )
+
     if TYPE_CHECKING:
         svg2pdf_command: str
         svg2dxf_command: str
@@ -738,6 +764,7 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         bonsai.bim.helper.draw_expandable_panel(self.layout, context, "Directories", self.draw_directories)
         bonsai.bim.helper.draw_expandable_panel(self.layout, context, "Drawing", self.draw_drawing_settings)
         bonsai.bim.helper.draw_expandable_panel(self.layout, context, "Other", self.draw_other_settings)
+        bonsai.bim.helper.draw_expandable_panel(self.layout, context, "Extras", self.draw_extras_settings)
 
     def draw_commands(self, layout: bpy.types.UILayout, context: bpy.types.Context) -> None:
         layout.prop(self, "svg2pdf_command")


### PR DESCRIPTION
This is in response to comment in https://community.osarch.org/discussion/2909/ifc-aggregates-vs-parent-child

> @sjb007 said:
> @falken10vdl Well this is how it used to be, and they (the main devs) intentionally moved away from this.  I didn't think it would be accepted because of this. I just ran into consistency issues with the newer method - mainly it just _doesn't_ work properly with the Status filter feature in the Scheduling tab. All I'm doing is restoring an older piece of code that worked better, at least in my usecase.

Proposal to add Extras to enable conditionally features that do not make it for main stream but that are very usefull for some users.

I have taken the example of commit by @sjb007 https://github.com/IfcOpenShell/IfcOpenShell/commit/fb77fca333a003390515bf1b220d794e5b705968.
@sjb007 I have copied your code with pride :) and add it as an Extra that can be enabled.

Cheers!
