### PR TITLE
Selector: negate list comparisons as an aggregate (#8129)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -1222,7 +1222,13 @@ class FacetTransformer(lark.Transformer):
 
     def compare(self, element_value, comparison, value) -> bool:
         if isinstance(element_value, (list, tuple)):
-            return any(self.compare(ev, comparison, value) for ev in element_value)
+            # Match if any item does, negating the aggregate rather than each
+            # item, so that e.g. != means "no item equals" and stays the
+            # complement of = (#8129).
+            result = any(self.compare(ev, comparison.lstrip("!"), value) for ev in element_value)
+            if comparison.startswith("!"):
+                return not result
+            return result
         elif isinstance(value, str):
             try:
                 if isinstance(element_value, int):

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -260,6 +260,12 @@ class TestFilterElements(test.bootstrap.IFC4):
         pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")
         ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": ["New"]})
         assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status=New") == {element}
+        # On multi-valued properties, != means "no value equals" and stays the
+        # complement of = (#8129).
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": ["New", "Demolish"]})
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status=New") == {element}
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status!=New") == {element2}
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status!=Temporary") == {element, element2}
 
     def test_selecting_by_property_with_comparisons(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")


### PR DESCRIPTION
Fixes the incoherent negation half of #8129.

## Problem

For a multi-valued property such as `CastingMethod = ['INSITU', 'PRINTED']`:

```
IfcWall, "Pset...".CastingMethod = "INSITU"   -> matches
IfcWall, "Pset...".CastingMethod != "INSITU"  -> also matches
```

`compare()` recursed into the list passing the negated comparison through to each item, then aggregated with `any()`. So `!=` evaluated as "at least one item differs", which is true for any list with two distinct values. `=` and `!=` were not complements; the reporter's `ifcquery` runs returned the same 70 elements for both.

## Fix

Strip the negation for the per-item comparison and negate the aggregate:

```python
result = any(self.compare(ev, comparison.lstrip("!"), value) for ev in element_value)
if comparison.startswith("!"):
    return not result
```

`!=` now means "no item equals" (and `!*=` "no item contains"), the exact complement of the existing any-semantics for `=`.

## Not changed

The reporter also questions whether `= "INSITU"` should match a multi-valued property at all (vs. requiring the whole set to be equal). The any-match semantics for `=` are long-established in this grammar (e.g. `material.Name` matching any layer), so I have left them untouched; this PR only makes negation coherent with them. Happy to follow up if a whole-set-equality operator is wanted.

## Verify

Extended `test_selecting_by_property` with a two-valued enumerated property: `=New` matches, `!=New` matches only the other element, `!=Temporary` matches both. Red-green verified (fails on previous code, passes with fix). Full `test_selector.py` passes (37 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)