### PR TITLE
Fix #7774: Fix Select Similar failing on pset names with spaces

### DIFF
--- a/src/bonsai/bonsai/bim/module/search/data.py
+++ b/src/bonsai/bonsai/bim/module/search/data.py
@@ -132,5 +132,12 @@ class SelectSimilarData:
             if pset.endswith("Common"):
                 keys.extend([f'/.*Common/."{name}"' for name in properties.keys() if name != "id"])
             else:
-                keys.extend([f"{pset}.{name}" for name in properties.keys() if name != "id"])
+                pset_part = f'"{pset}"' if " " in pset else pset
+                keys.extend(
+                    [
+                        f'{pset_part}."{name}"' if " " in name else f"{pset_part}.{name}"
+                        for name in properties.keys()
+                        if name != "id"
+                    ]
+                )
         return [(k, k, "") for k in keys]


### PR DESCRIPTION
Pset names containing spaces (e.g. "SOLIDWORKS Custom Properties") were not quoted when building selector keys in SelectSimilarData, causing get_element_value to fail when the operator ran. Now wraps pset names and property names in double quotes if they contain spaces, consistent with the selector syntax used elsewhere.

Generated with the assistance of an AI coding tool.