### PR TITLE
project(append_asset): reuse an existing IfcClassification instead of duplicating it (#7150)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -340,6 +340,25 @@ class Usecase:
                 return None
             return next((e for e in self.file.by_type(element.is_a()) if e.Name == name), None)
 
+        # Not really an asset, but a single classification system is shared by
+        # the IfcClassificationReferences of many assets. If we don't reuse an
+        # existing one, every appended asset that points at the same
+        # classification spawns a duplicate IfcClassification (see #7150).
+        elif element.is_a("IfcClassification"):
+            name = element.Name
+            if name is None:
+                return None
+            return next(
+                (
+                    e
+                    for e in self.file.by_type("IfcClassification")
+                    if e.Name == name
+                    and e.Source == element.Source
+                    and e.Edition == element.Edition
+                ),
+                None,
+            )
+
         # Not really assets but if we don't check them here,
         # their subgraph entities may be appended twice.
         elif (ifc_class := element.is_a()) == "IfcOrganization":
@@ -739,6 +758,21 @@ class Usecase:
                 if existing_style is not None:
                     reuse_identities[element_identity] = existing_style
                     return existing_style
+
+        elif element.is_a("IfcClassification"):
+            name = element.Name
+            if name is not None:
+                existing_classification = next(
+                    (
+                        e
+                        for e in ifc_file.by_type("IfcClassification")
+                        if e.Name == name and e.Source == element.Source and e.Edition == element.Edition
+                    ),
+                    None,
+                )
+                if existing_classification is not None:
+                    reuse_identities[element_identity] = existing_classification
+                    return existing_classification
 
         elif ifc_class == "IfcApplication":
             app_id = element.ApplicationIdentifier

--- a/src/ifcopenshell-python/test/api/project/test_append_asset.py
+++ b/src/ifcopenshell-python/test/api/project/test_append_asset.py
@@ -171,6 +171,30 @@ class TestAppendAssetIFC2X3(test.bootstrap.IFC2X3):
         assert ifcopenshell.util.element.get_material(new2).MaterialLayers[0].Material == material
         assert ifcopenshell.util.element.get_material(new2).MaterialLayers[1].Material == material
 
+    def test_append_two_type_products_sharing_the_same_classification(self):
+        ifcopenshell.api.root.create_entity(self.file, "IfcProject")
+        library = ifcopenshell.api.project.create_file(version=self.file.schema)
+        ifcopenshell.api.root.create_entity(library, "IfcProject")
+        element1 = ifcopenshell.api.root.create_entity(library, ifc_class="IfcWallType")
+        element2 = ifcopenshell.api.root.create_entity(library, ifc_class="IfcWallType")
+        classification = ifcopenshell.api.classification.add_classification(library, classification="MyClassification")
+        ifcopenshell.api.classification.add_reference(
+            library, products=[element1], identification="Code_1", classification=classification
+        )
+        ifcopenshell.api.classification.add_reference(
+            library, products=[element2], identification="Code_2", classification=classification
+        )
+
+        new1 = ifcopenshell.api.project.append_asset(self.file, library=library, element=element1)
+        new2 = ifcopenshell.api.project.append_asset(self.file, library=library, element=element2)
+
+        # The shared classification system must be reused, not duplicated (#7150).
+        classifications = self.file.by_type("IfcClassification")
+        assert len(classifications) == 1
+        references = self.file.by_type("IfcClassificationReference")
+        assert len(references) == 2
+        assert all(reference.ReferencedSource == classifications[0] for reference in references)
+
     def test_append_a_type_product_with_its_styles(self):
         library = ifcopenshell.api.project.create_file(version=self.file.schema)
         element = ifcopenshell.api.root.create_entity(library, ifc_class="IfcWallType")


### PR DESCRIPTION
Fixes #7150.

## Problem

Importing several types from a library, where the types reference the same classification system, creates a **duplicate `IfcClassification` for every imported type** instead of reusing the one already in the project.

## Root cause

`append_asset` has two places that reuse already-present shared entities instead of re-adding them:

- `Usecase.get_existing_element` (used by `add_element` while walking the subgraph), and
- `Usecase.file_add`, a reimplementation of `file.add` with its own inline dedup, which even carries a note that the two must stay in sync.

Both handle materials, material sets, profiles, presentation styles, applications, organisations and persons, but **neither handled `IfcClassification`**. So when the second type's `IfcClassificationReference` is added, `file_add` recreates its `ReferencedSource` classification from scratch.

## Fix

Add an `IfcClassification` branch to both methods, matching an existing classification by `Name`, `Source` and `Edition`. Matching the identifying triple (rather than name alone) means two genuinely different classification systems that happen to share a name are still kept separate.

## Verification

Reproduced first with the reporter's `lib_test.ifc`: appending its two column types produced 2 `IfcClassification`. With the fix, 1.

Added a regression test, `test_append_two_type_products_sharing_the_same_classification`, that runs under both IFC2X3 and IFC4. It appends two type products sharing one classification and asserts a single `IfcClassification` survives with both references pointing at it.

- Without the fix: the new test fails (`2 == 1`) on both schemas.
- With the fix: the full `test_append_asset.py` suite passes (79 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
