### PR TITLE
Fix JSON formatting in launch.json and add "justMyCode":false to allow for breakpoints in Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ venv
 .vscode
 !.vscode/launch.json
 !.vscode/tasks.json
+!.vscode/debugpy_port.py
 .vs
 
 # PyCharm files

--- a/.vscode/debugpy_port.py
+++ b/.vscode/debugpy_port.py
@@ -1,0 +1,36 @@
+import debugpy
+import os
+import sys
+
+
+def _kill_process_on_port(port):
+    my_pid = os.getpid()
+    if sys.platform in ("linux", "darwin"):
+        import subprocess, signal
+
+        if sys.platform == "linux":
+            result = subprocess.run(["fuser", f"{port}/tcp"], capture_output=True, text=True)
+        else:
+            result = subprocess.run(["lsof", "-ti", f"tcp:{port}"], capture_output=True, text=True)
+        for pid in [int(p) for p in result.stdout.split() if p.strip().isdigit()]:
+            if pid != my_pid:
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+    elif sys.platform == "win32":
+        import subprocess
+
+        result = subprocess.run(["netstat", "-ano"], capture_output=True, text=True)
+        for line in result.stdout.splitlines():
+            if f":{port}" in line and "LISTENING" in line:
+                try:
+                    pid = int(line.split()[-1])
+                    if pid != my_pid:
+                        subprocess.run(["taskkill", "/PID", str(pid), "/F"], capture_output=True)
+                except Exception:
+                    pass
+
+
+_kill_process_on_port(5678)
+debugpy.listen(5678)

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,8 @@
                     "localRoot": "${config:bonsai.localRoot}",
                     "remoteRoot": "${config:bonsai.remoteRoot}"
                 }
-            ]
+            ],
+            "justMyCode": false
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,7 +36,7 @@
             "args": [
                 "--background",
                 "--python-expr",
-                "import os, sys, subprocess; path=os.path.abspath(sys.executable); subprocess.call([path, '-m', 'ensurepip']); subprocess.call([path, '-m', 'pip', 'install', '--upgrade', 'debugpy'])"
+                "import os, sys, subprocess; path=os.path.abspath(sys.executable); subprocess.call([path, \"-m\", \"ensurepip\"]); subprocess.call([path, \"-m\", \"pip\", \"install\", \"--upgrade\", \"debugpy\"])"
             ],
             "problemMatcher": []
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,9 +21,9 @@
                 "cwd": "${config:bonsai.blenderPath}"
             },
             "args": [
-                "--python-expr",
-                "import debugpy; debugpy.listen(5678)"
+                "--python", "${workspaceFolder}/.vscode/debugpy_port.py"
             ],
+            "isBackground": true,
             "problemMatcher": []
         },
         {


### PR DESCRIPTION
This allows to follow a simple debuging proccess in Linux with vscode:

One-time setup:
- Run task "Install debugpy in Blender" — installs debugpy into Blender's Python.
- Run task "Configure bonsai/vscode development environment" — generates settings.json with the path mappings between your source tree and the installed addon.


Each debug session:
- Run task "Launch blender with debugpy" — opens Blender with debugpy listening on port 5678.
- Set breakpoints in your source files under bonsai.
- In VS Code, press F5 → select "Python Debugger: Remote Attach" to connect.

Trigger the operator/code path in Blender — VS Code will pause at your breakpoints.
