### PR TITLE
bonsai(bcf): store viewpoints in global coordinates on georeferenced models (#8205)

### DIFF
--- a/src/bonsai/bonsai/bim/module/bcf/operator.py
+++ b/src/bonsai/bonsai/bim/module/bcf/operator.py
@@ -555,15 +555,35 @@ class AddBcfViewpoint(bpy.types.Operator):
         blender_topic = props.active_topic
         topic = bcfxml.topics[blender_topic.name]
 
-        direction = blender_camera.matrix_world.to_quaternion() @ Vector((0.0, 0.0, -1.0))
-        up = blender_camera.matrix_world.to_quaternion() @ Vector((0.0, 1.0, 0.0))
+        # BCF viewpoints are stored in global (map) coordinates. On a
+        # georeferenced model the Blender camera is in the local, offset space,
+        # so convert it to global here, mirroring the global2local applied on
+        # restore in setup_camera(). Without this the saved viewpoint holds
+        # local coordinates and reloading shifts the camera by the offset. See #8205.
+        camera_matrix = blender_camera.matrix_world
+        geo_props = tool.Georeference.get_georeference_props()
+        if geo_props.has_blender_offset:
+            unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
+            camera_matrix = Matrix(
+                ifcopenshell.util.geolocation.local2global(
+                    np.array(blender_camera.matrix_world),
+                    float(geo_props.blender_offset_x) * unit_scale,
+                    float(geo_props.blender_offset_y) * unit_scale,
+                    float(geo_props.blender_offset_z) * unit_scale,
+                    float(geo_props.blender_x_axis_abscissa),
+                    float(geo_props.blender_x_axis_ordinate),
+                ).tolist()
+            )
+        camera_location = camera_matrix.translation
+        direction = camera_matrix.to_quaternion() @ Vector((0.0, 0.0, -1.0))
+        up = camera_matrix.to_quaternion() @ Vector((0.0, 1.0, 0.0))
 
         blender_render = context.scene.render
         assert isinstance(blender_camera.data, bpy.types.Camera)
         visinfo_guid = str(uuid.uuid4())
         if bcf_v2:
             camera_view_point = bcf.v2.model.Point(
-                x=blender_camera.location.x, y=blender_camera.location.y, z=blender_camera.location.z
+                x=camera_location.x, y=camera_location.y, z=camera_location.z
             )
             camera_direction = bcf.v2.model.Direction(x=direction.x, y=direction.y, z=direction.z)
             camera_up_vector = bcf.v2.model.Direction(x=up.x, y=up.y, z=up.z)
@@ -588,7 +608,7 @@ class AddBcfViewpoint(bpy.types.Operator):
                 return {"FINISHED"}
         else:
             camera_view_point = bcf.v3.model.Point(
-                x=blender_camera.location.x, y=blender_camera.location.y, z=blender_camera.location.z
+                x=camera_location.x, y=camera_location.y, z=camera_location.z
             )
             camera_direction = bcf.v3.model.Direction(x=direction.x, y=direction.y, z=direction.z)
             camera_up_vector = bcf.v3.model.Direction(x=up.x, y=up.y, z=up.z)


### PR DESCRIPTION
Part of #8205.

## Problem
On a georeferenced model, saving a BCF viewpoint and restoring it shifts the camera by the georeferencing offset (it jumps far from the model).

## Root cause
Asymmetry between write and restore. The restore path (`setup_camera`) applies `global2local` when `has_blender_offset` is set, so it expects the viewpoint to be stored in global (map) coordinates. But the write path stored the raw local Blender camera position, skipping `local2global`. So the viewpoint held local coordinates and restore subtracted the offset again, shifting the camera.

## Fix
Convert the camera to global coordinates on write, mirroring the `global2local` applied on restore (same offset, unit scale and axis handling). No change for non-georeferenced models (`has_blender_offset` false leaves the matrix untouched).

## Verification
Round trip with the real offset (E 158123.224, N 6406512.544):
- local pose (8.62, 9.76, 4.79) -> stored global (158131.84, 6406522.30, 4.79) -> restored local (8.62, 9.76, 4.79). Exact.
- the previous behaviour (store local, restore applies global2local) produced (-158114, -6406502), i.e. the reported shift.

`global2local` / `local2global` are confirmed exact inverses at matrix level, and the viewpoint view-vector reconstruction is exact for plan cameras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
