### PR TITLE
ifcpatch: add console script entry point (#6436)

### DIFF
--- a/src/ifcpatch/ifcpatch/__main__.py
+++ b/src/ifcpatch/ifcpatch/__main__.py
@@ -24,23 +24,28 @@ import ifcopenshell
 
 import ifcpatch
 
-parser = argparse.ArgumentParser(description="Patches IFC files to fix badly formatted data")
-parser.add_argument("-i", "--input", type=str, required=True, help="The IFC file to patch")
-parser.add_argument("-o", "--output", type=str, help="The output file to save the patched IFC")
-parser.add_argument("-r", "--recipe", type=str, required=True, help="Name of the recipe to use when patching")
-parser.add_argument("-l", "--log", type=str, help="Specify a log file", default="ifcpatch.log")
-parser.add_argument("-a", "--arguments", nargs="+", help="Specify custom arguments to the patch recipe")
-args = vars(parser.parse_args())
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Patches IFC files to fix badly formatted data")
+    parser.add_argument("-i", "--input", type=str, required=True, help="The IFC file to patch")
+    parser.add_argument("-o", "--output", type=str, help="The output file to save the patched IFC")
+    parser.add_argument("-r", "--recipe", type=str, required=True, help="Name of the recipe to use when patching")
+    parser.add_argument("-l", "--log", type=str, help="Specify a log file", default="ifcpatch.log")
+    parser.add_argument("-a", "--arguments", nargs="+", help="Specify custom arguments to the patch recipe")
+    args = vars(parser.parse_args())
 
-print("# Loading IFC file ...")
-args["file"] = ifcopenshell.open(args["input"])
+    print("# Loading IFC file ...")
+    args["file"] = ifcopenshell.open(args["input"])
 
-print("# Patching ...")
-output = ifcpatch.execute(args)
+    print("# Patching ...")
+    output = ifcpatch.execute(args)
 
-print("# Writing patched file ...")
-if not args["output"]:
-    args["output"] = args["input"]
-ifcpatch.write(output, args["output"])
+    print("# Writing patched file ...")
+    if not args["output"]:
+        args["output"] = args["input"]
+    ifcpatch.write(output, args["output"])
 
-print("# All tasks are complete :-)")
+    print("# All tasks are complete :-)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ifcpatch/pyproject.toml
+++ b/src/ifcpatch/pyproject.toml
@@ -17,6 +17,9 @@ classifiers = [
 ]
 dependencies = ["ifcopenshell", "toposort", "numpy"]
 
+[project.scripts]
+ifcpatch = "ifcpatch.__main__:main"
+
 [project.optional-dependencies]
 advanced = [
   "sqlite3",


### PR DESCRIPTION
**Request** (#6436): `ifcpatch` can only be run as `python -m ifcpatch`, which doesn't play well with pipx/uvx (`uvx --with ifcpatch python -m ifcpatch ...` instead of `uvx ifcpatch ...`).

**Change:** wrap the module-level CLI code in `main()` (behavior unchanged) and register `ifcpatch = "ifcpatch.__main__:main"` under `[project.scripts]` — the exact convention already used by `ifcquery`, `ifcedit`, and `ifcmcp` in this repo.

**How verified:** `python -m ifcpatch` still parses args and runs recipes end-to-end (ExtractElements on a small model, output checked), and the entry-point callable was exercised the way the generated script does it (`from ifcpatch.__main__ import main; main()`) with a second recipe run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)