### PR TITLE
win: use exit /b in build-deps.cmd so the console stays open (#7884)

### DIFF
--- a/win/build-deps.cmd
+++ b/win/build-deps.cmd
@@ -837,7 +837,7 @@ echo Build ended at %END_TIME%. Time elapsed %hh%:%mm%:%ss%.%cc%.
 :BuildTimeSkipped
 set PATH=%ORIGINAL_PATH%
 cd "%~dp0"
-exit %IFCOS_SCRIPT_RET%
+exit /b %IFCOS_SCRIPT_RET%
 
 ::::::::::::::::::::::::::::::::::::: Subroutines :::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
Implements #7884 (maintainer said PRs welcome).

`build-deps.cmd` had exactly one bare `exit` left — the final `exit %IFCOS_SCRIPT_RET%` at the end of the main flow — which closes the whole console window before the user can read the build result or error. Every other exit in the script (and in the other `win/*.cmd` files, verified by sweep) already uses `exit /b`. This changes that last one to `exit /b %IFCOS_SCRIPT_RET%`, preserving the return code for callers like `build-all.cmd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)