### PR TITLE
IfcDiff: compare container and aggregate by GlobalId (#4110)

### DIFF
--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -323,11 +323,25 @@ class IfcDiff:
                     self.change_register.setdefault(new.GlobalId, {}).update({"properties_changed": diff})
                     return True
             elif relationship == "container":
-                if ifcopenshell.util.element.get_container(old) != ifcopenshell.util.element.get_container(new):
+                old_container = ifcopenshell.util.element.get_container(old)
+                new_container = ifcopenshell.util.element.get_container(new)
+                if old_container is not None and new_container is not None:
+                    if old_container.GlobalId != new_container.GlobalId:
+                        self.change_register.setdefault(new.GlobalId, {}).update({"container_changed": True})
+                        return True
+                elif old_container != new_container:
+                    # one of the containers is None while the other is not None
                     self.change_register.setdefault(new.GlobalId, {}).update({"container_changed": True})
                     return True
             elif relationship == "aggregate":
-                if ifcopenshell.util.element.get_aggregate(old) != ifcopenshell.util.element.get_aggregate(new):
+                old_aggregate = ifcopenshell.util.element.get_aggregate(old)
+                new_aggregate = ifcopenshell.util.element.get_aggregate(new)
+                if old_aggregate is not None and new_aggregate is not None:
+                    if old_aggregate.GlobalId != new_aggregate.GlobalId:
+                        self.change_register.setdefault(new.GlobalId, {}).update({"aggregate_changed": True})
+                        return True
+                elif old_aggregate != new_aggregate:
+                    # one of the aggregates is None while the other is not None
                     self.change_register.setdefault(new.GlobalId, {}).update({"aggregate_changed": True})
                     return True
             elif relationship == "classification":

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -17,9 +17,11 @@
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
 import ifcopenshell
+import ifcopenshell.api.aggregate
 import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.root
+import ifcopenshell.api.spatial
 import ifcopenshell.api.unit
 import ifcopenshell.util.representation
 
@@ -94,3 +96,34 @@ class TestIfcDiff:
         assert ifc_diff.added_elements == set()
         assert ifc_diff.deleted_elements == set()
         assert ifc_diff.change_register == {wall.GlobalId: {"geometry_changed": True}}
+
+    def test_unchanged_container_is_not_reported(self):
+        # Regression test for #4110: containers were compared as cross-file
+        # entity instances, which are never equal, so every contained element
+        # was falsely reported as container_changed. Compare by GlobalId.
+        ifc_file = setup_project()
+        storey = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=storey)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {}
+
+    def test_changed_container_is_reported(self):
+        ifc_file = setup_project()
+        storey1 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=storey1)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        storey2 = ifcopenshell.api.root.create_entity(new_file, ifc_class="IfcBuildingStorey")
+        ifcopenshell.api.spatial.assign_container(
+            new_file, products=[new_file.by_id(wall.id())], relating_structure=storey2
+        )
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {wall.GlobalId: {"container_changed": True}}


### PR DESCRIPTION
Part of #4110.

## Problem

The `container` and `aggregate` relationship checks compared the results of `get_container`/`get_aggregate` between the two files directly:

```python
if ifcopenshell.util.element.get_container(old) != ifcopenshell.util.element.get_container(new):
```

Those are entity instances belonging to two different `ifcopenshell.file` objects, so `!=` is always true even when the container is unchanged. Every element with a container or aggregate was reported as changed. On the model in #4110 this produced 82 false "changes" for `container`.

The `type` check in the same method already does the right thing (compares `GlobalId`). This makes `container` and `aggregate` consistent with it.

## Verify

On the #4110 sample models, `relationships=["container"]` goes from 82 changes to 1, and that 1 is a real change (an element whose container GlobalId actually differs). Reproduced before/after.

Added `test_unchanged_container_is_not_reported` and `test_changed_container_is_reported`. Full `test.py` suite passes (6 tests).

## Not included here

The same models also show that a pure class change (`IfcWallStandardCase` -> `IfcController`, same GlobalId, same attribute values) is not detected, because `diff_element` never compares `is_a()`. That is a separate concern with an output-shape question (new key vs fold into `attributes_changed`); happy to send a follow-up PR if you want it addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)