### PR TITLE
Fix getting elements by predefined property sets in IFC2X3

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/element.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/element.py
@@ -477,7 +477,7 @@ def get_elements_by_pset(pset: ifcopenshell.entity_instance) -> set[ifcopenshell
     """Retrieve the elements (or element types) that are using the provided property set."""
     is_ifc2x3 = pset.file.schema == "IFC2X3"
     elements = set()
-    if pset.is_a("IfcPropertySet") or pset.is_a("IfcPreDefinedPropertySet") or pset.is_a("IfcElementQuantity"):
+    if pset.is_a("IfcPropertySetDefinition"):
         rels = pset.PropertyDefinitionOf if is_ifc2x3 else pset.DefinesOccurrence
         for rel in rels:
             elements.update(rel.RelatedObjects)


### PR DESCRIPTION
Getting all elements for a pset using `ifcopenshell.util.element.get_elements_by_pset` does not work for predefined psets like `IfcDoorPanelProperties`, etc. with IFC2X3.

The abstract super-class of all predefined property sets, `IfcPreDefinedPropertySet`, is not available in IFC2X3, and therefore the existing code would not work. 

This PR proposes to use the common super-class `IfcPropertySetDefinition` instead, which covers all previous cases and works with IFC2X3.

Relevant documentation: https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcPropertySetDefinition.htm