### PR TITLE
Selector: fix material != and NULL filtering (#6787)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -1017,15 +1017,21 @@ class FacetTransformer(lark.Transformer):
 
         def filter_function(element: ifcopenshell.entity_instance) -> bool:
             materials = ifcopenshell.util.element.get_materials(element)
-            result = False if materials else None
-            for material in materials:
-                if self.compare(material.Name, comparison, value):
-                    result = True
-                if self.compare(getattr(material, "Category", None), comparison, value):
-                    result = True
-            if result is not None:
-                return result if comparison == "=" else not result
-            return self.compare(None, comparison, value)
+            positive = comparison.lstrip("!")
+            if value is None:
+                # NULL means the element has no materials at all.
+                result = not materials
+            else:
+                # Compare each material positively and negate the aggregate,
+                # so that != means "no material matches" (#6787).
+                result = any(
+                    self.compare(material.Name, positive, value)
+                    or self.compare(getattr(material, "Category", None), positive, value)
+                    for material in materials
+                )
+            if comparison.startswith("!"):
+                return not result
+            return result
 
         self.add_default_elements()
         self.elements = set(filter(filter_function, self.elements))

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -261,6 +261,14 @@ class TestFilterElements(test.bootstrap.IFC4):
         ifcopenshell.api.material.assign_material(self.file, products=[element], material=material)
         assert subject.filter_elements(self.file, "IfcWall, material=CON01") == {element}
         assert subject.filter_elements(self.file, "IfcWall, material!=CON01") == {element2}
+        # != must also exclude elements with a different material, and NULL must
+        # mean "has no materials", even when other elements do have some (#6787).
+        material2 = ifcopenshell.api.material.add_material(self.file, name="STE01")
+        ifcopenshell.api.material.assign_material(self.file, products=[element2], material=material2)
+        assert subject.filter_elements(self.file, "IfcWall, material!=CON01") == {element2}
+        element3 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        assert subject.filter_elements(self.file, "IfcWall, material=NULL") == {element3}
+        assert subject.filter_elements(self.file, "IfcWall, material!=NULL") == {element, element2}
 
     def test_selecting_by_property(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")


### PR DESCRIPTION
Fixes #6787.

## Problem

With walls carrying CON01 / STE01 / no material, on current `v0.8.0`:

```
material=CON01   -> [w1]            OK
material!=CON01  -> [w3]            wrong: w2 (STE01) excluded
material=NULL    -> [w1, w2, w3]    wrong: returns everything
material!=NULL   -> []              wrong: returns nothing
```

Two defects in the `material` facet:

1. **Double negation**: `compare()` already applies `!` per material, and the facet then flips the aggregate again (`return result if comparison == "=" else not result`). Any element whose materials differ from the value passes the inner compare and is then flipped to excluded.
2. **NULL compared per-field**: `NULL` was compared against each material's `Name` and `Category`, so any material with no `Category` (`None is None`) matched `material=NULL` — i.e. nearly every element.

## Fix

Compare each material positively and negate the aggregate once (`!=` now means "no material's name or category matches", consistent with the equivalent fix for list values in #8254), and define `NULL` as "the element has no materials", which is what the existing test already asserted for the no-materials case.

## Verify

All four cases above now return the expected sets. Extended `test_selecting_by_material` with a second material and a material-less element; red-green verified (fails on the previous code, passes with the fix). Full `test_selector.py` passes (37 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)