### PR TITLE
Bonsai: relaunch the clipping-plane refresh modal after a .blend reload (#4641)

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/decorator.py
+++ b/src/bonsai/bonsai/bim/module/project/decorator.py
@@ -33,6 +33,7 @@ def toggle_decorations_on_load(*args):
     props = tool.Project.get_project_props()
     if props.clipping_planes:
         ClippingPlaneDecorator.install(bpy.context)
+        restart_clipping_planes_refresh()
     else:
         ClippingPlaneDecorator.uninstall()
 
@@ -40,6 +41,42 @@ def toggle_decorations_on_load(*args):
     # since selected_vertices and other data is stored in queried object's
     # custom attributes and they get purged after Blender session is closed
     # as queried object is linked from separate .blend file.
+
+
+def restart_clipping_planes_refresh() -> None:
+    """Restart the modal that keeps the viewport clip planes in sync.
+
+    See #4641. Clip planes are applied to the viewport by the modal
+    ``bim.refresh_clipping_planes`` operator. Modal operators do not survive a
+    ``.blend`` reload, so after reopening a saved file the clip is "stuck": the
+    model stays clipped by the last-applied planes (that viewport state is saved
+    in the .blend) but moving a plane no longer updates the view, until the user
+    creates a new clipping plane which relaunches the modal. Relaunch it here so
+    a saved clip works again on reopen without recreating a plane.
+
+    The operator is launched from a timer (not directly in the load_post
+    handler) because a modal operator needs a running event loop with a valid
+    window, which is not guaranteed inside a load_post handler.
+    """
+    if bpy.app.background:
+        return
+
+    def _launch() -> None:
+        if not tool.Project.get_project_props().clipping_planes:
+            return None
+        wm = bpy.context.window_manager
+        if not wm or not wm.windows:
+            return None
+        # The modal's refresh needs a 3D viewport to apply the clip planes.
+        if not any(a.type == "VIEW_3D" for w in wm.windows for a in w.screen.areas):
+            return None
+        try:
+            bpy.ops.bim.refresh_clipping_planes("INVOKE_DEFAULT")
+        except RuntimeError:
+            pass
+        return None
+
+    bpy.app.timers.register(_launch, first_interval=0.1)
 
 
 class ProjectDecorator:


### PR DESCRIPTION
Addresses #4641.

> Note: the diagnosis below is verified by code inspection and runtime introspection, but the fix itself could **not** be verified in an automated/headless harness, it needs a modal operator plus a real 3D viewport plus a `.blend` save/reopen round-trip. It should be confirmed in GUI Blender before merge (create a clipping plane, save the `.blend`, quit, reopen: the clip should be live without recreating the plane).

## Root cause
Viewport clipping is driven by the modal operator `bim.refresh_clipping_planes`, which keeps `RegionView3D.clip_planes` / `use_clip_planes` in sync with the plane objects. Modal operators do not survive a `.blend` reload. On reopen:
1. `props.clipping_planes` and the plane objects are restored from the blend.
2. `RegionView3D.clip_planes` + `use_clip_planes` are also saved viewport state, so the model still renders clipped by the last-applied planes → looks "stuck / not updated".
3. The `RefreshClippingPlanes` modal is gone, so nothing re-syncs when a plane moves.
4. Creating a new plane calls `refresh_clipping_planes` again → the modal restarts → clipping is live again. This matches the report exactly.

This is not specific to IFC2X3 or linked IFCs; those are incidental (with linked models the `.blend` is the file you reopen, so you land in this state).

## Fix
In the `load_post` handler `toggle_decorations_on_load` (`project/decorator.py`) that already re-installs the clipping-plane decorator, also relaunch the refresh modal when saved clipping planes exist, via `bpy.app.timers` (guarded for background sessions and requiring a VIEW_3D area, since a modal can't be started directly inside a load_post handler). No effect when no clipping planes exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
