### PR TITLE
Fix stale object reference crash in measure tool snapping

### DIFF
--- a/src/bonsai/bonsai/tool/raycast.py
+++ b/src/bonsai/bonsai/tool/raycast.py
@@ -969,6 +969,17 @@ class Raycast(bonsai.core.tool.Raycast):
     def create_snap_obj(cls, obj):
         if obj.data is None or not isinstance(obj.data, bpy.types.Mesh):
             return None
+        # Drop cache entries whose Blender object has been deleted. Accessing any
+        # attribute on a removed object raises ReferenceError ("StructRNA ... has
+        # been removed"), so test validity before comparing names below.
+        valid_snap_objs = []
+        for snap_obj in cls.snap_objs:
+            try:
+                snap_obj.obj.name
+            except ReferenceError:
+                continue
+            valid_snap_objs.append(snap_obj)
+        cls.snap_objs[:] = valid_snap_objs
         for i, snap_obj in enumerate(cls.snap_objs):
             if obj.name == snap_obj.obj.name:
                 # Handle objects modified while a modal operator is active.


### PR DESCRIPTION
Drop deleted Blender objects from the snap cache before comparing names. Accessing an attribute on a removed object raised ReferenceError ("StructRNA of type Object has been removed"), crashing detect_snapping_points after an object was deleted.