### PR TITLE
Refactor: Use ifcopenshell.util.profiler.Profiler in drawing operator

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -26,7 +26,6 @@ import subprocess
 import time
 from math import radians
 from pathlib import Path
-from timeit import default_timer as timer
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -52,6 +51,7 @@ import ifcopenshell.util.representation
 import ifcopenshell.util.selector
 import ifcopenshell.util.shape_builder
 import ifcopenshell.util.unit
+from ifcopenshell.util.profiler import Profiler
 import numpy as np
 import shapely
 from bpy_extras.image_utils import load_image
@@ -85,20 +85,6 @@ if TYPE_CHECKING:
 
 cwd = os.path.dirname(os.path.realpath(__file__))
 
-
-class profile:
-    """
-    A python context manager timing utility
-    """
-
-    def __init__(self, task):
-        self.task = task
-
-    def __enter__(self):
-        self.start = timer()
-
-    def __exit__(self, *args):
-        print(self.task, timer() - self.start)
 
 
 class LineworkContexts(NamedTuple):
@@ -328,8 +314,8 @@ class CreateDrawing(bpy.types.Operator):
             self.camera_document = tool.Drawing.get_drawing_document(self.camera_element)
             self.file = tool.Ifc.get()
 
-            with profile("Drawing generation process"):
-                with profile("Initialize drawing generation process"):
+            with Profiler("Drawing generation process"):
+                with Profiler("Initialize drawing generation process"):
                     self.cprops = tool.Drawing.get_camera_props(self.camera)
                     self.drawing = self.file.by_id(drawing_id)
                     self.drawing_name = self.drawing.Name
@@ -355,7 +341,7 @@ class CreateDrawing(bpy.types.Operator):
                 linework_svg = None
                 annotation_svg = None
 
-                with profile("Generate underlay"):
+                with Profiler("Generate underlay"):
                     if ifcopenshell.util.element.get_pset(self.drawing, "EPset_Drawing", "HasUnderlay"):
                         drawing_style = self.cprops.get_active_drawing_style()
                         if not drawing_style:
@@ -383,7 +369,7 @@ class CreateDrawing(bpy.types.Operator):
 
                         underlay_svg = self.generate_underlay(context)
 
-                with profile("Generate linework"):
+                with Profiler("Generate linework"):
                     if tool.Drawing.is_camera_orthographic():
                         if self.cprops.linework_mode == "OPENCASCADE":
                             linework_svg = self.generate_linework(context)
@@ -392,11 +378,11 @@ class CreateDrawing(bpy.types.Operator):
                     elif self.cprops.linework_mode == "FREESTYLE":
                         linework_svg = self.generate_freestyle_linework(context)
 
-                with profile("Generate annotation"):
+                with Profiler("Generate annotation"):
                     if tool.Drawing.is_camera_orthographic():
                         annotation_svg = self.generate_annotation(context)
 
-                with profile("Combine SVG layers"):
+                with Profiler("Combine SVG layers"):
                     svg_path = self.combine_svgs(context, underlay_svg, linework_svg, annotation_svg)
 
             if self.open_viewer:
@@ -606,7 +592,7 @@ class CreateDrawing(bpy.types.Operator):
         drawing_elements = drawing_elements.copy()
         contexts_: list[list[int]] = getattr(contexts, context_type)
         for context in contexts_:
-            with profile(f"Processing {context_type} context"):
+            with Profiler(f"Processing {context_type} context"):
                 if not context or not drawing_elements:
                     continue
                 geom_settings = ifcopenshell.geom.settings()
@@ -897,7 +883,7 @@ class CreateDrawing(bpy.types.Operator):
 
         # in case of printing multiple drawings we need to sync just once
         if self.sync and self.drawing_index == 0:
-            with profile("sync"):
+            with Profiler("sync"):
                 # All very hackish whilst prototyping
                 exporter = bonsai.bim.export_ifc.IfcExporter(None)
                 exporter.file = tool.Ifc.get()
@@ -953,7 +939,7 @@ class CreateDrawing(bpy.types.Operator):
             self.serialize_contexts_elements(ifc, tree, contexts, "annotation", drawing_elements, target_view)
 
             if tool.Ifc.get() == ifc and self.camera_element not in drawing_elements:
-                with profile("Camera element"):
+                with Profiler("Camera element"):
                     # The camera must always be included, regardless of any include/exclude filters.
                     geom_settings = ifcopenshell.geom.settings()
                     geom_settings.set("iterator-output", ifcopenshell.ifcopenshell_wrapper.NATIVE)
@@ -961,7 +947,7 @@ class CreateDrawing(bpy.types.Operator):
                     for elem in it:
                         self.serialiser.write(elem)
 
-        with profile("Finalizing"):
+        with Profiler("Finalizing"):
             self.serialiser.finalize()
         results = self.svg_buffer.get_value()
 


### PR DESCRIPTION
This PR replaces the local profiler context manager in src/bonsai/bonsai/bim/module/drawing/operator.py with the shared ifcopenshell.util.profiler.Profiler utility, as requested in #7328. Fixes #7328.