### PR TITLE
Fix #7838: Fix slab layer direction and thickness offset

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -1903,16 +1903,18 @@ class CutDecorator:
         # in object local space is on the wrong side of the starting plane, flip no.
         bb = [Vector(v) for v in obj.bound_box]
         mesh_centroid = sum(bb, Vector((0.0, 0.0, 0.0))) / 8
+        layers = list(layer_set.MaterialLayers)
         if (mesh_centroid - co).dot(no) < 0:
             no = -no
-        last_i = len(layer_set.MaterialLayers) - 1
+            layers = list(reversed(layers))
+        last_i = len(layers) - 1
 
         vert_map = {}
         verts = []
         edges = []
         j = 0
 
-        for i, layer in enumerate(layer_set.MaterialLayers):
+        for i, layer in enumerate(layers):
             prev_co = co.copy()
             co += no * layer.LayerThickness * self.unit_scale
             if i != last_i:

--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -1898,6 +1898,13 @@ class CutDecorator:
             no = tool.Drawing.get_extrusion_vector(element).normalized()
             no = Vector([1.0, 0.0, 0.0])
         no *= sense_factor
+        # Detect non-conformant exports (e.g. Revit) where DirectionSense=POSITIVE
+        # but the geometry extrudes in the negative direction. If the mesh centroid
+        # in object local space is on the wrong side of the starting plane, flip no.
+        bb = [Vector(v) for v in obj.bound_box]
+        mesh_centroid = sum(bb, Vector((0.0, 0.0, 0.0))) / 8
+        if (mesh_centroid - co).dot(no) < 0:
+            no = -no
         last_i = len(layer_set.MaterialLayers) - 1
 
         vert_map = {}

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -729,6 +729,13 @@ class CreateDrawing(bpy.types.Operator):
                 no = tool.Drawing.get_extrusion_vector(element).normalized()
                 no = Vector([1.0, 0.0, 0.0])
             no *= sense_factor
+            # Detect non-conformant exports (e.g. Revit) where DirectionSense=POSITIVE
+            # but the geometry extrudes in the negative direction. If the mesh centroid
+            # in object local space is on the wrong side of the starting plane, flip no.
+            bb = [Vector(v) for v in obj.bound_box]
+            mesh_centroid = sum(bb, Vector((0.0, 0.0, 0.0))) / 8
+            if (mesh_centroid - co).dot(no) < 0:
+                no = -no
             last_i = len(layer_set.MaterialLayers) - 1
             for i, layer in enumerate(layer_set.MaterialLayers):
                 prev_co = co.copy()

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -734,10 +734,12 @@ class CreateDrawing(bpy.types.Operator):
             # in object local space is on the wrong side of the starting plane, flip no.
             bb = [Vector(v) for v in obj.bound_box]
             mesh_centroid = sum(bb, Vector((0.0, 0.0, 0.0))) / 8
+            layers = list(layer_set.MaterialLayers)
             if (mesh_centroid - co).dot(no) < 0:
                 no = -no
-            last_i = len(layer_set.MaterialLayers) - 1
-            for i, layer in enumerate(layer_set.MaterialLayers):
+                layers = list(reversed(layers))
+            last_i = len(layers) - 1
+            for i, layer in enumerate(layers):
                 prev_co = co.copy()
                 co += no * layer.LayerThickness * self.unit_scale
 

--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -248,7 +248,8 @@ class DumbSlabPlaner:
 
     def change_thickness(self, element: ifcopenshell.entity_instance, thickness: float) -> None:
         self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
-        if tool.Model.get_usage_type(element) != "LAYER3":
+        usage_type = tool.Model.get_usage_type(element)
+        if usage_type != "LAYER3":
             return
         layer_params = tool.Model.get_material_layer_parameters(element)
         ifc_file = tool.Ifc.get()
@@ -304,11 +305,15 @@ class DumbSlabPlaner:
                 ifc_position = extrusion.Position
                 position = offset_direction * perpendicular_offset
                 material = ifcopenshell.util.element.get_material(element)
-                if material:
-                    if material.is_a("IfcMaterialLayerSetUsage"):
-                        material.OffsetFromReferenceLine = position.z
                 if ifc_position:
-                    ifc_position.Location.Coordinates = position
+                    orig = Vector(ifc_position.Location.Coordinates)
+                    layer_normal = offset_direction.normalized()
+                    perp = orig - orig.dot(layer_normal) * layer_normal
+                    new_coords = perp + layer_normal * perpendicular_offset
+                    ifc_position.Location.Coordinates = new_coords
+                    if material:
+                        if material.is_a("IfcMaterialLayerSetUsage"):
+                            material.OffsetFromReferenceLine = new_coords.z
                 else:
                     tool.Model.add_extrusion_position(extrusion, position)
 

--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -1090,6 +1090,13 @@ class Loader(bonsai.core.tool.Loader):
             no = cls.get_extrusion_vector(element).normalized()
             no = Vector([1.0, 0.0, 0.0])
         no *= sense_factor
+        # Detect non-conformant exports (e.g. Revit) where DirectionSense=POSITIVE
+        # but the geometry extrudes in the negative direction. If the mesh centroid
+        # in object local space is on the wrong side of the starting plane, flip no.
+        if bm.verts:
+            mesh_centroid = sum((v.co for v in bm.verts), Vector((0.0, 0.0, 0.0))) / len(bm.verts)
+            if (mesh_centroid - co).dot(no) < 0:
+                no = -no
         # Cache this
         body = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
         styles = {}

--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -1093,10 +1093,12 @@ class Loader(bonsai.core.tool.Loader):
         # Detect non-conformant exports (e.g. Revit) where DirectionSense=POSITIVE
         # but the geometry extrudes in the negative direction. If the mesh centroid
         # in object local space is on the wrong side of the starting plane, flip no.
+        layers = list(layer_set.MaterialLayers)
         if bm.verts:
             mesh_centroid = sum((v.co for v in bm.verts), Vector((0.0, 0.0, 0.0))) / len(bm.verts)
             if (mesh_centroid - co).dot(no) < 0:
                 no = -no
+                layers = list(reversed(layers))
         # Cache this
         body = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
         styles = {}
@@ -1104,8 +1106,8 @@ class Loader(bonsai.core.tool.Loader):
         for i, material in enumerate(mesh.materials):
             if style := tool.Ifc.get_entity(material):
                 styles[style] = i
-        last_i = len(layer_set.MaterialLayers) - 1
-        for i, layer in enumerate(layer_set.MaterialLayers):
+        last_i = len(layers) - 1
+        for i, layer in enumerate(layers):
             if i != last_i:
                 prev_co = co.copy()
                 co += no * layer.LayerThickness * cls.unit_scale


### PR DESCRIPTION

## PR Description

----------

### Fix slab layer visualization and thickness offset for Revit-exported IFC files

#### Problem

Two related bugs affected slabs imported from Revit-exported IFC files where `IfcExtrudedAreaSolid.Position` encodes a non-trivial XY profile origin and the extrusion direction is `(0, 0, -1)`.

**1. Slab jump on `edit_assigned_material`**

When `bim.edit_assigned_material` was called on a slab, `change_thickness` in `slab.py` computed a new extrusion position as:

```python
position = offset_direction * perpendicular_offset
ifc_position.Location.Coordinates = position

```

For Revit-exported slabs, `IfcExtrudedAreaSolid.Position.Location.Coordinates` encodes both the 2D profile origin in XY (e.g. `(62.845, 46.890, 0.0)`) and the Z layer offset. Overwriting the full coordinate tuple with `position` — which is purely along the layer normal (e.g. `(0.0, 0.0, 0.0)`) — destroyed the XY component, causing the slab to jump to the world origin.

**2. Layer visualization planes missing the mesh**

In `loader.py` (`slice_layerset_mesh`), `decoration.py` (`recalculate_fill`), and `operator.py` (`generate_material_layers`), the layer slicing direction for `AXIS3` was hardcoded to `(0, 0, 1)` after applying `sense_factor`. For conformant IFC files this is correct. However, Revit exports slabs with `DirectionSense=POSITIVE` while the geometry actually extrudes downward (`ExtrudedDirection=(0,0,-1)`), placing the mesh at `z=[-depth, 0]`. The layer planes stepping from `z=0` in `+Z` therefore missed the mesh entirely, resulting in no layer colours or hatching being displayed.

**3. Layer order inverted after direction correction**

Fixing the direction by flipping `no` to `(0,0,-1)` made layers visible, but placed them in the wrong order — the bottom layer appeared at the top and vice versa. This is because the IFC layer list is defined in bottom-to-top order (consistent with `DirectionSense=POSITIVE`), but after flipping `no` to traverse downward, iterating the list in its original order places layer 0 at the top of the mesh rather than the bottom.

#### Root cause analysis

The key insight is that `IfcExtrudedAreaSolid.ExtrudedDirection.DirectionRatios` describes the extrusion direction in the solid's **local** coordinate space, not in the element's local coordinate space. For these Revit slabs, `DirectionRatios=(0,0,-1)` but `DirectionSense=POSITIVE`, which are contradictory: the layer data is ordered as if layers stack upward, but the geometry goes downward. Bonsai was trusting `DirectionSense` alone, so the planes and mesh ended up on opposite sides of the reference surface.

This inconsistency is technically non-conformant with the IFC spec — `DirectionSense=POSITIVE` with `LayerSetDirection=AXIS3` implies layers stack in `+Z` — but it is a consistent and widespread pattern in Revit's IFC exporter that must be accommodated.

#### Fix

**`slab.py` — preserve XY profile origin in `change_thickness`:**

Instead of overwriting `ifc_position.Location.Coordinates` with the full computed position, decompose the original coordinates into components parallel and perpendicular to the layer normal, preserve the perpendicular (XY) component, and only update the parallel (Z) component:

```python
orig = Vector(ifc_position.Location.Coordinates)
layer_normal = offset_direction.normalized()
perp = orig - orig.dot(layer_normal) * layer_normal
new_coords = perp + layer_normal * perpendicular_offset
ifc_position.Location.Coordinates = new_coords

```

The `OffsetFromReferenceLine` update was also corrected to use `new_coords.z` rather than the pre-decomposition `position.z`.

**`loader.py`, `decoration.py`, `operator.py` — detect, correct, and preserve layer order:**

After computing `no *= sense_factor`, check whether the mesh centroid in object local space is on the correct side of the starting plane. If not, flip `no` **and** reverse the layer list so that the layer-to-geometry correspondence is preserved:

```python
layers = list(layer_set.MaterialLayers)
if (mesh_centroid - co).dot(no) < 0:
    no = -no
    layers = list(reversed(layers))

```

Flipping `no` alone corrects the traversal direction but inverts the layer order, since the IFC list is defined bottom-to-top for `POSITIVE`. Reversing the list in lockstep restores the correct correspondence: layer 0 remains at the reference end of the mesh and the last layer at the far end, regardless of which geometric direction `no` points.

#### Files changed

File

Change

`src/bonsai/bonsai/bim/module/model/slab.py`

Preserve XY profile origin when updating extrusion position

`src/bonsai/bonsai/tool/loader.py`

Flip layer normal and reverse layer list when mesh is behind starting plane (3D viewport colours)

`src/bonsai/bonsai/bim/module/drawing/decoration.py`

Same fix for viewport cut decorator layer fill

`src/bonsai/bonsai/bim/module/drawing/operator.py`

Same fix for SVG drawing layer line export

#### Compatibility

Changes are backward-compatible. For conformant IFC files the centroid check evaluates to false, `no` is unchanged, and the layer list is iterated in its original order — behaviour is identical to before. The `slab.py` fix is a strict improvement: decomposing and recombining a vector with a zero perpendicular component is mathematically equivalent to the original code for well-formed files.

Generated with the assistance of an AI coding tool.