### PR TITLE
Bonsai: drop deleted objects from the snap cache (#8207)

### DIFF
--- a/src/bonsai/bonsai/tool/raycast.py
+++ b/src/bonsai/bonsai/tool/raycast.py
@@ -969,6 +969,18 @@ class Raycast(bonsai.core.tool.Raycast):
     def create_snap_obj(cls, obj):
         if obj.data is None or not isinstance(obj.data, bpy.types.Mesh):
             return None
+        # Drop cache entries whose Blender object has been deleted. Accessing the
+        # freed object below (and in the raycast passes) otherwise raises
+        # ReferenceError ("StructRNA ... has been removed") and aborts snapping.
+        # See #8207.
+        valid_snap_objs = []
+        for snap_obj in cls.snap_objs:
+            try:
+                snap_obj.obj.name
+            except ReferenceError:
+                continue
+            valid_snap_objs.append(snap_obj)
+        cls.snap_objs[:] = valid_snap_objs
         for i, snap_obj in enumerate(cls.snap_objs):
             if obj.name == snap_obj.obj.name:
                 # Handle objects modified while a modal operator is active.


### PR DESCRIPTION
## Problem

Activating the measure tool (S M) after deleting an object that was previously snapped to crashes with `ReferenceError: StructRNA of type Object has been removed` (#8207). Thanks to @theoryshaw for the precise diagnosis.

## Cause

Snapping caches `SnapObj` entries in `tool.Raycast.snap_objs`, each holding a direct reference to a Blender object. `create_snap_obj` iterates that cache and reads `snap_obj.obj.name`; once the cached object has been deleted, that access hits a freed `StructRNA` and raises `ReferenceError`, aborting the snap pass (and the same stale reference would break the raycast passes downstream).

## Fix

At the start of `create_snap_obj`, prune cache entries whose Blender object no longer exists (detected by the `ReferenceError` on attribute access). Deleted objects are silently dropped and snapping continues, which is the expected behaviour. Because `filter_objects_to_raycast` only appends live `create_snap_obj` results to the raycast list, pruning here also protects the downstream passes.

## Verification

I don't have a Blender session to run the modal tool, but I verified the pruning logic in isolation: a cache with a deleted entry (which raises `ReferenceError` on `.name`, exactly as a freed `StructRNA` does) is reduced to only the live entries, and subsequent `.obj.name` access no longer raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)