### PR TITLE
Implement default handling for the 'IsVentilated' property when null.

### DIFF
--- a/src/bonsai/bonsai/bim/helper.py
+++ b/src/bonsai/bonsai/bim/helper.py
@@ -240,6 +240,8 @@ def import_attribute(
         attribute_type = attribute.type_of_attribute()
         is_logical = str(attribute_type) == "<type IfcLogical: <logical>>"
         enum_value = data[new.name]
+        if new.name == "IsVentilated" and enum_value is None:
+            enum_value = False
         if is_logical:
             new.special_type = "LOGICAL"
             enum_items = ("TRUE", "FALSE", "UNKNOWN")
@@ -254,6 +256,9 @@ def import_attribute(
 
         if enum_value is not None:
             new.enum_value = enum_value
+        
+        if new.name == "IsVentilated" and data[new.name] is None:
+            new.is_null = True
     elif data_type == "list[string]":
         value: Union[list[str], None] = data[attribute.name()]
         if value:


### PR DESCRIPTION
Now the dropdown selector for "IsVentilated" shows "FALSE" since "IsVentilated" is an optional field of "IfcMaterialLayer" which defaults to "FALSE" (https://standards.buildingsmart.org/IFC/DEV/IFC4_2/FINAL/HTML/schema/ifcmaterialresource/lexical/ifcmateriallayer.htm). 

If someone wants to make it concrete it can still click the radio button to toggle "Is Null".

<img width="286" height="203" alt="image" src="https://github.com/user-attachments/assets/509b9a4a-3b43-472d-92a5-474443854e78" />