### PR TITLE
Concatenate selections

### DIFF
--- a/src/bonsai/bonsai/bim/module/aggregate/operator.py
+++ b/src/bonsai/bonsai/bim/module/aggregate/operator.py
@@ -407,13 +407,18 @@ class BIM_OT_select_linked_aggregates(bpy.types.Operator):
     bl_label = "Select linked aggregates"
     bl_options = {"REGISTER", "UNDO"}
     select_parts: bpy.props.BoolProperty(default=False)
+    should_unhide: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
 
     @classmethod
     def description(cls, context, properties):
         if properties.select_parts:
-            return "Select all aggregates, subaggregates and all their parts"
+            return "Select all aggregates, subaggregates and all their parts\n\nALT+Click to also unhide hidden objects (viewport and local hide)"
         else:
-            return "Select all aggregates"
+            return "Select all aggregates\n\nALT+Click to also unhide hidden objects (viewport and local hide)"
+
+    def invoke(self, context, event):
+        self.should_unhide = event.alt
+        return self.execute(context)
 
     def execute(self, context):
         for obj in context.selected_objects:
@@ -446,11 +451,18 @@ class BIM_OT_select_linked_aggregates(bpy.types.Operator):
                     for element in parts_objs:
                         obj = tool.Ifc.get_object(element)
                         if obj:
+                            if self.should_unhide:
+                                obj.hide_viewport = False
+                                obj.hide_set(False)
                             obj.select_set(True)
                 else:
                     for element in parts:
                         obj = tool.Ifc.get_object(element)
-                        obj.select_set(True)
+                        if obj:
+                            if self.should_unhide:
+                                obj.hide_viewport = False
+                                obj.hide_set(False)
+                            obj.select_set(True)
 
         return {"FINISHED"}
 

--- a/src/bonsai/bonsai/bim/module/aggregate/operator.py
+++ b/src/bonsai/bonsai/bim/module/aggregate/operator.py
@@ -282,18 +282,20 @@ class BIM_OT_select_aggregate(bpy.types.Operator):
         return self.execute(context)
 
     def execute(self, context):
-        all_parts = []
+        aggregates = {}
         for obj in context.selected_objects:
             element = tool.Ifc.get_entity(obj)
             if element:
                 aggregate = ifcopenshell.util.element.get_aggregate(element)
                 if aggregate:
-                    all_parts.append(aggregate)
+                    aggregates[aggregate.id()] = aggregate
                     obj.select_set(False)
                 else:
                     pass
             if not element:
                 obj.select_set(False)
+
+        all_parts = list(aggregates.values())
 
         if self.select_parts:
             selected_parts = []

--- a/src/bonsai/bonsai/bim/module/aggregate/operator.py
+++ b/src/bonsai/bonsai/bim/module/aggregate/operator.py
@@ -266,17 +266,19 @@ class BIM_OT_select_aggregate(bpy.types.Operator):
     one_level_deep: bpy.props.BoolProperty(
         name="One Level Deep", description="Select only immediate children, not recursively", default=False
     )
+    should_unhide: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
 
     @classmethod
     def description(cls, context, properties):
         if properties.select_parts:
-            return "Select Aggregate and Parts.\n\nCtrl+click to select only one level deep"
+            return "Select Aggregate and Parts.\n\nCtrl+click to select only one level deep\nALT+Click to also unhide hidden objects (viewport and local hide)"
         else:
-            return "Select Aggregate"
+            return "Select Aggregate\n\nALT+Click to also unhide hidden objects (viewport and local hide)"
 
     def invoke(self, context, event):
         if event.type == "LEFTMOUSE" and event.ctrl:
             self.one_level_deep = True
+        self.should_unhide = event.alt
         return self.execute(context)
 
     def execute(self, context):
@@ -317,12 +319,18 @@ class BIM_OT_select_aggregate(bpy.types.Operator):
             for element in set(selected_parts + all_parts):
                 obj = tool.Ifc.get_object(element)
                 if obj:
+                    if self.should_unhide:
+                        obj.hide_viewport = False
+                        obj.hide_set(False)
                     obj.select_set(True)
 
         else:
             for aggregate_element in all_parts:
                 aggregate_obj = tool.Ifc.get_object(aggregate_element)
                 if aggregate_obj:
+                    if self.should_unhide:
+                        aggregate_obj.hide_viewport = False
+                        aggregate_obj.hide_set(False)
                     aggregate_obj.select_set(True)
                     bpy.context.view_layer.objects.active = aggregate_obj
 

--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -71,19 +71,97 @@ class SelectByMaterial(bpy.types.Operator):
         return self.execute(context)
 
     def execute(self, context):
-        material = tool.Ifc.get().by_id(self.material)
-        core.select_by_material(tool.Material, tool.Spatial, material=material, should_unhide=self.should_unhide)
+        # Determine the layer index hint from the explicit material prop, if any.
+        # When the user clicks a specific layer in the UI, self.material is that
+        # layer's IfcMaterial. We find its index so we can pull the same layer
+        # from every other selected object's layer set.
+        layer_index = None
+        if self.material:
+            ref_mat = tool.Ifc.get().by_id(self.material)
+            layer_index = self._get_layer_index(ref_mat)
 
-        # copy selection query to clipboard
-        if material.is_a("IfcMaterialLayerSet"):
-            material_name = material.LayerSetName
-        else:
-            material_name = material.Name
-        result = f'material="{material_name}"'
+        materials = {}
+        for obj in context.selected_objects:
+            element = tool.Ifc.get_entity(obj)
+            if not element:
+                continue
+            mat = ifcopenshell.util.element.get_material(element)
+            if not mat:
+                continue
+
+            resolved = self._resolve_material(mat, layer_index)
+            if resolved:
+                materials[resolved.id()] = resolved
+
+        # Fall back to the explicit material prop if selection yields nothing
+        if not materials and self.material:
+            materials = {self.material: tool.Ifc.get().by_id(self.material)}
+
+        if not materials:
+            return {"FINISHED"}
+
+        for mat in materials.values():
+            core.select_by_material(tool.Material, tool.Spatial, material=mat, should_unhide=self.should_unhide)
+
+        result = " + ".join(f'material = "{self._get_name(m)}"' for m in materials.values())
         bpy.context.window_manager.clipboard = result
         self.report({"INFO"}, f"({result}) was copied to the clipboard.")
 
         return {"FINISHED"}
+
+    def _get_layer_index(self, material):
+        """Return the 0-based layer index if material is an IfcMaterial inside a layer set."""
+        if not material.is_a("IfcMaterial"):
+            return None
+        ifc = tool.Ifc.get()
+        for layer in ifc.get_inverse(material):
+            if not layer.is_a("IfcMaterialLayer"):
+                continue
+            for layer_set in ifc.get_inverse(layer):
+                if not layer_set.is_a("IfcMaterialLayerSet"):
+                    continue
+                layers = list(layer_set.MaterialLayers)
+                if layer in layers:
+                    return layers.index(layer)
+        return None
+
+    def _resolve_material(self, mat, layer_index):
+        """Resolve an assigned material to the specific entity to select/name by.
+
+        When layer_index is set, drills into the layer set and returns the
+        IfcMaterial at that index (or None if the set has fewer layers).
+        Otherwise returns the layer set / profile set / constituent set itself.
+        """
+        if mat.is_a("IfcMaterialLayerSetUsage"):
+            mat = mat.ForLayerSet
+        elif mat.is_a("IfcMaterialProfileSetUsage"):
+            mat = mat.ForProfileSet
+
+        if layer_index is not None and mat.is_a("IfcMaterialLayerSet"):
+            layers = list(mat.MaterialLayers)
+            if layer_index < len(layers):
+                return layers[layer_index].Material
+            return None
+
+        return mat
+
+    def _get_name(self, material):
+        if material.is_a("IfcMaterialLayerSet"):
+            if material.LayerSetName:
+                return material.LayerSetName
+            names = [l.Material.Name for l in (material.MaterialLayers or []) if l.Material and l.Material.Name]
+            return ", ".join(names) if names else material.is_a()
+        if material.is_a("IfcMaterialProfileSet"):
+            if material.Name:
+                return material.Name
+            names = [p.Material.Name for p in (material.MaterialProfiles or []) if p.Material and p.Material.Name]
+            return ", ".join(names) if names else material.is_a()
+        if material.is_a("IfcMaterialConstituentSet"):
+            if material.Name:
+                return material.Name
+            names = [c.Material.Name for c in (material.MaterialConstituents or []) if c.Material and c.Material.Name]
+            return ", ".join(names) if names else material.is_a()
+        return getattr(material, "Name", None) or material.is_a()
 
 
 class EnableEditingMaterial(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -61,13 +61,18 @@ class DisableEditingMaterials(bpy.types.Operator):
 class SelectByMaterial(bpy.types.Operator):
     bl_idname = "bim.select_by_material"
     bl_label = "Select By Material"
-    bl_description = "Select objects using the provided material"
+    bl_description = "Select objects using the provided material\n\nALT+Click to also unhide hidden objects (viewport and local hide)"
     bl_options = {"REGISTER", "UNDO"}
     material: bpy.props.IntProperty()
+    should_unhide: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
+
+    def invoke(self, context, event):
+        self.should_unhide = event.alt
+        return self.execute(context)
 
     def execute(self, context):
         material = tool.Ifc.get().by_id(self.material)
-        core.select_by_material(tool.Material, tool.Spatial, material=material)
+        core.select_by_material(tool.Material, tool.Spatial, material=material, should_unhide=self.should_unhide)
 
         # copy selection query to clipboard
         if material.is_a("IfcMaterialLayerSet"):

--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -1264,15 +1264,17 @@ class SelectGlobalId(Operator):
 
 
 class SelectIfcClass(Operator):
-    """Click to select all objects that match with the given IFC class\nSHIFT + Click to also match Predefined Type"""
+    """Click to select all objects that match with the given IFC class\nSHIFT + Click to also match Predefined Type\nALT + Click to also unhide hidden objects (viewport and local hide)"""
 
     bl_idname = "bim.select_ifc_class"
     bl_label = "Select IFC Class"
     bl_options = {"REGISTER", "UNDO"}
     should_filter_predefined_type: BoolProperty(default=False)
+    should_unhide: BoolProperty(default=False)
 
     def invoke(self, context, event):
         self.should_filter_predefined_type = event.shift
+        self.should_unhide = event.alt
         return self.execute(context)
 
     def execute(self, context):
@@ -1292,6 +1294,9 @@ class SelectIfcClass(Operator):
                 ):
                     continue
                 if obj := tool.Ifc.get_object(element):
+                    if self.should_unhide:
+                        obj.hide_viewport = False
+                        obj.hide_set(False)
                     tool.Blender.select_object(obj)
 
             # copy selection query to clipboard

--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -1456,10 +1456,11 @@ class SelectSimilar(Operator):
     )
     calculated_sum: bpy.props.FloatProperty(name="Calculated Sum", default=0.0)
     remove_from_selection: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
+    should_unhide: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
 
     @classmethod
     def description(cls, context, properties):
-        base = "Select objects with a similar value\n\n" "SHIFT+CLICK remove from selection set."
+        base = "Select objects with a similar value\n\nSHIFT+CLICK remove from selection set.\nALT+CLICK also unhide hidden objects (viewport and local hide)."
 
         key = getattr(properties, "key", None)
         active = context.active_object
@@ -1486,6 +1487,7 @@ class SelectSimilar(Operator):
     def invoke(self, context, event):
         self.calculate_sum = event.ctrl and event.type == "LEFTMOUSE"
         self.remove_from_selection = event.shift and event.type == "LEFTMOUSE"
+        self.should_unhide = event.alt
         return self.execute(context)
 
     def execute(self, context):
@@ -1543,11 +1545,15 @@ class SelectSimilar(Operator):
 
     def _select_objects(self, context, key, reference_values, tolerance):
         count = 0
-        for obj in context.visible_objects:
+        objects = context.scene.objects if self.should_unhide else context.visible_objects
+        for obj in objects:
             obj_value = self._get_value(obj, key)
             if obj_value is None:
                 continue
             if any(self._compare_values(obj_value, ref_value, tolerance) for ref_value in reference_values):
+                if self.should_unhide:
+                    obj.hide_viewport = False
+                    obj.hide_set(False)
                 obj.select_set(not self.remove_from_selection)
                 count += 1
         return count

--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -1285,7 +1285,6 @@ class SelectIfcClass(Operator):
             if element := tool.Ifc.get_entity(obj):
                 classes.add(element.is_a())
                 predefined_types.add(ifcopenshell.util.element.get_predefined_type(element))
-        result = ""
         for cls in classes:
             for element in tool.Ifc.get().by_type(cls):
                 if (
@@ -1299,13 +1298,10 @@ class SelectIfcClass(Operator):
                         obj.hide_set(False)
                     tool.Blender.select_object(obj)
 
-            # copy selection query to clipboard
-            if not result:
-                result = f"{cls}"
-            else:
-                result += f", {cls}"
-            bpy.context.window_manager.clipboard = result
-            self.report({"INFO"}, f"({result}) was copied to the clipboard.")
+        # copy selection query to clipboard
+        result = " + ".join(classes)
+        bpy.context.window_manager.clipboard = result
+        self.report({"INFO"}, f"({result}) was copied to the clipboard.")
 
         return {"FINISHED"}
 

--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -1519,7 +1519,7 @@ class SelectSimilar(Operator):
                     f"{verb} all objects that share the same ({self.key}) value(s) from {len(reference_values)} reference object(s).",
                 )
 
-            self._generate_clipboard_query(reference_values[0] if reference_values else None, key)
+            self._generate_clipboard_query(reference_values, key)
 
         return {"FINISHED"}
 
@@ -1568,17 +1568,22 @@ class SelectSimilar(Operator):
         bpy.context.window_manager.clipboard = str(total)
         self.report({"INFO"}, f"({total}) was copied to the clipboard.")
 
-    def _generate_clipboard_query(self, value, key):
+    def _generate_clipboard_query(self, values, key):
         key = "PredefinedType" if key == "predefined_type" else key
-        if value is True:
-            value = "TRUE"
-        elif value is False:
-            value = "FALSE"
+        if not values:
+            return
 
-        if isinstance(value, list) and value:
-            result = ", ".join(f'{key} = "{item}"' for item in value)
-        else:
-            result = f'{key} = "{value}"'
+        def format_value(value):
+            if value is True:
+                return f'{key} = "TRUE"'
+            elif value is False:
+                return f'{key} = "FALSE"'
+            elif isinstance(value, list) and value:
+                return ", ".join(f'{key} = "{item}"' for item in value)
+            else:
+                return f'{key} = "{value}"'
+
+        result = " + ".join(format_value(v) for v in values)
 
         bpy.context.window_manager.clipboard = result
         self.report({"INFO"}, f"({result}) was copied to the clipboard.")

--- a/src/bonsai/bonsai/bim/module/spatial/operator.py
+++ b/src/bonsai/bonsai/bim/module/spatial/operator.py
@@ -299,19 +299,33 @@ class SelectSimilarContainer(bpy.types.Operator):
 
     def execute(self, context):
         if self.container:
-            container = tool.Ifc.get().by_id(self.container)
-        elif element := tool.Ifc.get_entity(context.active_object):
-            container = ifcopenshell.util.element.get_container(element)
+            # Called from container manager panel with explicit container
+            ifc_container = tool.Ifc.get().by_id(self.container)
+            containers = {ifc_container.id(): ifc_container} if ifc_container else {}
         else:
+            # Called from 3D viewport — derive containers from all selected objects
+            containers = {}
+            for obj in context.selected_objects or [context.active_object]:
+                element = tool.Ifc.get_entity(obj)
+                if not element:
+                    continue
+                container = tool.Spatial.get_container(element)
+                if container:
+                    containers[container.id()] = container
+
+        if not containers:
             return {"CANCELLED"}
-        if not container:
-            return {"CANCELLED"}
-        core.select_similar_container(
-            tool.Spatial,
-            container=container,
-            is_recursive=self.is_recursive,
-            should_unhide=self.should_unhide,
-        )
+
+        for container in containers.values():
+            tool.Spatial.select_products(
+                tool.Spatial.get_decomposed_elements(container, self.is_recursive),
+                unhide=self.should_unhide,
+            )
+
+        result = " + ".join(f'location = "{c.Name}"' for c in containers.values())
+        bpy.context.window_manager.clipboard = result
+        self.report({"INFO"}, f"({result}) was copied to the clipboard.")
+
         self.is_recursive = True  # <-- forcibly reset
         return {"FINISHED"}
 

--- a/src/bonsai/bonsai/bim/module/spatial/operator.py
+++ b/src/bonsai/bonsai/bim/module/spatial/operator.py
@@ -428,24 +428,29 @@ class SelectDecomposedElements(bpy.types.Operator):
     should_filter: bpy.props.BoolProperty(name="Should Filter", default=True, options={"SKIP_SAVE"})
     container: bpy.props.IntProperty()
     is_recursive: bpy.props.BoolProperty(default=True, options={"SKIP_SAVE"})
+    should_unhide: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
 
     @classmethod
     def description(cls, context, operator):
         return (
             "Select the active item"
-            + "\nALT+CLICK to select all listed elements.\nCTRL + CLICK to select only one level deep"
+            + "\nSHIFT+CLICK to select all listed elements.\nCTRL+CLICK to select only one level deep"
+            + "\nALT+CLICK to also unhide hidden objects (viewport and local hide)"
         )
 
     def invoke(self, context, event):
         if event.type == "LEFTMOUSE":
-            if event.alt:
+            if event.shift:
                 self.should_filter = False
             if event.ctrl:
                 self.is_recursive = False
+            self.should_unhide = event.alt
         return self.execute(context)
 
     def execute(self, context):
-        tool.Spatial.select_products(tool.Spatial.get_filtered_elements(self.should_filter, self.is_recursive))
+        tool.Spatial.select_products(
+            tool.Spatial.get_filtered_elements(self.should_filter, self.is_recursive), unhide=self.should_unhide
+        )
 
         # Make selected active element in list, the active object
         props = tool.Spatial.get_spatial_props()

--- a/src/bonsai/bonsai/bim/module/spatial/operator.py
+++ b/src/bonsai/bonsai/bim/module/spatial/operator.py
@@ -533,6 +533,11 @@ class SetContainerVisibility(bpy.types.Operator):
             if obj := tool.Ifc.get_object(container):
                 if collection := tool.Blender.get_object_bim_props(obj).collection:
                     collection.hide_viewport = should_hide
+            if not should_hide:
+                for element in tool.Spatial.get_decomposed_elements(container, is_recursive=False):
+                    if element_obj := tool.Ifc.get_object(element):
+                        element_obj.hide_viewport = False
+                        element_obj.hide_set(False)
             if self.should_include_children:
                 queue.extend(ifcopenshell.util.element.get_parts(container))
         return {"FINISHED"}

--- a/src/bonsai/bonsai/bim/module/spatial/operator.py
+++ b/src/bonsai/bonsai/bim/module/spatial/operator.py
@@ -287,6 +287,7 @@ class SelectSimilarContainer(bpy.types.Operator):
     bl_description = "Recursively selects all objects in the container.\n\nCtrl+click to select only one level deep\nAlt+click to also unhide hidden objects (viewport and local hide)"
     bl_options = {"REGISTER", "UNDO"}
 
+    container: bpy.props.IntProperty(default=0)
     is_recursive: bpy.props.BoolProperty(default=True)
     should_unhide: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
 
@@ -297,10 +298,17 @@ class SelectSimilarContainer(bpy.types.Operator):
         return self.execute(context)
 
     def execute(self, context):
+        if self.container:
+            container = tool.Ifc.get().by_id(self.container)
+        elif element := tool.Ifc.get_entity(context.active_object):
+            container = ifcopenshell.util.element.get_container(element)
+        else:
+            return {"CANCELLED"}
+        if not container:
+            return {"CANCELLED"}
         core.select_similar_container(
-            tool.Ifc,
             tool.Spatial,
-            obj=context.active_object,
+            container=container,
             is_recursive=self.is_recursive,
             should_unhide=self.should_unhide,
         )

--- a/src/bonsai/bonsai/bim/module/spatial/operator.py
+++ b/src/bonsai/bonsai/bim/module/spatial/operator.py
@@ -284,14 +284,16 @@ class SelectContainer(bpy.types.Operator):
 class SelectSimilarContainer(bpy.types.Operator):
     bl_idname = "bim.select_similar_container"
     bl_label = "Select Similar Container"
-    bl_description = "Recurvisevly selects all objects in the container.\n\nCtrl+click to select only one level deep"
+    bl_description = "Recursively selects all objects in the container.\n\nCtrl+click to select only one level deep\nAlt+click to also unhide hidden objects (viewport and local hide)"
     bl_options = {"REGISTER", "UNDO"}
 
     is_recursive: bpy.props.BoolProperty(default=True)
+    should_unhide: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
 
     def invoke(self, context, event):
         if event.type == "LEFTMOUSE" and event.ctrl:
             self.is_recursive = False
+        self.should_unhide = event.alt
         return self.execute(context)
 
     def execute(self, context):
@@ -300,6 +302,7 @@ class SelectSimilarContainer(bpy.types.Operator):
             tool.Spatial,
             obj=context.active_object,
             is_recursive=self.is_recursive,
+            should_unhide=self.should_unhide,
         )
         self.is_recursive = True  # <-- forcibly reset
         return {"FINISHED"}

--- a/src/bonsai/bonsai/bim/module/spatial/ui.py
+++ b/src/bonsai/bonsai/bim/module/spatial/ui.py
@@ -139,7 +139,7 @@ class BIM_PT_spatial_decomposition(Panel):
             op = col.operator("bim.set_default_container", icon="OUTLINER_COLLECTION", text="Set Default")
             op.container = ifc_definition_id
 
-            if tool.Blender.get_addon_preferences().container_hide_show_isolate:
+            if tool.Blender.get_addon_preferences().show_container_tools:
                 op = row.operator("bim.set_container_visibility", icon="FULLSCREEN_EXIT", text="")
                 op.mode = "ISOLATE"
                 op.container = ifc_definition_id
@@ -152,7 +152,10 @@ class BIM_PT_spatial_decomposition(Panel):
 
             # The only operator that's enabled for IfcProject.
             col = row.column(align=True)
-            col.operator("bim.select_container", icon="OBJECT_DATA", text="").container = ifc_definition_id
+            row_ = col.row(align=True)
+            row_.operator("bim.select_container", icon="OBJECT_DATA", text="").container = ifc_definition_id
+            if tool.Blender.get_addon_preferences().show_container_tools:
+                row_.operator("bim.select_similar_container", icon="RESTRICT_SELECT_OFF", text="").container = ifc_definition_id
 
             col = row.column(align=True)
             op = col.operator("bim.delete_container", icon="X", text="")

--- a/src/bonsai/bonsai/bim/module/type/operator.py
+++ b/src/bonsai/bonsai/bim/module/type/operator.py
@@ -221,10 +221,17 @@ class SelectType(bpy.types.Operator):
 
 
 class SelectSimilarType(bpy.types.Operator):
+    """Select Similar Type\nALT+Click to also unhide hidden objects (viewport and local hide)"""
+
     bl_idname = "bim.select_similar_type"
     bl_label = "Select Similar Type"
     bl_options = {"REGISTER", "UNDO"}
     related_object: bpy.props.StringProperty()
+    should_unhide: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
+
+    def invoke(self, context, event):
+        self.should_unhide = event.alt
+        return self.execute(context)
 
     def execute(self, context):
         self.file = tool.Ifc.get()
@@ -246,7 +253,10 @@ class SelectSimilarType(bpy.types.Operator):
 
             for element in related_objects:
                 obj = tool.Ifc.get_object(element)
-                if obj and obj in context.visible_objects:
+                if obj and (self.should_unhide or obj in context.visible_objects):
+                    if self.should_unhide:
+                        obj.hide_viewport = False
+                        obj.hide_set(False)
                     obj.select_set(True)
 
             # copy selection query to clipboard

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -714,9 +714,9 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         description="Default parameters for BIM elements",
     )
 
-    container_hide_show_isolate: BoolProperty(
-        name="Container hide/show/isolate",
-        description="Enable container hide/show/isolate feature in the UI",
+    show_container_tools: BoolProperty(
+        name="Show Container Tools (Select, Hide, Show, Isolate)",
+        description="Enable container select, hide/show/isolate tools in the UI",
         default=False,
     )
 
@@ -786,7 +786,7 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         pset_dir: str
         doc: DocPreferences
         default_parameters: DefaultParameters
-        container_hide_show_isolate: bool
+        show_container_tools: bool
         chain_filter_with_set_operations: bool
         save_metadata_blend_file: bool
         metadata_blend_file_suffix: str
@@ -984,7 +984,7 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         layout.prop(self, "bsdd_baseurl")
 
     def draw_extras_settings(self, layout: bpy.types.UILayout, context: bpy.types.Context) -> None:
-        layout.prop(self, "container_hide_show_isolate")
+        layout.prop(self, "show_container_tools")
         row = layout.row(align=True)
         row.prop(self, "chain_filter_with_set_operations")
         row.operator("bim.open_uri", text="", icon="HELP").uri = "https://community.osarch.org/discussion/3270"

--- a/src/bonsai/bonsai/core/material.py
+++ b/src/bonsai/bonsai/core/material.py
@@ -82,9 +82,12 @@ def disable_editing_materials(material: type[tool.Material]) -> None:
 
 
 def select_by_material(
-    material_tool: type[tool.Material], spatial: type[tool.Spatial], material: ifcopenshell.entity_instance
+    material_tool: type[tool.Material],
+    spatial: type[tool.Spatial],
+    material: ifcopenshell.entity_instance,
+    should_unhide: bool = False,
 ) -> None:
-    spatial.select_products(material_tool.get_elements_by_material(material))
+    spatial.select_products(material_tool.get_elements_by_material(material), unhide=should_unhide)
 
 
 def enable_editing_material(material_tool: type[tool.Material], material: ifcopenshell.entity_instance) -> None:

--- a/src/bonsai/bonsai/core/spatial.py
+++ b/src/bonsai/bonsai/core/spatial.py
@@ -124,10 +124,13 @@ def select_similar_container(
     spatial: type[tool.Spatial],
     obj: bpy.types.Object,
     is_recursive: bool = True,
+    should_unhide: bool = False,
 ) -> None:
     element = ifc.get_entity(obj)
     if element:
-        spatial.select_products(spatial.get_decomposed_elements(spatial.get_container(element), is_recursive))
+        spatial.select_products(
+            spatial.get_decomposed_elements(spatial.get_container(element), is_recursive), unhide=should_unhide
+        )
 
 
 def select_product(spatial: type[tool.Spatial], product: ifcopenshell.entity_instance) -> None:

--- a/src/bonsai/bonsai/core/spatial.py
+++ b/src/bonsai/bonsai/core/spatial.py
@@ -120,17 +120,12 @@ def select_container(
 
 
 def select_similar_container(
-    ifc: type[tool.Ifc],
     spatial: type[tool.Spatial],
-    obj: bpy.types.Object,
+    container: ifcopenshell.entity_instance,
     is_recursive: bool = True,
     should_unhide: bool = False,
 ) -> None:
-    element = ifc.get_entity(obj)
-    if element:
-        spatial.select_products(
-            spatial.get_decomposed_elements(spatial.get_container(element), is_recursive), unhide=should_unhide
-        )
+    spatial.select_products(spatial.get_decomposed_elements(container, is_recursive), unhide=should_unhide)
 
 
 def select_product(spatial: type[tool.Spatial], product: ifcopenshell.entity_instance) -> None:

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -200,6 +200,7 @@ class Spatial(bonsai.core.tool.Spatial):
             obj = tool.Ifc.get_object(product)
             if obj and view_layer.objects.get(obj.name):
                 if unhide:
+                    obj.hide_viewport = False
                     obj.hide_set(False)
                 obj.select_set(True)
 


### PR DESCRIPTION

## Branch:  `Concatenate_selections`

### Overview

This branch standardizes how Bonsai's "select similar" operators handle multiple selected objects. Previously, most operators either used only the active/first object, ignored duplicates, or built clipboard queries inside loops (producing overwrites or single-item output). All affected operators now collect their relevant entities from the full selection, deduplicate by entity id, and write a single clipboard query joining all values with `+` — consistent with IFC selector query syntax.

----------

### `bim.select_similar`  —  search/operator.py

Previously only `reference_values[0]` was passed to `_generate_clipboard_query`, so only the first selected object's value appeared in the clipboard.

Now all reference values are passed and joined with `+`.

**Example:** Select two walls and click "Select Similar" on `GlobalId`:

```
# Before
GlobalId = "1BDpUFH1P7$8huSfztD7Kp"

# After
GlobalId = "1BDpUFH1P7$8huSfztD7Kp" + GlobalId = "2yrtTmJoD5gvf_wIjwsNxp"

```

----------

### `bim.select_ifc_class`  —  search/operator.py

The clipboard was set and reported inside the per-class loop, overwriting on each iteration. The separator was also `,` rather than `+`.

Now the clipboard is written once after the loop with `+` as the separator.

**Example:** Select an `IfcWall` and an `IfcSlab`, then click "Select IFC Class":

```
# Before (last iteration wins, reported twice)
IfcWall, IfcSlab

# After (written once)
IfcWall + IfcSlab

```

----------

### `bim.select_similar_container`  —  spatial/operator.py

Only `context.active_object`'s container was used. No clipboard output existed at all.

Now all selected objects are iterated, containers are deduplicated by entity id, elements from all containers are selected, and a clipboard query is generated.

**Example:** Select objects from Level 1 and Level 2, then click "Select Similar Container":

```
# Before
(no clipboard output, only active object's container used)

# After
location = "Level 1" + location = "Level 2"

```

----------

### `bim.select_aggregate`  —  aggregate/operator.py

When multiple parts of the same aggregate were selected, the aggregate was appended to a plain list multiple times, producing duplicate entries in the clipboard query.

Aggregates are now collected into a dict keyed by entity id before selection and query generation.

**Example:** Select three parts all belonging to the same `IfcElementAssembly "Truss-A"`:

```
# Before
parent = "Truss-A" + parent = "Truss-A" + parent = "Truss-A"

# After
parent = "Truss-A"

```

----------

### `bim.select_by_material`  —  material/operator.py

The most involved change. The operator only used the explicit `material` prop (a single material ID set by the UI button), with no awareness of other selected objects. Layer set usages were not resolved to specific layers.

Now the operator derives materials from all selected objects. When the clicked material is an `IfcMaterial` within a layer set, its layer index is detected and the corresponding layer material is pulled from each other selected object's layer set. Falls back to the explicit prop if selection yields nothing.

**Example 1 — simple materials:** Select a concrete wall and a steel column, click "Select By Material" on either:

```
# Before
material = "Concrete"

# After
material = "Concrete" + material = "Steel"

```

**Example 2 — layer sets:** Select two walls, click "Select By Material" on Layer 1 (the exterior CMU layer). Wall A has `[CMU, Air, GWB]`, Wall B has `[Brick, Air, GWB]`:

```
# Before
material = "IfcMaterialLayerSet"

# After
material = "CMU" + material = "Brick"

```

The layer index from the clicked material is used to look up the matching layer on every other selected object's layer set.