### PR TITLE
util.placement: pad 2D RefDirection without in-place resize (#6256)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/placement.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/placement.py
@@ -77,8 +77,11 @@ def get_axis2placement(placement: ifcopenshell.entity_instance) -> MatrixType:
     elif ifc_class == "IfcAxis2Placement2D":
         z = np.array((0, 0, 1))
         if placement.RefDirection:
-            x = np.array(placement.RefDirection.DirectionRatios)
-            x.resize(3)
+            # Pad the 2D direction to 3D by construction. An in-place
+            # ndarray.resize raises "cannot resize an array that references or is
+            # referenced" when DirectionRatios is a view of ifcopenshell-owned
+            # data, which crashed editing 2D-placed items. See #6256.
+            x = np.array((*placement.RefDirection.DirectionRatios, 0.0, 0.0))[:3]
         else:
             x = np.array((1, 0, 0))
         o = (*placement.Location.Coordinates, 0.0)


### PR DESCRIPTION
## Problem

Editing a representation item placed with an `IfcAxis2Placement2D` crashed (#6256):

```
File ".../ifcopenshell/util/placement.py", line 85, in get_axis2placement
    x.resize(3)
ValueError: cannot resize an array that references or is referenced by another array
```

## Cause

The 2D branch built the X axis with `x = np.array(RefDirection.DirectionRatios)` then `x.resize(3)`. `ndarray.resize` is in-place and refuses to run when the array shares memory. In builds where `DirectionRatios` is returned as a numpy view of ifcopenshell-owned data, `x` references that buffer, so the resize raises.

## Fix

Construct the padded 3D vector directly instead of resizing in place:

```python
x = np.array((*placement.RefDirection.DirectionRatios, 0.0, 0.0))[:3]
```

This removes the only line that can raise the error and produces the identical result (zero-pad a 2D direction to 3D, truncate if longer).

## Verification

I could not reproduce the exact ValueError in my environment because there `DirectionRatios` returns a tuple (so `np.array` copies and the resize is allowed), but the fix removes the failing in-place resize entirely and I verified the placement result is unchanged: a 2D placement with `RefDirection (0.6, 0.8)` at `(1, 2)` gives X axis `(0.6, 0.8, 0)` and origin `(1, 2, 0)`, and the default (no `RefDirection`) gives X axis `(1, 0, 0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)