### PR TITLE
Bonsai: place auto-generated opening boundaries at their real position (#8237)

### DIFF
--- a/src/bonsai/bonsai/bim/module/boundary/operator.py
+++ b/src/bonsai/bonsai/bim/module/boundary/operator.py
@@ -842,13 +842,6 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
                         # Create shape of opening as a dissolved BMesh
                         settings = ifcopenshell.geom.settings()
                         shape = ifcopenshell.geom.create_shape(settings, opening)
-                        # get_vertices returns the opening's LOCAL geometry, so mat
-                        # (its placement, including translation) is what carries the
-                        # opening to its real position below. Zeroing the translation
-                        # collapsed every opening onto the origin, which is why
-                        # auto-generated window/door boundaries were misplaced while
-                        # the single-element path (create_element_boundary) was
-                        # correct. See #8237.
                         mat = Matrix(ifcopenshell.util.shape.get_shape_matrix(shape))
                         opening_bm = bmesh.new()
                         verts = ifcopenshell.util.shape.get_vertices(shape.geometry)

--- a/src/bonsai/bonsai/bim/module/boundary/operator.py
+++ b/src/bonsai/bonsai/bim/module/boundary/operator.py
@@ -842,8 +842,14 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
                         # Create shape of opening as a dissolved BMesh
                         settings = ifcopenshell.geom.settings()
                         shape = ifcopenshell.geom.create_shape(settings, opening)
+                        # get_vertices returns the opening's LOCAL geometry, so mat
+                        # (its placement, including translation) is what carries the
+                        # opening to its real position below. Zeroing the translation
+                        # collapsed every opening onto the origin, which is why
+                        # auto-generated window/door boundaries were misplaced while
+                        # the single-element path (create_element_boundary) was
+                        # correct. See #8237.
                         mat = Matrix(ifcopenshell.util.shape.get_shape_matrix(shape))
-                        mat.translation = (0, 0, 0)
                         opening_bm = bmesh.new()
                         verts = ifcopenshell.util.shape.get_vertices(shape.geometry)
                         for vert in verts:


### PR DESCRIPTION
## Problem

Generating 2nd-level space boundaries by selecting a space (the single-space auto mode) placed window and door boundaries in the wrong location, not aligned to their openings (#8237). @MDHering pinned it down: selecting a space **plus one element** (`create_element_boundary`) gives correct window placement, while selecting the **space alone** (`auto_generate_boundaries`) does not. Those are two separate code paths.

## Cause

In `auto_generate_boundaries`, each opening boundary is built from the opening's geometry:

```python
shape = ifcopenshell.geom.create_shape(settings, opening)
mat = Matrix(ifcopenshell.util.shape.get_shape_matrix(shape))
mat.translation = (0, 0, 0)   # <-- discards the opening's position
...
verts = ifcopenshell.util.shape.get_vertices(shape.geometry)   # LOCAL coords
...
opening_face_verts = [space_matrix_world_i @ mat @ v.co for v in opening_face.verts]
```

`get_vertices` returns the opening's **local** geometry, so `mat` (its placement, translation included) is exactly what carries it to its real position. Zeroing the translation collapsed every opening onto the origin. The wall itself is placed with its real `building_obj.matrix_world`, so openings were handled inconsistently.

## Fix

Keep the full placement matrix (drop the `mat.translation = (0, 0, 0)` line). The rotation-only use of `mat` (for the face-normal test) is unaffected.

## Verification

On the reporter's `RegressionInWindowsSpaceBoundariesGeneration.ifc`, the first opening's real placement translation is `(0.1, 1.5, 1.0)`. A vertex is placed at `(0.6, 0, 0)` under the old code (collapsed toward origin) and at `(0.7, 1.5, 1.0)` with the fix, i.e. shifted by exactly the `(0.1, 1.5, 1.0)` that was being discarded. That offset is the misplacement. A Blender run on the file is the final visual confirmation; @MDHering / @CyrilWaechter, this should align the window boundaries in the single-space mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)