### PR TITLE
ifcquery, ifcedit, ifcmcp: add Makefiles and PyPI publish workflows

### DIFF
--- a/.github/workflows/ci-ifcedit-pypi.yaml
+++ b/.github/workflows/ci-ifcedit-pypi.yaml
@@ -1,0 +1,35 @@
+name: ci-ifcedit-pypi
+
+on:
+  workflow_dispatch:
+
+jobs:
+  activate:
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'IfcOpenShell/IfcOpenShell'
+    steps:
+    - name: Set env
+      run: echo ok go
+
+  build:
+    needs: activate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Compile
+        run: |
+          pip install build
+          cd src/ifcedit &&
+          make dist IS_STABLE=TRUE
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: src/ifcedit/dist

--- a/.github/workflows/ci-ifcmcp-pypi.yaml
+++ b/.github/workflows/ci-ifcmcp-pypi.yaml
@@ -1,0 +1,35 @@
+name: ci-ifcmcp-pypi
+
+on:
+  workflow_dispatch:
+
+jobs:
+  activate:
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'IfcOpenShell/IfcOpenShell'
+    steps:
+    - name: Set env
+      run: echo ok go
+
+  build:
+    needs: activate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Compile
+        run: |
+          pip install build
+          cd src/ifcmcp &&
+          make dist IS_STABLE=TRUE
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: src/ifcmcp/dist

--- a/.github/workflows/ci-ifcquery-pypi.yaml
+++ b/.github/workflows/ci-ifcquery-pypi.yaml
@@ -1,0 +1,35 @@
+name: ci-ifcquery-pypi
+
+on:
+  workflow_dispatch:
+
+jobs:
+  activate:
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'IfcOpenShell/IfcOpenShell'
+    steps:
+    - name: Set env
+      run: echo ok go
+
+  build:
+    needs: activate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Compile
+        run: |
+          pip install build
+          cd src/ifcquery &&
+          make dist IS_STABLE=TRUE
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: src/ifcquery/dist

--- a/src/ifcedit/Makefile
+++ b/src/ifcedit/Makefile
@@ -1,0 +1,10 @@
+PACKAGE_NAME:=ifcedit
+include ../common.mk
+
+.PHONY: test
+test:
+	pytest tests
+
+.PHONY: qa
+qa:
+	black .

--- a/src/ifcmcp/Makefile
+++ b/src/ifcmcp/Makefile
@@ -1,0 +1,10 @@
+PACKAGE_NAME:=ifcmcp
+include ../common.mk
+
+.PHONY: test
+test:
+	pytest tests
+
+.PHONY: qa
+qa:
+	black .

--- a/src/ifcquery/Makefile
+++ b/src/ifcquery/Makefile
@@ -1,0 +1,10 @@
+PACKAGE_NAME:=ifcquery
+include ../common.mk
+
+.PHONY: test
+test:
+	pytest tests
+
+.PHONY: qa
+qa:
+	black .


### PR DESCRIPTION
## Summary

- Adds `Makefile` to `src/ifcquery/`, `src/ifcedit/`, and `src/ifcmcp/` — required by `src/common.mk` to build distribution wheels via `make dist`
- Adds `ci-ifcquery-pypi.yaml`, `ci-ifcedit-pypi.yaml`, `ci-ifcmcp-pypi.yaml` GitHub Actions workflows to publish these packages to PyPI on manual trigger

These three packages were recently added to the repo but couldn't be published because the build/publish infrastructure was missing. The workflows follow the same pattern as `ci-ifcpatch-pypi.yaml`, `ci-ifcclash-pypi.yaml`, etc.

## Test plan

- [ ] Verify `make dist IS_STABLE=TRUE` produces a wheel in `dist/` for each package
- [ ] Trigger each workflow manually via `workflow_dispatch` to publish initial versions to PyPI