### PR TITLE
Fix CGAL 6.x build: add Point_d_4d_Less comparator for std::map

### DIFF
--- a/src/ifcgeom/kernels/cgal/nef_to_halfspace_tree.h
+++ b/src/ifcgeom/kernels/cgal/nef_to_halfspace_tree.h
@@ -116,6 +116,18 @@ template <typename Kernel>
 using plane_map = std::map<typename Kernel::Plane_3, typename Kernel::Plane_3, PlaneLess<Kernel>>;
 // using plane_map = std::unordered_map<typename Kernel::Plane_3, typename Kernel::Plane_3, PlaneHash<Kernel>>;
 
+// Lexicographic comparator for CGAL Point_d (operator< is deleted in CGAL 6.x)
+struct Point_d_4d_Less {
+	using Point_d = CGAL::Epick_d<CGAL::Dimension_tag<4>>::Point_d;
+	bool operator()(const Point_d& a, const Point_d& b) const {
+		for (int i = 0; i < 4; ++i) {
+			if (a[i] < b[i]) return true;
+			if (b[i] < a[i]) return false;
+		}
+		return false;
+	}
+};
+
 // Snap halfspace planes
 // search_radius: max cartesian distance in plane equation parameters as 4d points in space
 template <typename Kernel>
@@ -131,8 +143,8 @@ plane_map<Kernel> snap_halfspaces(const std::list<CGAL::Plane_3<Kernel>>& planes
 
 	plane_map<Kernel> result;
 
-	std::map<Point_d, std::set<Point_d>> neighbours;
-	std::map<Point_d, std::list<CGAL::Plane_3<Kernel>>> originals;
+	std::map<Point_d, std::set<Point_d, Point_d_4d_Less>, Point_d_4d_Less> neighbours;
+	std::map<Point_d, std::list<CGAL::Plane_3<Kernel>>, Point_d_4d_Less> originals;
 	std::vector<Point_d> planes_as_point;
 
 	for (auto& p : planes) {
@@ -205,7 +217,7 @@ plane_map<Kernel> snap_halfspaces_2(const std::list<CGAL::Plane_3<Kernel>>& plan
 	plane_map<Kernel> result;
 
 	std::vector<Point_d> planes_as_point;
-	std::map<Point_d, CGAL::Plane_3<Kernel>> normalized_to_original;
+	std::map<Point_d, CGAL::Plane_3<Kernel>, Point_d_4d_Less> normalized_to_original;
 
 	for (auto& p : planes_fixed) {
 		// @todo can we skip normalization (simply divide by largest component perhaps)

--- a/src/ifcgeom/kernels/cgal/nef_to_halfspace_tree.h
+++ b/src/ifcgeom/kernels/cgal/nef_to_halfspace_tree.h
@@ -120,11 +120,9 @@ using plane_map = std::map<typename Kernel::Plane_3, typename Kernel::Plane_3, P
 struct Point_d_4d_Less {
 	using Point_d = CGAL::Epick_d<CGAL::Dimension_tag<4>>::Point_d;
 	bool operator()(const Point_d& a, const Point_d& b) const {
-		for (int i = 0; i < 4; ++i) {
-			if (a[i] < b[i]) return true;
-			if (b[i] < a[i]) return false;
-		}
-		return false;
+		return std::lexicographical_compare(
+			a.cartesian_begin(), a.cartesian_end(),
+			b.cartesian_begin(), b.cartesian_end());
 	}
 };
 


### PR DESCRIPTION
CGAL 6.x deleted operator< from Point_d, so std::map<Point_d, ...> no longer compiles.

This pull request adds a custom lexicographic comparator and updates the three affected maps in snap_halfspaces and snap_halfspaces_2.

This is a claude-suggested fix