### PR TITLE
Bonsai: fail profile detection cleanly on discontinuous loops (#8072)

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2343,7 +2343,13 @@ class Model(bonsai.core.tool.Model):
                             loop_verts.append(edge.verts[0])
                             loop_verts.append(edge.verts[1])
                     else:
-                        loop_verts.append(edge.other_vert(loop_verts[-1]))
+                        next_vert = edge.other_vert(loop_verts[-1])
+                        if next_vert is None:
+                            # The edges do not form a continuous chain (e.g.
+                            # branching or degenerate geometry), so this
+                            # cannot be a profile loop (#8072).
+                            return (False, "UNCLOSED_LOOP")
+                        loop_verts.append(next_vert)
 
                 if is_closed := loop_verts[0] == loop_verts[-1]:
                     loop_verts.pop()
@@ -2566,7 +2572,13 @@ class Model(bonsai.core.tool.Model):
                             loop_verts.append(edge.verts[0])
                             loop_verts.append(edge.verts[1])
                     else:
-                        loop_verts.append(edge.other_vert(loop_verts[-1]))
+                        next_vert = edge.other_vert(loop_verts[-1])
+                        if next_vert is None:
+                            # The edges do not form a continuous chain (e.g.
+                            # branching or degenerate geometry), so this
+                            # cannot be a profile loop (#8072).
+                            return (False, "UNCLOSED_LOOP")
+                        loop_verts.append(next_vert)
 
                 if is_closed := loop_verts[0] == loop_verts[-1]:
                     loop_verts.pop()


### PR DESCRIPTION
Fixes the crash in #8072.

## Problem

```
TypeError: BMEdge.other_vert(...): BMVert expected, not 'NoneType'
```

`auto_detect_profiles` (and its curves sibling) walk each candidate loop with `loop_verts.append(edge.other_vert(loop_verts[-1]))`, assuming the edges form a continuous chain. On branching or degenerate geometry — the reporter hit it while inserting a window — `other_vert` returns `None` for an edge that does not contain the previous vertex; the `None` is appended and the next iteration raises the `TypeError`, aborting the operation.

## Fix

Guard the walk in both places and return the module's existing failure tuple `(False, "UNCLOSED_LOOP")`, exactly the convention these functions already use for `FORKED_LOOP` / `3POINT_ARC` / `CIRCLE` cases — so the caller reports an invalid profile instead of crashing.

## Verify

Mechanism confirmed from the reporter's traceback (`auto_detect_profiles`, `edge.other_vert(loop_verts[-1])`). Syntax-checked; the failure path reuses the established convention, so callers need no change. Blender-bound path — GUI confirmation on messy geometry is the final check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)