### PR TITLE
test(ifcpatch): MergeProjects regression test for merging 3+ files (#7973)

### DIFF
--- a/src/ifcpatch/test/test_MergeProject.py
+++ b/src/ifcpatch/test/test_MergeProject.py
@@ -177,6 +177,28 @@ class TestMergeProjects(test.bootstrap.IFC4):
         assert np.any(np.all(np.isclose(np.array((17.847, 24.707, 3.0)), verts, atol=1e-3), axis=1))
         assert np.any(np.all(np.isclose(np.array((20.410, 25.902, 5.0)), verts, atol=1e-3), axis=1))
 
+    def test_merging_three_or_more_projects(self):
+        # Regression test for #7973: merging N>2 models must keep every
+        # project's elements and must not leave duplicated geometric contexts
+        # behind (which makes later disciplines appear "not merged" in viewers).
+        self.file = self.setup_project(self.file)
+        second_file = self.setup_project()
+        third_file = self.setup_project()
+        output = ifcpatch.execute(
+            {
+                "file": self.file,
+                "recipe": "MergeProjects",
+                "arguments": [[second_file, third_file]],
+            }
+        )
+        assert self.file == output
+        # Every model contributed exactly one wall.
+        assert len(output.by_type("IfcWall")) == 3
+        # A single merged project must remain.
+        assert len(output.by_type("IfcProject")) == 1
+        # Contexts must be reused, not accumulated: one Model + one Body.
+        assert len(output.by_type("IfcGeometricRepresentationContext")) == 2
+
 
 class TestMergeProjectsIFC2X3(test.bootstrap.IFC2X3, TestMergeProjects):
     pass


### PR DESCRIPTION
Follow-up to #7973, as requested by @aothms (formalize the problem into a test case).

## What this adds

A regression test in `src/ifcpatch/test/test_MergeProject.py` that merges **three** projects through the `MergeProjects` recipe and asserts:

- every model's elements are kept (`IfcWall == 3`)
- a single merged `IfcProject` remains
- geometric contexts are reused, not accumulated (`IfcGeometricRepresentationContext == 2`)

It runs under both IFC4 and IFC2X3 via the existing `TestMergeProjectsIFC2X3` subclass.

## What it reproduces

Merging more than two models does **not** drop elements. The visible "only the first models merged" symptom from #7973 comes from `reuse_existing_contexts()` failing to deduplicate contexts: every merged file adds its own `Model` context, so they pile up (2 files → 3 contexts, 3 files → 4). Viewers that render geometry under the first top-level context then show only part of the result.

This is the same root cause as the already-failing `test_reusing_geometric_contexts` (2-file case). The new test generalizes it to the N>2 scenario reported in the issue.

The element and project assertions pass today; the context assertion fails, capturing the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)