### PR TITLE
IfcTester: fix predefinedType restrictions that include USERDEFINED (#7855, #7856)

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -243,13 +243,14 @@ class Entity(Facet):
             reason = {"type": "NAME", "actual": inst.is_a().upper()}
 
         if is_pass and self.predefinedType:
-            if self.predefinedType == "USERDEFINED":
-                is_pass = ifcopenshell.util.element.is_userdefined_type(inst)
-                if not is_pass:
-                    predefined_type = ifcopenshell.util.element.get_predefined_type(inst)
-            else:
-                predefined_type = ifcopenshell.util.element.get_predefined_type(inst)
-                is_pass = predefined_type == self.predefinedType
+            predefined_type = ifcopenshell.util.element.get_predefined_type(inst)
+            is_pass = predefined_type == self.predefinedType
+            # A USERDEFINED element resolves its predefined type to its ObjectType,
+            # so it is matched via the literal "USERDEFINED" rather than that value.
+            # Comparing against self.predefinedType also handles the restriction case
+            # (e.g. an enumeration of "COLUMN" and "USERDEFINED").
+            if not is_pass and ifcopenshell.util.element.is_userdefined_type(inst):
+                is_pass = self.predefinedType == "USERDEFINED"
 
             if not is_pass:
                 reason = {"type": "PREDEFINEDTYPE", "actual": predefined_type}

--- a/src/ifctester/test/fixtures/predefinedtype_restriction_userdefined/predefinedtype_restriction_userdefined.ids
+++ b/src/ifctester/test/fixtures/predefinedtype_restriction_userdefined/predefinedtype_restriction_userdefined.ids
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>PredefinedType enumeration including USERDEFINED</title>
+        <description>An enumeration listing SOLIDWALL and USERDEFINED must still match SOLIDWALL.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must be SOLIDWALL or USERDEFINED" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                    <predefinedType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="SOLIDWALL"/>
+                            <xs:enumeration value="USERDEFINED"/>
+                        </xs:restriction>
+                    </predefinedType>
+                </entity>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/predefinedtype_restriction_userdefined/predefinedtype_restriction_userdefined.ifc
+++ b/src/ifctester/test/fixtures/predefinedtype_restriction_userdefined/predefinedtype_restriction_userdefined.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-07T00:00:00',(''),(''),'IfcOpenShell','IfcOpenShell','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('2Fu_ePwY1DZxzRl9jojPIx',$,'Wall1',$,$,$,$,$,.SOLIDWALL.);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -202,6 +202,32 @@ class TestEntity:
         facet = Entity(name="IFCWALL", predefinedType="X")
         run("Overridden predefined types should pass", facet=facet, inst=wall, expected=True)
 
+        # A predefined type enumeration that includes USERDEFINED must still match a
+        # specific value such as SOLIDWALL, and must match USERDEFINED elements (#7855, #7856).
+        restriction = Restriction(options={"enumeration": ["SOLIDWALL", "USERDEFINED"]})
+        facet = Entity(name="IFCWALL", predefinedType=restriction)
+        ifc = ifcopenshell.file()
+        run(
+            "A predefined type enumeration including USERDEFINED still matches a listed value",
+            facet=facet,
+            inst=ifc.createIfcWall(PredefinedType="SOLIDWALL"),
+            expected=True,
+        )
+        ifc = ifcopenshell.file()
+        run(
+            "A predefined type enumeration including USERDEFINED matches a USERDEFINED element",
+            facet=facet,
+            inst=ifc.createIfcWall(PredefinedType="USERDEFINED", ObjectType="WALDO"),
+            expected=True,
+        )
+        ifc = ifcopenshell.file()
+        run(
+            "A predefined type enumeration does not match an unlisted value",
+            facet=facet,
+            inst=ifc.createIfcWall(PredefinedType="PARTITIONING"),
+            expected=False,
+        )
+
         restriction = Restriction(options={"enumeration": ["IFCWALL", "IFCSLAB"]})
         facet = Entity(name=restriction)
         ifc = ifcopenshell.file()

--- a/src/ifctester/test/test_fixture_predefinedtype_restriction_userdefined.py
+++ b/src/ifctester/test/test_fixture_predefinedtype_restriction_userdefined.py
@@ -1,0 +1,49 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression test for a specific reported defect (#7855, #7856).
+
+Entity.__call__ compared self.predefinedType == "USERDEFINED" first. For a
+restriction enumeration that includes "USERDEFINED" among its values (e.g.
+SOLIDWALL, USERDEFINED), that comparison is truthy for the whole
+restriction object, routing every element into the USERDEFINED-only branch
+even when its actual predefined type (SOLIDWALL) was a listed, non-USERDEFINED
+value. The requirement failed even though SOLIDWALL was explicitly allowed.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "predefinedtype_restriction_userdefined")
+SPEC = os.path.join(FIXTURES, "predefinedtype_restriction_userdefined.ids")
+MODEL = os.path.join(FIXTURES, "predefinedtype_restriction_userdefined.ifc")
+
+
+class TestPredefinedTypeRestrictionUserdefinedFixture:
+    def test_solidwall_matches_enumeration_that_also_lists_userdefined(self):
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(MODEL)
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.requirements[0].status is True
+        assert spec.status is True


### PR DESCRIPTION
Fixes #7856 and the Entity-facet half of #7855.

## Problem

`Entity.__call__` tested `self.predefinedType == "USERDEFINED"` **first**. When the facet's predefined type is a restriction (e.g. an enumeration of `COLUMN` and `USERDEFINED`), that comparison is truthy because the restriction *contains* `USERDEFINED`. Every element was therefore routed into the USERDEFINED-only branch (`is_userdefined_type`), and elements whose actual predefined type was a listed value like `COLUMN` failed. On the reporter's sample the applicability matched nothing at all.

## Fix

Compare the resolved predefined type against the facet value first (which handles plain strings and restrictions uniformly), and only fall back to accepting a genuinely USERDEFINED element via the literal `"USERDEFINED"`:

```python
predefined_type = ifcopenshell.util.element.get_predefined_type(inst)
is_pass = predefined_type == self.predefinedType
if not is_pass and ifcopenshell.util.element.is_userdefined_type(inst):
    is_pass = self.predefinedType == "USERDEFINED"
```

All existing behaviours are preserved: plain `predefinedType="USERDEFINED"` still matches USERDEFINED elements, ObjectType matching for USERDEFINED still works (via `get_predefined_type` resolving to the ObjectType), and inherited/overridden types are unchanged.

## Verify

On the #7856 sample (`test.ifc` + `test.ids`), the Entity-facet applicability goes from matching **nothing** to matching both `IfcColumn` and `IfcColumnType`. Added three cases to `test_filtering_using_an_entity_facet` covering an enumeration of `{SOLIDWALL, USERDEFINED}`: listed value passes, USERDEFINED element passes, unlisted value fails. Red-green verified: the new assertions fail on the previous code and pass with the fix. Full `test_facet.py` passes (23 tests).

## Note on #7855

The remaining Entity-vs-Attribute difference in #7855 is by design: an `attribute` facet checks the literal `PredefinedType` attribute (genuinely `$` on the occurrence in the sample), while the `entity` facet resolves type inheritance and USERDEFINED/ObjectType semantics. The entity facet is the correct tool for predefined types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)