### PR TITLE
Bonsai: apply georeferencing offset to imported drawing cameras (#8205)

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1007,7 +1007,14 @@ class Drawing(bonsai.core.tool.Drawing):
         cls.import_camera_props(drawing, camera)
         tool.Ifc.link(drawing, obj)
 
-        obj.matrix_world = cls.get_camera_shape_matrix(drawing, shape)
+        # Apply the georeferencing/model offset like every other imported object
+        # (see import_ifc.py). Without this the drawing camera keeps absolute map
+        # coordinates while the rest of the scene is shifted to Blender-local, so
+        # on a georeferenced model the camera lands far away and drifts further on
+        # each save/reopen. See #8205.
+        obj.matrix_world = tool.Loader.apply_blender_offset_to_matrix_world(
+            obj, np.array(cls.get_camera_shape_matrix(drawing, shape))
+        )
 
         tool.Geometry.record_object_position(obj)
         tool.Collector.assign(obj)
@@ -1028,7 +1035,11 @@ class Drawing(bonsai.core.tool.Drawing):
         else:
             obj = bpy.data.objects.new(tool.Loader.get_name(drawing), camera)
 
-        obj.matrix_world = cls.get_camera_shape_matrix(drawing, shape)
+        # Match the georeferencing offset applied to every other imported object
+        # so the camera is not misplaced on georeferenced models. See #8205.
+        obj.matrix_world = tool.Loader.apply_blender_offset_to_matrix_world(
+            obj, np.array(cls.get_camera_shape_matrix(drawing, shape))
+        )
         return obj
 
     @classmethod


### PR DESCRIPTION
## Problem

On georeferenced / large-coordinate models, drawing and BCF section cameras are shifted away from their correct position after saving and reopening, and drift further on each save/reopen cycle (#8205, symptom 2).

## Cause

Every object imported from IFC has the model/georeferencing offset applied through `tool.Loader.apply_blender_offset_to_matrix_world` (`import_ifc.py:786/835/886`, etc.). The drawing camera import does not:

```python
# import_drawing / import_temporary_drawing_camera
obj.matrix_world = cls.get_camera_shape_matrix(drawing, shape)   # raw absolute map coords
```

So on a georeferenced model the rest of the scene is shifted to Blender-local via `global2local`, while the camera keeps absolute map coordinates and lands far away. Worse, on save `edit_object_placement` re-applies `local2global` to an already-absolute matrix, so the camera drifts further every save/reopen.

## Fix

Route the camera matrix through the same offset helper every other object uses, in both `import_drawing` and `import_temporary_drawing_camera`.

## Verification

- For **non-georeferenced** models the helper returns the matrix unchanged (camera has `obj.data`, no cartesian-point offset, `has_blender_offset` false), so behaviour is identical to before — no regression.
- For **georeferenced** models it applies `global2local` exactly like the 8 existing call sites; verified in isolation that an absolute placement (e.g. `1234567, 7654321`) is brought into the scene-local frame, matching the rest of the scene.

I don't have a Blender session with a georeferenced model to run the full save/reopen round-trip, so that end-to-end confirmation is welcome. This addresses symptom 2 (camera shift); symptom 1 (ortho zoom/crop not persisted) is a separate matter — `ortho_scale` is not stored in `EPset_Drawing` the way perspective `shift_x/shift_y` are — and is left for a maintainer to decide whether manual ortho zoom should be persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)