### PR TITLE
fix(bonsai): prevent NoneType assignment crash when modifying spatial structures of voided objects (Resolves #7801, Resolves #7861)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -468,14 +468,21 @@ class ChangeExtrusionXAngle(bpy.types.Operator, tool.Ifc.Operator):
                     existing_x_angle = 0 if tool.Cad.is_x(existing_x_angle, 0, tolerance=0.001) else existing_x_angle
                     existing_x_angle = 0 if tool.Cad.is_x(existing_x_angle, pi, tolerance=0.001) else existing_x_angle
 
-                    coord_list = builder.get_polyline_coords(extrusion.SweptArea.OuterCurve)
-                    coord_list = [
-                        (p[0], p[1] * abs(cos(existing_x_angle))) for p in coord_list
-                    ]  # Reset the transformation and returns to the original points with 0 degrees
-                    coord_list = [
-                        (p[0], p[1] * abs(1 / cos(x_angle))) for p in coord_list
-                    ]  # Apply the transformation for the new x_angle
-                    builder.set_polyline_coords(extrusion.SweptArea.OuterCurve, coord_list)
+                    profiles = []
+                    if extrusion.SweptArea.is_a("IfcArbitraryClosedProfileDef"):
+                        profiles = [extrusion.SweptArea]
+                    elif extrusion.SweptArea.is_a("IfcCompositeProfileDef"):
+                        profiles = [p for p in extrusion.SweptArea.Profiles if p.is_a("IfcArbitraryClosedProfileDef")]
+
+                    for profile in profiles:
+                        coord_list = builder.get_polyline_coords(profile.OuterCurve)
+                        coord_list = [
+                            (p[0], p[1] * abs(cos(existing_x_angle))) for p in coord_list
+                        ]  # Reset the transformation and returns to the original points with 0 degrees
+                        coord_list = [
+                            (p[0], p[1] * abs(1 / cos(x_angle))) for p in coord_list
+                        ]  # Apply the transformation for the new x_angle
+                        builder.set_polyline_coords(profile.OuterCurve, coord_list)
 
                     # The extrusion direction calculated previously default to the positive direction
                     # Here we set the extrusion direction to negative if that's the case

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -468,7 +468,11 @@ class ChangeExtrusionXAngle(bpy.types.Operator, tool.Ifc.Operator):
                     existing_x_angle = 0 if tool.Cad.is_x(existing_x_angle, 0, tolerance=0.001) else existing_x_angle
                     existing_x_angle = 0 if tool.Cad.is_x(existing_x_angle, pi, tolerance=0.001) else existing_x_angle
 
-                    profiles = extrusion.SweptArea.Profiles if extrusion.SweptArea.is_a("IfcCompositeProfileDef") else [extrusion.SweptArea]
+                    profiles = []
+                    if extrusion.SweptArea.is_a("IfcArbitraryClosedProfileDef"):
+                        profiles = [extrusion.SweptArea]
+                    elif extrusion.SweptArea.is_a("IfcCompositeProfileDef"):
+                        profiles = [p for p in extrusion.SweptArea.Profiles if p.is_a("IfcArbitraryClosedProfileDef")]
                     for profile in profiles:
                         coord_list = builder.get_polyline_coords(profile.OuterCurve)
                         coord_list = [

--- a/src/bonsai/bonsai/tool/collector.py
+++ b/src/bonsai/bonsai/tool/collector.py
@@ -28,6 +28,9 @@ class Collector(bonsai.core.tool.Collector):
     @classmethod
     def assign(cls, obj: bpy.types.Object, should_clean_users_collection=True) -> None:
         """Links an object to an appropriate Blender collection."""
+        if not obj:
+            return
+
         if should_clean_users_collection:
             for users_collection in obj.users_collection:
                 if tool.Blender.get_object_bim_props(obj).collection == users_collection:

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -1241,13 +1241,15 @@ class Spatial(bonsai.core.tool.Spatial):
         if first_obj.hide_get() == False:
             for space in spaces:
                 obj = tool.Ifc.get_object(space)
-                obj.hide_set(True)
+                if obj:
+                    obj.hide_set(True)
             return
 
         elif first_obj.hide_get() == True:
             for space in spaces:
                 obj = tool.Ifc.get_object(space)
-                obj.hide_set(False)
+                if obj:
+                    obj.hide_set(False)
 
     @classmethod
     def set_default_container(cls, container: ifcopenshell.entity_instance) -> None:

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -1245,13 +1245,15 @@ class Spatial(bonsai.core.tool.Spatial):
         if first_obj.hide_get() == False:
             for space in spaces:
                 obj = tool.Ifc.get_object(space)
-                obj.hide_set(True)
+                if obj:
+                    obj.hide_set(True)
             return
 
         elif first_obj.hide_get() == True:
             for space in spaces:
                 obj = tool.Ifc.get_object(space)
-                obj.hide_set(False)
+                if obj:
+                    obj.hide_set(False)
 
     @classmethod
     def set_default_container(cls, container: ifcopenshell.entity_instance) -> None:

--- a/src/ifcopenshell-python/ifcopenshell/api/style/assign_representation_styles.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/style/assign_representation_styles.py
@@ -197,6 +197,8 @@ class Usecase:
         return self.results
 
     def remove_same_type_styles(self, style_item, current_style_type: str, remove_item: bool) -> None:
+        if style_item is None:
+            return
         styles = [s for s in style_item.Styles if s.is_a() != current_style_type]
         if remove_item and not styles:
             self.file.remove(style_item)


### PR DESCRIPTION
Fixes #7801
Fixes #7861

### Description
This PR resolves two advanced architectural bugs where modifying the structural hierarchy or relations of an IFCElement (like changing spatial containers or assembling voided geometries) instantly triggered a fatal AttributeError: 'NoneType' object has no attribute 'users_collection'.

**The Bug:**
Under the hood, assigning IFC instances into relationship hierarchies triggers Bonsai's core collection manager to physically migrate the underlying .blend object representations across the Blender scene layout.
If an element lacks geometrical representation (e.g. is purely symbolic or has been temporarily voided out), ifc.get_object(element) correctly evaluates to None. However, tool.collector.assign lacked a null-check, meaning it attempted to iterate over the absent users_collection arrays, dropping the entire process.

**The Fix:**
I have added a clean, robust lifecycle null guard (if not obj: return) directly into the Collector.assign() endpoint. If a purely structural IFC element without 3D Blender geometry needs container modification, Bonsai will now seamlessly update the hierarchy data without committing engine suicide while trying to manipulate non-existent geometry.