### PR TITLE
util.cost: add calculate_total_applied_value (#5912)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/cost.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/cost.py
@@ -100,6 +100,21 @@ def calculate_applied_value(
     return 0.0
 
 
+def calculate_total_applied_value(
+    root_element: ifcopenshell.entity_instance, category_filter: Optional[str] = None
+) -> float:
+    """Sum :func:`calculate_applied_value` over all cost values of a cost item.
+
+    :param root_element: The IfcCostItem whose CostValues are summed.
+    :param category_filter: Optionally filter by cost value category.
+    :return: The total applied value of the cost item.
+    """
+    result = 0.0
+    for cost_value in root_element.CostValues or []:
+        result += calculate_applied_value(root_element, cost_value, category_filter)
+    return result
+
+
 def sum_child_root_elements(root_element: ifcopenshell.entity_instance, category_filter: Optional[str] = None) -> float:
     result = 0.0
     for rel in root_element.IsNestedBy:

--- a/src/ifcopenshell-python/test/util/test_cost.py
+++ b/src/ifcopenshell-python/test/util/test_cost.py
@@ -49,3 +49,31 @@ class TestGetCostItemForProduct(test.bootstrap.IFC4):
         cost_schedule = ifcopenshell.api.cost.add_cost_schedule(model)
         item1 = ifcopenshell.api.cost.add_cost_item(model, cost_schedule=cost_schedule)
         assert list(subject.get_cost_items_for_product(element)) == []
+
+
+class TestCalculateTotalAppliedValue(test.bootstrap.IFC4):
+    def test_run(self):
+        # A cost item with multiple composite cost values sums them all (#5912).
+        model = self.file
+        cost_schedule = ifcopenshell.api.cost.add_cost_schedule(model)
+        item = ifcopenshell.api.cost.add_cost_item(model, cost_schedule=cost_schedule)
+
+        def component(value: float) -> ifcopenshell.entity_instance:
+            return model.create_entity("IfcCostValue", AppliedValue=model.createIfcMonetaryMeasure(value))
+
+        value1 = model.create_entity(
+            "IfcCostValue", ArithmeticOperator="MULTIPLY", Components=[component(8.0), component(5.0)]
+        )
+        value2 = model.create_entity(
+            "IfcCostValue", ArithmeticOperator="MULTIPLY", Components=[component(6.0), component(7.0)]
+        )
+        item.CostValues = [value1, value2]
+        assert subject.calculate_applied_value(item, value1) == 40.0
+        assert subject.calculate_applied_value(item, value2) == 42.0
+        assert subject.calculate_total_applied_value(item) == 82.0
+
+    def test_no_cost_values(self):
+        model = self.file
+        cost_schedule = ifcopenshell.api.cost.add_cost_schedule(model)
+        item = ifcopenshell.api.cost.add_cost_item(model, cost_schedule=cost_schedule)
+        assert subject.calculate_total_applied_value(item) == 0.0


### PR DESCRIPTION
Implements the helper requested in #5912.

## What

`calculate_applied_value` evaluates one cost value at a time, so totalling a cost item that carries multiple `CostValues` (the reporter's case: two composite MULTIPLY formulas, 8×5 and 6×7) required a custom loop in every caller. This adds:

```python
ifcopenshell.util.cost.calculate_total_applied_value(cost_item)   # -> 82.0
```

mirroring `calculate_applied_value`'s signature including `category_filter`.

On the "AppliedValue not accurate" part of the issue: that attribute stores the *static* cached value, while `calculate_applied_value` evaluates the component formula — the 50 vs 40 difference is the cached attribute being out of date in the file, not a calculation bug, so nothing to fix there beyond using the calculation functions.

## Verify

Added `TestCalculateTotalAppliedValue` replicating the reporter's structure (two composite MULTIPLY cost values → 40 + 42 = 82) plus the empty case. Full `test_cost.py` passes (5 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)