### PR TITLE
cmake: read the VERSION file unconditionally so builds report the real version (#8164)

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -27,13 +27,14 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON) # not necessary, but encouraged
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-if(VERSION_OVERRIDE)
-    file(READ "../VERSION" "RELEASE_VERSION_")
-    string(STRIP "${RELEASE_VERSION_}" RELEASE_VERSION)
-    message(STATUS "Detected version '${RELEASE_VERSION}'")
-else()
-    set(RELEASE_VERSION "0.8.0")
-endif()
+# The VERSION file in the repository root is the single source of truth for the
+# release version. Read it unconditionally so a plain source build reports the
+# real version through buildinfo.cpp instead of the stale hardcoded 0.8.0
+# fallback (see #8164). VERSION_OVERRIDE still controls the branch name used
+# when ADD_COMMIT_SHA embeds a commit sha.
+file(READ "../VERSION" "RELEASE_VERSION_")
+string(STRIP "${RELEASE_VERSION_}" RELEASE_VERSION)
+message(STATUS "Detected version '${RELEASE_VERSION}'")
 
 add_definitions(-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 


### PR DESCRIPTION
## Problem
`IfcConvert --version` prints `0.8.0` on a plain source build even though the repository `VERSION` file says `0.8.6`. Reported in #8164.

`buildinfo.cpp` already falls back to the `IFCOPENSHELL_VERSION_STRING` macro, and CMake already passes it as `${RELEASE_VERSION}`. The gap is that `RELEASE_VERSION` was only read from the `VERSION` file when `VERSION_OVERRIDE` was on. A default build (both `VERSION_OVERRIDE` and `ADD_COMMIT_SHA` off, as the nixpkgs package builds it) fell through to the hardcoded `"0.8.0"`, so the fallback macro carried a stale value.

## Fix
Read the `VERSION` file unconditionally so `RELEASE_VERSION` is always the real version. `VERSION_OVERRIDE` still controls the branch name embedded when `ADD_COMMIT_SHA` is on, and `project()` / CPack now also report the true version in default builds.

## Verification
This is a compile-time constant, so it is not exercised by the Python test suite. The change removes an `if/else` wrapper around the exact three lines that already ran under `VERSION_OVERRIDE`, so there is no new CMake logic to fail. With the fix a default build defines `IFCOPENSHELL_VERSION_STRING=0.8.6`, which `buildinfo.cpp`'s existing `#elif` branch stringifies, so `IfcConvert --version` reports `0.8.6`. A maintainer with a native build can confirm the linked binary and that the release path (`ADD_COMMIT_SHA` on) still emits the expected `<branch>-<sha>` string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
