### PR TITLE
Fix: SVG Depth Ordering for Projections and Material Fills (Fix #7902)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -749,12 +749,11 @@ class CreateDrawing(bpy.types.Operator):
                 verts = [tuple(obj.matrix_world @ v.co) for v in bm_fill.verts]
                 edges = [[v.index for v in e.verts] for e in bm_fill.edges]
 
-                g = etree.SubElement(root, "{http://www.w3.org/2000/svg}g")
+                g = etree.Element("{http://www.w3.org/2000/svg}g")
                 g.attrib["{http://www.ifcopenshell.org/ns}guid"] = element.GlobalId
                 g.attrib["{http://www.ifcopenshell.org/ns}name"] = element.Name or ""
                 g.attrib["{http://www.ifcopenshell.org/ns}layer-id"] = str(layer.id())
 
-                lines = []
                 for edge in edges:
                     start = [o for o in (camera_matrix_i @ Vector(verts[edge[0]])).xy]
                     end = [o for o in (camera_matrix_i @ Vector(verts[edge[1]])).xy]
@@ -765,7 +764,7 @@ class CreateDrawing(bpy.types.Operator):
                     d = "M{}".format(d[1:])
                     path = etree.SubElement(g, "{http://www.w3.org/2000/svg}path")
                     path.attrib["d"] = d
-                group.append(g)
+                el.addprevious(g)
 
             bm.free()
 
@@ -1646,9 +1645,9 @@ class CreateDrawing(bpy.types.Operator):
         projections = root.xpath(
             ".//svg:g[contains(@class, 'projection')]", namespaces={"svg": "http://www.w3.org/2000/svg"}
         )
-        for projection in projections:
+        for i, projection in enumerate(projections):
             projection.getparent().remove(projection)
-            group.insert(0, projection)
+            group.insert(i, projection)
 
     def move_elements_to_top(self, root):
         group = root.find("{http://www.w3.org/2000/svg}g")


### PR DESCRIPTION
Fixes #7902

This PR addresses two critical Z-depth sorting bugs in the Bonsai drawing pipeline that caused projection lines to disappear behind material fills or background objects.

### Changes:
1. **Preserved Inter-Projection Depth Sorting**: `move_projection_to_bottom` previously pushed all projections to absolute index 0 sequentially, which effectively **reversed** the background-to-foreground sorting order originally established by `IfcConvert`. By using `enumerate(projections)` and inserting at `i`, the intended depth sorting is perfectly maintained.
2. 2. **Fixed Fill vs. Outline Occlusion**: `generate_material_layers` previously appended the solid grey cut fills to the absolute end of the SVG group. In standard SVG drawing order, this forced fills to render on top of both the projection lines AND the thick foreground cut outlines. The logic now leverages `el.addprevious(g)` to strictly insert the material fill intimately beneath its corresponding cut outline group.
These changes ensure all deck joists, low walls, and overlapping elements render correctly without losing their visual boundaries to hatch occlusion.