### PR TITLE
test(ifcpatch): ExtractElements regression test for georeferencing loss (#8199)

### DIFF
--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -20,6 +20,8 @@ import os
 
 import ifcopenshell
 import ifcopenshell.api.aggregate
+import ifcopenshell.api.context
+import ifcopenshell.api.georeference
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
 import ifcopenshell.util.element
@@ -78,6 +80,31 @@ class TestExtractElements(test.bootstrap.IFC4):
         output = ifcpatch.execute({"file": ifc, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
         assert output.by_type("IfcWall")
         assert not output.by_type("IfcSlab")
+
+    def test_preserving_georeferencing(self):
+        # Regression test for #8199: ExtractElements must carry IfcMapConversion
+        # and IfcProjectedCRS into the output. Without the fix these entities are
+        # silently dropped because they reference the IfcGeometricRepresentationContext
+        # via an inverse attribute and are therefore not reachable through the
+        # IfcProject forward-attribute walk used by self.new.add().
+        if self.file.schema == "IFC2X3":
+            pytest.skip("IfcMapConversion does not exist in IFC2X3")
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        ifcopenshell.api.georeference.add_georeferencing(self.file)
+        ifcopenshell.api.georeference.edit_georeferencing(
+            self.file,
+            coordinate_operation={"Eastings": 100000.0, "Northings": 200000.0},
+        )
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        assert len(output.by_type("IfcMapConversion")) == 1
+        assert len(output.by_type("IfcProjectedCRS")) == 1
+        conversion = output.by_type("IfcMapConversion")[0]
+        assert conversion.Eastings == 100000.0
+        assert conversion.Northings == 200000.0
 
     @pytest.mark.skipif(
         "IFC4X3" not in ifcopenshell.ifcopenshell_wrapper.schema_names(),


### PR DESCRIPTION
Follow-up to #8199, as requested by @aothms — encode the problem into a failing test.

## What this adds

A regression test in `src/ifcpatch/test/test_ExtractElements.py` that sets up a model with georeferencing (`IfcMapConversion` + `IfcProjectedCRS`, Eastings=100000, Northings=200000), runs the `ExtractElements` recipe, and asserts that both entities survive into the output with the original coordinate values intact.

The test is skipped for IFC2X3 (georeferencing lives in property sets there, not as `IfcMapConversion` entities).

## What it reproduces

`ExtractElements.patch()` adds `IfcProject` with `self.new.add(element)`, which follows forward attributes only. `IfcMapConversion.SourceCRS` points to the `IfcGeometricRepresentationContext`, not the other way around, so the conversion and its `IfcProjectedCRS` are invisible to the forward walk and are silently dropped. The extracted model then has no georeferencing at all, which causes viewers (Blender/Bonsai included) to absorb the large coordinates into a local offset instead.

The new test fails today — `IfcMapConversion` count in the output is 0 instead of 1 — capturing the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)