### PR TITLE
Add missing standard library includes for self-sufficient headers

### DIFF
--- a/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
+++ b/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
@@ -48,6 +48,7 @@
 #include <stack>
 #include <unordered_map>
 #include <unordered_set>
+#include <cstdint>
 #include <BRepExtrema_TriangleSet.hxx>
 #include <BRepLProp_SLProps.hxx>
 #include <BVH_BinaryTree.hxx>

--- a/src/ifcgeom/kernels/opencascade/clash_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/clash_utils.cpp
@@ -1,5 +1,7 @@
 #include "clash_utils.h"
 #include <cassert>
+#include <cstdint>
+#include <cfloat>
 
 #define GU_CULLING_EPSILON_RAY_TRIANGLE FLT_EPSILON*FLT_EPSILON
 #define PX_MAX_F32 3.4028234663852885981170418348452e+38F

--- a/src/ifcgeom/mapping/mapping.h
+++ b/src/ifcgeom/mapping/mapping.h
@@ -7,6 +7,7 @@
 #include "../../ifcparse/IfcLogger.h"
 
 #include <mutex>
+#include <cstdint>
 
 #define INCLUDE_SCHEMA(x) STRINGIFY(../../ifcparse/x.h)
 #include INCLUDE_SCHEMA(IfcSchema)

--- a/src/ifcgeom/taxonomy.h
+++ b/src/ifcgeom/taxonomy.h
@@ -17,6 +17,13 @@
 #include <tuple>
 #include <exception>
 #include <numeric>
+#include <cstdint>
+#include <cmath>
+#include <array>
+#include <limits>
+#include <functional>
+#include <algorithm>
+#include <stdexcept>
 
 #ifndef TAXONOMY_USE_UNIQUE_PTR
 #ifndef TAXONOMY_USE_NAKED_PTR
@@ -1625,19 +1632,19 @@ typedef item const* ptr;
 				// @todo Sad... now that we have templated collection members,
 				// we can't generally use collection_base anymore as a cast target.
 				if (auto s = std::dynamic_pointer_cast<taxonomy::collection>(i)) {
-					visit<taxonomy::collection>(s, fn);
+					ifcopenshell::geometry::visit<taxonomy::collection>(s, fn);
 				} else if (auto s = std::dynamic_pointer_cast<taxonomy::loop>(i)) {
-					visit<taxonomy::loop>(s, fn);
+					ifcopenshell::geometry::visit<taxonomy::loop>(s, fn);
 				} else if (auto s = std::dynamic_pointer_cast<taxonomy::face>(i)) {
-					visit<taxonomy::face>(s, fn);
+					ifcopenshell::geometry::visit<taxonomy::face>(s, fn);
 				} else if (auto s = std::dynamic_pointer_cast<taxonomy::shell>(i)) {
-					visit<taxonomy::shell>(s, fn);
+					ifcopenshell::geometry::visit<taxonomy::shell>(s, fn);
 				} else if (auto s = std::dynamic_pointer_cast<taxonomy::solid>(i)) {
-					visit<taxonomy::solid>(s, fn);
+					ifcopenshell::geometry::visit<taxonomy::solid>(s, fn);
 				} else if (auto s = std::dynamic_pointer_cast<taxonomy::loft>(i)) {
-					visit<taxonomy::loft>(s, fn);
+					ifcopenshell::geometry::visit<taxonomy::loft>(s, fn);
 				} else if (auto s = std::dynamic_pointer_cast<taxonomy::boolean_result>(i)) {
-					visit<taxonomy::boolean_result>(s, fn);
+					ifcopenshell::geometry::visit<taxonomy::boolean_result>(s, fn);
 				}
 				else {
 					fn(i);

--- a/src/ifcparse/IfcBaseClass.h
+++ b/src/ifcparse/IfcBaseClass.h
@@ -27,6 +27,7 @@
 #include "utils.h"
 
 #include <atomic>
+#include <cstdint>
 #include <boost/shared_ptr.hpp>
 
 class aggregate_of_instance;

--- a/src/ifcparse/IfcCharacterDecoder.cpp
+++ b/src/ifcparse/IfcCharacterDecoder.cpp
@@ -201,7 +201,7 @@ namespace {
                 if (character >= 0x20 && character <= 0x7e) {
                     stream.put((char)character);
                 } else {
-                    stream << "\\u" << character;
+                    stream << "\\u" << static_cast<uint32_t>(character);
                 }
             });
             return stream.str();

--- a/src/ifcparse/IfcEntityInstanceData.h
+++ b/src/ifcparse/IfcEntityInstanceData.h
@@ -36,6 +36,9 @@
 
 #endif
 
+#include <cstdint>
+#include <cstring>
+
 #include <boost/optional.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/logic/tribool.hpp>

--- a/src/ifcparse/IfcFile.h
+++ b/src/ifcparse/IfcFile.h
@@ -34,6 +34,7 @@
 #include <boost/circular_buffer.hpp>
 #include <iterator>
 #include <map>
+#include <cstdint>
 
 #ifdef IFOPSH_WITH_ROCKSDB
 #include <rocksdb/merge_operator.h>

--- a/src/ifcparse/IfcSchema.h
+++ b/src/ifcparse/IfcSchema.h
@@ -25,7 +25,9 @@
 #include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <cctype>
+#include <cstdint>
 #include <iterator>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/ifcparse/aggregate_of_instance.h
+++ b/src/ifcparse/aggregate_of_instance.h
@@ -26,6 +26,7 @@
 #include <boost/shared_ptr.hpp>
 #include <set>
 #include <vector>
+#include <algorithm>
 
 namespace IfcParse {
     class declaration;

--- a/src/ifcparse/rocksdb_map_adapter.h
+++ b/src/ifcparse/rocksdb_map_adapter.h
@@ -30,6 +30,8 @@
 #include <utility>
 #include <iterator>
 #include <cstddef>
+#include <cstdint>
+#include <cstring>
 
 template <typename T>
 struct is_std_tuple : std::false_type {};

--- a/src/ifcparse/storage.h
+++ b/src/ifcparse/storage.h
@@ -25,6 +25,8 @@ namespace rocksdb {
 
 #include <variant>
 #include <iterator>
+#include <cstdint>
+#include <cstring>
 #include <type_traits>
 #include <iostream>
 #include <vector>

--- a/src/ifcparse/variantarray.h
+++ b/src/ifcparse/variantarray.h
@@ -33,6 +33,10 @@ variant - which is the maximum size of its constituents - is reduced.
 #include <utility>
 #include <memory>
 #include <tuple>
+#include <cstdint>
+#include <cstring>
+#include <cstddef>
+#include <limits>
 
 #include "IfcException.h"
 

--- a/src/serializers/GltfSerializer.cpp
+++ b/src/serializers/GltfSerializer.cpp
@@ -23,6 +23,8 @@
 
 #include "../ifcparse/utils.h"
 
+#include <cstdint>
+
 #ifdef WITH_PROJ
 #include <proj.h>
 #endif

--- a/src/serializers/HdfSerializer.cpp
+++ b/src/serializers/HdfSerializer.cpp
@@ -34,6 +34,7 @@
 #include <numeric>
 #include <functional>
 #include <cmath>
+#include <cstdint>
 
 #ifdef USE_BINARY
 #define write_shape write_binary

--- a/src/serializers/RocksDbSerializer.cpp
+++ b/src/serializers/RocksDbSerializer.cpp
@@ -4,6 +4,9 @@
 
 #include <rocksdb/options.h>
 
+#include <cstdint>
+#include <cstring>
+
 #include "../ifcparse/IfcLogger.h"
 
 RocksDbSerializer::RocksDbSerializer(IfcParse::IfcFile* file, const std::string& rocksdb_filename)


### PR DESCRIPTION
Fixes builds with newer GCC/libstdc++ that no longer provide <cstdint>, <cstring>, <cfloat>, <memory>, <algorithm> etc. transitively.

This was needed because the latest RocksDB 11.x headers require c++20

Also disambiguates visit<> calls in taxonomy.h with the full namespace and casts the character value in IfcCharacterDecoder to uint32_t to silence ambiguous overload warnings.

These are claude-suggested fixes