### PR TITLE
pset.edit_pset: empty string for a numeric property stores no value (#4112)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
@@ -386,8 +386,18 @@ class Usecase:
                 if value is None:
                     nominal_value = value
                 else:
-                    value = self.cast_value_to_primary_measure_type(value, primary_measure_type)
-                    nominal_value = self.file.create_entity(primary_measure_type, value)
+                    try:
+                        cast_value = self.cast_value_to_primary_measure_type(value, primary_measure_type)
+                        nominal_value = self.file.create_entity(primary_measure_type, cast_value)
+                    except ValueError:
+                        if value == "":
+                            # An empty string is not a meaningful value for a
+                            # numeric or boolean measure (e.g. an unfilled bSDD
+                            # property), so store the property without a nominal
+                            # value instead of crashing on float("").
+                            nominal_value = None
+                        else:
+                            raise
                 args = {"Name": name, "NominalValue": nominal_value}
                 if unit:
                     args["Unit"] = unit

--- a/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
+++ b/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
@@ -59,6 +59,19 @@ class TestEditPsetIFC2X3(test.bootstrap.IFC2X3):
         pset = element.IsDefinedBy[0].RelatingPropertyDefinition
         assert len(pset.HasProperties) == 1
 
+    def test_an_empty_string_for_a_numeric_property_stores_no_value(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")
+        # An empty string for a numeric measure (e.g. an unfilled bSDD property)
+        # must not crash on float(""); the property is stored without a value.
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"ThermalTransmittance": ""})
+        transmittance = next(p for p in pset.HasProperties if p.Name == "ThermalTransmittance")
+        assert transmittance.NominalValue is None
+        # An empty string for a string measure stays an empty string.
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Reference": ""})
+        reference = next(p for p in pset.HasProperties if p.Name == "Reference")
+        assert reference.NominalValue.wrappedValue == ""
+
     def test_not_adding_a_property_if_it_is_none_and_should_purge_is_true(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")


### PR DESCRIPTION
## Problem

Classifying elements via bSDD crashed when a numeric property was left empty (#4112):

```
File ".../ifcopenshell/api/pset/edit_pset.py", line 410, in cast_value_to_primary_measure_type
    return type_fn(value)
ValueError: could not convert string to float: ''
```

## Cause

When a property is covered by a pset template, `get_primary_measure_type` returns the template's numeric `PrimaryMeasureType`. If the supplied value is an empty string (as bSDD produces for an unfilled numeric field), `cast_value_to_primary_measure_type` runs `float("")` and raises.

## Fix

Catch the `ValueError` at the call site and, for an empty-string value, store the property with no nominal value (`IfcPropertySingleValue` with `$`) instead of crashing. The change is surgical:
- an empty string on a **numeric or boolean** measure now yields a property with no value,
- an empty string on a **string** measure still stores the empty string,
- a genuinely invalid value (e.g. `"abc"` for a real) still raises.

## Verification

Red-green test added in `test_edit_pset.py::test_an_empty_string_for_a_numeric_property_stores_no_value` (runs for both IFC2X3 and IFC4): `ThermalTransmittance=""` no longer raises and yields `NominalValue is None`, while `Reference=""` keeps an empty `IfcIdentifier`. Confirmed the crash reproduces on `v0.8.0` before the fix and is resolved after, with the valid-value and invalid-value paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)