### PR TITLE
Ensuring that Entity name is a string

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -234,6 +234,7 @@ class Entity(Facet):
         if (
             not is_pass
             and inst.file.schema == "IFC2X3"
+            and isinstance(self.name, str)
             and not self.name.endswith("TYPE")
             and (element_type := ifcopenshell.util.element.get_type(inst))
         ):


### PR DESCRIPTION
Prevents from cheking ".endswith()" on a complex Restriction (enumeration ...)