### PR TITLE
ifctester: entity requirement as xs:restriction no longer crashes on fail (#8046)

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -231,16 +231,21 @@ class Entity(Facet):
         is_pass = inst.is_a().upper() == self.name
         reason = None
 
-        if (
-            not is_pass
-            and inst.file.schema == "IFC2X3"
-            and not self.name.endswith("TYPE")
-            and (element_type := ifcopenshell.util.element.get_type(inst))
-        ):
-            is_pass = element_type.is_a().upper() == f"{self.name}TYPE"
-            reason = {"type": "NAME", "actual": element_type.is_a().upper()[:-4]}
-        elif not is_pass:
-            reason = {"type": "NAME", "actual": inst.is_a().upper()}
+        if not is_pass:
+            # An IFC2X3 occurrence may only be typed, so also try matching it as
+            # its type with the TYPE suffix removed (IfcWallType -> IFCWALL).
+            # self.name may be a plain string or a Restriction; deriving the name
+            # from the type and comparing with == handles both and avoids calling
+            # string methods on a Restriction, which used to crash on the fail path.
+            element_type = (
+                ifcopenshell.util.element.get_type(inst) if inst.file.schema == "IFC2X3" else None
+            )
+            type_name = element_type.is_a().upper() if element_type else ""
+            if type_name.endswith("TYPE") and type_name[:-4] == self.name:
+                is_pass = True
+                reason = {"type": "NAME", "actual": type_name[:-4]}
+            else:
+                reason = {"type": "NAME", "actual": inst.is_a().upper()}
 
         if is_pass and self.predefinedType:
             if self.predefinedType == "USERDEFINED":

--- a/src/ifctester/test/fixtures/entity_restriction_ifc2x3_fail/entity_restriction_ifc2x3_fail.ids
+++ b/src/ifctester/test/fixtures/entity_restriction_ifc2x3_fail/entity_restriction_ifc2x3_fail.ids
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Entity requirement as xs:restriction on IFC2X3</title>
+        <description>A failing entity requirement written as an enumeration restriction must not crash on IFC2X3.</description>
+    </info>
+    <specifications>
+        <specification name="Flow terminals must be walls" ifcVersion="IFC2X3">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCFLOWTERMINAL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <entity>
+                    <name>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="IFCWALL"/>
+                        </xs:restriction>
+                    </name>
+                </entity>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/entity_restriction_ifc2x3_fail/entity_restriction_ifc2x3_fail.ifc
+++ b/src/ifctester/test/fixtures/entity_restriction_ifc2x3_fail/entity_restriction_ifc2x3_fail.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-07T00:00:00',(''),(''),'IfcOpenShell','IfcOpenShell','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCFLOWTERMINAL('2Fu_ePwY1DZxzRl9jojPIx',$,$,$,$,$,$,$);
+#3=IFCAIRTERMINALTYPE('3Fu_ePwY1DZxzRl9jojPIx',$,$,$,$,$,$,$,$,.NOTDEFINED.);
+#4=IFCRELDEFINESBYTYPE('4Fu_ePwY1DZxzRl9jojPIx',$,$,$,(#2),#3);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -266,6 +266,34 @@ class TestEntity:
         assert facet.filter(ifc) == []
         run("In IFC2X3 the type class is checked instead 2/2", facet=facet, inst=element, expected=False)
 
+    def test_ifc2x3_restriction_entity_requirement(self):
+        set_facet("entity")
+
+        ifc = ifcopenshell.file(schema="IFC2X3")
+        application = ifcopenshell.api.owner.add_application(ifc)
+        person = ifcopenshell.api.owner.add_person(
+            ifc, identification="LPARTEE", family_name="Partee", given_name="Leeable"
+        )
+        organisation = ifcopenshell.api.owner.add_organisation(
+            ifc, identification="AWB", name="Architects Without Ballpens"
+        )
+        user = ifcopenshell.api.owner.add_person_and_organisation(ifc, person=person, organisation=organisation)
+        ifcopenshell.api.owner.settings.get_user = lambda x: user
+        ifcopenshell.api.owner.settings.get_application = lambda x: application
+
+        element = ifcopenshell.api.root.create_entity(ifc, "IfcFlowTerminal")
+        element_type = ifcopenshell.api.root.create_entity(ifc, "IfcAirTerminalType")
+        ifcopenshell.api.type.assign_type(ifc, related_objects=[element], relating_type=element_type)
+
+        # A failing xs:restriction entity requirement used to crash on IFC2X3
+        # because the type-inference branch called str methods on a Restriction.
+        facet = Entity(name=Restriction(options={"enumeration": ["IFCWALL"]}, base="string"))
+        run("Restriction entity requirement fails cleanly", facet=facet, inst=element, expected=False)
+
+        # The pass path still resolves via the IFC2X3 type mapping.
+        facet = Entity(name=Restriction(options={"enumeration": ["IFCAIRTERMINAL"]}, base="string"))
+        run("Restriction entity requirement passes via type mapping", facet=facet, inst=element, expected=True)
+
     def test_to_string_required_applicability(self):
         spec = ifctester.ids.Specification(name="Foo", minOccurs=1, maxOccurs="unbounded")
         facet = Entity(name="IFCWALL")

--- a/src/ifctester/test/test_fixture_entity_restriction_ifc2x3_fail.py
+++ b/src/ifctester/test/test_fixture_entity_restriction_ifc2x3_fail.py
@@ -1,0 +1,49 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression test for a specific reported defect (#8046).
+
+An Entity facet's name written as an xs:restriction (an enumeration list
+rather than a single simpleValue) used to crash with AttributeError on
+IFC2X3 whenever the requirement failed: the type-inference branch called
+str methods (endswith, an f-string) directly on self.name, which is a
+Restriction object, not a string, when the requirement is a restriction.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "entity_restriction_ifc2x3_fail")
+SPEC = os.path.join(FIXTURES, "entity_restriction_ifc2x3_fail.ids")
+MODEL = os.path.join(FIXTURES, "entity_restriction_ifc2x3_fail.ifc")
+
+
+class TestEntityRestrictionIfc2x3FailFixture:
+    def test_failing_restriction_entity_requirement_does_not_crash(self):
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(MODEL)
+        # This used to raise AttributeError instead of returning a result.
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.requirements[0].status is False
+        assert spec.status is False


### PR DESCRIPTION
## Problem

When an element matches the applicability but fails an entity requirement expressed as `<xs:restriction><xs:enumeration>`, ifctester crashed instead of reporting a failure (#8046):

```
File "ifctester/facet.py", line 237, in __call__
    and not self.name.endswith("TYPE")
AttributeError: 'Restriction' object has no attribute 'endswith'
```

The `<xs:restriction>` form for entity names is valid per the IDS 1.0 schema and is covered by existing pass-path tests, but the fail path was untested and broken.

## Cause

In `Entity.__call__`, `self.name` can be a `Restriction` rather than a string. On the IFC2X3 fail path the type-inference branch called `self.name.endswith("TYPE")` and built `f"{self.name}TYPE"`, both of which assume a string. (The reporter also noted a missing `return True` in `Restriction.__eq__`; that is already present on `v0.8.0`, so only the string-method crash remained.)

## Fix

Rewrite the IFC2X3 branch so it never calls string methods on `self.name`. It derives the occurrence name from the element's type (`IfcWallType` -> `IFCWALL`) and compares it with `==`, which works for both plain strings and `Restriction`s. This keeps the existing string-name behaviour (direct match and type inference) and additionally makes restriction-based entity requirements resolve correctly.

## Verification

Red-green test added in `test_facet.py::TestEntity::test_ifc2x3_restriction_entity_requirement`, covering both the previously crashing fail path and the pass-via-type-mapping path. Verified against `v0.8.0`: before, an IFC2X3 element failing a restriction entity requirement raised `AttributeError`; after, it reports a clean fail, and string-name direct/inference and IFC4 restriction paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)