### PR TITLE
Fix Windows ARM64 Python Bindings Issue

### DIFF
--- a/win/build-all-win.py
+++ b/win/build-all-win.py
@@ -114,7 +114,7 @@ def archive_python_packages() -> None:
     deps_path = REPO_PATH / "_deps"
     python_versions: list[str] = []
     for d in deps_path.iterdir():
-        if d.is_dir() and d.name.startswith("python."):
+        if d.is_dir() and (d.name.startswith("python.") or d.name.startswith("pythonarm64.")):
             python_version = d.name.partition(".")[2]
             python_path = d / "tools"
             archive_python_package(python_version, python_path)


### PR DESCRIPTION
- This PR completes the Windows ARM64 port by ensuring Python bindings are built and packaged, matching the existing x64 behavior. Previously, the ARM64 CI path successfully built native tools (IfcConvert, IfcGeomServer, svgfill) but skipped Python packaging, resulting in missing ifcopenshell-python-* artifacts.

- The root cause was a packaging assumption:
NuGet installs CPython into _deps/python.<version> on x64, but into _deps/pythonarm64.<version> on ARM64. The `archive_python_packages` logic only detected directories starting with python., so ARM64 Python installs were ignored.

- This one-line change extends the directory check to also include pythonarm64.*, allowing ARM64 Python installations to be discovered and archived correctly. As a result, the Python build matrix (3.10–3.14) now produces Python artifacts on Windows ARM64, bringing it to parity with x64.