### PR TITLE
Repair IfcClash order

### DIFF
--- a/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
+++ b/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
@@ -1102,7 +1102,7 @@ namespace IfcGeom {
                                 clash intersection = test_intersection(task.b, task.a, tolerance, check_all);
                                 if (intersection.clash_type != -1) {
                                     //We invert the result, in order to keep the initial order, otherwise, it's all mixed.
-                                    result = {intersection.clash_type,intersection.b,intersection.a,intersection.distance,intersection.p1,intersection.p2}
+                                    result = {intersection.clash_type,intersection.b,intersection.a,intersection.distance,intersection.p2,intersection.p1}
 
                                     // Replace the clash result if any of these criteria apply:
                                     // - We don't have a clash yet

--- a/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
+++ b/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
@@ -1101,6 +1101,9 @@ namespace IfcGeom {
                                 is_manifold = true;
                                 clash intersection = test_intersection(task.b, task.a, tolerance, check_all);
                                 if (intersection.clash_type != -1) {
+                                    //We invert the result, in order to keep the initial order, otherwise, it's all mixed.
+                                    result = {intersection.clash_type,intersection.b,intersection.a,intersection.distance,intersection.p1,intersection.p2}
+
                                     // Replace the clash result if any of these criteria apply:
                                     // - We don't have a clash yet
                                     // - Our previous clash is piercing, and our new one is a protrusion


### PR DESCRIPTION
The result of IfcClash is coming inverted, only for intersection.
So i re-invert the result of intersection to produce a coherent result.

The p1 and p2 need to be inverted as well;