### PR TITLE
Fixes in  AddReferenceImage due to bugs added in 43b12d5

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -117,7 +117,6 @@ class MaterialCreator:
         for texture in texture_style.Textures or []:
             if coords := getattr(texture, "IsMappedBy", None):
                 coords = coords[0]
-                # IfcTextureCoordinateGenerator handled in the style shader graph
                 if coords.is_a("IfcIndexedTextureMap"):
                     return coords
                 # TODO: support IfcTextureMap
@@ -135,6 +134,10 @@ class MaterialCreator:
                 if shape_has_openings and coords.is_a("IfcIndexedTextureMap"):
                     continue
                 tool.Loader.load_indexed_map(coords, self.mesh)
+            elif tool.Style.get_texture_style(material):
+                # No explicit coordinate mapping (e.g. IFC4 COORD relies on
+                # generated UVs). Bake XY→UV so Solid Texture mode works.
+                tool.Loader.load_generated_uv_map(self.mesh)
 
     def assign_material_slots_to_faces(self) -> None:
         if not self.mesh["ios_materials"]:

--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -85,7 +85,7 @@ class MaterialCreator:
         if element.is_a("IfcTypeProduct"):
             self.parse_element_type_material_styles(element)
         self.parsed_meshes.add(self.mesh.name)
-        if not self.ifc_import_settings.load_indexed_maps:
+        if self.ifc_import_settings.load_indexed_maps:
             self.load_texture_maps(shape_has_openings)
         self.assign_material_slots_to_faces()
         tool.Geometry.record_object_materials(obj)

--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -135,8 +135,8 @@ class MaterialCreator:
                     continue
                 tool.Loader.load_indexed_map(coords, self.mesh)
             elif tool.Style.get_texture_style(material):
-                # No explicit coordinate mapping (e.g. IFC4 COORD relies on
-                # generated UVs). Bake XY→UV so Solid Texture mode works.
+                # No explicit coordinate mapping (e.g. IFC2X3 has no IsMappedBy,
+                # and IFC4 COORD uses generated UVs). Bake XY→UV as fallback.
                 tool.Loader.load_generated_uv_map(self.mesh)
 
     def assign_material_slots_to_faces(self) -> None:

--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -892,48 +892,6 @@ class IfcImporter:
                 obj, tool.Loader.apply_blender_offset_to_matrix_world(obj, self.get_element_matrix(element))
             )
 
-        if element.is_a("IfcAnnotation") and getattr(element, "ObjectType", None) == "IMAGE":
-            image = None
-            if obj.data and obj.data.materials and obj.data.materials[0]:
-                material = obj.data.materials[0]
-                if material.use_nodes and material.node_tree:
-                    for node in material.node_tree.nodes:
-                        if node.type == "TEX_IMAGE" and node.image:
-                            image = node.image
-                            break
-            if image:
-                import bmesh
-
-                bm = bmesh.new()
-                bm.from_mesh(obj.data)
-                if not bm.loops.layers.uv:
-                    uv_layer = bm.loops.layers.uv.new()
-                else:
-                    uv_layer = bm.loops.layers.uv.active
-
-                if bm.verts:
-                    min_x = min(v.co.x for v in bm.verts)
-                    max_x = max(v.co.x for v in bm.verts)
-                    min_y = min(v.co.y for v in bm.verts)
-                    max_y = max(v.co.y for v in bm.verts)
-
-                    width = max_x - min_x
-                    height = max_y - min_y
-
-                    for face in bm.faces:
-                        for loop in face.loops:
-                            vert = loop.vert
-                            u = (vert.co.x - min_x) / width if width > 0 else 0.5
-                            v = (vert.co.y - min_y) / height if height > 0 else 0.5
-
-                            u = max(0.0, min(1.0, u))
-                            v = max(0.0, min(1.0, v))
-
-                            loop[uv_layer].uv = (u, v)
-
-                bm.to_mesh(obj.data)
-                bm.free()
-                obj.data.update()
         return obj
 
     def load_existing_meshes(self) -> None:

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3813,7 +3813,7 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             "Override image if it was previously loaded to Blender. If disabled, will always create a new image"
         ),
     )
-    
+
     def get_existing_reference_images(self, context):
         ifc_file = tool.Ifc.get()
 
@@ -3823,14 +3823,11 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
                 f"{obj.Name} ({obj.GlobalId})",
                 f"Update existing reference image: {obj.Name}",
             )
-            for obj in ifcopenshell.util.selector.filter_elements(
-                ifc_file,
-                "IfcAnnotation, PredefinedType=IMAGE"
-            )
+            for obj in ifcopenshell.util.selector.filter_elements(ifc_file, "IfcAnnotation, PredefinedType=IMAGE")
         ]
 
         return [("NEW", "Create New", "Create a new reference image object"), *items]
-    
+
     existing_object_by_name: bpy.props.EnumProperty(
         name="",
         description="Select an existing reference image object to update, or create a new one",
@@ -3868,34 +3865,34 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         return super().invoke(context, event)
 
     def check(self, context):
-        if not hasattr(self, '_last_filepath'):
+        if not hasattr(self, "_last_filepath"):
             self._last_filepath = ""
-        
+
         if self.filepath and self.filepath != self._last_filepath:
             self._last_filepath = self.filepath
-            
+
             abs_path = Path(self.filepath).absolute().resolve()
             if abs_path.exists() and abs_path.is_file():
                 image = load_image(abs_path.name, str(abs_path.parent), check_existing=False)
                 image_width_px = image.size[0]
                 image_height_px = image.size[1]
                 aspect_ratio = image_width_px / image_height_px
-                
+
                 if aspect_ratio >= 1.0:
                     self.x_length = 1.0
                     self.y_length = 1.0 / aspect_ratio
                 else:
                     self.x_length = aspect_ratio
                     self.y_length = 1.0
-                
+
                 bpy.data.images.remove(image)
                 return True
-        
+
         return False
 
     def draw(self, context):
         layout = self.layout
-        
+
         # File path settings
         if Path(tool.Ifc.get_path()).is_file():
             layout.prop(self, "use_relative_path")
@@ -3905,7 +3902,7 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             layout.label(text="to use relative paths.")
         layout.prop(self, "override_existing_image")
         layout.prop(self, "existing_object_by_name")
-        
+
         if self.existing_object_by_name == "NEW":
             layout.separator()
             layout.prop(self, "x_length")
@@ -3966,21 +3963,21 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             obj = bpy.data.objects[self.existing_object_by_name]
             element = tool.Ifc.get_entity(obj)
             representation = element.Representation.Representations[0] if element.Representation else None
-            
+
             tool.Blender.set_active_object(obj)
-            
+
             material = obj.data.materials[0]
             style = tool.Ifc.get_entity(material)
-            
+
             texture_style = next(s for s in style.Styles if s.is_a("IfcSurfaceStyleWithTextures"))
             existing_texture = texture_style.Textures[0]
             if tool.Ifc.get_schema() == "IFC2X3":
                 existing_texture.UrlReference = image_filepath.as_posix()
             else:
                 existing_texture.URLReference = image_filepath.as_posix()
-            
+
             tool.Style.set_use_nodes(material, True)
-            image_node = next(node for node in material.node_tree.nodes if node.type == 'TEX_IMAGE')
+            image_node = next(node for node in material.node_tree.nodes if node.type == "TEX_IMAGE")
             image_node.image = image
             image.reload()
         else:
@@ -3990,22 +3987,20 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             element = tool.Drawing.run_root_assign_class(
                 obj=obj, ifc_class="IfcAnnotation", predefined_type="IMAGE", should_add_representation=False
             )
-            
+
             builder = ifcopenshell.util.shape_builder.ShapeBuilder(ifc_file)
             unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
-            
             bm = tool.Blender.get_bmesh_for_mesh(mesh)
             verts = [v.co / unit_scale for v in bm.verts]
             faces = [[v.index for v in p.verts] for p in bm.faces]
             item = builder.mesh(verts, faces)
             bm.free()
-            
+
             ifc_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
             representation = builder.get_representation(ifc_context, [item])
             ifcopenshell.api.geometry.assign_representation(ifc_file, element, representation)
 
             style = ifcopenshell.api.style.add_style(tool.Ifc.get(), name=image_filepath.stem)
-
             ifcopenshell.api.style.assign_representation_styles(
                 ifc_file, shape_representation=representation, styles=[style]
             )
@@ -4027,13 +4022,21 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
                 ifc_class="IfcSurfaceStyleRendering",
                 attributes=shading_attributes,
             )
-            
+
             if tool.Ifc.get_schema() == "IFC2X3":
-                texture = ifc_file.create_entity("IfcImageTexture", RepeatS=True, RepeatT=True, TextureType="TEXTURE", UrlReference=image_filepath.as_posix())
+                texture = ifc_file.create_entity(
+                    "IfcImageTexture",
+                    RepeatS=True,
+                    RepeatT=True,
+                    TextureType="TEXTURE",
+                    UrlReference=image_filepath.as_posix(),
+                )
             else:
-                texture = ifc_file.create_entity("IfcImageTexture", Mode="DIFFUSE", URLReference=image_filepath.as_posix())
+                texture = ifc_file.create_entity(
+                    "IfcImageTexture", Mode="DIFFUSE", URLReference=image_filepath.as_posix()
+                )
                 ifc_file.create_entity("IfcTextureCoordinateGenerator", Maps=[texture], Mode="COORD")
-            
+
             textures = [texture]
             ifcopenshell.api.style.add_surface_style(
                 ifc_file,

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3969,7 +3969,7 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
                 tool.Blender.Attribute.fill_attribute(obj.data, "ios_item_ids", "FACE", "INT", [item_id] * num_faces)
 
                 for item in representation.Items:
-                    if item.is_a("IfcPolygonalFaceSet") and item.Coordinates:
+                    if tool.Ifc.get_schema() != "IFC2X3" and item.is_a("IfcPolygonalFaceSet") and item.Coordinates:
                         new_coords = []
                         for vertex in obj.data.vertices:
                             co = obj.matrix_world @ vertex.co
@@ -4004,16 +4004,41 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             ifc_class="IfcSurfaceStyleRendering",
             attributes=shading_attributes,
         )
-        texture = ifc_file.create_entity("IfcImageTexture", Mode="DIFFUSE", URLReference=image_filepath.as_posix())
-        textures = [texture]
-        ifc_file.create_entity("IfcTextureCoordinateGenerator", Maps=textures, Mode="COORD")  # UV map
-        ifcopenshell.api.style.add_surface_style(
-            ifc_file,
-            style=style,
-            ifc_class="IfcSurfaceStyleWithTextures",
-            attributes={"Textures": textures},
-        )
-        tool.Style.reload_material_from_ifc(material)
+        
+        if tool.Ifc.get_schema() == "IFC2X3":
+            texture = ifc_file.create_entity("IfcImageTexture", RepeatS=True, RepeatT=True, TextureType="TEXTURE", UrlReference=image_filepath.as_posix())
+            textures = [texture]
+            ifcopenshell.api.style.add_surface_style(
+                ifc_file,
+                style=style,
+                ifc_class="IfcSurfaceStyleWithTextures",
+                attributes={"Textures": textures},
+            )
+            tool.Style.set_use_nodes(material, True)
+            tool.Loader.restart_material_node_tree(material)
+            bsdf = tool.Blender.get_material_node(material, "BSDF_PRINCIPLED")
+            bsdf.inputs["Base Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+            
+            node = material.node_tree.nodes.new(type="ShaderNodeTexImage")
+            node.image = image
+            node.location = bsdf.location - Vector((400, 0))
+            material.node_tree.links.new(node.outputs["Color"], bsdf.inputs["Base Color"])
+            
+            coord = material.node_tree.nodes.new(type="ShaderNodeTexCoord")
+            coord.location = node.location - Vector((200, 0))
+            material.node_tree.links.new(coord.outputs["UV"], node.inputs["Vector"])
+        else:
+            texture = ifc_file.create_entity("IfcImageTexture", Mode="DIFFUSE", URLReference=image_filepath.as_posix())
+            ifc_file.create_entity("IfcTextureCoordinateGenerator", Maps=[texture], Mode="COORD")
+            textures = [texture]
+            ifcopenshell.api.style.add_surface_style(
+                ifc_file,
+                style=style,
+                ifc_class="IfcSurfaceStyleWithTextures",
+                attributes={"Textures": textures},
+            )
+            tool.Style.reload_material_from_ifc(material)
+        
         tool.Geometry.record_object_materials(obj)
 
 

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -4016,8 +4016,6 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         tool.Style.reload_material_from_ifc(material)
         tool.Geometry.record_object_materials(obj)
 
-        return {"FINISHED"}
-
 
 class ConvertSVGToDXF(bpy.types.Operator):
     bl_idname = "bim.convert_svg_to_dxf"

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3886,18 +3886,7 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         params = {"check_existing": False}
         image = load_image(abs_path.name, str(abs_path.parent), **params)
 
-        def bm_add_image_plane(mesh):
-            bm = tool.Blender.get_bmesh_for_mesh(mesh, clean=True)
-
-            plane_scale = Vector((self.x_length / 2.0, self.y_length / 2.0, 1.0))
-            matrix = Matrix.LocRotScale(None, None, plane_scale)
-            bmesh.ops.create_grid(bm, x_segments=1, y_segments=1, size=1, matrix=matrix, calc_uvs=False)
-
-            tool.Blender.apply_bmesh(mesh, bm)
-            tool.Loader.load_generated_uv_map(mesh)
-
         mesh = bpy.data.meshes.new(image_filepath.stem)
-        bm_add_image_plane(mesh)
         obj = bpy.data.objects.new(image_filepath.stem, mesh)
         element = tool.Drawing.run_root_assign_class(
             obj=obj, ifc_class="IfcAnnotation", predefined_type="IMAGE", should_add_representation=False
@@ -3905,11 +3894,10 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
 
         builder = ifcopenshell.util.shape_builder.ShapeBuilder(ifc_file)
         unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
-        bm = tool.Blender.get_bmesh_for_mesh(mesh)
-        verts = [v.co / unit_scale for v in bm.verts]
-        faces = [[v.index for v in p.verts] for p in bm.faces]
-        item = builder.mesh(verts, faces)
-        bm.free()
+        hx = self.x_length * 0.5 / unit_scale
+        hy = self.y_length * 0.5 / unit_scale
+        verts = [(-hx, -hy, 0.0), ( hx, -hy, 0.0), ( hx,  hy, 0.0), (-hx,  hy, 0.0)]
+        item = builder.mesh(verts, [[0, 1, 2, 3]])
 
         ifc_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
         representation = builder.get_representation(ifc_context, [item])

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3985,16 +3985,10 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             mesh = bpy.data.meshes.new(image_filepath.stem)
             bm_add_image_plane(mesh)
             obj = bpy.data.objects.new(image_filepath.stem, mesh)
-            tool.Drawing.run_root_assign_class(
-                obj=obj,
-                ifc_class="IfcAnnotation",
-                predefined_type="IMAGE",
-                should_add_representation=False,
-                context=ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW"),
-                ifc_representation_class=None,
+            element = tool.Drawing.run_root_assign_class(
+                obj=obj, ifc_class="IfcAnnotation", predefined_type="IMAGE", should_add_representation=False
             )
             
-            element = tool.Ifc.get_entity(obj)
             builder = ifcopenshell.util.shape_builder.ShapeBuilder(ifc_file)
             unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
             

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3934,30 +3934,8 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             matrix = Matrix.LocRotScale(None, None, plane_scale)
             bmesh.ops.create_grid(bm, x_segments=1, y_segments=1, size=1, matrix=matrix, calc_uvs=False)
 
-            if not bm.loops.layers.uv:
-                uv_layer = bm.loops.layers.uv.new()
-            else:
-                uv_layer = bm.loops.layers.uv.active
-
-            min_x = min(v.co.x for v in bm.verts)
-            max_x = max(v.co.x for v in bm.verts)
-            min_y = min(v.co.y for v in bm.verts)
-            max_y = max(v.co.y for v in bm.verts)
-
-            width = max_x - min_x
-            height = max_y - min_y
-
-            for face in bm.faces:
-                for loop in face.loops:
-                    vert = loop.vert
-                    u = (vert.co.x - min_x) / width if width > 0 else 0.5
-                    v = (vert.co.y - min_y) / height if height > 0 else 0.5
-
-                    u = max(0.0, min(1.0, u))
-                    v = max(0.0, min(1.0, v))
-                    loop[uv_layer].uv = (u, v)
-
             tool.Blender.apply_bmesh(mesh, bm)
+            tool.Loader.load_generated_uv_map(mesh)
 
         if self.existing_object_by_name != "NEW":
             obj = bpy.data.objects[self.existing_object_by_name]

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -50,6 +50,7 @@ import ifcopenshell.ifcopenshell_wrapper
 import ifcopenshell.util.element
 import ifcopenshell.util.representation
 import ifcopenshell.util.selector
+import ifcopenshell.util.shape_builder
 import ifcopenshell.util.unit
 import numpy as np
 import shapely
@@ -3884,10 +3885,10 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         layout.prop(self, "override_existing_image")
         layout.prop(self, "use_existing_object_by_name")
         
-        # Dimension settings
-        layout.separator()
-        layout.prop(self, "x_length")
-        layout.prop(self, "y_length")
+        if not self.use_existing_object_by_name:
+            layout.separator()
+            layout.prop(self, "x_length")
+            layout.prop(self, "y_length")
 
     def _execute(self, context):
         space = tool.Blender.get_view3d_space()
@@ -3942,97 +3943,111 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
 
         if self.use_existing_object_by_name:
             obj = bpy.data.objects[self.use_existing_object_by_name]
-            bm_add_image_plane(obj.data)
-            bpy.ops.bim.update_representation(obj=obj.name, ifc_representation_class="")
+            element = tool.Ifc.get_entity(obj)
+            representation = element.Representation.Representations[0] if element.Representation else None
+            
+            tool.Blender.set_active_object(obj)
+            
+            material = obj.data.materials[0]
+            style = tool.Ifc.get_entity(material)
+            
+            texture_style = next(s for s in style.Styles if s.is_a("IfcSurfaceStyleWithTextures"))
+            existing_texture = texture_style.Textures[0]
+            if tool.Ifc.get_schema() == "IFC2X3":
+                existing_texture.UrlReference = image_filepath.as_posix()
+            else:
+                existing_texture.URLReference = image_filepath.as_posix()
+            
+            tool.Style.set_use_nodes(material, True)
+            image_node = next(node for node in material.node_tree.nodes if node.type == 'TEX_IMAGE')
+            image_node.image = image
+            image.reload()
         else:
-            temp_mesh = bpy.data.meshes.new("temp_mesh")
-            bm_add_image_plane(temp_mesh)
-            obj = bpy.data.objects.new(image_filepath.stem, temp_mesh)
+            mesh = bpy.data.meshes.new(image_filepath.stem)
+            bm_add_image_plane(mesh)
+            obj = bpy.data.objects.new(image_filepath.stem, mesh)
             tool.Drawing.run_root_assign_class(
                 obj=obj,
                 ifc_class="IfcAnnotation",
                 predefined_type="IMAGE",
-                should_add_representation=True,
+                should_add_representation=False,
                 context=ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW"),
                 ifc_representation_class=None,
             )
-            tool.Blender.remove_data_block(temp_mesh)
-
-        element = tool.Ifc.get_entity(obj)
-        if element and isinstance(obj.data, bpy.types.Mesh):
-            representation = ifcopenshell.util.representation.get_representation(element, "Model", "Body", "MODEL_VIEW")
-            if representation and representation.Items:
-                item_id = representation.Items[0].id()
-                num_faces = len(obj.data.polygons)
-                obj.data["ios_item_ids"] = [item_id] * num_faces
-                tool.Blender.Attribute.fill_attribute(obj.data, "ios_item_ids", "FACE", "INT", [item_id] * num_faces)
-
-                for item in representation.Items:
-                    if tool.Ifc.get_schema() != "IFC2X3" and item.is_a("IfcPolygonalFaceSet") and item.Coordinates:
-                        new_coords = []
-                        for vertex in obj.data.vertices:
-                            co = obj.matrix_world @ vertex.co
-                            new_coords.append([co.x, co.y, co.z])
-                        item.Coordinates.CoordList = new_coords
-
-        tool.Blender.set_active_object(obj)
-
-        material = bpy.data.materials.new(name=image_filepath.stem)
-        obj.data.materials.append(None)  # new slot
-        obj.material_slots[0].material = material
-        bpy.ops.bim.add_style()
-
-        style = tool.Ifc.get_entity(material)
-        assert style
-        tool.Style.assign_style_to_object(style, obj)
-
-        # TODO: IfcSurfaceStyleRendering is unnecessary here, added it only because
-        # we don't support IfcSurfaceStyleWithTextures without Rendering yet
-        shading_attributes = {
-            "SurfaceColour": {
-                "Red": 1.0,
-                "Green": 1.0,
-                "Blue": 1.0,
-            },
-            "Transparency": 0.0,
-            "ReflectanceMethod": "NOTDEFINED",
-        }
-        ifcopenshell.api.style.add_surface_style(
-            tool.Ifc.get(),
-            style=style,
-            ifc_class="IfcSurfaceStyleRendering",
-            attributes=shading_attributes,
-        )
-        
-        if tool.Ifc.get_schema() == "IFC2X3":
-            texture = ifc_file.create_entity("IfcImageTexture", RepeatS=True, RepeatT=True, TextureType="TEXTURE", UrlReference=image_filepath.as_posix())
-        else:
-            texture = ifc_file.create_entity("IfcImageTexture", Mode="DIFFUSE", URLReference=image_filepath.as_posix())
-            ifc_file.create_entity("IfcTextureCoordinateGenerator", Maps=[texture], Mode="COORD")
-        
-        textures = [texture]
-        ifcopenshell.api.style.add_surface_style(
-            ifc_file,
-            style=style,
-            ifc_class="IfcSurfaceStyleWithTextures",
-            attributes={"Textures": textures},
-        )
-        
-        tool.Style.set_use_nodes(material, True)
-        tool.Loader.restart_material_node_tree(material)
-        bsdf = tool.Blender.get_material_node(material, "BSDF_PRINCIPLED")
-        bsdf.inputs["Base Color"].default_value = (1.0, 1.0, 1.0, 1.0)
-        
-        node = material.node_tree.nodes.new(type="ShaderNodeTexImage")
-        node.image = image
-        node.location = bsdf.location - Vector((400, 0))
-        material.node_tree.links.new(node.outputs["Color"], bsdf.inputs["Base Color"])
-        
-        coord = material.node_tree.nodes.new(type="ShaderNodeTexCoord")
-        coord.location = node.location - Vector((200, 0))
-        material.node_tree.links.new(coord.outputs["UV"], node.inputs["Vector"])
-        
-        tool.Geometry.record_object_materials(obj)
+            
+            element = tool.Ifc.get_entity(obj)
+            builder = ifcopenshell.util.shape_builder.ShapeBuilder(ifc_file)
+            unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
+            
+            bm = tool.Blender.get_bmesh_for_mesh(mesh, clean=True)
+            verts = [v.co / unit_scale for v in bm.verts]
+            faces = [[v.index for v in p.verts] for p in bm.faces]
+            item = builder.mesh(verts, faces)
+            bm.free()
+            
+            ifc_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
+            representation = builder.get_representation(ifc_context, [item])
+            ifcopenshell.api.geometry.assign_representation(ifc_file, element, representation)
+            
+            mesh["ios_item_ids"] = str(item.id())
+            tool.Geometry.get_mesh_props(mesh).ifc_definition_id = representation.id()
+            
+            tool.Blender.set_active_object(obj)
+            
+            material = bpy.data.materials.new(name=image_filepath.stem)
+            obj.data.materials.append(material)
+            bpy.ops.bim.add_style()
+            
+            style = tool.Ifc.get_entity(material)
+            assert style
+            
+            ifcopenshell.api.style.assign_representation_styles(ifc_file, shape_representation=representation, styles=[style])
+            
+            # TODO: IfcSurfaceStyleRendering is unnecessary here, added it only because
+            # we don't support IfcSurfaceStyleWithTextures without Rendering yet
+            shading_attributes = {
+                "SurfaceColour": {
+                    "Red": 1.0,
+                    "Green": 1.0,
+                    "Blue": 1.0,
+                },
+                "Transparency": 0.0,
+                "ReflectanceMethod": "NOTDEFINED",
+            }
+            ifcopenshell.api.style.add_surface_style(
+                tool.Ifc.get(),
+                style=style,
+                ifc_class="IfcSurfaceStyleRendering",
+                attributes=shading_attributes,
+            )
+            
+            if tool.Ifc.get_schema() == "IFC2X3":
+                texture = ifc_file.create_entity("IfcImageTexture", RepeatS=True, RepeatT=True, TextureType="TEXTURE", UrlReference=image_filepath.as_posix())
+            else:
+                texture = ifc_file.create_entity("IfcImageTexture", Mode="DIFFUSE", URLReference=image_filepath.as_posix())
+                ifc_file.create_entity("IfcTextureCoordinateGenerator", Maps=[texture], Mode="COORD")
+            
+            textures = [texture]
+            ifcopenshell.api.style.add_surface_style(
+                ifc_file,
+                style=style,
+                ifc_class="IfcSurfaceStyleWithTextures",
+                attributes={"Textures": textures},
+            )
+            
+            tool.Style.set_use_nodes(material, True)
+            tool.Loader.restart_material_node_tree(material)
+            bsdf = tool.Blender.get_material_node(material, "BSDF_PRINCIPLED")
+            bsdf.inputs["Base Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+            
+            node = material.node_tree.nodes.new(type="ShaderNodeTexImage")
+            node.image = image
+            node.location = bsdf.location - Vector((400, 0))
+            material.node_tree.links.new(node.outputs["Color"], bsdf.inputs["Base Color"])
+            
+            coord = material.node_tree.nodes.new(type="ShaderNodeTexCoord")
+            coord.location = node.location - Vector((200, 0))
+            material.node_tree.links.new(coord.outputs["UV"], node.inputs["Vector"])
 
 
 class ConvertSVGToDXF(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3805,26 +3805,6 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
     use_relative_path: bpy.props.BoolProperty(name="Use Relative Path", default=True)
     filter_image: bpy.props.BoolProperty(default=True, options={"HIDDEN", "SKIP_SAVE"})
     filter_folder: bpy.props.BoolProperty(default=True, options={"HIDDEN", "SKIP_SAVE"})
-
-    def get_existing_reference_images(self, context):
-        ifc_file = tool.Ifc.get()
-
-        items = [
-            (
-                f"IfcAnnotation/{obj.Name}",
-                f"{obj.Name} ({obj.GlobalId})",
-                f"Update existing reference image: {obj.Name}",
-            )
-            for obj in ifcopenshell.util.selector.filter_elements(ifc_file, "IfcAnnotation, PredefinedType=IMAGE")
-        ]
-
-        return [("NEW", "Create New", "Create a new reference image object"), *items]
-
-    existing_object_by_name: bpy.props.EnumProperty(
-        name="",
-        description="Select an existing reference image object to update, or create a new one",
-        items=get_existing_reference_images,
-    )
     x_length: bpy.props.FloatProperty(
         name="X Length",
         description="Width of the reference image",
@@ -3853,7 +3833,6 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
 
     def invoke(self, context, event):
         self._last_filepath = ""
-        self.existing_object_by_name = "NEW"
         return super().invoke(context, event)
 
     def check(self, context):
@@ -3884,20 +3863,12 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
 
     def draw(self, context):
         layout = self.layout
-
-        # File path settings
         if Path(tool.Ifc.get_path()).is_file():
             layout.prop(self, "use_relative_path")
         else:
             self.use_relative_path = False
-            layout.label(text="Save the .ifc file first ")
-            layout.label(text="to use relative paths.")
-        layout.prop(self, "existing_object_by_name")
-
-        if self.existing_object_by_name == "NEW":
-            layout.separator()
-            layout.prop(self, "x_length")
-            layout.prop(self, "y_length")
+        layout.prop(self, "x_length")
+        layout.prop(self, "y_length")
 
     def _execute(self, context):
         space = tool.Blender.get_view3d_space()
@@ -3925,99 +3896,65 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             tool.Blender.apply_bmesh(mesh, bm)
             tool.Loader.load_generated_uv_map(mesh)
 
-        if self.existing_object_by_name != "NEW":
-            obj = bpy.data.objects[self.existing_object_by_name]
-            element = tool.Ifc.get_entity(obj)
-            representation = element.Representation.Representations[0] if element.Representation else None
+        mesh = bpy.data.meshes.new(image_filepath.stem)
+        bm_add_image_plane(mesh)
+        obj = bpy.data.objects.new(image_filepath.stem, mesh)
+        element = tool.Drawing.run_root_assign_class(
+            obj=obj, ifc_class="IfcAnnotation", predefined_type="IMAGE", should_add_representation=False
+        )
 
-            tool.Blender.set_active_object(obj)
+        builder = ifcopenshell.util.shape_builder.ShapeBuilder(ifc_file)
+        unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
+        bm = tool.Blender.get_bmesh_for_mesh(mesh)
+        verts = [v.co / unit_scale for v in bm.verts]
+        faces = [[v.index for v in p.verts] for p in bm.faces]
+        item = builder.mesh(verts, faces)
+        bm.free()
 
-            material = obj.data.materials[0]
-            style = tool.Ifc.get_entity(material)
+        ifc_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
+        representation = builder.get_representation(ifc_context, [item])
+        ifcopenshell.api.geometry.assign_representation(ifc_file, element, representation)
 
-            texture_style = next(s for s in style.Styles if s.is_a("IfcSurfaceStyleWithTextures"))
-            existing_texture = texture_style.Textures[0]
-            if tool.Ifc.get_schema() == "IFC2X3":
-                existing_texture.UrlReference = image_filepath.as_posix()
-            else:
-                existing_texture.URLReference = image_filepath.as_posix()
+        style = ifcopenshell.api.style.add_style(tool.Ifc.get(), name=image_filepath.stem)
+        ifcopenshell.api.style.assign_representation_styles(
+            ifc_file, shape_representation=representation, styles=[style]
+        )
 
-            tool.Style.set_use_nodes(material, True)
-            image_node = next(node for node in material.node_tree.nodes if node.type == "TEX_IMAGE")
-            image_node.image = image
-            image.reload()
+        # TODO: IfcSurfaceStyleRendering is unnecessary here, added it only because
+        # we don't support IfcSurfaceStyleWithTextures without Rendering yet
+        shading_attributes = {
+            "SurfaceColour": {"Red": 1.0, "Green": 1.0, "Blue": 1.0},
+            "Transparency": 0.0,
+            "ReflectanceMethod": "NOTDEFINED",
+        }
+        ifcopenshell.api.style.add_surface_style(
+            tool.Ifc.get(), style=style, ifc_class="IfcSurfaceStyleRendering", attributes=shading_attributes
+        )
+
+        if tool.Ifc.get_schema() == "IFC2X3":
+            texture = ifc_file.create_entity(
+                "IfcImageTexture",
+                RepeatS=True,
+                RepeatT=True,
+                TextureType="TEXTURE",
+                UrlReference=image_filepath.as_posix(),
+            )
         else:
-            mesh = bpy.data.meshes.new(image_filepath.stem)
-            bm_add_image_plane(mesh)
-            obj = bpy.data.objects.new(image_filepath.stem, mesh)
-            element = tool.Drawing.run_root_assign_class(
-                obj=obj, ifc_class="IfcAnnotation", predefined_type="IMAGE", should_add_representation=False
-            )
+            texture = ifc_file.create_entity("IfcImageTexture", Mode="DIFFUSE", URLReference=image_filepath.as_posix())
+            ifc_file.create_entity("IfcTextureCoordinateGenerator", Maps=[texture], Mode="COORD")
 
-            builder = ifcopenshell.util.shape_builder.ShapeBuilder(ifc_file)
-            unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
-            bm = tool.Blender.get_bmesh_for_mesh(mesh)
-            verts = [v.co / unit_scale for v in bm.verts]
-            faces = [[v.index for v in p.verts] for p in bm.faces]
-            item = builder.mesh(verts, faces)
-            bm.free()
+        textures = [texture]
+        ifcopenshell.api.style.add_surface_style(
+            ifc_file, style=style, ifc_class="IfcSurfaceStyleWithTextures", attributes={"Textures": textures}
+        )
 
-            ifc_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
-            representation = builder.get_representation(ifc_context, [item])
-            ifcopenshell.api.geometry.assign_representation(ifc_file, element, representation)
+        logger = logging.getLogger("ImportIFC")
+        ifc_import_settings = bonsai.bim.import_ifc.IfcImportSettings.factory(bpy.context, None, logger)
+        ifc_importer = bonsai.bim.import_ifc.IfcImporter(ifc_import_settings)
+        ifc_importer.file = tool.Ifc.get()
+        ifc_importer.create_style(style)
 
-            style = ifcopenshell.api.style.add_style(tool.Ifc.get(), name=image_filepath.stem)
-            ifcopenshell.api.style.assign_representation_styles(
-                ifc_file, shape_representation=representation, styles=[style]
-            )
-
-            # TODO: IfcSurfaceStyleRendering is unnecessary here, added it only because
-            # we don't support IfcSurfaceStyleWithTextures without Rendering yet
-            shading_attributes = {
-                "SurfaceColour": {
-                    "Red": 1.0,
-                    "Green": 1.0,
-                    "Blue": 1.0,
-                },
-                "Transparency": 0.0,
-                "ReflectanceMethod": "NOTDEFINED",
-            }
-            ifcopenshell.api.style.add_surface_style(
-                tool.Ifc.get(),
-                style=style,
-                ifc_class="IfcSurfaceStyleRendering",
-                attributes=shading_attributes,
-            )
-
-            if tool.Ifc.get_schema() == "IFC2X3":
-                texture = ifc_file.create_entity(
-                    "IfcImageTexture",
-                    RepeatS=True,
-                    RepeatT=True,
-                    TextureType="TEXTURE",
-                    UrlReference=image_filepath.as_posix(),
-                )
-            else:
-                texture = ifc_file.create_entity(
-                    "IfcImageTexture", Mode="DIFFUSE", URLReference=image_filepath.as_posix()
-                )
-                ifc_file.create_entity("IfcTextureCoordinateGenerator", Maps=[texture], Mode="COORD")
-
-            textures = [texture]
-            ifcopenshell.api.style.add_surface_style(
-                ifc_file,
-                style=style,
-                ifc_class="IfcSurfaceStyleWithTextures",
-                attributes={"Textures": textures},
-            )
-
-            logger = logging.getLogger("ImportIFC")
-            ifc_import_settings = bonsai.bim.import_ifc.IfcImportSettings.factory(bpy.context, None, logger)
-            ifc_importer = bonsai.bim.import_ifc.IfcImporter(ifc_import_settings)
-            ifc_importer.file = tool.Ifc.get()
-            ifc_importer.create_style(style)
-
-            bonsai.core.geometry.switch_representation(tool.Ifc, tool.Geometry, obj=obj, representation=representation)
+        bonsai.core.geometry.switch_representation(tool.Ifc, tool.Geometry, obj=obj, representation=representation)
 
 
 class ConvertSVGToDXF(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -139,7 +139,7 @@ class AddAnnotationType(bpy.types.Operator, tool.Ifc.Operator):
         element.ApplicableOccurrence = f"IfcAnnotation/{object_type}"
 
         if props.create_representation_for_type and object_type == "IMAGE":
-            bpy.ops.bim.add_reference_image("INVOKE_DEFAULT", use_existing_object_by_name=obj.name)
+            bpy.ops.bim.add_reference_image("INVOKE_DEFAULT", existing_object_by_name=obj.name)
 
 
 class EnableAddAnnotationType(bpy.types.Operator):
@@ -1760,7 +1760,7 @@ class AddAnnotation(bpy.types.Operator, tool.Ifc.Operator):
             enable_editing=True,
         )
         if props.object_type == "IMAGE":
-            bpy.ops.bim.add_reference_image("INVOKE_DEFAULT", use_existing_object_by_name=obj.name)
+            bpy.ops.bim.add_reference_image("INVOKE_DEFAULT", existing_object_by_name=obj.name)
 
 
 class AddSheet(bpy.types.Operator, tool.Ifc.Operator):
@@ -3811,10 +3811,27 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             "Override image if it was previously loaded to Blender. If disabled, will always create a new image"
         ),
     )
-    use_existing_object_by_name: bpy.props.StringProperty(
-        name="Use Existing Object By Name",
-        description="Existing object name to add a style with reference image to. If not provided will create a new object.",
-        options={"SKIP_SAVE"},
+    
+    def get_existing_reference_images(self, context):
+        items = [("NEW", "Create New", "Create a new reference image object")]
+        
+        ifc_file = tool.Ifc.get()
+        if not ifc_file:
+            return items
+        
+        for obj in context.scene.objects:
+            element = tool.Ifc.get_entity(obj)
+            if element and element.is_a("IfcAnnotation"):
+                predefined_type = ifcopenshell.util.element.get_predefined_type(element)
+                if predefined_type == "IMAGE":
+                    items.append((obj.name, obj.name, f"Update existing reference image: {obj.name}"))
+        
+        return items
+    
+    existing_object_by_name: bpy.props.EnumProperty(
+        name="",
+        description="Select an existing reference image object to update, or create a new one",
+        items=get_existing_reference_images,
     )
     x_length: bpy.props.FloatProperty(
         name="X Length",
@@ -3844,6 +3861,7 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
 
     def invoke(self, context, event):
         self._last_filepath = ""
+        self.existing_object_by_name = "NEW"
         return super().invoke(context, event)
 
     def check(self, context):
@@ -3883,9 +3901,9 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             layout.label(text="Save the .ifc file first ")
             layout.label(text="to use relative paths.")
         layout.prop(self, "override_existing_image")
-        layout.prop(self, "use_existing_object_by_name")
+        layout.prop(self, "existing_object_by_name")
         
-        if not self.use_existing_object_by_name:
+        if self.existing_object_by_name == "NEW":
             layout.separator()
             layout.prop(self, "x_length")
             layout.prop(self, "y_length")
@@ -3941,8 +3959,8 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
 
             tool.Blender.apply_bmesh(mesh, bm)
 
-        if self.use_existing_object_by_name:
-            obj = bpy.data.objects[self.use_existing_object_by_name]
+        if self.existing_object_by_name != "NEW":
+            obj = bpy.data.objects[self.existing_object_by_name]
             element = tool.Ifc.get_entity(obj)
             representation = element.Representation.Representations[0] if element.Representation else None
             

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3999,37 +3999,31 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         
         if tool.Ifc.get_schema() == "IFC2X3":
             texture = ifc_file.create_entity("IfcImageTexture", RepeatS=True, RepeatT=True, TextureType="TEXTURE", UrlReference=image_filepath.as_posix())
-            textures = [texture]
-            ifcopenshell.api.style.add_surface_style(
-                ifc_file,
-                style=style,
-                ifc_class="IfcSurfaceStyleWithTextures",
-                attributes={"Textures": textures},
-            )
-            tool.Style.set_use_nodes(material, True)
-            tool.Loader.restart_material_node_tree(material)
-            bsdf = tool.Blender.get_material_node(material, "BSDF_PRINCIPLED")
-            bsdf.inputs["Base Color"].default_value = (1.0, 1.0, 1.0, 1.0)
-            
-            node = material.node_tree.nodes.new(type="ShaderNodeTexImage")
-            node.image = image
-            node.location = bsdf.location - Vector((400, 0))
-            material.node_tree.links.new(node.outputs["Color"], bsdf.inputs["Base Color"])
-            
-            coord = material.node_tree.nodes.new(type="ShaderNodeTexCoord")
-            coord.location = node.location - Vector((200, 0))
-            material.node_tree.links.new(coord.outputs["UV"], node.inputs["Vector"])
         else:
             texture = ifc_file.create_entity("IfcImageTexture", Mode="DIFFUSE", URLReference=image_filepath.as_posix())
             ifc_file.create_entity("IfcTextureCoordinateGenerator", Maps=[texture], Mode="COORD")
-            textures = [texture]
-            ifcopenshell.api.style.add_surface_style(
-                ifc_file,
-                style=style,
-                ifc_class="IfcSurfaceStyleWithTextures",
-                attributes={"Textures": textures},
-            )
-            tool.Style.reload_material_from_ifc(material)
+        
+        textures = [texture]
+        ifcopenshell.api.style.add_surface_style(
+            ifc_file,
+            style=style,
+            ifc_class="IfcSurfaceStyleWithTextures",
+            attributes={"Textures": textures},
+        )
+        
+        tool.Style.set_use_nodes(material, True)
+        tool.Loader.restart_material_node_tree(material)
+        bsdf = tool.Blender.get_material_node(material, "BSDF_PRINCIPLED")
+        bsdf.inputs["Base Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+        
+        node = material.node_tree.nodes.new(type="ShaderNodeTexImage")
+        node.image = image
+        node.location = bsdf.location - Vector((400, 0))
+        material.node_tree.links.new(node.outputs["Color"], bsdf.inputs["Base Color"])
+        
+        coord = material.node_tree.nodes.new(type="ShaderNodeTexCoord")
+        coord.location = node.location - Vector((200, 0))
+        material.node_tree.links.new(coord.outputs["UV"], node.inputs["Vector"])
         
         tool.Geometry.record_object_materials(obj)
 

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -40,6 +40,7 @@ from typing import (
 
 import bmesh
 import bpy
+import logging
 import ifcopenshell
 import ifcopenshell.api
 import ifcopenshell.api.document
@@ -60,6 +61,7 @@ from bpy_extras.io_utils import ImportHelper
 from lxml import etree
 from mathutils import Color, Matrix, Vector
 
+import bonsai.bim.import_ifc
 import bonsai.bim.export_ifc
 import bonsai.bim.handler
 import bonsai.bim.helper
@@ -4001,21 +4003,13 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             ifc_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
             representation = builder.get_representation(ifc_context, [item])
             ifcopenshell.api.geometry.assign_representation(ifc_file, element, representation)
-            
-            mesh["ios_item_ids"] = str(item.id())
-            tool.Geometry.get_mesh_props(mesh).ifc_definition_id = representation.id()
-            
-            tool.Blender.set_active_object(obj)
-            
-            material = bpy.data.materials.new(name=image_filepath.stem)
-            obj.data.materials.append(material)
-            bpy.ops.bim.add_style()
-            
-            style = tool.Ifc.get_entity(material)
-            assert style
-            
-            ifcopenshell.api.style.assign_representation_styles(ifc_file, shape_representation=representation, styles=[style])
-            
+
+            style = ifcopenshell.api.style.add_style(tool.Ifc.get(), name=image_filepath.stem)
+
+            ifcopenshell.api.style.assign_representation_styles(
+                ifc_file, shape_representation=representation, styles=[style]
+            )
+
             # TODO: IfcSurfaceStyleRendering is unnecessary here, added it only because
             # we don't support IfcSurfaceStyleWithTextures without Rendering yet
             shading_attributes = {
@@ -4047,20 +4041,14 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
                 ifc_class="IfcSurfaceStyleWithTextures",
                 attributes={"Textures": textures},
             )
-            
-            tool.Style.set_use_nodes(material, True)
-            tool.Loader.restart_material_node_tree(material)
-            bsdf = tool.Blender.get_material_node(material, "BSDF_PRINCIPLED")
-            bsdf.inputs["Base Color"].default_value = (1.0, 1.0, 1.0, 1.0)
-            
-            node = material.node_tree.nodes.new(type="ShaderNodeTexImage")
-            node.image = image
-            node.location = bsdf.location - Vector((400, 0))
-            material.node_tree.links.new(node.outputs["Color"], bsdf.inputs["Base Color"])
-            
-            coord = material.node_tree.nodes.new(type="ShaderNodeTexCoord")
-            coord.location = node.location - Vector((200, 0))
-            material.node_tree.links.new(coord.outputs["UV"], node.inputs["Vector"])
+
+            logger = logging.getLogger("ImportIFC")
+            ifc_import_settings = bonsai.bim.import_ifc.IfcImportSettings.factory(bpy.context, None, logger)
+            ifc_importer = bonsai.bim.import_ifc.IfcImporter(ifc_import_settings)
+            ifc_importer.file = tool.Ifc.get()
+            ifc_importer.create_style(style)
+
+            bonsai.core.geometry.switch_representation(tool.Ifc, tool.Geometry, obj=obj, representation=representation)
 
 
 class ConvertSVGToDXF(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3813,20 +3813,21 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
     )
     
     def get_existing_reference_images(self, context):
-        items = [("NEW", "Create New", "Create a new reference image object")]
-        
         ifc_file = tool.Ifc.get()
-        if not ifc_file:
-            return items
-        
-        for obj in context.scene.objects:
-            element = tool.Ifc.get_entity(obj)
-            if element and element.is_a("IfcAnnotation"):
-                predefined_type = ifcopenshell.util.element.get_predefined_type(element)
-                if predefined_type == "IMAGE":
-                    items.append((obj.name, obj.name, f"Update existing reference image: {obj.name}"))
-        
-        return items
+
+        items = [
+            (
+                f"IfcAnnotation/{obj.Name}",
+                f"{obj.Name} ({obj.GlobalId})",
+                f"Update existing reference image: {obj.Name}",
+            )
+            for obj in ifcopenshell.util.selector.filter_elements(
+                ifc_file,
+                "IfcAnnotation, PredefinedType=IMAGE"
+            )
+        ]
+
+        return [("NEW", "Create New", "Create a new reference image object"), *items]
     
     existing_object_by_name: bpy.props.EnumProperty(
         name="",

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3815,14 +3815,79 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         description="Existing object name to add a style with reference image to. If not provided will create a new object.",
         options={"SKIP_SAVE"},
     )
-    size: bpy.props.FloatProperty(name="Size", description="Size of the reference image", default=1.0, unit="LENGTH")
+    x_length: bpy.props.FloatProperty(
+        name="X Length",
+        description="Width of the reference image in project units",
+        default=1.0,
+        min=0.001,
+        soft_min=0.01,
+        precision=3,
+    )
+    y_length: bpy.props.FloatProperty(
+        name="Y Length",
+        description="Height of the reference image in project units",
+        default=1.0,
+        min=0.001,
+        soft_min=0.01,
+        precision=3,
+    )
+
+    def invoke(self, context, event):
+        self._last_filepath = ""
+        return super().invoke(context, event)
+
+    def check(self, context):
+        if not hasattr(self, '_last_filepath'):
+            self._last_filepath = ""
+        
+        if self.filepath and self.filepath != self._last_filepath:
+            self._last_filepath = self.filepath
+            
+            abs_path = Path(self.filepath).absolute().resolve()
+            if abs_path.exists() and abs_path.is_file():
+                image = load_image(abs_path.name, str(abs_path.parent), check_existing=False)
+                image_width_px = image.size[0]
+                image_height_px = image.size[1]
+                aspect_ratio = image_width_px / image_height_px
+                
+                if aspect_ratio >= 1.0:
+                    self.x_length = 1.0
+                    self.y_length = 1.0 / aspect_ratio
+                else:
+                    self.x_length = aspect_ratio
+                    self.y_length = 1.0
+                
+                bpy.data.images.remove(image)
+                return True
+        
+        return False
 
     def draw(self, context):
+        layout = self.layout
+        
+        # File path settings
         if Path(tool.Ifc.get_path()).is_file():
-            self.layout.prop(self, "use_relative_path")
-        self.layout.prop(self, "override_existing_image")
-        self.layout.prop(self, "use_existing_object_by_name")
-        self.layout.prop(self, "size")
+            layout.prop(self, "use_relative_path")
+        else:
+            self.use_relative_path = False
+            layout.label(text="Save the .ifc file first ")
+            layout.label(text="to use relative paths.")
+        layout.prop(self, "override_existing_image")
+        layout.prop(self, "use_existing_object_by_name")
+        
+        # Dimension settings
+        layout.separator()
+        if tool.Ifc.get():
+            length_unit = ifcopenshell.util.unit.get_project_unit(tool.Ifc.get(), "LENGTHUNIT")
+            if length_unit:
+                unit_name = ifcopenshell.util.unit.get_full_unit_name(length_unit).lower()
+            else:
+                unit_name = "project units"
+            layout.label(text=f"Dimensions (in {unit_name}):")
+        else:
+            layout.label(text="Dimensions (in project units):")
+        layout.prop(self, "x_length")
+        layout.prop(self, "y_length")
 
     def _execute(self, context):
         space = tool.Blender.get_view3d_space()
@@ -3843,19 +3908,11 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             params = {"check_existing": False}
         image = load_image(abs_path.name, str(abs_path.parent), **params)
 
-        aspect_ratio = image.size[0] / image.size[1]
-        if aspect_ratio >= 1.0:  # Landscape
-            x_length = self.size
-            y_length = self.size / aspect_ratio
-        else:
-            x_length = self.size / aspect_ratio
-            y_length = self.size
-
         def bm_add_image_plane(mesh):
             bm = tool.Blender.get_bmesh_for_mesh(mesh, clean=True)
 
             unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
-            plane_scale = Vector((x_length / 2.0, y_length / 2.0, 1.0))
+            plane_scale = Vector((self.x_length * unit_scale / 2.0, self.y_length * unit_scale / 2.0, 1.0))
             matrix = Matrix.LocRotScale(None, None, plane_scale)
             bmesh.ops.create_grid(bm, x_segments=1, y_segments=1, size=1, matrix=matrix, calc_uvs=False)
 
@@ -3958,6 +4015,8 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         )
         tool.Style.reload_material_from_ifc(material)
         tool.Geometry.record_object_materials(obj)
+
+        return {"FINISHED"}
 
 
 class ConvertSVGToDXF(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3992,7 +3992,7 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             builder = ifcopenshell.util.shape_builder.ShapeBuilder(ifc_file)
             unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
             
-            bm = tool.Blender.get_bmesh_for_mesh(mesh, clean=True)
+            bm = tool.Blender.get_bmesh_for_mesh(mesh)
             verts = [v.co / unit_scale for v in bm.verts]
             faces = [[v.index for v in p.verts] for p in bm.faces]
             item = builder.mesh(verts, faces)

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3806,14 +3806,6 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
     filter_image: bpy.props.BoolProperty(default=True, options={"HIDDEN", "SKIP_SAVE"})
     filter_folder: bpy.props.BoolProperty(default=True, options={"HIDDEN", "SKIP_SAVE"})
 
-    override_existing_image: bpy.props.BoolProperty(
-        name="Override Existing Image",
-        default=True,
-        description=(
-            "Override image if it was previously loaded to Blender. If disabled, will always create a new image"
-        ),
-    )
-
     def get_existing_reference_images(self, context):
         ifc_file = tool.Ifc.get()
 
@@ -3900,7 +3892,6 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             self.use_relative_path = False
             layout.label(text="Save the .ifc file first ")
             layout.label(text="to use relative paths.")
-        layout.prop(self, "override_existing_image")
         layout.prop(self, "existing_object_by_name")
 
         if self.existing_object_by_name == "NEW":
@@ -3921,10 +3912,7 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         image_filepath = Path(tool.Ifc.get_uri(self.filepath, use_relative_path=self.use_relative_path))
         ifc_file = tool.Ifc.get()
 
-        if self.override_existing_image:
-            params = {"check_existing": True, "force_reload": True}
-        else:
-            params = {"check_existing": False}
+        params = {"check_existing": False}
         image = load_image(abs_path.name, str(abs_path.parent), **params)
 
         def bm_add_image_plane(mesh):

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3817,19 +3817,21 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
     )
     x_length: bpy.props.FloatProperty(
         name="X Length",
-        description="Width of the reference image in project units",
+        description="Width of the reference image",
         default=1.0,
         min=0.001,
         soft_min=0.01,
         precision=3,
+        unit="LENGTH",
     )
     y_length: bpy.props.FloatProperty(
         name="Y Length",
-        description="Height of the reference image in project units",
+        description="Height of the reference image",
         default=1.0,
         min=0.001,
         soft_min=0.01,
         precision=3,
+        unit="LENGTH",
     )
 
     def invoke(self, context, event):
@@ -3877,15 +3879,6 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         
         # Dimension settings
         layout.separator()
-        if tool.Ifc.get():
-            length_unit = ifcopenshell.util.unit.get_project_unit(tool.Ifc.get(), "LENGTHUNIT")
-            if length_unit:
-                unit_name = ifcopenshell.util.unit.get_full_unit_name(length_unit).lower()
-            else:
-                unit_name = "project units"
-            layout.label(text=f"Dimensions (in {unit_name}):")
-        else:
-            layout.label(text="Dimensions (in project units):")
         layout.prop(self, "x_length")
         layout.prop(self, "y_length")
 
@@ -3911,8 +3904,7 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         def bm_add_image_plane(mesh):
             bm = tool.Blender.get_bmesh_for_mesh(mesh, clean=True)
 
-            unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
-            plane_scale = Vector((self.x_length * unit_scale / 2.0, self.y_length * unit_scale / 2.0, 1.0))
+            plane_scale = Vector((self.x_length / 2.0, self.y_length / 2.0, 1.0))
             matrix = Matrix.LocRotScale(None, None, plane_scale)
             bmesh.ops.create_grid(bm, x_segments=1, y_segments=1, size=1, matrix=matrix, calc_uvs=False)
 

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3834,6 +3834,13 @@ class AddReferenceImage(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         unit="LENGTH",
     )
 
+    @classmethod
+    def poll(cls, context):
+        if not tool.Ifc.get():
+            cls.poll_message_set("No IFC project is loaded.")
+            return False
+        return True
+
     def invoke(self, context, event):
         self._last_filepath = ""
         return super().invoke(context, event)

--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -3245,29 +3245,9 @@ class ImageScalingTool(bpy.types.Operator, PolylineOperator):
 
             bmesh.ops.scale(bm, vec=(scale_factor, scale_factor, 1.0), verts=bm.verts)
 
-            if bm.loops.layers.uv:
-                uv_layer = bm.loops.layers.uv.active
-
-                min_x = min(v.co.x for v in bm.verts)
-                max_x = max(v.co.x for v in bm.verts)
-                min_y = min(v.co.y for v in bm.verts)
-                max_y = max(v.co.y for v in bm.verts)
-
-                width = max_x - min_x
-                height = max_y - min_y
-
-                for face in bm.faces:
-                    for loop in face.loops:
-                        vert = loop.vert
-                        u = (vert.co.x - min_x) / width if width > 0 else 0.5
-                        v = (vert.co.y - min_y) / height if height > 0 else 0.5
-
-                        u = max(0.0, min(1.0, u))
-                        v = max(0.0, min(1.0, v))
-                        loop[uv_layer].uv = (u, v)
-
             bm.to_mesh(mesh)
             bm.free()
+            tool.Loader.load_generated_uv_map(mesh)
             mesh.update()
 
             element = tool.Ifc.get_entity(self.target_object)

--- a/src/bonsai/bonsai/bim/module/style/operator.py
+++ b/src/bonsai/bonsai/bim/module/style/operator.py
@@ -87,6 +87,7 @@ class RemoveStyle(bpy.types.Operator, tool.Ifc.Operator):
         core.remove_style(tool.Ifc, tool.Style, style=tool.Ifc.get().by_id(self.style), reload_styles_ui=True)
 
 
+# TODO: remove completely
 class AddStyle(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_style"
     bl_label = "Add Style"

--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -540,6 +540,33 @@ class Loader(bonsai.core.tool.Loader):
             cls.load_indexed_map(colour, mesh)
 
     @classmethod
+    def load_generated_uv_map(cls, mesh: bpy.types.Mesh) -> None:
+        bm = bmesh.new()
+        bm.from_mesh(mesh)
+        uv_layer = bm.loops.layers.uv.active or bm.loops.layers.uv.new("UVMap")
+
+        all_verts = [v.co for v in bm.verts]
+        if not all_verts:
+            bm.free()
+            return
+
+        min_x = min(v.x for v in all_verts)
+        max_x = max(v.x for v in all_verts)
+        min_y = min(v.y for v in all_verts)
+        max_y = max(v.y for v in all_verts)
+        width = max_x - min_x
+        height = max_y - min_y
+
+        for face in bm.faces:
+            for loop in face.loops:
+                u = (loop.vert.co.x - min_x) / width if width > 0 else 0.5
+                v = (loop.vert.co.y - min_y) / height if height > 0 else 0.5
+                loop[uv_layer].uv = (max(0.0, min(1.0, u)), max(0.0, min(1.0, v)))
+
+        bm.to_mesh(mesh)
+        bm.free()
+
+    @classmethod
     def load_indexed_map(cls, index_map: ifcopenshell.entity_instance, mesh: bpy.types.Mesh) -> None:
         """Add data from index map as blender mesh attribute.
 

--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -179,7 +179,8 @@ class Loader(bonsai.core.tool.Loader):
     def surface_texture_to_dict(cls, surface_texture):
         if isinstance(surface_texture, dict):
             return surface_texture
-        mappings = surface_texture.IsMappedBy or []
+        # IsMappedBy is an IFC4+ inverse attribute, not available in IFC2X3.
+        mappings = getattr(surface_texture, "IsMappedBy", None) or []
         surface_texture = surface_texture.get_info()
         uv_mode = None
         if mappings:
@@ -188,7 +189,7 @@ class Loader(bonsai.core.tool.Loader):
                 uv_mode = "Generated"
             elif coordinates.is_a("IfcTextureCoordinateGenerator") and coordinates.Mode == "COORD-EYE":
                 uv_mode = "Camera"
-        surface_texture["uv_mode"] = uv_mode or "UV"
+        surface_texture["uv_mode"] = uv_mode or "Generated"
         return surface_texture
 
     @classmethod
@@ -286,6 +287,9 @@ class Loader(bonsai.core.tool.Loader):
 
         for texture in textures:
             mode = texture.get("Mode", None)
+            # IFC2X3 IfcImageTexture has no Mode attribute; default to DIFFUSE.
+            if mode is None and texture["type"] == "IfcImageTexture":
+                mode = "DIFFUSE"
             node = None
 
             image_url = None
@@ -293,7 +297,8 @@ class Loader(bonsai.core.tool.Loader):
             def get_image() -> Union[bpy.types.Image, None]:
                 # TODO: orphaned textures after shader recreated?
                 if texture["type"] == "IfcImageTexture":
-                    original_image_url = texture["URLReference"]
+                    # IFC2X3 uses UrlReference, IFC4+ uses URLReference.
+                    original_image_url = texture.get("URLReference") or texture.get("UrlReference", "")
                     is_relative = not os.path.isabs(original_image_url)
                     nonlocal image_url
                     image_url = Path(original_image_url)

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -934,7 +934,7 @@ class TestAddReferenceImage(NewFile):
         bpy.ops.bim.save_project(filepath=str(ifc_path), should_save_as=True)
 
         filepath = Path("test/files/image.jpg").absolute()
-        bpy.ops.bim.add_reference_image(filepath=str(filepath))
+        bpy.ops.bim.add_reference_image(filepath=str(filepath), x_length=3.53982, y_length=2.0)
 
         obj = bpy.data.objects["IfcAnnotation/image"]
         assert obj is not None

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -938,7 +938,7 @@ class TestAddReferenceImage(NewFile):
 
         obj = bpy.data.objects["IfcAnnotation/image"]
         assert obj is not None
-        assert tool.Cad.are_vectors_equal(obj.dimensions, Vector((1.0, 0.565, 0.0)))
+        assert tool.Cad.are_vectors_equal(obj.dimensions, Vector((3.53982, 2.0, 0.0)))
 
         material = obj.active_material
         assert material

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -957,4 +957,4 @@ class TestAddReferenceImage(NewFile):
         assert texture_filepath == filepath
 
         uv_node = material_nodes["Texture Coordinate"]
-        assert len(uv_node.outputs["Generated"].links[:]) == 1
+        assert len(uv_node.outputs["UV"].links[:]) == 1


### PR DESCRIPTION
This addresses the weird pattern used in the commit that breaks Blender tests, because return context.window_manager.invoke_props_dialog(self) segfaults on headless test execution of Blender.

