### PR TITLE
IfcParse: serialize REALs with shortest round-trip form (#7696)

### DIFF
--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <string>
 #include <iomanip>
+#include <charconv>
 
 #ifdef USE_MMAP
 #include <boost/filesystem/path.hpp>
@@ -746,11 +747,16 @@ namespace {
         // the output of the C++ ostream formatting operation.
         // REAL = [ SIGN ] DIGIT { DIGIT } "." { DIGIT } [ "E" [ SIGN ] DIGIT { DIGIT } ] .
         static std::string format_double(const double& d) {
+            // Use the shortest representation that round-trips exactly (like
+            // Python's repr) instead of max_digits10. max_digits10 padded clean
+            // values with noise digits (0.0174532925199433 -> 0.017453292519943299),
+            // which rewrote every REAL and produced huge diffs when a file was
+            // re-saved. See #7696.
+            char buf[64];
+            const auto res = std::to_chars(buf, buf + sizeof(buf), d);
+            const std::string str(buf, res.ptr);
             std::ostringstream oss;
             oss.imbue(std::locale::classic());
-            oss << std::setprecision(std::numeric_limits<double>::max_digits10) << d;
-            const std::string str = oss.str();
-            oss.str("");
             std::string::size_type e = str.find('e');
             if (e == std::string::npos) {
                 e = str.find('E');

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -752,25 +752,24 @@ namespace {
             // values with noise digits (0.0174532925199433 -> 0.017453292519943299),
             // which rewrote every REAL and produced huge diffs when a file was
             // re-saved. See #7696.
+            // std::to_chars is locale-independent, so no ostringstream/imbue is
+            // needed here.
             char buf[64];
             const auto res = std::to_chars(buf, buf + sizeof(buf), d);
             const std::string str(buf, res.ptr);
-            std::ostringstream oss;
-            oss.imbue(std::locale::classic());
             std::string::size_type e = str.find('e');
             if (e == std::string::npos) {
                 e = str.find('E');
             }
-            const std::string mantissa = str.substr(0, e);
-            oss << mantissa;
-            if (mantissa.find('.') == std::string::npos) {
-                oss << ".";
+            std::string result = str.substr(0, e);
+            if (result.find('.') == std::string::npos) {
+                result += '.';
             }
             if (e != std::string::npos) {
-                oss << "E";
-                oss << str.substr(e + 1);
+                result += 'E';
+                result += str.substr(e + 1);
             }
-            return oss.str();
+            return result;
         }
 
         static std::string format_binary(const boost::dynamic_bitset<>& b) {


### PR DESCRIPTION
## Problem

Opening a file and saving it rewrites every REAL value with extra noise digits (#7696), producing enormous diffs for anyone version-controlling IFC:

```diff
-#7=IFCMEASUREWITHUNIT(IFCREAL(0.0174532925199433),#6);
+#7=IFCMEASUREWITHUNIT(IFCREAL(0.017453292519943299),#6);
-#14=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#13,$);
+#14=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0000000000000001E-05,#13,$);
```

Confirmed still present on a current 0.8.6-alpha build.

## Cause

`format_double` (`src/ifcparse/IfcParse.cpp`) serialized doubles with `std::setprecision(std::numeric_limits<double>::max_digits10)` (17 significant digits). max_digits10 guarantees a round-trip but is not the *shortest* such representation, so clean values like `0.0174532925199433` gained trailing noise (`...99`).

## Fix

Use `std::to_chars`, which emits the shortest string that round-trips exactly (the same thing Python's `repr` does), then keep the existing mantissa/exponent post-formatting unchanged.

## Verification

Same standalone-isolation approach used for other IfcParse fixes: I compiled the exact function logic (old vs new) over a range of doubles.

| value | old (max_digits10) | new (to_chars) | round-trips |
|---|---|---|---|
| 0.0174532925199433 | 0.017453292519943299 | **0.0174532925199433** | yes |
| 1e-05 | 1.0000000000000001E-05 | **1.E-05** | yes |
| 0.1 | 0.10000000000000001 | **0.1** | yes |
| 2.2250738585072014e-308 (denormal) | same | same | yes |
| 0, 1, 123456.789, pi | correct | correct | yes |

Every tested value produces the shortest form and `strtod` parses it back to the identical double. Added `#include <charconv>`. A full build is the final integration check, but the function logic is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)