### PR TITLE
Fix: DetermFix: Deterministic and layered SVG annotation sort order (Resolves #6608)inistic and layered SVG annotation sort order (Resolves #6…

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
@@ -340,11 +340,21 @@ class SvgWriter:
         self.precision = precision
         self.decimal_places = decimal_places
 
-        # Sort annotations to ensure FILLAREA types are drawn first (at the bottom)
+        # Sort annotations to ensure deterministic layering
+        # 0 = Background fills (drawn first/at bottom)
+        # 1 = Linework and misc shapes
+        # 2 = Text and Dimensions (drawn last/on top)
         def sort_key(element):
             predefined_type = ifcopenshell.util.element.get_predefined_type(element)
-            # Return 0 for FILLAREA to draw them first, 1 for everything else
-            return 0 if predefined_type == "FILL_AREA" else 1
+            
+            if predefined_type == "FILL_AREA":
+                layer = 0
+            elif predefined_type in ("TEXT", "TEXT_LEADER", "DIMENSION", "ANGLE", "RADIUS", "DIAMETER", "ELEVATION", "SECTION_LEVEL", "PLAN_LEVEL"):
+                layer = 2
+            else:
+                layer = 1
+                
+            return (layer, element.GlobalId or "")
 
         annotations = sorted(annotations, key=sort_key)
 


### PR DESCRIPTION
Resolves #6608

This PR addresses the issue where the SVG compiler rendered annotations in a non-deterministic order (often obscuring text beneath underlying `misc` elements) and shuffled element ordering inconsistently between application restarts.

Implementation Details:
Inside `svgwriter.py`, I stabilized the `sort_key` logic for `draw_annotations`:
1. Layer Enforcement: Implemented strict Z-ordering so that `FILL_AREA` reliably draws at the absolute bottom (Layer 0), standard geometry draws in the middle (Layer 1), and explicit text/dimension annotations (`TEXT`, `DIMENSION`, etc.) are heavily favored to render last/on top (Layer 2).
2. Deterministic Sequence Fix: Shifted the return value to a tuple pairing the new graphical layout layer with `element.GlobalId`, definitively preventing the randomized looping problem that altered the drawing order between independent Blender startup instances.
