### PR TITLE
Selector: length formatters pass non-numeric values through (#5297)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -342,8 +342,15 @@ class FormatTransformer(lark.Transformer):
 
     def metric_length(self, args):
         value, precision, decimal_places = args
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            # The value is not numeric (e.g. "N/A"), so formatting it as a
+            # length is meaningless. Return it unchanged instead of crashing
+            # the whole expression (#5297).
+            return value
         return ifcopenshell.util.unit.format_length(
-            float(value), float(precision), int(decimal_places), unit_system="metric"
+            value, float(precision), int(decimal_places), unit_system="metric"
         )
 
     def imperial_length(self, args):
@@ -365,8 +372,14 @@ class FormatTransformer(lark.Transformer):
             input_unit = "inch" if input_unit == "inch" else "foot"
             output_unit = "inch" if output_unit == "inch" else "foot"
 
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            # Non-numeric values pass through unchanged, as in metric_length (#5297).
+            return value
+
         return ifcopenshell.util.unit.format_length(
-            float(value),
+            value,
             int(precision),
             suppress_zero_inches=(suppress_zero_inches if suppress_zero_inches is not None else False),
             unit_system="imperial",

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -67,6 +67,9 @@ class TestFormat(test.bootstrap.IFC4):
         assert subject.format("metric_length(123, 5, 2)") == "125.00"
         assert subject.format("metric_length(123.123, 0.1, 2)") == "123.10"
         assert subject.format('metric_length("123", 5, 2)') == "125.00"
+        # Non-numeric values (e.g. N/A cells) pass through unchanged (#5297).
+        assert subject.format('metric_length("N/A", 0.1, 1)') == "N/A"
+        assert subject.format('imperial_length("N/A", 2)') == "N/A"
         assert subject.format("imperial_length(1, 1)") == "1'"
         assert subject.format("imperial_length(3.123, 1)") == "3' - 1\""
         assert subject.format("imperial_length(3.123, 2)") == "3' - 1 1/2\""


### PR DESCRIPTION
Fixes #5297.

## Problem

`metric_length({{value}}, 0.1, 1)` in a Spreadsheet Import/Export column crashes with `could not convert string to float` as soon as one row's value is a placeholder like `"N/A"` — both `metric_length` and `imperial_length` in the format transformer cast with `float(value)` unguarded, so one non-numeric cell kills the whole export.

## Fix

Catch the failed conversion and return the value unchanged, the same graceful-fallback convention `round()` uses (see #8246 for the identical fix there):

```
metric_length(123.123, 0.1, 2) -> "123.10"
metric_length("N/A", 0.1, 2)   -> "N/A"      # was a crash
imperial_length("N/A", 2)      -> "N/A"      # was a crash
```

## Verify

Added both cases to `test_number_formatting`. Full `test_selector.py` passes (38 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)