### PR TITLE
Fix IfcSurfaceStyleRendering colour reset on save

### DIFF
--- a/src/bonsai/bonsai/bim/module/style/prop.py
+++ b/src/bonsai/bonsai/bim/module/style/prop.py
@@ -118,6 +118,19 @@ def update_shader_graph(self: Union["Texture", "BIMStylesProperties"], context: 
     tool.Loader.create_surface_style_with_textures(material, shading_data, textures_data)
 
 
+def _make_clear_null_updater(null_prop: str):
+    def _update(self: "BIMStylesProperties", context: bpy.types.Context) -> None:
+        self[null_prop] = False
+        update_shader_graph(self, context)
+
+    return _update
+
+
+update_diffuse_colour = _make_clear_null_updater("is_diffuse_colour_null")
+update_specular_colour = _make_clear_null_updater("is_specular_colour_null")
+update_specular_highlight_value = _make_clear_null_updater("is_specular_highlight_null")
+
+
 UV_MODES = [
     ("UV", "UV", _("Actual UV data presented on the geometry")),
     ("Generated", "Generated", _("Automatically-generated UV from the vertex positions of the mesh")),
@@ -221,24 +234,29 @@ class BIMStylesProperties(PropertyGroup):
     transparency: bpy.props.FloatProperty(
         name="Transparency", default=0.0, min=0.0, max=1.0, update=update_shader_graph
     )
-    # TODO: do something on null?
-    is_diffuse_colour_null: BoolProperty(name="Is Null")
+    is_diffuse_colour_null: BoolProperty(name="Is Null", update=update_shader_graph)
     diffuse_colour_class: EnumProperty(
         items=[(x, x, "") for x in get_args(ColourClass)],
         name="Diffuse Colour Class",
-        update=update_shader_graph,
+        update=update_diffuse_colour,
     )
     diffuse_colour: bpy.props.FloatVectorProperty(
-        name="Diffuse Colour", subtype="COLOR", default=(1, 1, 1), min=0.0, max=1.0, size=3, update=update_shader_graph
+        name="Diffuse Colour",
+        subtype="COLOR",
+        default=(1, 1, 1),
+        min=0.0,
+        max=1.0,
+        size=3,
+        update=update_diffuse_colour,
     )
     diffuse_colour_ratio: bpy.props.FloatProperty(
-        name="Diffuse Ratio", default=0.0, min=0.0, max=1.0, update=update_shader_graph
+        name="Diffuse Ratio", default=0.0, min=0.0, max=1.0, update=update_diffuse_colour
     )
-    is_specular_colour_null: BoolProperty(name="Is Null")
+    is_specular_colour_null: BoolProperty(name="Is Null", update=update_shader_graph)
     specular_colour_class: EnumProperty(
         items=[(x, x, "") for x in get_args(ColourClass)],
         name="Specular Colour Class",
-        update=update_shader_graph,
+        update=update_specular_colour,
         default="IfcNormalisedRatioMeasure",
     )
     specular_colour: bpy.props.FloatVectorProperty(
@@ -248,7 +266,7 @@ class BIMStylesProperties(PropertyGroup):
         min=0.0,
         max=1.0,
         size=3,
-        update=update_shader_graph,
+        update=update_specular_colour,
     )
     specular_colour_ratio: bpy.props.FloatProperty(
         name="Specular Ratio",
@@ -256,16 +274,16 @@ class BIMStylesProperties(PropertyGroup):
         default=0.0,
         min=0.0,
         max=1.0,
-        update=update_shader_graph,
+        update=update_specular_colour,
     )
-    is_specular_highlight_null: BoolProperty(name="Is Null")
+    is_specular_highlight_null: BoolProperty(name="Is Null", update=update_shader_graph)
     specular_highlight: bpy.props.FloatProperty(
         name="Specular Highlight",
         description="Used as Roughness value in PHYSICAL Reflectance Method",
         default=0.0,
         min=0.0,
         max=1.0,
-        update=update_shader_graph,
+        update=update_specular_highlight_value,
     )
     reflectance_method: EnumProperty(
         name="Reflectance Method",

--- a/src/bonsai/bonsai/tool/style.py
+++ b/src/bonsai/bonsai/tool/style.py
@@ -203,6 +203,11 @@ class Style(bonsai.core.tool.Style):
 
         available_props = props.bl_rna.properties.keys()
         for prop_blender, prop_ifc in STYLE_PROPS_MAP.items():
+            null_prop_name = f"is_{prop_blender}_null"
+            if null_prop_name in available_props and getattr(props, null_prop_name):
+                surface_style_data[prop_ifc] = None
+                continue
+
             class_prop_name = f"{prop_blender}_class"
 
             # get detailed color properties if available


### PR DESCRIPTION
## Problem

When an `IfcSurfaceStyleRendering` had `DiffuseColour`, `SpecularColour`, or `SpecularHighlight` set to `null` in the IFC file, loading the style into the Bonsai panel set the corresponding `is_*_null` flag to `True`. Editing the colour picker did not clear the flag. On save, `get_shading_style_data_from_props` read the flag and wrote `None` back, discarding the user's change and resetting the material to its default colour.

1. **`tool/style.py` — `get_shading_style_data_from_props`**: before reading a colour prop, check the corresponding null flag. If it is set, write `None` and skip. This makes live-preview and save agree on null vs. non-null.

2. **`bim/module/style/prop.py`**: a `_make_clear_null_updater` factory produces named callbacks that clear the null flag via dict access (`self[is_..._null] = False`) before delegating to `update_shader_graph`. The three aliases (`update_diffuse_colour`, `update_specular_colour`, `update_specular_highlight_value`) are wired to all colour/ratio/class pickers. The null `BoolProperty` toggles are also wired to `update_shader_graph` so toggling them triggers an immediate preview rebuild.

Cheers!