### PR TITLE
cmake: Link Eigen3 only against targets needing it

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -448,10 +448,6 @@ else()
     endif()
 endif(MSVC)
 
-
-find_package(Eigen3 REQUIRED)
-link_libraries(Eigen3::Eigen)
-
 include_directories(${INCLUDE_DIRECTORIES} ${OPENCOLLADA_INCLUDE_DIRS}
 	${Boost_INCLUDE_DIRS} ${LIBXML2_INCLUDE_DIR} ${JSON_INCLUDE_DIR} ${HDF5_INCLUDE_DIR}
     ${CGAL_INCLUDE_DIR} ${GMP_INCLUDE_DIR} ${MPFR_INCLUDE_DIR} ${USD_INCLUDE_DIR}

--- a/src/ifcgeom/CMakeLists.txt
+++ b/src/ifcgeom/CMakeLists.txt
@@ -20,6 +20,8 @@ if(UNIX)
     find_package(Threads)
 endif()
 
+find_package(Eigen3 REQUIRED)
+
 if(WASM_BUILD)
     target_link_libraries(IfcGeom ${kernel_libraries} ${mapping_libraries} ${CMAKE_THREAD_LIBS_INIT} "Eigen3::Eigen")
 else()

--- a/src/ifcgeom/kernels/CMakeLists.txt
+++ b/src/ifcgeom/kernels/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Eigen3 REQUIRED)
+
 foreach(kernel ${GEOMETRY_KERNELS})
     string(TOUPPER ${kernel} KERNEL_UPPER)
     file(GLOB IFCGEOM_H_FILES ${kernel}/*.h)
@@ -9,13 +11,13 @@ foreach(kernel ${GEOMETRY_KERNELS})
     add_library(${KERNEL_TARGET} OBJECT ${IFCGEOM_FILES})
     set_property(TARGET ${KERNEL_TARGET} APPEND PROPERTY COMPILE_FLAGS "-DIFC_GEOM_EXPORTS")
     list(APPEND kernel_libraries ${KERNEL_TARGET})
-    target_link_libraries(${KERNEL_TARGET} ${${KERNEL_UPPER}_LIBRARIES})
+    target_link_libraries(${KERNEL_TARGET} ${${KERNEL_UPPER}_LIBRARIES} Eigen3::Eigen)
 
     install(TARGETS ${KERNEL_TARGET})
 
     if(${kernel} STREQUAL "cgal")
         set_property(TARGET ${KERNEL_TARGET} APPEND_STRING PROPERTY COMPILE_FLAGS " -DCGAL_HAS_THREADS")
-
+        
         set(KERNEL_TARGET_SIMPLE "${KERNEL_TARGET}_simple")
         add_library(${KERNEL_TARGET_SIMPLE} OBJECT ${IFCGEOM_FILES})
         set_target_properties(${KERNEL_TARGET_SIMPLE} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIFOPSH_SIMPLE_KERNEL -DCGAL_HAS_THREADS")

--- a/src/ifcgeom/mapping/CMakeLists.txt
+++ b/src/ifcgeom/mapping/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Eigen3 REQUIRED)
+
 foreach(schema ${SCHEMA_VERSIONS})
     file(GLOB IFCGEOM_I_FILES *.i)
     file(GLOB IFCGEOM_H_FILES *.h)
@@ -6,7 +8,7 @@ foreach(schema ${SCHEMA_VERSIONS})
 
     add_library(geometry_mapping_ifc${schema} OBJECT ${IFCGEOM_FILES})
     set_target_properties(geometry_mapping_ifc${schema} PROPERTIES COMPILE_FLAGS "-DIFC_GEOM_EXPORTS -DIfcSchema=Ifc${schema}")
-    target_link_libraries(geometry_mapping_ifc${schema} IfcParse)
+    target_link_libraries(geometry_mapping_ifc${schema} IfcParse  Eigen3::Eigen)
 
     list(APPEND mapping_libraries geometry_mapping_ifc${schema})
 


### PR DESCRIPTION
Use target_link_libraries instead of link_libraries, to avoid linking Eigen3 against all targets. 