### PR TITLE
util.selector: match boolean properties by True/False spelling (#8100)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -1225,12 +1225,22 @@ class FacetTransformer(lark.Transformer):
             return any(self.compare(ev, comparison, value) for ev in element_value)
         elif isinstance(value, str):
             try:
-                if isinstance(element_value, int):
+                if isinstance(element_value, bool):
+                    # bool subclasses int, so handle it before the numeric
+                    # branches. A boolean property should match every common
+                    # spelling ("True"/"False") the same way "1"/"0" already do.
+                    if value in ("True", "true", "TRUE", "1"):
+                        value = True
+                    elif value in ("False", "false", "FALSE", "0"):
+                        value = False
+                elif isinstance(element_value, int):
                     value = int(value)
                 elif isinstance(element_value, float):
                     value = float(value)
 
-                if isinstance(element_value, (int, float)):
+                if isinstance(element_value, bool):
+                    result = element_value == value
+                elif isinstance(element_value, (int, float)):
                     operator = comparison.lstrip("!")
                     if operator == ">=":
                         result = element_value >= value

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -261,6 +261,23 @@ class TestFilterElements(test.bootstrap.IFC4):
         ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": ["New"]})
         assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status=New") == {element}
 
+    def test_selecting_by_boolean_property(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"LoadBearing": True})
+        pset2 = ifcopenshell.api.pset.add_pset(self.file, product=element2, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset2, properties={"LoadBearing": False})
+        # A boolean property must match every common spelling, not just "1"/"0".
+        for true_value in ("TRUE", "True", "true", "1"):
+            assert subject.filter_elements(self.file, f"IfcWall, Pset_WallCommon.LoadBearing={true_value}") == {
+                element
+            }, true_value
+        for false_value in ("FALSE", "False", "false", "0"):
+            assert subject.filter_elements(self.file, f"IfcWall, Pset_WallCommon.LoadBearing={false_value}") == {
+                element2
+            }, false_value
+
     def test_selecting_by_property_with_comparisons(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")


### PR DESCRIPTION
## Problem
In Bonsai's Search Group, filtering a boolean property by the offered `True` / `False` values matches nothing, while typing `1` or `0` works. Reported in #8100.

In `FacetTransformer.compare` (`ifcopenshell/util/selector.py`), when the property value is a Python `bool` and the typed value is a string, the string-coercion path ran `isinstance(element_value, int)` first. Because `bool` is a subclass of `int`, this caught booleans and did `int("True")`, which raises, is swallowed by the bare `except`, and returns no match. `1`/`0` worked only by accident: `int("1")` succeeds and `True == 1`.

## Fix
Handle `bool` before the `int` branch, mapping the common truthy/falsy spellings (`True`/`False`, `true`/`false`, `TRUE`/`FALSE`, `1`/`0`) to a real boolean, and compare booleans by equality. String and numeric comparisons are untouched.

## Verification
Added `test_selecting_by_boolean_property`. It fails before the change (a `True` filter returns an empty set) and passes after. The full `test_selector.py` suite passes (38 tests), so string and number comparisons are unbroken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
