### PR TITLE
Fix #6602: Print IfcSpaces in projection.

### DIFF
--- a/src/bonsai/bonsai/bim/data/assets/default.css
+++ b/src/bonsai/bonsai/bim/data/assets/default.css
@@ -78,6 +78,7 @@ text.GRID, tspan.GRID { /* 5mm */ font-size: 8.25px; }
 .material-sand { fill: url(#sand); }
 .material-concrete { fill: url(#concrete); stroke-width: 0.5; }
 .IfcSpace { fill: none; stroke: none; }
+.IfcSpace.projection { fill: white; stroke: black; stroke-linecap: round; stroke-width: 0.25; }
 .PredefinedType-STUD { stroke: black; stroke-width: 1; }
 .PredefinedType-WOOD { fill: url(#wood); stroke: black; stroke-width: 0.5; }
 .PredefinedType-STEEL { fill: url(#steel); stroke: black; stroke-width: 0.5; }

--- a/src/bonsai/bonsai/bim/data/assets/sample.css
+++ b/src/bonsai/bonsai/bim/data/assets/sample.css
@@ -28,3 +28,4 @@
 .break { fill: white; }
 .breakline { fill: none; stroke: black; stroke-linecap: 'round'; stroke-width: 0.25; marker-mid: url(#breakline-marker); }
 .IfcSpace { fill: none; stroke: none; }
+.IfcSpace.projection { fill: white; stroke: black; stroke-linecap: round; stroke-width: 0.25; }

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -653,26 +653,69 @@ class CreateDrawing(bpy.types.Operator):
                 continue
             if not (element := tool.Ifc.get_entity(obj)):
                 continue
-            if not tool.Drawing.is_intersecting_camera(obj, context.scene.camera):
-                continue
-            verts, edges = tool.Drawing.bisect_mesh(obj, context.scene.camera)
+            if tool.Drawing.is_intersecting_camera(obj, context.scene.camera):
+                verts, edges = tool.Drawing.bisect_mesh(obj, context.scene.camera)
 
-            g = etree.SubElement(root, "{http://www.w3.org/2000/svg}g")
-            g.attrib["{http://www.ifcopenshell.org/ns}guid"] = element.GlobalId
-            g.attrib["{http://www.ifcopenshell.org/ns}name"] = element.Name or ""
+                g = etree.SubElement(root, "{http://www.w3.org/2000/svg}g")
+                g.attrib["{http://www.ifcopenshell.org/ns}guid"] = element.GlobalId
+                g.attrib["{http://www.ifcopenshell.org/ns}name"] = element.Name or ""
 
-            lines = []
-            for edge in edges:
-                start = [o for o in (camera_matrix_i @ Vector(verts[edge[0]])).xy]
-                end = [o for o in (camera_matrix_i @ Vector(verts[edge[1]])).xy]
-                coords = [start, end]
-                d = " ".join(
-                    ["L{},{}".format((x_offset + p[0]) * svg_scale, (y_offset - p[1]) * svg_scale) for p in coords]
-                )
-                d = "M{}".format(d[1:])
-                path = etree.SubElement(g, "{http://www.w3.org/2000/svg}path")
-                path.attrib["d"] = d
-            group.append(g)
+                for edge in edges:
+                    start = [o for o in (camera_matrix_i @ Vector(verts[edge[0]])).xy]
+                    end = [o for o in (camera_matrix_i @ Vector(verts[edge[1]])).xy]
+                    coords = [start, end]
+                    d = " ".join(
+                        ["L{},{}".format((x_offset + p[0]) * svg_scale, (y_offset - p[1]) * svg_scale) for p in coords]
+                    )
+                    d = "M{}".format(d[1:])
+                    path = etree.SubElement(g, "{http://www.w3.org/2000/svg}path")
+                    path.attrib["d"] = d
+                group.append(g)
+            elif element.is_a("IfcSpatialElement"):
+                bm = bmesh.new()
+                bm.from_mesh(obj.data)
+                bm.transform(obj.matrix_world)
+                bm.normal_update()
+                camera_direction = context.scene.camera.matrix_world.to_3x3() @ Vector((0, 0, -1))
+                g = etree.SubElement(root, "{http://www.w3.org/2000/svg}g")
+                g.attrib["{http://www.ifcopenshell.org/ns}guid"] = element.GlobalId
+                g.attrib["{http://www.ifcopenshell.org/ns}name"] = element.Name or ""
+                g.set("class", "projection")
+                edge_count = 0
+                for edge in bm.edges:
+                    link_faces = edge.link_faces
+                    if len(link_faces) == 1:
+                        should_draw = True
+                    elif len(link_faces) == 2:
+                        f0_front = link_faces[0].normal.dot(camera_direction) < 0
+                        f1_front = link_faces[1].normal.dot(camera_direction) < 0
+                        if f0_front != f1_front:
+                            should_draw = True  # silhouette edge
+                        elif f0_front and f1_front:
+                            # both front-facing: only draw real creases, skip flat triangulation edges
+                            should_draw = link_faces[0].normal.dot(link_faces[1].normal) < 0.99
+                        else:
+                            should_draw = False  # both back-facing
+                    else:
+                        should_draw = False
+                    if not should_draw:
+                        continue
+                    p0 = camera_matrix_i @ edge.verts[0].co
+                    p1 = camera_matrix_i @ edge.verts[1].co
+                    d = "M{},{} L{},{}".format(
+                        (x_offset + p0[0]) * svg_scale,
+                        (y_offset - p0[1]) * svg_scale,
+                        (x_offset + p1[0]) * svg_scale,
+                        (y_offset - p1[1]) * svg_scale,
+                    )
+                    path = etree.SubElement(g, "{http://www.w3.org/2000/svg}path")
+                    path.attrib["d"] = d
+                    edge_count += 1
+                bm.free()
+                if edge_count:
+                    group.insert(0, g)
+                else:
+                    root.remove(g)
 
     def generate_material_layers(self, context: bpy.types.Context, root) -> None:
         for el in root.findall(".//{http://www.w3.org/2000/svg}g[@{http://www.ifcopenshell.org/ns}guid]"):
@@ -1002,10 +1045,9 @@ class CreateDrawing(bpy.types.Operator):
 
         group = root.find("{http://www.w3.org/2000/svg}g")
         if group is None:
-            with open(svg_path, "wb") as svg:
-                svg.write(etree.tostring(root))
-
-            return svg_path
+            group = etree.Element("{http://www.w3.org/2000/svg}g")
+            group.tail = "\n"
+            root.insert(0, group)
 
         # Add target_view and scale classes to the parent group from IFC data
         if group is not None:
@@ -1256,49 +1298,6 @@ class CreateDrawing(bpy.types.Operator):
             results = dom1.toxml()
             results = results.encode("ascii", "xmlcharrefreplace")
             root = etree.fromstring(results)
-
-        # Spaces are handled as a special case, since they are often overlayed
-        # in addition to elements. For example, a space should not obscure
-        # other elements in projection. Spaces should also not override cut
-        # elements but instead be drawn in addition to cut elements.
-        spaces = tool.Drawing.get_drawing_spaces(self.camera_element)
-
-        group = root.findall(".//{http://www.w3.org/2000/svg}g")[0]
-
-        x_offset = self.svg_writer.raw_width / 2
-        y_offset = self.svg_writer.raw_height / 2
-
-        for space in spaces:
-            obj = tool.Ifc.get_object(space)
-            if not obj or not tool.Drawing.is_intersecting_camera(obj, self.camera):
-                continue
-            verts, edges = tool.Drawing.bisect_mesh(obj, self.camera)
-            verts = [self.svg_writer.project_point_onto_camera(Vector(v)) for v in verts]
-            line_strings = [
-                shapely.LineString(
-                    [
-                        (
-                            (x_offset + verts[e[0]][0]) * self.svg_writer.svg_scale,
-                            (y_offset - verts[e[0]][1]) * self.svg_writer.svg_scale,
-                        ),
-                        (
-                            (x_offset + verts[e[1]][0]) * self.svg_writer.svg_scale,
-                            (y_offset - verts[e[1]][1]) * self.svg_writer.svg_scale,
-                        ),
-                    ]
-                )
-                for e in edges
-            ]
-            closed_polygons = shapely.polygonize(line_strings)
-            for polygon in closed_polygons.geoms:
-                classes = self.get_svg_classes(space)
-                path = etree.Element("path")
-                d = "M" + " L".join([",".join([str(o) for o in co]) for co in polygon.exterior.coords[0:-1]]) + " Z"
-                for interior in polygon.interiors:
-                    d += " M" + " L".join([",".join([str(o) for o in co]) for co in interior.coords[0:-1]]) + " Z"
-                path.attrib["d"] = d
-                path.set("class", " ".join(list(classes)))
-                group.append(path)
 
         with open(svg_path, "wb") as svg:
             svg.write(etree.tostring(root))

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -642,26 +642,69 @@ class CreateDrawing(bpy.types.Operator):
                 continue
             if not (element := tool.Ifc.get_entity(obj)):
                 continue
-            if not tool.Drawing.is_intersecting_camera(obj, context.scene.camera):
-                continue
-            verts, edges = tool.Drawing.bisect_mesh(obj, context.scene.camera)
+            if tool.Drawing.is_intersecting_camera(obj, context.scene.camera):
+                verts, edges = tool.Drawing.bisect_mesh(obj, context.scene.camera)
 
-            g = etree.SubElement(root, "{http://www.w3.org/2000/svg}g")
-            g.attrib["{http://www.ifcopenshell.org/ns}guid"] = element.GlobalId
-            g.attrib["{http://www.ifcopenshell.org/ns}name"] = element.Name or ""
+                g = etree.SubElement(root, "{http://www.w3.org/2000/svg}g")
+                g.attrib["{http://www.ifcopenshell.org/ns}guid"] = element.GlobalId
+                g.attrib["{http://www.ifcopenshell.org/ns}name"] = element.Name or ""
 
-            lines = []
-            for edge in edges:
-                start = [o for o in (camera_matrix_i @ Vector(verts[edge[0]])).xy]
-                end = [o for o in (camera_matrix_i @ Vector(verts[edge[1]])).xy]
-                coords = [start, end]
-                d = " ".join(
-                    ["L{},{}".format((x_offset + p[0]) * svg_scale, (y_offset - p[1]) * svg_scale) for p in coords]
-                )
-                d = "M{}".format(d[1:])
-                path = etree.SubElement(g, "{http://www.w3.org/2000/svg}path")
-                path.attrib["d"] = d
-            group.append(g)
+                for edge in edges:
+                    start = [o for o in (camera_matrix_i @ Vector(verts[edge[0]])).xy]
+                    end = [o for o in (camera_matrix_i @ Vector(verts[edge[1]])).xy]
+                    coords = [start, end]
+                    d = " ".join(
+                        ["L{},{}".format((x_offset + p[0]) * svg_scale, (y_offset - p[1]) * svg_scale) for p in coords]
+                    )
+                    d = "M{}".format(d[1:])
+                    path = etree.SubElement(g, "{http://www.w3.org/2000/svg}path")
+                    path.attrib["d"] = d
+                group.append(g)
+            elif element.is_a("IfcSpatialElement"):
+                bm = bmesh.new()
+                bm.from_mesh(obj.data)
+                bm.transform(obj.matrix_world)
+                bm.normal_update()
+                camera_direction = context.scene.camera.matrix_world.to_3x3() @ Vector((0, 0, -1))
+                g = etree.SubElement(root, "{http://www.w3.org/2000/svg}g")
+                g.attrib["{http://www.ifcopenshell.org/ns}guid"] = element.GlobalId
+                g.attrib["{http://www.ifcopenshell.org/ns}name"] = element.Name or ""
+                g.set("class", "projection")
+                edge_count = 0
+                for edge in bm.edges:
+                    link_faces = edge.link_faces
+                    if len(link_faces) == 1:
+                        should_draw = True
+                    elif len(link_faces) == 2:
+                        f0_front = link_faces[0].normal.dot(camera_direction) < 0
+                        f1_front = link_faces[1].normal.dot(camera_direction) < 0
+                        if f0_front != f1_front:
+                            should_draw = True  # silhouette edge
+                        elif f0_front and f1_front:
+                            # both front-facing: only draw real creases, skip flat triangulation edges
+                            should_draw = link_faces[0].normal.dot(link_faces[1].normal) < 0.99
+                        else:
+                            should_draw = False  # both back-facing
+                    else:
+                        should_draw = False
+                    if not should_draw:
+                        continue
+                    p0 = camera_matrix_i @ edge.verts[0].co
+                    p1 = camera_matrix_i @ edge.verts[1].co
+                    d = "M{},{} L{},{}".format(
+                        (x_offset + p0[0]) * svg_scale,
+                        (y_offset - p0[1]) * svg_scale,
+                        (x_offset + p1[0]) * svg_scale,
+                        (y_offset - p1[1]) * svg_scale,
+                    )
+                    path = etree.SubElement(g, "{http://www.w3.org/2000/svg}path")
+                    path.attrib["d"] = d
+                    edge_count += 1
+                bm.free()
+                if edge_count:
+                    group.insert(0, g)
+                else:
+                    root.remove(g)
 
     def generate_material_layers(self, context: bpy.types.Context, root) -> None:
         for el in root.findall(".//{http://www.w3.org/2000/svg}g[@{http://www.ifcopenshell.org/ns}guid]"):
@@ -969,10 +1012,9 @@ class CreateDrawing(bpy.types.Operator):
 
         group = root.find("{http://www.w3.org/2000/svg}g")
         if group is None:
-            with open(svg_path, "wb") as svg:
-                svg.write(etree.tostring(root))
-
-            return svg_path
+            group = etree.Element("{http://www.w3.org/2000/svg}g")
+            group.tail = "\n"
+            root.insert(0, group)
 
         # Add target_view and scale classes to the parent group from IFC data
         if group is not None:
@@ -1233,49 +1275,6 @@ class CreateDrawing(bpy.types.Operator):
             results = dom1.toxml()
             results = results.encode("ascii", "xmlcharrefreplace")
             root = etree.fromstring(results)
-
-        # Spaces are handled as a special case, since they are often overlayed
-        # in addition to elements. For example, a space should not obscure
-        # other elements in projection. Spaces should also not override cut
-        # elements but instead be drawn in addition to cut elements.
-        spaces = tool.Drawing.get_drawing_spaces(self.camera_element)
-
-        group = root.findall(".//{http://www.w3.org/2000/svg}g")[0]
-
-        x_offset = self.svg_writer.raw_width / 2
-        y_offset = self.svg_writer.raw_height / 2
-
-        for space in spaces:
-            obj = tool.Ifc.get_object(space)
-            if not obj or not tool.Drawing.is_intersecting_camera(obj, self.camera):
-                continue
-            verts, edges = tool.Drawing.bisect_mesh(obj, self.camera)
-            verts = [self.svg_writer.project_point_onto_camera(Vector(v)) for v in verts]
-            line_strings = [
-                shapely.LineString(
-                    [
-                        (
-                            (x_offset + verts[e[0]][0]) * self.svg_writer.svg_scale,
-                            (y_offset - verts[e[0]][1]) * self.svg_writer.svg_scale,
-                        ),
-                        (
-                            (x_offset + verts[e[1]][0]) * self.svg_writer.svg_scale,
-                            (y_offset - verts[e[1]][1]) * self.svg_writer.svg_scale,
-                        ),
-                    ]
-                )
-                for e in edges
-            ]
-            closed_polygons = shapely.polygonize(line_strings)
-            for polygon in closed_polygons.geoms:
-                classes = self.get_svg_classes(space)
-                path = etree.Element("path")
-                d = "M" + " L".join([",".join([str(o) for o in co]) for co in polygon.exterior.coords[0:-1]]) + " Z"
-                for interior in polygon.interiors:
-                    d += " M" + " L".join([",".join([str(o) for o in co]) for co in interior.coords[0:-1]]) + " Z"
-                path.attrib["d"] = d
-                path.set("class", " ".join(list(classes)))
-                group.append(path)
 
         with open(svg_path, "wb") as svg:
             svg.write(etree.tostring(root))

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2342,12 +2342,15 @@ class Drawing(bonsai.core.tool.Drawing):
                 elements = camera_view_elements
             else:
                 # This can probably be smarter
-                elements = set(ifc_file.by_type("IfcElement"))
+                if ifc_file.schema == "IFC2X3":
+                    elements = set(ifc_file.by_type("IfcElement") + ifc_file.by_type("IfcSpatialStructureElement"))
+                else:
+                    elements = set(ifc_file.by_type("IfcElement") + ifc_file.by_type("IfcSpatialElement"))
             if ifc_file.schema == "IFC2X3":
                 base_elements = set(ifc_file.by_type("IfcElement") + ifc_file.by_type("IfcSpatialStructureElement"))
             else:
                 base_elements = set(ifc_file.by_type("IfcElement") + ifc_file.by_type("IfcSpatialElement"))
-            elements = {e for e in (elements & base_elements) if e.is_a() != "IfcSpace"}
+            elements = elements & base_elements
 
         updated_set = set()
         for i in elements:
@@ -2543,7 +2546,7 @@ class Drawing(bonsai.core.tool.Drawing):
         assert drawing and isinstance(camera.data, bpy.types.Camera)
         cls.import_annotations_in_group(cls.get_drawing_group(drawing))
 
-        filtered_elements = cls.get_drawing_elements(drawing) | cls.get_drawing_spaces(drawing)
+        filtered_elements = cls.get_drawing_elements(drawing)
         filtered_elements.add(drawing)
 
         target_view = cls.get_drawing_target_view(drawing)

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2268,7 +2268,10 @@ class Drawing(bonsai.core.tool.Drawing):
             elements = cls.get_elements_in_camera_view(tool.Ifc.get_object(drawing), bpy.data.objects)
         else:
             # This can probably be smarter
-            elements = set(ifc_file.by_type("IfcElement"))
+            if ifc_file.schema == "IFC2X3":
+                elements = set(ifc_file.by_type("IfcElement") + ifc_file.by_type("IfcSpatialStructureElement"))
+            else:
+                elements = set(ifc_file.by_type("IfcElement") + ifc_file.by_type("IfcSpatialElement"))
         pset = ifcopenshell.util.element.get_psets(drawing).get("EPset_Drawing", {})
         include = pset.get("Include", None)
         if include:
@@ -2287,7 +2290,7 @@ class Drawing(bonsai.core.tool.Drawing):
                 base_elements = set(ifc_file.by_type("IfcElement") + ifc_file.by_type("IfcSpatialStructureElement"))
             else:
                 base_elements = set(ifc_file.by_type("IfcElement") + ifc_file.by_type("IfcSpatialElement"))
-            elements = {e for e in (elements & base_elements) if e.is_a() != "IfcSpace"}
+            elements = elements & base_elements
 
         updated_set = set()
         for i in elements:
@@ -2483,7 +2486,7 @@ class Drawing(bonsai.core.tool.Drawing):
         assert drawing and isinstance(camera.data, bpy.types.Camera)
         cls.import_annotations_in_group(cls.get_drawing_group(drawing))
 
-        filtered_elements = cls.get_drawing_elements(drawing) | cls.get_drawing_spaces(drawing)
+        filtered_elements = cls.get_drawing_elements(drawing)
         filtered_elements.add(drawing)
 
         target_view = cls.get_drawing_target_view(drawing)


### PR DESCRIPTION
Fix #6602: Print IfcSpaces in projection.

## Remove special-case space handling in drawings

### Summary

Previously, `IfcSpace` elements were excluded from the standard drawing element pipeline and rendered through a separate ad-hoc loop in `generate_linework()`. This loop only handled spaces that intersected the cut plane (cut view), leaving spaces entirely invisible in projection — a significant limitation for any drawing where a space sits outside the cut range.

This PR removes that special case entirely, integrating `IfcSpace` into the same pipeline as all other elements.

### Changes

-   **`tool/drawing.py`  —  `get_drawing_elements()`**: Removed the explicit  `IfcSpace`  exclusion filter. Also fixed the initial element set (used for linked file processing) to include  `IfcSpatialElement`  alongside  `IfcElement`, so spaces are not inadvertently dropped before the intersection step.
-   **`tool/drawing.py`  —  `activate_drawing()`**: Removed the separate  `get_drawing_spaces()`  call; spaces now come through  `get_drawing_elements()`  like everything else.
-   **`operator.py`  —  `generate_linework()`**: Added a guard to create an empty  `<g>`  element when the OpenCASCADE serializer produces no group (which occurs in BISECT cut mode when the serializer output contains only  `<defs>`). Without this, the function returned early before any space geometry could be added.
-   **`operator.py`  —  `generate_bisect_linework()`**: Extended the visible-object loop to handle  `IfcSpatialElement`  types that do not intersect the cut plane. These are rendered by projecting mesh edges onto the camera plane. Back-face culling (via face normal dot product against the camera direction) is applied so only visible faces contribute edges. A coplanarity threshold (`dot > 0.99`) suppresses triangulation edges within flat faces, producing clean output that matches the HLR edge style of regular projected elements.
-   **`default.css`  /  `sample.css`**: Added  `.IfcSpace.projection`  two-class selector, which has higher CSS specificity than the existing  `.IfcSpace { fill: none; stroke: none; }`  rule and makes projected spaces visible with a standard stroke.

### Why this matters

The old approach treated `IfcSpace` as a special drawing concern, hard-coding the assumption that spaces only matter at the cut plane. In practice, users compose drawings at many scales and section heights — a reflected ceiling plan, a high-level section, or an elevation may need to show spaces that are entirely above or below the cut. Under the old code, those spaces were simply absent from the SVG output with no way for the user to include them.

By routing spaces through the standard element pipeline, users gain the same compositional freedom they have with any other element: spaces respond to `EPset_Drawing` include/exclude filters, appear correctly in all target views, and can be styled through CSS like any other projected element. This aligns `IfcSpace` behaviour with the broader drawing system rather than maintaining a separate code path that had to be manually kept in sync.