### PR TITLE
bonsai(classification): report a clear error when adding a manual reference with no classification (#7506)

### DIFF
--- a/src/bonsai/bonsai/bim/module/classification/operator.py
+++ b/src/bonsai/bonsai/bim/module/classification/operator.py
@@ -76,6 +76,10 @@ class AddManualClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
     obj_type: bpy.props.StringProperty()
 
     def _execute(self, context):
+        props = tool.Classification.get_classification_reference_props()
+        if not props.classifications:
+            self.report({"ERROR"}, "Add a classification before adding a manual reference to it.")
+            return
         if self.obj_type == "Object":
             if context.selected_objects:
                 objects = [o.name for o in context.selected_objects]
@@ -83,7 +87,6 @@ class AddManualClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
                 objects = [context.active_object.name]
         else:
             objects = [self.obj]
-        props = tool.Classification.get_classification_reference_props()
         attributes = bonsai.bim.helper.export_attributes(props.reference_attributes)
         products = [
             tool.Ifc.get().by_id(ifc_definition_id)


### PR DESCRIPTION
Fixes #7506.

## Problem

On a fresh file, selecting an element, choosing **Manual Entry** under Classification References, clicking **Add Reference**, filling in the fields and clicking **Save** throws an error and the reference is not saved.

The manual-reference UI shows a dropdown of existing classifications (`props.classifications`). On a file with no classification system yet, that enum is empty, so `AddManualClassificationReference._execute` runs:

```python
classification = tool.Ifc.get().by_id(int(props.classifications))
```

with `props.classifications == ""`, raising `ValueError: invalid literal for int() with base 10: ''`.

## Fix

Guard the empty case and report an actionable message (`"Add a classification before adding a manual reference to it."`) instead of crashing, matching how other operators surface missing prerequisites. A classification reference needs a parent classification, so this points the user at the right next step.

## Verification

Reproduced and fixed in headless Blender 5.1.2 (Bonsai from wheels), driving the real operator:

- **No classification (was a crash):** with the fix, no `ValueError`; the operator reports the clear message and no reference is created.
- **With a classification selected (happy path):** unchanged, the reference is created and its `ReferencedSource` points at the selected classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
