### PR TITLE
fix(ifcdiff): check attributes by default so PredefinedType changes are caught (#8214)

### DIFF
--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -51,8 +51,10 @@ class IfcDiff:
 
     :param old: IFC file object for the old model
     :param new: IFC file object for the new model
-    :param relationships: List of relationships to check. None means that only
-        geometry is compared. See RELATIONSHIP_TYPE for available relationships.
+    :param relationships: List of relationships to check. None means that
+        attributes and geometry are compared, so changes such as a modified or
+        removed PredefinedType are reported. See RELATIONSHIP_TYPE for available
+        relationships.
     :param is_shallow: True if you want only the first difference to be listed.
         False if you want all differences to be checked. Choosing False means
         that comparisons will take longer.
@@ -86,7 +88,7 @@ class IfcDiff:
         self.new = new
         self.change_register = {}
         self.representation_ids = {}
-        self.relationships = relationships or ["geometry"]
+        self.relationships = relationships or ["attributes", "geometry"]
         self.precision = 1e-4
         self.is_shallow = is_shallow
         self.filter_elements = filter_elements
@@ -435,7 +437,11 @@ if __name__ == "__main__":
         "-r",
         "--relationships",
         type=str,
-        help='A list of space-separated relationships, chosen from "type", "property", "container", "aggregate", "classification"',
+        help=(
+            'A list of space-separated relationships, chosen from "attributes", "geometry", '
+            '"type", "property", "container", "aggregate", "classification". '
+            'Defaults to "attributes geometry" when omitted.'
+        ),
         default="",
     )
     args = parser.parse_args()

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -77,6 +77,23 @@ class TestIfcDiff:
         assert ifc_diff.deleted_elements == set()
         assert ifc_diff.change_register == {wall.GlobalId: {"attributes_changed": True}}
 
+    def test_changed_predefined_type_is_caught_by_default(self):
+        # Regression test for #8214: a plain diff (no relationships specified)
+        # must report a modified or removed PredefinedType. Previously the
+        # default only compared geometry, so attribute-only edits were missed.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        wall.PredefinedType = "SOLIDWALL"
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        new_file.by_id(wall.id()).PredefinedType = "NOTDEFINED"
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file)
+        ifc_diff.diff()
+        assert ifc_diff.added_elements == set()
+        assert ifc_diff.deleted_elements == set()
+        assert ifc_diff.change_register == {wall.GlobalId: {"attributes_changed": True}}
+
     def test_changed_geometry(self):
         ifc_file = setup_project()
         wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")


### PR DESCRIPTION
Fixes #8214.

## Root cause

`IfcDiff` defaulted to `relationships = ["geometry"]`, so a plain diff only ever compared geometry. Any attribute-only edit on an element that kept its `GlobalId` (a modified or removed `PredefinedType`, a renamed element, and so on) was silently missed, because `should_check_attributes` stayed `False`.

The CLI made this worse: `--relationships` documented only `"type"`, `"property"`, `"container"`, `"aggregate"`, `"classification"`. It never listed `"attributes"` or `"geometry"`, so there was no documented way for a user to turn attribute diffing on. The result matched this issue exactly: predefined-type edits were not reported as changes.

## Fix

- Default is now `["attributes", "geometry"]`, so a plain `ifcdiff old new` (and a Bonsai diff with no explicit relationship rows) reports attribute changes alongside geometry changes.
- The CLI `--relationships` help and the `IfcDiff` docstring now document every valid value, including `"attributes"` and `"geometry"`.

Behaviour is unchanged when relationships are passed explicitly, so callers that asked for `["geometry"]` still get geometry-only.

## Verification

Reproduced the reporter's case (a `PredefinedType` change on an element that keeps its `GlobalId`): before the fix a default diff reported `0` changes, after the fix it reports the element as `attributes_changed`.

Added `test_changed_predefined_type_is_caught_by_default`. Full `src/ifcdiff/test.py` suite passes (5 tests).

## Note

While confirming against the attached sample models, most of the edits in those two files landed as new `GlobalId`s (add/delete pairs) rather than surviving-GUID attribute changes, which is why they surface as adds/deletes. The underlying defect this fixes is the one the title describes: an attribute change on a stable element (predefined type) was never inspected by the default diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)