### PR TITLE
Bonsai: sync storey placement on Load Spatial Structure + stop re-import resetting elevations to 0 (#4048, #8545)

### DIFF
--- a/src/bonsai/bonsai/bim/module/spatial/prop.py
+++ b/src/bonsai/bonsai/bim/module/spatial/prop.py
@@ -78,7 +78,9 @@ def update_elevation(self: "BIMContainer", context: bpy.types.Context) -> None:
             elevation = float(self.elevation)
         except Exception as e:
             print(f"Elevation parsing failed for '{self.elevation}': {e}")
-            elevation = 0
+            # Don't silently move the storey to Z=0 on unparseable input — leave the
+            # existing placement untouched instead of corrupting it. See #8545.
+            return
 
     # Update the object's position in the 3D scene
     if ifc_definition_id := self.ifc_definition_id:

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -522,8 +522,26 @@ class Spatial(bonsai.core.tool.Spatial):
         previous_container_index = props.active_container_index
         props.containers.clear()
         cls.contracted_containers = json.loads(props.contracted_containers)
+        cls.sync_moved_spatial_placements()
         cls.import_spatial_element(tool.Ifc.get().by_type("IfcProject")[0], 0)
         props.active_container_index = tool.Blender.get_valid_uilist_index(previous_container_index, props.containers)
+
+    @classmethod
+    def sync_moved_spatial_placements(cls) -> None:
+        """Write back any spatial element whose Blender object was moved but not yet
+        committed to IFC, so the container manager shows its current placement.
+
+        Elevations displayed here come from ``get_storey_elevation``, which reads the
+        element's ``ObjectPlacement``. Dragging a storey empty along Z updates the
+        Blender object but not the IFC placement until a sync point (e.g. project
+        save) runs, so the manager would otherwise show a stale elevation. This
+        mirrors the placement sync that runs on save, scoped to spatial elements."""
+        ifc_file = tool.Ifc.get()
+        spatial_class = "IfcSpatialStructureElement" if ifc_file.schema == "IFC2X3" else "IfcSpatialElement"
+        for element in ifc_file.by_type(spatial_class):
+            obj = tool.Ifc.get_object(element)
+            if isinstance(obj, bpy.types.Object):
+                tool.Geometry.commit_placement_if_moved(obj)
 
     @classmethod
     def import_spatial_element(cls, element: ifcopenshell.entity_instance, level_index: int) -> None:

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -552,12 +552,16 @@ class Spatial(bonsai.core.tool.Spatial):
         new.ifc_class = element.is_a()
         new["name"] = element.Name or "Unnamed"
         new.description = element.Description or ""
-        new.long_name = element.LongName or ""
+        # Assign via subscript so the update callbacks don't fire on this programmatic
+        # import. update_long_name and update_elevation write back to IFC, and
+        # update_elevation in particular re-moves the storey placement on every rebuild
+        # (which can collapse every storey to Z=0 on a parse failure). See #8545.
+        new["long_name"] = element.LongName or ""
         if not element.is_a("IfcProject"):
             elevation = ifcopenshell.util.placement.get_storey_elevation(element)
             unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
             elevation_in_meters = elevation * unit_scale
-            new.elevation = tool.Unit.format_distance(elevation_in_meters)
+            new["elevation"] = tool.Unit.format_distance(elevation_in_meters)
         new.is_expanded = element.id() not in cls.contracted_containers
         new.level_index = level_index
         children = ifcopenshell.util.element.get_parts(element)


### PR DESCRIPTION
This PR bundles two closely-related fixes in the spatial decomposition (container manager) subsystem.

## 1. Sync moved storey placement on Load Spatial Structure (#4048)

Dragging a storey empty along Z updates the Blender object but not the IFC placement until a sync point (e.g. project save) runs, so the container manager would show a stale elevation. `import_spatial_decomposition` now commits any moved-but-uncommitted spatial placement to IFC before reading elevations for display, mirroring the placement sync that runs on save (scoped to spatial elements).

## 2. Stop spatial re-import from resetting storey elevations to 0 (#8545)

`BIMContainer.elevation` is a `StringProperty` whose `update=update_elevation` callback **writes back to the IFC placement** (`obj.matrix_world[2][3] = elevation` + `edit_object_placement`). `import_spatial_element` assigned `new.elevation` / `new.long_name` by attribute, which **fires those callbacks on every programmatic rebuild** — and `import_spatial_decomposition` runs constantly (after editing attributes, geometry edits, aggregate changes, expand/contract, project load, …).

Consequences on each rebuild:

- Every storey's elevation is round-tripped `format_distance → string → parse_distance_string → back into IFC`, introducing 1/256" drift.
- On a parse failure, `update_elevation` fell into its fallback branch and wrote `0`, moving **every** storey to `Z = 0` in a single pass. This is intermittent because `format_distance` picks its unit system from the IFC project unit while `parse_distance_string` picks its grammar from the Blender scene unit; when those diverge the parse can fail.

Fixes:

- Assign `long_name` / `elevation` via subscript (`new["..."]`) during import — matching the existing `new["name"]` idiom — so the callbacks only fire on genuine UI edits, not on programmatic rebuilds.
- `update_elevation` now leaves the existing placement untouched on unparseable input instead of silently zeroing it.

Fixes #4048
Fixes #8545
