### PR TITLE
Fix #7230  : Fix cad tool tooltips showing python code snippets

### DIFF
--- a/src/bonsai/bonsai/bim/module/cad/operator.py
+++ b/src/bonsai/bonsai/bim/module/cad/operator.py
@@ -125,6 +125,8 @@ class CadMitre(bpy.types.Operator):
 
 
 class CadFillet(bpy.types.Operator):
+    """Add fillet to the 2 selected edges."""
+
     bl_idname = "bim.cad_fillet"
     bl_label = "CAD Fillet"
     bl_description = "Add fillet to the 2 selected edges."
@@ -214,6 +216,8 @@ class CadFillet(bpy.types.Operator):
 
 
 class CadArcFrom2Points(bpy.types.Operator):
+    """Add an arc to the active mesh based on 2 selected vertices."""
+
     bl_idname = "bim.cad_arc_from_2_points"
     bl_label = "CAD Arc from 2 Points"
     bl_description = "Add an arc to the active mesh based on 2 selected vertices."
@@ -277,6 +281,8 @@ class CadArcFrom2Points(bpy.types.Operator):
 
 
 class CadArcFrom3Points(bpy.types.Operator):
+    """Create a points based arc from 3 selected points."""
+
     bl_idname = "bim.cad_arc_from_3_points"
     bl_label = "CAD Arc from 3 Points"
     bl_options = {"REGISTER", "UNDO"}
@@ -341,6 +347,8 @@ class CadArcFrom3Points(bpy.types.Operator):
 
 
 class CadOffset(bpy.types.Operator):
+    """Copy selected mesh geometry at provided offset."""
+
     bl_idname = "bim.cad_offset"
     bl_label = "CAD Offset"
     bl_description = "Copy selected mesh geometry at provided offset. Mesh copied based on the current viewport angle."
@@ -540,6 +548,8 @@ class CadOffset(bpy.types.Operator):
 
 
 class AddIfcCircle(bpy.types.Operator):
+    """Add IfcCircle to the currently active mesh."""
+
     bl_idname = "bim.add_ifccircle"
     bl_label = "Add IfcCircle"
     bl_description = "Add IfcCircle to the currently active mesh."
@@ -622,6 +632,8 @@ class AddIfcCircle(bpy.types.Operator):
 
 
 class AddIfcArcIndexFillet(bpy.types.Operator):
+    """Add a fillet for the selected vertices."""
+
     bl_idname = "bim.add_ifcarcindex_fillet"
     bl_label = "Add Arc Index Fillet"
     bl_description = "Add a fillet for the selected vertices."
@@ -809,6 +821,8 @@ class AlignViewToProfile(bpy.types.Operator):
 
 
 class AddRectangle(bpy.types.Operator):
+    """Add rectangle shape to the active mesh."""
+
     bl_idname = "bim.add_rectangle"
     bl_label = "Add Rectangle"
     bl_description = "Add rectangle shape to the active mesh."

--- a/src/bonsai/bonsai/bim/module/cad/workspace.py
+++ b/src/bonsai/bonsai/bim/module/cad/workspace.py
@@ -112,17 +112,17 @@ class CadTool(WorkSpaceTool):
                 row, "Join", "S_T", "Joins two non-parallel paths at their intersection", ui_context
             )
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "Fillet", "S_F", bpy.ops.bim.add_ifcarcindex_fillet.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "Fillet", "S_F", "Add a fillet for the selected vertices.", ui_context)
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "Offset", "S_O", bpy.ops.bim.cad_offset.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "Offset", "S_O", "Copy selected mesh geometry at provided offset.", ui_context)
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "Rectangle", "S_R", bpy.ops.bim.add_rectangle.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "Rectangle", "S_R", "Add rectangle shape to the active mesh.", ui_context)
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "Circle", "S_C", bpy.ops.bim.add_ifccircle.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "Circle", "S_C", "Add IfcCircle to the currently active mesh.", ui_context)
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "3-Point Arc", "S_V", bpy.ops.bim.set_arc_index.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "3-Point Arc", "S_V", "Add an IfcArcIndex based 3 point arc for the selected vertices.", ui_context)
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "Reset Vertex", "S_X", bpy.ops.bim.reset_vertex.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "Reset Vertex", "S_X", "Reset selected vertices group assignments (e.g. remove curve/circle).", ui_context)
 
         elif (
             isinstance(data, tool.Geometry.TYPES_WITH_MESH_PROPERTIES)
@@ -138,9 +138,9 @@ class CadTool(WorkSpaceTool):
                 row, "Join", "S_T", "Joins two non-parallel paths at their intersection", ui_context
             )
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "Fillet", "S_F", bpy.ops.bim.cad_fillet.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "Fillet", "S_F", "Add fillet to the 2 selected edges.", ui_context)
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "Offset", "S_O", bpy.ops.bim.cad_offset.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "Offset", "S_O", "Copy selected mesh geometry at provided offset.", ui_context)
 
         else:
             if (
@@ -174,13 +174,13 @@ class CadTool(WorkSpaceTool):
                 row, "Join", "S_T", "Joins two non-parallel paths at their intersection", ui_context
             )
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "Fillet", "S_F", bpy.ops.bim.add_ifcarcindex_fillet.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "Fillet", "S_F", "Add a fillet for the selected vertices.", ui_context)
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "Offset", "S_O", bpy.ops.bim.cad_offset.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "Offset", "S_O", "Copy selected mesh geometry at provided offset.", ui_context)
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "2-Point Arc", "S_C", bpy.ops.bim.cad_arc_from_2_points.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "2-Point Arc", "S_C", "Add an arc to the active mesh based on 2 selected vertices.", ui_context)
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
-            add_layout_hotkey_operator(row, "3-Point Arc", "S_V", bpy.ops.bim.cad_arc_from_3_points.__doc__, ui_context)
+            add_layout_hotkey_operator(row, "3-Point Arc", "S_V", "Create a points based arc from 3 selected points.", ui_context)
 
 
 class CadHotkey(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -756,6 +756,8 @@ class EditExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):
 
 
 class ResetVertex(bpy.types.Operator):
+    """Reset selected vertices group assignments (e.g. remove curve/circle)."""
+
     bl_idname = "bim.reset_vertex"
     bl_label = "Reset Vertex"
     bl_description = "Reset selected vertices group assignments (e.g. remove curve/circle)."
@@ -781,6 +783,8 @@ class ResetVertex(bpy.types.Operator):
 
 
 class SetArcIndex(bpy.types.Operator):
+    """Add an IfcArcIndex based 3 point arc for the selected vertices."""
+
     bl_idname = "bim.set_arc_index"
     bl_label = "Set Arc Index"
     bl_description = (


### PR DESCRIPTION
This PR fixes #7230.
CAD tool buttons (Fillet, Offset, 2-Point Arc, 3-Point Arc, Circle, Rectangle, Reset Vertex) were displaying Python code snippets like "bpy.ops.bim.cad_fillet(radius=0.1)" instead of user-friendly descriptions. 
This change replaces the bpy.ops.*.__doc__ with hardcoded strings, matching the existing code for join and extend.