### PR TITLE
Fix sign of temporary offset restore in sweep_along_curve

### DIFF
--- a/src/ifcgeom/kernels/opencascade/sweep_along_curve.cpp
+++ b/src/ifcgeom/kernels/opencascade/sweep_along_curve.cpp
@@ -300,7 +300,11 @@ bool OpenCascadeKernel::convert(const taxonomy::sweep_along_curve::ptr scs, Topo
 
 	if (applied_temporary_offset) {
         gp_Trsf trsf;
-        trsf.SetTranslation(gp_Vec(-mean.x(), -mean.y(), -mean.z()));
+        // Restore original position: add back the mean subtracted from the
+        // directrix points above. Previously negated, which placed the swept
+        // solid at -mean instead of its original location for geometry far
+        // from the origin.
+        trsf.SetTranslation(gp_Vec(mean.x(), mean.y(), mean.z()));
         result.Move(trsf);
     }
 


### PR DESCRIPTION
## Summary

Fixes the sign of the temporary-offset restore in `OpenCascadeKernel::convert(sweep_along_curve)`.

The temporary-offset workaround introduced in #7408 (commit `bd57cc8735`) subtracts the directrix centroid (`mean`) from the curve points so the sweep is built near the origin (OCCT is unstable for geometry far from origin). After building, it must translate the result **back** by `+mean` to restore the original position. The restore negated the sign:

```cpp
trsf.SetTranslation(gp_Vec(-mean.x(), -mean.y(), -mean.z()));  // before
trsf.SetTranslation(gp_Vec( mean.x(),  mean.y(),  mean.z()));  // after
```

`Move(-mean)` places the swept solid at `-mean` (mirrored through the origin) instead of its true location.

## Impact

The buggy branch only runs when:
- the directrix is a pure polyline (`is_polyhedron()`), and
- its centroid is more than 100 m from the origin (`mean.norm() > 1e2`).

So models centered near the origin are unaffected, which is why this went unnoticed. But IFC files that keep **absolute site coordinates** (common in Revit/ODA exports) render affected swept solids — reinforcing bars, pipes — at a mirrored phantom location hundreds of meters away from the rest of the model.

## Testing

Reproduced with a real reinforced-concrete beam IFC (rebar as `IfcSweptDiskSolid` with composite-curve directrixes, exported from Revit via ODA, absolute site coordinates):
- **Before:** 18 of 54 bars (the straight ones — polyline directrix) placed in a phantom cluster ~300 m from the other 36.
- **After:** all 54 bars co-located correctly.

Straight bars/stirrups hit the polyline branch; bent stirrups (whose directrix contains arc segments) are not `is_polyhedron()` and were already correct — consistent with the diagnosis.
