### PR TITLE
root.reassign_class: raise a clear error when no class is applicable (#8210)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/root/reassign_class.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/root/reassign_class.py
@@ -197,8 +197,13 @@ class Usecase:
                 # but currently type_to_entity_map doesn't completely match entity_to_type_map,
                 # see type.py for more details.
                 occurrence_class = next(
-                    iter(ifcopenshell.util.type.get_applicable_entities(ifc_class, self.file.schema))
+                    iter(ifcopenshell.util.type.get_applicable_entities(ifc_class, self.file.schema)), None
                 )
+                if occurrence_class is None:
+                    raise TypeError(
+                        f"No applicable occurrence class found for '{ifc_class}' in schema "
+                        f"{self.file.schema}. Provide 'occurrence_class' explicitly."
+                    )
             assert not self.schema.declaration_by_name(occurrence_class)._is(
                 "IfcTypeProduct"
             ), f"Unexpected occurrence_class: '{occurrence_class}' / '{self.occurrence_class}'."
@@ -208,7 +213,13 @@ class Usecase:
         else:
             element_type = ifcopenshell.util.element.get_type(element)
             if element_type:
-                ifc_class_ = next(iter(ifcopenshell.util.type.get_applicable_types(ifc_class, self.file.schema)))
+                ifc_class_ = next(
+                    iter(ifcopenshell.util.type.get_applicable_types(ifc_class, self.file.schema)), None
+                )
+                if ifc_class_ is None:
+                    raise TypeError(
+                        f"No applicable type class found for '{ifc_class}' in schema {self.file.schema}."
+                    )
                 element_type = self.reassign_class(element_type, ifc_class_, predefined_type)
                 ifc_class = element.is_a()
                 for occurrence in ifcopenshell.util.element.get_types(element_type):

--- a/src/ifcopenshell-python/test/api/root/test_reassign_class.py
+++ b/src/ifcopenshell-python/test/api/root/test_reassign_class.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
+
 import ifcopenshell.api.aggregate
 import ifcopenshell.api.geometry
 import ifcopenshell.api.pset
@@ -77,6 +79,23 @@ class TestReassignClass(test.bootstrap.IFC4):
         # original clases are gone
         assert len(self.file.by_type("IfcWall")) == 0
         assert len(self.file.by_type("IfcWallType")) == 0
+
+    def test_raising_a_clear_error_when_no_occurrence_class_is_applicable(self):
+        # Regression test for #8210: classes with no applicable occurrences
+        # (e.g. IfcTypeProduct) raised an uncaught StopIteration instead of
+        # a clear error when the type had occurrences to reassign.
+        element_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=element_type)
+        with pytest.raises(TypeError):
+            ifcopenshell.api.root.reassign_class(self.file, product=element_type, ifc_class="IfcTypeProduct")
+
+    def test_raising_a_clear_error_when_no_type_class_is_applicable(self):
+        element_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=element_type)
+        with pytest.raises(TypeError):
+            ifcopenshell.api.root.reassign_class(self.file, product=element, ifc_class="IfcAnnotation")
 
     def test_reassigning_type_class_and_its_occurrences_classes_if_entity_was_typed(self):
         element_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")


### PR DESCRIPTION
Addresses the latent bug @Gorgious56 flagged in #8210 after #8211 merged.

## Problem

`reassign_class.py` resolves the counterpart class with `next(iter(...))` and no default in two places:

- the occurrence class for a reassigned type (`get_applicable_entities`)
- the type class for a reassigned occurrence (`get_applicable_types`)

For classes with an empty applicability map (the same abstract-`IfcTypeProduct` family as #8210, or `IfcAnnotation` for a typed occurrence) this raised an uncaught `StopIteration` instead of a friendly error.

## Fix

Give both `next()` calls a `None` default and raise a `TypeError` naming the class and schema; the type path additionally points at the `occurrence_class` parameter, which remains the explicit override (the Bonsai path).

## Verify

Two regression tests added, run under IFC4 / IFC4X3 / IFC2X3 via the existing class hierarchy. Red-green verified: all six fail with `StopIteration` on the previous code, pass with the fix. Full `test_reassign_class.py` passes (49 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)