### PR TITLE
Bonsai: report incompatible aggregates instead of crashing (#7983)

### DIFF
--- a/src/bonsai/bonsai/bim/module/aggregate/operator.py
+++ b/src/bonsai/bonsai/bim/module/aggregate/operator.py
@@ -208,23 +208,28 @@ class BIM_OT_add_aggregate(bpy.types.Operator, tool.Ifc.Operator):
 
             current_aggregate = ifcopenshell.util.element.get_aggregate(element)
             current_container = ifcopenshell.util.element.get_container(element)
-            if current_aggregate:
-                core.assign_object(
-                    tool.Ifc,
-                    tool.Aggregate,
-                    tool.Collector,
-                    relating_obj=tool.Ifc.get_object(current_aggregate),
-                    related_obj=aggregate,
-                )
-            elif current_container:
-                bonsai.core.spatial.assign_container(
-                    tool.Ifc,
-                    tool.Collector,
-                    tool.Spatial,
-                    container=current_container,
-                    objs=[aggregate],
-                )
-            core.assign_object(tool.Ifc, tool.Aggregate, tool.Collector, relating_obj=aggregate, related_obj=obj)
+            try:
+                if current_aggregate:
+                    core.assign_object(
+                        tool.Ifc,
+                        tool.Aggregate,
+                        tool.Collector,
+                        relating_obj=tool.Ifc.get_object(current_aggregate),
+                        related_obj=aggregate,
+                    )
+                elif current_container:
+                    bonsai.core.spatial.assign_container(
+                        tool.Ifc,
+                        tool.Collector,
+                        tool.Spatial,
+                        container=current_container,
+                        objs=[aggregate],
+                    )
+                core.assign_object(tool.Ifc, tool.Aggregate, tool.Collector, relating_obj=aggregate, related_obj=obj)
+            except core.IncompatibleAggregateError:
+                self.report({"ERROR"}, f"Cannot aggregate {obj.name} to {aggregate.name}")
+            except core.AggregateRepresentationError:
+                self.report({"ERROR"}, f"Cannot aggregate to {aggregate.name} with a body representation")
 
     def create_aggregate(self, context: bpy.types.Context, ifc_class: str, aggregate_name: str) -> bpy.types.Object:
         aggregate = bpy.data.objects.new(aggregate_name, None)


### PR DESCRIPTION
Fixes #7983.

## Problem

`core.aggregate.assign_object` raises `IncompatibleAggregateError` by design, and `BIM_OT_aggregate_assign_object` catches it and reports a friendly error. The aggregate-creation path in the same file (the reporter's traceback: `aggregate/operator.py` → `core.assign_object` → `raise IncompatibleAggregateError`) calls the same core function **without** that handling, so aggregating aggregates that the core rejects crashed with an uncaught exception instead of the message.

## Fix

Wrap the unguarded path with exactly the `except`/`report` pair the sibling operator already uses (`IncompatibleAggregateError` and `AggregateRepresentationError`).

## Verify

Mechanism confirmed from the reporter's traceback; the handling is copied verbatim from the established pattern at the other call site. Syntax-checked; Blender-bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)