### PR TITLE
cmake: Use same PRIVATE scope for Serializers target

### DIFF
--- a/src/serializers/CMakeLists.txt
+++ b/src/serializers/CMakeLists.txt
@@ -17,7 +17,7 @@ if(WITH_PROJ)
     target_link_libraries(Serializers PRIVATE proj::proj)
 endif()
 
-target_link_libraries(Serializers ${SERIALIZER_SCHEMA_LIBRARIES} ${OPENCOLLADA_LIBRARIES} ${USD_LIBRARIES} IfcGeom ${OPENCASCADE_LIBRARIES} ${kernel_libraries} IfcParse)
+target_link_libraries(Serializers PRIVATE ${SERIALIZER_SCHEMA_LIBRARIES} ${OPENCOLLADA_LIBRARIES} ${USD_LIBRARIES} IfcGeom ${OPENCASCADE_LIBRARIES} ${kernel_libraries} IfcParse)
 
 install(TARGETS Serializers)
 


### PR DESCRIPTION
cmake: Use same PRIVATE scope for Serializers target