### PR TITLE
Bonsai: auto-create Model/Body context on drawing creation for external IFCs (#3217)

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -706,7 +706,22 @@ class Drawing(bonsai.core.tool.Drawing):
 
     @classmethod
     def get_body_context(cls) -> ifcopenshell.entity_instance:
-        return ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
+        ifc_file = tool.Ifc.get()
+        context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
+        if context is None:
+            # Externally authored IFCs may not include the standard Model/Body
+            # context Bonsai relies on. Create it on demand instead of crashing.
+            parent = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+            if parent is None:
+                parent = ifcopenshell.api.context.add_context(ifc_file, context_type="Model")
+            context = ifcopenshell.api.context.add_context(
+                ifc_file,
+                context_type="Model",
+                context_identifier="Body",
+                target_view="MODEL_VIEW",
+                parent=parent,
+            )
+        return context
 
     @classmethod
     def get_document_uri(


### PR DESCRIPTION
Fixes #3217.

## Problem
Creating a Drawing on an externally authored IFC that lacks the standard `Model`/`Body` `IfcGeometricRepresentationSubContext` crashed:
```
AttributeError: 'NoneType' object has no attribute 'ContextType'
```
in `ifcopenshell.api.geometry.add_representation`.

## Root cause
`tool.Drawing.get_body_context()` returned `ifcopenshell.util.representation.get_context(f, "Model", "Body", "MODEL_VIEW")`, which is `None` when that subcontext is absent, and that `None` was passed straight into `add_representation` as the representation context.

## Fix
`get_body_context()` now creates the `Model` context and `Body` subcontext on demand when they're missing (via `ifcopenshell.api.context.add_context`), matching what a user previously had to add by hand and what the reporter and @theoryshaw requested. Idempotent: repeated calls return the same context, no duplicates.

## Verification
A minimal IFC with no representation contexts crashes before the change; after it, the `Model` + `Body` contexts are auto-created and drawing/representation creation proceeds. The same latent pattern exists in `get_annotation_context()` (not on this crash path); left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
