### PR TITLE
Selector: match boolean properties by True/False spelling (#8100)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -1225,12 +1225,22 @@ class FacetTransformer(lark.Transformer):
             return any(self.compare(ev, comparison, value) for ev in element_value)
         elif isinstance(value, str):
             try:
-                if isinstance(element_value, int):
+                if isinstance(element_value, bool):
+                    # bool subclasses int, so handle it before the numeric
+                    # branches. A boolean property should match every common
+                    # spelling ("True"/"False") the same way "1"/"0" already do.
+                    if value in ("True", "true", "TRUE", "1"):
+                        value = True
+                    elif value in ("False", "false", "FALSE", "0"):
+                        value = False
+                elif isinstance(element_value, int):
                     value = int(value)
                 elif isinstance(element_value, float):
                     value = float(value)
 
-                if isinstance(element_value, (int, float)):
+                if isinstance(element_value, bool):
+                    result = element_value == value
+                elif isinstance(element_value, (int, float)):
                     operator = comparison.lstrip("!")
                     if operator == ">=":
                         result = element_value >= value

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -261,6 +261,23 @@ class TestFilterElements(test.bootstrap.IFC4):
         ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": ["New"]})
         assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status=New") == {element}
 
+    def test_selecting_by_boolean_property(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"LoadBearing": True})
+        pset2 = ifcopenshell.api.pset.add_pset(self.file, product=element2, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset2, properties={"LoadBearing": False})
+        # A boolean property must match every common spelling, not just "1"/"0".
+        for true_value in ("TRUE", "True", "true", "1"):
+            assert subject.filter_elements(self.file, f"IfcWall, Pset_WallCommon.LoadBearing={true_value}") == {
+                element
+            }, true_value
+        for false_value in ("FALSE", "False", "false", "0"):
+            assert subject.filter_elements(self.file, f"IfcWall, Pset_WallCommon.LoadBearing={false_value}") == {
+                element2
+            }, false_value
+
     def test_selecting_by_property_with_comparisons(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")


### PR DESCRIPTION
## Problem

Filtering by a boolean property (e.g. `LoadBearing`) with the search UI or a query only worked when the value was written as the special token `TRUE`/`FALSE` or as `1`/`0`. Typing `True` or `False` matched nothing, which is what the Bonsai search dropdown offers by default. Reported in #8100.

## Cause

In `util.selector.FacetTransformer.compare`, a boolean property value is a Python `bool`, and `bool` subclasses `int`. A string query value therefore entered the `isinstance(element_value, int)` branch and ran `int("True")`, which raises and is swallowed, so the comparison fell through to no match. `int("1")` succeeds and `True == 1`, which is why only the numeric spellings worked.

## Fix

Handle `bool` before the numeric branches and coerce the common string spellings (`True`/`true`/`TRUE`/`1` and `False`/`false`/`FALSE`/`0`) to the matching boolean, then compare by equality. The special `TRUE`/`FALSE` tokens and `1`/`0` still work exactly as before.

## Verification

Red-green regression test added in `test/util/test_selector.py::test_selecting_by_boolean_property`. Before the fix, `True`/`true`/`False`/`false` return the empty set; after, all four spellings resolve to the correct element. Numeric, string, and NULL comparisons were re-checked for regressions and pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)