### PR TITLE
Bonsai: don't crash Add Bend on parallel/collinear MEP segments (#3932)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/mep.py
+++ b/src/bonsai/bonsai/bim/module/model/mep.py
@@ -1259,10 +1259,23 @@ class MEPAddBend(bpy.types.Operator, tool.Ifc.Operator):
         }
 
         get_z_basis = lambda o: tool.Cad.get_basis_vector(o, 2)
-        segments_intersection_ws = tool.Cad.intersect_edges(
+        # intersect_edges returns None when the two axes are parallel / collinear
+        # (mathutils.intersect_line_line has no crossing to report). Guard it the
+        # same way compute_bend_preview_polylines does, so a bend on parallel
+        # segments fails with a clear message instead of raising
+        # "'NoneType' object is not subscriptable". See issue #3932.
+        segments_intersection = tool.Cad.intersect_edges(
             (start_object.location, start_object.location + get_z_basis(start_object)),
             (end_object.location, end_object.location + get_z_basis(end_object)),
-        )[0]
+        )
+        if segments_intersection is None:
+            self.report(
+                {"ERROR"},
+                "The two segments are parallel or collinear, so their axes never cross. "
+                "A bend needs two segments that meet at an angle.",
+            )
+            return {"CANCELLED"}
+        segments_intersection_ws = segments_intersection[0]
 
         start_point, first_segment_start = tool.Cad.closest_and_furthest_vectors(
             segments_intersection_ws, (start_segment_data["start_point"], start_segment_data["end_point"])

--- a/src/bonsai/test/bim/module/model/test_mep_bend_preview.py
+++ b/src/bonsai/test/bim/module/model/test_mep_bend_preview.py
@@ -369,3 +369,89 @@ def test_finish_bend_preview_catches_runtime_error_from_dispatch():
     assert "CANCELLED" in result, "RuntimeError from dispatch must be converted to CANCELLED"
     assert fake_props.is_active is True, "failed dispatch must leave preview active for re-tune"
     op_self.report.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# MEPAddBend._execute — parallel/degenerate intersection guard (issue #3932)
+# ---------------------------------------------------------------------------
+
+
+def test_mep_add_bend_cancels_cleanly_when_axes_do_not_cross():
+    """``tool.Cad.intersect_edges`` returns ``None`` when the two segment
+    axes are parallel / collinear (no crossing). Before the guard,
+    ``MEPAddBend._execute`` indexed that ``None`` with ``[0]`` and raised
+    ``TypeError: 'NoneType' object is not subscriptable`` (issue #3932).
+
+    The commit operator must instead report an ERROR and return CANCELLED,
+    matching the None-guard ``compute_bend_preview_polylines`` already uses
+    and the ERROR+CANCELLED contract ``FinishBendPreview`` relies on."""
+    from types import SimpleNamespace
+
+    import ifcopenshell.util.element
+    import ifcopenshell.util.unit
+    from mathutils import Matrix, Vector
+
+    from bonsai import tool
+    from bonsai.bim.module.model import mep as mep_module
+    from bonsai.bim.module.model.mep import MEPAddBend
+
+    class _Stand:
+        editing_bend_id = 0
+        start_segment_id = 101
+        end_segment_id = 102
+        start_length = 0.1
+        end_length = 0.1
+        radius = 0.2
+
+        def __init__(self):
+            self.report = MagicMock()
+
+    # Two parallel segments (both along +Z, offset in X) — identity rotation
+    # so the rotation-difference precheck passes and execution reaches the
+    # axis-intersection step.
+    start_obj = MagicMock(name="start_obj")
+    start_obj.matrix_world = Matrix.Identity(4)
+    start_obj.location = Vector((0, 0, 0))
+    end_obj = MagicMock(name="end_obj")
+    end_obj.matrix_world = Matrix.Identity(4)
+    end_obj.location = Vector((2, 0, 0))
+
+    start_el = MagicMock(name="start_el")
+    end_el = MagicMock(name="end_el")
+    seg_type = MagicMock(name="seg_type")
+
+    circle = MagicMock(name="circle_profile")
+    circle.Radius = 0.05
+    circle.is_a = lambda c: c == "IfcCircleProfileDef"
+
+    def _seg_data(_element):
+        # start_point / end_point must be distinct Vector objects — _execute
+        # keys a ports map by id() of these vectors.
+        return {
+            "start_point": Vector((0, 0, 0)),
+            "end_point": Vector((0, 0, 1)),
+            "start_port": MagicMock(name="start_port"),
+            "end_port": MagicMock(name="end_port"),
+        }
+
+    ifc_file = MagicMock(name="ifc_file")
+    ifc_file.by_id = lambda i: {101: start_el, 102: end_el}[i]
+    objects = {id(start_el): start_obj, id(end_el): end_obj}
+
+    op_self = _Stand()
+    with (
+        patch.object(tool.Ifc, "get", return_value=ifc_file),
+        patch.object(tool.Ifc, "get_object", side_effect=lambda e: objects[id(e)]),
+        patch.object(ifcopenshell.util.unit, "calculate_unit_scale", return_value=1.0),
+        patch.object(ifcopenshell.util.element, "get_type", side_effect=lambda e: seg_type),
+        patch.object(tool.Model, "get_flow_segment_profile", return_value=circle),
+        patch.object(mep_module.MEPGenerator, "get_segment_data", side_effect=_seg_data),
+        patch.object(tool.Cad, "intersect_edges", return_value=None),
+    ):
+        result = MEPAddBend._execute(op_self, MagicMock(name="context"))
+
+    assert result == {"CANCELLED"}, f"parallel axes must cancel, got {result}"
+    op_self.report.assert_called_once()
+    level, message = op_self.report.call_args[0]
+    assert "ERROR" in level
+    assert "parallel" in message.lower()


### PR DESCRIPTION
Fixes #3932 (the crash).

## Problem
Tweaking any prop in the "Add Bend" redo panel raised `TypeError: 'NoneType' object is not subscriptable`. `MEPAddBend._execute` indexed `tool.Cad.intersect_edges(...)[0]` directly, and `intersect_edges` returns `None` for parallel/collinear segment axes (no crossing), so adding a bend on parallel segments crashed instead of being rejected cleanly.

## Fix
Guard the `None` the same way `compute_bend_preview_polylines` already does: report an ERROR and return `CANCELLED` before any IFC mutation, honouring the ERROR+CANCELLED contract `FinishBendPreview` relies on. In the realistic crash path `editing_bend_id` is 0, so the guard returns before any IFC write, no corrupt half-state. Adds a mock-driven regression test that raises the `TypeError` against the old code and passes against the fix.

## Scope
This fixes the crash only. The residual stray-fitting duplication on the legacy direct "Add Bend" redo-panel path (the toolbar button invokes `MEPAddBend` directly rather than routing through the newer preview flow, so a redo-panel tweak can still create a second fitting) is noted in the issue and left for a follow-up, since routing that button through the preview is a workflow change rather than a crash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
