### PR TITLE
fix(ifctester): add setuptools to venv pip install for Python 3.12+ compatibility

### DIFF
--- a/src/ifctester/Makefile
+++ b/src/ifctester/Makefile
@@ -100,7 +100,7 @@ else
 	$(SED) 's/version = "0.0.0"/version = "$(VERSION)a$(VERSION_DATE)"/' $(WEBAPP_IFCTESTER_BUILD_DIR)/pyproject.toml
 	$(SED) 's/version = "0.0.0"/version = "$(VERSION)-alpha$(VERSION_DATE)"/' $(WEBAPP_IFCTESTER_BUILD_DIR)/$(PACKAGE_NAME)/__init__.py
 endif
-	cd $(WEBAPP_IFCTESTER_BUILD_DIR) && $(PYTHON) -m venv env --system-site-packages && . env/$(VENV_ACTIVATE) && python -m pip install build && python -m build --wheel --no-isolation
+	cd $(WEBAPP_IFCTESTER_BUILD_DIR) && $(PYTHON) -m venv env --system-site-packages && . env/$(VENV_ACTIVATE) && python -m pip install build setuptools && python -m build --wheel --no-isolation
 	mkdir -p $(WEBAPP_GENERATED_DIR)
 	wheel=$$(basename $(WEBAPP_IFCTESTER_BUILD_DIR)/dist/$(PACKAGE_NAME)-*.whl); \
 	cp "$(WEBAPP_IFCTESTER_BUILD_DIR)/dist/$$wheel" "$(WEBAPP_GENERATED_DIR)/$$wheel"; \


### PR DESCRIPTION
The `webapp-stage-ifctester-wheel` target in `src/ifctester/Makefile` fails when building with Python 3.12 or 3.13:

```
ERROR Backend 'setuptools.build_meta' is not available.
make[1]: *** [Makefile:98: webapp-stage-ifctester-wheel] Error 1
make: *** [Makefile:138: dist] Error 2
```

Python 3.12 changed the behaviour of `python -m venv`: new virtual environments no longer include `setuptools` by default ([PEP 668](https://peps.python.org/pep-0668/), [CPython issue #95299](https://github.com/python/cpython/issues/95299)).

The target uses `--no-isolation`, meaning `python -m build` expects the `setuptools.build_meta` backend to already be present in the venv. On Python 3.11 this works because `--system-site-packages` inherits `setuptools` from the system interpreter. On Python 3.12+ the system interpreter no longer ships `setuptools` by default in venvs either, so the backend is simply absent.

## Fix

Explicitly install `setuptools` alongside `build` in the venv setup step.

```diff
-python -m pip install build && python -m build --wheel --no-isolation
+python -m pip install build setuptools && python -m build --wheel --no-isolation
```
