### PR TITLE
Fix #6652: Extend grab selection to include BBIM_Array members

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -4124,6 +4124,31 @@ class OverrideMoveSelect(bpy.types.Operator):
                 self.new_active_obj = obj
             return {"FINISHED"}
 
+        # Get arrays
+        ifc_file = tool.Ifc.get()
+        array_parents_to_move: list[bpy.types.Object] = []
+        for obj in list(context.selected_objects):
+            element = tool.Ifc.get_entity(obj)
+            if not element:
+                continue
+            pset = ifcopenshell.util.element.get_pset(element, "BBIM_Array")
+            if not pset:
+                continue
+            parent_element = ifc_file.by_guid(pset["Parent"])
+            parent_obj = tool.Ifc.get_object(parent_element)
+            if parent_obj not in array_parents_to_move:
+                array_parents_to_move.append(parent_obj)
+            if element.GlobalId != pset["Parent"]:
+                obj.select_set(False)
+
+        if array_parents_to_move:
+            for parent_obj in array_parents_to_move:
+                parent_element = tool.Ifc.get_entity(parent_obj)
+                for array_obj in tool.Array.get_all_objects(parent_element):
+                    array_obj.select_set(True)
+                self.new_active_obj = parent_obj
+            return {"FINISHED"}
+
         # Get nests
         props = tool.Nest.get_nest_props()
         not_editing_objs = [o.obj for o in props.not_editing_objects]


### PR DESCRIPTION
## Summary

When pressing **G** (grab/move) on any member of a `BBIM_Array`, Bonsai now automatically expands the selection to include the array parent and all its children before the move operator runs — matching the existing behavior for aggregates and nests.

Previously, grabbing an array child would move only that child, breaking the array's spatial relationship. Users had to manually select the full array before moving.

## How It Works

The fix is a single block added to `OverrideMoveSelect._execute` in geometry/operator.py, inserted between the existing aggregate and nest handling blocks. For each selected object:

1.  Check for a  `BBIM_Array`  pset.
2.  Resolve the array parent via  `pset["Parent"]`  (a GlobalId).
3.  If the selected object is a  **child**  (its GlobalId differs from  `pset["Parent"]`), deselect it.
4.  Expand selection to the full array — parent + all children — via  `tool.Blender.Modifier.Array.get_all_objects()`.
5.  Set the active object to the array parent.

Aggregates take priority over arrays (checked first), and arrays take priority over nests, consistent with the existing ordering.

## Test Plan

-   Select an array  **child**  and press G — full array (parent + all children) should be selected and move together.
-   Select the array  **parent**  and press G — same result.
-   Select multiple objects from  **different arrays**  and press G — each array should be fully selected.
-   Verify aggregate grab behavior is unchanged.
-   Verify nest grab behavior is unchanged.
-   Verify non-array, non-aggregate, non-nest objects move normally.

## Notes

This PR contains AI-generated code (the added block in `OverrideMoveSelect._execute`).