### PR TITLE
Bonsai: import representations that mix polygons and curves (#4606)

### DIFF
--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -1039,12 +1039,20 @@ class Loader(bonsai.core.tool.Loader):
         if verts is None:
             verts = ifcopenshell.util.shape.get_vertices(geometry)
         faces = ifcopenshell.util.shape.get_faces(geometry)
-        if faces.shape[0] > 0:
+        material_style_ids = geometry.material_ids
+        num_faces = faces.shape[0]
+        # A single representation may mix faces/polygons and loose curves (e.g. an Annotation2D
+        # holding both an IfcAnnotationFillArea and an IfcGeometricCurveSet, see #4606). In that
+        # case IfcOpenShell packs material ids as [face materials, loose edge materials] and emits
+        # the loose edges after the face edges, so anything past num_faces belongs to loose edges.
+        num_loose_edges = len(material_style_ids) - num_faces
+        if num_faces > 0:
+            all_edges = ifcopenshell.util.shape.get_edges(geometry)
             # See bug 3546
             # ios_edges holds true edges that aren't triangulated.
             #
             # we do `.tolist()` because Blender can't assign `np.int32` to it's custom attributes
-            mesh["ios_edges"] = list(set(tuple(e) for e in ifcopenshell.util.shape.get_edges(geometry).tolist()))
+            mesh["ios_edges"] = list(set(tuple(e) for e in all_edges.tolist()))
             ios_item_ids = ifcopenshell.util.shape.get_faces_representation_item_ids(geometry).tolist()
             mesh["ios_item_ids"] = ios_item_ids
 
@@ -1059,7 +1067,24 @@ class Loader(bonsai.core.tool.Loader):
                     tool.Loader.load_indexed_colour_map(rep, mesh)
 
             tool.Blender.Attribute.fill_attribute(mesh, "ios_item_ids", "FACE", "INT", ios_item_ids)
-            tool.Blender.Attribute.fill_attribute(mesh, "ios_material_ids", "FACE", "INT", geometry.material_ids)
+            # Only the first num_faces material ids belong to the faces (the rest, if any, are for
+            # loose edges), so slice to keep the FACE attribute the right length (#4606).
+            tool.Blender.Attribute.fill_attribute(mesh, "ios_material_ids", "FACE", "INT", material_style_ids[:num_faces])
+
+            if num_loose_edges > 0:
+                # Mixed representation: also import the loose curve edges so both the curves and the
+                # filled area end up in the same object (#4606). The loose edges are the last ones.
+                loose_edges = all_edges[-num_loose_edges:]
+                bm = bmesh.new()
+                bm.from_mesh(mesh)
+                bm.verts.ensure_lookup_table()
+                for v1, v2 in loose_edges.tolist():
+                    try:
+                        bm.edges.new((bm.verts[v1], bm.verts[v2]))
+                    except ValueError:
+                        pass  # Edge already exists (shared with a face).
+                bm.to_mesh(mesh)
+                bm.free()
         else:
             edges = ifcopenshell.util.shape.get_edges(geometry)
             mesh.from_pydata(verts.tolist(), edges.tolist(), [])


### PR DESCRIPTION
Fixes #4606.

## Problem
A single representation can hold both faces/polygons and loose curves (e.g. an `Annotation2D` with an `IfcAnnotationFillArea` plus an `IfcGeometricCurveSet`). Activating such a representation crashed:
```
RuntimeError: internal error setting the array   (fill_attribute, FACE)
  -> create_mesh returns None
AttributeError: 'NoneType' object has no attribute 'BIMMeshProperties'
```

## Root cause
IfcOpenShell returns mixed geometry as faces + loose edges and packs `material_ids` as `[face materials, loose-edge materials]`. `convert_geometry_to_mesh` assumed a representation was either all faces or all edges, so it fed the full material-id array (2 face + 36 loose = 38) into the per-face `ios_material_ids` attribute of a 2-face mesh, raising `internal error setting the array`. `create_mesh` swallowed it and returned `None`, hence the `NoneType ... BIMMeshProperties` crash. The curves were also dropped.

## Fix
Slice `material_ids` to the face count for the FACE attribute, and when there are loose edges, add them to the mesh via bmesh. Normal geometry (all-face or all-edge) is unaffected: `num_loose_edges` is 0 and the slice is a no-op.

## Verification (headless Blender 5.1.2)
- Ground truth (`ifcopenshell.geom`): the representation is 2 faces + 40 edges.
- Before: `RuntimeError` → `AttributeError` crash.
- After: imports as 2 faces + 36 loose curve edges (the 32-segment circle + 4-segment square), no crash.
- Regression: a normal tessellated cube imports unchanged (12 faces, 8 verts).

## Scope
Delivers what the issue asks: no crash, and both the fill area and the curves import into the one object. Per-item (item-mode) editing of the individual curve items inside a mixed representation is a separate enhancement, not wired up here; that path degrades gracefully (guarded downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
