### PR TITLE
Bonsai: allow removing a drawing with no associated document (#8122)

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2830,6 +2830,10 @@ class Drawing(bonsai.core.tool.Drawing):
     def get_sheet_references(cls, drawing: ifcopenshell.entity_instance) -> list[ifcopenshell.entity_instance]:
         sheet_references: list[ifcopenshell.entity_instance] = []
         drawing_reference = cls.get_drawing_document(drawing)
+        if drawing_reference is None:
+            # A corrupt drawing with no associated document has no sheet
+            # references; return empty so it can still be removed (#8122).
+            return sheet_references
         for sheet in tool.Ifc.get().by_type("IfcDocumentInformation"):
             if not sheet.Scope == "SHEET":
                 continue


### PR DESCRIPTION
## Problem

`bim.remove_drawing` on a corrupt drawing crashed (#8122):

```
File ".../bonsai/tool/drawing.py", in get_sheet_references
    if reference.Location == drawing_reference.Location:
AttributeError: 'NoneType' object has no attribute 'Location'
```

## Cause

`get_sheet_references` calls `get_drawing_document(drawing)`, which returns `None` when the drawing has no `IfcRelAssociatesDocument` (i.e. a corrupt drawing). The code then dereferenced `drawing_reference.Location`, so the drawing could not be removed at all.

## Fix

Return an empty list of sheet references when `get_drawing_document` returns `None` — a drawing with no document has no sheet references — so `remove_drawing` proceeds instead of aborting.

## Verification

Confirmed that `get_drawing_document` returns `None` for a drawing with no `IfcRelAssociatesDocument`, and the guard then returns an empty list rather than dereferencing `None.Location`. @theoryshaw a run of `bim.remove_drawing` on the `Type A2` drawing in your file would confirm end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)