### PR TITLE
Selector: add referenced_structures value key (#7806)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -474,6 +474,8 @@ def _get_element_value(element: ifcopenshell.entity_instance, keys: list[str]) -
             value = ifcopenshell.util.classification.get_references(value)
         elif key == "group":
             value = ifcopenshell.util.element.get_groups(value)
+        elif key == "referenced_structures":
+            value = ifcopenshell.util.element.get_referenced_structures(value)
         elif key == "system":
             value = ifcopenshell.util.system.get_element_systems(value)
         elif key == "zone":

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -143,6 +143,15 @@ class TestGetElementValue(test.bootstrap.IFC4):
         # Provide shortform for convenience
         assert subject.get_element_value(element, "mat.i.Name") == ["L1", "L2"]
 
+    def test_selecting_referenced_structures(self):
+        # Structures referenced via IfcRelReferencedInSpatialStructure (#7806).
+        storey = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey", name="L1")
+        space = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSpace", name="Kitchen")
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcDoor")
+        ifcopenshell.api.spatial.reference_structure(self.file, products=[element], relating_structure=storey)
+        ifcopenshell.api.spatial.reference_structure(self.file, products=[element], relating_structure=space)
+        assert subject.get_element_value(element, "referenced_structures.Name") == ["L1", "Kitchen"]
+
     def test_selecting_a_query_that_fails_silently(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         assert subject.get_element_value(element, "material.item.Name.0") is None


### PR DESCRIPTION
Implements #7806, essentially as @steverugi proposed in-thread.

## What

Structures assigned via `IfcRelReferencedInSpatialStructure` (a door referencing its space, columns spanning storeys) were not reachable from selector value queries, so spreadsheet schedules could not include them. This exposes the existing `ifcopenshell.util.element.get_referenced_structures` as a value key, mirroring how `group` wraps `get_groups`:

```
referenced_structures.Name          -> ["L1", "Kitchen"]
join(", ", {{referenced_structures.Name}})  -> "L1, Kitchen"   # spreadsheet formatting
```

The second form is the exact IfcCsv use case from the issue.

## Verify

Added `test_selecting_referenced_structures` (door referencing a storey and a space). Full `test_selector.py` passes (38 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)