### PR TITLE
Fix #7969: Preserve local view on aggregate mode exit

### DIFF
--- a/src/bonsai/bonsai/bim/module/aggregate/prop.py
+++ b/src/bonsai/bonsai/bim/module/aggregate/prop.py
@@ -148,6 +148,10 @@ class BIMAggregateProperties(PropertyGroup):
         name="True if it was previously in aggregate mode",
         default=False,
     )
+    was_in_local_view: BoolProperty(
+        name="Was In Local View",
+        default=False,
+    )
 
     if TYPE_CHECKING:
         in_aggregate_mode: bool
@@ -157,3 +161,4 @@ class BIMAggregateProperties(PropertyGroup):
         not_editing_objects: bpy.types.bpy_prop_collection_idprop[Objects]
         aggregate_decorator: bool
         previous_state: bool
+        was_in_local_view: bool

--- a/src/bonsai/bonsai/tool/aggregate.py
+++ b/src/bonsai/bonsai/tool/aggregate.py
@@ -202,6 +202,7 @@ class Aggregate(bonsai.core.tool.Aggregate):
                     editing_obj = props.editing_objects.add()
                     editing_obj.obj = obj.original
 
+        props.was_in_local_view = bool(context.space_data and context.space_data.local_view)
         props.in_aggregate_mode = True
         return {"FINISHED"}
 
@@ -219,8 +220,9 @@ class Aggregate(bonsai.core.tool.Aggregate):
             if not element:
                 continue
 
-        if context.space_data.local_view:
+        if context.space_data.local_view and not props.was_in_local_view:
             bpy.ops.view3d.localview()
+        props.was_in_local_view = False
 
         props.in_aggregate_mode = False
         props.not_editing_objects.clear()


### PR DESCRIPTION
If local view was already active when aggregate mode was entered, disable_aggregate_mode no longer toggles it off. The pre-existing state is saved in was_in_local_view on BIMAggregateProperties and only cleared if local view was entered after aggregate mode began.

Generated with the assistance of an AI coding tool.