### PR TITLE
Fix remove_drawing crash on corrupted drawing

### DIFF
--- a/src/bonsai/bonsai/core/drawing.py
+++ b/src/bonsai/bonsai/core/drawing.py
@@ -412,16 +412,20 @@ def remove_drawing(
             drawing_tool.delete_object(reference_obj)
         ifc.run("root.remove_product", product=reference)
 
-    information = drawing_tool.get_reference_document(drawing_tool.get_drawing_document(drawing))
-    uri = ifc.resolve_uri(drawing_tool.get_document_uri(information))
-    if drawing_tool.does_file_exist(uri):
-        drawing_tool.delete_file(uri)
-    ifc.run("document.remove_information", information=information)
+    drawing_document = drawing_tool.get_drawing_document(drawing)
+    if drawing_document is not None:
+        information = drawing_tool.get_reference_document(drawing_document)
+        uri = ifc.resolve_uri(drawing_tool.get_document_uri(information))
+        if drawing_tool.does_file_exist(uri):
+            drawing_tool.delete_file(uri)
+        ifc.run("document.remove_information", information=information)
 
     group = drawing_tool.get_drawing_group(drawing)
     if group:
         drawing_tool.delete_drawing_elements(drawing_tool.get_group_elements(group))
         ifc.run("group.remove_group", group=group)
+    else:
+        drawing_tool.delete_drawing_elements([drawing])
 
     drawing_tool.import_drawings()
 

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2765,6 +2765,8 @@ class Drawing(bonsai.core.tool.Drawing):
     def get_sheet_references(cls, drawing: ifcopenshell.entity_instance) -> list[ifcopenshell.entity_instance]:
         sheet_references: list[ifcopenshell.entity_instance] = []
         drawing_reference = cls.get_drawing_document(drawing)
+        if drawing_reference is None:
+            return sheet_references
         for sheet in tool.Ifc.get().by_type("IfcDocumentInformation"):
             if not sheet.Scope == "SHEET":
                 continue


### PR DESCRIPTION
Fix #8122: Guard get_sheet_references against a missing document reference. Guard remove_drawing against a missing document association to skip the document/file cleanup steps. Fall back to direct entity removal when the drawing's group association is also missing, so the IFC entity is purged and the Drawings panel refreshes correctly.

Generated with the assistance of an AI coding tool.