### PR TITLE
sequence: give sub-day durations a real intraday finish (#8245)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/sequence.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/sequence.py
@@ -115,13 +115,28 @@ def get_start_or_finish_date(
     calendar: ifcopenshell.entity_instance,
     date_type: Literal["START", "FINISH"] = "FINISH",
 ):
-    if not duration.days:
+    seconds = int(getattr(duration, "seconds", 0))
+    if not duration.days and not seconds:
         # Typically a milestone will have zero duration, so the start == finish
         return start
     # We minus 1 because the start day itself is counted as a day
     months = int(getattr(duration, "months", 0))
     years = int(getattr(duration, "years", 0))
     total_duration = duration.days + months * 30 + years * 12 * 30
+
+    if not total_duration:
+        # Pure sub-day (intraday) duration such as PT5H or PT10H30M. Preserve the
+        # anchor's clock time and offset by the exact hours/minutes/seconds, so a
+        # PT5H task from a 09:00 start finishes at 14:00, and an overnight PT8H
+        # from 22:00 finishes at 06:00 the next day, instead of collapsing to a
+        # milestone or occupying a whole day. See #8245.
+        if isinstance(start, datetime.datetime):
+            anchor = start
+        else:
+            anchor = datetime.datetime.combine(start, datetime.time(9 if date_type == "FINISH" else 17))
+        delta = datetime.timedelta(seconds=seconds)
+        return anchor + delta if date_type == "FINISH" else anchor - delta
+
     duration = datetime.timedelta(days=total_duration - 1)
 
     if date_type == "START":

--- a/src/ifcopenshell-python/test/api/sequence/test_cascade_schedule.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_cascade_schedule.py
@@ -156,6 +156,24 @@ class TestCascadeSchedule(test.bootstrap.IFC4):
         assert task3.TaskTime.ScheduleStart == "1999-12-30T09:00:00"
         assert task3.TaskTime.ScheduleFinish == "2000-01-01T17:00:00"
 
+    def test_sub_day_durations_produce_an_intraday_finish(self):
+        # #8245: a sub-day duration such as PT5H must produce a real intraday
+        # finish (09:00 + 5h = 14:00) instead of collapsing to a milestone or
+        # occupying the whole day.
+        task = self._create_task("PT5H")
+        ifcopenshell.api.sequence.cascade_schedule(self.file, task=task)
+        assert task.TaskTime.ScheduleStart == "2000-01-01T09:00:00"
+        assert task.TaskTime.ScheduleFinish == "2000-01-01T14:00:00"
+
+        task2 = self._create_task("PT10H30M")
+        ifcopenshell.api.sequence.cascade_schedule(self.file, task=task2)
+        assert task2.TaskTime.ScheduleFinish == "2000-01-01T19:30:00"
+
+        # Whole-day durations remain day-granular.
+        task3 = self._create_task("P2D")
+        ifcopenshell.api.sequence.cascade_schedule(self.file, task=task3)
+        assert task3.TaskTime.ScheduleFinish == "2000-01-02T17:00:00"
+
     def _create_task(self, duration):
         task = ifcopenshell.api.sequence.add_task(self.file)
         if duration == "P0D":


### PR DESCRIPTION
## Motivation

Raised by @SautaRoc on #8245: construction schedules sometimes need intraday resolution (an overnight bridge push, etc.), and `IfcDuration` allows durations down to seconds (`P2Y10M15DT10H30M20S`). The scheduling engine reduced every duration to whole days, so the hours/minutes/seconds were dropped: a `PT5H` task either collapsed to a milestone or occupied a full day.

## Change

In `get_start_or_finish_date`, a **pure sub-day** duration now preserves the anchor's clock time and offsets by the exact hours/minutes/seconds:

- `PT5H` from a 09:00 start finishes at **14:00** (was 17:00 / vanished)
- `PT10H30M` finishes at **19:30**
- whole-day and mixed durations keep their existing day-granular behaviour (`P2D` still finishes at day 2 17:00)

## Verification

Verified through the real `cascade_schedule` API and a new regression test (`test_sub_day_durations_produce_an_intraday_finish`):

| duration | ScheduleFinish |
|---|---|
| PT5H | 2000-01-01T14:00:00 |
| PT10H30M | 2000-01-01T19:30:00 |
| P2D | 2000-01-02T17:00:00 (unchanged) |

## Scope / honest limits

This is the first, safe step. The engine still normalises task **starts** to 09:00, so a task cannot yet begin at an arbitrary clock time like 22:00 (an overnight window that crosses midnight from a chosen start). Full working-hour-aware intraday scheduling (using the calendar's actual working-time periods, and mixed day-plus-time durations) is a larger follow-up; this change delivers real intraday finishes for sub-day durations without disturbing day-granular scheduling. This supersedes the sub-day handling in #8256 (14:00 instead of 17:00).

🤖 Generated with [Claude Code](https://claude.com/claude-code)