### PR TITLE
Fix recursion cost item bug

### DIFF
--- a/src/bonsai/bonsai/tool/cost.py
+++ b/src/bonsai/bonsai/tool/cost.py
@@ -987,7 +987,8 @@ class Cost(bonsai.core.tool.Cost):
     def disable_editing_cost_item_parent(cls) -> None:
         props = cls.get_cost_props()
         props.active_cost_item_id = 0
-        props.change_cost_item_parent = False
+        if props.change_cost_item_parent == True:
+            props.change_cost_item_parent = False
 
     @classmethod
     def load_cost_item_quantities(cls, cost_item: Optional[ifcopenshell.entity_instance] = None) -> None:

--- a/src/bonsai/test/tool/test_cost.py
+++ b/src/bonsai/test/tool/test_cost.py
@@ -1,0 +1,49 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import test.bim.bootstrap
+import ifcopenshell.api.cost
+
+import bonsai.core.tool
+import bonsai.tool as tool
+import test.bim.bootstrap
+from test.bim.bootstrap import NewFile
+
+from bonsai.tool.cost import Cost as subject
+
+class TestImplementsTool(NewFile):
+    def test_run(self):
+        assert isinstance(subject(), bonsai.core.tool.Cost)
+
+class TestDisableEditingCostItemParent(NewFile):
+    def test_avoid_recursion_error(newfile, monkeypatch):
+        class DummyProps:
+            def __init__(self):
+                self.change_cost_item_parent = None
+                self.active_cost_item_id = 5
+
+        props = DummyProps()
+        monkeypatch.setattr(
+            "bonsai.tool.Cost.get_cost_props",
+            lambda: props
+        )
+        subject.disable_editing_cost_item_parent()
+        assert props.active_cost_item_id == 0
+        assert props.change_cost_item_parent is not False
+


### PR DESCRIPTION
There is a subtle bug that affect the cost panel.
When you disable a cost item editing, it appears in the console but it doesn't stops blender (so the user doesn't see anything).
It is caused by the update function defined for property change_cost_item_parent because blender activate that also when that variable has the same value of the assignment (for example it is already false and i assign false).
So in order to prevent that, i fixed with an if statement and also added a test for it.