### PR TITLE
resource.assign_resource: fix typo in duplicate guard (#8203)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/resource/assign_resource.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/resource/assign_resource.py
@@ -81,7 +81,7 @@ def assign_resource(
     """
     if related_object.HasAssignments:
         for assignment in related_object.HasAssignments:
-            if assignment.is_a("IfclRelAssignsToResource") and assignment.RelatingResource == relating_resource:
+            if assignment.is_a("IfcRelAssignsToResource") and assignment.RelatingResource == relating_resource:
                 return assignment
 
     resource_of = None

--- a/src/ifcopenshell-python/test/api/resource/test_assign_resource.py
+++ b/src/ifcopenshell-python/test/api/resource/test_assign_resource.py
@@ -1,0 +1,62 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2024 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.api.resource
+import ifcopenshell.api.root
+import test.bootstrap
+
+
+class TestAssignResource(test.bootstrap.IFC4):
+    def test_run(self):
+        self.file.create_entity("IfcProject")
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcCrewResource")
+        product = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingElementProxy")
+
+        rel = ifcopenshell.api.resource.assign_resource(
+            self.file, relating_resource=resource, related_object=product
+        )
+        assert rel.is_a("IfcRelAssignsToResource")
+        assert rel.RelatingResource == resource
+        assert list(rel.RelatedObjects) == [product]
+
+    def test_assigning_twice_does_not_duplicate_the_related_object(self):
+        # Regression test for #8203: the duplicate-assignment guard checked for
+        # a misspelled class "IfclRelAssignsToResource", so it never matched and
+        # the same object was appended to RelatedObjects a second time.
+        self.file.create_entity("IfcProject")
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcCrewResource")
+        product = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingElementProxy")
+
+        rel1 = ifcopenshell.api.resource.assign_resource(
+            self.file, relating_resource=resource, related_object=product
+        )
+        rel2 = ifcopenshell.api.resource.assign_resource(
+            self.file, relating_resource=resource, related_object=product
+        )
+
+        assert rel1 == rel2
+        assert len(self.file.by_type("IfcRelAssignsToResource")) == 1
+        assert list(rel2.RelatedObjects) == [product]
+
+
+class TestAssignResourceIFC2X3(test.bootstrap.IFC2X3, TestAssignResource):
+    pass
+
+
+class TestAssignResourceIFC4X3(test.bootstrap.IFC4X3, TestAssignResource):
+    pass


### PR DESCRIPTION
## Problem

Assigning the same object to the same resource twice appends it to `RelatedObjects` again, producing duplicates like `[8, 8]` (#8203). Thanks @john-rogers for the precise report.

## Cause

The duplicate guard checks `assignment.is_a("IfclRelAssignsToResource")` — a stray `l`. No such class exists, so the guard never matched and the early return was dead code. The second call then fell through to the append branch.

## Fix

Correct the class name to `"IfcRelAssignsToResource"` so the existing relationship is found and returned.

## Verification

Red-green with a minimal repro (assign the same actor to the same crew resource twice):
- Before: `RelatedObjects` ids `[2, 2]`
- After: `RelatedObjects` ids `[2]`, single `IfcRelAssignsToResource`

🤖 Generated with [Claude Code](https://claude.com/claude-code)