### PR TITLE
Center IfcOpeningElement bbox on 3D cursor

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -622,14 +622,16 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
                     elif usage.LayerSetDirection == "AXIS3":
                         z_axis = tuple(local_z) if direction_sense == "POSITIVE" else tuple(-local_z)
 
+                    half_mag = 0.25 / unit_scale
                     item = builder.extrude(
                         profile,
                         magnitude=0.5 / unit_scale,
+                        position=tuple(-Vector(z_axis) * half_mag),
                         position_x_axis=tuple(local_x),
                         position_z_axis=z_axis,
                     )
                 else:
-                    item = builder.extrude(curve, magnitude=0.5 / unit_scale)
+                    item = builder.extrude(curve, magnitude=0.5 / unit_scale, position=(0.0, 0.0, -0.25 / unit_scale))
 
             representation = builder.get_representation(ifc_context, [item])
             ifcopenshell.api.geometry.assign_representation(tool.Ifc.get(), element, representation)


### PR DESCRIPTION
When placing an IfcOpeningElement via add_element, the extruded void is now centered on the 3D cursor rather than starting at it, so the cursor sits at the depth midpoint of the opening.

Generated with the assistance of an AI coding tool.