### PR TITLE
Bonsai: fall back to adaptive units for unsupported SI prefixes (#8074)

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -980,8 +980,13 @@ class IfcImporter:
                     if unit.Name == "METRE":
                         if not unit.Prefix:
                             bpy.context.scene.unit_settings.length_unit = "METERS"
-                        else:
+                        elif f"{unit.Prefix}METERS" in ("KILOMETERS", "CENTIMETERS", "MILLIMETERS", "MICROMETERS"):
                             bpy.context.scene.unit_settings.length_unit = f"{unit.Prefix}METERS"
+                        else:
+                            # Blender's length_unit enum has no entry for other
+                            # SI prefixes (e.g. DECIMETERS), so fall back to
+                            # adaptive display instead of failing to open.
+                            bpy.context.scene.unit_settings.length_unit = "ADAPTIVE"
                 else:
                     bpy.context.scene.unit_settings.system = "IMPERIAL"
                     name = unit.Name.lower()


### PR DESCRIPTION
Fixes #8074.

## Problem

`import_ifc.py` sets the Blender scene unit from the project length unit as `f"{unit.Prefix}METERS"`. Blender's `unit_settings.length_unit` enum only defines `KILOMETERS`, `CENTIMETERS`, `MILLIMETERS`, `MICROMETERS` (plus `METERS`/`ADAPTIVE`), so a project whose length unit is `.DECI. .METRE.` produces `"DECIMETERS"`, the enum assignment raises, and the file fails to open. That matches the reporter's matrix exactly: METRE/CENTIMETRE/MILLIMETRE open, DECIMETRE does not (verified the attached `dm.ifc` carries `IfcSIUnit(*,.LENGTHUNIT.,.DECI.,.METRE.)`; `ifcopenshell` itself and `util.unit` handle it fine — `calculate_unit_scale` returns 0.1).

## Fix

Guard the assignment with the set of prefixes Blender supports and fall back to `ADAPTIVE` display for the rest (DECI, DECA, HECTO, ...). Model data is unaffected — this only controls Blender's display unit, and adaptive display shows correctly scaled values.

## Verify

Logic-only change in the Blender-bound loader, so no headless test is possible; the supported-enum facts are from the Blender API docs. Anyone with a GUI can confirm by opening the `dm.ifc` from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)