### PR TITLE
Fix #7784: Fix drawing names with special chars in sheets

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/sheeter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/sheeter.py
@@ -435,7 +435,7 @@ class SheetBuilder:
                 data = reference.get_info()
                 data.update({"Sheet" + k: v for k, v in sheet.get_info().items()})
                 if not data["Name"]:
-                    data["Name"] = ntpath.basename(foreground_path)[0:-4]
+                    data["Name"] = drawing.Name or ntpath.basename(foreground_path)[0:-4]
 
                 # If a perspective drawing, don't add scale to view title
                 try:

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -482,8 +482,10 @@ class Drawing(bonsai.core.tool.Drawing):
         for reference in cls.get_document_references(sheet):
             reference_description = cls.get_reference_description(reference)
             if reference_description == "DRAWING":
-                drawing_references[Path(reference.Location).stem] = reference
-                drawing_names.append(Path(reference.Location).stem)
+                info = cls.get_reference_document(reference)
+                drawing_name = info.Name if info else Path(reference.Location).stem
+                drawing_references[drawing_name] = reference
+                drawing_names.append(drawing_name)
         for drawing_annotation in [e for e in tool.Ifc.get().by_type("IfcAnnotation") if e.ObjectType == "DRAWING"]:
             if drawing_annotation.Name in drawing_names:
                 sheet_builder.add_drawing(drawing_references[drawing_annotation.Name], drawing_annotation, sheet)
@@ -1131,6 +1133,12 @@ class Drawing(bonsai.core.tool.Drawing):
             if not new.is_expanded:
                 continue
 
+            drawing_name_by_location = {
+                cls.get_document_uri(cls.get_drawing_document(d)): d.Name
+                for d in tool.Ifc.get().by_type("IfcAnnotation")
+                if d.ObjectType == "DRAWING" and cls.get_drawing_document(d)
+            }
+
             for reference in cls.get_document_references(sheet):
                 reference_description = cls.get_reference_description(reference)
                 if reference_description in ("SHEET", "LAYOUT", "RASTER"):
@@ -1145,7 +1153,8 @@ class Drawing(bonsai.core.tool.Drawing):
                 else:
                     new.identification = reference.Identification or ""
 
-                new.name = os.path.basename(reference.Location)
+                resolved_location = cls.get_document_uri(reference)
+                new.name = drawing_name_by_location.get(resolved_location) or os.path.basename(reference.Location)
                 new.reference_type = reference_description
 
     @classmethod


### PR DESCRIPTION


Drawing names containing special characters such as `(`, `)`, and `&` were being unintentionally stripped in several places in the sheet and drawing workflow.

The root cause is `Drawing.sanitise_filename`, which intentionally restricts filenames to alphanumeric characters and `._-` for filesystem safety. This is correct behaviour for file paths. However, the sanitised filename stem was leaking back into three places where the full human-readable IFC name should be used instead:

**1. `Drawing.add_drawings` (tool/drawing.py)** When building a sheet layout, drawings were matched to their sheet references by comparing `Path(reference.Location).stem` (the sanitised filename) against `IfcAnnotation.Name`. If the drawing name contained special characters, these two values would differ and the drawing would silently not be added to the sheet. Fixed by keying on `IfcDocumentInformation.Name` via `get_reference_document()` instead of the file stem.

**2. `SheetBuilder.build_drawings` (sheeter.py)** When building the final sheet SVG, the view title data fell back to `ntpath.basename(foreground_path)[0:-4]` (the sanitised filename stem) when `IfcDocumentReference.Name` was empty — which it always is for sheet drawing references, since it is never explicitly set. The `IfcAnnotation` entity is already in scope at this point and carries the full name, so the fallback now uses `drawing.Name` instead.

**3. `Drawing.import_sheets` (tool/drawing.py)** The sheet list UI displayed `os.path.basename(reference.Location)` as the drawing name under each sheet, again using the sanitised filename. Fixed by building a reverse lookup from resolved file location to `IfcAnnotation.Name` across all drawing annotations, so the full name is shown in the UI.

In all three cases the fix is to use the IFC name as the authoritative source, keeping `sanitise_filename` strictly limited to constructing file paths.