### PR TITLE
Suppress reportRedeclaration in Pyright config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ extend-exclude = '''
 reportInvalidTypeForm = false
 disableBytesTypePromotions = true
 reportUnnecessaryTypeIgnoreComment = true
+reportRedeclaration = false
 # Pylance doesn't respect gitignore, so we have to exclude files manually here
 # to avoid VS Code slowing down.
 # https://github.com/microsoft/pylance-release/issues/5169


### PR DESCRIPTION
The `if TYPE_CHECKING:` redeclaration pattern used in Bonsai `prop.py` files triggers Pyright/Pylance's `reportRedeclaration` diagnostic. Suppressing it globally in `pyproject.toml` avoids scattering `# type: ignore` comments throughout the code.