### PR TITLE
fix(ifctester): allow IFCLOGICAL properties with UNKNOWN value to pass existence check

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -705,7 +705,7 @@ class Property(Facet):
                         for p in self.get_properties(inst.wrapped_data.file.by_id(pset_props["id"]))
                         if p.Name == self.baseName
                     ).NominalValue.is_a("IfcLogical"):
-                        pass
+                        props[pset_name][self.baseName] = prop
                     elif prop is not None and prop != "":
                         props[pset_name][self.baseName] = prop
                 else:


### PR DESCRIPTION
### Description
This PR fixes a false-positive validation error in `IfcTester` when checking `IFCLOGICAL` properties containing the value `UNKNOWN`.

Previously, the code hit a silent `pass` inside the `IfcLogical` evaluation block, which prevented the property from being recorded in the `props` dictionary. This caused a false-positive `NOVALUE` error downstream, incorrectly indicating that the property did not exist in the model, even though it was structurally and semantically valid. 

While requiring an explicit `UNKNOWN` value in an IDS might be an edge case, the buildingSMART IDS specification supports it. Therefore, the validation engine should handle it correctly rather than throwing a false-positive.

### Changes
* Replaced the silent `pass` statement with a proper dictionary assignment (`props[pset_name][self.baseName] = prop`) inside the `IfcLogical` condition block in `src/ifctester/ifctester/facet.py`.

### Testing
Verified by using an evaluation pipeline I had set up for my bachelor thesis. `IFCLOGICAL` properties set to `UNKNOWN` now successfully pass the initial existence filter and can be audited against IDS restrictions as expected.