### PR TITLE
Update formatting expression evaluation to include element context

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -365,13 +365,11 @@ class DecoratorData:
 
         for literal in literals:
             literal_value = literal.Literal
-
             try:
-                current_value = cls.evaluate_formatting_expressions(literal_value)
-                current_value = tool.Drawing.replace_text_literal_variables(current_value, product)
+                eval_value = cls.evaluate_formatting_expressions(literal_value, product)
+                current_value = tool.Drawing.replace_text_literal_variables(eval_value, product)
             except Exception:
                 current_value = literal_value
-
             literal_data = {
                 "Literal": literal_value,
                 "BoxAlignment": literal.BoxAlignment,
@@ -404,14 +402,14 @@ class DecoratorData:
         return element
 
     @classmethod
-    def evaluate_formatting_expressions(cls, text: str) -> str:
-        """Evaluate formatting expressions wrapped in backticks using ifcopenshell.util.selector.format"""
+    def evaluate_formatting_expressions(cls, text: str, element=None) -> str:
+        """Evaluate formatting expressions wrapped in backticks using ifcopenshell.util.selector.format, always passing element context"""
         import re
 
         def evaluate_expression(match):
             try:
                 expression = match.group(1)
-                result = ifcopenshell.util.selector.format(expression)
+                result = ifcopenshell.util.selector.format(expression, element)
                 return str(result)
             except Exception as e:
                 return match.group(0)

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2119,17 +2119,12 @@ class Drawing(bonsai.core.tool.Drawing):
 
         for command in re.findall("``.*?``", text):
             original_command = command
-            for variable in re.findall("{{.*?}}", command):
-                value = ifcopenshell.util.selector.get_element_value(product, variable[2:-2])
-                value = '"' + str(value).replace('"', '\\"') + '"'
-                command = command.replace(variable, value)
-            # Defensive: skip if command[2:-2] is None or 'None'
             command_content = command[2:-2]
             if command_content is None or str(command_content).strip().lower() == "none":
                 text = text.replace(original_command, "")
             else:
                 try:
-                    text = text.replace(original_command, ifcopenshell.util.selector.format(command_content))
+                    text = text.replace(original_command, ifcopenshell.util.selector.format(command_content, product))
                 except Exception:
                     text = text.replace(original_command, "")
         for variable in re.findall("{{.*?}}", text):


### PR DESCRIPTION
This addresses https://github.com/IfcOpenShell/IfcOpenShell/issues/7520
In non editing mode the element context was not passed and the resolution for that format including elements information was defaulting to wrong value.

Cheers!
