### PR TITLE
Fix #8024 - Fix TypeError when CardinalPoint is None

### DIFF
--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -630,7 +630,7 @@ class EditAssignedMaterial(bpy.types.Operator, tool.Ifc.Operator):
                     slab.DumbSlabPlaner().regenerate_from_layer_set(layer_set)
 
             if material_set_usage.is_a("IfcMaterialProfileSetUsage"):
-                if "CardinalPoint" in attributes:
+                if "CardinalPoint" in attributes and attributes["CardinalPoint"] is not None:
                     attributes["CardinalPoint"] = int(attributes["CardinalPoint"])
                 ifcopenshell.api.material.edit_profile_usage(
                     self.file,


### PR DESCRIPTION
Fix #8024 - Fix TypeError when CardinalPoint is None

Guard the int() cast on CardinalPoint in
BIM_OT_edit_assigned_material so a None value (no cardinal point set) no longer raises a TypeError.

Generated with the assistance of an AI coding tool.