### PR TITLE
Enhance filter value suggestions to support enumerated properties in search

### DIFF
--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -445,20 +445,17 @@ class FilterValueSuggestions(Operator):
                             if pset.HasProperties:
                                 for prop in pset.HasProperties:
                                     if hasattr(prop, "Name") and prop.Name == property_name:
-                                        if hasattr(prop, "NominalValue") and prop.NominalValue:
-                                            try:
-                                                value = prop.NominalValue.wrappedValue
-                                                if value is not None and value != "":
-                                                    if not hasattr(value, "is_a") and not isinstance(
-                                                        value, (tuple, list)
-                                                    ):
-                                                        str_value = str(value)
-                                                        if not str_value.startswith("#") and not str_value.startswith(
-                                                            "("
-                                                        ):
-                                                            property_values.add(str_value)
-                                            except:
-                                                continue
+                                        if prop.is_a("IfcPropertyEnumeratedValue"):
+                                            if hasattr(prop, "EnumerationReference") and prop.EnumerationReference:
+                                                enum_reference = prop.EnumerationReference
+                                                if hasattr(enum_reference, "EnumerationValues"):
+                                                    for enum_value in enum_reference.EnumerationValues:
+                                                        property_values.add(str(enum_value.wrappedValue))
+                                            if hasattr(prop, "EnumerationValues") and prop.EnumerationValues:
+                                                for enum_value in prop.EnumerationValues:
+                                                    property_values.add(str(enum_value.wrappedValue))
+                                        elif hasattr(prop, "NominalValue") and prop.NominalValue:
+                                            property_values.add(str(prop.NominalValue.wrappedValue))
             except:
                 continue
         return property_values


### PR DESCRIPTION
Allows to populate the suggestions for search with ENUM values. Currently they are not parsed correctly and no suggestions are provided for them.
