### PR TITLE
IfcParse: don't strip delimiters from a single-character token (#5683)

### DIFF
--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -449,7 +449,14 @@ const std::string& TokenFunc::asStringRef(const Token& token) {
     }
     std::string& str = token.lexer->GetTempString();
     token.lexer->TokenString(token.startPos, str);
-    if ((isString(token) || isEnumeration(token) || isBinary(token)) && !str.empty()) {
+    // A well-formed string/enumeration/binary token has both delimiters (e.g.
+    // '...', .XXX., "...."), so at least two characters. Malformed input from a
+    // fuzzer can produce a single-character token (e.g. a bare '.' left by
+    // ".)" instead of ".PHYSICAL."); stripping both ends would then erase past
+    // the end of an already-empty string, which is undefined behaviour and
+    // aborts under hardened standard libraries (_GLIBCXX_ASSERTIONS). Require
+    // two characters before stripping. See #5683.
+    if ((isString(token) || isEnumeration(token) || isBinary(token)) && str.size() >= 2) {
         //remove start+end characters in-place
         str.erase(str.end() - 1);
         str.erase(str.begin());


### PR DESCRIPTION
## Problem

The last remaining fuzzed file in #5683, `segfault_85914_436.ifc`, aborts `IfcConvert` during scanning on @brunopostle's Fedora build (`std::length_error` in `basic_string::append`, under `_GLIBCXX_ASSERTIONS`/`_FORTIFY_SOURCE=3`), but parses cleanly for @aothms and on the pre-built wheels. That split is the tell: it is undefined behaviour that only a hardened standard library traps.

## Root cause

I narrowed the 108 KB file to one mutated token on the `IFCRELSPACEBOUNDARY2NDLEVEL` line: the fuzzer turned `.PHYSICAL.` into `.)HYSICAL.`, injecting a stray `)` and leaving a bare `.` token.

Any token beginning with `.` is classified as `Token_ENUMERATION` (`GeneralTokenPtr`). In `TokenFunc::asStringRef`, string/enumeration/binary tokens have their first and last characters stripped to drop the delimiters:

```cpp
if ((isString(token) || isEnumeration(token) || isBinary(token)) && !str.empty()) {
    str.erase(str.end() - 1);
    str.erase(str.begin());
}
```

The guard only checks `!str.empty()` (length ≥ 1). For the single-character token `.`, the first erase empties the string and the second `str.erase(str.begin())` runs on an **empty** string, i.e. `erase(end())` — undefined behaviour. It is benign on a normal build (returns empty) but aborts under hardening, surfacing as the reported `length_error`.

## Fix

Require at least two characters (both delimiters present) before stripping: `str.size() >= 2`.

## Verification

I cannot reproduce the abort on macOS (libc++, not libstdc++), but I isolated the exact `asStringRef` stripping logic into a standalone program and ran it under libc++ hardening, which is analogous to Fedora's `_GLIBCXX_ASSERTIONS`:

- **Before the fix**, input `"."` aborts: `libc++ Hardening assertion __pos != end() failed: string::erase(iterator) called with a non-dereferenceable iterator`.
- **After the fix** (`size() >= 2`), no abort, and every valid case is unchanged: `..`→``, `''`→``, `'A'`→`A`, `.EXTERNAL.`→`EXTERNAL`; the malformed `.` and a lone `'` are left as-is.

@brunopostle since you have the Fedora copr repro, could you confirm `IfcConvert segfault_85914_436.ifc` no longer aborts with this change? That is the definitive test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)