### PR TITLE
Fix large BCF file creation by allowing Zip64

### DIFF
--- a/src/bcf/bcf/inmemory_zipfile.py
+++ b/src/bcf/bcf/inmemory_zipfile.py
@@ -26,7 +26,7 @@ class InMemoryZipFile:
         self._file_name: Optional[str | Path] = str(file_name) if hasattr(file_name, "_from_parts") else file_name
         self.in_memory_data = BytesIO()
         # Create the in-memory zipfile
-        self.in_memory_zip = zipfile.ZipFile(self.in_memory_data, "w", compression, False)
+        self.in_memory_zip = zipfile.ZipFile(self.in_memory_data, "w", compression, True)
         self.in_memory_zip.debug = debug
 
     def writestr(self, filename_in_zip: str | zipfile.ZipInfo, file_contents: bytes | str) -> None:


### PR DESCRIPTION
When saving BCF files, currently, `allowZip64` is explicitly set to False. With larger BCFs this leads to the creation crashing with the error `Files count would require ZIP64 extensions` and leaving an incomplete BCF.

Allowing zip64 fixes this.