### PR TITLE
bonsai(model): TAB on a wall enters IFC Item Mode again (#8330)

### DIFF
--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1537,11 +1537,14 @@ class Blender(bonsai.core.tool.Blender):
                 bpy.ops.bim.enable_editing_railing_path()
             elif feature := tool.Parametric.is_object_editing(obj):
                 tool.Parametric.run_bim_op(feature.finish_op)
-            elif tool.Parametric.is_wall(element):
-                # Placed after the generic finish dispatch so the TAB toggle splits:
-                # wall already editing → finish above; wall not editing → enter here.
-                bpy.ops.bim.enable_editing_wall()
             else:
+                # A fresh LAYER2 wall deliberately falls through here so the
+                # caller routes TAB to item mode (see issue #8330). Wall
+                # parametric edit is entered from the pen icon on the wall
+                # gizmo, not from TAB, so TAB stays the universal item/edit
+                # mode key it has always been across every element type. The
+                # finish leg above still fires when a wall is already editing,
+                # so TAB continues to close an in-progress parametric edit.
                 return False
             return True
 

--- a/src/bonsai/test/bim/module/model/test_wall_tab_routes_to_item_mode.py
+++ b/src/bonsai/test/bim/module/model/test_wall_tab_routes_to_item_mode.py
@@ -20,10 +20,16 @@
 
 """Pins TAB-key dispatch on a LAYER2 wall through ``Modifier.try_applying_edit_mode``.
 
-Three behavioural legs of the TAB toggle:
+Regression guard for issue #8330: TAB on a wall must reach item mode (to add
+representation items such as a Half Space Solid), not get hijacked into wall
+parametric edit. Parametric edit is entered from the pen icon on the wall
+gizmo instead.
 
-* Fresh LAYER2 wall → enters parametric edit via ``bim.enable_editing_wall``.
-* LAYER2 wall already in parametric edit → finishes (toggle close).
+Three behavioural legs of the TAB dispatch:
+
+* Fresh LAYER2 wall → returns False, so the caller routes TAB to item mode.
+* LAYER2 wall already in parametric edit → finishes (closes the edit), so TAB
+  still exits an edit that was opened from the pen icon.
 * Wall without ``IfcMaterialLayerSetUsage`` → dispatch returns False so the
   caller routes the TAB to item mode."""
 
@@ -56,16 +62,20 @@ def _add_layer2_wall_occurrence():
     return wall, obj
 
 
-class TestTabOnLayer2WallEntersParametricEdit(NewFile):
-    def test_dispatch_enables_wall_edit(self):
+class TestTabOnFreshLayer2WallRoutesToItemMode(NewFile):
+    def test_dispatch_falls_through_for_fresh_layer2_wall(self):
+        """A fresh LAYER2 wall is a parametric-edit target, but TAB must not
+        enter parametric edit (issue #8330). The dispatch returns False so the
+        caller routes the TAB to item mode; parametric edit is reached from the
+        pen icon on the wall gizmo instead."""
         wall, obj = _add_layer2_wall_occurrence()
         assert tool.Parametric.is_wall(wall) is True
         assert obj.BIMWallProperties.is_editing is False
 
         result = tool.Blender.Modifier.try_applying_edit_mode(obj, wall)
 
-        assert result is True
-        assert obj.BIMWallProperties.is_editing is True
+        assert result is False
+        assert obj.BIMWallProperties.is_editing is False
 
 
 class TestTabOnLayer2WallAlreadyEditingFinishes(NewFile):


### PR DESCRIPTION
Fixes #8330.

## Problem
Since the recent gizmo work, pressing **Tab** on a wall no longer enters **IFC Item Mode** (needed to Add Item, e.g. a Half Space Solid). The workaround is the top-right "IFC Interaction Mode" > "IFC Item Mode" menu.

## Root cause
Not a keymap or gizmo-keymap change (the Tab keymap is intact; plain Tab in Object Mode is still bound only to `bim.override_mode_set_edit`). The regression is in operator dispatch.

Commit `4004344c2` ("Bonsai: TAB enters wall parametric edit") added an `is_wall` leg to `tool.Blender.Modifier.try_applying_edit_mode`. For a fresh LAYER2 wall that leg runs `bim.enable_editing_wall()` and returns `True`. Its caller `OverrideModeSetEdit.handle_single_object` treats a `True` return as "handled", so Tab never falls through to the `else` branch that opens Item Mode via `import_representation_items()`. The top-right menu still worked because it calls `import_representation_items` directly, bypassing this dispatch.

## Fix
Remove the `is_wall` entry leg so a fresh wall falls through and Tab routes to Item Mode as before. Nothing else changes:
- Wall parametric edit is still entered from the pen icon on the wall gizmo (the commit's own message describes Tab as a mirror of that icon-click entry).
- The exit path is preserved: `wall` is in `Parametric.EDIT_TYPES`, so a wall already in parametric edit is caught by the `is_object_editing` finish branch above the removed leg. Tab still closes an in-progress edit.

The test the original commit added is renamed and inverted to guard the restored contract (`test_wall_tab_routes_to_item_mode.py`).

## Verification
Headless, comparing installed code to a monkeypatch mirroring the edit on a real LAYER2 wall:
- keymap dump: only `bim.override_mode_set_edit` bound to plain Tab; no gizmo/tool grabs Tab.
- before: fresh wall Tab -> `try_applying_edit_mode` returns True, enters parametric edit (the bug).
- after: fresh wall Tab -> returns False, falls through -> caller opens Item Mode.
- after: wall already editing -> returns True, Tab still closes the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
