### PR TITLE
vscode config for Bonsai debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ venv
 
 # Visual Studio Code files
 .vscode
+!.vscode/launch.json
+!.vscode/tasks.json
 .vs
 
 # PyCharm files

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Python Debugger: Remote Attach",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${config:bonsai.localRoot}",
+                    "remoteRoot": "${config:bonsai.remoteRoot}"
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,53 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Configure bonsai/vscode development environment",
+            "type": "shell",
+            "command": "${input:blenderPath}",
+            "args": [
+                "--background",
+                "--python", "${workspaceFolder}/src/bonsai/scripts/dev_environment_vscode_config.py"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "Launch blender with debugpy",
+            "type": "shell",
+            "command": "blender",
+            "options": {
+                "cwd": "${config:bonsai.blenderPath}"
+            },
+            "args": [
+                "--python-expr",
+                "import debugpy; debugpy.listen(5678)"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "Install debugpy in Blender",
+            "type": "shell",
+            "command": "blender",
+            "options": {
+                "cwd": "${config:bonsai.blenderPath}"
+            },
+            "args": [
+                "--background",
+                "--python-expr",
+                "import os, sys, subprocess; path=os.path.abspath(sys.executable); subprocess.call([path, '-m', 'ensurepip']); subprocess.call([path, '-m', 'pip', 'install', '--upgrade', 'debugpy'])"
+            ],
+            "problemMatcher": []
+        }
+         
+    ],
+    "inputs": [
+        {
+            "id": "blenderPath",
+            "type": "promptString",
+            "description": "Enter the path to the blender executable",
+            "default": "blender"
+        }
+    ]
+}

--- a/src/bonsai/scripts/dev_environment_vscode_config.py
+++ b/src/bonsai/scripts/dev_environment_vscode_config.py
@@ -1,0 +1,24 @@
+
+import bonsai, json, bpy
+from pathlib import Path
+
+repo_path = Path(bonsai.__file__).resolve().parent
+install_path = Path(bonsai.__file__).absolute().parent
+assert repo_path != install_path, "Run `dev_environment.py` to setup the development environment symlinks first."
+
+repo_root = repo_path.parent.parent.parent
+settings_path = repo_root / ".vscode" / "settings.json"
+settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+settings = json.loads(settings_path.read_text()) if settings_path.exists() else {}
+settings.update({
+    "bonsai.localRoot": repo_path.as_posix(),
+    "bonsai.remoteRoot": install_path.as_posix(), 
+    "bonsai.blenderPath": Path(bpy.app.binary_path).parent.as_posix(),
+})
+json_data = json.dumps(settings, indent=2)
+
+settings_path.write_text(json_data)
+
+print("\n\nBonsai/VSCode development environment configured successfully!\n\n")
+


### PR DESCRIPTION
This is my first PR for Bonsai and I expect it might lead to some discussion.

# Current guidelines

Current [development](https://docs.bonsaibim.org/guides/development/installation.html) [guides](https://docs.bonsaibim.org/guides/development/ide/windows_ide.html) recommend using the “Blender Development” VS Code extension. For Bonsai development this extension offers limited value:

* Its primary function - symlinking an add-on repository into Blender’s installation directory - is already handled by `src/bonsai/scripts/dev_environment.py`.

* Its debug workflow launches Blender with its own arguments and manages a debugpy server internally. This bypasses VS Code’s launch configurations and prevents correct source-path mapping between the Blender install tree and the repository tree.

A mentioned alternative is the lightweight [hextant_python_debugger](https://github.com/hextantstudios/hextant_python_debugger) add-on, which supports custom launch configurations. However, it must be installed separately, and starting the debugpy server requires manual steps inside Blender each time it's started.

# Proposed Change

This PR introduces:

* `launch.json`
* `tasks.json`
* A helper script that generates/updates `settings.json` with the correct Blender installation path and source-mapping configuration.

The workflow becomes:

* Task 1 (once): Runs the helper script to populate the necessary workspace settings.
* Task 2 (once): Installs debugpy into the Blender Python environment if required.
* Task 3: Launches Blender and starts the debugpy server with the correct arguments.

The launch configuration then attaches to Blender with full path mapping, ensuring that breakpoints resolve to files in the repository rather than the installation directory. It also enables reliable use of “Just My Code”.

# Benefits

* Consistent and reproducible debug configuration across contributors.
* Proper source-path mapping without manual intervention.
* No additional Blender add-ons required.
* Debug workflow fully integrated into VS Code tasks and launch configurations.
* Faster onboarding for new contributors.

This PR intends to streamline and simplify the development and debugging experience for Bonsai developers.