### PR TITLE
Bonsai Makefile - pin deepdiff<9.1

### DIFF
--- a/src/bonsai/Makefile
+++ b/src/bonsai/Makefile
@@ -192,7 +192,11 @@ endif
 	# Provides networkx graph analysis for project dependency calculations
 	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download networkx --dest=./wheels
 	# Required by IFCDiff
-	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download deepdiff --dest=./wheels
+	# Pinned <9.1: deepdiff 9.1.0 adds cachebox<6,>=5.2 which only ships macOS x86_64
+	# wheels for macosx_10_12+ and is incompatible with our macos py311 --platform
+	# macosx_10_10_x86_64 target. Revisit once the macos py311 platform tag is bumped
+	# to 10_13 (matching py312/py313).
+	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download "deepdiff<9.1" --dest=./wheels
 	# Required by IFCCSV and ifcopenshell.util.selector
 	cd build && . env/$(VENV_ACTIVATE) && $(PIP) download lark --dest=./wheels
 	# Required by IFC4D


### PR DESCRIPTION
deepdiff 9.1.0 added cachebox<6,>=5.2 as a direct runtime dep. cachebox 5.2.3 only publishes macOS x86_64 wheels for macosx_10_12+, incompatible with the macos py311 build's --platform macosx_10_10_x86_64. The daily build's linux-wheel safeguard fires when the resulting cachebox-*-manylinux_*.whl leaks into the macOS / windows wheels folder (builds run on ubuntu-latest and cross-build via pip download --platform).

Pin deepdiff to <9.1 (resolves to 9.0.0, no cachebox transitive dep) as the minimal hotfix. Long-term cleanup: bump the macos py311 platform tag from 10_10 to 10_13 (matching py312/py313) and re-flag this line with the standard \$(PYPI_PLATFORM) --only-binary=:all: pattern used by brickschema and python-socketio.

Partly generated with the assistance of an AI coding tool.