### PR TITLE
pset.edit_pset: support updating IfcPropertyListValue properties (#5195)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
@@ -226,6 +226,10 @@ class Usecase:
                 prop = self.update_existing_prop_single_value(prop)
                 if prop:
                     existing_props.append(prop)
+            elif prop.is_a("IfcPropertyListValue"):
+                prop = self.update_existing_prop_list_value(prop)
+                if prop:
+                    existing_props.append(prop)
             else:
                 raise NotImplementedError(f"Updating '{prop.is_a()}' properties is not supported yet")
         return existing_props
@@ -310,6 +314,43 @@ class Usecase:
             )
             value = self.cast_value_to_primary_measure_type(value, primary_measure_type)
             prop.NominalValue = self.file.create_entity(primary_measure_type, value)
+        if unit:
+            prop.Unit = unit
+        del self.settings["properties"][prop.Name]
+        return prop
+
+    def update_existing_prop_list_value(
+        self, prop: ifcopenshell.entity_instance
+    ) -> Union[ifcopenshell.entity_instance, None]:
+        """
+        NOTE: Assumes the prop exists
+        """
+        value = self.settings["properties"][prop.Name]
+        unit, value = self.unpack_unit_value(value)
+        if value is None or (isinstance(value, (tuple, list)) and not value):
+            if self._try_purge(prop):
+                return
+            prop.ListValues = None
+        else:
+            if not isinstance(value, (tuple, list)):
+                value = [value]
+            # Reuse the measure type of the existing values, falling back to the
+            # template when the list was previously empty.
+            if existing_values := prop.ListValues:
+                primary_measure_type = existing_values[0].is_a()
+            else:
+                primary_measure_type = self.get_primary_measure_type(prop.Name, new_value=value[0])
+            list_values = []
+            for val in value:
+                if isinstance(val, ifcopenshell.entity_instance):
+                    list_values.append(val)
+                else:
+                    list_values.append(
+                        self.file.create_entity(
+                            primary_measure_type, self.cast_value_to_primary_measure_type(val, primary_measure_type)
+                        )
+                    )
+            prop.ListValues = tuple(list_values)
         if unit:
             prop.Unit = unit
         del self.settings["properties"][prop.Name]

--- a/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
+++ b/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
@@ -330,3 +330,15 @@ class TestEditPsetIFC4(test.bootstrap.IFC4, TestEditPsetIFC2X3):
         assert len(pset.HasProperties[0].ListValues) == 3
         assert set(map(ifcopenshell.entity_instance.is_a, pset.HasProperties[0].ListValues)) == {"IfcIdentifier"}
         assert list(map(operator.itemgetter(0), pset.HasProperties[0].ListValues)) == ["One", "Two", "Three"]
+
+        # Updating an existing IfcPropertyListValue must not raise NotImplementedError.
+        ifcopenshell.api.pset.edit_pset(
+            self.file,
+            pset=pset,
+            properties={
+                "Protocols": ["Four", "Five"],
+            },
+        )
+        assert pset.HasProperties[0].is_a("IfcPropertyListValue")
+        assert set(map(ifcopenshell.entity_instance.is_a, pset.HasProperties[0].ListValues)) == {"IfcIdentifier"}
+        assert list(map(operator.itemgetter(0), pset.HasProperties[0].ListValues)) == ["Four", "Five"]


### PR DESCRIPTION
## Problem

`edit_pset` could create an `IfcPropertyListValue` but not update one. Editing an existing list property raised (#5195):

```
File ".../ifcopenshell/api/pset/edit_pset.py", in update_existing_properties
    raise NotImplementedError(f"Updating '{prop.is_a()}' properties is not supported yet")
NotImplementedError: Updating 'IfcPropertyListValue' properties is not supported yet
```

## Fix

Add `update_existing_prop_list_value`, following the existing `update_existing_prop_single_value` / `update_existing_prop_enum` handlers:
- reuse the measure type of the existing list values, falling back to the template when the list was previously empty,
- rebuild `ListValues` from the supplied sequence (casting primitives, passing through entity instances),
- purge the property on an empty value (respecting `should_purge`),
- keep the `Unit` handling consistent with the other handlers.

This covers the reported case (`properties={"Spacing": (1, 1, 2, 3)}` on an existing list property). `IfcPropertyBoundedValue` updates remain unimplemented and out of scope here.

## Verification

Extended `test_edit_pset.py::test_editing_list_valued_properties` to also update the list property (`["Four", "Five"]`) and assert the values and `IfcIdentifier` measure type. Before the fix the update raised `NotImplementedError`; after, it updates in place and the property stays an `IfcPropertyListValue`. Confirmed the measure type is preserved, empty-value purge works, and the value round-trips through `get_pset`.

Related to #3236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)