### PR TITLE
IfcClash: default NotRequired clash set keys instead of asserting (#8224)

### DIFF
--- a/src/ifcclash/ifcclash/ifcclash.py
+++ b/src/ifcclash/ifcclash/ifcclash.py
@@ -107,28 +107,27 @@ class Clasher:
             b = "a"
 
         mode = clash_set["mode"]
+        # These keys are NotRequired in ClashSet, so fall back to the same
+        # defaults as ifcopenshell.geom.tree instead of asserting presence.
         if mode == "intersection":
-            assert "tolerance" in clash_set and "check_all" in clash_set
             results = self.tree.clash_intersection_many(
                 list(self.groups["a"]["elements"].values()),
                 list(self.groups[b]["elements"].values()),
-                tolerance=clash_set["tolerance"],
-                check_all=clash_set["check_all"],
+                tolerance=clash_set.get("tolerance", 0.002),
+                check_all=clash_set.get("check_all", True),
             )
         elif mode == "collision":
-            assert "allow_touching" in clash_set
             results = self.tree.clash_collision_many(
                 list(self.groups["a"]["elements"].values()),
                 list(self.groups[b]["elements"].values()),
-                allow_touching=clash_set["allow_touching"],
+                allow_touching=clash_set.get("allow_touching", False),
             )
         elif mode == "clearance":
-            assert "clearance" in clash_set and "check_all" in clash_set
             results = self.tree.clash_clearance_many(
                 list(self.groups["a"]["elements"].values()),
                 list(self.groups[b]["elements"].values()),
-                clearance=clash_set["clearance"],
-                check_all=clash_set["check_all"],
+                clearance=clash_set.get("clearance", 0.05),
+                check_all=clash_set.get("check_all", False),
             )
         else:
             assert_never(mode)


### PR DESCRIPTION
Fixes #8224.

## Problem

The reporter's minimal dict-based configuration (`mode: "collision"` without `allow_touching`) crashes with a bare `AssertionError` right after "Element metadata finished":

```python
elif mode == "collision":
    assert "allow_touching" in clash_set
```

`ClashSet` declares `tolerance`, `check_all`, `allow_touching` and `clearance` as `NotRequired`, so the asserts directly contradict the type contract — any config that omits them (which the TypedDict says is fine) dies with no message. The same applies to `intersection` and `clearance` modes.

## Fix

Use `.get()` with the same defaults as `ifcopenshell.geom.tree`'s own clash methods (`tolerance=0.002, check_all=True`; `allow_touching=False`; `clearance=0.05, check_all=False`), so the dict config, the TypedDict, and the underlying API agree.

## Verify

Reproduced the reporter's configuration headless on current `v0.8.0`: `AssertionError` before, completes cleanly after (`clash()` runs through collision mode with two generated wall models and exports results). Explicitly provided keys behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)