### PR TITLE
Fix UnboundLocalError in reporter.py cardinality assignment

### DIFF
--- a/src/ifctester/ifctester/reporter.py
+++ b/src/ifctester/ifctester/reporter.py
@@ -367,6 +367,12 @@ class Json(Reporter):
             cardinality = "optional"
         elif specification.minOccurs == 0 and specification.maxOccurs == 0:
             cardinality = "prohibited"
+        elif specification.minOccurs >= 1:
+            # Any minimum occurrence >= 1 means the specification is required
+            cardinality = "required"
+        else:
+            # minOccurs == 0 with any other maxOccurs value means optional
+            cardinality = "optional"
 
         return ResultsSpecification(
             name=specification.name,


### PR DESCRIPTION
Problem:
The cardinality variable was only assigned for three specific cases:
- minOccurs=1, maxOccurs="unbounded" → "required"
- minOccurs=0, maxOccurs="unbounded" → "optional"
- minOccurs=0, maxOccurs=0 → "prohibited"

However, the IDS schema allows other valid combinations such as:
- minOccurs=0, maxOccurs=1 (commonly used for optional specifications)
- minOccurs=1, maxOccurs=1 (exactly one occurrence required)
- Any other valid XML Schema cardinality values

When processing IDS files with these combinations, the cardinality variable remained unassigned, causing an UnboundLocalError.

Solution:
Added fallback logic to handle all valid IDS cardinality combinations:
- If minOccurs >= 1: cardinality = "required" (must occur at least once)
- Otherwise (minOccurs == 0): cardinality = "optional" (may occur)

This maintains semantic compatibility with the existing codebase, which expects cardinality to be one of the semantic strings ("required", "optional", "prohibited") rather than numeric ranges. 