### PR TITLE
Sequence: sub-day durations occupy their day when cascading (#8245)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/cascade_schedule.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/cascade_schedule.py
@@ -156,7 +156,10 @@ class Usecase:
                 finish = self.get_task_time_attribute(predecessor, "ScheduleFinish")
                 if not finish:
                     continue
-                days = 0 if predecessor_duration.days == 0 else 1
+                # A sub-day duration (e.g. PT5H) still occupies its day, so
+                # only true zero durations (milestones) start the same day.
+                is_milestone = predecessor_duration.days == 0 and not getattr(predecessor_duration, "seconds", 0)
+                days = 0 if is_milestone else 1
                 duration_type = "WORKTIME"
                 if rel.TimeLag:
                     # updated to handle IfcRatioMeasure as a TimeLag value

--- a/src/ifcopenshell-python/ifcopenshell/util/sequence.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/sequence.py
@@ -115,13 +115,18 @@ def get_start_or_finish_date(
     calendar: ifcopenshell.entity_instance,
     date_type: Literal["START", "FINISH"] = "FINISH",
 ):
-    if not duration.days:
+    seconds = int(getattr(duration, "seconds", 0))
+    if not duration.days and not seconds:
         # Typically a milestone will have zero duration, so the start == finish
         return start
     # We minus 1 because the start day itself is counted as a day
     months = int(getattr(duration, "months", 0))
     years = int(getattr(duration, "years", 0))
     total_duration = duration.days + months * 30 + years * 12 * 30
+    if not total_duration and seconds:
+        # The schedule is day-granular, so a sub-day duration (e.g. PT5H)
+        # still occupies its start day rather than being a zero-day milestone.
+        total_duration = 1
     duration = datetime.timedelta(days=total_duration - 1)
 
     if date_type == "START":

--- a/src/ifcopenshell-python/test/api/sequence/test_cascade_schedule.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_cascade_schedule.py
@@ -96,6 +96,19 @@ class TestCascadeSchedule(test.bootstrap.IFC4):
         assert task3.TaskTime.ScheduleStart == "2000-01-02T09:00:00"
         assert task3.TaskTime.ScheduleFinish == "2000-01-04T17:00:00"
 
+    def test_cascading_finish_to_start_for_sub_day_durations(self):
+        # Regression test for #8245: an hour-based duration such as PT5H must
+        # occupy its day rather than behave like a zero-duration milestone.
+        task = self._create_task("PT5H")
+        task2 = self._create_task("P2D")
+        self._create_sequence(task, task2, "FINISH_START")
+
+        ifcopenshell.api.sequence.cascade_schedule(self.file, task=task)
+        assert task.TaskTime.ScheduleStart == "2000-01-01T09:00:00"
+        assert task.TaskTime.ScheduleFinish == "2000-01-01T17:00:00"
+        assert task2.TaskTime.ScheduleStart == "2000-01-02T09:00:00"
+        assert task2.TaskTime.ScheduleFinish == "2000-01-03T17:00:00"
+
     def test_cascading_finish_to_finish(self):
         task = self._create_task("P1D")
         task2 = self._create_task("P2D")


### PR DESCRIPTION
Fixes #8245.

## Problem

With a task duration of `PT5H`, cascading produced `ScheduleFinish == ScheduleStart` — the five hours vanished — and the FINISH_START successor was scheduled from that wrong finish (same day as the predecessor's start). Reproduced on current `v0.8.0`:

```
T1: 2026-07-06T09:00 -> 2026-07-06T09:00  dur PT5H     # finish == start
T2: 2026-07-06T09:00 -> ...                            # successor starts same day
```

Two places assume day-only durations:
- `ifcopenshell.util.sequence.get_start_or_finish_date` returns `start` unchanged whenever `duration.days == 0` (intended for milestones, but `PT5H` has `days == 0, seconds == 18000`).
- `cascade_schedule`'s FINISH_START branch computes `days = 0 if predecessor_duration.days == 0 else 1`, so a sub-day predecessor was treated as a milestone.

## Fix

The engine is deliberately day-granular (times snap to 09:00/17:00), so the minimal consistent behaviour is that a sub-day duration occupies its start day:

- `get_start_or_finish_date`: only a true zero duration (no days, no seconds) is a milestone; a sub-day duration counts as one day.
- FINISH_START cascade: only true zero durations let the successor start the same day.

After the fix:

```
T1: 2026-07-06T09:00 -> 2026-07-06T17:00  dur PT5H
T2: 2026-07-07T09:00 -> 2026-07-07T17:00
```

The stored `ScheduleDuration` keeps its full precision (`PT5H`); milestone behaviour (`P0D`) is unchanged.

## Verify

Added `test_cascading_finish_to_start_for_sub_day_durations`, mirroring the existing FS test style. Red-green verified: fails on the previous code (`finish == 09:00`), passes with the fix. Full `test/api/sequence/` suite passes (67 tests).

Hour-granular scheduling (finishing at 14:00 after 5h) would be a larger redesign of the day-walking calendar logic; this PR makes sub-day durations behave consistently within the existing day-granular model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)