### PR TITLE
Bonsai: round length attributes to model precision on write (#3129)

### DIFF
--- a/src/bonsai/bonsai/bim/prop.py
+++ b/src/bonsai/bonsai/bim/prop.py
@@ -17,10 +17,12 @@
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import math
 import os
 from typing import TYPE_CHECKING, Any, Literal, Union, assert_never, get_args
 
 import bpy
+import ifcopenshell.util.representation
 import ifcopenshell.util.unit
 from bpy.props import (
     BoolProperty,
@@ -260,6 +262,27 @@ def set_length_value(self: "Attribute", value: float) -> None:
     self.float_value = value / si_conversion
 
 
+def get_length_decimal_places(ifc_file: ifcopenshell.file) -> int:
+    """Number of decimal places implied by the model's geometric precision.
+
+    ``IfcGeometricRepresentationContext.Precision`` is a length tolerance
+    expressed in the project's length units. Length attribute values are stored
+    and exported in those same units, so any digits finer than the precision are
+    not meaningful. The number of meaningful decimal places is therefore
+    ``-log10(precision)``.
+
+    This lets us strip the float32 rounding noise that Blender introduces when it
+    stores a length in a single-precision ``FloatProperty`` (e.g. a clean 67.74
+    becomes 67.7399978637695), without discarding any real precision. See #3129.
+    """
+    context = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+    precision = getattr(context, "Precision", None) if context else None
+    if not precision or precision <= 0:
+        # Same default Bonsai uses when it creates a Model context (add_context).
+        precision = 1e-5
+    return max(0, math.ceil(-math.log10(precision)))
+
+
 def get_display_name(self: "Attribute") -> str:
     DISPLAY_UNIT_TYPES = ("AREA", "VOLUME", "FORCE")
     name = self.name
@@ -392,6 +415,14 @@ class Attribute(PropertyGroup):
             value = tool.Blender.get_enum_safe(self, "enum_value")
         else:
             value = getattr(self, value_name, None)
+        if self.special_type == "LENGTH" and isinstance(value, float):
+            # Blender stores floats as single-precision (float32), so a length
+            # that is round in the model's units (e.g. 67.74) comes back with
+            # noise digits (67.7399978637695). Round to the model's geometric
+            # precision so it exports cleanly instead of exposing the artifact.
+            # See #3129.
+            if (ifc_file := tool.Ifc.get()) is not None:
+                value = round(value, get_length_decimal_places(ifc_file))
         if self.special_type == "LOGICAL" and value != "UNKNOWN":
             # IfcOpenShell expects bool if IfcLogical is True/False.
             value = value == "TRUE"


### PR DESCRIPTION
Fixes #3129.

## Problem
Storey `Elevation` (and other length attributes) export with float32 noise: `IFCBUILDINGSTOREY(...,67.7399978637695)` where the value should be `67.74`. It looks wrong and imports poorly in other software.

## Root cause
Bonsai keeps attribute values in a Blender `FloatProperty`, which is single precision (float32). A length that is round in the model's units (e.g. `67.74`) is read back with noise digits (`67.73999786376953`) and, since v0.8.0's serializer prints the shortest round-trip of the stored double (#7696), that noise is written verbatim. Nothing rounds the value back to the model's meaningful precision before export.

## Fix
When `Attribute.get_value` returns a `LENGTH` measure, round it to the decimal places implied by the model's geometric precision (`IfcGeometricRepresentationContext("Model").Precision`, expressed in project length units). A new helper `get_length_decimal_places` returns `ceil(-log10(precision))`, falling back to Bonsai's default `1e-5` when no context/precision is present. Only `LENGTH` floats are rounded; everything else is untouched, and no unit-scale conversion is applied because both the value and `Precision` are in project units.

## Before/after (metre project, Precision 1e-5 → 5 decimals)
```
      true |  float32 (before, exported)  |  after (exported)
     67.74 |            67.73999786376953 |            67.74
   67.7412 |            67.74120330810547 |          67.7412
  12.34567 |           12.345669746398926 |         12.34567
   123.456 |           123.45600128173828 |          123.456
```
The reported garbage exports clean; genuinely precise values are preserved, not truncated.

## Follow-up (Moult's second point)
`ifcopenshell.api.context.add_context` still hardcodes `Precision = 1e-5` regardless of unit; it should be unit-dependent. Left as a separate change since it touches a core API and the whole test suite. This fix already reads the real `Precision` when it's set, so it's forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
