### PR TITLE
Fixes example in documentation

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/spatial/reference_structure.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/spatial/reference_structure.py
@@ -63,14 +63,15 @@ def reference_structure(
         storey1 = ifcopenshell.api.root.create_entity(model, ifc_class="IfcBuildingStorey")
         storey2 = ifcopenshell.api.root.create_entity(model, ifc_class="IfcBuildingStorey")
         storey3 = ifcopenshell.api.root.create_entity(model, ifc_class="IfcBuildingStorey")
+        space = ifcopenshell.api.root.create_entity(model, ifc_class="IfcSpace")
 
         # The project contains a site (note that project aggregation is a special case in IFC)
         ifcopenshell.api.aggregate.assign_object(model, products=[site], relating_object=project)
 
         # The site has a building, the building has a storey, and the storey has a space
         ifcopenshell.api.aggregate.assign_object(model, products=[building], relating_object=site)
-        ifcopenshell.api.aggregate.assign_object(model, products=[storey], relating_object=building)
-        ifcopenshell.api.aggregate.assign_object(model, products=[space], relating_object=storey)
+        ifcopenshell.api.aggregate.assign_object(model, products=[storey1,storey2,storey3], relating_object=building)
+        ifcopenshell.api.aggregate.assign_object(model, products=[space], relating_object=storey1)
 
         # Create a column, this column spans 3 storeys
         column = ifcopenshell.api.root.create_entity(model, ifc_class="IfcWall")
@@ -80,7 +81,11 @@ def reference_structure(
 
         # And referenced in the others
         ifcopenshell.api.spatial.reference_structure(
-            model, products=[column], relating_structure=[storey2, storey3]
+            model, products=[column], relating_structure=storey2
+        )
+
+        ifcopenshell.api.spatial.reference_structure(
+            model, products=[column], relating_structure=storey3
         )
     """
 


### PR DESCRIPTION
The small example for ifcopenshell.api.spatial.reference_structure doesn't work. I've fixed up the example.

I am wondering if the example is the problem or the function itself.

It seems like it would be convenient to reference multiple objects in multiple spatial structures at the same time.