### PR TITLE
Fix #7115: Add toggle for annotation decorator visibility 

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -2082,6 +2082,11 @@ class DecorationsHandler:
         if context.region_data.view_perspective != "CAMERA":
             return
 
+        # Check if annotation decorator is enabled
+        model_props = tool.Model.get_model_props()
+        if not model_props.show_annotation_decorator:
+            return
+
         if not DrawingsData.is_loaded:
             DrawingsData.load()
 

--- a/src/bonsai/bonsai/bim/module/model/prop.py
+++ b/src/bonsai/bonsai/bim/module/model/prop.py
@@ -328,6 +328,11 @@ class BIMModelProperties(PropertyGroup):
         default=True,
         description="Show Cut Decorator Fill",
     )
+    show_annotation_decorator: bpy.props.BoolProperty(
+        name="Show Annotation Decorator",
+        default=True,
+        description="Shows the annotation decorator (dimensions, text, leaders, etc.)",
+    )
 
     if TYPE_CHECKING:
         ifc_class: str
@@ -366,6 +371,7 @@ class BIMModelProperties(PropertyGroup):
         show_bounding_box: bool
         show_cut_decorator: bool
         show_cut_decorator_fill: bool
+        show_annotation_decorator: bool
 
 
 class BIMArrayProperties(PropertyGroup):

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -2059,6 +2059,8 @@ class BIM_PT_decorators_overlay(Panel):
         row = col.row(align=True)
         row.prop(model_props, "show_cut_decorator", text="Cut Decorator")
         row.prop(model_props, "show_cut_decorator_fill", text="Fill Cut Decorator")
+        row = col.row(align=True)
+        row.prop(model_props, "show_annotation_decorator", text="Annotation Decorator")
 
 
 class BIM_PT_snappping(Panel):


### PR DESCRIPTION
- adds `show_annotation_decorator` property to BIMModelProperties
- checks the property in DecorationsHandler before rendering decorations
- adds UI toggle in the Decorators panel

closes #7115 :^)

https://github.com/user-attachments/assets/f7c3efd8-7ca9-4af6-91d4-debe6fa85e60

