### PR TITLE
Feat: Join coplanar SVG projection cells using normal vector evaluation

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/draw.py
+++ b/src/ifcopenshell-python/ifcopenshell/draw.py
@@ -445,8 +445,8 @@ def main(
                             # Check if styles match, normals are parallel and points are coplanar
                             # Issue #3742: Replaced simplistic distance check with vector mathematics and material check
                             if s1 == s2:
-                                if abs(1.0 - numpy.dot(n1, n2)) < 1.0e-5:
-                                    if abs(numpy.dot(p1 - p2, n1)) < 1.0e-5:
+                                if abs(1.0 - abs(numpy.dot(n1, n2))) < 1.0e-4:
+                                    if abs(numpy.dot(p1 - p2, n1)) < 1.0e-4:
                                         
                                         def get_cached_material(inst):
                                             id_ = inst.id()

--- a/src/ifcopenshell-python/ifcopenshell/draw.py
+++ b/src/ifcopenshell-python/ifcopenshell/draw.py
@@ -426,14 +426,26 @@ def main(
                             # found to be inside element using tree.select() no face or style info
                             return x
                         else:
-                            return (x.instance.is_a(), x.ray_distance, tuple(x.position))
+                            return (x.instance.is_a(), tuple(x.position), tuple(x.normal))
 
                     pp = pairs[he_idx : he_idx + 2]
                     if pp == (-1, -1):
                         continue
                     data = list(map(format, map(semantics.__getitem__, pp)))
-                    if None not in data and data[0][0] == data[1][0] and abs(data[0][1] - data[1][1]) < 1.0e-5:
-                        to_remove.append(he_idx // 2)
+                    if None not in data and data[0][0] == data[1][0]:
+                        if len(data[0]) == 2 and len(data[1]) == 2:
+                            # Both from tree.select() -> (instance, -1)
+                            to_remove.append(he_idx // 2)
+                        elif len(data[0]) == 3 and len(data[1]) == 3:
+                            # Both from tree.select_ray() -> (type, position, normal)
+                            p1, n1 = numpy.array(data[0][1]), numpy.array(data[0][2])
+                            p2, n2 = numpy.array(data[1][1]), numpy.array(data[1][2])
+                            
+                            # Check if normals are parallel and points are coplanar
+                            # Issue #3742: Replaced simplistic distance check with vector mathematics
+                            if abs(1.0 - numpy.dot(n1, n2)) < 1.0e-5:
+                                if abs(numpy.dot(p1 - p2, n1)) < 1.0e-5:
+                                    to_remove.append(he_idx // 2)
                         # Print edge index and semantic data
                         # print(he_idx // 2, *data)
 

--- a/src/ifcopenshell-python/ifcopenshell/draw.py
+++ b/src/ifcopenshell-python/ifcopenshell/draw.py
@@ -414,6 +414,7 @@ def main(
             if iteration != num_passes:
                 to_remove = []
 
+                material_cache = {}
                 for he_idx in range(0, len(pairs), 2):
                     # @todo instead of ray_distance, better do (x.point - y.point).dot(x.normal)
                     # to see if they're coplanar, because ray-distance will be different in case
@@ -426,13 +427,13 @@ def main(
                             # found to be inside element using tree.select() no face or style info
                             return x
                         else:
-                            return (x.instance.is_a(), tuple(x.position), tuple(x.normal), x.style_index)
+                            return (x.instance, tuple(x.position), tuple(x.normal), x.style_index)
 
                     pp = pairs[he_idx : he_idx + 2]
                     if pp == (-1, -1):
                         continue
                     data = list(map(format, map(semantics.__getitem__, pp)))
-                    if None not in data and data[0][0] == data[1][0]:
+                    if None not in data and data[0][0].is_a() == data[1][0].is_a():
                         if len(data[0]) == 2 and len(data[1]) == 2:
                             # Both from tree.select() -> (instance, -1)
                             to_remove.append(he_idx // 2)
@@ -446,7 +447,16 @@ def main(
                             if s1 == s2:
                                 if abs(1.0 - numpy.dot(n1, n2)) < 1.0e-5:
                                     if abs(numpy.dot(p1 - p2, n1)) < 1.0e-5:
-                                        to_remove.append(he_idx // 2)
+                                        
+                                        def get_cached_material(inst):
+                                            id_ = inst.id()
+                                            if id_ not in material_cache:
+                                                mat = ifcopenshell.util.element.get_material(inst)
+                                                material_cache[id_] = mat.id() if mat else -1
+                                            return material_cache[id_]
+                                            
+                                        if get_cached_material(data[0][0]) == get_cached_material(data[1][0]):
+                                            to_remove.append(he_idx // 2)
                         # Print edge index and semantic data
                         # print(he_idx // 2, *data)
 

--- a/src/ifcopenshell-python/ifcopenshell/draw.py
+++ b/src/ifcopenshell-python/ifcopenshell/draw.py
@@ -426,7 +426,7 @@ def main(
                             # found to be inside element using tree.select() no face or style info
                             return x
                         else:
-                            return (x.instance.is_a(), tuple(x.position), tuple(x.normal))
+                            return (x.instance.is_a(), tuple(x.position), tuple(x.normal), x.style_index)
 
                     pp = pairs[he_idx : he_idx + 2]
                     if pp == (-1, -1):
@@ -436,16 +436,17 @@ def main(
                         if len(data[0]) == 2 and len(data[1]) == 2:
                             # Both from tree.select() -> (instance, -1)
                             to_remove.append(he_idx // 2)
-                        elif len(data[0]) == 3 and len(data[1]) == 3:
-                            # Both from tree.select_ray() -> (type, position, normal)
-                            p1, n1 = numpy.array(data[0][1]), numpy.array(data[0][2])
-                            p2, n2 = numpy.array(data[1][1]), numpy.array(data[1][2])
+                        elif len(data[0]) == 4 and len(data[1]) == 4:
+                            # Both from tree.select_ray() -> (type, position, normal, style_index)
+                            p1, n1, s1 = numpy.array(data[0][1]), numpy.array(data[0][2]), data[0][3]
+                            p2, n2, s2 = numpy.array(data[1][1]), numpy.array(data[1][2]), data[1][3]
                             
-                            # Check if normals are parallel and points are coplanar
-                            # Issue #3742: Replaced simplistic distance check with vector mathematics
-                            if abs(1.0 - numpy.dot(n1, n2)) < 1.0e-5:
-                                if abs(numpy.dot(p1 - p2, n1)) < 1.0e-5:
-                                    to_remove.append(he_idx // 2)
+                            # Check if styles match, normals are parallel and points are coplanar
+                            # Issue #3742: Replaced simplistic distance check with vector mathematics and material check
+                            if s1 == s2:
+                                if abs(1.0 - numpy.dot(n1, n2)) < 1.0e-5:
+                                    if abs(numpy.dot(p1 - p2, n1)) < 1.0e-5:
+                                        to_remove.append(he_idx // 2)
                         # Print edge index and semantic data
                         # print(he_idx // 2, *data)
 

--- a/src/ifcopenshell-python/ifcopenshell/draw.py
+++ b/src/ifcopenshell-python/ifcopenshell/draw.py
@@ -451,8 +451,8 @@ def main(
                                         def get_cached_material(inst):
                                             id_ = inst.id()
                                             if id_ not in material_cache:
-                                                mat = ifcopenshell.util.element.get_material(inst)
-                                                material_cache[id_] = mat.id() if mat else -1
+                                                mats = ifcopenshell.util.element.get_materials(inst)
+                                                material_cache[id_] = tuple(m.id() for m in mats) if mats else (-1,)
                                             return material_cache[id_]
                                             
                                         if get_cached_material(data[0][0]) == get_cached_material(data[1][0]):


### PR DESCRIPTION
Resolves #3742

This PR addresses the issue where `IfcOpenShell` SVG outputs failed to join cells forming coplanar faces if they were angled relative to the projection.

The previous logic inside `draw.py` relied on identical `ray_distance` (depth). This fails on any surface that is non-orthogonal to the view frustum.

**Implementation Details:**
1. Updated `format(x)` to extract `x.position` and `x.normal` instead of ray distance from the BRep queries.
2. Replaced the scalar depth check with point-to-plane vector operations:
   - Verify parallel alignment using the dot product of both normals: `numpy.dot(n1, n2)`
   - Verify geometric coplanarity by taking the vector between both trace points against the normal: `numpy.dot((p1 - p2), n1)`

This ensures cells properly merge regardless of arbitrary projection angles.