### PR TITLE
Fix #8046 - Entity xs:restriction name crashes with AttributeError on…

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -234,6 +234,7 @@ class Entity(Facet):
         if (
             not is_pass
             and inst.file.schema == "IFC2X3"
+            and isinstance(self.name, str)
             and not self.name.endswith("TYPE")
             and (element_type := ifcopenshell.util.element.get_type(inst))
         ):

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -240,6 +240,23 @@ class TestEntity:
         wall3 = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall", predefined_type="BAZFOO")
         run("Restrictions an be specified for the predefined type 3/3", facet=facet, inst=wall3, expected=False)
 
+        restriction = Restriction(options={"enumeration": ["IFCWALL"]})
+        facet = Entity(name=restriction)
+        ifc = ifcopenshell.file(schema="IFC2X3")
+        run(
+            "Restriction entity names do not crash on IFC2X3 fail path 1/2",
+            facet=facet,
+            inst=ifc.createIfcWall(),
+            expected=True,
+        )
+        ifc = ifcopenshell.file(schema="IFC2X3")
+        run(
+            "Restriction entity names do not crash on IFC2X3 fail path 2/2",
+            facet=facet,
+            inst=ifc.createIfcColumn(),
+            expected=False,
+        )
+
     def test_ifc2x3_occurrence_type_mapping(self):
         set_facet("entity")
 


### PR DESCRIPTION
Fix #8046   - Entity xs:restriction name crashes with AttributeError on IFC2X3 fail path 

When an IDS entity requirement uses xs:restriction (e.g. an enumeration of entity names) and an IFC2X3 model element fails that requirement, Entity.__call__ entered the IFC2X3 type-inference block and called self.name.endswith("TYPE"), which raises AttributeError because self.name is a Restriction object, not a str. Fix by guarding the IFC2X3 block with isinstance(self.name, str), consistent with the existing guard in Entity.filter(). IFC2X3 type inference is intentionally skipped for Restriction names as filter() does the same and adds regression tests covering the IFC2X3 + Restriction pass and fail paths.