### PR TITLE
Fix window/door preview alignment regression in ProductDecorator

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -1567,7 +1567,7 @@ class ProductDecorator:
                     obj_type,
                     representation,
                 )
-                context.view_layer.update()
+                bpy.context.view_layer.update()
                 break
 
         translate_mouse = Matrix.Translation(mouse_point)

--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -1531,7 +1531,8 @@ class ProductDecorator:
             point_on_side_axis = tool.Cad.point_on_edge(mouse_point, axis_side)
             if (point_on_base_axis - mouse_point).length_squared <= (point_on_side_axis - mouse_point).length_squared:
                 # mouse is snapped to the base axis, the preview looks exactly like the placed door / window
-                rot_mat = snap_obj.matrix_world
+                rot_mat = snap_obj.matrix_world.copy()
+                rot_mat.translation = (0, 0, 0)
             else:
                 # mouse is snapped to the side axis, the preview is inverted, rotate it now and correct x position later
                 rot_mat = (
@@ -1571,7 +1572,9 @@ class ProductDecorator:
 
         translate_mouse = Matrix.Translation(mouse_point)
         translate_rl = Matrix.Translation((0.0, 0.0, rl))
-        combined_m = translate_mouse @ rot_mat @ translate_rl @ self.obj_matrix_i
+        # Recalculate the inverted matrix to handle potential representation switches
+        obj_matrix_i = obj_type.matrix_world.inverted()
+        combined_m = translate_mouse @ rot_mat @ translate_rl @ obj_matrix_i
         data["verts"] = [tuple(combined_m @ v) for v in data["raw_verts"]]
         return data
 


### PR DESCRIPTION
## Summary
- Fix preview position offset for windows/doors on walls not at origin
- Fix undefined 'context' variable (use bpy.context instead)
- Recalculate type object's inverted matrix each frame to handle representation switches

These are regressions introduced in e55955b72 ("Fix unusable lag due to dense meshes with product preview").

## Test plan
- [ ] Select Window Tool, hover over walls at different positions - preview should follow mouse correctly
- [ ] Test with walls at origin and walls far from origin - both should work
- [ ] Test window placement on both sides of a wall

🤖 Generated with [Claude Code](https://claude.ai/code)