### PR TITLE
Fix #7999: Fix isolate_objects context for select_all op

### DIFF
--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1964,14 +1964,12 @@ class Blender(bonsai.core.tool.Blender):
         override = cls.get_viewport_context()
         with bpy.context.temp_override(**override):
             bpy.ops.object.hide_view_clear(select=False)
-
-        bpy.ops.object.select_all(action="DESELECT")
+            bpy.ops.object.select_all(action="DESELECT")
         for obj in objs:
             obj.select_set(True)
         with bpy.context.temp_override(**override):
             bpy.ops.object.hide_view_set(unselected=True)
-
-        bpy.ops.object.select_all(action="DESELECT")
+            bpy.ops.object.select_all(action="DESELECT")
         for name in previously_selected:
             obj = bpy.data.objects.get(name)
             if obj:


### PR DESCRIPTION
bpy.ops.object.select_all requires a VIEW_3D context to pass its poll() check. The two calls were outside the existing temp_override blocks, causing a RuntimeError when the operator was invoked from a non-3D-view area (e.g. a properties panel). Moved both calls inside the adjacent temp_override blocks.

Generated with the assistance of an AI coding tool.