### PR TITLE
Bonsai: don't crash editing a non-extrusion slab (#6283)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -633,6 +633,10 @@ class EnableEditingExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):
         body = ifcopenshell.util.representation.get_representation(element, "Model", "Body", "MODEL_VIEW")
         body = ifcopenshell.util.representation.resolve_representation(body)
         extrusion = tool.Model.get_extrusion(body)
+        if extrusion is None:
+            # Not an extrusion-based (parametric) slab, so there is no extrusion
+            # profile to edit here; bail instead of crashing on None. See #6283.
+            return
         existing_x_angle = tool.Model.get_existing_x_angle(extrusion)
         layer_params = tool.Model.get_material_layer_parameters(element)
 
@@ -685,6 +689,10 @@ class EditExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):
         body = ifcopenshell.util.representation.get_representation(element, "Model", "Body", "MODEL_VIEW")
         body = ifcopenshell.util.representation.resolve_representation(body)
         extrusion = tool.Model.get_extrusion(body)
+        if extrusion is None:
+            # Not an extrusion-based (parametric) slab, so there is no extrusion
+            # profile to edit here; bail instead of crashing on None. See #6283.
+            return
         existing_x_angle = tool.Model.get_existing_x_angle(extrusion)
         layer_params = tool.Model.get_material_layer_parameters(element)
 


### PR DESCRIPTION
## Problem

Editing certain slabs crashed (#6283):

```
File ".../bonsai/tool/model.py", in get_existing_x_angle
    x, y, z = extrusion.ExtrudedDirection.DirectionRatios
AttributeError: 'NoneType' object has no attribute 'ExtrudedDirection'
```

## Cause

Two slab edit operators do:

```python
extrusion = tool.Model.get_extrusion(body)
existing_x_angle = tool.Model.get_existing_x_angle(extrusion)   # crash
...
if extrusion.Position:                                          # would also crash
```

`get_extrusion` returns `None` when the slab's Body is not an extrusion (a non-parametric slab), so both the `get_existing_x_angle(None)` call and the later `extrusion.Position` access blow up.

## Fix

Bail early when there is no extrusion. These operators edit the extrusion profile, which does not exist for a non-parametric slab. This matches the existing `if extrusion:` guard already used on the same call earlier in the module (line ~269).

## Verification

Static: both patched call sites are the only unguarded `get_existing_x_angle(get_extrusion(...))` sites (the third, line ~274, is already guarded). I could not exercise the two operators on a non-extrusion slab in a live Blender session, so the guard is the safe minimal fix for the reported `NoneType` crash; a maintainer with such a slab can confirm the bail is the desired UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)