### PR TITLE
Fix PermissionError deleting locked HDF5 cache on Windows

### DIFF
--- a/src/bonsai/bonsai/bim/ifc.py
+++ b/src/bonsai/bonsai/bim/ifc.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import gc
 import hashlib
 import os
 import shutil
@@ -170,7 +171,13 @@ class IfcStore:
                     # No point to trying again the same operation.
                     return
 
-                os.remove(IfcStore.cache_path)
+                # Force GC to release any dangling HDF5 C-level file handle (Windows).
+                gc.collect()
+                try:
+                    os.remove(IfcStore.cache_path)
+                except PermissionError as e:
+                    print(f"Could not delete locked cache file '{cache_path.name}': {str(e)}. Skipping cache.")
+                    return
                 try:
                     IfcStore.cache = ifcopenshell.geom.serializers.hdf5(
                         IfcStore.cache_path, cache_settings, serializer_settings

--- a/src/bonsai/bonsai/tool/raycast.py
+++ b/src/bonsai/bonsai/tool/raycast.py
@@ -25,6 +25,7 @@ import bmesh
 import bpy
 import mathutils
 import numpy as np
+from bpy_extras import view3d_utils
 from mathutils import Vector
 
 import bonsai.core.tool


### PR DESCRIPTION
When the hdf5 serializer constructor fails on an existing file, the HDF5 C library retains the file handle on Windows. Force gc.collect() before os.remove() to release it, and catch PermissionError to skip the cache gracefully if the file is still locked.

Generated with the assistance of an AI coding tool.

Was getting the following errors...

```
Python: Traceback (most recent call last):
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\ifc.py", line 527, in execute_ifc_operator
    result = getattr(operator, "_modal")(context, event)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\module\model\product.py", line 236, in _modal
    self.handle_mouse_move(context, event)
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\module\model\polyline.py", line 411, in handle_mouse_move
    detected_snaps = tool.Snap.detect_snapping_points(context, event, self.objs_2d_bbox, self.tool_state)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\tool\snap.py", line 402, in detect_snapping_points
    snap_points = tool.Raycast.ray_cast_by_proximity_2d(context, event, snap_obj)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\tool\raycast.py", line 380, in ray_cast_by_proximity_2d
    verts_2d = [
               ^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\tool\raycast.py", line 381, in <listcomp>
    view3d_utils.location_3d_to_region_2d(region, rv3d, v) for v in snap_obj.verts_3d
    ^^^^^^^^^^^^
NameError: name 'view3d_utils' is not defined

```

```

bpy.ops.bim.draw_occurrence()
Python: Traceback (most recent call last):
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\ifc.py", line 527, in execute_ifc_operator
    result = getattr(operator, "_modal")(context, event)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\module\model\product.py", line 250, in _modal
    self.create_occurrence(context, event)
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\module\model\product.py", line 201, in create_occurrence
    bpy.ops.bim.add_occurrence("INVOKE_DEFAULT")
  File "C:\Program Files\Blender Foundation\Blender 4.5\4.5\scripts\modules\bpy\ops.py", line 107, in __call__
    ret = _op_call(self.idname_py(), kw, C_exec, C_undo)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Error: Python: Traceback (most recent call last):
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\ifc.py", line 158, in get_cache
    IfcStore.cache = ifcopenshell.geom.serializers.hdf5(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\ifcopenshell\ifcopenshell_wrapper.py", line 3384, in __init__
    _ifcopenshell_wrapper.HdfSerializer_swiginit(self, _ifcopenshell_wrapper.new_HdfSerializer(hdf_filename, geometry_settings, settings, read_only))
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: H5Fopen failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\ifc.py", line 523, in execute_ifc_operator
    result = getattr(operator, "_execute")(context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\module\model\product.py", line 358, in _execute
    if obj := profile.DumbProfileGenerator(relating_type).generate():
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\module\model\profile.py", line 85, in generate
    return self.derive_from_cursor()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\module\model\profile.py", line 110, in derive_from_cursor
    return self.create_profile()
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\module\model\profile.py", line 147, in create_profile
    bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\core\geometry.py", line 47, in edit_object_placement
    geometry.clear_cache(element)
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\tool\geometry.py", line 118, in clear_cache
    cache = IfcStore.get_cache()
            ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Ryan Schultz\AppData\Roaming\Blender Foundation\Blender\4.5\extensions\.local\lib\python3.11\site-packages\bonsai\bim\ifc.py", line 173, in get_cache
    os.remove(IfcStore.cache_path)
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\Ryan Schultz\\AppData\\Local\\bonsai\\bonsai\\Cache\\7f428058a8b495ff5aede5f4698b3bb5.h5'
Location: C:\Program Files\Blender Foundation\Blender 4.5\4.5\scripts\modules\bpy\ops.py:107

```