### PR TITLE
Skip quantity takeoff for elements with empty geometry (#7147)

### DIFF
--- a/src/ifc5d/ifc5d/qto.py
+++ b/src/ifc5d/ifc5d/qto.py
@@ -366,6 +366,13 @@ class IfcOpenShell(QtoCalculator):
                                 if value is None:
                                     continue
                             else:
+                                # An element can be included by the iterator yet still
+                                # produce empty geometry (no vertices). Bounding-box and
+                                # elevation helpers can't be evaluated on it, and emitting
+                                # a fabricated value (e.g. 0.0) would silently corrupt the
+                                # quantity, so skip it instead.
+                                if len(geometry.verts) == 0:
+                                    continue
                                 value = formula_functions[formula](geometry)
                                 assert isinstance(value, (float, int))
                                 value = cls.unit_converter.convert(value, IfcOpenShell.raw_functions[formula].measure)


### PR DESCRIPTION
## Problem

Quantity takeoff crashed in #7147:

```
File ".../ifcopenshell/util/shape.py", line 118, in get_z
    return (np.max(verts_flat[2::3]) - np.min(verts_flat[2::3])).item()
ValueError: zero-size array to reduction operation maximum which has no identity
```

An element can be included by the geometry iterator yet still produce empty geometry (no vertices). The bounding-box / elevation helpers in `util.shape` then call `np.max`/`np.min` on a zero-size array and raise, aborting the whole takeoff run.

## Fix (revised after review)

The first version made the `util.shape` helpers return `0.0` for empty geometry. As @aothms pointed out, that is wrong: no geometry is not the same as a bounding box or bottom elevation of `0.0`, and silently fabricating that value corrupts quantities. Reverted.

Instead this handles it at the domain layer: `ifc5d` qto skips an element's geometric quantity when the geometry has no vertices, matching the existing pattern of `continue`-ing past quantities that cannot be computed (`get_segment_length`/`get_weight` returning `None`). The `util.shape` helpers are left unchanged.

## Verification

Confirmed `geometry.verts` is the right accessor and `len(geometry.verts) == 0` cleanly flags empty geometry (0 for empty, 24 for a real wall) via the geom iterator, so the guard skips only genuinely empty elements and does not alter normal takeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)