### PR TITLE
Fix #7655: Handle missing spline data in decoration.py

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -218,6 +218,9 @@ class BaseDecorator:
         indices = []
         topology = []
 
+        if not obj.data or not hasattr(obj.data, "splines"):
+            return vertices, indices, topology
+
         idx = 0
         for spline in obj.data.splines:
             spline_points = spline.bezier_points if spline.bezier_points else spline.points
@@ -914,6 +917,8 @@ class LeaderDecorator(BaseDecorator):
     objecttype = "TEXT_LEADER"
 
     def get_spline_end(self, obj):
+        if not obj.data or not hasattr(obj.data, "splines") or not obj.data.splines:
+            return Vector((0, 0, 0))
         spline = obj.data.splines[0]
         spline_points = spline.bezier_points if spline.bezier_points else spline.points
         if not spline_points:
@@ -933,6 +938,8 @@ class RadiusDecorator(BaseDecorator):
     objecttype = "RADIUS"
 
     def get_spline_points(self, obj):
+        if not obj.data or not hasattr(obj.data, "splines") or not obj.data.splines:
+            return [Vector((0, 0, 0)), Vector((0, 0, 0))]
         spline = obj.data.splines[0]
         spline_points = spline.bezier_points if spline.bezier_points else spline.points
         if not spline_points:
@@ -991,6 +998,8 @@ class FallDecorator(BaseDecorator):
         if not (pos := location_3d_to_region_2d(region, region3d, self.get_spline_end(obj))):
             return
 
+        if not obj.data or not hasattr(obj.data, "splines") or not obj.data.splines:
+            return
         spline = obj.data.splines[0]
         spline_points = spline.bezier_points if spline.bezier_points else spline.points
 
@@ -1027,6 +1036,8 @@ class FallDecorator(BaseDecorator):
             self.draw_label(context, text, pos, dir, gap=0, center=False, vcenter=False)
 
     def get_spline_end(self, obj):
+        if not obj.data or not hasattr(obj.data, "splines") or not obj.data.splines:
+            return Vector((0, 0, 0))
         spline = obj.data.splines[0]
         spline_points = spline.bezier_points if spline.bezier_points else spline.points
         if not spline_points:
@@ -1788,7 +1799,7 @@ class CutDecorator:
 
         # Handle both old float64 and new float32 checksums for version compatibility
         rot_checksum_bytes: bytes = eval(DecoratorData.camera_rotation_checksum)
-        rot_check = tool.Blender.np_frombuffer_legacy(rot_checksum_bytes, 9)
+        rot_check = tool.Blender.np_frombuffer_legacy(rot_checksum_bytes, 9).reshape(3, 3)
         rot_real = tool.Blender.np_array_legacy(obj.matrix_world.to_3x3())
         rot_dot = np.dot(rot_check, rot_real.T)
         angle_rad = np.arccos(np.clip((np.trace(rot_dot) - 1) / 2, -1, 1))


### PR DESCRIPTION
## Summary
- Add defensive checks for annotations with missing or incomplete curve geometry
- Fix `is_camera_moved()` missing `.reshape(3,3)` for rotation matrix comparison

## Changes
- `get_path_geom()`: Return empty lists when `obj.data` or splines missing
- `LeaderDecorator.get_spline_end()`: Return zero vector when no splines
- `RadiusDecorator.get_spline_points()`: Return zero vectors when no splines  
- `FallDecorator.get_spline_end()`: Return zero vector when no splines
- `FallDecorator.draw_labels()`: Return early when no splines
- `is_camera_moved()`: Add missing `reshape(3,3)` for rotation matrix

## Root Cause
TEXT_LEADER annotations can have text (`IFCTEXTLITERALWITHEXTENT`) but be missing leader line geometry (`IFCGEOMETRICCURVESET`), causing `IndexError` when accessing `splines[0]`.

## Test plan
- [ ] Open the attached IFC file from issue #7655
- [ ] Verify text decoration works without crashing

Fixes #7655

🤖 Generated with [Claude Code](https://claude.ai/code)