### PR TITLE
Feature/use blender angle snap settings

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -211,22 +211,21 @@ class PolylineOperator:
         context.workspace.status_text_set(draw_instructions)
 
     def handle_lock_axis(self, context: bpy.types.Context, event: bpy.types.Event) -> None:
+        angle_snap = tool.Snap.get_angle_snap_value(context)
         if event.value == "PRESS" and event.type == "A":
             self.tool_state.lock_axis = False if self.tool_state.lock_axis else True
             if self.tool_state.lock_axis:
                 self.tool_state.snap_angle = self.input_ui.get_number_value("WORLD_ANGLE")
-                # Round to the closest 5
-                self.tool_state.snap_angle = round(self.tool_state.snap_angle / 5) * 5
+                self.tool_state.snap_angle = round(self.tool_state.snap_angle / angle_snap) * angle_snap
 
         if event.shift and event.type in {"WHEELUPMOUSE", "WHEELDOWNMOUSE"}:
             self.tool_state.lock_axis = True
             self.tool_state.snap_angle = self.input_ui.get_number_value("WORLD_ANGLE")
-            # Round to the closest 5
-            self.tool_state.snap_angle = round(self.tool_state.snap_angle / 5) * 5
+            self.tool_state.snap_angle = round(self.tool_state.snap_angle / angle_snap) * angle_snap
             if event.type in {"WHEELUPMOUSE"}:
-                self.tool_state.snap_angle += 5
+                self.tool_state.snap_angle += angle_snap
             else:
-                self.tool_state.snap_angle -= 5
+                self.tool_state.snap_angle -= angle_snap
             self.handle_mouse_move(context, event)
             detected_snaps = tool.Snap.detect_snapping_points(context, event, self.objs_2d_bbox, self.tool_state)
             self.snapping_points = tool.Snap.select_snapping_points(context, event, self.tool_state, detected_snaps)

--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -17,7 +17,7 @@
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
-from math import atan2, degrees, pi
+from math import atan2, degrees, pi, radians
 from typing import Any, Literal, Optional, Union
 
 import bmesh
@@ -195,8 +195,8 @@ class DumbProfileGenerator:
         if should_round:
             # Round to nearest 50mm (yes, metric for now)
             self.length = 0.05 * round(length / 0.05)
-            # Round to nearest 5 degrees
-            nearest_degree = (pi / 180) * 5
+            angle_snap = tool.Snap.get_angle_snap_value(bpy.context)
+            nearest_degree = radians(angle_snap)
             self.rotation = nearest_degree * round(self.rotation / nearest_degree)
         self.location = coords[0]
         data["obj"] = self.create_profile()

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -916,8 +916,8 @@ class DumbWallGenerator:
         if should_round:
             # Round to nearest 50mm (yes, metric for now)
             self.length = 0.05 * round(length / 0.05)
-            # Round to nearest 5 degrees
-            nearest_degree = (math.pi / 180) * 5
+            angle_snap = tool.Snap.get_angle_snap_value(bpy.context)
+            nearest_degree = math.radians(angle_snap)
             self.rotation = nearest_degree * round(self.rotation / nearest_degree)
         self.location = coords[0]
         data["obj"] = self.create_wall()

--- a/src/bonsai/bonsai/tool/polyline.py
+++ b/src/bonsai/bonsai/tool/polyline.py
@@ -191,7 +191,8 @@ class Polyline(bonsai.core.tool.Polyline):
             orientation_angle = 0
         if input_ui:
             if should_round:
-                angle = 5 * round(angle / 5) if distance < angle_round_threshold else angle
+                angle_snap = tool.Snap.get_angle_snap_value(context)
+                angle = angle_snap * round(angle / angle_snap) if distance < angle_round_threshold else angle
                 factor = tool.Snap.get_increment_snap_value(context)
                 distance = factor * round(distance / factor)
             input_ui.set_value("X", mouse_vector.x)

--- a/src/bonsai/bonsai/tool/snap.py
+++ b/src/bonsai/bonsai/tool/snap.py
@@ -115,6 +115,15 @@ class Snap(bonsai.core.tool.Snap):
         return increment
 
     @classmethod
+    def get_angle_snap_value(cls, context: bpy.types.Context) -> float:
+        """Get the angle snap increment from Blender's tool settings.
+
+        :param context: Blender context
+        :return: Angle snap increment in degrees
+        """
+        return context.scene.tool_settings.snap_angle_increment
+
+    @classmethod
     def get_snap_points_on_raycasted_face(cls, context, event, obj, face_index):
         matrix = obj.matrix_world.copy()
         face = obj.data.polygons[face_index]

--- a/src/bonsai/bonsai/tool/snap.py
+++ b/src/bonsai/bonsai/tool/snap.py
@@ -118,10 +118,14 @@ class Snap(bonsai.core.tool.Snap):
     def get_angle_snap_value(cls, context: bpy.types.Context) -> float:
         """Get the angle snap increment from Blender's tool settings.
 
+        Uses snap_angle_increment_3d (Blender 5.0+) or snap_angle_increment (Blender 4.x).
+
         :param context: Blender context
         :return: Angle snap increment in degrees
         """
-        return context.scene.tool_settings.snap_angle_increment
+        if bpy.app.version >= (5, 0, 0):
+            return math.degrees(context.scene.tool_settings.snap_angle_increment_3d)
+        return math.degrees(context.scene.tool_settings.snap_angle_increment)
 
     @classmethod
     def get_snap_points_on_raycasted_face(cls, context, event, obj, face_index):


### PR DESCRIPTION
## Summary
- Add `get_angle_snap_value()` helper to `tool/snap.py` that retrieves angle snap increment from Blender's `tool_settings`
- Replace all hardcoded 5-degree angle snapping with calls to this helper
- Supports both Blender 4.x (`snap_angle_increment`) and 5.0+ (`snap_angle_increment_3d`)
- 
## Changes
- `tool/snap.py`: New helper function with version detection
- `tool/polyline.py`: Use helper in `calculate_distance_and_angle()`
- `bim/module/model/polyline.py`: Use helper in `handle_lock_axis()`
- `bim/module/model/wall.py`: Use helper in `create_wall_from_2_points()`
- `bim/module/model/profile.py`: Use helper in `create_profile_from_2_points()`
