### PR TITLE
Bonsai: don't crash TAB when EDIT is not in the mode enum (#8066)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -2417,7 +2417,14 @@ class OverrideModeSetEdit(bpy.types.Operator, tool.Ifc.Operator):
         props = tool.Geometry.get_geometry_props()
         props.is_changing_mode = True
         if props.mode != "EDIT":
-            props.mode = "EDIT"
+            try:
+                props.mode = "EDIT"
+            except TypeError:
+                # The mode enum is built dynamically (ViewportData.mode) and
+                # does not offer EDIT for every element, so syncing the UI
+                # mode can fail even though Blender's edit mode toggled fine.
+                # Keep the current mode instead of crashing TAB (#8066).
+                pass
         props.is_changing_mode = False
 
     def has_aggregates(self, objs):
@@ -2719,7 +2726,14 @@ class OverrideModeSetObject(bpy.types.Operator, tool.Ifc.Operator):
         props = tool.Geometry.get_geometry_props()
         props.is_changing_mode = True
         if props.mode != "EDIT":
-            props.mode = "EDIT"
+            try:
+                props.mode = "EDIT"
+            except TypeError:
+                # The mode enum is built dynamically (ViewportData.mode) and
+                # does not offer EDIT for every element, so syncing the UI
+                # mode can fail even though Blender's edit mode toggled fine.
+                # Keep the current mode instead of crashing TAB (#8066).
+                pass
         props.is_changing_mode = False
 
     def _is_annotation_object(self, element: ifcopenshell.entity_instance) -> bool:


### PR DESCRIPTION
Fixes the crash in #8066.

## Problem

```
TypeError: bpy_struct: item.attr = val: enum "EDIT" not found in ('OBJECT', 'ITEM')
```

Both `enable_edit_mode` implementations in `geometry/operator.py` sync the UI mode with `props.mode = "EDIT"` unconditionally after toggling Blender's edit mode. But the `mode` enum's items are generated dynamically (`ViewportData.mode()`) and only include `EDIT` for eligible elements — profile-based meshes, space boundaries, grid axes, roofs, railings. Entering edit on anything else (the reporter hit it after joining slabs) raises the enum `TypeError` and aborts the operator, even though Blender's own edit mode toggled successfully.

## Fix

Guard the enum assignment in both copies: if the current items don't offer `EDIT`, keep the current UI mode instead of crashing. Elements that qualify behave exactly as before.

## Verify

Mechanism confirmed from the reporter's traceback plus the gating in `geometry/data.py::ViewportData.mode()`. Syntax-checked; Blender-bound modal path, so GUI confirmation is the final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)