### PR TITLE
Place IfcSpatialZone in its spatial parent's collection instead of Unsorted

### DIFF
--- a/src/bonsai/bonsai/tool/collector.py
+++ b/src/bonsai/bonsai/tool/collector.py
@@ -114,6 +114,21 @@ class Collector(bonsai.core.tool.Collector):
                 cls.link_collection_child_safe(tool.Blender.get_object_bim_props(project_obj).collection, collection)
             if not tool.Spatial.get_spatial_props().is_visible:
                 obj.hide_viewport = True
+        elif element.is_a("IfcSpatialZone") and (parent := ifcopenshell.util.element.get_aggregate(element)):
+            # Spatial zones are non-hierarchical so they don't get their own
+            # collection, but when aggregated in the spatial tree they belong
+            # in the collection of their spatial parent.
+            if tool.Geometry.is_locked(element):
+                tool.Geometry.lock_object(obj)
+            while parent.is_a("IfcSpace") or parent.is_a("IfcSpatialZone"):
+                parent = ifcopenshell.util.element.get_aggregate(parent)
+            parent_obj = tool.Ifc.get_object(parent)
+            if not (collection := tool.Blender.get_object_bim_props(parent_obj).collection):
+                cls.assign(parent_obj)
+                collection = tool.Blender.get_object_bim_props(parent_obj).collection
+            cls.link_collection_object_safe(collection, obj)
+            if not tool.Spatial.get_spatial_props().is_visible:
+                obj.hide_viewport = True
         elif element.is_a("IfcAnnotation") and element.ObjectType == "DRAWING":
             if collection := cls._create_own_collection(obj):
                 cls.link_collection_object_safe(collection, obj)

--- a/src/bonsai/test/tool/test_collector.py
+++ b/src/bonsai/test/tool/test_collector.py
@@ -125,6 +125,22 @@ class TestAssign(NewIfc):
         assert len(space_obj.users_collection) == 2
         assert space_obj.users_collection[0].name != space_obj.name
 
+    def test_spatial_zone_elements_are_placed_in_their_spatial_parents_collection(self):
+        assert bpy.context.scene
+        zone_obj = bpy.data.objects.new("IfcSpatialZone/Name", None)
+        zone_element = tool.Ifc.get().createIfcSpatialZone()
+        tool.Ifc.link(zone_element, zone_obj)
+        bpy.context.scene.collection.objects.link(zone_obj)
+        ifcopenshell.api.aggregate.assign_object(
+            tool.Ifc.get(),
+            relating_object=tool.Ifc.get().by_type("IfcSite")[0],
+            products=[zone_element],
+        )
+        subject.assign(zone_obj)
+        assert len(zone_obj.users_collection) == 2
+        assert zone_obj.users_collection[0].name == "IfcSite/My Site"
+        assert not bpy.data.collections.get("Unsorted")
+
     def test_aggregates_are_also_placed_in_their_container(self):
         assert bpy.context.scene
         element_obj = bpy.data.objects.new("IfcElementAssembly/Name", None)


### PR DESCRIPTION
Spatial zones are intentionally excluded from getting their own collection (008fa7034) since they are non-hierarchical, but they then fell through to the Unsorted collection because get_container() only follows IfcRelContainedInSpatialStructure while zones added from the spatial decomposition panel are aggregated. As Unsorted is hidden by default, a freshly created spatial zone disappeared from the viewport.

Link aggregated spatial zones to the collection of their nearest spatial parent that owns one, mirroring how aggregated elements are placed in their container.