### PR TITLE
Fix #7927: Fix SECTION annotation for MODEL_VIEW drawings

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1756,6 +1756,10 @@ class Drawing(bonsai.core.tool.Drawing):
             # For section/elevation views, elevate the segment vertically
             if not (points := helper.elevate_segment(bounds, [v1, v2])):
                 return
+        elif target_view == "MODEL_VIEW":
+            # For model views, clip to XY bounds and keep Z (3D line at true elevation)
+            if not (points := helper.clip_segment(bounds, [v1, v2])):
+                return
         else:
             return
 


### PR DESCRIPTION
generate_section_reference_points had no handler for MODEL_VIEW target view, causing it to silently return None. Add MODEL_VIEW branch that clips the section line to XY camera bounds while preserving the Z coordinate for correct 3D placement.

Generated with the assistance of an AI coding tool.