### PR TITLE
bonsai(drawing): plan drawings for spatial containers without a building storey

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -125,10 +125,20 @@ class DrawingsData:
     def location_hint(cls) -> list[tuple[tool.Drawing.LocationHintType, str, str]]:
         props = tool.Drawing.get_document_props()
         if props.target_view in ["PLAN_VIEW", "REFLECTED_PLAN_VIEW"]:
+            ifc = tool.Ifc.get()
             results = [("0", "Origin", "")]
             results.extend(
-                [(str(s.id()), s.Name or "Unnamed", "") for s in tool.Ifc.get().by_type("IfcBuildingStorey")]
+                [(str(s.id()), s.Name or "Unnamed", "") for s in ifc.by_type("IfcBuildingStorey")]
             )
+            # Also offer other spatial containers that directly contain elements
+            # (roads, facility parts, sites, ...). Without this, infrastructure
+            # models that have no IfcBuildingStorey only offer "Origin", forcing
+            # the plan camera to (0,0,0) away from the geometry, so the drawing
+            # comes up empty.
+            for s in ifc.by_type("IfcSpatialStructureElement"):
+                if s.is_a("IfcBuildingStorey") or not getattr(s, "ContainsElements", None):
+                    continue
+                results.append((str(s.id()), f"{s.Name or 'Unnamed'} ({s.is_a()})", ""))
             return results
         elif props.target_view in ["MODEL_VIEW"]:
             return [(h.upper(), h, "") for h in ["Orthographic", "Perspective"]]

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -426,6 +426,18 @@ class Drawing(bonsai.core.tool.Drawing):
         return rep
 
     @classmethod
+    def get_spatial_geometry_corners(cls, element: ifcopenshell.entity_instance) -> list[Vector]:
+        """World-space bounding-box corners of the geometry directly contained
+        in a spatial element. Empty if it holds no mesh geometry."""
+        return [
+            obj.matrix_world @ Vector(corner)
+            for rel in getattr(element, "ContainsElements", [])
+            for contained in rel.RelatedElements
+            if (obj := tool.Ifc.get_object(contained)) and getattr(obj, "type", None) == "MESH"
+            for corner in obj.bound_box
+        ]
+
+    @classmethod
     def create_camera(
         cls,
         name: str,
@@ -441,6 +453,22 @@ class Drawing(bonsai.core.tool.Drawing):
         else:
             props.camera_type = "ORTHO"
         camera_data.ortho_scale = 50  # The default of 6m is too small
+        # For a plan of a non-building container (a road, facility part, ...),
+        # size the view to the container's extent so a large element like a
+        # road actually fits instead of showing a default 50m slice.
+        if (
+            isinstance(location_hint, int)
+            and location_hint
+            and target_view in ("PLAN_VIEW", "REFLECTED_PLAN_VIEW")
+        ):
+            spatial = tool.Ifc.get().by_id(location_hint)
+            if not spatial.is_a("IfcBuildingStorey") and (corners := cls.get_spatial_geometry_corners(spatial)):
+                span = max(
+                    max(c.x for c in corners) - min(c.x for c in corners),
+                    max(c.y for c in corners) - min(c.y for c in corners),
+                )
+                if span > 0:
+                    camera_data.ortho_scale = span * 1.1
         camera_data.clip_start = 0.002  # 2mm is close to zero but allows any GPU-drawn lines to be visible.
         if target_view == "MODEL_VIEW":
             assert (space := tool.Blender.get_view3d_space())
@@ -821,9 +849,20 @@ class Drawing(bonsai.core.tool.Drawing):
                 # Flip Z axis.
                 m.col[2] *= -1
             if location_hint:
-                storey = tool.Ifc.get_object(tool.Ifc.get().by_id(location_hint))
+                spatial = tool.Ifc.get().by_id(location_hint)
+                storey = tool.Ifc.get_object(spatial)
                 assert isinstance(storey, bpy.types.Object)
                 z = storey.matrix_world.translation.z
+                if not spatial.is_a("IfcBuildingStorey") and (corners := cls.get_spatial_geometry_corners(spatial)):
+                    # Infrastructure containers (roads, facility parts, ...) are
+                    # often far from the cursor/origin, so center the plan on the
+                    # container's own contents; otherwise the drawing comes up empty.
+                    x = (min(c.x for c in corners) + max(c.x for c in corners)) / 2
+                    y = (min(c.y for c in corners) + max(c.y for c in corners)) / 2
+                    # Sit above the top of the geometry, not the container's
+                    # placement (roads sit at z=0 while the surface is higher),
+                    # so the top-down view actually looks onto the elements.
+                    z = max(c.z for c in corners)
                 if target_view == "PLAN_VIEW":
                     # Keep default camera direction - Z-.
                     m.translation = (x, y, z + 1.6)


### PR DESCRIPTION
## Problem
Plan and reflected-plan drawings can only be placed relative to **Origin** or an **IfcBuildingStorey**. Any model whose elements live in a different spatial container (roads, bridges, railways, facility parts, sites, ...) has no building storey, so the only option is Origin. That forces the camera to (0,0,0), at the wrong height, with the default 50 view size, and the drawing comes up empty.

## Fix
Offer any `IfcSpatialStructureElement` that directly contains elements as a plan-view location, in addition to building storeys. For such non-storey containers:
- **center** the camera on the container's own geometry (X/Y),
- place it **above the top** of that geometry (containers like roads sit at z=0 while the surface is higher),
- **size** the view to the container's extent so the contents fit.

`IfcBuildingStorey` behaviour is unchanged. Works across IFC2X3 / IFC4 / IFC4X3, since `IfcSpatialStructureElement` and `ContainsElements` exist in all of them.

## Verification (headless, IFC4X3 road model + IFC building)
- Road container now appears in the plan location dropdown (was Origin only).
- With the cursor at origin, the plan camera lands centered over the container at Z 9.8 (above the 7.5–8.2 geometry) instead of empty at (0,0,1.6).
- ortho_scale auto-fits (e.g. 80 for a ~73 m container vs the default 50).
- Building-storey plan drawings unchanged (still cursor-placed, ortho_scale 50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
