### PR TITLE
Add markdown-it-py and mdurl dependencies for drawing module annotations

### DIFF
--- a/src/bonsai/Makefile
+++ b/src/bonsai/Makefile
@@ -155,6 +155,9 @@ endif
 	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download six --dest=./wheels
 	# Required by drawing module
 	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download lxml $(PYPI_PLATFORM) --python-version $(PYPI_VERSION) --implementation $(PYPI_IMP) --only-binary=:all: --dest=./wheels
+	# Required by drawing module for markdown hyperlinks in annotations
+	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download markdown-it-py --dest=./wheels
+	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download mdurl --dest=./wheels
 	# Required by qto and drawing module
 	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download shapely $(PYPI_PLATFORM) --python-version $(PYPI_VERSION) --implementation $(PYPI_IMP) --only-binary=:all: --dest=./wheels
 	# Required by the BIM type manager thumbnail generator

--- a/src/bonsai/pyproject.toml
+++ b/src/bonsai/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "ifcopenshell",
-    "markdown-it-py",
 ]
 
 [project.optional-dependencies]

--- a/src/bonsai/pyproject.toml
+++ b/src/bonsai/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "ifcopenshell",
+    "markdown-it-py",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
PR to prepare for use of markdown-it in annotation drawings.
Addresses https://github.com/IfcOpenShell/IfcOpenShell/issues/7319

Cheers!
