### PR TITLE
Bonsai: accept comma decimals in dimension input (#8262)

### DIFF
--- a/src/bonsai/bonsai/tool/polyline.py
+++ b/src/bonsai/bonsai/tool/polyline.py
@@ -378,7 +378,7 @@ class Polyline(bonsai.core.tool.Polyline):
 
         expr: (ADD | SUB | MUL | DIV) dim
 
-        NUMBER: /-?\\d+(?:\\.\\d+)?/
+        NUMBER: /-?\\d+(?:[.,]\\d+)?/
         ADD: "+"
         SUB: "-"
         MUL: "*"
@@ -389,7 +389,8 @@ class Polyline(bonsai.core.tool.Polyline):
 
         class InputTransform(Transformer):
             def NUMBER(self, n):
-                return float(n)
+                # Accept a comma as the decimal separator (#8262).
+                return float(n.replace(",", "."))
 
             def fraction(self, numbers):
                 return numbers[0] / numbers[1]


### PR DESCRIPTION
Implements #8262.

## What

The dimension text input (polyline/parametric controls) is parsed by `Polyline.validate_input`, whose metric grammar token `NUMBER: /-?\d+(?:\.\d+)?/` only matched dot decimals — a European keyboard's `1,5` was rejected. Two-line change: the metric `NUMBER` now matches `[.,]` and the transformer normalises the comma before `float()`. The validated value is stored as the transformer's dot-decimal output, so all downstream `float()` sites are unaffected; the imperial grammar (feet/inches) is untouched.

## Verify

Grammar + transformer proven standalone with lark:

```
1,5     -> 1.5
1.5     -> 1.5
2,5m    -> 2.5
=1,5*2  -> 3.0
```

Blender-bound module, so the UI keystroke path needs a GUI confirmation, but the parser is the only gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)