### PR TITLE
Bonsai: guess_false_origin tolerates a file without a project (#7350)

### DIFF
--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -972,10 +972,14 @@ class Loader(bonsai.core.tool.Loader):
 
     @classmethod
     def guess_false_origin(cls, ifc_file: ifcopenshell.file) -> None:
-        if ifc_file.schema == "IFC2X3":
-            project = ifc_file.by_type("IfcProject")[0]
-        else:
-            project = ifc_file.by_type("IfcContext")[0]
+        project_class = "IfcProject" if ifc_file.schema == "IFC2X3" else "IfcContext"
+        projects = ifc_file.by_type(project_class)
+        if not projects:
+            # A file without a project/context is malformed, but the loader
+            # should still open it rather than crash with an IndexError. There
+            # is no spatial tree to walk, so guess purely from element geometry.
+            return cls.guess_false_origin_from_elements(ifc_file)
+        project = projects[0]
         site = cls.find_decomposed_ifc_class(project, "IfcSite")
         if site and cls.is_element_far_away(site):
             return cls.guess_false_origin_and_project_north(ifc_file, site)


### PR DESCRIPTION
## Problem

Opening a file crashed during import with (#7350):

```
File ".../bonsai/tool/loader.py", line 920, in guess_false_origin
    project = ifc_file.by_type("IfcContext")[0]
IndexError: list index out of range
```

## Cause

`guess_false_origin` takes `by_type("IfcProject"|"IfcContext")[0]` unconditionally. As the maintainers noted on the issue, the file is malformed (it has no project/context), but the loader still blows up with an opaque `IndexError` mid-import instead of opening it.

## Fix

Guard the lookup. When there is no project/context there is no spatial tree to walk, so fall back to `guess_false_origin_from_elements`, which derives the offset purely from element geometry and is already the final fallback of this method anyway. The malformed file now opens instead of crashing.

## Verification

Confirmed a project-less file makes `by_type("IfcContext")` return `[]`, so `[0]` raised the reported `IndexError`; the guard routes that case to the element-based path. This runs inside Blender's import pipeline so I could not exercise the full load locally, but the change is a null-guard around an existing, project-independent fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)