### PR TITLE
IfcTester: guard IFC2X3 entity type inference against restriction names (#8046)

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -234,6 +234,7 @@ class Entity(Facet):
         if (
             not is_pass
             and inst.file.schema == "IFC2X3"
+            and isinstance(self.name, str)
             and not self.name.endswith("TYPE")
             and (element_type := ifcopenshell.util.element.get_type(inst))
         ):

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -211,6 +211,11 @@ class TestEntity:
         ifc = ifcopenshell.file()
         run("Entities can be specified as an enumeration 3/3", facet=facet, inst=ifc.createIfcBeam(), expected=False)
 
+        # An enumeration name that fails in IFC2X3 must report a failure, not crash (#8046).
+        # The IFC2X3 type-inference path used to call str methods on the Restriction name.
+        ifc = ifcopenshell.file(schema="IFC2X3")
+        run("Enumeration entity that fails in IFC2X3 does not crash", facet=facet, inst=ifc.createIfcBeam(), expected=False)
+
         restriction = Restriction(options={"pattern": "IFC.*TYPE"})
         facet = Entity(name=restriction)
         ifc = ifcopenshell.file()


### PR DESCRIPTION
Fixes #8046.

## Problem

When an element matches the applicability but fails an entity requirement whose name is expressed as an `xs:restriction` (for example an `xs:enumeration`), `Entity.__call__` crashes instead of reporting a failure:

```
AttributeError: 'Restriction' object has no attribute 'endswith'
```

The IFC2X3 type-inference branch assumes `self.name` is a class-name string (it appends `"TYPE"`), but for a restriction facet `self.name` is a `Restriction`. The `xs:restriction` form for entity names is valid per IDS 1.0 and is already covered by pass-path tests; only the fail path in IFC2X3 was broken.

(The other half of the original report, `Restriction.__eq__` returning `None` implicitly, is already fixed on `v0.8.0` — it now ends with `return True`.)

## Fix

Guard the IFC2X3 branch with `isinstance(self.name, str)`. When the name is a restriction, the type-inference heuristic (which only makes sense for a concrete class name) is skipped and the element falls through to a normal reported failure.

## Verify

Reproduced on IFC2X3 with an `IfcColumn` and an enumeration requirement of `["IFCWALL"]`: crashes before, reports a failure after. Added an IFC2X3 case to `test_filtering_using_an_entity_facet`. Full `test_facet.py` passes (23 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)