### PR TITLE
fix test_number_formatting tests

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -259,6 +259,7 @@ class FormatTransformer(lark.Transformer):
         )
 
     def imperial_length(self, args):
+        args = list(filter(lambda x: x is not None, args))
         if len(args) == 2:
             input_unit, output_unit = "foot", "foot"
             value, precision = args
@@ -279,7 +280,7 @@ class FormatTransformer(lark.Transformer):
         return ifcopenshell.util.unit.format_length(
             float(value),
             int(precision),
-            suppress_zero_inches=suppress_zero_inches,
+            suppress_zero_inches=(suppress_zero_inches if suppress_zero_inches is not None else False),
             unit_system="imperial",
             input_unit=input_unit,
             output_unit=output_unit,

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -73,6 +73,10 @@ class TestFormat:
         assert subject.format('imperial_length("3.123", 2)') == "3' - 1 1/2\""
         assert subject.format('imperial_length("123.123", 2, "inch", "foot")') == "10' - 3\""
         assert subject.format('imperial_length("123.123", 2, "inch", "inch")') == '123"'
+        assert subject.format('imperial_length(3.0, 4, "foot", "foot", true)') == "3'"
+        assert subject.format('imperial_length(3.0, 4, "foot", "foot", True)') == "3'"
+        assert subject.format('imperial_length(3.0, 4, "foot", "foot", false)') == "3' - 0\""
+        assert subject.format('imperial_length(3.0, 4, "foot", "foot", False)') == "3' - 0\""
 
 
 class TestGetElementValue(test.bootstrap.IFC4):


### PR DESCRIPTION
An quick and dirty attempt to fix failure on https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.8.0/src/ifcopenshell-python/test/util/test_selector.py#L70 (test.util.test_selector.TestFormat#test_number_formatting).

This seems fails since https://github.com/IfcOpenShell/IfcOpenShell/commit/3f2cad0490f220d3e62d32f99c3357522c6664d9 but not sure because CI is always red.

Debuging this failure, I see that in https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.8.0/src/ifcopenshell-python/ifcopenshell/util/selector.py#L275, args array has 5 items whose 3 None at the end.
Consequently condition at https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.8.0/src/ifcopenshell-python/ifcopenshell/util/unit.py#L763C16-L763C36 is always false because suppress_zero_inches is at None.
I don't know lark, looking at https://stackoverflow.com/questions/75712893/python3-lark-convenient-way-to-handle-a-rule-with-optional-terminals, it seems to have 2 mode to use "transformer".
Because of these None values, all the "len(args) == X" conditions seems dead code.
