### PR TITLE
Fix #7885: LAYER3 crash on IfcCompositeProfileDef

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -468,14 +468,16 @@ class ChangeExtrusionXAngle(bpy.types.Operator, tool.Ifc.Operator):
                     existing_x_angle = 0 if tool.Cad.is_x(existing_x_angle, 0, tolerance=0.001) else existing_x_angle
                     existing_x_angle = 0 if tool.Cad.is_x(existing_x_angle, pi, tolerance=0.001) else existing_x_angle
 
-                    coord_list = builder.get_polyline_coords(extrusion.SweptArea.OuterCurve)
-                    coord_list = [
-                        (p[0], p[1] * abs(cos(existing_x_angle))) for p in coord_list
-                    ]  # Reset the transformation and returns to the original points with 0 degrees
-                    coord_list = [
-                        (p[0], p[1] * abs(1 / cos(x_angle))) for p in coord_list
-                    ]  # Apply the transformation for the new x_angle
-                    builder.set_polyline_coords(extrusion.SweptArea.OuterCurve, coord_list)
+                    profiles = extrusion.SweptArea.Profiles if extrusion.SweptArea.is_a("IfcCompositeProfileDef") else [extrusion.SweptArea]
+                    for profile in profiles:
+                        coord_list = builder.get_polyline_coords(profile.OuterCurve)
+                        coord_list = [
+                            (p[0], p[1] * abs(cos(existing_x_angle))) for p in coord_list
+                        ]  # Reset the transformation and returns to the original points with 0 degrees
+                        coord_list = [
+                            (p[0], p[1] * abs(1 / cos(x_angle))) for p in coord_list
+                        ]  # Apply the transformation for the new x_angle
+                        builder.set_polyline_coords(profile.OuterCurve, coord_list)
 
                     # The extrusion direction calculated previously default to the positive direction
                     # Here we set the extrusion direction to negative if that's the case


### PR DESCRIPTION
The x-angle transformation for LAYER3 slabs assumed SweptArea is always IfcArbitraryClosedProfileDef (which has OuterCurve), but composite profiles use IfcCompositeProfileDef instead. Apply the coord scaling to each sub-profile individually.

Generated with the assistance of an AI coding tool.