### PR TITLE
Scale-font-in-PolylineDecorator

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -29,7 +29,6 @@ import bpy
 import gpu
 import ifcopenshell
 import mathutils
-import sys
 from bpy.types import SpaceView3D
 from bpy_extras import view3d_utils
 from bpy_extras.view3d_utils import location_3d_to_region_2d
@@ -467,14 +466,9 @@ class PolylineDecorator:
 
         self.addon_prefs = tool.Blender.get_addon_preferences()
         self.font_id = 0
-        ui_style = context.preferences.ui_styles[0]
-        widget_font_points = ui_style.widget.points
-        ui_scale = context.preferences.view.ui_scale
-        platform_scale = 2 if sys.platform == "darwin" else 1
-
-        font_size = widget_font_points * ui_scale * platform_scale
-        offset = widget_font_points * ui_scale * (1.5 * platform_scale)
-        line_height = widget_font_points * ui_scale * (1.25 * platform_scale)
+        font_size = tool.Blender.scale_font_size(None)
+        offset = tool.Blender.scale_font_size(None) * 1.5
+        line_height = tool.Blender.scale_font_size(None) * 1.25
         blf.size(self.font_id, font_size)
         blf.enable(self.font_id, blf.SHADOW)
         blf.shadow(self.font_id, 6, 0, 0, 0, 1)
@@ -522,12 +516,7 @@ class PolylineDecorator:
         self.addon_prefs = tool.Blender.get_addon_preferences()
         self.font_id = 1
         self.shader = gpu.shader.from_builtin("UNIFORM_COLOR")
-        ui_style = context.preferences.ui_styles[0]
-        widget_font_points = ui_style.widget.points
-        ui_scale = context.preferences.view.ui_scale
-        platform_scale = 2 if sys.platform == "darwin" else 1
-
-        font_size = widget_font_points * ui_scale * platform_scale
+        font_size = tool.Blender.scale_font_size(None)
         blf.size(self.font_id, font_size)
         blf.enable(self.font_id, blf.SHADOW)
         blf.shadow(self.font_id, 6, 0, 0, 0, 1)
@@ -1948,13 +1937,7 @@ class BoundingBoxDecorator:
 
         addon_prefs = tool.Blender.get_addon_preferences()
         font_id = 0
-        # Get Blender's default UI widget font size from preferences
-        ui_style = context.preferences.ui_styles[0]
-        widget_font_points = ui_style.widget.points
-        ui_scale = context.preferences.view.ui_scale
-        platform_scale = 2 if sys.platform == "darwin" else 1
-
-        font_size = widget_font_points * ui_scale * platform_scale
+        font_size = tool.Blender.scale_font_size(None)
         blf.size(font_id, font_size)
         blf.enable(font_id, blf.SHADOW)
         blf.shadow(font_id, 6, 0, 0, 0, 1)

--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -29,6 +29,7 @@ import bpy
 import gpu
 import ifcopenshell
 import mathutils
+import sys
 from bpy.types import SpaceView3D
 from bpy_extras import view3d_utils
 from bpy_extras.view3d_utils import location_3d_to_region_2d
@@ -466,13 +467,19 @@ class PolylineDecorator:
 
         self.addon_prefs = tool.Blender.get_addon_preferences()
         self.font_id = 0
-        font_size = tool.Blender.scale_font_size(12)
+        ui_style = context.preferences.ui_styles[0]
+        widget_font_points = ui_style.widget.points
+        ui_scale = context.preferences.view.ui_scale
+        platform_scale = 2 if sys.platform == 'darwin' else 1
+        
+        font_size = widget_font_points * ui_scale * platform_scale
+        offset = widget_font_points * ui_scale * (1.5 * platform_scale)
+        line_height = widget_font_points * ui_scale * (1.25 * platform_scale)
         blf.size(self.font_id, font_size)
         blf.enable(self.font_id, blf.SHADOW)
         blf.shadow(self.font_id, 6, 0, 0, 0, 1)
         color = self.addon_prefs.decorations_colour
         color_highlight = self.addon_prefs.decorator_color_special
-        offset = 20
         new_line = 0
         for i, (key, field_name) in enumerate(texts.items()):
             formatted_value = None
@@ -480,7 +487,7 @@ class PolylineDecorator:
                 # Controls which options are displayed in the UI
                 if key not in self.input_ui.input_options:
                     continue
-                new_line += 20
+                new_line += line_height
                 if self.tool_state and key != self.tool_state.input_type:
                     formatted_value = self.input_ui.get_formatted_value(key)
                 else:
@@ -515,7 +522,12 @@ class PolylineDecorator:
         self.addon_prefs = tool.Blender.get_addon_preferences()
         self.font_id = 1
         self.shader = gpu.shader.from_builtin("UNIFORM_COLOR")
-        font_size = tool.Blender.scale_font_size(12)
+        ui_style = context.preferences.ui_styles[0]
+        widget_font_points = ui_style.widget.points
+        ui_scale = context.preferences.view.ui_scale
+        platform_scale = 2 if sys.platform == 'darwin' else 1
+        
+        font_size = widget_font_points * ui_scale * platform_scale
         blf.size(self.font_id, font_size)
         blf.enable(self.font_id, blf.SHADOW)
         blf.shadow(self.font_id, 6, 0, 0, 0, 1)
@@ -1936,7 +1948,13 @@ class BoundingBoxDecorator:
 
         addon_prefs = tool.Blender.get_addon_preferences()
         font_id = 0
-        font_size = tool.Blender.scale_font_size(12)
+        # Get Blender's default UI widget font size from preferences
+        ui_style = context.preferences.ui_styles[0]
+        widget_font_points = ui_style.widget.points
+        ui_scale = context.preferences.view.ui_scale
+        platform_scale = 2 if sys.platform == 'darwin' else 1
+        
+        font_size = widget_font_points * ui_scale * platform_scale
         blf.size(font_id, font_size)
         blf.enable(font_id, blf.SHADOW)
         blf.shadow(font_id, 6, 0, 0, 0, 1)

--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -470,8 +470,8 @@ class PolylineDecorator:
         ui_style = context.preferences.ui_styles[0]
         widget_font_points = ui_style.widget.points
         ui_scale = context.preferences.view.ui_scale
-        platform_scale = 2 if sys.platform == 'darwin' else 1
-        
+        platform_scale = 2 if sys.platform == "darwin" else 1
+
         font_size = widget_font_points * ui_scale * platform_scale
         offset = widget_font_points * ui_scale * (1.5 * platform_scale)
         line_height = widget_font_points * ui_scale * (1.25 * platform_scale)
@@ -525,8 +525,8 @@ class PolylineDecorator:
         ui_style = context.preferences.ui_styles[0]
         widget_font_points = ui_style.widget.points
         ui_scale = context.preferences.view.ui_scale
-        platform_scale = 2 if sys.platform == 'darwin' else 1
-        
+        platform_scale = 2 if sys.platform == "darwin" else 1
+
         font_size = widget_font_points * ui_scale * platform_scale
         blf.size(self.font_id, font_size)
         blf.enable(self.font_id, blf.SHADOW)
@@ -1952,8 +1952,8 @@ class BoundingBoxDecorator:
         ui_style = context.preferences.ui_styles[0]
         widget_font_points = ui_style.widget.points
         ui_scale = context.preferences.view.ui_scale
-        platform_scale = 2 if sys.platform == 'darwin' else 1
-        
+        platform_scale = 2 if sys.platform == "darwin" else 1
+
         font_size = widget_font_points * ui_scale * platform_scale
         blf.size(font_id, font_size)
         blf.enable(font_id, blf.SHADOW)

--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -466,9 +466,9 @@ class PolylineDecorator:
 
         self.addon_prefs = tool.Blender.get_addon_preferences()
         self.font_id = 0
-        font_size = tool.Blender.scale_font_size(None)
-        offset = tool.Blender.scale_font_size(None) * 1.5
-        line_height = tool.Blender.scale_font_size(None) * 1.25
+        font_size = tool.Blender.scale_font_size()
+        offset = tool.Blender.scale_font_size() * 1.5
+        line_height = tool.Blender.scale_font_size() * 1.25
         blf.size(self.font_id, font_size)
         blf.enable(self.font_id, blf.SHADOW)
         blf.shadow(self.font_id, 6, 0, 0, 0, 1)
@@ -516,7 +516,7 @@ class PolylineDecorator:
         self.addon_prefs = tool.Blender.get_addon_preferences()
         self.font_id = 1
         self.shader = gpu.shader.from_builtin("UNIFORM_COLOR")
-        font_size = tool.Blender.scale_font_size(None)
+        font_size = tool.Blender.scale_font_size()
         blf.size(self.font_id, font_size)
         blf.enable(self.font_id, blf.SHADOW)
         blf.shadow(self.font_id, 6, 0, 0, 0, 1)
@@ -1937,7 +1937,7 @@ class BoundingBoxDecorator:
 
         addon_prefs = tool.Blender.get_addon_preferences()
         font_id = 0
-        font_size = tool.Blender.scale_font_size(None)
+        font_size = tool.Blender.scale_font_size()
         blf.size(font_id, font_size)
         blf.enable(font_id, blf.SHADOW)
         blf.shadow(font_id, 6, 0, 0, 0, 1)

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -736,6 +736,12 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         default=".ifc.metadata.blend",
     )
 
+    decorator_font_scale: bpy.props.FloatProperty(
+        name="Decorator Font Scale",
+        description="Scale factor for decorator font size.",
+        default=1.0,
+    )
+
     if TYPE_CHECKING:
         svg2pdf_command: str
         svg2dxf_command: str
@@ -775,6 +781,7 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         mass_time_units_in_wizard: bool
         chain_filter_with_set_operations: bool
         save_metadata_blend_file: bool
+        decorator_font_scale: float
 
     def draw(self, context: bpy.types.Context) -> None:
         layout = self.layout
@@ -997,6 +1004,7 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
             else:
                 row = layout.row()
                 row.operator("bim.manage_tab_visibility", icon="PREFERENCES")
+        layout.prop(self, "decorator_font_scale")
 
 
 # Scene panel groups

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1563,12 +1563,17 @@ class Blender(bonsai.core.tool.Blender):
 
     @classmethod
     def scale_font_size(cls, size):
+        default_dpi = 72
+        default_pixel_size = 1.0
         ui_style = bpy.context.preferences.ui_styles[0]
         base_size = ui_style.widget.points if size is None else size
-        ui_scale = bpy.context.preferences.view.ui_scale
-        platform_scale = 2 if sys.platform == "darwin" else 1
-        
-        return base_size * ui_scale * platform_scale
+        platform_scale = 0.5 if sys.platform == "darwin" else 1
+
+        default_scale = default_dpi * default_pixel_size
+        system = bpy.context.preferences.system
+        system_scale = system.dpi * system.pixel_size
+        return (system_scale / default_scale) * base_size *platform_scale
+
 
     @classmethod
     def apply_transform_as_local(cls, obj: bpy.types.Object) -> bool:

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1572,7 +1572,7 @@ class Blender(bonsai.core.tool.Blender):
         default_scale = default_dpi * default_pixel_size
         system = bpy.context.preferences.system
         system_scale = system.dpi * system.pixel_size
-        return (system_scale / default_scale) * base_size *platform_scale
+        return (system_scale / default_scale) * base_size *platform_scale * tool.Blender.get_addon_preferences().decorator_font_scale
 
 
     @classmethod

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1563,12 +1563,12 @@ class Blender(bonsai.core.tool.Blender):
 
     @classmethod
     def scale_font_size(cls, size):
-        default_dpi = 72
-        default_pixel_size = 1.0
-        default_scale = default_dpi * default_pixel_size
-        system = bpy.context.preferences.system
-        system_scale = system.dpi * system.pixel_size
-        return (system_scale / default_scale) * size
+        ui_style = bpy.context.preferences.ui_styles[0]
+        base_size = ui_style.widget.points if size is None else size
+        ui_scale = bpy.context.preferences.view.ui_scale
+        platform_scale = 2 if sys.platform == "darwin" else 1
+        
+        return base_size * ui_scale * platform_scale
 
     @classmethod
     def apply_transform_as_local(cls, obj: bpy.types.Object) -> bool:

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1562,7 +1562,7 @@ class Blender(bonsai.core.tool.Blender):
         return getattr(scene, "sun_pos_properties", None)
 
     @classmethod
-    def scale_font_size(cls, size):
+    def scale_font_size(cls, size=None):
         default_dpi = 72
         default_pixel_size = 1.0
         ui_style = bpy.context.preferences.ui_styles[0]


### PR DESCRIPTION
Addresses https://github.com/IfcOpenShell/IfcOpenShell/issues/7555
Makes the text decorations for polyline and boundingbox decorations to follow blender's ui_style.widget.points and view.ui_scale.

Cheers!
