### PR TITLE
fix(ifcpatch): guard None RepresentationContexts; add placement roundtrip test (#8199)

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -110,7 +110,7 @@ class Patcher(ifcpatch.BasePatcher):
             pass
         if element.is_a("IfcProject"):
             proj = self.new.add(element)
-            for ctx in element.RepresentationContexts:
+            for ctx in (element.RepresentationContexts or []):
                 for coop in ctx.HasCoordinateOperation:
                     self.new.add(coop)
             return proj

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -20,6 +20,8 @@ import os
 
 import ifcopenshell
 import ifcopenshell.api.aggregate
+import ifcopenshell.api.context
+import ifcopenshell.api.georeference
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
 import ifcopenshell.util.element
@@ -78,6 +80,31 @@ class TestExtractElements(test.bootstrap.IFC4):
         output = ifcpatch.execute({"file": ifc, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
         assert output.by_type("IfcWall")
         assert not output.by_type("IfcSlab")
+
+    def test_preserving_georeferencing(self):
+        # Regression test for #8199: ExtractElements must carry IfcMapConversion
+        # and IfcProjectedCRS into the output. Without the fix these entities are
+        # silently dropped because they reference the IfcGeometricRepresentationContext
+        # via an inverse attribute and are therefore not reachable through the
+        # IfcProject forward-attribute walk used by self.new.add().
+        if self.file.schema == "IFC2X3":
+            pytest.skip("IfcMapConversion does not exist in IFC2X3")
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        ifcopenshell.api.georeference.add_georeferencing(self.file)
+        ifcopenshell.api.georeference.edit_georeferencing(
+            self.file,
+            coordinate_operation={"Eastings": 100000.0, "Northings": 200000.0},
+        )
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        assert len(output.by_type("IfcMapConversion")) == 1
+        assert len(output.by_type("IfcProjectedCRS")) == 1
+        conversion = output.by_type("IfcMapConversion")[0]
+        assert conversion.Eastings == 100000.0
+        assert conversion.Northings == 200000.0
 
     @pytest.mark.skipif(
         "IFC4X3" not in ifcopenshell.ifcopenshell_wrapper.schema_names(),

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -18,13 +18,18 @@
 
 import os
 
+import numpy as np
+
 import ifcopenshell
 import ifcopenshell.api.aggregate
 import ifcopenshell.api.context
+import ifcopenshell.api.geometry
 import ifcopenshell.api.georeference
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
+import ifcopenshell.api.unit
 import ifcopenshell.util.element
+import ifcopenshell.util.placement
 import pytest
 
 import ifcpatch
@@ -105,6 +110,35 @@ class TestExtractElements(test.bootstrap.IFC4):
         conversion = output.by_type("IfcMapConversion")[0]
         assert conversion.Eastings == 100000.0
         assert conversion.Northings == 200000.0
+
+    def test_georeferencing_offset_not_baked_into_local_placement(self):
+        # Regression test for #8199: when extracting from a georeferenced model,
+        # element local placements must stay in local coordinates. Before the fix,
+        # IfcMapConversion was missing from the output, so auto_global2local() in
+        # append_asset() had no georef to undo and the full easting/northing offset
+        # was baked into every element's ObjectPlacement ("Blender offset" symptom).
+        if self.file.schema == "IFC2X3":
+            pytest.skip("IfcMapConversion does not exist in IFC2X3")
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        unit = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="LENGTHUNIT")
+        ifcopenshell.api.unit.assign_unit(self.file, units=[unit])
+        ifcopenshell.api.georeference.add_georeferencing(self.file)
+        ifcopenshell.api.georeference.edit_georeferencing(
+            self.file,
+            coordinate_operation={"Eastings": 100000.0, "Northings": 200000.0},
+        )
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        m = np.eye(4)
+        m[:3, 3] = [5.0, 10.0, 0.0]
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=wall, matrix=m)
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        wall_out = output.by_type("IfcWall")[0]
+        pos = ifcopenshell.util.placement.get_local_placement(wall_out.ObjectPlacement)[:3, 3]
+        # Position must stay at local (5, 10, 0), not shift to (100005, 200010, 0).
+        assert np.allclose(pos, [5.0, 10.0, 0.0], atol=1e-3)
 
     @pytest.mark.skipif(
         "IFC4X3" not in ifcopenshell.ifcopenshell_wrapper.schema_names(),


### PR DESCRIPTION
Follow-up to #8199 and the fix in e6dc582, addressing Thomas's comment.

## Two changes

### 1. Bug fix — `TypeError` on projects with no contexts

`e6dc582` iterates `element.RepresentationContexts` directly. In IFC this attribute is optional and will be `None` for any `IfcProject` that has no representation contexts (e.g. the minimal project in `test_basic`). This crashes all tests that do not explicitly create a context:

```
TypeError: 'NoneType' object is not iterable
```

Fix: `for ctx in (element.RepresentationContexts or []):`

### 2. New test — element local placement is not baked with the georef offset

Answers Thomas's question:

> I wonder if this was a byproduct of `append_asset()` from a library with georef to a model without — and should hence be fixed automatically — or whether this was caused by something else.

**Answer: yes, it was automatic.** `append_asset()` does `auto_local2global(library) → auto_global2local(target)`. Before the fix, the target had no `IfcMapConversion`, so `auto_global2local` was a no-op and global coordinates landed as local coordinates (the "Blender offset"). After the fix the target has georef, so the roundtrip is correct.

`test_georeferencing_offset_not_baked_into_local_placement` verifies this: a wall at local (5, 10, 0) in a model with Eastings=100000, Northings=200000 must still be at (5, 10, 0) in the output, not (100005, 200010, 0).

All 12 tests pass, 2 correctly skipped for IFC2X3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)