### PR TITLE
Fix for #7861 and #7801: Fix error in assign_container for unloaded e…

### DIFF
--- a/src/bonsai/bonsai/core/spatial.py
+++ b/src/bonsai/bonsai/core/spatial.py
@@ -67,7 +67,8 @@ def assign_container(
     if products := [e for e in root_elements if spatial.can_contain(container, root_element)]:
         ifc.run("spatial.assign_container", products=products, relating_structure=container)
     for element in all_elements:
-        collector.assign(ifc.get_object(element))
+        if obj := ifc.get_object(element):
+            collector.assign(obj)
 
 
 def enable_editing_container(spatial: type[tool.Spatial], obj: bpy.types.Object) -> None:


### PR DESCRIPTION
…lements

Decomposed elements collected via get_decomposition may not have a corresponding Blender object if they are not loaded into the scene. Guard against None before calling collector.assign.

Regression introduced in ff35666ad.

Generated with the assistance of an AI coding tool.