### PR TITLE
spatial.assign_container: clear error for non-containable products (#8084)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/spatial/assign_container.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/spatial/assign_container.py
@@ -105,6 +105,18 @@ def assign_container(
     if not products:
         return
 
+    # Only elements carry the ContainedInStructure inverse (IfcElement,
+    # IfcAnnotation, IfcGrid and their subtypes). Passing a type such as
+    # IfcBeamType otherwise crashed with an opaque AttributeError deep in the
+    # loop below, so reject it up front with a clear message instead.
+    non_containable = [p for p in products if not hasattr(p, "ContainedInStructure")]
+    if non_containable:
+        raise TypeError(
+            "Only spatially containable elements can be assigned to a container. "
+            "These products have no ContainedInStructure and cannot be contained: "
+            + ", ".join(str(p) for p in non_containable)
+        )
+
     products_set = set(products)
     structure_rel = next(iter(relating_structure.ContainsElements), None)
 

--- a/src/ifcopenshell-python/test/api/spatial/test_assign_container.py
+++ b/src/ifcopenshell-python/test/api/spatial/test_assign_container.py
@@ -41,6 +41,19 @@ class TestAssignContainer(test.bootstrap.IFC4):
         assert ifcopenshell.util.element.get_container(subelement2) == element
         assert rel.is_a("IfcRelContainedInSpatialStructure")
 
+    def test_raising_a_clear_error_for_non_containable_products(self):
+        storey = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        beam_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBeamType")
+        with pytest.raises(TypeError):
+            ifcopenshell.api.spatial.assign_container(self.file, products=[beam_type], relating_structure=storey)
+        # A type mixed into an otherwise valid selection must not be partially applied.
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        with pytest.raises(TypeError):
+            ifcopenshell.api.spatial.assign_container(
+                self.file, products=[wall, beam_type], relating_structure=storey
+            )
+        assert ifcopenshell.util.element.get_container(wall) is None
+
     def test_doing_nothing_if_the_container_is_already_assigned(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuilding")
         subelement = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")


### PR DESCRIPTION
## Problem

Assigning a container (floor) to a selection that included a type crashed with an opaque error (#8084):

```
File ".../ifcopenshell/api/spatial/assign_container.py", line 117, in assign_container
    product_rel = next(iter(product.ContainedInStructure), None)
AttributeError: entity instance of type 'IFC4.IfcBeamType' has no attribute 'ContainedInStructure'
```

## Cause

`ContainedInStructure` is an inverse attribute only on containable elements (`IfcElement`, `IfcAnnotation`, `IfcGrid` and their subtypes). A type like `IfcBeamType` has no such attribute, so the access threw deep inside the loop with a message that gives the user no idea what to do. The docstring already specifies `products` should be physical `IfcElement`s, but the precondition was not enforced.

## Fix

Validate products up front and raise a clear `TypeError` that names the offending instances. The check runs before any mutation, so a type accidentally mixed into an otherwise valid selection no longer partially applies the containment. Containable elements are detected with `hasattr(p, "ContainedInStructure")`, which is schema-accurate because `entity_instance.__getattr__` only exposes attributes declared for that entity.

## Verification

Red-green regression test added in `test_assign_container.py::test_raising_a_clear_error_for_non_containable_products`: a type raises `TypeError`, a type mixed with a wall raises and leaves the wall uncontained, and the existing tests confirm normal elements still assign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)