### PR TITLE
GltfSerializer: clamp roughnessFactor into the valid glTF range (#8073)

### DIFF
--- a/src/serializers/GltfSerializer.cpp
+++ b/src/serializers/GltfSerializer.cpp
@@ -108,9 +108,13 @@ int GltfSerializer::writeMaterial(const ifcopenshell::geometry::taxonomy::style:
 		base[3] = 1. - style->transparency;
 	}
 
-	if (style->has_specularity())
-		json_["materials"].push_back({ {"name", style->name}, {"doubleSided", true}, {"pbrMetallicRoughness", {{"baseColorFactor", base}, {"metallicFactor", 0}, {"roughnessFactor", 1.0 / style->specularity}}}});
-	else
+	if (style->has_specularity()) {
+		// glTF requires roughnessFactor in [0, 1]. A specular exponent of 0
+		// previously produced 1/0 = inf, which nlohmann::json serialises as
+		// null and makes the file invalid; exponents below 1 exceeded 1. #8073
+		const double roughness = style->specularity > 1.0 ? 1.0 / style->specularity : 1.0;
+		json_["materials"].push_back({ {"name", style->name}, {"doubleSided", true}, {"pbrMetallicRoughness", {{"baseColorFactor", base}, {"metallicFactor", 0}, {"roughnessFactor", roughness}}}});
+	} else
 		json_["materials"].push_back({ {"name", style->name}, {"doubleSided", true}, {"pbrMetallicRoughness", {{"baseColorFactor", base}, {"metallicFactor", 0}}}});
 	
 	if (style->transparency == style->transparency && style->transparency > 1.e-9) {


### PR DESCRIPTION
Fixes the invalid-material half of #8073.

## Problem

`GltfSerializer.cpp` computed `"roughnessFactor", 1.0 / style->specularity`. The reporter's style carries `IFCSPECULAREXPONENT(0.)`, so the division yields infinity, which nlohmann::json serialises as `null` — exactly the `"roughnessFactor": null` in the report, and invalid per the glTF spec. Exponents below 1 are also broken: they produce factors above 1, outside glTF's required [0, 1].

## Fix

```cpp
const double roughness = style->specularity > 1.0 ? 1.0 / style->specularity : 1.0;
```

Physically: a specular exponent of 0 means no shininess → full roughness; large exponents keep the existing `1/exponent` mapping. The factor now always lands in [0, 1].

## Not included

The report's second point — the material being named `IfcSurfaceStyleRendering-538744` instead of the `IfcSurfaceStyle` name — comes from how `style->name` is populated upstream of the serializer and deserves its own change.

## Verify

One-line arithmetic change; relying on the CI `build-ifcopenshell` job for compilation (I cannot build the C++ locally). The mapping is verifiable by inspection: exponent 0 → 1.0, exponent 0.5 → 1.0, exponent 4 → 0.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)