### PR TITLE
Support RocksDB shared library and new unique_ptr DB::Open API

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -258,10 +258,14 @@ if(WITH_ROCKSDB)
     set(ROCKSDB_LIBRARIES "IFCOPENSHELL_RocksDB")
     target_compile_definitions(IFCOPENSHELL_RocksDB INTERFACE IFOPSH_WITH_ROCKSDB)
     set(SWIG_DEFINES ${SWIG_DEFINES} -DIFOPSH_WITH_ROCKSDB)
-    # Shared binaries for `rocksdb` only support limited API (only `c.h`), but we use `db.h` API.
-    # So rocksdb supported only as a static library.
     # See https://github.com/facebook/rocksdb/issues/981.
-    target_link_libraries(IFCOPENSHELL_RocksDB INTERFACE RocksDB::rocksdb)
+    if(TARGET RocksDB::rocksdb)
+        target_link_libraries(IFCOPENSHELL_RocksDB INTERFACE RocksDB::rocksdb)
+    elseif(TARGET RocksDB::rocksdb-shared)
+        target_link_libraries(IFCOPENSHELL_RocksDB INTERFACE RocksDB::rocksdb-shared)
+    else()
+        message(FATAL_ERROR "RocksDB found but neither RocksDB::rocksdb nor RocksDB::rocksdb-shared target exists")
+    endif()
 
     if(WITH_ZSTD)
         # @todo do we actually need the zstd include dir or rather just pass

--- a/src/ifcparse/IfcFile.cpp
+++ b/src/ifcparse/IfcFile.cpp
@@ -4,6 +4,7 @@
 #ifdef IFOPSH_WITH_ROCKSDB
 #include <rocksdb/table.h>
 #include <rocksdb/convenience.h>
+#include <rocksdb/version.h>
 #endif
 
 #include <fstream>
@@ -412,30 +413,8 @@ IfcUtil::IfcBaseClass* IfcParse::impl::rocks_db_file_storage::assert_existance(s
 }
 
 namespace {
+    std::unique_ptr<rocksdb::DB> init_db(const std::string& filepath, bool readonly) {
 #ifdef IFOPSH_WITH_ROCKSDB
-    // Newer RocksDB releases (e.g. the one shipped by Fedora rawhide) changed
-    // DB::Open / DB::OpenForReadOnly to take a std::unique_ptr<DB>* and removed
-    // the raw DB** overloads. These helpers select whichever signature the
-    // installed RocksDB exposes, so the code builds against both old and new
-    // headers. The int/long tag prefers the unique_ptr form when both exist.
-    template <typename Fn>
-    auto rocksdb_open(Fn&& open, rocksdb::DB*& db, int)
-        -> decltype(open(std::declval<std::unique_ptr<rocksdb::DB>*>())) {
-        std::unique_ptr<rocksdb::DB> owned;
-        auto status = open(&owned);
-        db = owned.release();
-        return status;
-    }
-    template <typename Fn>
-    auto rocksdb_open(Fn&& open, rocksdb::DB*& db, long)
-        -> decltype(open(std::declval<rocksdb::DB**>())) {
-        return open(&db);
-    }
-#endif
-    rocksdb::DB* init_db(const std::string& filepath, bool readonly) {
-        rocksdb::DB* db = nullptr;
-#ifdef IFOPSH_WITH_ROCKSDB
-        
         rocksdb::Options options;
         // options.disable_auto_compactions = true;
         options.create_if_missing = true;
@@ -467,20 +446,31 @@ namespace {
         options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(tbo));
 
         rocksdb::Status status;
+        std::unique_ptr<rocksdb::DB> db;
         if (readonly) {
-            status = rocksdb_open([&](auto* dbptr) -> decltype(rocksdb::DB::OpenForReadOnly(options, filepath, dbptr)) {
-                return rocksdb::DB::OpenForReadOnly(options, filepath, dbptr);
-            }, db, 0);
+#if ROCKSDB_MAJOR > 9 || (ROCKSDB_MAJOR == 9 && ROCKSDB_MINOR >= 11)
+            status = rocksdb::DB::OpenForReadOnly(options, filepath, &db);
+#else
+            rocksdb::DB* raw = nullptr;
+            status = rocksdb::DB::OpenForReadOnly(options, filepath, &raw);
+            db.reset(raw);
+#endif
         } else {
-            status = rocksdb_open([&](auto* dbptr) -> decltype(rocksdb::DB::Open(options, filepath, dbptr)) {
-                return rocksdb::DB::Open(options, filepath, dbptr);
-            }, db, 0);
+#if ROCKSDB_MAJOR > 9 || (ROCKSDB_MAJOR == 9 && ROCKSDB_MINOR >= 11)
+            status = rocksdb::DB::Open(options, filepath, &db);
+#else
+            rocksdb::DB* raw = nullptr;
+            status = rocksdb::DB::Open(options, filepath, &raw);
+            db.reset(raw);
+#endif
         }
         if (!status.ok()) {
             return nullptr;
         }
-#endif // IFOPSH_WITH_ROCKSDB#
         return db;
+#else
+        return nullptr;
+#endif
     }
 }
 
@@ -489,12 +479,12 @@ IfcParse::impl::rocks_db_file_storage::rocks_db_file_storage(const std::string& 
     : file(ffile)
     , db(init_db(filepath, readonly))
     // @todo streaming serializer does not populate the byguid map
-    , byguid_internal_(db, "g|")
+    , byguid_internal_(db.get(), "g|")
     , byguid_(&byguid_internal_, [this](size_t v) { return assert_existance(v, entityinstance_ref); }, [](IfcUtil::IfcBaseClass* v) { return v->identity(); })
-    , instance_ids_(db, "i|")
+    , instance_ids_(db.get(), "i|")
     , instance_by_name_(&instance_ids_, [this](size_t v) { return assert_existance(v, entityinstance_ref); })
-    , bytype_(db, "t|")
-    , byref_excl_(db, "v|")
+    , bytype_(db.get(), "t|")
+    , byref_excl_(db.get(), "v|")
     // @todo by_identity is probably not correct here, this mapping is Name -> Identity, so Fn should have access to full pair?
     // , byidentity_(&byid_, [this](size_t v) { return assert_existance(v, by_identity); }, [](IfcUtil::IfcBaseClass* v) { return v->identity(); })
 {
@@ -517,7 +507,6 @@ IfcParse::impl::rocks_db_file_storage::~rocks_db_file_storage()
     assert(s.ok());
 
     db->Close();
-    delete db;
 #endif
 }
 

--- a/src/ifcparse/IfcFile.cpp
+++ b/src/ifcparse/IfcFile.cpp
@@ -7,6 +7,8 @@
 #endif
 
 #include <fstream>
+#include <memory>
+#include <utility>
 #include <sys/types.h>
 #include <sys/stat.h>
 
@@ -410,6 +412,26 @@ IfcUtil::IfcBaseClass* IfcParse::impl::rocks_db_file_storage::assert_existance(s
 }
 
 namespace {
+#ifdef IFOPSH_WITH_ROCKSDB
+    // Newer RocksDB releases (e.g. the one shipped by Fedora rawhide) changed
+    // DB::Open / DB::OpenForReadOnly to take a std::unique_ptr<DB>* and removed
+    // the raw DB** overloads. These helpers select whichever signature the
+    // installed RocksDB exposes, so the code builds against both old and new
+    // headers. The int/long tag prefers the unique_ptr form when both exist.
+    template <typename Fn>
+    auto rocksdb_open(Fn&& open, rocksdb::DB*& db, int)
+        -> decltype(open(std::declval<std::unique_ptr<rocksdb::DB>*>())) {
+        std::unique_ptr<rocksdb::DB> owned;
+        auto status = open(&owned);
+        db = owned.release();
+        return status;
+    }
+    template <typename Fn>
+    auto rocksdb_open(Fn&& open, rocksdb::DB*& db, long)
+        -> decltype(open(std::declval<rocksdb::DB**>())) {
+        return open(&db);
+    }
+#endif
     rocksdb::DB* init_db(const std::string& filepath, bool readonly) {
         rocksdb::DB* db = nullptr;
 #ifdef IFOPSH_WITH_ROCKSDB
@@ -446,9 +468,13 @@ namespace {
 
         rocksdb::Status status;
         if (readonly) {
-            status = rocksdb::DB::OpenForReadOnly(options, filepath, &db);
+            status = rocksdb_open([&](auto* dbptr) -> decltype(rocksdb::DB::OpenForReadOnly(options, filepath, dbptr)) {
+                return rocksdb::DB::OpenForReadOnly(options, filepath, dbptr);
+            }, db, 0);
         } else {
-            status = rocksdb::DB::Open(options, filepath, &db);
+            status = rocksdb_open([&](auto* dbptr) -> decltype(rocksdb::DB::Open(options, filepath, dbptr)) {
+                return rocksdb::DB::Open(options, filepath, dbptr);
+            }, db, 0);
         }
         if (!status.ok()) {
             return nullptr;

--- a/src/ifcparse/storage.h
+++ b/src/ifcparse/storage.h
@@ -29,6 +29,7 @@ namespace rocksdb {
 #include <iostream>
 #include <vector>
 #include <list>
+#include <memory>
 
 #ifndef SWIG
 
@@ -306,7 +307,7 @@ namespace IfcParse {
 
         class IFC_PARSE_API rocks_db_file_storage {
         public:
-            rocksdb::DB* db;
+            std::unique_ptr<rocksdb::DB> db;
             rocksdb::WriteOptions wopts;
             rocksdb::ReadOptions ropts;
             IfcParse::IfcFile* file;


### PR DESCRIPTION
Some distributions (e.g. Fedora) ship only a shared RocksDB that exports RocksDB::rocksdb-shared rather than RocksDB::rocksdb. The CMake target selection now falls back to the shared target when the static one is absent.

Newer RocksDB also changed DB::Open and DB::OpenForReadOnly to take std::unique_ptr<DB>* instead of DB**. IfcFile.cpp uses SFINAE tag dispatch to build against both old and new APIs without version detection.

These are claude-suggested fixes