### PR TITLE
bonsai(pset): bind schema module directly so pset UI survives add-on reload (#8236)

### DIFF
--- a/src/bonsai/bonsai/tool/pset.py
+++ b/src/bonsai/bonsai/tool/pset.py
@@ -28,7 +28,13 @@ import ifcopenshell.util.attribute
 import ifcopenshell.util.element
 
 import bonsai.bim.helper
-import bonsai.bim.schema
+# Bind the schema module directly rather than referencing it as
+# ``bonsai.bim.schema`` at call time: on a Blender restart / add-on reload the
+# ``bonsai.bim`` package can lose its ``schema`` attribute before the pset UI
+# draws, which raised ``AttributeError: module 'bonsai.bim' has no attribute
+# 'schema'`` and left the panels blank (see #8236). A directly bound reference
+# survives that, since it points at the module object itself.
+from bonsai.bim import schema as bim_schema
 import bonsai.core.tool
 import bonsai.tool as tool
 
@@ -142,7 +148,7 @@ class Pset(bonsai.core.tool.Pset):
             predefined_type = ifcopenshell.util.element.get_predefined_type(element)
         return bool(
             pset_name
-            in bonsai.bim.schema.ifc.psetqto.get_applicable_names(
+            in bim_schema.ifc.psetqto.get_applicable_names(
                 element.is_a(), predefined_type, pset_only=True, schema=tool.Ifc.get_schema()
             )
         )
@@ -444,7 +450,7 @@ class Pset(bonsai.core.tool.Pset):
 
     @classmethod
     def get_pset_template(cls, name: str) -> Union[ifcopenshell.entity_instance, None]:
-        return bonsai.bim.schema.ifc.psetqto.get_by_name(name)
+        return bim_schema.ifc.psetqto.get_by_name(name)
 
     @classmethod
     def add_proposed_property(cls, name: str, value: Any, props: bpy.types.PropertyGroup) -> Union[None, str]:


### PR DESCRIPTION
## Problem

Reported in #8236: after restarting Blender (Bonsai 0.8.6 alpha), the add-on stops showing properties and the pset/qto panels are blank. The console shows:

```
File ".../bonsai/tool/pset.py", line 447, in get_pset_template
    return bonsai.bim.schema.ifc.psetqto.get_by_name(name)
AttributeError: module 'bonsai.bim' has no attribute 'schema'
```

The reporter notes it "works initially, but after restarting Blender" it breaks.

## Root cause

`tool/pset.py` imports `bonsai.bim.schema` at module level but then resolves `bonsai.bim.schema.ifc...` **at call time** (during the pset UI draw) in `get_pset_template` and `is_pset_applicable`. On an add-on reload the `bonsai.bim` package object can lose its `schema` attribute before the pset UI draws, so the attribute lookup raises and the panel draw fails.

## Fix

Bind the module directly with `from bonsai.bim import schema as bim_schema` and reference `bim_schema.ifc...`. The local name points at the module object itself, so it no longer depends on `bonsai.bim` retaining the `schema` attribute across a reload.

## Verification

Verified the mechanism in isolation: after a package's submodule attribute is cleared (as happens on reload), resolving it via the `parent.submodule` chain raises `AttributeError: module 'parent' has no attribute 'submodule'` (matching the report), while a directly bound module reference still resolves. The file compiles clean.

Note: I could not reproduce the exact Blender-restart trigger headlessly, so this targets the mechanism behind the reported `AttributeError`. Happy to adjust if a maintainer prefers fixing it at the package-load level instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)