### PR TITLE
Fix #7718: Fix FallDecorator label calculation for all slope annotation types

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -997,7 +997,7 @@ class FallDecorator(BaseDecorator):
         # generate label text
         # same function as in svgwriter.py
         def get_label_text():
-            B, A = [v.co.xyz for v in spline_points[:2]]
+            B, A = [obj.matrix_world @ v.co.xyz for v in spline_points[:2]]
             rise = abs(A.z - B.z)
             O = A.copy()
             O.z = B.z
@@ -1009,13 +1009,14 @@ class FallDecorator(BaseDecorator):
                 angle = 90
 
             # uses SLOPE_ANGLE as default
-            object_type = DecoratorData.data["fall"].get(obj, {}).get("object_type", None)
+            object_type = DecoratorData.data["fall"].get(obj.name, {}).get("object_type", None)
             if object_type in ("FALL", "SLOPE_ANGLE"):
                 return f"{angle}°"
             elif object_type == "SLOPE_FRACTION":
                 if angle == 90:
                     return "-"
-                return f"{self.format_value(context, rise)} / {self.format_value(context, run)}"
+                segment_length = (B - A).length
+                return f"{self.format_value(context, rise)} / {self.format_value(context, segment_length)}"
             elif object_type == "SLOPE_PERCENT":
                 if angle == 90:
                     return "-"

--- a/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
@@ -1446,7 +1446,7 @@ class SvgWriter:
             # generate label text
             # same function as in decoration.py
             def get_label_text():
-                B, A = [v.co.xyz for v in points[:2]]
+                B, A = [matrix_world @ v.co.xyz for v in points[:2]]
                 rise = abs(A.z - B.z)
                 O = A.copy()
                 O.z = B.z


### PR DESCRIPTION
Fix #7718: Fix FallDecorator label calculation for all slope annotation types

- Fix wrong dict key type in decoration.py: DecoratorData.data["fall"] is keyed by obj.name (str) but was looked up with obj (Object), causing object_type to always be None
- Apply obj.matrix_world transform to spline points before computing rise/run in both decoration.py and svgwriter.py; local coordinates have Z=0 for flat annotations, world coordinates correctly reflect elevation change
- Use hypotenuse (segment_length) instead of run as the denominator for SLOPE_FRACTION label display

Generated with the assistance of an AI coding tool.