### PR TITLE
Fixes needed to build IfcOpenShell with ParaView

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -279,7 +279,11 @@ endif()
 # Find Boost: On win32 the (hardcoded) default is to use static libraries and
 # runtime, when doing running conda-build we pick what conda prepared for us.
 if(WIN32 AND NOT DEFINED ENV{CONDA_BUILD})
-    set(Boost_USE_STATIC_LIBS ON)
+    if (BUILD_SHARED_LIBS)
+      set(Boost_USE_STATIC_LIBS OFF)
+    else()
+      set(Boost_USE_STATIC_LIBS ON)
+    endif()
     set(Boost_USE_STATIC_RUNTIME OFF)
     set(Boost_USE_MULTITHREADED ON)
 

--- a/cmake/IfcOpenShellConfig.cmake.in
+++ b/cmake/IfcOpenShellConfig.cmake.in
@@ -10,7 +10,11 @@ set(IFCOPENSHELL_WITH_ROCKSDB @WITH_ROCKSDB@)
 
 include(CMakeFindDependencyMacro)
 
-set(Boost_USE_STATIC_LIBS ON)
+if (BUILD_SHARED_LIBS)
+  set(Boost_USE_STATIC_LIBS OFF)
+else()
+  set(Boost_USE_STATIC_LIBS ON)
+endif()
 set(Boost_USE_STATIC_RUNTIME OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_COMPONENTS

--- a/src/ifcgeom/taxonomy.cpp
+++ b/src/ifcgeom/taxonomy.cpp
@@ -591,6 +591,7 @@ const std::string& ifcopenshell::geometry::taxonomy::kind_to_string(kinds k) {
 }
 
 std::atomic_uint32_t item::counter_(0);
+item::item(const IfcUtil::IfcBaseInterface* instance) : identity_(counter_++), computed_hash_(0), instance(instance) {}          
 
 void ifcopenshell::geometry::taxonomy::item::print(std::ostream& o, int indent) const {
 	o << std::string(indent, ' ') << kind_to_string(kind()) << std::endl;

--- a/src/ifcgeom/taxonomy.h
+++ b/src/ifcgeom/taxonomy.h
@@ -178,7 +178,7 @@ typedef item const* ptr;
 					return computed_hash_;
 				}
 
-				item(const IfcUtil::IfcBaseInterface* instance = nullptr) : identity_(counter_++), computed_hash_(0), instance(instance) {}
+				item(const IfcUtil::IfcBaseInterface* instance = nullptr);
 
 				virtual ~item() {}
 

--- a/src/svgfill/CMakeLists.txt
+++ b/src/svgfill/CMakeLists.txt
@@ -11,7 +11,11 @@ if(POLICY CMP0167) # 3.30 find_package(Boost) to use BoostConfig instead of Find
 endif()
 
 if(WIN32 AND NOT DEFINED ENV{CONDA_BUILD})
-    set(Boost_USE_STATIC_LIBS ON)
+    if (BUILD_SHARED_LIBS)
+      set(Boost_USE_STATIC_LIBS OFF)
+    else()
+      set(Boost_USE_STATIC_LIBS ON)
+    endif()
     set(Boost_USE_MULTITHREADED ON)
     if(USE_STATIC_MSVC_RUNTIME)
         set(Boost_USE_STATIC_RUNTIME ON)


### PR DESCRIPTION
We build a VTK IFC reader and we added it to ParaView. When using the ParaView superbuild we found and fixed a few minor issues as seen in this PR.

We found these issues when building as a shared library on Windows.

See:
https://gitlab.kitware.com/paraview/paraview-superbuild/-/merge_requests/1310

