### PR TITLE
Fix #7948: Fix duplicate not applying openings to geometry

### DIFF
--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2374,6 +2374,25 @@ class Geometry(bonsai.core.tool.Geometry):
 
         # Recreate decompositions
         tool.Duplicate.recreate_decompositions(decomposition_relationships, old_to_new)
+
+        # Reload geometry for duplicated elements that have unfilled openings.
+        # copy_class (API) copies HasOpenings in IFC, but the mesh geometry is
+        # just a data-block copy of the original — switch_representation must be
+        # called so the opening boolean is actually computed for the new element.
+        for new_els in old_to_new.values():
+            for new_el in new_els:
+                has_openings = getattr(new_el, "HasOpenings", None)
+                if not has_openings:
+                    continue
+                # Only reload for openings that have no filling (filled openings
+                # are already handled by recreate_decompositions).
+                unfilled = [rel for rel in has_openings if not rel.RelatedOpeningElement.HasFillings]
+                if not unfilled:
+                    continue
+                new_obj_final = tool.Ifc.get_object(new_el)
+                if new_obj_final:
+                    tool.Model.reload_body_representation(new_obj_final)
+
         cls.remove_linked_aggregate_data(old_to_new)
         bonsai.bim.handler.refresh_ui_data()
         tool.Root.reload_grid_decorator()


### PR DESCRIPTION
## Fix #7948: Duplicated elements with  `HasOpenings`  don't show opening in geometry

### Problem

When duplicating an object (via `bim.override_object_duplicate_move_macro`) that has an applied `IfcOpeningElement` (i.e. the element has `HasOpenings`), the duplicate's Blender mesh does not visually show the opening cut. The opening exists correctly in the IFC data, but the geometry appears as if no opening was ever applied.

As a workaround, the user had to manually trigger three operators in sequence to force the geometry to update:

```python
bpy.ops.bim.show_openings()
bpy.ops.bim.update_openings_focus()
bpy.ops.bim.edit_openings(apply_all=True)

```

### Root Cause

The duplication path in `tool.Geometry.duplicate_ifc_objects` correctly calls `ifcopenshell.api.root.copy_class`, which — per its documented behaviour — copies `IfcRelVoidsElement` relationships into IFC. The new element therefore has valid `HasOpenings` data.

However, the Blender-side mesh is never regenerated for this case. The new object's mesh data is just a copied data-block from the original, with its `ifc_definition_id` repointed to the new representation. The `has_openings_applied` flag reads `True` (inherited from the copy), but the actual boolean subtraction geometry was never computed for the new element.

The existing `recreate_decompositions` logic in `tool.Root` handles the inverse case — elements that _fill_ a void (doors/windows) — by calling `switch_representation` on the voided host after re-creating the opening. But it does not handle the case where the _host element itself_ is the one being duplicated and already carries `HasOpenings`.

### Fix

After `recreate_decompositions` completes, iterate over all newly created elements. For any new element that has unfilled `HasOpenings` (openings without a filling — filled openings are already handled by `recreate_decompositions`), call `tool.Model.reload_body_representation()` on its Blender object. This is the same call that `bim.edit_openings` uses internally, and it triggers `switch_representation` so the IFC geometry engine recomputes the mesh with the opening boolean subtraction applied.

### Files Changed

-   src/bonsai/bonsai/tool/geometry.py  —  `duplicate_ifc_objects`: reload body representation for new elements with unfilled openings