### PR TITLE
Fix get_part_of_product crash and IFC2X3 typo (#8081)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/representation.py
@@ -440,6 +440,8 @@ def get_part_of_product(
     if element.is_a("IfcProduct"):
         return element.Representation
     elif element.is_a("IfcTypeProduct") and element.file.schema != "IFX2X3":
+        if not element.RepresentationMaps:
+            return None
         if maps := [r for r in element.RepresentationMaps if r.MappedRepresentation.ContextOfItems == context]:
             return maps[0]
 

--- a/src/ifcopenshell-python/ifcopenshell/util/representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/representation.py
@@ -439,7 +439,7 @@ def get_part_of_product(
     """
     if element.is_a("IfcProduct"):
         return element.Representation
-    elif element.is_a("IfcTypeProduct") and element.file.schema != "IFX2X3":
+    elif element.is_a("IfcTypeProduct") and element.file.schema != "IFC2X3":
         if not element.RepresentationMaps:
             return None
         if maps := [r for r in element.RepresentationMaps if r.MappedRepresentation.ContextOfItems == context]:

--- a/src/ifcopenshell-python/test/util/test_representation.py
+++ b/src/ifcopenshell-python/test/util/test_representation.py
@@ -1,0 +1,71 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.util.representation as subject
+import test.bootstrap
+
+
+class TestGetPartOfProduct(test.bootstrap.IFC4):
+    def test_returns_representation_for_a_product(self):
+        context = self.file.createIfcGeometricRepresentationSubContext()
+        shape = self.file.createIfcShapeRepresentation(ContextOfItems=context)
+        element = self.file.createIfcWall(
+            Representation=self.file.create_entity("IfcProductDefinitionShape", Representations=[shape])
+        )
+        assert subject.get_part_of_product(element, context) == element.Representation
+
+    def test_returns_none_for_a_type_product_with_no_representation_maps(self):
+        context = self.file.createIfcGeometricRepresentationSubContext()
+        type = self.file.createIfcWallType()
+        assert type.RepresentationMaps is None
+        assert subject.get_part_of_product(type, context) is None
+
+    def test_returns_matching_representation_map_for_a_type_product(self):
+        context = self.file.createIfcGeometricRepresentationSubContext()
+        map = self.file.createIfcRepresentationMap(
+            MappedRepresentation=self.file.createIfcShapeRepresentation(ContextOfItems=context)
+        )
+        type = self.file.createIfcWallType(RepresentationMaps=[map])
+        assert subject.get_part_of_product(type, context) == map
+
+    def test_returns_none_when_no_representation_map_matches_the_context(self):
+        context = self.file.createIfcGeometricRepresentationSubContext()
+        other_context = self.file.createIfcGeometricRepresentationSubContext()
+        map = self.file.createIfcRepresentationMap(
+            MappedRepresentation=self.file.createIfcShapeRepresentation(ContextOfItems=other_context)
+        )
+        type = self.file.createIfcWallType(RepresentationMaps=[map])
+        assert subject.get_part_of_product(type, context) is None
+
+
+class TestGetPartOfProductIFC2X3(test.bootstrap.IFC2X3):
+    def test_returns_none_for_a_type_product_with_no_representation_maps(self):
+        context = self.file.createIfcGeometricRepresentationSubContext()
+        type = self.file.createIfcWallType()
+        assert type.RepresentationMaps is None
+        assert subject.get_part_of_product(type, context) is None
+
+    def test_returns_none_for_a_type_product_even_with_matching_representation_maps(self):
+        # As documented, get_part_of_product always returns None for IFC2X3
+        # type products, since IFC2X3 does not fully support shape aspects.
+        context = self.file.createIfcGeometricRepresentationSubContext()
+        map = self.file.createIfcRepresentationMap(
+            MappedRepresentation=self.file.createIfcShapeRepresentation(ContextOfItems=context)
+        )
+        type = self.file.createIfcWallType(RepresentationMaps=[map])
+        assert subject.get_part_of_product(type, context) is None


### PR DESCRIPTION
Fixes #8081

## Credit

@PahlawanJoey reported the crash and, on request, pasted the full console traceback (from `Window > Toggle System Console`). Those extra frames are what pinned this down to `get_part_of_product`.

## Problem

Creating a door type crashed:

```
File ".../bonsai/bim/module/model/door.py", line 99, in update_door_modifier_representation
    representation_data["part_of_product"] = ifcopenshell.util.representation.get_part_of_product(element, body)
File ".../ifcopenshell/util/representation.py", line 443, in get_part_of_product
    if maps := [r for r in element.RepresentationMaps if r.MappedRepresentation.ContextOfItems == context]:
TypeError: 'NoneType' object is not iterable
```

Reproduced end to end in headless Blender: a new IFC4 project whose file has no `Model/Profile/ELEVATION_VIEW` context skips the elevation representation step in `door.py`, so the very first call into `get_part_of_product` hits a freshly created `IfcDoorType` whose `RepresentationMaps` is still unset. That matches Joey's frames exactly, including `root/operator.py:786` and `product.py:157`.

## Two defects, both fixed

1. `RepresentationMaps` is an optional `IfcTypeProduct` attribute (confirmed against the schema declaration for both IFC4 and IFC2X3). When unset it is `None`, and the list comprehension iterates it unconditionally. Fixed by returning `None` early, matching what the rest of the function already does when there is no match.
2. Line 442 read `element.file.schema != "IFX2X3"`, a typo for `"IFC2X3"` that has been there since this function was introduced (`dc79e9e005`, one commit, no later edits). Since `file.schema` never equals `"IFX2X3"`, the guard always evaluated true, so IFC2X3 type products always fell into the `RepresentationMaps` branch, contradicting the function's own docstring ("this will return `None` for IFC2X3 element types"). Fixed the string.

## Behaviour change for existing IFC2X3 users

Before this fix, an IFC2X3 type product with populated `RepresentationMaps` matching the context returned that map instead of `None` (the typo defeated the intended early return). After the fix it always returns `None` for IFC2X3, as documented.

The only consumers are `add_door_representation` and the analogous window path, and both already guard on `part_of_product` being falsy purely to skip attaching `IfcShapeAspect`s:

```python
if self.settings["part_of_product"]:
    ifcopenshell.api.geometry.add_shape_aspect(...)
```

So for IFC2X3 the representation is still created normally, it just no longer gets Lining/Framing/Glazing shape aspects tied back to the type. That is a graceful, already-supported no-op path, not a new crash, and it is what the docstring says should happen.

## Verification

Reproduced pre-fix and post-fix at two levels:

- Direct unit level: `get_part_of_product` on a freshly created `IfcDoorType` (IFC4) and `IfcDoorStyle` (IFC2X3) with `RepresentationMaps` unset raises the exact reported `TypeError` on the exact reported line, both before this fix.
- Full Blender level (headless, isolated `BLENDER_USER_RESOURCES`, Blender 5.2): `bpy.ops.bim.add_default_type(ifc_element_type="IfcDoorType")` on a fresh IFC4 project with its `Model/Profile/ELEVATION_VIEW` context removed reproduces Joey's traceback frame for frame, then succeeds after the fix.
- Confirmed the non-2X3 "has matching maps" and "no matching maps" paths are unchanged (existing behaviour preserved) with both direct calls and a normal in-app door-type creation (which already has representation maps populated by the time `get_part_of_product` runs, so it never hit the crash in the first place, only files missing that context did).

Added `test/util/test_representation.py` (`TestGetPartOfProduct`, `TestGetPartOfProductIFC2X3`), 6 tests. 3 of them fail against the pre-fix code (2 crash with the reported `TypeError`, 1 asserts the documented IFC2X3 `None` behaviour); all 6 pass after both fixes.

```
$ pytest test/util/test_representation.py -v
6 passed
```

## Lint

`black --check` and `ruff check` (CI-exact toolchain) both clean on the touched files.

---

AI-generated with [Claude Code](https://claude.com/claude-code), reviewed by Petru Conduraru.
