### PR TITLE
Bonsai: remove_drawing tolerates a drawing with no document (#6518)

### DIFF
--- a/src/bonsai/bonsai/core/drawing.py
+++ b/src/bonsai/bonsai/core/drawing.py
@@ -412,11 +412,16 @@ def remove_drawing(
             drawing_tool.delete_object(reference_obj)
         ifc.run("root.remove_product", product=reference)
 
-    information = drawing_tool.get_reference_document(drawing_tool.get_drawing_document(drawing))
-    uri = ifc.resolve_uri(drawing_tool.get_document_uri(information))
-    if drawing_tool.does_file_exist(uri):
-        drawing_tool.delete_file(uri)
-    ifc.run("document.remove_information", information=information)
+    # A corrupt drawing may have no associated document; skip the document and
+    # file cleanup in that case so the drawing can still be removed instead of
+    # crashing on None.ReferencedDocument. See #6518.
+    drawing_document = drawing_tool.get_drawing_document(drawing)
+    information = drawing_tool.get_reference_document(drawing_document) if drawing_document else None
+    if information:
+        uri = ifc.resolve_uri(drawing_tool.get_document_uri(information))
+        if drawing_tool.does_file_exist(uri):
+            drawing_tool.delete_file(uri)
+        ifc.run("document.remove_information", information=information)
 
     group = drawing_tool.get_drawing_group(drawing)
     if group:


### PR DESCRIPTION
## Problem

Removing a drawing crashed (#6518):

```
File ".../bonsai/tool/drawing.py", in get_reference_document
    return reference.ReferencedDocument
AttributeError: 'NoneType' object has no attribute 'ReferencedDocument'
```

## Cause

`core.drawing.remove_drawing` did `get_reference_document(get_drawing_document(drawing))`. For a corrupt drawing with no `IfcRelAssociatesDocument`, `get_drawing_document` returns `None`, and `get_reference_document(None)` then dereferences `None.ReferencedDocument`. Same underlying cause as #8122, on the removal path.

## Fix

Only run the document and file cleanup when the drawing actually has a document. A document-less drawing skips that step and is still removed (collection, references, and group cleanup are unaffected).

## Verification

In headless Bonsai: a drawing with no `IfcRelAssociatesDocument` gives `get_drawing_document -> None`, `get_reference_document(None)` raises the exact reported `AttributeError`, and the guard leaves `information` as `None` so the block is skipped and removal proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)