### PR TITLE
Bonsai: don't assert on non-surface item styles in swept disk loader (#8194)

### DIFF
--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -1267,10 +1267,14 @@ class Loader(bonsai.core.tool.Loader):
         item_styles: list[Union[bpy.types.Material, None]] = []
         for item_data in rep_items:
             item = item_data["item"]
-            item_style = tool.Style.get_representation_item_style(item) or material_style
+            # Only surface styles map to Blender materials. Items may carry
+            # other style kinds too (DDScad writes an IfcCurveStyle before the
+            # IfcSurfaceStyle on swept disk items), so ask for the surface
+            # style explicitly and degrade to no material instead of asserting.
+            item_style = tool.Style.get_representation_item_style(item, ifc_class="IfcSurfaceStyle") or material_style
             if item_style is not None:
-                item_style = tool.Ifc.get_object(item_style)
-                assert isinstance(item_style, bpy.types.Material)
+                blender_material = tool.Ifc.get_object(item_style)
+                item_style = blender_material if isinstance(blender_material, bpy.types.Material) else None
             item_styles.append(item_style)
         item_styles_unique = list(set(item_styles))
         for item_style in item_styles_unique:

--- a/src/bonsai/bonsai/tool/style.py
+++ b/src/bonsai/bonsai/tool/style.py
@@ -652,16 +652,23 @@ class Style(bonsai.core.tool.Style):
 
     @classmethod
     def get_representation_item_style(
-        cls, representation_item: ifcopenshell.entity_instance
+        cls, representation_item: ifcopenshell.entity_instance, ifc_class: str = "IfcPresentationStyle"
     ) -> Union[ifcopenshell.entity_instance, None]:
-        """Return IfcPresentationStyle associated with a representation item."""
+        """Return IfcPresentationStyle associated with a representation item.
+
+        :param ifc_class: Only consider styles of this class. An item can carry
+            several styles at once (e.g. DDScad writes an IfcCurveStyle and an
+            IfcSurfaceStyle on the same styled item), so callers that need a
+            specific kind should ask for it, e.g. "IfcSurfaceStyle".
+        """
         is_4x3 = representation_item.file.schema == "IFC4X3"
         for style in representation_item.StyledByItem:
             for style_or_assignment in style.Styles:
                 if not is_4x3 and style_or_assignment.is_a("IfcPresentationStyleAssignment"):
                     for assignment_style in style_or_assignment.Styles:
-                        return assignment_style
-                else:  # IfcPresentationStyle
+                        if assignment_style.is_a(ifc_class):
+                            return assignment_style
+                elif style_or_assignment.is_a(ifc_class):  # IfcPresentationStyle
                     return style_or_assignment
 
     @classmethod


### PR DESCRIPTION
**What broke** (#8194): importing a DDScad MEP model (DDScad Version 21) into Bonsai failed with `AssertionError` in `create_native_swept_disk_solid`. DDScad writes **both** an `IfcCurveStyle` and an `IfcSurfaceStyle` on the styled item of every `IfcSweptDiskSolid`, curve style first — verified on the reporter's model: all 86 swept disk items carry `(IfcCurveStyle, IfcSurfaceStyle)` in that order. `tool.Style.get_representation_item_style` returns the first style found (the curve style), `tool.Ifc.get_object` on a curve style is `None` (only surface styles become Blender materials), and the loader asserted `isinstance(None, bpy.types.Material)` — killing the whole import. The styles are valid IFC; the loader's assumption was the bug.

**Fix:**
- `get_representation_item_style` gains an optional `ifc_class` filter; the default (`IfcPresentationStyle`) preserves the existing behavior for the item-style editing UI, the only other caller.
- the swept disk loader asks for `"IfcSurfaceStyle"` explicitly, and if the resolved style still has no Blender material it degrades to an empty material slot instead of asserting.

**How verified:** headless against the reporter's model with a mirror of the patched resolution logic — unfiltered lookup resolves all 86 items to `IfcCurveStyle` (the crash path), the filtered lookup resolves all 86 to their `IfcSurfaceStyle` with zero unresolved, and the default-argument behavior is byte-identical to the old function. GUI confirmation of the full import pending (model is confidential, but the traceback pins this exact line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)