### PR TITLE
ifcdiff: compare container and aggregate by GlobalId, not identity (#4110)

### DIFF
--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -323,11 +323,21 @@ class IfcDiff:
                     self.change_register.setdefault(new.GlobalId, {}).update({"properties_changed": diff})
                     return True
             elif relationship == "container":
-                if ifcopenshell.util.element.get_container(old) != ifcopenshell.util.element.get_container(new):
+                # The two containers come from different files, so their instances
+                # never compare equal. Compare by GlobalId, as the type branch does.
+                old_container = ifcopenshell.util.element.get_container(old)
+                new_container = ifcopenshell.util.element.get_container(new)
+                old_guid = old_container.GlobalId if old_container is not None else None
+                new_guid = new_container.GlobalId if new_container is not None else None
+                if old_guid != new_guid:
                     self.change_register.setdefault(new.GlobalId, {}).update({"container_changed": True})
                     return True
             elif relationship == "aggregate":
-                if ifcopenshell.util.element.get_aggregate(old) != ifcopenshell.util.element.get_aggregate(new):
+                old_aggregate = ifcopenshell.util.element.get_aggregate(old)
+                new_aggregate = ifcopenshell.util.element.get_aggregate(new)
+                old_guid = old_aggregate.GlobalId if old_aggregate is not None else None
+                new_guid = new_aggregate.GlobalId if new_aggregate is not None else None
+                if old_guid != new_guid:
                     self.change_register.setdefault(new.GlobalId, {}).update({"aggregate_changed": True})
                     return True
             elif relationship == "classification":

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -17,9 +17,11 @@
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
 import ifcopenshell
+import ifcopenshell.api.aggregate
 import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.root
+import ifcopenshell.api.spatial
 import ifcopenshell.api.unit
 import ifcopenshell.util.representation
 
@@ -76,6 +78,48 @@ class TestIfcDiff:
         assert ifc_diff.added_elements == set()
         assert ifc_diff.deleted_elements == set()
         assert ifc_diff.change_register == {wall.GlobalId: {"attributes_changed": True}}
+
+    def test_unchanged_container_is_not_a_change(self):
+        ifc_file = setup_project()
+        storey = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey", name="Level 1")
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=storey)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+
+        # The container instances live in two different files and never compare
+        # equal, so the diff must compare them by GlobalId, not by identity.
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {}
+
+    def test_changed_container(self):
+        ifc_file = setup_project()
+        storey1 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey", name="Level 1")
+        storey2 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey", name="Level 2")
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=storey1)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        storey2_new = new_file.by_id(storey2.id())
+        ifcopenshell.api.spatial.assign_container(new_file, products=[wall_new], relating_structure=storey2_new)
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {wall.GlobalId: {"container_changed": True}}
+
+    def test_unchanged_aggregate_is_not_a_change(self):
+        ifc_file = setup_project()
+        assembly = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcElementAssembly")
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+        ifcopenshell.api.aggregate.assign_object(ifc_file, products=[wall], relating_object=assembly)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["aggregate"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {}
 
     def test_changed_geometry(self):
         ifc_file = setup_project()


### PR DESCRIPTION
## Problem

Running IfcDiff with the `container` relationship reported far too many changes (the reporter saw 82 spurious changes for a file where only a handful of things changed). #4110.

## Cause

`diff_element_relationships` compared the container and aggregate of the old and new element directly:

```python
if ifcopenshell.util.element.get_container(old) != ifcopenshell.util.element.get_container(new):
```

Those two instances come from two different `ifcopenshell.file` objects. `entity_instance.__eq__` treats a proper instance's identity as its step id within its file, so instances from different files never compare equal. Every element that had a container (or an aggregate) was therefore flagged as changed, even when it had not moved. The `type` branch had already been fixed to sidestep exactly this by comparing GlobalIds; `container` and `aggregate` were left behind.

## Fix

Compare the container and aggregate by GlobalId (with `None` handling for the added/removed case), mirroring the `type` branch.

## Verification

Red-green regression tests added in `test.py`:
- `test_unchanged_container_is_not_a_change` and `test_unchanged_aggregate_is_not_a_change`: a round-tripped copy with the same containment now yields no changes (before the fix both failed, reporting a spurious `*_changed`).
- `test_changed_container`: genuinely moving a wall to another storey is still reported as `container_changed`.

Full `ifcdiff` suite passes (7 tests). Confirmed the two new "unchanged" tests fail on `v0.8.0` without the fix and pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)