### PR TITLE
sequence.cascade_schedule: milestones cascade with zero duration (#6834)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/cascade_schedule.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/cascade_schedule.py
@@ -136,9 +136,11 @@ class Usecase:
         if not task.TaskTime:
             return
 
+        # Milestones have no duration by definition, even if a stray
+        # ScheduleDuration is present in the data.
         duration = (
             ifcopenshell.util.date.ifc2datetime(task.TaskTime.ScheduleDuration)
-            if task.TaskTime.ScheduleDuration
+            if task.TaskTime.ScheduleDuration and not task.IsMilestone
             else datetime.timedelta()
         )
 
@@ -149,7 +151,7 @@ class Usecase:
             predecessor = rel.RelatingProcess
             predecessor_duration = (
                 ifcopenshell.util.date.ifc2datetime(predecessor.TaskTime.ScheduleDuration)
-                if predecessor.TaskTime and predecessor.TaskTime.ScheduleDuration
+                if predecessor.TaskTime and predecessor.TaskTime.ScheduleDuration and not predecessor.IsMilestone
                 else datetime.timedelta()
             )
             if rel.SequenceType == "FINISH_START":

--- a/src/ifcopenshell-python/test/api/sequence/test_cascade_schedule.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_cascade_schedule.py
@@ -96,6 +96,26 @@ class TestCascadeSchedule(test.bootstrap.IFC4):
         assert task3.TaskTime.ScheduleStart == "2000-01-02T09:00:00"
         assert task3.TaskTime.ScheduleFinish == "2000-01-04T17:00:00"
 
+    def test_milestone_with_stray_duration_cascades_as_zero_duration(self):
+        # Regression test for #6834: per the IFC documentation a task with
+        # IsMilestone shall have no duration. If the data nevertheless carries
+        # a ScheduleDuration, the cascade must ignore it instead of stretching
+        # the milestone and pushing its successors.
+        task = self._create_task("P2D")
+        milestone = self._create_task("P2D")
+        milestone.IsMilestone = True
+        task2 = self._create_task("P2D")
+        self._create_sequence(task, milestone, "FINISH_START")
+        self._create_sequence(milestone, task2, "FINISH_START")
+
+        ifcopenshell.api.sequence.cascade_schedule(self.file, task=task)
+        assert task.TaskTime.ScheduleStart == "2000-01-01T09:00:00"
+        assert task.TaskTime.ScheduleFinish == "2000-01-02T17:00:00"
+        assert milestone.TaskTime.ScheduleStart == "2000-01-03T09:00:00"
+        assert milestone.TaskTime.ScheduleFinish == "2000-01-03T09:00:00"
+        assert task2.TaskTime.ScheduleStart == "2000-01-03T09:00:00"
+        assert task2.TaskTime.ScheduleFinish == "2000-01-04T17:00:00"
+
     def test_cascading_finish_to_finish(self):
         task = self._create_task("P1D")
         task2 = self._create_task("P2D")


### PR DESCRIPTION
**What broke** (#6834): per the [IFC documentation](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcTask.htm), an `IfcTask` with `IsMilestone` shall have no duration. `cascade_schedule` never consulted `IsMilestone`: a milestone carrying a stray `ScheduleDuration` was cascaded like a normal task — the milestone got stretched across the duration (`ScheduleFinish != ScheduleStart`) and every successor was pushed late (the FINISH_START day offset also kicked in because the predecessor duration was non-zero).

**Fix:** ignore `ScheduleDuration` when `IsMilestone` is set, in both places durations are read (the task being cascaded, and the predecessor side). Milestones already cascaded correctly when modeled cleanly with no duration; this makes the schedule calculation follow the spec even when the data violates it.

**How verified:** new regression test `test_milestone_with_stray_duration_cascades_as_zero_duration` (chain task → milestone with stray P2D → task): red without the fix (milestone finish lands 2 days late), green with it. All 67 `test/api/sequence` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)