### PR TITLE
util.selector: numeric format functions pass through non-numeric values (#6776)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -18,7 +18,7 @@
 
 import re
 from collections.abc import Iterable
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from types import EllipsisType
 from typing import Any, Optional, Union
 
@@ -319,10 +319,10 @@ class FormatTransformer(lark.Transformer):
     def round(self, args):
         try:
             value = Decimal(0.0 if args[0] == "None" else args[0] or 0.0)
-        except InvalidOperation:
-            # The value is not numeric (e.g. a text property, or a value with
-            # a unit suffix like "12.5 m"). Rounding is meaningless here, so
-            # return it unchanged instead of crashing the whole expression.
+        except (ArithmeticError, TypeError, ValueError):
+            # A non-numeric value (a text property, or a value carrying a unit
+            # suffix like "12.5 m") cannot be rounded. Pass it through unchanged
+            # rather than failing the whole format expression (#6776).
             return args[0]
         nearest = Decimal(args[1])
         result = round(value / nearest) * nearest
@@ -333,7 +333,10 @@ class FormatTransformer(lark.Transformer):
     def number(self, args):
         arg_val = args[0]
         if isinstance(arg_val, str):
-            arg_val = float(arg_val) if "." in arg_val else int(arg_val)
+            try:
+                arg_val = float(arg_val) if "." in arg_val else int(arg_val)
+            except ValueError:
+                return args[0]
         if len(args) >= 3 and args[2]:
             return "{:,}".format(arg_val).replace(".", "*").replace(",", args[2]).replace("*", args[1])
         elif len(args) >= 2 and args[1]:
@@ -379,7 +382,11 @@ class FormatTransformer(lark.Transformer):
 
     def int(self, args: list[str]) -> str:
         value = 0.0 if args[0] == "None" else args[0] or 0.0
-        return str(int(float(value)))
+        try:
+            return str(int(float(value)))
+        except (TypeError, ValueError):
+            # Non-numeric value: pass through rather than fail the expression (#6776).
+            return args[0]
 
 
 class GetElementTransformer(lark.Transformer):

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -51,6 +51,14 @@ class TestFormat(test.bootstrap.IFC4):
         assert subject.format('substr("foobar", 1, 2)') == "o"
         assert subject.format('substr("foobar", 1, -1)') == "ooba"
 
+    def test_numeric_formatters_pass_through_non_numeric_values(self):
+        # A non-numeric value (a text property, or a value with a unit suffix)
+        # must not fail the whole format expression, it is passed through (#6776).
+        assert subject.format('round("12.5 m", 1)') == "12.5 m"
+        assert subject.format('round("Foo", 1)') == "Foo"
+        assert subject.format('int("Foo")') == "Foo"
+        assert subject.format('number("Foo")') == "Foo"
+
     def test_number_formatting(self):
         assert subject.format("round(123, 5)") == "125"
         assert subject.format('round("123", 5)') == "125"


### PR DESCRIPTION
## Problem

A spreadsheet export using `round({{value}}, 1)` crashed on one model (#6776):

```
File ".../ifcopenshell/util/selector.py", in round
    value = Decimal(0.0 if args[0] == "None" else args[0] or 0.0)
decimal.InvalidOperation: [<class 'decimal.ConversionSyntax'>]
```

## Cause

The value being rounded was a non-numeric string (a text property, or a value carrying a unit suffix like `"12.5 m"`). `round` calls `Decimal()` on it directly and raises, which aborts the whole format expression, so a single such value takes down the entire export. `int` (`float()`) and `number` (`float()`/`int()`) have the same flaw.

## Fix

When the value cannot be converted to a number, pass it through unchanged instead of raising. This applies to `round`, `int`, and `number`, so a text cell simply keeps its text rather than failing the export.

## Verification

Red-green test added in `test_selector.py::TestFormat::test_numeric_formatters_pass_through_non_numeric_values`: `round("12.5 m", 1)`, `round("Foo", 1)`, `int("Foo")`, `number("Foo")` now return the original value instead of crashing. All existing numeric formatting assertions still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)