### PR TITLE
Handle unsupported length unit prefixes on project load (#8074)

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -978,10 +978,16 @@ class IfcImporter:
                 if unit.is_a("IfcSIUnit"):
                     bpy.context.scene.unit_settings.system = "METRIC"
                     if unit.Name == "METRE":
-                        if not unit.Prefix:
+                        try:
+                            if not unit.Prefix:
+                                bpy.context.scene.unit_settings.length_unit = "METERS"
+                            else:
+                                bpy.context.scene.unit_settings.length_unit = f"{unit.Prefix}METERS"
+                        except TypeError:
+                            # Blender's length_unit enum only supports a subset of SI
+                            # prefixes (KILO/CENTI/MILLI/MICRO). Others such as DECI
+                            # are not valid, so fall back to the base unit for display.
                             bpy.context.scene.unit_settings.length_unit = "METERS"
-                        else:
-                            bpy.context.scene.unit_settings.length_unit = f"{unit.Prefix}METERS"
                 else:
                     bpy.context.scene.unit_settings.system = "IMPERIAL"
                     name = unit.Name.lower()


### PR DESCRIPTION
## Problem

Bonsai crashes when opening any IFC whose default `LengthUnit` uses an SI prefix that Blender's `length_unit` enum does not support. Reported in #8074 for `DECIMETRE` (reproducible on the attached `dm.ifc`), but the same crash applies to `DECA`, `HECTO`, `MEGA`, `NANO`, and other valid IFC prefixes.

## Root cause

`import_ifc.py` `set_units()` builds the Blender enum value as `f"{unit.Prefix}METERS"`. For `DECI` this produces `"DECIMETERS"`, which is not a member of Blender's enum:

```
TypeError: bpy_struct: item.attr = val: enum "DECIMETERS" not found in
('ADAPTIVE', 'KILOMETERS', 'METERS', 'CENTIMETERS', 'MILLIMETERS', 'MICROMETERS')
```

The exception propagates out of `load_project_elements` and aborts the whole import, so the file never opens.

## Fix

Wrap the `length_unit` assignment in `try/except TypeError` and fall back to `METERS` for display when the prefix is not a valid Blender enum. This mirrors the existing `try/except` fallbacks for `AREAUNIT` (`SQUARE_METRE`) and `VOLUMEUNIT` (`CUBIC_METRE`) a few lines below in the same function. Only the Blender display unit falls back; the model's real unit assignment is unchanged.

## Verification

Confirmed headless in Blender 5.1.2: assigning `length_unit = "DECIMETERS"` raises the reported `TypeError`, the `METERS` fallback is accepted, and the supported prefixes (KILO/CENTI/MILLI/MICRO) still apply. Files that previously failed to open now load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)