### PR TITLE
Fix optional cardinality handling for Attribute and PartOf facets

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -353,6 +353,8 @@ class Attribute(Facet):
             if non_empty_values:
                 values = non_empty_values
             else:
+                if self.cardinality == "optional":
+                    return AttributeResult(True)
                 is_pass = False
                 reason = {"type": "FALSEY", "actual": values if len(values) > 1 else values[0]}
 
@@ -519,11 +521,15 @@ class PartOf(Facet):
                     break
                 parent = self.get_parent(parent)
             if not is_pass:
+                if not ancestors and self.cardinality == "optional":
+                    return PartOfResult(True)
                 reason = {"type": "ENTITY", "actual": ancestors}
         elif self.relation == "IFCRELAGGREGATES":
             aggregate = ifcopenshell.util.element.get_aggregate(inst)
             is_pass = aggregate is not None
             if not is_pass:
+                if self.cardinality == "optional":
+                    return PartOfResult(True)
                 reason = {"type": "NOVALUE"}
             if is_pass and self.name:
                 is_pass = False
@@ -550,6 +556,8 @@ class PartOf(Facet):
                     break
             is_pass = group is not None
             if not is_pass:
+                if self.cardinality == "optional":
+                    return PartOfResult(True)
                 reason = {"type": "NOVALUE"}
             if is_pass and self.name:
                 if group.is_a().upper() != self.name:
@@ -564,6 +572,8 @@ class PartOf(Facet):
             container = ifcopenshell.util.element.get_container(inst)
             is_pass = container is not None
             if not is_pass:
+                if self.cardinality == "optional":
+                    return PartOfResult(True)
                 reason = {"type": "NOVALUE"}
             if is_pass and self.name:
                 if container.is_a().upper() != self.name:
@@ -578,6 +588,8 @@ class PartOf(Facet):
             nest = ifcopenshell.util.element.get_nest(inst)
             is_pass = nest is not None
             if not is_pass:
+                if self.cardinality == "optional":
+                    return PartOfResult(True)
                 reason = {"type": "NOVALUE"}
             if is_pass and self.name:
                 is_pass = False
@@ -606,6 +618,8 @@ class PartOf(Facet):
                     building_element = ifcopenshell.util.element.get_voided_element(opening)
             is_pass = building_element is not None
             if not is_pass:
+                if self.cardinality == "optional":
+                    return PartOfResult(True)
                 reason = {"type": "NOVALUE"}
             if is_pass and self.name:
                 if building_element.is_a().upper() != self.name:

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -345,6 +345,31 @@ class TestAttribute:
         )
 
         ifc = ifcopenshell.file()
+        facet = Attribute(name="Description", value="Foobar", cardinality="optional")
+        run(
+            "An optional facet with a null attribute value should pass",
+            facet=facet,
+            inst=ifc.createIfcWall(Name="Waldo"),
+            expected=True,
+        )
+        ifc = ifcopenshell.file()
+        facet = Attribute(name="Name", cardinality="optional")
+        run(
+            "An optional facet with an empty string attribute value should pass",
+            facet=facet,
+            inst=ifc.createIfcWall(Name=""),
+            expected=True,
+        )
+        ifc = ifcopenshell.file()
+        facet = Attribute(name="Description", value="Foobar", cardinality="optional")
+        run(
+            "An optional facet with a present but non-matching value should fail",
+            facet=facet,
+            inst=ifc.createIfcWall(Name="Waldo", Description="NotFoobar"),
+            expected=False,
+        )
+
+        ifc = ifcopenshell.file()
         facet = Attribute(name="Name")
         run("Attributes with null values always fail", facet=facet, inst=ifc.createIfcWall(), expected=False)
         # The logic is that unfortunately most BIM users cannot differentiate between the two.
@@ -1563,6 +1588,16 @@ class TestPartOf:
         run("A required facet checks all parameters as normal", facet=facet, inst=subelement, expected=True)
         facet = PartOf(name="IFCELEMENTASSEMBLY", relation="IFCRELAGGREGATES", cardinality="prohibited")
         run("A prohibited facet returns the opposite of a required facet", facet=facet, inst=subelement, expected=False)
+
+        ifc = ifcopenshell.file()
+        standalone = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        facet = PartOf(name="IFCELEMENTASSEMBLY", relation="IFCRELAGGREGATES", cardinality="optional")
+        run(
+            "An optional facet with no relationship should pass",
+            facet=facet,
+            inst=standalone,
+            expected=True,
+        )
 
         ifc = ifcopenshell.file()
         element = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcSlab")

--- a/src/ifctester/test/test_ids.py
+++ b/src/ifctester/test/test_ids.py
@@ -395,3 +395,24 @@ class TestSpecification:
             [wall],
             [],
         )
+
+    def test_optional_facet_with_empty_value_passes(self):
+        """Specification with required + optional facets should pass when optional attribute is empty."""
+        specs = ids.Ids(title="Title")
+        spec = ids.Specification(name="Name")
+        spec.applicability.append(ids.Entity(name="IFCWALL"))
+        spec.requirements.append(ids.Attribute(name="Name", value="Waldo", cardinality="required"))
+        spec.requirements.append(ids.Attribute(name="Description", value="Foobar", cardinality="optional"))
+        specs.specifications.append(spec)
+
+        spec.set_usage("required")
+        model = ifcopenshell.file()
+        wall = model.createIfcWall(Name="Waldo")
+        run(
+            "Optional facet with empty value should not cause specification failure",
+            specs,
+            model,
+            True,
+            [wall],
+            [],
+        )


### PR DESCRIPTION
Fixes #6323 | Related: buildingSMART/IDS#402

## Summary
- Attribute facet: add early return for optional cardinality when value is null/empty (the existing check only covered schema-level absence)
- PartOf facet: add optional cardinality checks at all 6 missing-relationship paths

## Test plan
- [x] All 23 existing facet tests pass
- [x] All 15 existing IDS tests pass
- [x] New unit tests for optional+null, optional+empty, optional+wrong-value (Attribute)
- [x] New unit test for optional+no-relationship (PartOf)
- [x] New integration test: required Name + optional Description with empty Description passes