### PR TITLE
Patched the diagram_scale  on unit change

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2689,8 +2689,10 @@ class Drawing(bonsai.core.tool.Drawing):
 
     @classmethod
     def get_scale_ratio(cls, scale: str) -> float:
-        numerator, denominator = scale.split("/")
-        return float(numerator) / float(denominator)
+        try:
+            return float(Fraction(scale))
+        except (ValueError, ZeroDivisionError) as e:
+            raise ValueError(f"Invalid diagram scale format: {scale!r}") from e
 
     @classmethod
     def get_diagram_scale(cls, camera: Union[bpy.types.Object, bpy.types.Camera]) -> dict[str, str]:
@@ -2705,7 +2707,8 @@ class Drawing(bonsai.core.tool.Drawing):
         denominator = tool.Drawing.convert_scale_string(denominator_string)
         if not numerator or not denominator:
             return
-        scale = str(Fraction(numerator / denominator).limit_denominator(1000))  # Any ratio >1000 is stupid.
+        scale_fraction = Fraction(numerator / denominator).limit_denominator(1000)  # Any ratio >1000 is stupid.
+        scale = f"{scale_fraction.numerator}/{scale_fraction.denominator}"
         if "'" in scale or '"' in scale:
             human_separator = "="  # Imperial scales use "=", like 1" = 1' - 0"
             # If for some crazy reason we mix metric and imperial, assume metric is SI units, like 1m = 1'

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -897,6 +897,35 @@ def convert_file_length_units(ifc_file: ifcopenshell.file, target_units: str = "
             return convert_unit(value, old_length, new_length)
         return tuple(convert_value(v) for v in value)
 
+    def convert_diagram_scale(scale: float, length_scale: float) -> float:
+        return scale / length_scale
+
+    def parse_diagram_scale(value: str) -> Union[float, None]:
+        try:
+            return float(Fraction(value))
+        except (TypeError, ValueError, ZeroDivisionError):
+            return None
+
+    def format_diagram_scale(scale: float) -> str:
+        if scale == 0:
+            return "0/1"
+        fraction = Fraction(scale).limit_denominator(10**12)
+        # Preserve tiny non-zero scales instead of collapsing them to 0.
+        if fraction == 0:
+            fraction = Fraction(str(scale))
+        return f"{fraction.numerator}/{fraction.denominator}"
+
+    def format_human_diagram_scale(scale: float) -> str:
+        denominator = 1 / scale
+        denominator_rounded = round(denominator)
+        if abs(denominator - denominator_rounded) < 1e-9:
+            denominator_str = str(denominator_rounded)
+        else:
+            denominator_str = f"{denominator:.8g}"
+        return f"1:{denominator_str}"
+
+    length_scale = convert_value(1)
+
     # Traverse all elements and their nested attributes in the file and convert them
     for element, attr, val in iter_element_and_attributes_per_type(file_patched, "IfcLengthMeasure"):
         # NOTE: There is no risk of editing same entities twice as they're all recreated
@@ -906,6 +935,50 @@ def convert_file_length_units(ifc_file: ifcopenshell.file, target_units: str = "
         else:
             new_value = convert_value(val)
             setattr(element, attr.name(), new_value)
+
+    # TargetScale is unit-sensitive and should stay visually equivalent after model units change.
+    for subcontext in file_patched.by_type("IfcGeometricRepresentationSubContext"):
+        if subcontext.TargetScale:
+            subcontext.TargetScale = convert_diagram_scale(subcontext.TargetScale, length_scale)
+
+    # Bonsai drawings store diagram scale in EPset_Drawing as labels (e.g. "1/100" and "1:100").
+    for pset in file_patched.by_type("IfcPropertySet"):
+        if pset.Name != "EPset_Drawing":
+            continue
+        scale_prop = next(
+            (
+                p
+                for p in pset.HasProperties or []
+                if p.is_a("IfcPropertySingleValue")
+                and p.Name == "Scale"
+                and p.NominalValue
+                and p.NominalValue.is_a("IfcLabel")
+            ),
+            None,
+        )
+        if not scale_prop:
+            continue
+        diagram_scale = parse_diagram_scale(scale_prop.NominalValue.wrappedValue)
+        if diagram_scale is None:
+            continue
+        converted_scale = convert_diagram_scale(diagram_scale, length_scale)
+        scale_prop.NominalValue.wrappedValue = format_diagram_scale(converted_scale)
+
+        if converted_scale == 0:
+            continue
+        human_scale_prop = next(
+            (
+                p
+                for p in pset.HasProperties or []
+                if p.is_a("IfcPropertySingleValue")
+                and p.Name == "HumanScale"
+                and p.NominalValue
+                and p.NominalValue.is_a("IfcLabel")
+            ),
+            None,
+        )
+        if human_scale_prop:
+            human_scale_prop.NominalValue.wrappedValue = format_human_diagram_scale(converted_scale)
 
     has_map_unit = False
     if (

--- a/src/ifcopenshell-python/test/util/test_unit.py
+++ b/src/ifcopenshell-python/test/util/test_unit.py
@@ -386,6 +386,63 @@ class TestConvertFileLengthUnits(test.bootstrap.IFC2X3):
         assert unit_assignment
         assert len(unit_assignment.Units) == 1
 
+    def test_converting_drawing_scales(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        unit = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="LENGTHUNIT", prefix="MILLI")
+        ifcopenshell.api.unit.assign_unit(self.file, units=[unit])
+
+        model_context = ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        ifcopenshell.api.context.add_context(
+            self.file,
+            parent=model_context,
+            context_identifier="Annotation",
+            target_view="PLAN_VIEW",
+            target_scale=0.01,
+        )
+
+        drawing = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcAnnotation")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=drawing, name="EPset_Drawing")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Scale": "1/100", "HumanScale": "1:100"})
+
+        output = subject.convert_file_length_units(self.file, target_units="METER")
+
+        subcontext = output.by_type("IfcGeometricRepresentationSubContext")[0]
+        assert np.isclose(subcontext.TargetScale, 10.0)
+
+        drawing = output.by_type("IfcAnnotation")[0]
+        pset_data = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing")
+        assert pset_data["Scale"] == "10/1"
+        assert pset_data["HumanScale"] == "1:0.1"
+
+    def test_converting_drawing_scales_to_smaller_units(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        unit = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="LENGTHUNIT")
+        ifcopenshell.api.unit.assign_unit(self.file, units=[unit])
+
+        model_context = ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        ifcopenshell.api.context.add_context(
+            self.file,
+            parent=model_context,
+            context_identifier="Annotation",
+            target_view="PLAN_VIEW",
+            target_scale=0.01,
+        )
+
+        drawing = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcAnnotation")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=drawing, name="EPset_Drawing")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Scale": "1/100", "HumanScale": "1:100"})
+
+        output = subject.convert_file_length_units(self.file, target_units="MILLIMETER")
+
+        subcontext = output.by_type("IfcGeometricRepresentationSubContext")[0]
+        assert np.isclose(subcontext.TargetScale, 0.00001)
+
+        drawing = output.by_type("IfcAnnotation")[0]
+        pset_data = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing")
+        assert pset_data["Scale"] == "1/100000"
+        assert pset_data["Scale"] != "0"
+        assert pset_data["HumanScale"] == "1:100000"
+
 
 class TestConvertFileLengthUnitsIFC4(test.bootstrap.IFC4, TestConvertFileLengthUnits):
     pass


### PR DESCRIPTION
Fixes: #7776

 Updated `convert_file_length_units` to also convert drawing-related scales:
Preserved very small non-zero scales (avoid collapsing to 0).
Keept` EPset_Drawing.Scale` in slash-ratio format (n/d, e.g. 10/1) for compatibility
 Added/adjustedtests covering:
       mm -> m drawing scale conversion
       m -> mm small-scale preservation and slash-format output.

Tested it by converting the unit from mm->m;(in Python console)
```
import ifcopenshell
import ifcpatch

file_path = r"C:\Users\PARAG\Desktop\folder1\blender\test_mm.ifc"
file = ifcopenshell.open(file_path)

patched_file = ifcpatch.execute({
    "input": file_path,
    "file": file,
    "recipe": "ConvertLengthUnit",
    "arguments": ["METRE"]
})

output_path = r"C:\Users\PARAG\Desktop\folder1\blender\test_m_v2.ifc"   # new name so we don't overwrite
patched_file.write(output_path)

print("Done. New file:", output_path)
  ```    
 