### PR TITLE
Bonsai: coerce non-string enum values when importing quick favorites (#7773)

### DIFF
--- a/src/bonsai/bonsai/bim/module/misc/prop.py
+++ b/src/bonsai/bonsai/bim/module/misc/prop.py
@@ -70,6 +70,10 @@ class QuickFavoriteProperty(PropertyGroup):
     )
 
     def set_value(self, value: Any) -> None:
+        if self.value_prop == "enum_value" and not isinstance(value, str):
+            # Enum items store identifiers as strings, but some operators
+            # declare integer enum values (#7773).
+            value = str(value)
         setattr(self, self.value_prop, value)
 
     def set_enum_items(self, items: list[tuple[str, str, str]]) -> None:


### PR DESCRIPTION
Fixes #7773.

`QuickFavorite...set_value` assigns straight into the typed slot; for enum favorites whose source operator uses integer identifiers, Blender's enum assignment rejects the int (`expected a string enum, not int`) — the reporter's exact traceback (`misc/prop.py` `set_value`). Coerce to `str` for the `enum_value` slot only; all other slots keep their native types. Matches why the import "did seem to work anyway": the failing assignment was the stored default display, not the applied operator value.

Syntax-checked; Blender-bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)