### PR TITLE
util.selector: set_element_value accepts a trailing index like get_element_value (#4687)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -869,11 +869,22 @@ def set_element_value(
                     pass
             return
         elif isinstance(element, (list, tuple, set)):  # If we use regex
-            if key.isnumeric():
+            if isinstance(key, str) and key.isnumeric():
                 try:
                     element = element[int(key)]
                 except IndexError:
                     return
+            elif isinstance(keys[-1], str) and keys[-1].isnumeric() and i != len(keys) - 1:
+                # get_element_value maps the remaining attribute keys over the
+                # list and applies a trailing numeric index to the mapped result
+                # (e.g. "item.Material.Name.0"). To stay consistent, select that
+                # element up front and set the attribute chain on it (#4687).
+                try:
+                    selected = list(element)[int(keys[-1])]
+                except IndexError:
+                    return
+                set_element_value(ifc_file, selected, keys[i:-1], value)
+                return
             else:
                 for v in element:
                     set_element_value(ifc_file, v, keys[i:], value)

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -405,6 +405,23 @@ class TestSetElementValue(test.bootstrap.IFC4):
         subject.set_element_value(self.file, layer, "Material.Name", "Foo")
         assert material.Name == "Foo"
 
+    def test_set_value_with_a_trailing_index(self):
+        layer_set = self.file.create_entity("IfcMaterialLayerSet")
+        material0 = self.file.create_entity("IfcMaterial", Name="0")
+        layer0 = self.file.create_entity("IfcMaterialLayer", Material=material0)
+        material1 = self.file.create_entity("IfcMaterial", Name="1")
+        layer1 = self.file.create_entity("IfcMaterialLayer", Material=material1)
+        layer_set.MaterialLayers = [layer0, layer1]
+        # get_element_value accepts a trailing index; set_element_value must set
+        # exactly the same attribute so a query round trips (#4687).
+        assert subject.get_element_value(layer_set, "item.Material.Name.0") == "0"
+        subject.set_element_value(self.file, layer_set, "item.Material.Name.0", "a")
+        assert material0.Name == "a"
+        assert material1.Name == "1"
+        subject.set_element_value(self.file, layer_set, "item.Material.Name.1", "b")
+        assert material1.Name == "b"
+        assert material0.Name == "a"
+
 
 class TestSetElementValuePredefinedType(test.bootstrap.IFC4):
     def test_setting_an_element_predefined_type(self):


### PR DESCRIPTION
## Problem

`get_element_value` accepts a query with a trailing numeric index, but `set_element_value` does not, so a value read with a query cannot be written back with the same query (#4687). This matters for round trips such as exporting to CSV and importing back without dropping columns.

```python
query = "item.Material.Name.0"
ifcopenshell.util.selector.get_element_value(layer_set, query)          # "1"
ifcopenshell.util.selector.set_element_value(file, layer_set, query, "2")
# SetElementValueException: ... with query '['Material', 'Name', '0']' (invalid or unsupported query)
```

## Cause

`get_element_value` maps the remaining attribute keys over a list and then applies a trailing numeric index to the mapped result. `set_element_value` instead fans out into the list elements immediately, so by the time the trailing index is reached the element is already a scalar and no branch handles it, raising `SetElementValueException`.

## Fix

In the list branch of `set_element_value`, when the list is reached via a non-numeric key and the query ends in a numeric index, select that element up front and set the remaining attribute chain on it. This mirrors `get_element_value` for the common linear case (`item.Material.Name.0` is equivalent to `item.0.Material.Name`). Fan-out to all elements is preserved when there is no trailing index. Also guards the existing `key.isnumeric()` call against non-string regex keys.

## Verification

Red-green test added in `test_selector.py::TestSetElementValue::test_set_value_with_a_trailing_index`: `item.Material.Name.0` and `.1` now set the correct material's name (index 0 vs 1), matching `get_element_value`; before the fix these raised `SetElementValueException`. The existing adjacent-index form (`item.0.Material.Name`) and the index-less fan-out form (`item.Material.Name`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)