### PR TITLE
Add newline handling with add_newline_between_words  in SvgWriter for text literals

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
@@ -1026,7 +1026,8 @@ class SvgWriter:
 
         for text_literal in text_literals:
             text = tool.Drawing.replace_text_literal_variables(text_literal.Literal, product or element)
-
+            if newline_at:
+                text = helper.add_newline_between_words(text, newline_at)
             text_segments = parse_markdown_it(text)
 
             if len(text_segments) == 1 and text_segments[0]["url"] is None and not text_segments[0].get("break", False):


### PR DESCRIPTION
This is addressing  https://github.com/IfcOpenShell/IfcOpenShell/issues/7703

Note: Markdown-it still behaving as before (if new lines are within the url text, only the last line is used as token).

Cheers!
