### PR TITLE
Refactor filter mode handling to simplify chained filters with set operations

### DIFF
--- a/src/bonsai/bonsai/bim/helper.py
+++ b/src/bonsai/bonsai/bim/helper.py
@@ -511,14 +511,15 @@ def draw_filter(
                 row.operator("bim.edit_element_filter", icon="CHECKMARK", text="").filter_mode = "EXCLUDE"
             row.operator("bim.enable_editing_element_filter", icon="CANCEL", text="").filter_mode = "NONE"
     row = layout.row(align=True)
-    if not tool.Blender.get_addon_preferences().chain_filter_with_set_operations:
+    preferences = tool.Blender.get_addon_preferences()
+    if not preferences.chain_filter_with_set_operations:
         row.operator("bim.add_filter_group", text="Add Search Group", icon="ADD").module = module
     else:
-        if not filter_groups or not any(fg.filters for fg in filter_groups):
-            op = row.operator("bim.add_filter", text="Add Filter", icon="ADD")
-            op.type = "entity"
-            op.index = 0
-            op.module = module
+        row.prop(sprops, "facet", text="")
+        op = row.operator("bim.add_filter", text="Add Filter", icon="ADD")
+        op.type = sprops.facet
+        op.index = 0
+        op.module = module
     op = row.operator("bim.edit_filter_query", text="", icon="FILTER")
     if "module" in op.bl_rna.properties:
         op.module = module
@@ -526,26 +527,23 @@ def draw_filter(
     for i, filter_group in enumerate(filter_groups):
         box = layout.box()
 
-        row = box.row(align=True)
-        row.prop(sprops, "facet", text="")
-        op = row.operator("bim.add_filter", text="Add Filter", icon="ADD")
-        op.type = sprops.facet
-        op.index = i
-        op.module = module
-        op = row.operator("bim.remove_filter_group", text="", icon="X")
-        op.index = i
-        op.module = module
+        preferences = tool.Blender.get_addon_preferences()
+        if not preferences.chain_filter_with_set_operations:
+            row = box.row(align=True)
+            row.prop(sprops, "facet", text="")
+            op = row.operator("bim.add_filter", text="Add Filter", icon="ADD")
+            op.type = sprops.facet
+            op.index = i
+            op.module = module
+            op = row.operator("bim.remove_filter_group", text="", icon="X")
+            op.index = i
+            op.module = module
 
         for j, ifc_filter in enumerate(filter_group.filters):
             if ifc_filter.type == "entity":
                 row = box.row(align=True)
                 preferences = tool.Blender.get_addon_preferences()
-                if preferences.chain_filter_with_set_operations:
-                    show_mode_toggle = j > 0
-                else:
-                    show_mode_toggle = (
-                        preferences.default_filter_with_set_operations_for_globalid_and_class and j > 0
-                    )  # PR 7315 mode
+                show_mode_toggle = preferences.chain_filter_with_set_operations and j > 0
                 if show_mode_toggle:
                     mode_icons = {"ADD": "ADD", "SUBTRACT": "REMOVE", "FILTER": "FILTER"}
                     op = row.operator(
@@ -761,12 +759,7 @@ def draw_filter(
             elif ifc_filter.type == "instance":
                 row = box.row(align=True)
                 preferences = tool.Blender.get_addon_preferences()
-                if preferences.chain_filter_with_set_operations:
-                    show_mode_toggle = j > 0
-                else:
-                    show_mode_toggle = (
-                        preferences.default_filter_with_set_operations_for_globalid_and_class and j > 0
-                    )  # PR 7315 mode
+                show_mode_toggle = preferences.chain_filter_with_set_operations and j > 0
                 if show_mode_toggle:
                     mode_icons = {"ADD": "ADD", "SUBTRACT": "REMOVE", "FILTER": "FILTER"}
                     op = row.operator(

--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -765,10 +765,7 @@ class Search(Operator):
         preferences = tool.Blender.get_addon_preferences()
 
         # Migrate old ! prefix filters to new filter_mode system when preferences are enabled
-        if (
-            preferences.chain_filter_with_set_operations
-            or preferences.default_filter_with_set_operations_for_globalid_and_class
-        ):
+        if preferences.chain_filter_with_set_operations:
             for filter_group in props.filter_groups:
                 for ifc_filter in filter_group.filters:
                     if ifc_filter.type not in ["entity", "instance"]:

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -724,13 +724,8 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
     )
 
     chain_filter_with_set_operations: BoolProperty(
-        name="NEW filter mode: Enable chained filters with set operations",
+        name="NEW Filter mode: Enable chained filters with set operations",
         description="Enable chaining search filters with set operations: ADD (union: combine sets), SUBTRACT (difference: remove from set), FILTER (intersection: only elements in both sets), with autocomplete suggestions for filter values",
-        default=False,
-    )
-    default_filter_with_set_operations_for_globalid_and_class: BoolProperty(
-        name="DEFAULT filter mode: Enable set operations for GlobalId/Class",
-        description="Enable ADD/SUBTRACT/FILTER toggle buttons on entity (Class) and instance (GlobalId) filters for the DEFAULT filter mode",
         default=False,
     )
 
@@ -783,7 +778,6 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         container_hide_show_isolate: bool
         mass_time_units_in_wizard: bool
         chain_filter_with_set_operations: bool
-        default_filter_with_set_operations_for_globalid_and_class: bool
         save_metadata_blend_file: bool
 
     def draw(self, context: bpy.types.Context) -> None:
@@ -979,14 +973,9 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
     def draw_extras_settings(self, layout: bpy.types.UILayout, context: bpy.types.Context) -> None:
         layout.prop(self, "container_hide_show_isolate")
         layout.prop(self, "mass_time_units_in_wizard")
-        layout.label(text="Filtering modes:")
-        box = layout.box()
-        row = box.row(align=True)
+        row = layout.row(align=True)
         row.prop(self, "chain_filter_with_set_operations")
         row.operator("bim.open_uri", text="", icon="HELP").uri = "https://community.osarch.org/discussion/3270"
-        row = box.row(align=True)
-        row.prop(self, "default_filter_with_set_operations_for_globalid_and_class")
-        row.operator("bim.open_uri", text="", icon="HELP").uri = "https://community.osarch.org/discussion/comment/27030"
         layout.prop(self, "save_metadata_blend_file")
         if self.save_metadata_blend_file:
             row = layout.row()

--- a/src/bonsai/bonsai/tool/search.py
+++ b/src/bonsai/bonsai/tool/search.py
@@ -132,10 +132,7 @@ class Search(bonsai.core.tool.Search):
             else:
                 value = ifc_filter.value
 
-            if (
-                preferences.chain_filter_with_set_operations
-                or preferences.default_filter_with_set_operations_for_globalid_and_class
-            ):
+            if preferences.chain_filter_with_set_operations:
                 value = value.lstrip("!")
                 if ifc_filter.filter_mode == "SUBTRACT":
                     value = f"!{value}"
@@ -144,10 +141,7 @@ class Search(bonsai.core.tool.Search):
         elif ifc_filter.type == "entity":
             value = ifc_filter.value
 
-            if (
-                preferences.chain_filter_with_set_operations
-                or preferences.default_filter_with_set_operations_for_globalid_and_class
-            ):
+            if preferences.chain_filter_with_set_operations:
                 value = value.lstrip("!")
                 if ifc_filter.filter_mode == "SUBTRACT":
                     value = f"!{value}"
@@ -215,19 +209,10 @@ class Search(bonsai.core.tool.Search):
                 if filter_index == 0:
                     mode = "ADD"
                 else:
-                    if ifc_filter.type in ["entity", "instance"]:
-                        if (
-                            preferences.chain_filter_with_set_operations
-                            or preferences.default_filter_with_set_operations_for_globalid_and_class
-                        ):
-                            mode = ifc_filter.filter_mode
-                        else:
-                            mode = "FILTER" if group_results else "ADD"
+                    if preferences.chain_filter_with_set_operations:
+                        mode = ifc_filter.filter_mode
                     else:
-                        if preferences.chain_filter_with_set_operations:
-                            mode = ifc_filter.filter_mode
-                        else:
-                            mode = "FILTER" if group_results else "ADD"
+                        mode = "FILTER" if group_results else "ADD"
 
                 if mode == "ADD":
                     results = ifcopenshell.util.selector.filter_elements(tool.Ifc.get(), query)


### PR DESCRIPTION
Simplify filtering to just have two modes. The default one and this new one using set operations chained (add, substract, filter).
Cheers!
