### PR TITLE
Fix assign_container  in spatial.py

### DIFF
--- a/src/bonsai/bonsai/core/spatial.py
+++ b/src/bonsai/bonsai/core/spatial.py
@@ -67,7 +67,8 @@ def assign_container(
     if products := [e for e in root_elements if spatial.can_contain(container, root_element)]:
         ifc.run("spatial.assign_container", products=products, relating_structure=container)
     for element in all_elements:
-        collector.assign(ifc.get_object(element))
+        if obj := ifc.get_object(element):
+            collector.assign(obj)
 
 
 def enable_editing_container(spatial: type[tool.Spatial], obj: bpy.types.Object) -> None:


### PR DESCRIPTION
ifc.get_object(element) can return None for IFC elements that aren't loaded as Blender objects (e.g., decomposed sub-elements).  The loop now skips those instead of passing None into collector.assign().

Cheers!