### PR TITLE
Fix closing edge for IfcPolyline in convert_curve_to_mesh

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -539,7 +539,7 @@ class Model(bonsai.core.tool.Model):
 
             cls.edges.extend([(i, i + 1) for i in range(offset, len(cls.vertices) - 1)])
             if is_closed:
-                cls.edges[-1] = (len(cls.vertices) - 1, offset)  # Close the loop
+                cls.edges.append((len(cls.vertices) - 1, offset))  # Close the loop
 
         elif curve.is_a("IfcCompositeCurve"):
             # This is a first pass incomplete implementation only for simple polylines, and misses many details.


### PR DESCRIPTION
Use append in the same way as in the IfcIndexedPolyCurve branch.
This fixes the error in IFC2x3 fro example if you create a slab with more than 5 vertices the IfcPolyline will fail to be closed

Cheers!
