### PR TITLE
bonsai(material): keep the layer panel in stored order so a wall flip does not reorder it (#8240)

### DIFF
--- a/src/bonsai/bonsai/bim/module/material/data.py
+++ b/src/bonsai/bonsai/bim/module/material/data.py
@@ -307,18 +307,17 @@ class ObjectMaterialData:
                 else:
                     data["material"] = item.Material.Name or "Unnamed"
                 results.append(data)
-        should_reverse = cls.material.is_a("IfcMaterialLayerSetUsage") and cls.material.DirectionSense == "POSITIVE"
+        # Present the layers in their stored order (ForLayerSet.MaterialLayers),
+        # which is the order the user manages directly. Previously the list was
+        # reversed for an IfcMaterialLayerSetUsage with a POSITIVE DirectionSense
+        # so the layer farthest from the reference line showed on top. That made
+        # a wall flip silently reorder the panel, because flip toggles
+        # DirectionSense, even though the stored layers never change (see #8240).
         last_i = len(results) - 1
         for i, result in enumerate(results):
             result["index"] = i
-            if should_reverse:
-                result["index_up"] = i + 1 if i != last_i else None
-                result["index_down"] = i - 1 if i != 0 else None
-            else:
-                result["index_down"] = i + 1 if i != last_i else None
-                result["index_up"] = i - 1 if i != 0 else None
-        if should_reverse:
-            return list(reversed(results))
+            result["index_down"] = i + 1 if i != last_i else None
+            result["index_up"] = i - 1 if i != 0 else None
         return results
 
     @classmethod


### PR DESCRIPTION
## Problem
Flipping a wall reorders the Material Layers panel, which is confusing since the user manages that list directly. Reported in #8240.

## Root cause
`ObjectMaterialData.set_items` (`material/data.py`) reversed the layer list when an `IfcMaterialLayerSetUsage` had `DirectionSense == "POSITIVE"`, so the layer farthest from the reference line showed on top. A wall flip toggles `DirectionSense`, so the panel order flipped with it, even though the stored `ForLayerSet.MaterialLayers` never change.

## Fix
Present the layers in their stored order and drop the DirectionSense based reversal. The reorder arrow indices follow the same stored order.

## Verification (Blender 5.1.2, Bonsai)
Built a LAYER2 wall with three distinct layers (EXT 0.1, MID 0.2, INT 0.3) and flipped it, reading the real `ObjectMaterialData` panel data:

| | DirectionSense | Panel top to bottom | Layer world position |
| --- | --- | --- | --- |
| Before flip | POSITIVE | EXT, MID, INT | EXT 0.05, MID 0.20, INT 0.45 |
| After flip | NEGATIVE | EXT, MID, INT (stable) | EXT 0.55, MID 0.40, INT 0.15 |

The panel no longer reorders on a flip, while the flip still mirrors the layer geometry (EXT moves from 0.05 to 0.55). Reorder arrow indices stay consistent.

## Tradeoff
This also changes the baseline for any existing wall with a POSITIVE `DirectionSense`: its panel now reads in stored order instead of the previous reversed view. That reversed view was a deliberate presentation choice (farthest layer from the reference line on top), so this is a convention change rather than a pure bug fix. Raising it here for a maintainer decision, since it directly addresses the reported behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
