### PR TITLE
entity_instance: get_info_2 falls back to get_info for unsupported arguments (#4270)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/entity_instance.py
+++ b/src/ifcopenshell-python/ifcopenshell/entity_instance.py
@@ -642,16 +642,16 @@ class entity_instance:
         return_type: type[dict] = dict,
         ignore: Sequence[str] = (),
     ) -> dict[str, Any]:
-        """More perfomant version of `.get_info()` but with limited arguments values.\n
-        Method has exactly the same signature as `.get_info()` but it doesn't support getting information non-recursively.
-
-        Currently supported arguments values:
-            * recursive: `True` (will fail with default `False` value from `.get_info()`)
-            * return_type: `dict`
-            * ignore: `()` (empty tuple)
+        """More perfomant version of `.get_info()`.\n
+        Method has exactly the same signature as `.get_info()`, but the fast C++
+        path only implements ``recursive=True``, ``return_type=dict`` and
+        ``ignore=()``. Any other combination falls back to the pure Python
+        `.get_info()`, where no meaningful performance gain is possible anyway
+        as the cost is dominated by the recursive traversal.
         """
 
-        assert recursive
-        assert return_type is dict
-        assert len(ignore) == 0
-        return ifcopenshell_wrapper.get_info_cpp(self.wrapped_data, include_identifier)
+        if recursive and return_type is dict and not ignore:
+            return ifcopenshell_wrapper.get_info_cpp(self.wrapped_data, include_identifier)
+        return self.get_info(
+            include_identifier=include_identifier, recursive=recursive, return_type=return_type, ignore=ignore
+        )

--- a/src/ifcopenshell-python/test/test_entity_instance.py
+++ b/src/ifcopenshell-python/test/test_entity_instance.py
@@ -64,3 +64,14 @@ class TestGetInfo2(test.bootstrap.IFC4):
             "Outer": {"CfsFaces": None, "type": "IfcClosedShell"},
             "type": "IfcFacetedBrep",
         }
+
+    def test_unsupported_arguments_fall_back_to_get_info(self):
+        # Regression test for #4270: get_info_2 raised a bare AssertionError
+        # when called with its own default arguments (recursive=False) or any
+        # other combination the C++ fast path does not implement. It must
+        # delegate to get_info instead of crashing.
+        brep = self.file.create_entity("IfcFacetedBrep")
+        shell = self.file.create_entity("IfcClosedShell")
+        brep.Outer = shell
+        assert brep.get_info_2() == brep.get_info()
+        assert brep.get_info_2(recursive=True, ignore=("Outer",)) == brep.get_info(recursive=True, ignore=("Outer",))


### PR DESCRIPTION
**What broke** (#4270): `get_info_2()` advertises the exact same signature as `get_info()` but crashed with a bare `AssertionError` on any argument combination the C++ fast path doesn't implement — including its own defaults (`recursive=False`), so `element.get_info_2()` always raised.

**Fix:** keep the `get_info_cpp` fast path when its constraints hold (`recursive=True`, `return_type=dict`, `ignore=()`) and delegate to the pure Python `get_info()` otherwise. Per @aothms in the thread, a non-recursive call has no meaningful performance gain to lose by delegating, and `return_type`/`ignore` are exactly the arguments the C++ path can't easily support — so the fallback gives full signature parity with zero behavior change on the fast path.

**How verified:** new test `test_unsupported_arguments_fall_back_to_get_info` asserts `get_info_2() == get_info()` for the default and `ignore`-carrying combinations; the pre-fix behavior is the reported bare `AssertionError`. Existing `TestGetInfo2` fast-path tests unchanged and passing. (Note for local runs: `test/bootstrap.py` strips the repo path so this file tests the installed build — the fix was additionally exercised directly against the patched sources.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)