### PR TITLE
Updated documentation on Introduction to IFC 

### DIFF
--- a/src/ifcopenshell-python/docs/introduction/introduction_to_ifc.rst
+++ b/src/ifcopenshell-python/docs/introduction/introduction_to_ifc.rst
@@ -67,7 +67,7 @@ Begin learning IFC
 ------------------
 
 IFC has three versions published by ISO: **IFC2X3** from 2007, **IFC4** from
-2017, and **IFC4X3** in draft form. Each version improves on the previous
+2017, and **IFC4X3** from 2024. Each version improves on the previous
 version, and will have different **IFC Classes** with different attributes and
 different **IFC Concepts**.
 
@@ -85,6 +85,9 @@ You can access the official documentation here:
    It is recommended to use IFC4. However, the IFC4X3 documentation is a lot
    more friendly to newcomers.
 
+   For infrastructure projects IFC4X3 is recommended to use as this has implemented
+   **IFC Classes** for road, railway, bridge and common infrastructure elements.
+   
 The official ISO documentation is written for a technical audience and may be
 overwhelming. This guide will take you slowly through the core concepts, and
 leave you with the knowledge you need to discover more.

--- a/src/ifcopenshell-python/docs/introduction/introduction_to_ifc.rst
+++ b/src/ifcopenshell-python/docs/introduction/introduction_to_ifc.rst
@@ -82,12 +82,10 @@ You can access the official documentation here:
 
 .. tip::
 
-   It is recommended to use IFC4. However, the IFC4X3 documentation is a lot
-   more friendly to newcomers.
+   For most buildings, IFC4 is recommended. For infrastructure projects (road,
+   railway, bridge, and other civil elements), use IFC4X3. The IFC4X3 documentation
+   is also generally more newcomer-friendly.
 
-   For infrastructure projects IFC4X3 is recommended to use as this has implemented
-   **IFC Classes** for road, railway, bridge and common infrastructure elements.
-   
 The official ISO documentation is written for a technical audience and may be
 overwhelming. This guide will take you slowly through the core concepts, and
 leave you with the knowledge you need to discover more.


### PR DESCRIPTION
The documentation on introduction to IFCstill have IFC4x3 as a draft. This is updated to being a published version from 2024. Updated tip on using IFC4 to have a second paragraph that recommend using IFC 4x3 for infractructure