### PR TITLE
Fix #7840: Auto-create body context when adding drawing

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -670,7 +670,19 @@ class Drawing(bonsai.core.tool.Drawing):
 
     @classmethod
     def get_body_context(cls) -> ifcopenshell.entity_instance:
-        return ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
+        context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
+        if context:
+            return context
+        parent = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model")
+        if not parent:
+            parent = ifcopenshell.api.context.add_context(tool.Ifc.get(), context_type="Model")
+        return ifcopenshell.api.context.add_context(
+            tool.Ifc.get(),
+            context_type="Model",
+            context_identifier="Body",
+            target_view="MODEL_VIEW",
+            parent=parent,
+        )
 
     @classmethod
     def get_document_uri(


### PR DESCRIPTION
Fix #7840: Auto-create body context when adding drawing

If the Model/Body/MODEL_VIEW context does not exist in the IFC file, get_body_context now creates it (and the Model parent if also missing) rather than returning None and crashing with an AssertionError.

Generated with the assistance of an AI coding tool.