### PR TITLE
Bonsai: fetch bSDD class properties from the properties endpoint (#7985)

### DIFF
--- a/src/bonsai/bonsai/tool/bsdd.py
+++ b/src/bonsai/bonsai/tool/bsdd.py
@@ -267,6 +267,15 @@ class Bsdd(bonsai.core.tool.Bsdd):
         return bsdd_class
 
     @classmethod
+    def get_bsdd_class_properties(cls, uri: str) -> list[ClassPropertyContractV1]:
+        # Only the class properties are needed here. get_class also pulls class
+        # relations and child class references, a heavier request that pressures
+        # the bSDD rate limit and made every class report "No bSDD Props Found"
+        # once a 429 came back (#7985). Class/Properties/v1 asks for just what we use.
+        class_properties = cls.client.get_class_properties(uri)
+        return class_properties.get("classProperties", []) or []
+
+    @classmethod
     def get_bsdd_property(cls, uri: str) -> dict:
         if not (bsdd_property := cls.bsdd_properties.get(uri, {})):
             # Cache miss occurs for keyword search mode, for classes cache is prepopulated.
@@ -315,9 +324,7 @@ class Bsdd(bonsai.core.tool.Bsdd):
         props.properties.clear()
         if not (active_class := props.active_class):
             return
-        if not (bsdd_class := cls.get_bsdd_class(active_class.uri)):
-            return
-        for bsdd_prop in bsdd_class.get("classProperties", []):
+        for bsdd_prop in cls.get_bsdd_class_properties(active_class.uri):
             if not bsdd_prop.get("propertySet", None):
                 continue
             cls.bsdd_properties[bsdd_prop["uri"]] = bsdd_prop


### PR DESCRIPTION
## Problem

Adding properties from a bSDD classification reported "No bSDD Props Found" for every class. As diagnosed in #7985, `tool.Bsdd.bsdd_classes` came back holding a rate-limit response:

```
{'...class/Pumpe': {'statusCode': 429, 'message': 'Rate limit is exceeded. Try again in 3 seconds.'}}
```

## Cause

`import_class_properties` needs only a class's properties, but it went through `get_class` (`Class/v1`), which by default also pulls `includeClassRelations` and `includeChildClassReferences` (and can trigger reverse-relation lookups). That is a heavier call than the task needs, and it pushed the bSDD API into rate limiting. Once a 429 came back it was consumed as if it were class data, so no properties were found.

## Fix

Add `Bsdd.get_bsdd_class_properties`, which calls the existing lighter `Class/Properties/v1` client endpoint (`client.get_class_properties`) and returns just the `classProperties` list, then use it in `import_class_properties`. The endpoint returns the same `ClassPropertyContractV1` items the importer already reads (`name`, `propertyCode`, `propertySet`, `uri`), so nothing downstream changes.

This avoids adding retry/backoff into the client by simply not over-fetching. Credit to @c-mellueh for the diagnosis and for pointing at the properties endpoint.

## Verification

The change is a like-for-like swap between two endpoints that return the same property payload. The existing live-API classification tests exercise this path (`test_add_classification_refence_with_props` expects exactly one property, the airport test expects twenty), so a shape or count regression would surface there. I do not have a Blender plus live bSDD environment to run them locally; @c-mellueh reported the properties endpoint avoids the rate limiting in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)