### PR TITLE
* Fix #3742: Remove coplanar boundary lines between adjacent same-mat…

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1668,7 +1668,7 @@ class CreateDrawing(bpy.types.Operator):
             # Quick AABB guard
             corners_a = [obj_a.matrix_world @ Vector(c) for c in obj_a.bound_box]
             corners_b = [obj_b.matrix_world @ Vector(c) for c in obj_b.bound_box]
-            _verbose = {"1eW6OACmXD1hWJLDeB6erW", "2x0$XNlFH6FxlvS7eYJttx"} == {guid_a, guid_b}
+            _verbose = {"3S7QeSPVn3EB3T9TkDUy1e", "0YyL6RtCL8axn6AG9ItFhs"} == {guid_a, guid_b}
             for axis in range(3):
                 min_a = min(c[axis] for c in corners_a)
                 max_a = max(c[axis] for c in corners_a)
@@ -1789,6 +1789,39 @@ class CreateDrawing(bpy.types.Operator):
                     pass
             return None
 
+        def segs_bbox(segs):
+            """Compute AABB (min_x, max_x, min_y, max_y) from a parsed segment list."""
+            if not segs:
+                return None
+            xs = [c for _, (p0, p1) in segs for c in (p0[0], p1[0])]
+            ys = [c for _, (p0, p1) in segs for c in (p0[1], p1[1])]
+            return (min(xs), max(xs), min(ys), max(ys))
+
+        def seg_on_boundary_of(seg, bbox):
+            """True if seg is axis-aligned, lies on a bbox face, and meaningfully overlaps it.
+
+            Used for unilateral matching: when one element's shared edge is not
+            explicitly drawn (it's implicit or on the interior), the other element's
+            segments that lie on that missing edge can still be detected and removed.
+            """
+            (x0, y0), (x1, y1) = seg
+            min_x, max_x, min_y, max_y = bbox
+            is_v = abs(x0 - x1) < TOL
+            is_h = abs(y0 - y1) < TOL
+            if is_v:
+                x_mid = (x0 + x1) / 2
+                if abs(x_mid - min_x) < TOL or abs(x_mid - max_x) < TOL:
+                    y_lo, y_hi = min(y0, y1), max(y0, y1)
+                    overlap = min(y_hi, max_y) - max(y_lo, min_y)
+                    return overlap > TOL
+            if is_h:
+                y_mid = (y0 + y1) / 2
+                if abs(y_mid - min_y) < TOL or abs(y_mid - max_y) < TOL:
+                    x_lo, x_hi = min(x0, x1), max(x0, x1)
+                    overlap = min(x_hi, max_x) - max(x_lo, min_x)
+                    return overlap > TOL
+            return False
+
         def lines_match(a, b):
             """Return True if segments a and b represent the same physical edge.
 
@@ -1883,7 +1916,7 @@ class CreateDrawing(bpy.types.Operator):
                 for j, (grp_j, mat_j, style_j, segs_j, guid_j) in enumerate(group_data):
                     if j <= i:
                         continue
-                    _target = {"1eW6OACmXD1hWJLDeB6erW", "2x0$XNlFH6FxlvS7eYJttx"} == {guid_i, guid_j}
+                    _target = {"0QpDRRuif0R80d4CYPEQ$L", "0YyL6RtCL8axn6AG9ItFhs"} == {guid_i, guid_j}
                     if mat_j != mat_i:
                         if _target:
                             print(f"[TARGET PAIR] SKIPPED: different mat {mat_i!r} vs {mat_j!r}")
@@ -1904,6 +1937,26 @@ class CreateDrawing(bpy.types.Operator):
                                 to_remove.add(id(path_i))
                                 to_remove.add(id(path_j))
                                 matched += 1
+                    # Unilateral fallback: when one element's shared edge is implicit
+                    # (not explicitly drawn as a path segment), segments from the other
+                    # element that lie on the boundary of that element's SVG bbox are
+                    # still on the shared face and should be removed.
+                    if matched == 0 and segs_i and segs_j:
+                        bbox_i = segs_bbox(segs_i)
+                        bbox_j = segs_bbox(segs_j)
+                        if bbox_i and bbox_j:
+                            for path_j, line_j in segs_j:
+                                if seg_on_boundary_of(line_j, bbox_i):
+                                    if _target:
+                                        print(f"[TARGET PAIR] UNILATERAL j-on-i: {line_j}")
+                                    to_remove.add(id(path_j))
+                                    matched += 1
+                            for path_i, line_i in segs_i:
+                                if seg_on_boundary_of(line_i, bbox_j):
+                                    if _target:
+                                        print(f"[TARGET PAIR] UNILATERAL i-on-j: {line_i}")
+                                    to_remove.add(id(path_i))
+                                    matched += 1
                     if _target:
                         print(f"[TARGET PAIR] adj=True, matched={matched} segment pair(s)")
                         if matched == 0:

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1747,7 +1747,7 @@ class CreateDrawing(bpy.types.Operator):
                 adjacency_cache[key] = True
                 return True
             dot = abs(n_a.dot(n_b))
-            if dot <= 1.0 - 1e-3:
+            if dot <= 1.0 - 3.8e-5:
                 adjacency_cache[key] = False
                 return False
             # Normals are parallel — also verify the elements share a face plane.

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1655,8 +1655,6 @@ class CreateDrawing(bpy.types.Operator):
 
         adjacency_cache = {}
 
-        _watch_adj = frozenset({"39Iwvbn41B7OZ72qQGJq6v", "08yv0FO$j2AwVYFWEkXEuh"})
-
         def are_coplanar_and_adjacent(guid_a, guid_b, tol=0.01):
             """True if the two meshes share a vertex AND have parallel face normals.
 
@@ -1665,14 +1663,11 @@ class CreateDrawing(bpy.types.Operator):
             shared face is coplanar — elements meeting at a fold angle are rejected.
             """
             key = (min(guid_a, guid_b), max(guid_a, guid_b))
-            _dbg = frozenset({guid_a, guid_b}) == _watch_adj
             if key in adjacency_cache:
                 return adjacency_cache[key]
             obj_a = get_obj(guid_a)
             obj_b = get_obj(guid_b)
             if obj_a is None or obj_b is None or obj_a.type != "MESH" or obj_b.type != "MESH":
-                if _dbg:
-                    print(f"[WATCH] {guid_a} vs {guid_b}: no mesh obj -> True")
                 adjacency_cache[key] = True
                 return True
             # Quick AABB guard
@@ -1684,13 +1679,9 @@ class CreateDrawing(bpy.types.Operator):
                 min_b = min(c[axis] for c in corners_b)
                 max_b = max(c[axis] for c in corners_b)
                 if min_a > max_b + tol:
-                    if _dbg:
-                        print(f"[WATCH] {guid_a} vs {guid_b}: AABB separated on axis {axis} -> False")
                     adjacency_cache[key] = False
                     return False
                 if min_b > max_a + tol:
-                    if _dbg:
-                        print(f"[WATCH] {guid_a} vs {guid_b}: AABB separated on axis {axis} -> False")
                     adjacency_cache[key] = False
                     return False
             # Proximity check: vertex-to-vertex OR vertex-to-edge.
@@ -1724,8 +1715,6 @@ class CreateDrawing(bpy.types.Operator):
             if not has_shared:
                 # Slower vertex-on-edge check for containment cases
                 has_shared = vertex_near_edges(verts_b, obj_a, tol_sq) or vertex_near_edges(verts_a, obj_b, tol_sq)
-            if _dbg:
-                print(f"[WATCH] {guid_a} vs {guid_b}: has_shared={has_shared}")
             if not has_shared:
                 adjacency_cache[key] = False
                 return False
@@ -1740,10 +1729,7 @@ class CreateDrawing(bpy.types.Operator):
                         return False
                 return True
 
-            contained = aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a)
-            if _dbg:
-                print(f"[WATCH] {guid_a} vs {guid_b}: aabb_contained={contained}")
-            if contained:
+            if aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a):
                 adjacency_cache[key] = True
                 return True
             # Coplanarity check: use the largest-face normal for each object.
@@ -1758,17 +1744,10 @@ class CreateDrawing(bpy.types.Operator):
             n_a = dominant_world_normal(obj_a)
             n_b = dominant_world_normal(obj_b)
             if n_a is None or n_b is None:
-                if _dbg:
-                    print(f"[WATCH] {guid_a} vs {guid_b}: no dominant normal -> True")
                 adjacency_cache[key] = True
                 return True
             dot = abs(n_a.dot(n_b))
-            if _dbg:
-                import math
-                print(f"[WATCH] {guid_a} vs {guid_b}: n_a={tuple(round(x,4) for x in n_a)} n_b={tuple(round(x,4) for x in n_b)} dot={dot:.6f} angle={math.degrees(math.acos(min(dot,1.0))):.3f}°")
-            if dot <= 1.0 - 3.8e-5:
-                if _dbg:
-                    print(f"[WATCH] {guid_a} vs {guid_b}: not coplanar (dot too low) -> False")
+            if dot <= 1.0 - 3.8e-5:  # ~0.5° tolerance
                 adjacency_cache[key] = False
                 return False
             # Normals are parallel — also verify the elements share a face plane.
@@ -1782,8 +1761,6 @@ class CreateDrawing(bpy.types.Operator):
             range_b = (min(projs_b), max(projs_b))
             overlap = min(range_a[1], range_b[1]) - max(range_a[0], range_b[0])
             same_plane = overlap > tol
-            if _dbg:
-                print(f"[WATCH] {guid_a} vs {guid_b}: range_a={range_a} range_b={range_b} overlap={overlap:.5f} same_plane={same_plane}")
             adjacency_cache[key] = same_plane
             return same_plane
 
@@ -2003,6 +1980,7 @@ class CreateDrawing(bpy.types.Operator):
 
                 Compatible means the visible cross-section at the shared face is
                 the same material.  Checks in order:
+
                   - Exact match (identical layer sequences).
                   - Reversed match (same assembly in opposite orientation).
                   - Suffix match: one sequence ends with all layers of the other.
@@ -2010,9 +1988,11 @@ class CreateDrawing(bpy.types.Operator):
                   - Camera-face match: when the camera-facing layer ID is known for
                     both elements (AXIS3 slabs/roofs), only those layers are compared
                     so that a plan view and an RCP of the same elements can produce
-                    different join decisions.
-                  - Boundary match fallback: any end layer of a matches any end layer
-                    of b (used when camera-face direction cannot be determined).
+                    different join decisions. This is the final check for AXIS3 elements.
+
+                For AXIS1/AXIS2 walls the full cross-section is always visible in plan,
+                so only exact/reversed/prefix/suffix matches are accepted — sharing only
+                an interior or exterior layer is not sufficient.
                 """
                 if a == b or a == b[::-1]:
                     return True
@@ -2020,13 +2000,11 @@ class CreateDrawing(bpy.types.Operator):
                 n = len(short)
                 if long_[-n:] == short or long_[:n] == short:
                     return True
-                # Camera-directional boundary check for AXIS3 elements
+                # Camera-directional boundary check for AXIS3 elements (slabs/roofs).
+                # Only reached when exact/prefix/suffix checks failed.
                 if face_a is not None and face_b is not None:
                     return face_a == face_b
-                # Generic boundary check: any end layer matches any end layer
-                a_ends = {a[0], a[-1]} if a else set()
-                b_ends = {b[0], b[-1]} if b else set()
-                return bool(a_ends & b_ends)
+                return False
 
             def get_style_key(guid):
                 """IDs of IfcPresentationStyles directly on the element's geometry items."""

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1776,29 +1776,45 @@ class CreateDrawing(bpy.types.Operator):
             ys = [c for _, (p0, p1) in segs for c in (p0[1], p1[1])]
             return (min(xs), max(xs), min(ys), max(ys))
 
-        def seg_on_boundary_of(seg, bbox):
-            """True if seg is axis-aligned, lies on a bbox face, and meaningfully overlaps it.
+        def seg_on_boundary_of(seg, bbox_self, bbox_other):
+            """True if seg (from 'other' element) lies on the shared interface with 'self'.
 
-            Used for unilateral matching: when one element's shared edge is not
-            explicitly drawn (it's implicit or on the interior), the other element's
-            segments that lie on that missing edge can still be detected and removed.
+            A segment from 'other' is on the shared interface when it lies on 'other's
+            OWN bbox edge AND 'self' extends past that edge on the adjacent side.
+
+            This handles both simple abutment (elements side-by-side, bbox edges touching)
+            and notch/wrap cases (one L-shaped element wraps around a smaller one, so the
+            shared face is interior to the larger element's bbox).
+
+            External edges shared by both elements (e.g. both having the same min_y) are
+            correctly rejected: 'self' would have to extend PAST the edge, not merely
+            reach the same boundary.
             """
             (x0, y0), (x1, y1) = seg
-            min_x, max_x, min_y, max_y = bbox
+            min_xs, max_xs, min_ys, max_ys = bbox_self
+            min_xo, max_xo, min_yo, max_yo = bbox_other
             is_v = abs(x0 - x1) < TOL
             is_h = abs(y0 - y1) < TOL
             if is_v:
                 x_mid = (x0 + x1) / 2
-                if abs(x_mid - min_x) < TOL or abs(x_mid - max_x) < TOL:
+                # Seg on other's RIGHT edge; self must extend further right
+                if abs(x_mid - max_xo) < TOL and max_xs > max_xo + TOL and min_xs < max_xo + TOL:
                     y_lo, y_hi = min(y0, y1), max(y0, y1)
-                    overlap = min(y_hi, max_y) - max(y_lo, min_y)
-                    return overlap > TOL
+                    return min(y_hi, max_ys) - max(y_lo, min_ys) > TOL
+                # Seg on other's LEFT edge; self must extend further left
+                if abs(x_mid - min_xo) < TOL and min_xs < min_xo - TOL and max_xs > min_xo - TOL:
+                    y_lo, y_hi = min(y0, y1), max(y0, y1)
+                    return min(y_hi, max_ys) - max(y_lo, min_ys) > TOL
             if is_h:
                 y_mid = (y0 + y1) / 2
-                if abs(y_mid - min_y) < TOL or abs(y_mid - max_y) < TOL:
+                # Seg on other's BOTTOM edge; self must extend further down
+                if abs(y_mid - max_yo) < TOL and max_ys > max_yo + TOL and min_ys < max_yo + TOL:
                     x_lo, x_hi = min(x0, x1), max(x0, x1)
-                    overlap = min(x_hi, max_x) - max(x_lo, min_x)
-                    return overlap > TOL
+                    return min(x_hi, max_xs) - max(x_lo, min_xs) > TOL
+                # Seg on other's TOP edge; self must extend further up
+                if abs(y_mid - min_yo) < TOL and min_ys < min_yo - TOL and max_ys > min_yo - TOL:
+                    x_lo, x_hi = min(x0, x1), max(x0, x1)
+                    return min(x_hi, max_xs) - max(x_lo, min_xs) > TOL
             return False
 
         def lines_match(a, b):
@@ -1960,11 +1976,11 @@ class CreateDrawing(bpy.types.Operator):
                         bbox_j = segs_bbox(segs_j)
                         if bbox_i and bbox_j:
                             for path_j, line_j in segs_j:
-                                if seg_on_boundary_of(line_j, bbox_i):
+                                if seg_on_boundary_of(line_j, bbox_i, bbox_j):
                                     to_remove.add(id(path_j))
                                     matched += 1
                             for path_i, line_i in segs_i:
-                                if seg_on_boundary_of(line_i, bbox_j):
+                                if seg_on_boundary_of(line_i, bbox_j, bbox_i):
                                     to_remove.add(id(path_i))
                                     matched += 1
 

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1729,7 +1729,8 @@ class CreateDrawing(bpy.types.Operator):
                         return False
                 return True
 
-            if aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a):
+            contained = aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a)
+            if contained:
                 adjacency_cache[key] = True
                 return True
             # Coplanarity check: use the largest-face normal for each object.
@@ -1750,13 +1751,15 @@ class CreateDrawing(bpy.types.Operator):
             if dot <= 1.0 - 3.8e-5:  # ~0.5° tolerance
                 adjacency_cache[key] = False
                 return False
-            # Normals are parallel — also verify the elements share a face plane.
-            # Project all vertices onto n_a to get the 1-D depth range of each
-            # element along the normal axis. Side-by-side elements span the same
-            # depth range (overlap > tol). Elements stacked end-to-end only touch
-            # at a single interface point (overlap ≈ 0) and must not be joined.
-            projs_a = [v.dot(n_a) for v in verts_a]
-            projs_b = [v.dot(n_a) for v in verts_b]
+            # Check whether both elements are at the same depth relative to the
+            # camera. Project vertices onto the camera look direction: elements
+            # at the same camera depth have overlapping ranges; depth-stacked
+            # elements (one in front of the other) have separated ranges.
+            # Using the camera direction rather than n_a is critical — n_a may
+            # be perpendicular to the camera (e.g. X-normal boxes in plan view)
+            # which would produce zero overlap for legitimate side-by-side pairs.
+            projs_a = [v.dot(_cam_look) for v in verts_a]
+            projs_b = [v.dot(_cam_look) for v in verts_b]
             range_a = (min(projs_a), max(projs_a))
             range_b = (min(projs_b), max(projs_b))
             overlap = min(range_a[1], range_b[1]) - max(range_a[0], range_b[0])

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1005,12 +1005,14 @@ class CreateDrawing(bpy.types.Operator):
             if self.cprops.generate_material_layers:
                 self.generate_material_layers(context, root)
             self.merge_linework_and_add_metadata(root)
+            self.remove_coplanar_boundary_lines(root)
             self.move_elements_to_top(root)
         elif self.cprops.cut_mode == "OPENCASCADE":
             self.move_projection_to_bottom(root)
             if self.cprops.generate_material_layers:
                 self.generate_material_layers(context, root)
             self.merge_linework_and_add_metadata(root)
+            self.remove_coplanar_boundary_lines(root)
             self.move_elements_to_top(root)
 
         if self.cprops.fill_mode == "SHAPELY":
@@ -1088,6 +1090,7 @@ class CreateDrawing(bpy.types.Operator):
         if self.cprops.fill_mode == "SVGFILL":
             results = etree.tostring(root).decode("utf8")
             svg_data_1 = results
+            from collections import defaultdict
             from xml.dom.minidom import parseString
 
             def yield_groups(n):
@@ -1102,8 +1105,19 @@ class CreateDrawing(bpy.types.Operator):
 
             ls_groups = ifcopenshell.ifcopenshell_wrapper.svg_to_line_segments(results, "projection")
 
-            for i, (ls, g1) in enumerate(zip(ls_groups, groups1)):
-                projection, g1 = g1, g1.parentNode
+            # Group projection elements by their parent section-view group so that all
+            # projection linework from the same view is merged in one cell decomposition.
+            # This enables coplanar surfaces from *different* elements to be joined.
+            groups_by_parent = defaultdict(list)
+            ls_by_parent = defaultdict(list)
+            for ls, g in zip(ls_groups, groups1):
+                pid = id(g.parentNode)
+                groups_by_parent[pid].append(g)
+                ls_by_parent[pid].extend(ls)
+
+            for pid, projection_groups in groups_by_parent.items():
+                section_parent = projection_groups[0].parentNode
+                combined_ls = ls_by_parent[pid]
 
                 svgfill_context = ifcopenshell.ifcopenshell_wrapper.context(
                     ifcopenshell.ifcopenshell_wrapper.EXACT_CONSTRUCTIONS, 1.0e-3
@@ -1111,10 +1125,11 @@ class CreateDrawing(bpy.types.Operator):
 
                 # EXACT_CONSTRUCTIONS is significantly faster than FILTERED_CARTESIAN_QUOTIENT
                 # remove duplicates (without tolerance)
-                ls = [l for l in map(tuple, set(map(frozenset, ls))) if len(l) == 2 and l[0] != l[1]]
-                svgfill_context.add(ls)
+                combined_ls = [l for l in map(tuple, set(map(frozenset, combined_ls))) if len(l) == 2 and l[0] != l[1]]
+                svgfill_context.add(combined_ls)
 
-                num_passes = 0
+                num_passes = 1
+                g2 = None
 
                 for iteration in range(num_passes + 1):
                     # initialize empty group, note that in the current approach only one
@@ -1189,11 +1204,8 @@ class CreateDrawing(bpy.types.Operator):
                     if iteration != num_passes:
                         to_remove = []
 
+                        material_cache = {}
                         for he_idx in range(0, len(pairs), 2):
-                            # @todo instead of ray_distance, better do (x.point - y.point).dot(x.normal)
-                            # to see if they're coplanar, because ray-distance will be different in case
-                            # of element surfaces non-orthogonal to the view direction
-
                             def format(x):
                                 if x is None:
                                     return None
@@ -1201,34 +1213,48 @@ class CreateDrawing(bpy.types.Operator):
                                     # found to be inside element using tree.select() no face or style info
                                     return x
                                 else:
-                                    return (x.instance.is_a(), x.ray_distance, tuple(x.position))
+                                    return (x.instance, tuple(x.position), tuple(x.normal), x.style_index)
 
                             pp = pairs[he_idx : he_idx + 2]
                             if pp == (-1, -1):
                                 continue
                             data = list(map(format, map(semantics.__getitem__, pp)))
-                            if None not in data and data[0][0] == data[1][0] and abs(data[0][1] - data[1][1]) < 1.0e-5:
-                                to_remove.append(he_idx // 2)
-                                # Print edge index and semantic data
-                                # print(he_idx // 2, *data)
+                            if None not in data and data[0][0].is_a() == data[1][0].is_a():
+                                if len(data[0]) == 2 and len(data[1]) == 2:
+                                    # Both from tree.select() -> same element = same surface
+                                    if data[0][0] == data[1][0]:
+                                        to_remove.append(he_idx // 2)
+                                elif len(data[0]) == 4 and len(data[1]) == 4:
+                                    # Both from tree.select_ray() -> coplanar + same style + same material
+                                    p1, n1, s1 = np.array(data[0][1]), np.array(data[0][2]), data[0][3]
+                                    p2, n2, s2 = np.array(data[1][1]), np.array(data[1][2]), data[1][3]
+
+                                    if s1 == s2:
+                                        if abs(1.0 - abs(np.dot(n1, n2))) < 1.0e-4:
+                                            if abs(np.dot(p1 - p2, n1)) < 1.0e-4:
+                                                def get_cached_material(inst):
+                                                    id_ = inst.id()
+                                                    if id_ not in material_cache:
+                                                        mats = ifcopenshell.util.element.get_materials(inst)
+                                                        material_cache[id_] = tuple(m.id() for m in mats) if mats else (-1,)
+                                                    return material_cache[id_]
+
+                                                if get_cached_material(data[0][0]) == get_cached_material(data[1][0]):
+                                                    to_remove.append(he_idx // 2)
+                            # print(he_idx // 2, *data)
 
                         svgfill_context.merge(to_remove)
 
-                # Swap the XML nodes from the files
-                # Remove the original hidden line node we still have in the serializer output
-                g1.removeChild(projection)
+                # Replace all per-element projection groups with one merged cell group.
+                # SVG draw order: projections must be below sections, so insert first.
+                for pg in projection_groups:
+                    section_parent.removeChild(pg)
                 g2.setAttribute("class", "projection")
-                # Find the children of the projection node parent
-                children = [x for x in g1.childNodes if x.nodeType == x.ELEMENT_NODE]
+                children = [x for x in section_parent.childNodes if x.nodeType == x.ELEMENT_NODE]
                 if children:
-                    # Insert the new semantically enriched cell-based projection node
-                    # *before* the node with sections from the serializer. SVG derives
-                    # draw order from node order in the DOM so sections are draw over
-                    # the projections.
-                    g1.insertBefore(g2, children[0])
+                    section_parent.insertBefore(g2, children[0])
                 else:
-                    # This generally shouldn't happen
-                    g1.appendChild(g2)
+                    section_parent.appendChild(g2)
 
             results = dom1.toxml()
             results = results.encode("ascii", "xmlcharrefreplace")
@@ -1599,6 +1625,171 @@ class CreateDrawing(bpy.types.Operator):
                 path.attrib["d"] = d
                 g.set("class", " ".join(list(polygon_classes)))
                 group.append(g)
+
+    def remove_coplanar_boundary_lines(self, root):
+        """Remove projection line segments shared between same-material elements.
+
+        After merge_linework_and_add_metadata() adds material-* CSS classes,
+        this scans all per-element projection <g> groups under each common
+        parent, finds path segments (M x0,y0 L x1,y1) that appear in two or
+        more groups that carry the same material-* class, and deletes them from
+        both groups so coplanar surfaces of the same material appear seamless.
+        """
+        SVG = "http://www.w3.org/2000/svg"
+        TOL = 0.01  # SVG coordinate tolerance for matching line endpoints
+
+        obj_cache = {}
+
+        def get_obj(guid):
+            if guid in obj_cache:
+                return obj_cache[guid]
+            element = self.get_element_by_guid(guid)
+            obj = tool.Ifc.get_object(element) if element is not None else None
+            obj_cache[guid] = obj
+            return obj
+
+        adjacency_cache = {}
+
+        def are_coplanar_and_adjacent(guid_a, guid_b, tol=0.01):
+            """True if the two meshes share a vertex AND have parallel face normals.
+
+            Sharing a vertex confirms physical adjacency (rules out depth-stacked elements
+            whose 2D projections accidentally overlap). Parallel normals confirms the
+            shared face is coplanar — elements meeting at a fold angle are rejected.
+            """
+            key = (min(guid_a, guid_b), max(guid_a, guid_b))
+            if key in adjacency_cache:
+                return adjacency_cache[key]
+            obj_a = get_obj(guid_a)
+            obj_b = get_obj(guid_b)
+            if obj_a is None or obj_b is None or obj_a.type != "MESH" or obj_b.type != "MESH":
+                adjacency_cache[key] = True
+                return True
+            # Quick AABB guard
+            corners_a = [obj_a.matrix_world @ Vector(c) for c in obj_a.bound_box]
+            corners_b = [obj_b.matrix_world @ Vector(c) for c in obj_b.bound_box]
+            for axis in range(3):
+                if min(c[axis] for c in corners_a) > max(c[axis] for c in corners_b) + tol:
+                    adjacency_cache[key] = False
+                    return False
+                if min(c[axis] for c in corners_b) > max(c[axis] for c in corners_a) + tol:
+                    adjacency_cache[key] = False
+                    return False
+            # Shared vertex check
+            tol_sq = tol * tol
+            verts_a = [obj_a.matrix_world @ v.co for v in obj_a.data.vertices]
+            verts_b = [obj_b.matrix_world @ v.co for v in obj_b.data.vertices]
+            has_shared = any((va - vb).length_squared < tol_sq for va in verts_a for vb in verts_b)
+            if not has_shared:
+                adjacency_cache[key] = False
+                return False
+            # Coplanarity check: use the largest-face normal for each object.
+            # Area-weighted averages fail for slabs because top/bottom faces cancel.
+            def dominant_world_normal(obj):
+                mat3 = obj.matrix_world.to_3x3().normalized()
+                best = max(obj.data.polygons, key=lambda p: p.area, default=None)
+                if best is None or best.area < 1e-10:
+                    return None
+                return (mat3 @ best.normal).normalized()
+
+            n_a = dominant_world_normal(obj_a)
+            n_b = dominant_world_normal(obj_b)
+            if n_a is None or n_b is None:
+                adjacency_cache[key] = True
+                return True
+            result = abs(n_a.dot(n_b)) > 1.0 - 1e-3
+            adjacency_cache[key] = result
+            return result
+
+        def parse_line(d):
+            # Format is "Mx0,y0 Lx1,y1" (no space after M/L)
+            parts = d.strip().split()
+            if len(parts) == 2 and parts[0].startswith("M") and parts[1].startswith("L"):
+                try:
+                    x0, y0 = map(float, parts[0][1:].split(","))
+                    x1, y1 = map(float, parts[1][1:].split(","))
+                    return (x0, y0), (x1, y1)
+                except ValueError:
+                    pass
+            return None
+
+        def lines_match(a, b):
+            (x0a, y0a), (x1a, y1a) = a
+            (x0b, y0b), (x1b, y1b) = b
+            return (
+                abs(x0a - x0b) < TOL and abs(y0a - y0b) < TOL and abs(x1a - x1b) < TOL and abs(y1a - y1b) < TOL
+            ) or (
+                abs(x0a - x1b) < TOL and abs(y0a - y1b) < TOL and abs(x1a - x0b) < TOL and abs(y1a - y0b) < TOL
+            )
+
+        # Group projection <g> elements by their immediate parent
+        parent_to_groups = {}
+        for g in root.iter(f"{{{SVG}}}g"):
+            cls_list = g.get("class", "").split()
+            if "projection" not in cls_list:
+                continue
+            parent = g.getparent()
+            if parent is None:
+                continue
+            parent_to_groups.setdefault(id(parent), []).append(g)
+
+        for pid, proj_groups in parent_to_groups.items():
+            if len(proj_groups) < 2:
+                continue
+
+            def get_material_key(guid):
+                element = self.get_element_by_guid(guid)
+                if element is None:
+                    return None
+                mats = ifcopenshell.util.element.get_materials(element)
+                return tuple(sorted(m.id() for m in mats)) if mats else ()
+
+            def get_style_key(guid):
+                """IDs of IfcPresentationStyles directly on the element's geometry items."""
+                element = self.get_element_by_guid(guid)
+                if element is None or not getattr(element, "Representation", None):
+                    return ()
+                style_ids = set()
+                for rep in element.Representation.Representations:
+                    for item in rep.Items:
+                        for si in getattr(item, "StyledByItem", ()):
+                            for style in si.Styles:
+                                style_ids.add(style.id())
+                return tuple(sorted(style_ids))
+
+            group_data = []
+            for grp in proj_groups:
+                guid = grp.get("{http://www.ifcopenshell.org/ns}guid", "")
+                mat_key = get_material_key(guid)
+                style_key = get_style_key(guid)
+                segs = []
+                for path_el in grp.findall(f"{{{SVG}}}path"):
+                    line = parse_line(path_el.get("d", ""))
+                    if line is not None:
+                        segs.append((path_el, line))
+                group_data.append((grp, mat_key, style_key, segs, guid))
+
+            to_remove = set()
+            for i, (grp_i, mat_i, style_i, segs_i, guid_i) in enumerate(group_data):
+                if mat_i is None:
+                    continue
+                for j, (grp_j, mat_j, style_j, segs_j, guid_j) in enumerate(group_data):
+                    if j <= i:
+                        continue
+                    if mat_j != mat_i or style_j != style_i:
+                        continue
+                    if not are_coplanar_and_adjacent(guid_i, guid_j):
+                        continue
+                    for path_i, line_i in segs_i:
+                        for path_j, line_j in segs_j:
+                            if lines_match(line_i, line_j):
+                                to_remove.add(id(path_i))
+                                to_remove.add(id(path_j))
+            if to_remove:
+                for grp, mat, style, segs, guid in group_data:
+                    for path_el, _ in segs:
+                        if id(path_el) in to_remove:
+                            grp.remove(path_el)
 
     def drawing_to_model_co(self, x: float, y: float) -> Vector:
         camera_xy = np.array((x, -y)) / self.scale / 1000

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1646,7 +1646,7 @@ class CreateDrawing(bpy.types.Operator):
         camera_looks_up = self.camera.matrix_world.col[2].z < 0
 
         # GUIDs of pairs under investigation (first 12 chars used as key)
-        _dg = {"39Iwvbn41B7O", "08yv0FO$j2Aw", "1dM2d4kqjFH8", "2lwj_pzhrADf"}
+        _dg = {"39Iwvbn41B7O", "08yv0FO$j2Aw", "1dM2d4kqjFH8", "2lwj_pzhrADf", "2NR8CMK21CwO", "0XMcotQ9nDsx"}
 
         obj_cache = {}
 
@@ -1740,11 +1740,14 @@ class CreateDrawing(bpy.types.Operator):
                         return False
                 return True
 
-            contained = aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a)
-            if contained:
-                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS contained")
-                adjacency_cache[key] = True
-                return True
+            if aabb_contains(corners_a, corners_b):
+                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS contained (b inside a)")
+                adjacency_cache[key] = "contained_b"
+                return "contained_b"
+            if aabb_contains(corners_b, corners_a):
+                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS contained (a inside b)")
+                adjacency_cache[key] = "contained_a"
+                return "contained_a"
             # Coplanarity check: use the largest-face normal for each object.
             # Area-weighted averages fail for slabs because top/bottom faces cancel.
             def dominant_world_normal(obj):
@@ -2116,11 +2119,14 @@ class CreateDrawing(bpy.types.Operator):
                     if style_j != style_i:
                         if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} SKIP style style_i={style_i} style_j={style_j}")
                         continue
-                    if not are_coplanar_and_adjacent(guid_i, guid_j):
+                    _copl_result = are_coplanar_and_adjacent(guid_i, guid_j)
+                    if not _copl_result:
                         if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} SKIP coplanar")
                         continue
                     if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} JOINED — segs_i={len(segs_i)} segs_j={len(segs_j)}")
                     matched = 0
+
+                    _is_contained = _copl_result in ("contained_a", "contained_b")
 
                     # Group each element's segments by axis-aligned line.
                     # All segments on the same line (within TOL) are merged into a
@@ -2143,6 +2149,17 @@ class CreateDrawing(bpy.types.Operator):
                     lines_i = group_by_line(segs_i)
                     lines_j = group_by_line(segs_j)
 
+                    if _is_contained and _wp:
+                        print(f"[DBG] CONTAINED keys_i={sorted(lines_i)} keys_j={sorted(lines_j)}")
+                        print(f"[DBG] CONTAINED bbox_i={segs_bbox(segs_i)} bbox_j={segs_bbox(segs_j)}")
+                        for _k in sorted(set(lines_i) & set(lines_j)):
+                            _ui = ivs_union(lines_i[_k]["ivs"])
+                            _uj = ivs_union(lines_j[_k]["ivs"])
+                            print(f"[DBG] SHARED key={_k} union_i={_ui} union_j={_uj} intersect={ivs_intersect(_ui, _uj)}")
+                        for _k in sorted(set(lines_i) - set(lines_j)):
+                            _ui = ivs_union(lines_i[_k]["ivs"])
+                            print(f"[DBG] ONLY-I  key={_k} union_i={_ui}")
+
                     # Track whether bilateral found shared keys but skipped them
                     # due to offset overlap.  If so, both elements have explicit
                     # segments at the shared line — the unilateral fallback must
@@ -2158,14 +2175,11 @@ class CreateDrawing(bpy.types.Operator):
                         if not shared:
                             continue
                         _bilateral_had_explicit_keys = True
-                        # Only remove when the shared portion covers the full union
-                        # of at least one element on this line.  An offset partial
-                        # overlap — where two back-to-back walls happen to have
-                        # segments on the same line but at different running-direction
-                        # positions — would cover neither element's full union and
-                        # must not be removed (the line between them is a real
-                        # architectural boundary).
-                        if not (ivs_equal(shared, union_i) or ivs_equal(shared, union_j)):
+                        # For contained pairs the ivs_equal full-extent guard is
+                        # skipped: a partial overlap between an outer element's long
+                        # edge and a physically-contained inner element's short edge
+                        # is still a genuine shared interface, not an offset-wall case.
+                        if not _is_contained and not (ivs_equal(shared, union_i) or ivs_equal(shared, union_j)):
                             if _wp: print(f"[DBG] SKIP offset-overlap key={key} shared={shared} union_i={union_i} union_j={union_j}")
                             continue
                         if _wp: print(f"[DBG] MATCHED key={key} shared={shared} union_i={union_i} union_j={union_j}")
@@ -2187,7 +2201,9 @@ class CreateDrawing(bpy.types.Operator):
                     # (not explicitly drawn as a path segment), segments from the other
                     # element that lie on the boundary of that element's SVG bbox are
                     # still on the shared face and should be removed.
-                    if matched == 0 and not _bilateral_had_explicit_keys and segs_i and segs_j:
+                    # Not applicable to contained pairs (bilateral handles their
+                    # shared interface; unilateral would over-remove here).
+                    if not _is_contained and matched == 0 and not _bilateral_had_explicit_keys and segs_i and segs_j:
                         bbox_i = segs_bbox(segs_i)
                         bbox_j = segs_bbox(segs_j)
                         if bbox_i and bbox_j:

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1940,25 +1940,33 @@ class CreateDrawing(bpy.types.Operator):
                 mats = ifcopenshell.util.element.get_materials(element)
                 return tuple(sorted(m.id() for m in mats)) if mats else ()
 
+            # Camera look direction (unit vector pointing from camera into scene)
+            _cam_look = -self.camera.matrix_world.col[2].to_3d().normalized()
+
             def get_camera_face_layer_id(guid):
                 """Return the material ID of the layer the camera sees for this element.
 
-                For IfcMaterialLayerSetUsage elements with AXIS3 (vertical stacking —
-                slabs, roofs), the visible face depends on camera direction:
-                  - Plan view (camera looks down): the top layer is visible.
-                  - RCP (camera looks up): the bottom layer is visible.
-                DirectionSense POSITIVE means layers stack upward (Layer[0] = bottom,
-                Layer[-1] = top). NEGATIVE means layers stack downward (Layer[0] = top).
-                Returns None for walls (non-AXIS3) or elements without layer usage —
-                these fall back to the generic boundary-ends check.
+                For IfcMaterialLayerSetUsage elements the camera-facing layer depends
+                on the LayerSetDirection and which side of the element the camera is on:
+
+                  AXIS3 (slabs/roofs — vertical stacking):
+                    Plan view (camera looks down) → top layer visible.
+                    RCP (camera looks up) → bottom layer visible.
+
+                  AXIS1/AXIS2 (walls — horizontal stacking):
+                    The dominant face normal is computed for the element. If the camera
+                    look direction is opposite to the face normal the camera sees the
+                    face-normal side (the "positive" face). Otherwise it sees the
+                    "negative" face (the interior side of the layer sequence).
+
+                DirectionSense POSITIVE: Layer[0] is the negative/interior face,
+                Layer[-1] is the positive/exterior face. NEGATIVE reverses this.
                 """
                 element = self.get_element_by_guid(guid)
                 if element is None:
                     return None
                 material = ifcopenshell.util.element.get_material(element)
                 if material is None or not material.is_a("IfcMaterialLayerSetUsage"):
-                    return None
-                if material.LayerSetDirection != "AXIS3":
                     return None
                 layer_set = material.ForLayerSet
                 if layer_set is None:
@@ -1967,13 +1975,32 @@ class CreateDrawing(bpy.types.Operator):
                 if not layers:
                     return None
                 positive = material.DirectionSense == "POSITIVE"
-                # POSITIVE: Layer[0]=bottom, Layer[-1]=top
-                # NEGATIVE: Layer[0]=top,    Layer[-1]=bottom
-                if camera_looks_up:
-                    face_layer = layers[0] if positive else layers[-1]
-                else:
-                    face_layer = layers[-1] if positive else layers[0]
-                return face_layer.Material.id()
+                layer_dir = material.LayerSetDirection
+
+                # For all LayerSetDirections, determine which side of the element
+                # the camera is on by projecting the camera look vector onto the
+                # object's local stacking axis in world space:
+                #   AXIS3 → stacking along local Z (col[2]) — slabs/roofs
+                #   AXIS2 → stacking along local Y (col[1]) — most walls
+                #   AXIS1 → stacking along local X (col[0]) — rare walls
+                # DirectionSense POSITIVE: Layer[-1] is on the +axis side.
+                # dot < 0 → camera look is opposite to stacking axis
+                #         → camera is on the +axis (positive/exterior) side.
+                # This correctly handles sloped slabs seen by two plan-view
+                # cameras from opposite sides, unlike the simpler camera_looks_up
+                # flag which cannot distinguish them.
+                col_idx = {"AXIS1": 0, "AXIS2": 1, "AXIS3": 2}.get(layer_dir)
+                if col_idx is not None:
+                    obj = get_obj(guid)
+                    if obj is None or obj.type != "MESH":
+                        return None
+                    stack_axis = obj.matrix_world.col[col_idx].to_3d().normalized()
+                    dot = _cam_look.dot(stack_axis)
+                    on_positive_side = dot < 0
+                    face_layer = (layers[-1] if positive else layers[0]) if on_positive_side else (layers[0] if positive else layers[-1])
+                    return face_layer.Material.id()
+
+                return None
 
             def mat_keys_match(a, b, face_a=None, face_b=None):
                 """True if two ordered layer-material tuples represent compatible assemblies.

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1817,43 +1817,73 @@ class CreateDrawing(bpy.types.Operator):
                     return min(x_hi, max_xs) - max(x_lo, min_xs) > TOL
             return False
 
-        def lines_match(a, b):
-            """Return True if segments a and b represent the same physical edge.
+        def seg_line_key(seg):
+            """Return a bucketed key for the axis-aligned line containing seg.
 
-            Two cases are handled:
-            1. Exact match (same endpoints within TOL, either order).
-            2. Collinear overlap: both axis-aligned, on the same line, with
-               overlapping extents. This handles L-shaped walls whose boundary
-               is split into sub-segments that collectively cover the same edge
-               as a single segment in the adjacent element.
+            Returns ('h', int_key) for horizontal or ('v', int_key) for vertical.
+            int_key is round(coord / TOL) so segments within TOL of the same
+            line map to the same bucket. Returns None for diagonal segments.
             """
-            (x0a, y0a), (x1a, y1a) = a
-            (x0b, y0b), (x1b, y1b) = b
-            # Case 1: exact endpoint match (either orientation)
-            if (
-                abs(x0a - x0b) < TOL and abs(y0a - y0b) < TOL and abs(x1a - x1b) < TOL and abs(y1a - y1b) < TOL
-            ) or (
-                abs(x0a - x1b) < TOL and abs(y0a - y1b) < TOL and abs(x1a - x0b) < TOL and abs(y1a - y0b) < TOL
-            ):
-                return True
-            # Case 2: collinear overlap for axis-aligned segments
-            is_horiz_a = abs(y0a - y1a) < TOL
-            is_horiz_b = abs(y0b - y1b) < TOL
-            if is_horiz_a and is_horiz_b:
-                # Both horizontal: same y, overlapping x ranges
-                if abs((y0a + y1a) / 2 - (y0b + y1b) / 2) < TOL:
-                    min_xa, max_xa = min(x0a, x1a), max(x0a, x1a)
-                    min_xb, max_xb = min(x0b, x1b), max(x0b, x1b)
-                    return max(min_xa, min_xb) < min(max_xa, max_xb) - TOL
-            is_vert_a = abs(x0a - x1a) < TOL
-            is_vert_b = abs(x0b - x1b) < TOL
-            if is_vert_a and is_vert_b:
-                # Both vertical: same x, overlapping y ranges
-                if abs((x0a + x1a) / 2 - (x0b + x1b) / 2) < TOL:
-                    min_ya, max_ya = min(y0a, y1a), max(y0a, y1a)
-                    min_yb, max_yb = min(y0b, y1b), max(y0b, y1b)
-                    return max(min_ya, min_yb) < min(max_ya, max_yb) - TOL
-            return False
+            (x0, y0), (x1, y1) = seg
+            if abs(y0 - y1) < TOL:
+                return ("h", round((y0 + y1) / 2 / TOL))
+            if abs(x0 - x1) < TOL:
+                return ("v", round((x0 + x1) / 2 / TOL))
+            return None
+
+        def seg_interval(seg):
+            """Return the (lo, hi) 1-D interval of an axis-aligned segment."""
+            (x0, y0), (x1, y1) = seg
+            if abs(y0 - y1) < TOL:
+                return (min(x0, x1), max(x0, x1))
+            return (min(y0, y1), max(y0, y1))
+
+        def seg_axis_coord(seg, kind):
+            """Return the fixed coordinate (y for 'h', x for 'v') of a segment."""
+            (x0, y0), (x1, y1) = seg
+            return (y0 + y1) / 2 if kind == "h" else (x0 + x1) / 2
+
+        def ivs_union(ivs):
+            """Merge a list of (lo, hi) intervals into a non-overlapping sorted list."""
+            merged = []
+            for lo, hi in sorted(ivs):
+                if merged and lo <= merged[-1][1] + TOL:
+                    merged[-1] = (merged[-1][0], max(merged[-1][1], hi))
+                else:
+                    merged.append([lo, hi])
+            return [(lo, hi) for lo, hi in merged]
+
+        def ivs_intersect(a_ivs, b_ivs):
+            """Return the intersection of two sets of intervals."""
+            result = []
+            for a_lo, a_hi in a_ivs:
+                for b_lo, b_hi in b_ivs:
+                    lo, hi = max(a_lo, b_lo), min(a_hi, b_hi)
+                    if hi > lo + TOL:
+                        result.append((lo, hi))
+            return result
+
+        def ivs_subtract(ivs, sub):
+            """Subtract interval list sub from interval list ivs."""
+            result = list(ivs)
+            for s_lo, s_hi in sub:
+                new_result = []
+                for r_lo, r_hi in result:
+                    if s_hi <= r_lo + TOL or s_lo >= r_hi - TOL:
+                        new_result.append((r_lo, r_hi))
+                    else:
+                        if r_lo < s_lo - TOL:
+                            new_result.append((r_lo, s_lo))
+                        if r_hi > s_hi + TOL:
+                            new_result.append((s_hi, r_hi))
+                result = new_result
+            return result
+
+        def make_seg(kind, coord, lo, hi):
+            """Reconstruct a segment tuple from a line kind, fixed coord, and interval."""
+            if kind == "h":
+                return ((lo, coord), (hi, coord))
+            return ((coord, lo), (coord, hi))
 
         # Group projection <g> elements by their immediate parent
         parent_to_groups = {}
@@ -1948,6 +1978,9 @@ class CreateDrawing(bpy.types.Operator):
                 group_data.append((grp, mat_key, style_key, segs, guid))
 
             to_remove = set()
+            # New path segments to add back: list of (grp_element, seg) pairs
+            to_add = []
+
             for i, (grp_i, mat_i, style_i, segs_i, guid_i) in enumerate(group_data):
                 if mat_i is None:
                     continue
@@ -1961,12 +1994,50 @@ class CreateDrawing(bpy.types.Operator):
                     if not are_coplanar_and_adjacent(guid_i, guid_j):
                         continue
                     matched = 0
-                    for path_i, line_i in segs_i:
-                        for path_j, line_j in segs_j:
-                            if lines_match(line_i, line_j):
-                                to_remove.add(id(path_i))
-                                to_remove.add(id(path_j))
-                                matched += 1
+
+                    # Group each element's segments by axis-aligned line.
+                    # All segments on the same line (within TOL) are merged into a
+                    # single interval union before computing the shared portion.
+                    # This correctly handles cases where one element has a single
+                    # long edge while the other has multiple shorter segments on
+                    # the same line (e.g. an L-shaped element).
+                    def group_by_line(segs):
+                        d = {}
+                        for path_el, seg in segs:
+                            key = seg_line_key(seg)
+                            if key is None:
+                                continue
+                            if key not in d:
+                                d[key] = {"paths": [], "ivs": [], "coord": seg_axis_coord(seg, key[0])}
+                            d[key]["paths"].append(path_el)
+                            d[key]["ivs"].append(seg_interval(seg))
+                        return d
+
+                    lines_i = group_by_line(segs_i)
+                    lines_j = group_by_line(segs_j)
+
+                    for key in set(lines_i) & set(lines_j):
+                        entry_i = lines_i[key]
+                        entry_j = lines_j[key]
+                        union_i = ivs_union(entry_i["ivs"])
+                        union_j = ivs_union(entry_j["ivs"])
+                        shared = ivs_intersect(union_i, union_j)
+                        if not shared:
+                            continue
+                        matched += len(shared)
+                        kind = key[0]
+                        coord = entry_i["coord"]
+                        for path_el in entry_i["paths"]:
+                            to_remove.add(id(path_el))
+                        for path_el in entry_j["paths"]:
+                            to_remove.add(id(path_el))
+                        rem_i = ivs_subtract(union_i, shared)
+                        rem_j = ivs_subtract(union_j, shared)
+                        for lo, hi in rem_i:
+                            to_add.append((grp_i, make_seg(kind, coord, lo, hi)))
+                        for lo, hi in rem_j:
+                            to_add.append((grp_j, make_seg(kind, coord, lo, hi)))
+
                     # Unilateral fallback: when one element's shared edge is implicit
                     # (not explicitly drawn as a path segment), segments from the other
                     # element that lie on the boundary of that element's SVG bbox are
@@ -1989,6 +2060,11 @@ class CreateDrawing(bpy.types.Operator):
                     for path_el, _ in segs:
                         if id(path_el) in to_remove:
                             grp.remove(path_el)
+
+            for grp_el, seg in to_add:
+                path_el = etree.SubElement(grp_el, f"{{{SVG}}}path")
+                (x0, y0), (x1, y1) = seg
+                path_el.set("d", f"M{x0},{y0} L{x1},{y1}")
 
     def drawing_to_model_co(self, x: float, y: float) -> Vector:
         camera_xy = np.array((x, -y)) / self.scale / 1000

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1638,6 +1638,11 @@ class CreateDrawing(bpy.types.Operator):
         SVG = "http://www.w3.org/2000/svg"
         TOL = 0.01  # SVG coordinate tolerance for matching line endpoints
 
+        # Determine whether the camera is looking up (RCP) or down (plan view).
+        # In Blender the camera looks along its local -Z axis. If the camera's
+        # local Z axis in world space points downward, the camera looks upward.
+        camera_looks_up = self.camera.matrix_world.col[2].z < 0
+
         obj_cache = {}
 
         def get_obj(guid):
@@ -1932,23 +1937,70 @@ class CreateDrawing(bpy.types.Operator):
                 mats = ifcopenshell.util.element.get_materials(element)
                 return tuple(sorted(m.id() for m in mats)) if mats else ()
 
-            def mat_keys_match(a, b):
+            def get_camera_face_layer_id(guid):
+                """Return the material ID of the layer the camera sees for this element.
+
+                For IfcMaterialLayerSetUsage elements with AXIS3 (vertical stacking —
+                slabs, roofs), the visible face depends on camera direction:
+                  - Plan view (camera looks down): the top layer is visible.
+                  - RCP (camera looks up): the bottom layer is visible.
+                DirectionSense POSITIVE means layers stack upward (Layer[0] = bottom,
+                Layer[-1] = top). NEGATIVE means layers stack downward (Layer[0] = top).
+                Returns None for walls (non-AXIS3) or elements without layer usage —
+                these fall back to the generic boundary-ends check.
+                """
+                element = self.get_element_by_guid(guid)
+                if element is None:
+                    return None
+                material = ifcopenshell.util.element.get_material(element)
+                if material is None or not material.is_a("IfcMaterialLayerSetUsage"):
+                    return None
+                if material.LayerSetDirection != "AXIS3":
+                    return None
+                layer_set = material.ForLayerSet
+                if layer_set is None:
+                    return None
+                layers = [l for l in layer_set.MaterialLayers if l.Material is not None]
+                if not layers:
+                    return None
+                positive = material.DirectionSense == "POSITIVE"
+                # POSITIVE: Layer[0]=bottom, Layer[-1]=top
+                # NEGATIVE: Layer[0]=top,    Layer[-1]=bottom
+                if camera_looks_up:
+                    face_layer = layers[0] if positive else layers[-1]
+                else:
+                    face_layer = layers[-1] if positive else layers[0]
+                return face_layer.Material.id()
+
+            def mat_keys_match(a, b, face_a=None, face_b=None):
                 """True if two ordered layer-material tuples represent compatible assemblies.
 
                 Compatible means the visible cross-section at the shared face is
-                the same material.  Four cases are accepted:
+                the same material.  Checks in order:
                   - Exact match (identical layer sequences).
                   - Reversed match (same assembly in opposite orientation).
-                  - Suffix match: one sequence ends with all layers of the other
-                    (the larger assembly has extra layers on the far side).
-                  - Prefix match: one sequence starts with all layers of the other
-                    (extra layers on the near side).
+                  - Suffix match: one sequence ends with all layers of the other.
+                  - Prefix match: one sequence starts with all layers of the other.
+                  - Camera-face match: when the camera-facing layer ID is known for
+                    both elements (AXIS3 slabs/roofs), only those layers are compared
+                    so that a plan view and an RCP of the same elements can produce
+                    different join decisions.
+                  - Boundary match fallback: any end layer of a matches any end layer
+                    of b (used when camera-face direction cannot be determined).
                 """
                 if a == b or a == b[::-1]:
                     return True
                 short, long_ = (a, b) if len(a) <= len(b) else (b, a)
                 n = len(short)
-                return long_[-n:] == short or long_[:n] == short
+                if long_[-n:] == short or long_[:n] == short:
+                    return True
+                # Camera-directional boundary check for AXIS3 elements
+                if face_a is not None and face_b is not None:
+                    return face_a == face_b
+                # Generic boundary check: any end layer matches any end layer
+                a_ends = {a[0], a[-1]} if a else set()
+                b_ends = {b[0], b[-1]} if b else set()
+                return bool(a_ends & b_ends)
 
             def get_style_key(guid):
                 """IDs of IfcPresentationStyles directly on the element's geometry items."""
@@ -1968,6 +2020,7 @@ class CreateDrawing(bpy.types.Operator):
                 guid = grp.get("{http://www.ifcopenshell.org/ns}guid", "")
                 cls = grp.get("class", "")
                 mat_key = get_material_key(guid)
+                face_mat_id = get_camera_face_layer_id(guid)
                 style_key = get_style_key(guid)
                 segs = []
                 all_paths = grp.findall(f"{{{SVG}}}path")
@@ -1975,19 +2028,19 @@ class CreateDrawing(bpy.types.Operator):
                     line = parse_line(path_el.get("d", ""))
                     if line is not None:
                         segs.append((path_el, line))
-                group_data.append((grp, mat_key, style_key, segs, guid))
+                group_data.append((grp, mat_key, face_mat_id, style_key, segs, guid))
 
             to_remove = set()
             # New path segments to add back: list of (grp_element, seg) pairs
             to_add = []
 
-            for i, (grp_i, mat_i, style_i, segs_i, guid_i) in enumerate(group_data):
+            for i, (grp_i, mat_i, face_i, style_i, segs_i, guid_i) in enumerate(group_data):
                 if mat_i is None:
                     continue
-                for j, (grp_j, mat_j, style_j, segs_j, guid_j) in enumerate(group_data):
+                for j, (grp_j, mat_j, face_j, style_j, segs_j, guid_j) in enumerate(group_data):
                     if j <= i:
                         continue
-                    if not mat_keys_match(mat_i, mat_j):
+                    if not mat_keys_match(mat_i, mat_j, face_i, face_j):
                         continue
                     if style_j != style_i:
                         continue
@@ -2056,7 +2109,7 @@ class CreateDrawing(bpy.types.Operator):
                                     matched += 1
 
             if to_remove:
-                for grp, mat, style, segs, guid in group_data:
+                for grp, mat, face, style, segs, guid in group_data:
                     for path_el, _ in segs:
                         if id(path_el) in to_remove:
                             grp.remove(path_el)

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1655,6 +1655,8 @@ class CreateDrawing(bpy.types.Operator):
 
         adjacency_cache = {}
 
+        _watch_adj = frozenset({"39Iwvbn41B7OZ72qQGJq6v", "08yv0FO$j2AwVYFWEkXEuh"})
+
         def are_coplanar_and_adjacent(guid_a, guid_b, tol=0.01):
             """True if the two meshes share a vertex AND have parallel face normals.
 
@@ -1663,11 +1665,14 @@ class CreateDrawing(bpy.types.Operator):
             shared face is coplanar — elements meeting at a fold angle are rejected.
             """
             key = (min(guid_a, guid_b), max(guid_a, guid_b))
+            _dbg = frozenset({guid_a, guid_b}) == _watch_adj
             if key in adjacency_cache:
                 return adjacency_cache[key]
             obj_a = get_obj(guid_a)
             obj_b = get_obj(guid_b)
             if obj_a is None or obj_b is None or obj_a.type != "MESH" or obj_b.type != "MESH":
+                if _dbg:
+                    print(f"[WATCH] {guid_a} vs {guid_b}: no mesh obj -> True")
                 adjacency_cache[key] = True
                 return True
             # Quick AABB guard
@@ -1679,9 +1684,13 @@ class CreateDrawing(bpy.types.Operator):
                 min_b = min(c[axis] for c in corners_b)
                 max_b = max(c[axis] for c in corners_b)
                 if min_a > max_b + tol:
+                    if _dbg:
+                        print(f"[WATCH] {guid_a} vs {guid_b}: AABB separated on axis {axis} -> False")
                     adjacency_cache[key] = False
                     return False
                 if min_b > max_a + tol:
+                    if _dbg:
+                        print(f"[WATCH] {guid_a} vs {guid_b}: AABB separated on axis {axis} -> False")
                     adjacency_cache[key] = False
                     return False
             # Proximity check: vertex-to-vertex OR vertex-to-edge.
@@ -1715,6 +1724,8 @@ class CreateDrawing(bpy.types.Operator):
             if not has_shared:
                 # Slower vertex-on-edge check for containment cases
                 has_shared = vertex_near_edges(verts_b, obj_a, tol_sq) or vertex_near_edges(verts_a, obj_b, tol_sq)
+            if _dbg:
+                print(f"[WATCH] {guid_a} vs {guid_b}: has_shared={has_shared}")
             if not has_shared:
                 adjacency_cache[key] = False
                 return False
@@ -1729,7 +1740,10 @@ class CreateDrawing(bpy.types.Operator):
                         return False
                 return True
 
-            if aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a):
+            contained = aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a)
+            if _dbg:
+                print(f"[WATCH] {guid_a} vs {guid_b}: aabb_contained={contained}")
+            if contained:
                 adjacency_cache[key] = True
                 return True
             # Coplanarity check: use the largest-face normal for each object.
@@ -1744,20 +1758,32 @@ class CreateDrawing(bpy.types.Operator):
             n_a = dominant_world_normal(obj_a)
             n_b = dominant_world_normal(obj_b)
             if n_a is None or n_b is None:
+                if _dbg:
+                    print(f"[WATCH] {guid_a} vs {guid_b}: no dominant normal -> True")
                 adjacency_cache[key] = True
                 return True
             dot = abs(n_a.dot(n_b))
+            if _dbg:
+                import math
+                print(f"[WATCH] {guid_a} vs {guid_b}: n_a={tuple(round(x,4) for x in n_a)} n_b={tuple(round(x,4) for x in n_b)} dot={dot:.6f} angle={math.degrees(math.acos(min(dot,1.0))):.3f}°")
             if dot <= 1.0 - 3.8e-5:
+                if _dbg:
+                    print(f"[WATCH] {guid_a} vs {guid_b}: not coplanar (dot too low) -> False")
                 adjacency_cache[key] = False
                 return False
             # Normals are parallel — also verify the elements share a face plane.
-            # Two walls can have parallel normals but be on different parallel planes
-            # (e.g., offset walls meeting at a corner). Project all vertices of each
-            # object onto the same reference normal (n_a) so that anti-parallel
-            # normals (one face is flipped) don't produce mirrored projections.
-            plane_pos_a = {round(v.dot(n_a), 5) for v in verts_a}
-            plane_pos_b = {round(v.dot(n_a), 5) for v in verts_b}
-            same_plane = any(abs(pa - pb) < tol for pa in plane_pos_a for pb in plane_pos_b)
+            # Project all vertices onto n_a to get the 1-D depth range of each
+            # element along the normal axis. Side-by-side elements span the same
+            # depth range (overlap > tol). Elements stacked end-to-end only touch
+            # at a single interface point (overlap ≈ 0) and must not be joined.
+            projs_a = [v.dot(n_a) for v in verts_a]
+            projs_b = [v.dot(n_a) for v in verts_b]
+            range_a = (min(projs_a), max(projs_a))
+            range_b = (min(projs_b), max(projs_b))
+            overlap = min(range_a[1], range_b[1]) - max(range_a[0], range_b[0])
+            same_plane = overlap > tol
+            if _dbg:
+                print(f"[WATCH] {guid_a} vs {guid_b}: range_a={range_a} range_b={range_b} overlap={overlap:.5f} same_plane={same_plane}")
             adjacency_cache[key] = same_plane
             return same_plane
 

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1668,21 +1668,82 @@ class CreateDrawing(bpy.types.Operator):
             # Quick AABB guard
             corners_a = [obj_a.matrix_world @ Vector(c) for c in obj_a.bound_box]
             corners_b = [obj_b.matrix_world @ Vector(c) for c in obj_b.bound_box]
+            _verbose = {"1eW6OACmXD1hWJLDeB6erW", "2x0$XNlFH6FxlvS7eYJttx"} == {guid_a, guid_b}
             for axis in range(3):
-                if min(c[axis] for c in corners_a) > max(c[axis] for c in corners_b) + tol:
+                min_a = min(c[axis] for c in corners_a)
+                max_a = max(c[axis] for c in corners_a)
+                min_b = min(c[axis] for c in corners_b)
+                max_b = max(c[axis] for c in corners_b)
+                if _verbose:
+                    print(f"[TARGET PAIR] axis={axis} {guid_a}=[{min_a:.4f},{max_a:.4f}] {guid_b}=[{min_b:.4f},{max_b:.4f}]")
+                if min_a > max_b + tol:
+                    if _verbose:
+                        print(f"[TARGET PAIR] AABB separated on axis {axis} (min_a={min_a:.4f} > max_b={max_b:.4f})")
                     adjacency_cache[key] = False
                     return False
-                if min(c[axis] for c in corners_b) > max(c[axis] for c in corners_a) + tol:
+                if min_b > max_a + tol:
+                    if _verbose:
+                        print(f"[TARGET PAIR] AABB separated on axis {axis} (min_b={min_b:.4f} > max_a={max_a:.4f})")
                     adjacency_cache[key] = False
                     return False
-            # Shared vertex check
+            # Proximity check: vertex-to-vertex OR vertex-to-edge.
+            # Vertex-to-vertex handles adjacent elements sharing a corner.
+            # Vertex-to-edge handles containment (inner element's corners lie
+            # on edges of outer element, never at its corner vertices).
             tol_sq = tol * tol
+
+            def point_to_seg_dist_sq(p, a, b):
+                ab = b - a
+                len_sq = ab.length_squared
+                if len_sq < 1e-12:
+                    return (p - a).length_squared
+                t = max(0.0, min(1.0, (p - a).dot(ab) / len_sq))
+                return (p - (a + t * ab)).length_squared
+
+            def vertex_near_edges(verts, obj, tol_sq):
+                mat = obj.matrix_world
+                for v in verts:
+                    for edge in obj.data.edges:
+                        v0 = mat @ obj.data.vertices[edge.vertices[0]].co
+                        v1 = mat @ obj.data.vertices[edge.vertices[1]].co
+                        if point_to_seg_dist_sq(v, v0, v1) < tol_sq:
+                            return True
+                return False
+
             verts_a = [obj_a.matrix_world @ v.co for v in obj_a.data.vertices]
             verts_b = [obj_b.matrix_world @ v.co for v in obj_b.data.vertices]
+            # Fast vertex-vertex check first
             has_shared = any((va - vb).length_squared < tol_sq for va in verts_a for vb in verts_b)
+            if _verbose and not has_shared:
+                # Find closest vertex pair for diagnostic output
+                closest = min(((va - vb).length, ia, ib) for ia, va in enumerate(verts_a) for ib, vb in enumerate(verts_b))
+                print(f"[TARGET PAIR] no v-v match, closest vertex gap={closest[0]:.6f}m")
+            if not has_shared:
+                # Slower vertex-on-edge check for containment cases
+                has_shared = vertex_near_edges(verts_b, obj_a, tol_sq) or vertex_near_edges(verts_a, obj_b, tol_sq)
+                if _verbose:
+                    print(f"[TARGET PAIR] vertex-on-edge result={has_shared}")
+            if _verbose:
+                print(f"[TARGET PAIR] proximity_check={has_shared}")
             if not has_shared:
                 adjacency_cache[key] = False
                 return False
+            # Containment check: if one AABB fully contains the other, the
+            # dominant-normal test is unreliable (a flat inner element's largest
+            # face is its top/bottom, not its side face). Skip normal check.
+            def aabb_contains(outer, inner):
+                for axis in range(3):
+                    if min(c[axis] for c in inner) < min(c[axis] for c in outer) - tol:
+                        return False
+                    if max(c[axis] for c in inner) > max(c[axis] for c in outer) + tol:
+                        return False
+                return True
+
+            if aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a):
+                if _verbose:
+                    print(f"[TARGET PAIR] AABB containment detected, skipping normal check")
+                adjacency_cache[key] = True
+                return True
             # Coplanarity check: use the largest-face normal for each object.
             # Area-weighted averages fail for slabs because top/bottom faces cancel.
             def dominant_world_normal(obj):
@@ -1697,9 +1758,24 @@ class CreateDrawing(bpy.types.Operator):
             if n_a is None or n_b is None:
                 adjacency_cache[key] = True
                 return True
-            result = abs(n_a.dot(n_b)) > 1.0 - 1e-3
-            adjacency_cache[key] = result
-            return result
+            dot = abs(n_a.dot(n_b))
+            if dot <= 1.0 - 1e-3:
+                if _verbose:
+                    print(f"[TARGET PAIR] normal_dot={dot:.6f} coplanar=False (not parallel)")
+                adjacency_cache[key] = False
+                return False
+            # Normals are parallel — also verify the elements share a face plane.
+            # Two walls can have parallel normals but be on different parallel planes
+            # (e.g., offset walls meeting at a corner). Project all vertices of each
+            # object onto the same reference normal (n_a) so that anti-parallel
+            # normals (one face is flipped) don't produce mirrored projections.
+            plane_pos_a = {round(v.dot(n_a), 5) for v in verts_a}
+            plane_pos_b = {round(v.dot(n_a), 5) for v in verts_b}
+            same_plane = any(abs(pa - pb) < tol for pa in plane_pos_a for pb in plane_pos_b)
+            if _verbose:
+                print(f"[TARGET PAIR] normal_dot={dot:.6f} plane_pos_a={sorted(plane_pos_a)} plane_pos_b={sorted(plane_pos_b)} same_plane={same_plane}")
+            adjacency_cache[key] = same_plane
+            return same_plane
 
         def parse_line(d):
             # Format is "Mx0,y0 Lx1,y1" (no space after M/L)
@@ -1714,13 +1790,42 @@ class CreateDrawing(bpy.types.Operator):
             return None
 
         def lines_match(a, b):
+            """Return True if segments a and b represent the same physical edge.
+
+            Two cases are handled:
+            1. Exact match (same endpoints within TOL, either order).
+            2. Collinear overlap: both axis-aligned, on the same line, with
+               overlapping extents. This handles L-shaped walls whose boundary
+               is split into sub-segments that collectively cover the same edge
+               as a single segment in the adjacent element.
+            """
             (x0a, y0a), (x1a, y1a) = a
             (x0b, y0b), (x1b, y1b) = b
-            return (
+            # Case 1: exact endpoint match (either orientation)
+            if (
                 abs(x0a - x0b) < TOL and abs(y0a - y0b) < TOL and abs(x1a - x1b) < TOL and abs(y1a - y1b) < TOL
             ) or (
                 abs(x0a - x1b) < TOL and abs(y0a - y1b) < TOL and abs(x1a - x0b) < TOL and abs(y1a - y0b) < TOL
-            )
+            ):
+                return True
+            # Case 2: collinear overlap for axis-aligned segments
+            is_horiz_a = abs(y0a - y1a) < TOL
+            is_horiz_b = abs(y0b - y1b) < TOL
+            if is_horiz_a and is_horiz_b:
+                # Both horizontal: same y, overlapping x ranges
+                if abs((y0a + y1a) / 2 - (y0b + y1b) / 2) < TOL:
+                    min_xa, max_xa = min(x0a, x1a), max(x0a, x1a)
+                    min_xb, max_xb = min(x0b, x1b), max(x0b, x1b)
+                    return max(min_xa, min_xb) < min(max_xa, max_xb) - TOL
+            is_vert_a = abs(x0a - x1a) < TOL
+            is_vert_b = abs(x0b - x1b) < TOL
+            if is_vert_a and is_vert_b:
+                # Both vertical: same x, overlapping y ranges
+                if abs((x0a + x1a) / 2 - (x0b + x1b) / 2) < TOL:
+                    min_ya, max_ya = min(y0a, y1a), max(y0a, y1a)
+                    min_yb, max_yb = min(y0b, y1b), max(y0b, y1b)
+                    return max(min_ya, min_yb) < min(max_ya, max_yb) - TOL
+            return False
 
         # Group projection <g> elements by their immediate parent
         parent_to_groups = {}
@@ -1760,10 +1865,12 @@ class CreateDrawing(bpy.types.Operator):
             group_data = []
             for grp in proj_groups:
                 guid = grp.get("{http://www.ifcopenshell.org/ns}guid", "")
+                cls = grp.get("class", "")
                 mat_key = get_material_key(guid)
                 style_key = get_style_key(guid)
                 segs = []
-                for path_el in grp.findall(f"{{{SVG}}}path"):
+                all_paths = grp.findall(f"{{{SVG}}}path")
+                for path_el in all_paths:
                     line = parse_line(path_el.get("d", ""))
                     if line is not None:
                         segs.append((path_el, line))
@@ -1776,15 +1883,40 @@ class CreateDrawing(bpy.types.Operator):
                 for j, (grp_j, mat_j, style_j, segs_j, guid_j) in enumerate(group_data):
                     if j <= i:
                         continue
-                    if mat_j != mat_i or style_j != style_i:
+                    _target = {"1eW6OACmXD1hWJLDeB6erW", "2x0$XNlFH6FxlvS7eYJttx"} == {guid_i, guid_j}
+                    if mat_j != mat_i:
+                        if _target:
+                            print(f"[TARGET PAIR] SKIPPED: different mat {mat_i!r} vs {mat_j!r}")
                         continue
-                    if not are_coplanar_and_adjacent(guid_i, guid_j):
+                    if style_j != style_i:
+                        if _target:
+                            print(f"[TARGET PAIR] SKIPPED: different style {style_i!r} vs {style_j!r}")
                         continue
+                    adj = are_coplanar_and_adjacent(guid_i, guid_j)
+                    if not adj:
+                        continue
+                    matched = 0
                     for path_i, line_i in segs_i:
                         for path_j, line_j in segs_j:
                             if lines_match(line_i, line_j):
+                                if _target:
+                                    print(f"[TARGET PAIR] MATCH: {line_i} == {line_j}")
                                 to_remove.add(id(path_i))
                                 to_remove.add(id(path_j))
+                                matched += 1
+                    if _target:
+                        print(f"[TARGET PAIR] adj=True, matched={matched} segment pair(s)")
+                        if matched == 0:
+                            print(f"[TARGET PAIR] segs_i ({guid_i}, {len(segs_i)} segs):")
+                            for _, li in segs_i:
+                                print(f"  {li}")
+                            print(f"[TARGET PAIR] segs_j ({guid_j}, {len(segs_j)} segs):")
+                            for _, lj in segs_j:
+                                print(f"  {lj}")
+                    elif matched:
+                        print(f"[MERGED] {guid_i} vs {guid_j}: {matched} segment(s) removed")
+
+            print(f"[COPLANAR DEBUG] Total paths to remove: {len(to_remove)}")
             if to_remove:
                 for grp, mat, style, segs, guid in group_data:
                     for path_el, _ in segs:

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1645,6 +1645,9 @@ class CreateDrawing(bpy.types.Operator):
         # local Z axis in world space points downward, the camera looks upward.
         camera_looks_up = self.camera.matrix_world.col[2].z < 0
 
+        # GUIDs of pairs under investigation (first 12 chars used as key)
+        _dg = {"39Iwvbn41B7O", "08yv0FO$j2Aw", "1dM2d4kqjFH8", "2lwj_pzhrADf"}
+
         obj_cache = {}
 
         def get_obj(guid):
@@ -1667,9 +1670,11 @@ class CreateDrawing(bpy.types.Operator):
             key = (min(guid_a, guid_b), max(guid_a, guid_b))
             if key in adjacency_cache:
                 return adjacency_cache[key]
+            _dbg = guid_a[:12] in _dg and guid_b[:12] in _dg
             obj_a = get_obj(guid_a)
             obj_b = get_obj(guid_b)
             if obj_a is None or obj_b is None or obj_a.type != "MESH" or obj_b.type != "MESH":
+                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS (no mesh)")
                 adjacency_cache[key] = True
                 return True
             # Quick AABB guard
@@ -1681,9 +1686,11 @@ class CreateDrawing(bpy.types.Operator):
                 min_b = min(c[axis] for c in corners_b)
                 max_b = max(c[axis] for c in corners_b)
                 if min_a > max_b + tol:
+                    if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL aabb axis={axis}")
                     adjacency_cache[key] = False
                     return False
                 if min_b > max_a + tol:
+                    if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL aabb axis={axis}")
                     adjacency_cache[key] = False
                     return False
             # Proximity check: vertex-to-vertex OR vertex-to-edge.
@@ -1718,8 +1725,10 @@ class CreateDrawing(bpy.types.Operator):
                 # Slower vertex-on-edge check for containment cases
                 has_shared = vertex_near_edges(verts_b, obj_a, tol_sq) or vertex_near_edges(verts_a, obj_b, tol_sq)
             if not has_shared:
+                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL proximity")
                 adjacency_cache[key] = False
                 return False
+            if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS proximity")
             # Containment check: if one AABB fully contains the other, the
             # dominant-normal test is unreliable (a flat inner element's largest
             # face is its top/bottom, not its side face). Skip normal check.
@@ -1733,6 +1742,7 @@ class CreateDrawing(bpy.types.Operator):
 
             contained = aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a)
             if contained:
+                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS contained")
                 adjacency_cache[key] = True
                 return True
             # Coplanarity check: use the largest-face normal for each object.
@@ -1747,27 +1757,41 @@ class CreateDrawing(bpy.types.Operator):
             n_a = dominant_world_normal(obj_a)
             n_b = dominant_world_normal(obj_b)
             if n_a is None or n_b is None:
+                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS (no normal)")
                 adjacency_cache[key] = True
                 return True
             dot = abs(n_a.dot(n_b))
+            if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} n_a={tuple(round(x,3) for x in n_a)} n_b={tuple(round(x,3) for x in n_b)} dot={dot:.6f}")
             if dot <= 1.0 - 3.8e-5:  # ~0.5° tolerance
+                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL normal dot={dot:.6f}")
                 adjacency_cache[key] = False
                 return False
-            # Check whether both elements are at the same depth relative to the
-            # camera. Project vertices onto the camera look direction: elements
-            # at the same camera depth have overlapping ranges; depth-stacked
-            # elements (one in front of the other) have separated ranges.
-            # Using the camera direction rather than n_a is critical — n_a may
-            # be perpendicular to the camera (e.g. X-normal boxes in plan view)
-            # which would produce zero overlap for legitimate side-by-side pairs.
+            # Face-plane check: parallel normals don't guarantee the elements are
+            # on the same plane — they could be offset (e.g. two walls facing the
+            # same direction at different Y positions meeting at a corner).
+            # Project all vertices of both elements onto n_a (using n_a for both
+            # so that anti-parallel normals +Y/-Y produce matching values).
+            #
+            plane_pos_a = {round(v.dot(n_a), 5) for v in verts_a}
+            plane_pos_b = {round(v.dot(n_a), 5) for v in verts_b}
+            same_plane = any(abs(pa - pb) < tol for pa in plane_pos_a for pb in plane_pos_b)
+            if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} plane_pos_a={sorted(plane_pos_a)} plane_pos_b={sorted(plane_pos_b)} same_plane={same_plane}")
+            if not same_plane:
+                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL face-plane")
+                adjacency_cache[key] = False
+                return False
+            # Depth check: confirm both elements span the same camera depth range.
+            # Catches elements at the same X-Y face plane but different Z heights
+            # (e.g. same wall type on two different floor levels).
             projs_a = [v.dot(_cam_look) for v in verts_a]
             projs_b = [v.dot(_cam_look) for v in verts_b]
             range_a = (min(projs_a), max(projs_a))
             range_b = (min(projs_b), max(projs_b))
             overlap = min(range_a[1], range_b[1]) - max(range_a[0], range_b[0])
-            same_plane = overlap > tol
-            adjacency_cache[key] = same_plane
-            return same_plane
+            same_depth = overlap > tol
+            if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} depth range_a={tuple(round(x,3) for x in range_a)} range_b={tuple(round(x,3) for x in range_b)} overlap={overlap:.4f} -> {'PASS' if same_depth else 'FAIL'}")
+            adjacency_cache[key] = same_depth
+            return same_depth
 
         def parse_line(d):
             # Format is "Mx0,y0 Lx1,y1" (no space after M/L)
@@ -1897,6 +1921,15 @@ class CreateDrawing(bpy.types.Operator):
             if kind == "h":
                 return ((lo, coord), (hi, coord))
             return ((coord, lo), (coord, hi))
+
+        def ivs_equal(a, b):
+            """True if two interval lists are equal within TOL."""
+            if len(a) != len(b):
+                return False
+            return all(
+                abs(a_lo - b_lo) <= TOL and abs(a_hi - b_hi) <= TOL
+                for (a_lo, a_hi), (b_lo, b_hi) in zip(a, b)
+            )
 
         # Group projection <g> elements by their immediate parent
         parent_to_groups = {}
@@ -2076,12 +2109,17 @@ class CreateDrawing(bpy.types.Operator):
                 for j, (grp_j, mat_j, face_j, style_j, segs_j, guid_j) in enumerate(group_data):
                     if j <= i:
                         continue
+                    _wp = guid_i[:12] in _dg and guid_j[:12] in _dg
                     if not mat_keys_match(mat_i, mat_j, face_i, face_j):
+                        if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} SKIP mat mat_i={mat_i} mat_j={mat_j} face_i={face_i} face_j={face_j}")
                         continue
                     if style_j != style_i:
+                        if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} SKIP style style_i={style_i} style_j={style_j}")
                         continue
                     if not are_coplanar_and_adjacent(guid_i, guid_j):
+                        if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} SKIP coplanar")
                         continue
+                    if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} JOINED — segs_i={len(segs_i)} segs_j={len(segs_j)}")
                     matched = 0
 
                     # Group each element's segments by axis-aligned line.
@@ -2105,6 +2143,12 @@ class CreateDrawing(bpy.types.Operator):
                     lines_i = group_by_line(segs_i)
                     lines_j = group_by_line(segs_j)
 
+                    # Track whether bilateral found shared keys but skipped them
+                    # due to offset overlap.  If so, both elements have explicit
+                    # segments at the shared line — the unilateral fallback must
+                    # not run for this pair (it would remove the same boundary
+                    # segments that bilateral correctly rejected).
+                    _bilateral_had_explicit_keys = False
                     for key in set(lines_i) & set(lines_j):
                         entry_i = lines_i[key]
                         entry_j = lines_j[key]
@@ -2113,6 +2157,18 @@ class CreateDrawing(bpy.types.Operator):
                         shared = ivs_intersect(union_i, union_j)
                         if not shared:
                             continue
+                        _bilateral_had_explicit_keys = True
+                        # Only remove when the shared portion covers the full union
+                        # of at least one element on this line.  An offset partial
+                        # overlap — where two back-to-back walls happen to have
+                        # segments on the same line but at different running-direction
+                        # positions — would cover neither element's full union and
+                        # must not be removed (the line between them is a real
+                        # architectural boundary).
+                        if not (ivs_equal(shared, union_i) or ivs_equal(shared, union_j)):
+                            if _wp: print(f"[DBG] SKIP offset-overlap key={key} shared={shared} union_i={union_i} union_j={union_j}")
+                            continue
+                        if _wp: print(f"[DBG] MATCHED key={key} shared={shared} union_i={union_i} union_j={union_j}")
                         matched += len(shared)
                         kind = key[0]
                         coord = entry_i["coord"]
@@ -2131,16 +2187,18 @@ class CreateDrawing(bpy.types.Operator):
                     # (not explicitly drawn as a path segment), segments from the other
                     # element that lie on the boundary of that element's SVG bbox are
                     # still on the shared face and should be removed.
-                    if matched == 0 and segs_i and segs_j:
+                    if matched == 0 and not _bilateral_had_explicit_keys and segs_i and segs_j:
                         bbox_i = segs_bbox(segs_i)
                         bbox_j = segs_bbox(segs_j)
                         if bbox_i and bbox_j:
                             for path_j, line_j in segs_j:
                                 if seg_on_boundary_of(line_j, bbox_i, bbox_j):
+                                    if _wp: print(f"[DBG] UNILATERAL j->i seg={line_j}")
                                     to_remove.add(id(path_j))
                                     matched += 1
                             for path_i, line_i in segs_i:
                                 if seg_on_boundary_of(line_i, bbox_j, bbox_i):
+                                    if _wp: print(f"[DBG] UNILATERAL i->j seg={line_i}")
                                     to_remove.add(id(path_i))
                                     matched += 1
 

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1645,9 +1645,6 @@ class CreateDrawing(bpy.types.Operator):
         # local Z axis in world space points downward, the camera looks upward.
         camera_looks_up = self.camera.matrix_world.col[2].z < 0
 
-        # GUIDs of pairs under investigation (first 12 chars used as key)
-        _dg = {"39Iwvbn41B7O", "08yv0FO$j2Aw", "1dM2d4kqjFH8", "2lwj_pzhrADf", "2NR8CMK21CwO", "0XMcotQ9nDsx"}
-
         obj_cache = {}
 
         def get_obj(guid):
@@ -1670,11 +1667,9 @@ class CreateDrawing(bpy.types.Operator):
             key = (min(guid_a, guid_b), max(guid_a, guid_b))
             if key in adjacency_cache:
                 return adjacency_cache[key]
-            _dbg = guid_a[:12] in _dg and guid_b[:12] in _dg
             obj_a = get_obj(guid_a)
             obj_b = get_obj(guid_b)
             if obj_a is None or obj_b is None or obj_a.type != "MESH" or obj_b.type != "MESH":
-                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS (no mesh)")
                 adjacency_cache[key] = True
                 return True
             # Quick AABB guard
@@ -1686,11 +1681,9 @@ class CreateDrawing(bpy.types.Operator):
                 min_b = min(c[axis] for c in corners_b)
                 max_b = max(c[axis] for c in corners_b)
                 if min_a > max_b + tol:
-                    if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL aabb axis={axis}")
                     adjacency_cache[key] = False
                     return False
                 if min_b > max_a + tol:
-                    if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL aabb axis={axis}")
                     adjacency_cache[key] = False
                     return False
             # Proximity check: vertex-to-vertex OR vertex-to-edge.
@@ -1725,10 +1718,8 @@ class CreateDrawing(bpy.types.Operator):
                 # Slower vertex-on-edge check for containment cases
                 has_shared = vertex_near_edges(verts_b, obj_a, tol_sq) or vertex_near_edges(verts_a, obj_b, tol_sq)
             if not has_shared:
-                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL proximity")
                 adjacency_cache[key] = False
                 return False
-            if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS proximity")
             # Containment check: if one AABB fully contains the other, the
             # dominant-normal test is unreliable (a flat inner element's largest
             # face is its top/bottom, not its side face). Skip normal check.
@@ -1741,11 +1732,9 @@ class CreateDrawing(bpy.types.Operator):
                 return True
 
             if aabb_contains(corners_a, corners_b):
-                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS contained (b inside a)")
                 adjacency_cache[key] = "contained_b"
                 return "contained_b"
             if aabb_contains(corners_b, corners_a):
-                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS contained (a inside b)")
                 adjacency_cache[key] = "contained_a"
                 return "contained_a"
             # Coplanarity check: use the largest-face normal for each object.
@@ -1760,13 +1749,10 @@ class CreateDrawing(bpy.types.Operator):
             n_a = dominant_world_normal(obj_a)
             n_b = dominant_world_normal(obj_b)
             if n_a is None or n_b is None:
-                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} PASS (no normal)")
                 adjacency_cache[key] = True
                 return True
             dot = abs(n_a.dot(n_b))
-            if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} n_a={tuple(round(x,3) for x in n_a)} n_b={tuple(round(x,3) for x in n_b)} dot={dot:.6f}")
             if dot <= 1.0 - 3.8e-5:  # ~0.5° tolerance
-                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL normal dot={dot:.6f}")
                 adjacency_cache[key] = False
                 return False
             # Face-plane check: parallel normals don't guarantee the elements are
@@ -1778,9 +1764,7 @@ class CreateDrawing(bpy.types.Operator):
             plane_pos_a = {round(v.dot(n_a), 5) for v in verts_a}
             plane_pos_b = {round(v.dot(n_a), 5) for v in verts_b}
             same_plane = any(abs(pa - pb) < tol for pa in plane_pos_a for pb in plane_pos_b)
-            if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} plane_pos_a={sorted(plane_pos_a)} plane_pos_b={sorted(plane_pos_b)} same_plane={same_plane}")
             if not same_plane:
-                if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} FAIL face-plane")
                 adjacency_cache[key] = False
                 return False
             # Depth check: confirm both elements span the same camera depth range.
@@ -1792,9 +1776,18 @@ class CreateDrawing(bpy.types.Operator):
             range_b = (min(projs_b), max(projs_b))
             overlap = min(range_a[1], range_b[1]) - max(range_a[0], range_b[0])
             same_depth = overlap > tol
-            if _dbg: print(f"[DBG] COPL {guid_a[:12]}/{guid_b[:12]} depth range_a={tuple(round(x,3) for x in range_a)} range_b={tuple(round(x,3) for x in range_b)} overlap={overlap:.4f} -> {'PASS' if same_depth else 'FAIL'}")
-            adjacency_cache[key] = same_depth
-            return same_depth
+            if not same_depth:
+                adjacency_cache[key] = False
+                return False
+            # Distinguish elements on the exact same surface (identical layer plane
+            # positions) from elements on adjacent parallel surfaces (sharing only
+            # one plane position at their interface).  Same-surface pairs may have
+            # offset SVG segments that are still a genuine shared interface;
+            # adjacent-surface pairs need the ivs_equal guard to avoid removing
+            # boundary lines between offset walls meeting at a corner.
+            coplanar_result = "same_surface" if plane_pos_a == plane_pos_b else True
+            adjacency_cache[key] = coplanar_result
+            return coplanar_result
 
         def parse_line(d):
             # Format is "Mx0,y0 Lx1,y1" (no space after M/L)
@@ -2112,21 +2105,17 @@ class CreateDrawing(bpy.types.Operator):
                 for j, (grp_j, mat_j, face_j, style_j, segs_j, guid_j) in enumerate(group_data):
                     if j <= i:
                         continue
-                    _wp = guid_i[:12] in _dg and guid_j[:12] in _dg
                     if not mat_keys_match(mat_i, mat_j, face_i, face_j):
-                        if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} SKIP mat mat_i={mat_i} mat_j={mat_j} face_i={face_i} face_j={face_j}")
                         continue
                     if style_j != style_i:
-                        if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} SKIP style style_i={style_i} style_j={style_j}")
                         continue
                     _copl_result = are_coplanar_and_adjacent(guid_i, guid_j)
                     if not _copl_result:
-                        if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} SKIP coplanar")
                         continue
-                    if _wp: print(f"[DBG] PAIR {guid_i[:12]}/{guid_j[:12]} JOINED — segs_i={len(segs_i)} segs_j={len(segs_j)}")
                     matched = 0
 
                     _is_contained = _copl_result in ("contained_a", "contained_b")
+                    _is_same_surface = (_copl_result == "same_surface")
 
                     # Group each element's segments by axis-aligned line.
                     # All segments on the same line (within TOL) are merged into a
@@ -2149,17 +2138,6 @@ class CreateDrawing(bpy.types.Operator):
                     lines_i = group_by_line(segs_i)
                     lines_j = group_by_line(segs_j)
 
-                    if _is_contained and _wp:
-                        print(f"[DBG] CONTAINED keys_i={sorted(lines_i)} keys_j={sorted(lines_j)}")
-                        print(f"[DBG] CONTAINED bbox_i={segs_bbox(segs_i)} bbox_j={segs_bbox(segs_j)}")
-                        for _k in sorted(set(lines_i) & set(lines_j)):
-                            _ui = ivs_union(lines_i[_k]["ivs"])
-                            _uj = ivs_union(lines_j[_k]["ivs"])
-                            print(f"[DBG] SHARED key={_k} union_i={_ui} union_j={_uj} intersect={ivs_intersect(_ui, _uj)}")
-                        for _k in sorted(set(lines_i) - set(lines_j)):
-                            _ui = ivs_union(lines_i[_k]["ivs"])
-                            print(f"[DBG] ONLY-I  key={_k} union_i={_ui}")
-
                     # Track whether bilateral found shared keys but skipped them
                     # due to offset overlap.  If so, both elements have explicit
                     # segments at the shared line — the unilateral fallback must
@@ -2179,10 +2157,8 @@ class CreateDrawing(bpy.types.Operator):
                         # skipped: a partial overlap between an outer element's long
                         # edge and a physically-contained inner element's short edge
                         # is still a genuine shared interface, not an offset-wall case.
-                        if not _is_contained and not (ivs_equal(shared, union_i) or ivs_equal(shared, union_j)):
-                            if _wp: print(f"[DBG] SKIP offset-overlap key={key} shared={shared} union_i={union_i} union_j={union_j}")
+                        if not _is_contained and not _is_same_surface and not (ivs_equal(shared, union_i) or ivs_equal(shared, union_j)):
                             continue
-                        if _wp: print(f"[DBG] MATCHED key={key} shared={shared} union_i={union_i} union_j={union_j}")
                         matched += len(shared)
                         kind = key[0]
                         coord = entry_i["coord"]
@@ -2209,12 +2185,10 @@ class CreateDrawing(bpy.types.Operator):
                         if bbox_i and bbox_j:
                             for path_j, line_j in segs_j:
                                 if seg_on_boundary_of(line_j, bbox_i, bbox_j):
-                                    if _wp: print(f"[DBG] UNILATERAL j->i seg={line_j}")
                                     to_remove.add(id(path_j))
                                     matched += 1
                             for path_i, line_i in segs_i:
                                 if seg_on_boundary_of(line_i, bbox_j, bbox_i):
-                                    if _wp: print(f"[DBG] UNILATERAL i->j seg={line_i}")
                                     to_remove.add(id(path_i))
                                     matched += 1
 

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1668,22 +1668,15 @@ class CreateDrawing(bpy.types.Operator):
             # Quick AABB guard
             corners_a = [obj_a.matrix_world @ Vector(c) for c in obj_a.bound_box]
             corners_b = [obj_b.matrix_world @ Vector(c) for c in obj_b.bound_box]
-            _verbose = {"3S7QeSPVn3EB3T9TkDUy1e", "0YyL6RtCL8axn6AG9ItFhs"} == {guid_a, guid_b}
             for axis in range(3):
                 min_a = min(c[axis] for c in corners_a)
                 max_a = max(c[axis] for c in corners_a)
                 min_b = min(c[axis] for c in corners_b)
                 max_b = max(c[axis] for c in corners_b)
-                if _verbose:
-                    print(f"[TARGET PAIR] axis={axis} {guid_a}=[{min_a:.4f},{max_a:.4f}] {guid_b}=[{min_b:.4f},{max_b:.4f}]")
                 if min_a > max_b + tol:
-                    if _verbose:
-                        print(f"[TARGET PAIR] AABB separated on axis {axis} (min_a={min_a:.4f} > max_b={max_b:.4f})")
                     adjacency_cache[key] = False
                     return False
                 if min_b > max_a + tol:
-                    if _verbose:
-                        print(f"[TARGET PAIR] AABB separated on axis {axis} (min_b={min_b:.4f} > max_a={max_a:.4f})")
                     adjacency_cache[key] = False
                     return False
             # Proximity check: vertex-to-vertex OR vertex-to-edge.
@@ -1714,17 +1707,9 @@ class CreateDrawing(bpy.types.Operator):
             verts_b = [obj_b.matrix_world @ v.co for v in obj_b.data.vertices]
             # Fast vertex-vertex check first
             has_shared = any((va - vb).length_squared < tol_sq for va in verts_a for vb in verts_b)
-            if _verbose and not has_shared:
-                # Find closest vertex pair for diagnostic output
-                closest = min(((va - vb).length, ia, ib) for ia, va in enumerate(verts_a) for ib, vb in enumerate(verts_b))
-                print(f"[TARGET PAIR] no v-v match, closest vertex gap={closest[0]:.6f}m")
             if not has_shared:
                 # Slower vertex-on-edge check for containment cases
                 has_shared = vertex_near_edges(verts_b, obj_a, tol_sq) or vertex_near_edges(verts_a, obj_b, tol_sq)
-                if _verbose:
-                    print(f"[TARGET PAIR] vertex-on-edge result={has_shared}")
-            if _verbose:
-                print(f"[TARGET PAIR] proximity_check={has_shared}")
             if not has_shared:
                 adjacency_cache[key] = False
                 return False
@@ -1740,8 +1725,6 @@ class CreateDrawing(bpy.types.Operator):
                 return True
 
             if aabb_contains(corners_a, corners_b) or aabb_contains(corners_b, corners_a):
-                if _verbose:
-                    print(f"[TARGET PAIR] AABB containment detected, skipping normal check")
                 adjacency_cache[key] = True
                 return True
             # Coplanarity check: use the largest-face normal for each object.
@@ -1760,8 +1743,6 @@ class CreateDrawing(bpy.types.Operator):
                 return True
             dot = abs(n_a.dot(n_b))
             if dot <= 1.0 - 1e-3:
-                if _verbose:
-                    print(f"[TARGET PAIR] normal_dot={dot:.6f} coplanar=False (not parallel)")
                 adjacency_cache[key] = False
                 return False
             # Normals are parallel — also verify the elements share a face plane.
@@ -1772,8 +1753,6 @@ class CreateDrawing(bpy.types.Operator):
             plane_pos_a = {round(v.dot(n_a), 5) for v in verts_a}
             plane_pos_b = {round(v.dot(n_a), 5) for v in verts_b}
             same_plane = any(abs(pa - pb) < tol for pa in plane_pos_a for pb in plane_pos_b)
-            if _verbose:
-                print(f"[TARGET PAIR] normal_dot={dot:.6f} plane_pos_a={sorted(plane_pos_a)} plane_pos_b={sorted(plane_pos_b)} same_plane={same_plane}")
             adjacency_cache[key] = same_plane
             return same_plane
 
@@ -1876,11 +1855,54 @@ class CreateDrawing(bpy.types.Operator):
                 continue
 
             def get_material_key(guid):
+                """Return an ordered tuple of material IDs for comparison.
+
+                For elements with IfcMaterialLayerSetUsage (walls, slabs), use
+                the ordered layer material IDs — this ignores extra materials
+                assigned via surface styles or other mechanisms that don't affect
+                the visible cross-section. The tuple is normalised so that
+                reversed layer sequences (same assembly, opposite orientation)
+                compare equal.
+
+                Falls back to a sorted tuple of all material IDs for elements
+                that don't use a layer set.
+                """
                 element = self.get_element_by_guid(guid)
                 if element is None:
                     return None
+                material = ifcopenshell.util.element.get_material(element)
+                if material is not None:
+                    layer_set = None
+                    if material.is_a("IfcMaterialLayerSetUsage"):
+                        layer_set = material.ForLayerSet
+                    elif material.is_a("IfcMaterialLayerSet"):
+                        layer_set = material
+                    if layer_set is not None:
+                        return tuple(
+                            layer.Material.id()
+                            for layer in layer_set.MaterialLayers
+                            if layer.Material is not None
+                        )
                 mats = ifcopenshell.util.element.get_materials(element)
                 return tuple(sorted(m.id() for m in mats)) if mats else ()
+
+            def mat_keys_match(a, b):
+                """True if two ordered layer-material tuples represent compatible assemblies.
+
+                Compatible means the visible cross-section at the shared face is
+                the same material.  Four cases are accepted:
+                  - Exact match (identical layer sequences).
+                  - Reversed match (same assembly in opposite orientation).
+                  - Suffix match: one sequence ends with all layers of the other
+                    (the larger assembly has extra layers on the far side).
+                  - Prefix match: one sequence starts with all layers of the other
+                    (extra layers on the near side).
+                """
+                if a == b or a == b[::-1]:
+                    return True
+                short, long_ = (a, b) if len(a) <= len(b) else (b, a)
+                n = len(short)
+                return long_[-n:] == short or long_[:n] == short
 
             def get_style_key(guid):
                 """IDs of IfcPresentationStyles directly on the element's geometry items."""
@@ -1916,24 +1938,16 @@ class CreateDrawing(bpy.types.Operator):
                 for j, (grp_j, mat_j, style_j, segs_j, guid_j) in enumerate(group_data):
                     if j <= i:
                         continue
-                    _target = {"0QpDRRuif0R80d4CYPEQ$L", "0YyL6RtCL8axn6AG9ItFhs"} == {guid_i, guid_j}
-                    if mat_j != mat_i:
-                        if _target:
-                            print(f"[TARGET PAIR] SKIPPED: different mat {mat_i!r} vs {mat_j!r}")
+                    if not mat_keys_match(mat_i, mat_j):
                         continue
                     if style_j != style_i:
-                        if _target:
-                            print(f"[TARGET PAIR] SKIPPED: different style {style_i!r} vs {style_j!r}")
                         continue
-                    adj = are_coplanar_and_adjacent(guid_i, guid_j)
-                    if not adj:
+                    if not are_coplanar_and_adjacent(guid_i, guid_j):
                         continue
                     matched = 0
                     for path_i, line_i in segs_i:
                         for path_j, line_j in segs_j:
                             if lines_match(line_i, line_j):
-                                if _target:
-                                    print(f"[TARGET PAIR] MATCH: {line_i} == {line_j}")
                                 to_remove.add(id(path_i))
                                 to_remove.add(id(path_j))
                                 matched += 1
@@ -1947,29 +1961,13 @@ class CreateDrawing(bpy.types.Operator):
                         if bbox_i and bbox_j:
                             for path_j, line_j in segs_j:
                                 if seg_on_boundary_of(line_j, bbox_i):
-                                    if _target:
-                                        print(f"[TARGET PAIR] UNILATERAL j-on-i: {line_j}")
                                     to_remove.add(id(path_j))
                                     matched += 1
                             for path_i, line_i in segs_i:
                                 if seg_on_boundary_of(line_i, bbox_j):
-                                    if _target:
-                                        print(f"[TARGET PAIR] UNILATERAL i-on-j: {line_i}")
                                     to_remove.add(id(path_i))
                                     matched += 1
-                    if _target:
-                        print(f"[TARGET PAIR] adj=True, matched={matched} segment pair(s)")
-                        if matched == 0:
-                            print(f"[TARGET PAIR] segs_i ({guid_i}, {len(segs_i)} segs):")
-                            for _, li in segs_i:
-                                print(f"  {li}")
-                            print(f"[TARGET PAIR] segs_j ({guid_j}, {len(segs_j)} segs):")
-                            for _, lj in segs_j:
-                                print(f"  {lj}")
-                    elif matched:
-                        print(f"[MERGED] {guid_i} vs {guid_j}: {matched} segment(s) removed")
 
-            print(f"[COPLANAR DEBUG] Total paths to remove: {len(to_remove)}")
             if to_remove:
                 for grp, mat, style, segs, guid in group_data:
                     for path_el, _ in segs:

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1005,14 +1005,16 @@ class CreateDrawing(bpy.types.Operator):
             if self.cprops.generate_material_layers:
                 self.generate_material_layers(context, root)
             self.merge_linework_and_add_metadata(root)
-            self.remove_coplanar_boundary_lines(root)
+            if self.cprops.generate_material_layers and self.cprops.join_coplanar_surfaces:
+                self.remove_coplanar_boundary_lines(root)
             self.move_elements_to_top(root)
         elif self.cprops.cut_mode == "OPENCASCADE":
             self.move_projection_to_bottom(root)
             if self.cprops.generate_material_layers:
                 self.generate_material_layers(context, root)
             self.merge_linework_and_add_metadata(root)
-            self.remove_coplanar_boundary_lines(root)
+            if self.cprops.generate_material_layers and self.cprops.join_coplanar_surfaces:
+                self.remove_coplanar_boundary_lines(root)
             self.move_elements_to_top(root)
 
         if self.cprops.fill_mode == "SHAPELY":

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -500,6 +500,11 @@ class BIMCameraProperties(PropertyGroup):
     generate_material_layers: bpy.props.BoolProperty(
         name="Generate Material Layers", description="Generate material layer linework in drawings", default=True
     )
+    join_coplanar_surfaces: bpy.props.BoolProperty(
+        name="Join Coplanar Surfaces",
+        description="Remove shared boundary lines between adjacent coplanar elements of the same material",
+        default=False,
+    )
     fill_mode: EnumProperty(
         items=[
             ("NONE", "None", "Disable filling areas seen in projection"),

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -104,6 +104,10 @@ class BIM_PT_camera(Panel):
         row.prop(props, "linework_mode")
         row = self.layout.row()
         row.prop(props, "generate_material_layers")
+        if props.generate_material_layers:
+            row = self.layout.row()
+            row.separator(factor=1.0)
+            row.prop(props, "join_coplanar_surfaces")
         if props.linework_mode == "OPENCASCADE":
             row = self.layout.row()
             row.prop(props, "fill_mode")


### PR DESCRIPTION
…erial elements in Bonsai SVG drawings

Adds `remove_coplanar_boundary_lines()` to operator.py (Bonsai uses this path, not draw.py's main()). After `merge_linework_and_add_metadata()` assigns material CSS classes, this post-processes the SVG to delete projection line segments that appear in two or more adjacent, coplanar elements with the same material and presentation style.

Key design decisions:
- Material identity: compared via sorted IFC material ID tuples from `get_materials()`, not CSS class names — avoids false matches between unrelated `material-null` elements.
- Presentation style identity: compared via IFC IfcPresentationStyle IDs from `StyledByItem` on geometry representation items — handles elements with no material but distinct visual styles.
- Physical adjacency: confirmed by a 3D shared-vertex test (tol=0.01 m) after a quick AABB guard, rejecting elements whose 2D projections overlap but sit at different depths.
- Coplanarity: determined by the dominant (largest-area) face normal of each Blender mesh object — area-weighted averages are unreliable for slabs whose equal top/bottom faces cancel out. Folded walls sharing an edge but meeting at an angle are correctly rejected (normal dot ≪ 1.0).