### PR TITLE
Fixes snap angle.

### DIFF
--- a/src/bonsai/bonsai/tool/snap.py
+++ b/src/bonsai/bonsai/tool/snap.py
@@ -118,14 +118,10 @@ class Snap(bonsai.core.tool.Snap):
     def get_angle_snap_value(cls, context: bpy.types.Context) -> float:
         """Get the angle snap increment from Blender's tool settings.
 
-        Uses snap_angle_increment_3d (Blender 5.0+) or snap_angle_increment (Blender 4.x).
-
         :param context: Blender context
         :return: Angle snap increment in degrees
         """
-        if bpy.app.version >= (5, 0, 0):
-            return math.degrees(context.scene.tool_settings.snap_angle_increment_3d)
-        return math.degrees(context.scene.tool_settings.snap_angle_increment)
+        return math.degrees(context.scene.tool_settings.snap_angle_increment_3d)
 
     @classmethod
     def get_snap_points_on_raycasted_face(cls, context, event, obj, face_index):


### PR DESCRIPTION
In my previous commit, I mistakenly believed that there was an API change from snap_angle_increment to snap_angle_increment_3d
But since the feature was introduced in blender 4.2 the setting is called snap_angle_increment_3d.

Fixes #7680