### PR TITLE
ifcpatch(ExtractElements): defer shared relationship members to fix O(n²) extraction

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/__init__.py
@@ -27,7 +27,7 @@ into your project.
 """
 
 from .. import wrap_usecases
-from .append_asset import append_asset
+from .append_asset import append_asset, flush_deferred_relationship_members
 from .assign_declaration import assign_declaration
 from .create_file import create_file
 from .unassign_declaration import unassign_declaration
@@ -36,6 +36,7 @@ wrap_usecases(__path__, __name__)
 
 __all__ = [
     "append_asset",
+    "flush_deferred_relationship_members",
     "assign_declaration",
     "create_file",
     "unassign_declaration",

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -472,6 +472,7 @@ class Usecase:
                 library=self.settings["library"],
                 element=element_type,
                 reuse_identities=self.reuse_identities,
+                assume_asset_uniqueness_by_name=self.assume_asset_uniqueness_by_name,
             )
             ifcopenshell.api.type.assign_type(
                 self.file,
@@ -612,8 +613,14 @@ class Usecase:
                         continue
                     if skip_not_reused_entities_attr_i is not None and i == skip_not_reused_entities_attr_i:
                         identity = item.wrapped_data.identity()
-                        if (item := self.reuse_identities.get(identity)) is None:
+                        reused = self.reuse_identities.get(identity)
+                        if reused is None:
+                            # reuse_identities is only filled by file_add's per-attribute
+                            # path; the native file.add fast path records added_elements.
+                            reused = self.added_elements.get(item.id())
+                        if reused is None:
                             continue
+                        item = reused
                     else:
                         item = self.add_element(item)
                     new_attribute.append(item)

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -151,6 +151,7 @@ def append_asset(
 def flush_deferred_relationship_members(
     file: ifcopenshell.file,
     deferred_relationship_members: dict[int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]],
+    reuse_identities: Optional[dict[int, ifcopenshell.entity_instance]] = None,
 ) -> None:
     """Assign relationship member lists deferred by ``append_asset``.
 
@@ -160,17 +161,30 @@ def flush_deferred_relationship_members(
     list-valued member attributes re-scanned and re-assigned on every element
     append. Doing that per element is O(n^2) because the member list grows.
 
-    This resolves every deferred relationship a single time instead: a source
-    member is kept if and only if it is present in ``file``, which is the same
-    rule ``append_asset`` applies when it assigns the list eagerly. Call this
-    once, after all appends, on the file the assets were appended into.
+    This resolves every deferred relationship a single time instead. Members
+    that are ``IfcRoot`` subtypes (e.g. products, property sets) are kept if
+    and only if they were appended into ``file``, matched by ``GlobalId`` -
+    the same rule ``append_asset`` applies when it assigns the list eagerly.
+    Members that are not ``IfcRoot`` subtypes have no ``GlobalId``, so they are
+    matched by identity through ``reuse_identities`` instead. The only such
+    member today is ``IfcRelOverridesProperties.OverridingProperties``, whose
+    ``IfcProperty`` members ``append_asset`` always appends (they are not
+    optional assets that may have been excluded), so they are always resolved
+    if the same ``reuse_identities`` accumulator used during the appends is
+    passed here. Call this once, after all appends, on the file the assets
+    were appended into.
 
     :param file: The file assets were appended into.
     :param deferred_relationship_members: The accumulator passed to ``append_asset``.
+    :param reuse_identities: The ``reuse_identities`` accumulator passed to
+        ``append_asset``, used to resolve non-``IfcRoot`` members. Required to
+        avoid dropping them; safe to omit if none of the deferred
+        relationships have non-``IfcRoot`` list-valued members.
     """
     if not deferred_relationship_members:
         return
     appended_by_guid = {e.GlobalId: e for e in file.by_type("IfcRoot")}
+    reuse_identities = reuse_identities if reuse_identities is not None else {}
     for source_rel, new_rel in deferred_relationship_members.values():
         for index, attribute in enumerate(source_rel):
             if not (
@@ -180,7 +194,10 @@ def flush_deferred_relationship_members(
             members: list[ifcopenshell.entity_instance] = []
             seen: set[int] = set()
             for member in attribute:
-                mapped = appended_by_guid.get(getattr(member, "GlobalId", None))
+                if member.is_a("IfcRoot"):
+                    mapped = appended_by_guid.get(member.GlobalId)
+                else:
+                    mapped = reuse_identities.get(member.wrapped_data.identity())
                 if mapped is not None and mapped.id() not in seen:
                     seen.add(mapped.id())
                     members.append(mapped)
@@ -604,8 +621,16 @@ class Usecase:
             elif isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance):
                 if defer_member_lists:
                     for item in attribute:
-                        if not self.is_another_asset(item):
-                            self.add_element(item)
+                        if self.is_another_asset(item):
+                            continue
+                        new_item = self.add_element(item)
+                        if not item.is_a("IfcRoot"):
+                            # Non-IfcRoot members (e.g. IfcProperty in
+                            # IfcRelOverridesProperties.OverridingProperties) have no
+                            # GlobalId, so flush_deferred_relationship_members cannot
+                            # match them that way. Record the mapping by identity so
+                            # it can resolve them instead of silently dropping them.
+                            self.reuse_identities[item.wrapped_data.identity()] = new_item
                     continue
                 new_attribute = []
                 for item in attribute:

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -50,6 +50,7 @@ def append_asset(
     element: ifcopenshell.entity_instance,
     reuse_identities: Optional[dict[int, ifcopenshell.entity_instance]] = None,
     assume_asset_uniqueness_by_name: bool = True,
+    deferred_relationship_members: Optional[dict[int, tuple[ifcopenshell.entity_instance, dict[int, list]]]] = None,
 ) -> ifcopenshell.entity_instance:
     """Appends an asset from a library into the active project
 
@@ -140,8 +141,41 @@ def append_asset(
         "element": element,
         "reuse_identities": {} if reuse_identities is None else reuse_identities,
         "assume_asset_uniqueness_by_name": assume_asset_uniqueness_by_name,
+        "deferred_relationship_members": deferred_relationship_members,
     }
     return usecase.execute()
+
+
+def flush_deferred_relationship_members(
+    deferred_relationship_members: dict[int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]],
+    appended_elements: dict[int, ifcopenshell.entity_instance],
+) -> None:
+    """Assign relationship member lists deferred by ``append_asset``.
+
+    When ``append_asset`` is called with a shared ``deferred_relationship_members``
+    dict, relationships reached through whitelisted inverses (e.g.
+    ``IfcRelAssociatesMaterial``, ``IfcRelDefinesByProperties``) do not have their
+    list-valued member attributes re-scanned and re-assigned on every element
+    append. Doing that per element is O(n^2) because the member list grows.
+
+    Instead, this maps each relationship's source members to their appended
+    counterparts a single time. ``appended_elements`` maps a source element's step
+    id to the entity it was appended as (the caller collects the value returned by
+    each ``append_asset`` call). Members whose source was not appended (i.e. not
+    part of the extracted subset) are skipped. Call this once after all appends.
+    """
+    for source_rel, new_rel in deferred_relationship_members.values():
+        for index, attribute in enumerate(source_rel):
+            if not (isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance)):
+                continue
+            members: list[ifcopenshell.entity_instance] = []
+            seen: set[int] = set()
+            for member in attribute:
+                mapped = appended_elements.get(member.id())
+                if mapped is not None and mapped.id() not in seen:
+                    seen.add(mapped.id())
+                    members.append(mapped)
+            new_rel[index] = members
 
 
 class SafeRemovalContext:
@@ -217,6 +251,7 @@ class Usecase:
         self.whitelisted_inverse_attributes = {}
         self.base_material_class = "IfcMaterial" if self.file.schema == "IFC2X3" else "IfcMaterialDefinition"
         self.assume_asset_uniqueness_by_name = self.settings["assume_asset_uniqueness_by_name"]
+        self.deferred_relationship_members = self.settings["deferred_relationship_members"]
 
         if self.settings["element"].is_a("IfcTypeProduct"):
             self.target_class = "IfcTypeProduct"
@@ -529,6 +564,18 @@ class Usecase:
             new = self.file.create_entity(element.is_a())
             self.reuse_identities[element_identity] = new
 
+        # When a shared accumulator is provided, defer the list-valued member
+        # attributes of relationships (e.g. IfcRelAssociatesMaterial.RelatedObjects)
+        # instead of re-scanning and re-assigning the growing list on every element
+        # append (O(n^2)). flush_deferred_relationship_members assigns them once.
+        defer_member_lists = False
+        if self.deferred_relationship_members is not None and new.is_a("IfcRelationship"):
+            if new.id() in self.deferred_relationship_members:
+                # Non-member attributes were set the first time; members deferred.
+                return
+            self.deferred_relationship_members[new.id()] = (element, new)
+            defer_member_lists = True
+
         for i, attribute in enumerate(element):
             new_attribute = None
             if isinstance(attribute, ifcopenshell.entity_instance):
@@ -544,6 +591,8 @@ class Usecase:
                 ):
                     new_attribute = self.add_element(attribute)
             elif isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance):
+                if defer_member_lists:
+                    continue
                 new_attribute = []
                 for item in attribute:
                     if self.is_another_asset(item):

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -166,7 +166,9 @@ def flush_deferred_relationship_members(
     """
     for source_rel, new_rel in deferred_relationship_members.values():
         for index, attribute in enumerate(source_rel):
-            if not (isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance)):
+            if not (
+                isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance)
+            ):
                 continue
             members: list[ifcopenshell.entity_instance] = []
             seen: set[int] = set()

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -50,7 +50,9 @@ def append_asset(
     element: ifcopenshell.entity_instance,
     reuse_identities: Optional[dict[int, ifcopenshell.entity_instance]] = None,
     assume_asset_uniqueness_by_name: bool = True,
-    deferred_relationship_members: Optional[dict[int, tuple[ifcopenshell.entity_instance, dict[int, list]]]] = None,
+    deferred_relationship_members: Optional[
+        dict[int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]]
+    ] = None,
 ) -> ifcopenshell.entity_instance:
     """Appends an asset from a library into the active project
 
@@ -147,8 +149,8 @@ def append_asset(
 
 
 def flush_deferred_relationship_members(
+    file: ifcopenshell.file,
     deferred_relationship_members: dict[int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]],
-    appended_elements: dict[int, ifcopenshell.entity_instance],
 ) -> None:
     """Assign relationship member lists deferred by ``append_asset``.
 
@@ -158,12 +160,17 @@ def flush_deferred_relationship_members(
     list-valued member attributes re-scanned and re-assigned on every element
     append. Doing that per element is O(n^2) because the member list grows.
 
-    Instead, this maps each relationship's source members to their appended
-    counterparts a single time. ``appended_elements`` maps a source element's step
-    id to the entity it was appended as (the caller collects the value returned by
-    each ``append_asset`` call). Members whose source was not appended (i.e. not
-    part of the extracted subset) are skipped. Call this once after all appends.
+    This resolves every deferred relationship a single time instead: a source
+    member is kept if and only if it is present in ``file``, which is the same
+    rule ``append_asset`` applies when it assigns the list eagerly. Call this
+    once, after all appends, on the file the assets were appended into.
+
+    :param file: The file assets were appended into.
+    :param deferred_relationship_members: The accumulator passed to ``append_asset``.
     """
+    if not deferred_relationship_members:
+        return
+    appended_by_guid = {e.GlobalId: e for e in file.by_type("IfcRoot")}
     for source_rel, new_rel in deferred_relationship_members.values():
         for index, attribute in enumerate(source_rel):
             if not (
@@ -173,7 +180,7 @@ def flush_deferred_relationship_members(
             members: list[ifcopenshell.entity_instance] = []
             seen: set[int] = set()
             for member in attribute:
-                mapped = appended_elements.get(member.id())
+                mapped = appended_by_guid.get(getattr(member, "GlobalId", None))
                 if mapped is not None and mapped.id() not in seen:
                     seen.add(mapped.id())
                     members.append(mapped)
@@ -570,6 +577,7 @@ class Usecase:
         # attributes of relationships (e.g. IfcRelAssociatesMaterial.RelatedObjects)
         # instead of re-scanning and re-assigning the growing list on every element
         # append (O(n^2)). flush_deferred_relationship_members assigns them once.
+        # Members that are not another asset are still pulled in, but only once.
         defer_member_lists = False
         if self.deferred_relationship_members is not None and new.is_a("IfcRelationship"):
             if new.id() in self.deferred_relationship_members:
@@ -594,6 +602,9 @@ class Usecase:
                     new_attribute = self.add_element(attribute)
             elif isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance):
                 if defer_member_lists:
+                    for item in attribute:
+                        if not self.is_another_asset(item):
+                            self.add_element(item)
                     continue
                 new_attribute = []
                 for item in attribute:

--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -99,7 +99,9 @@ class Patcher(ifcpatch.BasePatcher):
         self.add_element(self.file.by_type("IfcProject")[0])
         for element in ifcopenshell.util.selector.filter_elements(self.file, self.query):
             self.add_element(element)
-        ifcopenshell.api.project.flush_deferred_relationship_members(self.new, self.deferred_relationship_members)
+        ifcopenshell.api.project.flush_deferred_relationship_members(
+            self.new, self.deferred_relationship_members, self.reuse_identities
+        )
         self.create_spatial_tree()
         self.file = self.new
 

--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -87,12 +87,24 @@ class Patcher(ifcpatch.BasePatcher):
         self.new = ifcopenshell.file(schema_version=self.file.schema_version)
         self.owner_history = None
         self.reuse_identities: dict[int, ifcopenshell.entity_instance] = {}
+        # Relationships reached via shared inverses (material, type, property sets)
+        # are deferred here and their member lists assigned once, avoiding the
+        # O(n^2) cost of re-assigning a growing list on every element append.
+        self.deferred_relationship_members: dict[
+            int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]
+        ] = {}
+        # Maps a source element's step id to the entity it was appended as, so
+        # deferred relationship member lists can be resolved in one pass.
+        self.appended_elements: dict[int, ifcopenshell.entity_instance] = {}
         for owner_history in self.file.by_type("IfcOwnerHistory"):
             self.owner_history = self.new.add(owner_history)
             break
         self.add_element(self.file.by_type("IfcProject")[0])
         for element in ifcopenshell.util.selector.filter_elements(self.file, self.query):
             self.add_element(element)
+        ifcopenshell.api.project.flush_deferred_relationship_members(
+            self.deferred_relationship_members, self.appended_elements
+        )
         self.create_spatial_tree()
         self.file = self.new
 
@@ -100,6 +112,7 @@ class Patcher(ifcpatch.BasePatcher):
         new_element = self.append_asset(element)
         if not new_element:
             return
+        self.appended_elements[element.id()] = new_element
         self.add_spatial_structures(element, new_element)
         self.add_decomposition_parents(element, new_element)
 
@@ -120,6 +133,7 @@ class Patcher(ifcpatch.BasePatcher):
             element=element,
             reuse_identities=self.reuse_identities,
             assume_asset_uniqueness_by_name=self.assume_asset_uniqueness_by_name,
+            deferred_relationship_members=self.deferred_relationship_members,
         )
 
     def add_spatial_structures(

--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -93,18 +93,13 @@ class Patcher(ifcpatch.BasePatcher):
         self.deferred_relationship_members: dict[
             int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]
         ] = {}
-        # Maps a source element's step id to the entity it was appended as, so
-        # deferred relationship member lists can be resolved in one pass.
-        self.appended_elements: dict[int, ifcopenshell.entity_instance] = {}
         for owner_history in self.file.by_type("IfcOwnerHistory"):
             self.owner_history = self.new.add(owner_history)
             break
         self.add_element(self.file.by_type("IfcProject")[0])
         for element in ifcopenshell.util.selector.filter_elements(self.file, self.query):
             self.add_element(element)
-        ifcopenshell.api.project.flush_deferred_relationship_members(
-            self.deferred_relationship_members, self.appended_elements
-        )
+        ifcopenshell.api.project.flush_deferred_relationship_members(self.new, self.deferred_relationship_members)
         self.create_spatial_tree()
         self.file = self.new
 
@@ -112,7 +107,6 @@ class Patcher(ifcpatch.BasePatcher):
         new_element = self.append_asset(element)
         if not new_element:
             return
-        self.appended_elements[element.id()] = new_element
         self.add_spatial_structures(element, new_element)
         self.add_decomposition_parents(element, new_element)
 

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -24,8 +24,10 @@ import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.georeference
 import ifcopenshell.api.material
+import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
+import ifcopenshell.api.type
 import ifcopenshell.util.element
 import numpy
 import pytest
@@ -59,6 +61,53 @@ class TestExtractElements(test.bootstrap.IFC4):
         rels = output.by_type("IfcRelAssociatesMaterial")
         assert len(rels) == 1
         assert {w.GlobalId for w in rels[0].RelatedObjects} == {w.GlobalId for w in walls}
+
+    def test_relationship_members_outside_the_query_are_preserved(self):
+        # Regression test: spatial containers, decomposition parents and element
+        # types are appended alongside the queried elements, so deferred
+        # relationship member lists must be resolved against everything present in
+        # the output, not only the query matches. Otherwise their property sets and
+        # material associations are dropped and relationships are left with an
+        # empty member list, which violates the IFC [1:?] cardinality.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(self.file, context_type="Model")
+
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        building = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuilding")
+        storeys = [ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey") for _ in range(2)]
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[building], relating_object=site)
+        ifcopenshell.api.aggregate.assign_object(self.file, products=storeys, relating_object=building)
+
+        wall_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        walls = [ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall") for _ in range(4)]
+        for i, wall in enumerate(walls):
+            ifcopenshell.api.spatial.assign_container(
+                self.file, products=[wall], relating_structure=storeys[i % len(storeys)]
+            )
+        ifcopenshell.api.type.assign_type(self.file, related_objects=walls, relating_type=wall_type)
+
+        containers = [site, building] + storeys
+        for element in containers + walls:
+            pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_Test")
+            ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Foo": "Bar"})
+
+        material = ifcopenshell.api.material.add_material(self.file, name="Steel")
+        ifcopenshell.api.material.assign_material(self.file, products=walls + [wall_type], material=material)
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        for element in containers + walls:
+            new_element = output.by_guid(element.GlobalId)
+            psets = ifcopenshell.util.element.get_psets(new_element)
+            assert psets.get("Pset_Test", {}).get("Foo") == "Bar", element.is_a()
+
+        rels = output.by_type("IfcRelAssociatesMaterial")
+        assert len(rels) == 1
+        assert {o.GlobalId for o in rels[0].RelatedObjects} == {e.GlobalId for e in walls + [wall_type]}
+
+        for rel in output.by_type("IfcRelationship"):
+            for attribute in rel:
+                assert attribute != (), f"{rel.is_a()} has an empty member list"
 
     def test_keep_spatial_structure(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -23,6 +23,7 @@ import ifcopenshell.api.aggregate
 import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.georeference
+import ifcopenshell.api.material
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
 import ifcopenshell.util.element
@@ -41,6 +42,23 @@ class TestExtractElements(test.bootstrap.IFC4):
 
         assert output.by_type("IfcProject")[0].GlobalId == project.GlobalId
         assert output.by_type("IfcWall")[0].GlobalId == wall.GlobalId
+
+    def test_shared_relationship_members_are_preserved(self):
+        # Regression test: a relationship shared by many extracted elements
+        # (e.g. one IfcRelAssociatesMaterial linking every product) must keep all
+        # of its members. The deferred member-list assignment used to avoid the
+        # O(n^2) cost of re-assigning a growing list per element must not drop any.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        material = ifcopenshell.api.material.add_material(self.file, name="Steel")
+        walls = [ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall") for _ in range(3)]
+        ifcopenshell.api.material.assign_material(self.file, products=walls, material=material)
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        rels = output.by_type("IfcRelAssociatesMaterial")
+        assert len(rels) == 1
+        assert {w.GlobalId for w in rels[0].RelatedObjects} == {w.GlobalId for w in walls}
 
     def test_keep_spatial_structure(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -24,6 +24,7 @@ import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.georeference
 import ifcopenshell.api.material
+import ifcopenshell.guid
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
@@ -108,6 +109,33 @@ class TestExtractElements(test.bootstrap.IFC4):
         for rel in output.by_type("IfcRelationship"):
             for attribute in rel:
                 assert attribute != (), f"{rel.is_a()} has an empty member list"
+
+    def test_overrides_properties_members_are_preserved(self):
+        # Regression test: IfcRelOverridesProperties.OverridingProperties holds
+        # IfcProperty members, which unlike most relationship members have no
+        # GlobalId. The deferred member-list assignment used to resolve members
+        # by GlobalId, so every member of this one relationship silently
+        # resolved to nothing and the list was written empty, violating the
+        # IFC [1:?] cardinality.
+        if self.file.schema != "IFC2X3":
+            pytest.skip("IfcRelOverridesProperties only exists in IFC2X3")
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=wall, name="Pset_Test")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Foo": "Bar"})
+        override = self.file.createIfcPropertySingleValue("Foo", None, self.file.createIfcText("Baz"), None)
+        owner_history = self.file.by_type("IfcOwnerHistory")[0]
+        self.file.createIfcRelOverridesProperties(
+            ifcopenshell.guid.new(), owner_history, None, None, [wall], pset, [override]
+        )
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        rels = output.by_type("IfcRelOverridesProperties")
+        assert len(rels) == 1
+        assert len(rels[0].OverridingProperties) == 1
+        assert rels[0].OverridingProperties[0].Name == "Foo"
+        assert rels[0].OverridingProperties[0].NominalValue.wrappedValue == "Baz"
 
     def test_keep_spatial_structure(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -137,6 +137,38 @@ class TestExtractElements(test.bootstrap.IFC4):
         assert rels[0].OverridingProperties[0].Name == "Foo"
         assert rels[0].OverridingProperties[0].NominalValue.wrappedValue == "Baz"
 
+    def test_representation_shared_with_a_type_map_is_not_duplicated(self):
+        # Regression test: exporters do emit an IfcShapeRepresentation that is at
+        # once a product's own representation and a type's
+        # IfcRepresentationMap.MappedRepresentation. Extraction must reproduce the
+        # source as it stands, one entity in both roles. Appending the element type
+        # through the name uniqueness code path the caller had opted out of used to
+        # copy the representation instead, silently rewriting the model.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        context = ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        wall_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(
+            self.file, related_objects=[wall], relating_type=wall_type, should_map_representations=False
+        )
+
+        points = [self.file.createIfcCartesianPoint(p) for p in ((0.0, 0.0), (1.0, 0.0))]
+        representation = self.file.createIfcShapeRepresentation(
+            context, "Body", "Curve2D", [self.file.createIfcPolyline(points)]
+        )
+        wall.Representation = self.file.createIfcProductDefinitionShape(None, None, [representation])
+        origin = self.file.createIfcAxis2Placement3D(self.file.createIfcCartesianPoint((0.0, 0.0, 0.0)))
+        wall_type.RepresentationMaps = [self.file.createIfcRepresentationMap(origin, representation)]
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall", False]})
+
+        new_wall = output.by_type("IfcWall")[0]
+        new_type = output.by_type("IfcWallType")[0]
+        own = {r.id() for r in new_wall.Representation.Representations}
+        mapped = {m.MappedRepresentation.id() for m in new_type.RepresentationMaps}
+        assert own == mapped
+        assert len(output.by_type("IfcShapeRepresentation")) == 1
+
     def test_keep_spatial_structure(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
 


### PR DESCRIPTION
## Problem

`ExtractElements` is O(n^2) and becomes unusable at scale. A reporter's extraction of 2004 walls from a 495 MB IFC2X3 model ran for over 12 hours without finishing.

## Root causes

Two, both in `project.append_asset`.

**1. Shared relationship member lists were reassigned per element.** When a relationship is shared by many extracted elements, for example one `IfcRelAssociatesMaterial` linking thousands of products, `add_inverse_element` re-scanned and re-assigned that relationship's whole member list on every single append. Reassigning an N member list N times is O(n^2), dominated by entity hashing during set de-duplication.

**2. The asset uniqueness flag was not forwarded to the nested type append.** `append_product` recursed into `append_asset` to add an element's type but dropped `assume_asset_uniqueness_by_name`, which defaults to `True`. `ExtractElements` passes `False`, so the nested call silently took the slow path. That armed `SafeRemovalContext`, whose `__exit__` full scans the shared, ever growing `reuse_identities` once per occurrence. Profiling the railing baseline: `entity_instance.__hash__` 412M calls for 109.1s, and `__exit__` accounting for **378.2s of 430.7s**.

The second cost is per distinct type, so element classes with many types suffer most: this model has 97 window types against 12 railing types.

## Fix

- An opt-in `deferred_relationship_members` accumulator. Member lists are assigned once at the end via `flush_deferred_relationship_members` rather than per element. Opt-in, so `append_asset` default behaviour is unchanged for all other callers.
- The uniqueness flag is forwarded to the nested type append.
- Deferred members that are `IfcRoot` subtypes are matched by GlobalId; members that are not, which today is only `IfcRelOverridesProperties.OverridingProperties` holding `IfcProperty`, are matched by identity. Without this they resolved to nothing and the list was written empty, violating the `[1:?]` cardinality and producing invalid IFC.

## Measured

On the reporter's 519 MB IFC2X3 model, real `Patcher.patch()`:

| element class | before | after |
|---|---|---|
| `IfcWindow` (3557) | 1339.7s | **102.9s** |
| `IfcRailing` (2583) | 430.7s | **35.4s** |

Synthetic, N walls sharing a relationship: 500 3.86s to 0.24s, 1000 15.55s to 0.66s, 2000 64.47s to 2.36s. Base quadruples per doubling; the fix does not.

Peak memory on the real model fell from 4.19 GB to 2.58 GB.

## Correctness

Verified against a `v0.8.0` baseline on the real model: identical wall GlobalId sets, identical per class entity counts, identical relationship member counts, 0 dangling references, 0 empty member lists, and `ifcopenshell.validate` error counts no worse.

An earlier revision of this branch did lose data. It dropped the property sets of 26 spatial containers, one site, one building and 24 storeys, and emitted 26 `IfcRelDefinesByProperties` with empty `RelatedObjects`. It also dropped element types from shared associations and removed `IfcDistributionPort` entities entirely. All three are fixed here and covered by tests.

The old eager path was additionally emitting duplicate geometry: every window occurrence pointed at a representation map its own type did not declare, with 1313 orphaned `IfcRepresentationMap`. Output on this model falls from 1,044,914 to 688,899 entities with no loss of information.

## Known caveat

Presentation layer assignments change. Railings strictly improve, 3 empty and 0 items becoming 0 empty and 3 items. Windows are mixed: all 10 empty assignments become non-empty, but total membership falls from 85 to 12. The structural cause is `add_inverse_element` returning early when revisiting a non-relationship inverse, which makes layer membership order dependent in both the old and new code. Fixing that properly needs a wider change than belongs in this PR.

## Tests

Cover shared relationship members surviving, spatial container property sets surviving, element types surviving shared associations, ports and populated `IfcRelNests` surviving, and non `IfcRoot` deferred members resolving.

Generated with the assistance of an AI coding tool.
