### PR TITLE
IsVentilated now defaults to False

### DIFF
--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -717,13 +717,38 @@ class EnableEditingMaterialSetItem(bpy.types.Operator):
         self.props.material_set_item_material = str(material_set_item.Material.id())
 
         self.props.material_set_item_attributes.clear()
-        bonsai.bim.helper.import_attributes(material_set_item, self.props.material_set_item_attributes)
+        bonsai.bim.helper.import_attributes(
+            material_set_item,
+            self.props.material_set_item_attributes,
+            callback=self.import_attributes_callback,
+        )
 
         if material_set_item.is_a("IfcMaterialProfile"):
             if material_set_item.Profile and material_set_item.Profile.ProfileName:
                 self.mprops.profiles = str(material_set_item.Profile.id())
 
         return {"FINISHED"}
+
+    def import_attributes_callback(
+        self, name: str, prop: Union["Attribute", None], data: dict[str, Any]
+    ) -> None | Literal[True]:
+        if data["type"] != "IfcMaterialLayer" or name != "IsVentilated" or not prop:
+            return None
+
+        # Keep null semantics unchanged on export, but avoid an empty UI selection.
+        prop.data_type = "enum"
+        prop.special_type = "LOGICAL"
+        prop.enum_items = json.dumps(("TRUE", "FALSE", "UNKNOWN"))
+
+        value = data[name]
+        if value == "UNKNOWN":
+            prop.enum_value = "UNKNOWN"
+        elif value is None:
+            prop.enum_value = "FALSE"
+        else:
+            prop.enum_value = "TRUE" if value else "FALSE"
+
+        return True
 
 
 class DisableEditingMaterialSetItem(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -744,7 +744,9 @@ class EnableEditingMaterialSetItem(bpy.types.Operator):
         if value == "UNKNOWN":
             prop.enum_value = "UNKNOWN"
         elif value is None:
+            # Keep visible default as FALSE, but preserve null semantics on save.
             prop.enum_value = "FALSE"
+            prop.is_null = True
         else:
             prop.enum_value = "TRUE" if value else "FALSE"
 

--- a/src/bonsai/test/bim/feature/material.feature
+++ b/src/bonsai/test/bim/feature/material.feature
@@ -422,6 +422,24 @@ Scenario: Enable editing material set item
     When I press "bim.enable_editing_material_set_item(material_set_item={material_profile})"
     Then nothing happens
 
+Scenario: Edit layer item defaults null IsVentilated to FALSE in UI
+    Given an empty IFC project
+    And I add a cube
+    And the object "Cube" is selected
+    And I look at the "Class" panel
+    And I set the "Products" property to "IfcElement"
+    And I set the "Class" property to "IfcWall"
+    And I click "Assign IFC Class"
+    And I press "bim.add_material()"
+    And I set "active_object.BIMObjectMaterialProperties.material_type" to "IfcMaterialLayerSet"
+    And I press "bim.assign_material"
+    And I press "bim.enable_editing_assigned_material"
+    And the variable "layer" is "{ifc}.by_type('IfcMaterialLayer')[0].id()"
+    And I press "bim.enable_editing_material_set_item(material_set_item={layer})"
+    When I evaluate expression "attrs = bpy.context.active_object.BIMObjectMaterialProperties.material_set_item_attributes; is_vent = next(a for a in attrs if a.name == 'IsVentilated'); assert is_vent.enum_value == 'FALSE'; assert is_vent.is_null is True"
+    And I press "bim.edit_material_set_item(material_set_item={layer})"
+    Then I evaluate expression "assert {ifc}.by_id({layer}).IsVentilated is None"
+
 Scenario: Add material set layer
     Given an empty IFC project
     And I add a cube


### PR DESCRIPTION
Fixes: #7585

When editing a material layer with `IsVentilated` unset (None), the dropdown now shows FALSE instead of appearing blank. This is a visual default only: null semantics are preserved, so saving without user changes still keeps IsVentilated unset in IFC. 

**Local Testing**:-


https://github.com/user-attachments/assets/00b48876-56ba-4c30-a645-43855dbd249f

