### PR TITLE
buildinfo: report the release version instead of a hardcoded fallback (#8164)

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -660,6 +660,11 @@ if(ADD_COMMIT_SHA)
     endif()
 endif(ADD_COMMIT_SHA)
 
+# Always expose the release version (from the VERSION file) to buildinfo.cpp so
+# that a build without commit-sha info reports the correct version instead of a
+# stale hardcoded fallback. See #8164.
+target_compile_definitions(IfcParse PRIVATE IFCOPENSHELL_VERSION_STRING=${RELEASE_VERSION})
+
 if(MSVC)
     # @todo still needs to be understood better, but the cgal and cgal-simple kernel cause multiply defined boost lambda placeholders _1 ... _3
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /FORCE:MULTIPLE")

--- a/src/ifcparse/buildinfo.cpp
+++ b/src/ifcparse/buildinfo.cpp
@@ -30,6 +30,10 @@
 
 #if defined(IFCOPENSHELL_BRANCH) && defined(IFCOPENSHELL_COMMIT)
 const char *IFCOPENSHELL_VERSION = STRINGIFY(IFCOPENSHELL_BRANCH) "-" STRINGIFY(IFCOPENSHELL_COMMIT);
+#elif defined(IFCOPENSHELL_VERSION_STRING)
+// Set from CMake's RELEASE_VERSION (the repository VERSION file) so a release
+// build without commit-sha info still reports the correct version. See #8164.
+const char *IFCOPENSHELL_VERSION = STRINGIFY(IFCOPENSHELL_VERSION_STRING);
 #else
 const char *IFCOPENSHELL_VERSION = "0.8.0";
 #endif


### PR DESCRIPTION
## Problem

`IfcConvert --version` on a 0.8.5 build reports `0.8.0`, and the same stale string is written into file headers (`preprocessor_version`/`originating_system`). Reported in #8164.

## Cause

`src/ifcparse/buildinfo.cpp` sets `IFCOPENSHELL_VERSION` from `IFCOPENSHELL_BRANCH`/`IFCOPENSHELL_COMMIT` when `ADD_COMMIT_SHA` is on, otherwise falls back to a **hardcoded** `"0.8.0"`. Release tarballs build with `ADD_COMMIT_SHA=OFF`, so they always get the stale literal, disconnected from CMake's `RELEASE_VERSION` (read from the repo `VERSION` file, currently `0.8.6`).

## Fix

Pass `RELEASE_VERSION` to the `IfcParse` target as `IFCOPENSHELL_VERSION_STRING` (unconditionally), and use it as the fallback in `buildinfo.cpp`, mirroring how `BRANCH`/`COMMIT` are handled via `STRINGIFY`. So the precedence is now: commit-sha build → `branch-commit`; otherwise → the real `RELEASE_VERSION`; the hardcoded literal remains only as a last resort.

## Verification

I verified the preprocessor path in isolation (same `STRINGIFY` macro):
- `-DIFCOPENSHELL_VERSION_STRING=0.8.6` (release build) → `0.8.6` (was `0.8.0`)
- `-DIFCOPENSHELL_BRANCH=v0.8.0 -DIFCOPENSHELL_COMMIT=1c5b825` → `v0.8.0-1c5b825` (unchanged)
- no defines → `0.8.0` (last-resort fallback, unchanged)

(The reporter also noted a stale `0.7.0-dev` in `ifcparse.h`; that no longer exists in the current headers.) I don't have a full local build to run `IfcConvert --version` end to end, but the change only routes the existing `RELEASE_VERSION` into the existing macro path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)