### PR TITLE
Bonsai: OverrideModeSetObject must survive direct execution (#8042)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -2557,7 +2557,9 @@ class OverrideModeSetObject(bpy.types.Operator, tool.Ifc.Operator):
     def _execute(self, context):
         if not context.active_object:
             return {"FINISHED"}
-        for obj in self.edited_objs:
+        # When run directly (e.g. bpy.ops.bim.override_mode_set_object() from
+        # another operator), invoke never populated these lists (#8042).
+        for obj in getattr(self, "edited_objs", []):
             if self.should_save:
                 bpy.ops.bim.update_representation(obj=obj.name, ifc_representation_class="")
                 if getattr(tool.Ifc.get_entity(obj), "HasOpenings", False):
@@ -2566,7 +2568,7 @@ class OverrideModeSetObject(bpy.types.Operator, tool.Ifc.Operator):
                 tool.Geometry.reload_representation(obj)
             tool.Ifc.finish_edit(obj)
 
-        for obj in self.unchanged_objs_with_openings:
+        for obj in getattr(self, "unchanged_objs_with_openings", []):
             tool.Geometry.reload_representation(obj)
             tool.Ifc.finish_edit(obj)
         return {"FINISHED"}


### PR DESCRIPTION
Fixes #8042.

## Problem

`OverrideModeSetObject.invoke` builds `self.edited_objs` / `self.unchanged_objs_with_openings` and then calls `self.execute(context)`. But the operator is also called **directly** — `handle_exit_edit_mode` does `bpy.ops.bim.override_mode_set_object()` — in which case Blender runs `execute` without `invoke`, the attributes never exist, and `_execute` crashes on `for obj in self.edited_objs`. That is exactly the reporter's traceback (new model → exit edit mode → RuntimeError chain ending in this operator).

## Fix

Guard both loops with `getattr(self, ..., [])`, so direct execution behaves as "nothing was being edited" — which is precisely the state when invoke didn't run. The interactive path is unchanged.

## Duplicate sweep

Searched the tracker for the `override_mode_set_object`/`edited_objs` signature: no other open reports of this family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)