### PR TITLE
Fix #7799: Fix elements hidden when activating plan drawings

### DIFF
--- a/src/bonsai/bonsai/core/geometry.py
+++ b/src/bonsai/bonsai/core/geometry.py
@@ -127,6 +127,7 @@ def switch_representation(
     assert element
     geometry.clear_cache(element)
     geometry.reimport_element_representations(obj, representation, apply_openings=apply_openings)
+    geometry.update_bbox_accumulation(obj)
 
 
 def get_representation_ifc_parameters(geometry: type[tool.Geometry], obj: bpy.types.Object) -> None:

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2530,15 +2530,80 @@ class Drawing(bonsai.core.tool.Drawing):
         y = props.height
 
         camera_inverse_matrix = camera.matrix_world.inverted()
-        return set(
-            [
-                tool.Ifc.get_entity(o)
-                for o in objs
-                if o
-                and cls.is_in_camera_view(o, camera_inverse_matrix, x, y, camera.data.clip_start, camera.data.clip_end)
-                and tool.Ifc.get_entity(o)
-            ]
-        )
+        result = set()
+        for o in objs:
+            if not o:
+                continue
+            element = tool.Ifc.get_entity(o)
+            if not element:
+                continue
+            if cls.is_in_camera_view(o, camera_inverse_matrix, x, y, camera.data.clip_start, camera.data.clip_end, element):
+                result.add(element)
+        return result
+
+    @classmethod
+    def _get_bbox_corners(
+        cls, obj: bpy.types.Object, element: Optional[ifcopenshell.entity_instance] = None
+    ) -> list[Vector]:
+        """Return 8 bbox corners in object-local space for camera frustum testing.
+
+        Unions all available bbox sources so that the result covers the full geometric
+        extent of the element regardless of which representation is currently active:
+        1. IfcBoundingBox from a ``Box`` representation context.
+        2. Accumulated union bbox stored in ``obj["ifc_bbox_min/max"]`` custom properties.
+        3. Current ``obj.bound_box``.
+        """
+        all_corners: list[Vector] = []
+
+        # 1. IfcBoundingBox (typically the floor-plan XY footprint)
+        if element is not None and getattr(element, "Representation", None):
+            unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
+            for rep in element.Representation.Representations:
+                try:
+                    resolved = tool.Geometry.resolve_mapped_representation(rep)
+                except Exception:
+                    continue
+                ctx = resolved.ContextOfItems
+                if getattr(ctx, "ContextIdentifier", None) == "Box":
+                    for item in resolved.Items:
+                        if item.is_a("IfcBoundingBox"):
+                            c = item.Corner.Coordinates
+                            cx = c[0] * unit_scale
+                            cy = c[1] * unit_scale
+                            cz = c[2] * unit_scale
+                            dx = item.XDim * unit_scale
+                            dy = item.YDim * unit_scale
+                            dz = item.ZDim * unit_scale
+                            all_corners.extend([
+                                Vector((cx, cy, cz)),
+                                Vector((cx + dx, cy + dy, cz + dz)),
+                            ])
+
+        # 2. Accumulated bbox custom properties (union of all representations ever loaded)
+        if "ifc_bbox_min" in obj and "ifc_bbox_max" in obj:
+            mn = obj["ifc_bbox_min"]
+            mx = obj["ifc_bbox_max"]
+            all_corners.extend([Vector((mn[0], mn[1], mn[2])), Vector((mx[0], mx[1], mx[2]))])
+
+        # 3. Current Blender bound_box
+        all_corners.extend(Vector(v) for v in obj.bound_box)
+
+        # Return 8 corners of the union bounding box
+        xs = [v.x for v in all_corners]
+        ys = [v.y for v in all_corners]
+        zs = [v.z for v in all_corners]
+        mn_x, mn_y, mn_z = min(xs), min(ys), min(zs)
+        mx_x, mx_y, mx_z = max(xs), max(ys), max(zs)
+        return [
+            Vector((mn_x, mn_y, mn_z)),
+            Vector((mx_x, mn_y, mn_z)),
+            Vector((mn_x, mx_y, mn_z)),
+            Vector((mx_x, mx_y, mn_z)),
+            Vector((mn_x, mn_y, mx_z)),
+            Vector((mx_x, mn_y, mx_z)),
+            Vector((mn_x, mx_y, mx_z)),
+            Vector((mx_x, mx_y, mx_z)),
+        ]
 
     @classmethod
     def is_in_camera_view(
@@ -2549,8 +2614,9 @@ class Drawing(bonsai.core.tool.Drawing):
         y: float,
         clip_start: float,
         clip_end: float,
+        element: Optional[ifcopenshell.entity_instance] = None,
     ) -> bool:
-        local_bbox = [camera_inverse_matrix @ obj.matrix_world @ Vector(v) for v in obj.bound_box]
+        local_bbox = [camera_inverse_matrix @ obj.matrix_world @ v for v in cls._get_bbox_corners(obj, element)]
         local_x = [v.x for v in local_bbox]
         local_y = [v.y for v in local_bbox]
         local_z = [v.z for v in local_bbox]

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2477,7 +2477,10 @@ class Geometry(bonsai.core.tool.Geometry):
         Stores the union of all representation bboxes ever loaded for this object as
         ``obj["ifc_bbox_min"]`` and ``obj["ifc_bbox_max"]`` in object-local space.
         """
-        if not obj.bound_box:
+        try:
+            if not obj.bound_box:
+                return
+        except ReferenceError:
             return
         corners = obj.bound_box
         xs = [v[0] for v in corners]

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2469,3 +2469,27 @@ class Geometry(bonsai.core.tool.Geometry):
         bm.to_mesh(mesh)
         bm.free()
         mesh.update()
+
+    @classmethod
+    def update_bbox_accumulation(cls, obj: bpy.types.Object) -> None:
+        """Expand the accumulated IFC bounding box custom properties to include the current mesh bbox.
+
+        Stores the union of all representation bboxes ever loaded for this object as
+        ``obj["ifc_bbox_min"]`` and ``obj["ifc_bbox_max"]`` in object-local space.
+        """
+        if not obj.bound_box:
+            return
+        corners = obj.bound_box
+        xs = [v[0] for v in corners]
+        ys = [v[1] for v in corners]
+        zs = [v[2] for v in corners]
+        new_min = [min(xs), min(ys), min(zs)]
+        new_max = [max(xs), max(ys), max(zs)]
+        if "ifc_bbox_min" in obj:
+            prev_min = list(obj["ifc_bbox_min"])
+            prev_max = list(obj["ifc_bbox_max"])
+            obj["ifc_bbox_min"] = [min(new_min[i], prev_min[i]) for i in range(3)]
+            obj["ifc_bbox_max"] = [max(new_max[i], prev_max[i]) for i in range(3)]
+        else:
+            obj["ifc_bbox_min"] = new_min
+            obj["ifc_bbox_max"] = new_max


### PR DESCRIPTION
## Problem

When activating a plan view drawing (`bim.activate_drawing`) after previously
activating a reflected ceiling plan (RCP) drawing — or vice versa — certain
elements would be hidden from the scene even though they belong to that storey
level. In the reported case, an `IfcLightFixture` with both `PLAN_VIEW` and
`REFLECTED_PLAN_VIEW` representations was invisible after switching between the
two drawing types.

## Root Cause

`activate_drawing` calls `get_drawing_elements`, which calls
`get_elements_in_camera_view` to determine which objects fall within the
camera's frustum. The frustum test in `is_in_camera_view` used `obj.bound_box`
— the bounding box of the **currently active Blender mesh** — to determine
whether an element intersects the camera.

The problem is that `activate_drawing` switches each element's active
representation to match the target view **after** the camera frustum test. So
when switching from an RCP drawing to a plan view drawing:

1. The element's active mesh is the `REFLECTED_PLAN_VIEW` geometry (ceiling
   level, e.g. local z ≈ +1.2 m above the element origin).
2. The plan view camera looks downward from z = 1.6 m world. The camera frustum
   in camera-local space spans z ∈ [−10, −0.002].
3. The ceiling-level mesh transforms to **positive** z in camera-local space
   (above the camera), falling entirely outside the frustum.
4. `is_in_camera_view` returns `False`, the element is excluded from
   `filtered_elements`, and it is hidden — regardless of the fact that a
   `PLAN_VIEW` representation exists that would be within the frustum.

The same failure occurs in reverse: activating an RCP drawing when the
element's active mesh is the `PLAN_VIEW` geometry (floor level, below the
upward-looking RCP camera).

## Fix

### `tool/drawing.py` — representation-independent bbox

A new helper `_get_bbox_corners(obj, element)` replaces the direct use of
`obj.bound_box` in `is_in_camera_view`. It unions three bbox sources to produce
a spatial envelope that is independent of which representation is currently
active:

1. **`IfcBoundingBox`** — if the element has a `Box` representation context,
   the `IfcBoundingBox` item is read and converted to metres. This provides the
   canonical floor-plan footprint defined in the IFC file, which is always
   present regardless of which Blender mesh is active.

2. **Accumulated custom properties** (`obj["ifc_bbox_min"]` /
   `obj["ifc_bbox_max"]`) — a growing union of every representation bbox that
   has been loaded for this object, populated by `update_bbox_accumulation` (see
   below). After the first round-trip between drawing types, this covers all
   previously seen geometry extents.

3. **`obj.bound_box`** — the existing fallback for objects without IFC metadata
   or on first load.

The union of these three sources ensures the bounding envelope spans both the
floor-level footprint (for plan cameras) and the ceiling-level geometry (for
RCP cameras), so the frustum test returns `True` for both view types regardless
of which mesh is currently active.

`is_in_camera_view` gains an optional `element` parameter passed through from
`get_elements_in_camera_view`, which now iterates objects explicitly rather than
using a list comprehension so the entity lookup is available for both the test
and the result set.

### `tool/geometry.py` — bbox accumulation

New method `update_bbox_accumulation(obj)` unions the current `obj.bound_box`
into `obj["ifc_bbox_min"]` / `obj["ifc_bbox_max"]` Blender custom properties.
The union grows monotonically as representations are loaded, so after any two
representation switches the accumulated bbox covers all seen extents.

### `core/geometry.py` — hook into representation switching

`switch_representation` calls `geometry.update_bbox_accumulation(obj)` after
`reimport_element_representations` completes. This means every time a drawing
activation switches an element's mesh, the new geometry is harvested into the
accumulation automatically.

## Notes

- No changes to IFC reading, writing, or any operator logic outside of the
  three files listed above.
- The `IfcBoundingBox` path only activates when the element has a `Box`
  representation context; elements without one fall through to the accumulated
  props and `obj.bound_box` unchanged.
- On a cold Blender session (no prior representation switches), the
  `IfcBoundingBox` alone is sufficient to fix the plan-view case for elements
  that carry a `Box` context. For elements without a `Box` context, the
  accumulated props will build up after the first switch.

## Testing

Tested with an IFC file containing an `IfcLightFixture` with
`Model/Body/PLAN_VIEW`, `Model/Body/REFLECTED_PLAN_VIEW`, and
`Model/Box/MODEL_VIEW` representations:

- Activating the plan view drawing from a cold session (RCP mesh active):
  fixture is now included and switches to `PLAN_VIEW` representation. ✓
- Activating the RCP drawing after the plan view: fixture is included and
  switches to `REFLECTED_PLAN_VIEW` representation. ✓
- Toggling between the two drawings repeatedly: both continue to work. ✓

---

*Generated with the assistance of an AI coding tool.*
