### PR TITLE
fix(selector): round() should not crash on non-numeric values (#6776)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -18,7 +18,7 @@
 
 import re
 from collections.abc import Iterable
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from types import EllipsisType
 from typing import Any, Optional, Union
 
@@ -320,7 +320,13 @@ class FormatTransformer(lark.Transformer):
         return value in ("true", "1", "yes")
 
     def round(self, args):
-        value = Decimal(0.0 if args[0] == "None" else args[0] or 0.0)
+        try:
+            value = Decimal(0.0 if args[0] == "None" else args[0] or 0.0)
+        except InvalidOperation:
+            # The value is not numeric (e.g. a text property, or a value with
+            # a unit suffix like "12.5 m"). Rounding is meaningless here, so
+            # return it unchanged instead of crashing the whole expression.
+            return args[0]
         nearest = Decimal(args[1])
         result = round(value / nearest) * nearest
         if nearest % 1 == 0:

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -55,6 +55,9 @@ class TestFormat(test.bootstrap.IFC4):
         assert subject.format("round(123, 5)") == "125"
         assert subject.format('round("123", 5)') == "125"
         assert subject.format("round(-123, 5)") == "-125"
+        # Non-numeric values must pass through unchanged instead of crashing (#6776).
+        assert subject.format('round("Level 1", 0.01)') == "Level 1"
+        assert subject.format('round("12.5 m", 0.01)') == "12.5 m"
         assert subject.format("int(123.123)") == "123"
         assert subject.format("int(123)") == "123"
         assert subject.format("number(123)") == "123"


### PR DESCRIPTION
Fixes #6776.

## Problem

`FormatTransformer.round()` calls `Decimal()` directly on the input value:

```python
value = Decimal(0.0 if args[0] == "None" else args[0] or 0.0)
```

When the resolved value is a non-numeric string (a text property, or a value carrying a unit suffix like `"12.5 m"`), `Decimal()` raises `decimal.InvalidOperation`. In a spreadsheet export this crashes the entire operation as soon as a single element carries such a value, which is exactly what the reporter hit ("works on most models, but I get this error in one model").

## Reproduce

```python
import ifcopenshell.util.selector as selector
selector.format('round("Level 1", 0.01)')   # decimal.InvalidOperation before this fix
```

## Fix

Catch `InvalidOperation` and return the value unchanged, the same graceful-fallback convention already used by `add()`. Numeric rounding is unaffected.

```
round("3.14159", 0.01) -> "3.14"
round("Level 1", 0.01) -> "Level 1"   # was a crash
round("12.5 m",  0.01) -> "12.5 m"    # was a crash
```

Added two assertions to `test_number_formatting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)