### PR TITLE
Bonsai: fix KeyError in format_distance for kilometre and mile units (#8255)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/helper.py
+++ b/src/bonsai/bonsai/bim/module/drawing/helper.py
@@ -189,14 +189,20 @@ def format_distance(
             if hasattr(length_unit, "Prefix") and length_unit.Prefix:
                 unit_length = length_unit.Prefix + length_unit.Name
             unit_length_mapping = {
+                "MILE": "MILES",
                 "FOOT": "FEET",
                 "INCH": "INCHES",
+                "KILOMETRE": "KILOMETERS",
                 "METRE": "METERS",
                 "DECIMETRE": "DECIMETERS",
                 "CENTIMETRE": "CENTIMETERS",
                 "MILLIMETRE": "MILLIMETERS",
+                "MICROMETRE": "MICROMETERS",
             }
-            unit_length = unit_length_mapping[unit_length]
+            # Fall through for units without a dedicated formatter (e.g.
+            # HECTOMETRE) so they use the adaptive branch instead of a
+            # KeyError (#8255).
+            unit_length = unit_length_mapping.get(unit_length, unit_length)
         # For now we only format area in IFC Units
         if area_unit := ifcopenshell.util.unit.get_project_unit(tool.Ifc.get(), "AREAUNIT"):
             area_unit_symbol = " " + ifcopenshell.util.unit.get_unit_symbol(area_unit)


### PR DESCRIPTION
Fixes #8255. Thanks @S59-Koara for the traceback — it pinpointed this immediately.

## Problem

`format_distance` (`src/bonsai/bonsai/bim/module/drawing/helper.py`) maps the project length unit to a Blender-style token via a fixed dict that only knows FOOT / INCH / METRE / DECIMETRE / CENTIMETRE / MILLIMETRE. Creating a project with **Kilometers** (metric) or **Miles** (imperial) in the New Project Wizard therefore crashes with `KeyError: 'KILOMETRE'` (or `'MILE'`) the moment the spatial tree formats a storey elevation — exactly the reported wizard error. `MICROMETRE` and `THOU`-era units would hit the same KeyError from any model, not just the wizard.

## Fix

- Add the missing units Blender itself supports: `KILOMETRE`, `MILE`, `MICROMETRE`.
- Use `.get(unit_length, unit_length)` so any remaining exotic unit (e.g. `HECTOMETRE`) falls through to the formatter's existing adaptive branch instead of raising — the metric section already has an adaptive `else`, and the imperial section has its own defaults.

Kilometre/micrometre values render via the adaptive metric branch (m/cm/mm as magnitude dictates); mile projects format through the imperial defaults. No dedicated km/mile display formats are invented here — this removes the crash and degrades gracefully, which is the wizard's requirement.

## Verify

Mechanism confirmed against the reporter's traceback (`helper.py:199`, `KeyError: 'KILOMETRE'` from `BIM_OT_create_project` → `import_spatial_element` → `format_distance`). Syntax-checked; Blender-bound path, so a GUI check of the wizard with Kilometers/Miles is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)