### PR TITLE
pset.edit_pset: treat an empty string for a numeric property as no value (#4112)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
@@ -308,8 +308,13 @@ class Usecase:
             primary_measure_type = self.get_primary_measure_type(
                 prop.Name, old_value=prop.NominalValue, new_value=value
             )
-            value = self.cast_value_to_primary_measure_type(value, primary_measure_type)
-            prop.NominalValue = self.file.create_entity(primary_measure_type, value)
+            if self.is_empty_numeric_value(value, primary_measure_type):
+                if self._try_purge(prop):
+                    return
+                prop.NominalValue = None
+            else:
+                value = self.cast_value_to_primary_measure_type(value, primary_measure_type)
+                prop.NominalValue = self.file.create_entity(primary_measure_type, value)
         if unit:
             prop.Unit = unit
         del self.settings["properties"][prop.Name]
@@ -383,8 +388,8 @@ class Usecase:
 
             else:
                 primary_measure_type = self.get_primary_measure_type(name, new_value=value)
-                if value is None:
-                    nominal_value = value
+                if value is None or self.is_empty_numeric_value(value, primary_measure_type):
+                    nominal_value = None
                 else:
                     value = self.cast_value_to_primary_measure_type(value, primary_measure_type)
                     nominal_value = self.file.create_entity(primary_measure_type, value)
@@ -453,6 +458,18 @@ class Usecase:
                 return "IfcDateTime"
             elif isinstance(new_value, datetime.date):
                 return "IfcDate"
+
+    def is_empty_numeric_value(self, value: Any, primary_measure_type: str) -> bool:
+        """Whether an empty string is being assigned to a numeric measure.
+
+        Casting an empty string to a number raises (e.g. ``float("")``), which
+        would abort the whole edit. Callers treat this as "no value" instead,
+        the same way ``None`` is handled. Empty strings for string-based
+        measures (e.g. IfcLabel) are left untouched.
+        """
+        if value != "":
+            return False
+        return self.file.create_entity(primary_measure_type).attribute_type(0) in ("DOUBLE", "INT")
 
     def cast_value_to_primary_measure_type(self, value, primary_measure_type):
         type_str = self.file.create_entity(primary_measure_type).attribute_type(0)

--- a/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
+++ b/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
@@ -52,6 +52,24 @@ class TestEditPsetIFC2X3(test.bootstrap.IFC2X3):
         assert pset.HasProperties[0].NominalValue.is_a("IfcThermalTransmittanceMeasure")
         assert pset.HasProperties[0].NominalValue.wrappedValue == 42
 
+    def test_an_empty_string_for_a_numeric_property_is_treated_as_no_value(self):
+        # Regression test for #4112: an empty string assigned to a numeric
+        # property used to crash with "could not convert string to float: ''".
+        # It is now treated as no value, the same as None.
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(
+            self.file, pset=pset, properties={"ThermalTransmittance": ""}, should_purge=False
+        )
+        pset = element.IsDefinedBy[0].RelatingPropertyDefinition
+        prop = next(p for p in pset.HasProperties if p.Name == "ThermalTransmittance")
+        assert prop.NominalValue is None
+        # An empty string for a string property is still preserved, not dropped.
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Reference": ""}, should_purge=False)
+        pset = element.IsDefinedBy[0].RelatingPropertyDefinition
+        reference = next(p for p in pset.HasProperties if p.Name == "Reference")
+        assert reference.NominalValue.wrappedValue == ""
+
     def test_adding_a_property_if_it_is_none(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")


### PR DESCRIPTION
Fixes #4112.

## Problem

Assigning an empty string to a numeric property crashes the whole `edit_pset` call:

```python
ifcopenshell.api.pset.edit_pset(model, pset=pset, properties={"ThermalTransmittance": ""})
# ValueError: could not convert string to float: ''
```

The value is cast directly with `float()` / `int()` in `cast_value_to_primary_measure_type`. This is what the original bSDD report hit: a bulk operation left one numeric cell blank and took down the entire edit. (The old blenderbim bSDD operator in the traceback has since been rewritten, but the underlying library behaviour still reproduces on `v0.8.0`.)

## Fix

An empty string for a numeric measure now means "no value", consistent with how `None` is already handled: the property is purged (or its `NominalValue` cleared with `should_purge=False`). A small helper `is_empty_numeric_value` gates this on the measure resolving to `DOUBLE`/`INT`, so:

- empty strings for string measures (`IfcLabel`, `IfcText`) are left untouched,
- a genuinely non-numeric string (e.g. `"abc"`) still raises, since that is a real caller error.

A null-valued numeric measure cannot be created (it is invalid IFC), so treating it as "no value" is the correct handling rather than writing an empty measure.

## Verify

Added `test_an_empty_string_for_a_numeric_property_is_treated_as_no_value`, which runs under both IFC2X3 and IFC4. Full `test_edit_pset.py` passes (29 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)