### PR TITLE
Bonsai: drop stale kwarg when invoking add_reference_image (#8130)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -137,7 +137,7 @@ class AddAnnotationType(bpy.types.Operator, tool.Ifc.Operator):
         element.ApplicableOccurrence = f"IfcAnnotation/{object_type}"
 
         if props.create_representation_for_type and object_type == "IMAGE":
-            bpy.ops.bim.add_reference_image("INVOKE_DEFAULT", existing_object_by_name=obj.name)
+            bpy.ops.bim.add_reference_image("INVOKE_DEFAULT")
 
 
 class EnableAddAnnotationType(bpy.types.Operator):
@@ -966,7 +966,9 @@ class CreateDrawing(bpy.types.Operator):
             # Specifically for PLAN_VIEW and REFLECTED_PLAN_VIEW, any Plan context is also prioritised.
             contexts = self.get_linework_contexts(ifc, target_view)
             self.serialize_contexts_elements(ifc, tree, contexts, "body", drawing_elements, target_view, link_matrix)
-            self.serialize_contexts_elements(ifc, tree, contexts, "annotation", drawing_elements, target_view, link_matrix)
+            self.serialize_contexts_elements(
+                ifc, tree, contexts, "annotation", drawing_elements, target_view, link_matrix
+            )
 
             if tool.Ifc.get() == ifc and self.camera_element not in drawing_elements:
                 with profile("Camera element"):
@@ -1775,7 +1777,7 @@ class AddAnnotation(bpy.types.Operator, tool.Ifc.Operator):
             enable_editing=True,
         )
         if props.object_type == "IMAGE":
-            bpy.ops.bim.add_reference_image("INVOKE_DEFAULT", existing_object_by_name=obj.name)
+            bpy.ops.bim.add_reference_image("INVOKE_DEFAULT")
 
 
 class AddSheet(bpy.types.Operator, tool.Ifc.Operator):


### PR DESCRIPTION
Fixes #8130. The in-thread suspicion about #7684 was right, with a small twist.

## Problem

#7684 rewrote `AddReferenceImage` and **removed** its `use_existing_object_by_name` property — but at the two call sites it *renamed* the argument (`use_existing_object_by_name=` → `existing_object_by_name=`) instead of deleting it:

```python
bpy.ops.bim.add_reference_image("INVOKE_DEFAULT", existing_object_by_name=obj.name)
```

The rewritten operator declares no such property (only `use_relative_path`, `filter_*`, `x_length`, `y_length`, `show_texture_solid_mode`), and passing an unknown property to a Blender operator raises `TypeError: ... keyword "existing_object_by_name" unrecognized`. That fires on exactly the reporter's repro: annotation tool → type `image` → Add (`operator.py:1778`; same stale kwarg at `:140` in the annotation-type path).

## Fix

Remove the dead kwarg at both call sites, so the operator runs with its post-#7684 behaviour (file browser, new image object with x/y length). If attaching the image style to the just-created annotation object should be restored, that is a design call for the #7684 author — this PR only removes the crash.

## Verify

Grep confirms no other call site and no such property anywhere in the tree; syntax-checked. Blender-bound modal path, so no headless test is possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)