### PR TITLE
style.assign_representation_styles: fix crash on IfcPresentationStyleAssignment (#7883)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/style/assign_representation_styles.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/style/assign_representation_styles.py
@@ -160,7 +160,11 @@ class Usecase:
                                 style_assignment = style_
                                 self.remove_same_type_styles(style_assignment, current_style_type, remove_item=False)
                             else:
-                                self.remove_same_type_styles(style_assignment, current_style_type, remove_item=True)
+                                # Operate on the assignment found in this iteration, not the
+                                # style_assignment accumulator, which is still None when the
+                                # file uses IfcPresentationStyleAssignment but we are not
+                                # reusing it (e.g. an IFC4 file authored by AVEVA E3D). See #7883.
+                                self.remove_same_type_styles(style_, current_style_type, remove_item=True)
 
                     if use_style_assignment:
                         if style_assignment:


### PR DESCRIPTION
## Problem

Assigning an `IfcSurfaceStyle` to an element imported from AVEVA E3D crashed (#7883):

```
File ".../api/style/assign_representation_styles.py", line 199, in remove_same_type_styles
    styles = [s for s in style_item.Styles if s.is_a() != current_style_type]
AttributeError: 'NoneType' object has no attribute 'Styles'
```

## Cause

AVEVA E3D authors IFC4 files that still wrap styles in the deprecated `IfcPresentationStyleAssignment`. When `replace_previous_same_type_style` iterates the previous styled item's `Styles` and finds such an assignment, but `use_style_assignment` is False (the IFC4 default), it falls into the `else` branch and calls `remove_same_type_styles(style_assignment, ...)` while `style_assignment` is still `None`, so `None.Styles` blows up.

## Fix

Operate on `style_`, the assignment found in the current iteration, rather than the `style_assignment` accumulator. That is the entity we actually want to clean/remove here, and it is never `None`. This also corrects the `use_style_assignment=True` second-assignment case, where the accumulator pointed at the assignment being kept rather than the redundant one.

## Verification

Red-green with a minimal IFC4 file whose item's `IfcStyledItem` wraps an `IfcPresentationStyleAssignment`, then `assign_representation_styles(..., replace_previous_same_type_style=True, should_use_presentation_style_assignment=False)`:
- Before: `AttributeError: 'NoneType' object has no attribute 'Styles'`
- After: no crash, the new `IfcSurfaceStyle` is assigned to the item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)