### PR TITLE
Bonsai: skip linework paths without a d attribute (#6876)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1486,6 +1486,10 @@ class CreateDrawing(bpy.types.Operator):
             old_paths = []
             has_open_paths = False
             for path in el.findall("{http://www.w3.org/2000/svg}path"):
+                # A generated <path> can lack a "d" attribute (no geometry);
+                # skip it instead of raising KeyError 'd'. See #6876.
+                if "d" not in path.attrib:
+                    continue
                 for subpath in path.attrib["d"].split("M")[1:]:
                     subpath = "M" + subpath.strip()
                     coords = [[float(o) for o in co[1:].split(",")] for co in subpath.split()]


### PR DESCRIPTION
## Problem

Create Drawing crashed (#6876):

```
File ".../drawing/operator.py", in merge_linework_and_add_metadata
    for subpath in path.attrib["d"].split("M")[1:]:
File "src/lxml/etree.pyx", in lxml.etree._Attrib.__getitem__
KeyError: 'd'
```

## Cause

`merge_linework_and_add_metadata` iterates the generated `<path>` elements and reads `path.attrib["d"]` unconditionally. A generated path can have no `d` attribute (no geometry), so the lookup raises `KeyError: 'd'`.

## Fix

Skip any `<path>` that has no `d` attribute. There is nothing to merge for a path with no geometry, so the rest of the linework processes normally.

## Verification

Reproduced the mechanism with ElementTree: a `<path>` with no `d` attribute raises `KeyError: 'd'` on `attrib["d"]`, and the guard skips it and processes the remaining valid paths. (I could not regenerate the reporter's exact linework without their model, but the guard prevents precisely the reported `KeyError: 'd'`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)