### PR TITLE
util.representation + Bonsai: fix two nested mapped-item transform bugs (#3019)

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -440,7 +440,10 @@ class IfcImporter:
             if rep.Items and len(rep.Items) == 1 and rep.Items[0].is_a("IfcMappedItem"):
                 rep_matrix = ifcopenshell.util.placement.get_mappeditem_transformation(rep.Items[0])
                 if not np.allclose(rep_matrix, np.eye(4)):
-                    matrix = rep_matrix @ matrix
+                    # We walk from the outer mapped item inwards, so the outer
+                    # transform is applied last. Post-multiply to keep the
+                    # nesting order M_outer @ M_inner (see #3019).
+                    matrix = matrix @ rep_matrix
                     if representation_id is None:
                         representation_id = rep.id()
                 rep = rep.Items[0].MappingSource.MappedRepresentation

--- a/src/ifcopenshell-python/ifcopenshell/util/representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/representation.py
@@ -332,7 +332,10 @@ def resolve_items(
         if item.is_a("IfcMappedItem"):
             rep_matrix = ifcopenshell.util.placement.get_mappeditem_transformation(item)
             if not np.allclose(rep_matrix, np.eye(4)):
-                rep_matrix = rep_matrix @ matrix.copy()
+                # ``matrix`` maps this representation into the top space, and
+                # ``rep_matrix`` maps the mapped geometry into this one, so the
+                # accumulated transform is M_outer @ M_inner (see #3019).
+                rep_matrix = matrix.copy() @ rep_matrix
             results.extend(resolve_items(item.MappingSource.MappedRepresentation, rep_matrix))
         else:
             results.append(ResolvedItemDict(matrix=matrix.copy(), item=item))

--- a/src/ifcopenshell-python/ifcopenshell/util/representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/representation.py
@@ -331,11 +331,13 @@ def resolve_items(
     for item in representation.Items or []:  # Be forgiving of invalid IFCs because Revit :(
         if item.is_a("IfcMappedItem"):
             rep_matrix = ifcopenshell.util.placement.get_mappeditem_transformation(item)
-            if not np.allclose(rep_matrix, np.eye(4)):
-                # ``matrix`` maps this representation into the top space, and
-                # ``rep_matrix`` maps the mapped geometry into this one, so the
-                # accumulated transform is M_outer @ M_inner (see #3019).
-                rep_matrix = matrix.copy() @ rep_matrix
+            # ``matrix`` maps this representation into the top space, and
+            # ``rep_matrix`` maps the mapped geometry into this one, so the
+            # accumulated transform is M_outer @ M_inner (see #3019). Always
+            # compose, even when ``rep_matrix`` is the identity: skipping the
+            # composition in that case would drop the accumulated ``matrix``
+            # instead of carrying it through unchanged.
+            rep_matrix = matrix.copy() @ rep_matrix
             results.extend(resolve_items(item.MappingSource.MappedRepresentation, rep_matrix))
         else:
             results.append(ResolvedItemDict(matrix=matrix.copy(), item=item))

--- a/src/ifcopenshell-python/test/util/test_representation.py
+++ b/src/ifcopenshell-python/test/util/test_representation.py
@@ -1,0 +1,118 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import numpy as np
+import ifcopenshell.util.representation as subject
+import test.bootstrap
+
+
+def translation_matrix(dx: float, dy: float, dz: float) -> np.ndarray:
+    m = np.eye(4)
+    m[0, 3] = dx
+    m[1, 3] = dy
+    m[2, 3] = dz
+    return m
+
+
+def rotation_z_matrix(degrees: float, dx: float = 0, dy: float = 0, dz: float = 0) -> np.ndarray:
+    theta = np.radians(degrees)
+    m = np.eye(4)
+    m[0, 0] = np.cos(theta)
+    m[0, 1] = -np.sin(theta)
+    m[1, 0] = np.sin(theta)
+    m[1, 1] = np.cos(theta)
+    m[0, 3] = dx
+    m[1, 3] = dy
+    m[2, 3] = dz
+    return m
+
+
+class TestResolveItems(test.bootstrap.IFC4):
+    def add_mapped_item(self, mapped_representation, matrix: np.ndarray):
+        target = self.file.createIfcCartesianTransformationOperator3D(
+            Axis1=self.file.createIfcDirection(tuple(matrix[:3, 0].tolist())),
+            Axis2=self.file.createIfcDirection(tuple(matrix[:3, 1].tolist())),
+            LocalOrigin=self.file.createIfcCartesianPoint(tuple(matrix[:3, 3].tolist())),
+            Scale=1.0,
+            Axis3=self.file.createIfcDirection(tuple(matrix[:3, 2].tolist())),
+        )
+        source = self.file.createIfcRepresentationMap(
+            MappingOrigin=self.file.createIfcAxis2Placement3D(
+                Location=self.file.createIfcCartesianPoint((0.0, 0.0, 0.0))
+            ),
+            MappedRepresentation=mapped_representation,
+        )
+        return self.file.createIfcMappedItem(MappingSource=source, MappingTarget=target)
+
+    def wrap(self, mapped_representation, matrix: np.ndarray):
+        item = self.add_mapped_item(mapped_representation, matrix)
+        return self.file.createIfcShapeRepresentation(RepresentationType="MappedRepresentation", Items=[item])
+
+    def test_outer_translation_is_not_dropped_when_the_inner_mapped_item_is_identity(self):
+        # See #3019: when the inner IfcMappedItem's own transform happens to
+        # be the identity, the accumulated outer transform must still be
+        # carried through, not discarded.
+        innermost = self.file.createIfcShapeRepresentation(Items=[self.file.createIfcExtrudedAreaSolid()])
+        inner = self.wrap(innermost, np.eye(4))
+        outer_matrix = translation_matrix(10, 20, 30)
+        outer = self.wrap(inner, outer_matrix)
+
+        results = subject.resolve_items(outer)
+
+        assert len(results) == 1
+        assert np.allclose(results[0]["matrix"], outer_matrix)
+
+    def test_inner_translation_is_kept_when_the_outer_mapped_item_is_identity(self):
+        innermost = self.file.createIfcShapeRepresentation(Items=[self.file.createIfcExtrudedAreaSolid()])
+        inner_matrix = translation_matrix(5, 6, 7)
+        inner = self.wrap(innermost, inner_matrix)
+        outer = self.wrap(inner, np.eye(4))
+
+        results = subject.resolve_items(outer)
+
+        assert len(results) == 1
+        assert np.allclose(results[0]["matrix"], inner_matrix)
+
+    def test_non_identity_transforms_compose_outer_after_inner(self):
+        innermost = self.file.createIfcShapeRepresentation(Items=[self.file.createIfcExtrudedAreaSolid()])
+        inner_matrix = translation_matrix(10, 0, 0)
+        inner = self.wrap(innermost, inner_matrix)
+        outer_matrix = rotation_z_matrix(90, dx=100)
+        outer = self.wrap(inner, outer_matrix)
+
+        results = subject.resolve_items(outer)
+
+        expected = outer_matrix @ inner_matrix
+        assert len(results) == 1
+        assert np.allclose(results[0]["matrix"], expected)
+
+    def test_three_levels_deep_with_an_identity_middle_item(self):
+        innermost = self.file.createIfcShapeRepresentation(Items=[self.file.createIfcExtrudedAreaSolid()])
+        inner_matrix = translation_matrix(1, 2, 3)
+        inner = self.wrap(innermost, inner_matrix)
+        middle = self.wrap(inner, np.eye(4))
+        outer_matrix = translation_matrix(10, 20, 30)
+        outer = self.wrap(middle, outer_matrix)
+
+        results = subject.resolve_items(outer)
+
+        expected = outer_matrix @ np.eye(4) @ inner_matrix
+        assert len(results) == 1
+        assert np.allclose(results[0]["matrix"], expected)


### PR DESCRIPTION
Fixes #3019.

Two distinct bugs in the same few lines of nested mapped-item transform handling. They are shipped together because they overlap textually, and splitting them would guarantee a conflict.

## Bug 1: composition order

`IfcImporter.is_native` (`src/bonsai/bonsai/bim/import_ifc.py`) walks a chain of single-item mapped representations accumulating `matrix = rep_matrix @ matrix`. For a nested chain that yields `M_inner @ M_outer`, but the correct nesting is `M_outer @ M_inner`: the inner mapping places geometry into the middle representation, the outer places that into the product. A single non-nested mapped item reduces to `M_outer` either way, which is why this only ever showed up "on certain files" (aothms, 2023).

`ifcopenshell/util/representation.py`'s `resolve_items` had the same order bug and is fixed the same way.

**Verified against the geometry engine as ground truth:** a swept disk solid inside an inner mapped item (translate +10 x) inside an outer mapped item (rotate 90 degrees Z, translate +100 y), deliberately non-commuting. The fixed order composes to (0, 110, 0), matching the geometry engine's world bounding box. The old order gives (10, 100, 0), which lands nowhere near it.

## Bug 2: an identity transform discarded the whole parent chain

`resolve_items` only composed the accumulated matrix when the mapped item's own transform was non-identity:

```python
if not np.allclose(rep_matrix, np.eye(4)):
    rep_matrix = matrix.copy() @ rep_matrix
```

When a nested `IfcMappedItem`'s own transform **is** the identity, that guard skipped the composition and passed a bare identity matrix down as the new accumulator, **silently discarding every parent transform above it**.

Measured: outer mapped item translating (10, 20, 30) with an identity inner item returned (0, 0, 0). Three levels deep with an identity middle returned (1, 2, 3) instead of (11, 22, 33). The expected matrices were derived by composing the hand-built transforms directly, not by reading the patched code's output.

The guard was never needed, since `matrix @ eye(4)` is `matrix`, so the fix is to compose unconditionally.

## Correction to an earlier version of this description

A previous version of this text stated that the `resolve_items` change had "no runtime change today" because all callers read only the item. **That is wrong, and the effect is real.**

`Loader.create_native_swept_disk_solid` (`src/bonsai/bonsai/tool/loader.py:1264`) calls `resolve_items`, then at line 1299 does `matrix = item_data["matrix"]` and uses it to transform every vertex of the resulting curve. So both bugs above **misplace native swept disk solid geometry** rather than being latent. Bug 2 needs two or more levels of mapped-item nesting with a trivial inner level, which is plausible in Revit and Tekla style type instantiation chains.

## Tests

Adds `src/ifcopenshell-python/test/util/test_representation.py` with a `TestResolveItems` class covering four nesting combinations plus a three-level chain. There was **no existing test for `resolve_items`**, so nothing enshrined the old behaviour. Both failing cases fail before and pass after; the "outer identity, inner non-identity" case passes either way, since there is no parent transform to lose.

Merge-order note for whoever takes this: two other open PRs, #9013 and #8317, also intend to create `test/util/test_representation.py`. Whichever lands first wins the file, and the others will need their test classes merged in by hand.

Generated with the assistance of an AI coding tool.
