### PR TITLE
Bonsai: keep an explicit denominator in custom drawing scales (#7957)

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2776,7 +2776,10 @@ class Drawing(bonsai.core.tool.Drawing):
         denominator = tool.Drawing.convert_scale_string(denominator_string)
         if not numerator or not denominator:
             return
-        scale = str(Fraction(numerator / denominator).limit_denominator(1000))  # Any ratio >1000 is stupid.
+        fraction = Fraction(numerator / denominator).limit_denominator(1000)  # Any ratio >1000 is stupid.
+        # str(Fraction(2, 1)) is "2" with no slash, but every consumer of
+        # "Scale" splits on "/", so keep the denominator explicit (#7957).
+        scale = f"{fraction.numerator}/{fraction.denominator}"
         if "'" in scale or '"' in scale:
             human_separator = "="  # Imperial scales use "=", like 1" = 1' - 0"
             # If for some crazy reason we mix metric and imperial, assume metric is SI units, like 1m = 1'


### PR DESCRIPTION
Fixes #7957.

## Problem

A custom enlargement scale of 2:1 cannot create a drawing, while 2:1.001 works. Root cause in `tool/drawing.py::get_diagram_scale`:

```python
scale = str(Fraction(numerator / denominator).limit_denominator(1000))
```

`str(Fraction(2, 1))` is `"2"` — Python drops the `/1` — and every consumer of the stored `Scale` value unpacks with `split("/")` (e.g. `helper.py`'s numeric-scale getter), so any whole-number ratio crashes. `2:1.001` survives only because it never reduces to an integer. The same failure hits 3:1, 4:1, etc.

## Fix

Format explicitly: `f"{fraction.numerator}/{fraction.denominator}"` → `2:1` stores `"2/1"`, `1:100` stays `"1/100"`.

## Verify

```
2:1   -> old '2'      new '2/1'
1:100 -> old '1/100'  new '1/100'
1:0.5 -> old '2'      new '2/1'
```

Blender-bound path; the formatting is proven above and reduction behaviour is unchanged for all fractional scales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)