### PR TITLE
Bonsai: don't crash the task time editor on malformed IfcDuration (#3091)

### DIFF
--- a/src/bonsai/bonsai/bim/module/sequence/helper.py
+++ b/src/bonsai/bonsai/bim/module/sequence/helper.py
@@ -52,7 +52,15 @@ def canonicalise_time(time: Union[datetime, None]) -> str:
 def parse_duration_as_blender_props(dt: Union[Any, str]) -> dict[str, int]:
     if True:
         if isinstance(dt, str):
-            dt = ifcopenshell.util.date.ifc2datetime(dt)
+            try:
+                dt = ifcopenshell.util.date.ifc2datetime(dt)
+            except (ValueError, TypeError):
+                # A malformed or partial IfcDuration (e.g. "1D" without the leading
+                # "P", "WORKTIME", or an empty string) makes ifc2datetime misparse it
+                # as a date/time and raise. Don't take down the task time editor and
+                # don't fabricate a wrong value: warn clearly and treat it as empty.
+                print(f"WARNING: could not parse duration value {dt!r}, treating it as empty.")
+                dt = None
 
         seconds = getattr(dt, "seconds", 0)
         hours, seconds = divmod(seconds, 3600)


### PR DESCRIPTION
Fixes #3091.

## Problem
Editing a work-schedule task's time crashed with an uncaught `ValueError: not enough values to unpack (expected 2, got 1)` when `ScheduleDuration` held a malformed or partial IfcDuration.

## Root cause
`parse_duration_as_blender_props` hands the raw string to `ifcopenshell.util.date.ifc2datetime`, which dispatches by string shape. A duration missing the leading `P` (e.g. `1D`), a stray `WORKTIME`, or an empty string is misrouted to date/time `fromisoformat` and raises. Commit cd27a02 hardened the write path and the `parse_duration` wrapper now swallows unparseable `P` durations, but non-`P` malformed values still crashed this read path.

## Fix
Guard the `ifc2datetime` call in the task-time editor: on `ValueError`/`TypeError`, log the offending value and treat the duration as empty (all-zero props), matching the existing behaviour for unparseable `P` durations. `ifc2datetime` is left pure so real bugs elsewhere aren't masked, and no wrong date is fabricated, the failure is logged and identifiable.

## Verification
Tested `parse_duration_as_blender_props` directly against representative malformed inputs (`""`, `1D`, `WORKTIME`, `9:00`, `2023-13-45`, `abc`, `T8H`, `5`): all now handled (warn + empty) instead of crashing; valid durations (e.g. `P1Y2M3DT4H5M6S`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
