### PR TITLE
docs: remove TODO placeholder sections from the create-model quickstart (#8208)

### DIFF
--- a/src/bonsai/docs/quickstart/create_model.rst
+++ b/src/bonsai/docs/quickstart/create_model.rst
@@ -77,18 +77,3 @@ the image below. Three simple open source online viewers you can test with are
 <https://3dviewer.net/>`__.
 
 .. image:: images/ifc-pipeline.png
-
-Placing occurrences of an element type
---------------------------------------
-
-TODO
-
-Changing the locations of elements
-----------------------------------
-
-TODO
-
-Modeling a simple building
---------------------------
-
-TODO


### PR DESCRIPTION
Fixes #8208.

The quickstart page (`src/bonsai/docs/quickstart/create_model.rst`) ended with three headings whose entire bodies were `TODO` — the dead end the reporter hit on docs.bonsaibim.org. Per the reporter's own suggestion (delete or redirect), this removes the placeholders so the page ends cleanly on the completed save-and-view flow. If those tutorials get written later, the headings come back with content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)