### PR TITLE
bonsai(drawing): persist drawing camera zoom and crop on save (#8205)

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -2018,6 +2018,12 @@ class ExportIFC(bpy.types.Operator, ExportHelper):
             if not cam_element or not cam_element.is_a("IfcAnnotation"):
                 continue
             cam_props = tool.Drawing.get_camera_props(cam_obj.data)
+            # Skip cameras without an active representation: bim.update_representation
+            # asserts on one (geometry/operator.py) and would otherwise abort the whole
+            # save. update_representation() may report a bounds change on a camera whose
+            # representation isn't (yet) set up, e.g. one never activated this session.
+            if not tool.Geometry.get_active_representation(cam_obj):
+                continue
             if cam_props.update_representation(cam_obj.matrix_world):
                 bpy.ops.bim.update_representation(obj=cam_obj.name, ifc_representation_class="")
         # Suffix is appended to the IFC save-success report below so the auto-commit

--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -2007,6 +2007,19 @@ class ExportIFC(bpy.types.Operator, ExportHelper):
         # gizmo polls gate on each preview's is_active flag, and a stuck flag
         # persisted through the save would silently hide them on reload.
         preview_base.discard_pending_previews(context.scene)
+        # Flush any pending drawing camera bounds (zoom / crop) into the IFC
+        # representation. These are otherwise only written when a drawing is
+        # (re)activated, so saving while staying in a drawing lost the zoom and
+        # crop on reload. See #8205.
+        for cam_obj in context.scene.objects:
+            if cam_obj.type != "CAMERA":
+                continue
+            cam_element = tool.Ifc.get_entity(cam_obj)
+            if not cam_element or not cam_element.is_a("IfcAnnotation"):
+                continue
+            cam_props = tool.Drawing.get_camera_props(cam_obj.data)
+            if cam_props.update_representation(cam_obj.matrix_world):
+                bpy.ops.bim.update_representation(obj=cam_obj.name, ifc_representation_class="")
         # Suffix is appended to the IFC save-success report below so the auto-commit
         # info isn't immediately overwritten by the success message in Blender's
         # status bar (only the latest self.report({"INFO"}, ...) sticks).


### PR DESCRIPTION
Part of #8205.

## Problem
On a drawing, set a zoom factor / crop area for the print sheet, Save, then reopen: the zoom and crop reset to the scale default. Reported for georeferenced models but it is not georeferencing specific, it happens on any model.

## Root cause
The drawing camera's bounds (`ortho_scale`, raster, `clip_end`, matrix) are written to the IFC representation only inside `ActivateDrawing`, via `BIMCameraProperties.update_representation`. Saving the project while staying in a drawing never flushed them, so the drawing's `IfcBlock` kept its creation size and the camera rebuilt from it on reload.

## Fix
Flush any loaded drawing camera whose bounds changed at the start of the save operator, using the same `update_representation` check activation already relies on. No-op for cameras that have not changed and for projects without drawing cameras.

## Verification (headless)
Create a plan drawing, set `ortho_scale` to 12.5, save, reopen and activate:
- before: reopens at 50.0 (reset)
- after: reopens at 12.5 (preserved)

Existing `test/core/test_drawing.py` failures (`tool.Ifc has no attribute 'by_type'`) are pre-existing on `v0.8.0` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
