### PR TITLE
Bonsai - change add_grid operator namespace to bim

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/grid.py
+++ b/src/bonsai/bonsai/bim/module/model/grid.py
@@ -82,7 +82,7 @@ def add_object(self: "BIM_OT_add_object", context: bpy.types.Context) -> None:
 
 
 class BIM_OT_add_object(Operator, tool.Ifc.Operator):
-    bl_idname = "mesh.add_grid"
+    bl_idname = "bim.add_grid"
     bl_label = "Grid"
     bl_description = "Add IfcGrid."
     bl_options = {"REGISTER", "UNDO"}

--- a/src/bonsai/bonsai/bim/module/spatial/ui.py
+++ b/src/bonsai/bonsai/bim/module/spatial/ui.py
@@ -251,7 +251,7 @@ class BIM_PT_grids(Panel):
     bl_options = {"HEADER_LAYOUT_EXPAND"}
 
     def draw(self, context):
-        self.layout.row().operator("mesh.add_grid", icon="ADD", text="Add Grids")
+        self.layout.row().operator("bim.add_grid", icon="ADD", text="Add Grids")
 
     def draw_header(self, context):
         props = tool.Spatial.get_grid_props()

--- a/src/bonsai/test/bim/feature/model.feature
+++ b/src/bonsai/test/bim/feature/model.feature
@@ -57,7 +57,7 @@ Scenario: Add one type from the Construction Type Browser
 
 Scenario: Add grid
     Given an empty IFC project
-    When I press "mesh.add_grid"
+    When I press "bim.add_grid"
     Then the object "IfcGrid/Grid" is an "IfcGrid"
     And the object "IfcGridAxis/A" is an "IfcGridAxis"
     And the object "IfcGridAxis/B" is an "IfcGridAxis"

--- a/src/bonsai/test/bim/feature/project.feature
+++ b/src/bonsai/test/bim/feature/project.feature
@@ -914,7 +914,7 @@ Scenario: Export IFC - with moved object location synchronised
 
 Scenario: Export IFC - with moved grid axis location synchronised
     Given an empty IFC project
-    And I press "mesh.add_grid"
+    And I press "bim.add_grid"
     When the object "IfcGridAxis/01" is moved to "1,0,0"
     And I save IFC project
     And I load previously saved IFC project


### PR DESCRIPTION
Change the namespace of the `add_grid` operator from `mesh.add_grid` to `bim.add_grid` to distinguish them from the Blender provided operators and have a  consistent namespace across the Bonsai project.

relates to #7702
