### PR TITLE
Selector: negated operators on list properties mean none-match (#8129)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -1222,6 +1222,14 @@ class FacetTransformer(lark.Transformer):
 
     def compare(self, element_value, comparison, value) -> bool:
         if isinstance(element_value, (list, tuple)):
+            if comparison.startswith("!"):
+                # For a negated operator the intuitive meaning is "none of the
+                # values match", i.e. NOT (any value matches the positive form).
+                # Distributing the negation into `any` instead would return the
+                # list whenever it holds a single differing value, so "!=" and
+                # "!*=" wrongly matched a list that actually contained the value.
+                positive = comparison.lstrip("!")
+                return not any(self.compare(ev, positive, value) for ev in element_value)
             return any(self.compare(ev, comparison, value) for ev in element_value)
         elif isinstance(value, str):
             try:

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -261,6 +261,19 @@ class TestFilterElements(test.bootstrap.IFC4):
         ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": ["New"]})
         assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status=New") == {element}
 
+    def test_selecting_by_multivalue_property(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": ["NEW", "EXISTING"]})
+        # A value present in the list matches "=" and "*=".
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status=NEW") == {element}
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status*=NEW") == {element}
+        # Negated operators mean "none of the values match", not "some value differs".
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status!=NEW") == set()
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status!*=NEW") == set()
+        # A value absent from the list is excluded by "=" and included by "!=".
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status=DEMOLISH") == set()
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status!=DEMOLISH") == {element}
     def test_selecting_by_property_with_comparisons(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")


### PR DESCRIPTION
## Problem

For a list-valued property such as a multi-selected enumeration (`CastingMethod = ['INSITU', 'PRINTED']`), the negated filter operators behaved counterintuitively (#8129):

- `!= "INSITU"` returned the element even though it contains `INSITU`
- `!*= "INSITU"` (does not contain) returned the element even though it does contain `INSITU`
- `=` and `!=` gave the same result

## Cause

`util.selector.FacetTransformer.compare` distributes the comparison over each list value with `any(...)`. For a negated operator that pushes the negation inside the `any`, so the element matched whenever it held a single value that differed. `['INSITU','PRINTED'] != 'INSITU'` became `any(v != 'INSITU')`, which is true because `PRINTED` differs.

## Fix

Handle a negated operator as `not any(positive match)`, i.e. "none of the values match", which is the intuitive reading of `!=` and `!*=` on a list. Positive operators (`=`, `*=`) are unchanged.

Resulting semantics for a list property:
- `=`   element has at least one value equal
- `!=`  element has no value equal
- `*=`  element has at least one value containing the substring
- `!*=` element has no value containing the substring

## Verification

Red-green regression test added in `test/util/test_selector.py::test_selecting_by_multivalue_property`. Scalar comparisons are unaffected (single values never enter the list branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)