### PR TITLE
ExtractElements: handle IfcProject without RepresentationContexts (#8199 follow-up)

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -110,7 +110,7 @@ class Patcher(ifcpatch.BasePatcher):
             pass
         if element.is_a("IfcProject"):
             proj = self.new.add(element)
-            for ctx in element.RepresentationContexts:
+            for ctx in element.RepresentationContexts or ():
                 for coop in getattr(ctx, 'HasCoordinateOperation', ()):
                     self.new.add(coop)
             return proj

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -21,10 +21,12 @@ import os
 import ifcopenshell
 import ifcopenshell.api.aggregate
 import ifcopenshell.api.context
+import ifcopenshell.api.geometry
 import ifcopenshell.api.georeference
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
 import ifcopenshell.util.element
+import numpy
 import pytest
 
 import ifcpatch
@@ -96,7 +98,10 @@ class TestExtractElements(test.bootstrap.IFC4):
             self.file,
             coordinate_operation={"Eastings": 100000.0, "Northings": 200000.0},
         )
-        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        matrix = numpy.eye(4)
+        matrix[:3, 3] = [5.0, 10.0, 2.0]
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=wall, matrix=matrix)
 
         output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
 
@@ -105,6 +110,11 @@ class TestExtractElements(test.bootstrap.IFC4):
         conversion = output.by_type("IfcMapConversion")[0]
         assert conversion.Eastings == 100000.0
         assert conversion.Northings == 200000.0
+        # Placements must be copied verbatim: extraction must not bake map
+        # coordinates (or any other georeferencing transform) into the local
+        # placements of the extracted elements.
+        wall_new = output.by_type("IfcWall")[0]
+        assert wall_new.ObjectPlacement.RelativePlacement.Location.Coordinates == (5.0, 10.0, 2.0)
 
     @pytest.mark.skipif(
         "IFC4X3" not in ifcopenshell.ifcopenshell_wrapper.schema_names(),


### PR DESCRIPTION
**What broke:** the #8199 georeferencing fix (e6dc582) iterates `IfcProject.RepresentationContexts` unconditionally. The attribute is OPTIONAL, so any file whose project has no representation contexts now crashes every `ExtractElements` run with `TypeError: 'NoneType' object is not iterable`. On current `v0.8.0`, 8 of the existing `test_ExtractElements.py` tests fail this way (`test_basic` included).

**Fix:** iterate `element.RepresentationContexts or ()`.

**Test refinement** (per @aothms' request on #8199): the georeferencing regression test now also asserts the extracted wall's local placement coordinates are byte-identical to the source. `append_asset()` has no georeferencing logic and copies placements verbatim, so the "eastings and northings converted into Blender offset" symptom in the report was purely downstream: with `IfcMapConversion` dropped, Bonsai's automatic false-origin guess turned the large coordinates into a session Blender offset. The recipe fix makes that go away automatically; the new assertion pins that extraction never bakes map coordinates into placements.

**How verified:** red-green on the recipe fix (revert makes 8 tests fail with the TypeError, restore passes 11/11 + 1 skip). Remaining `ifcpatch` suite failures are the known pre-existing wheel/repo drift in `test_Migrate`/`test_Ifc2Sql`, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)