### PR TITLE
Bonsai: fix DXF export dropping/scrambling polylines with integer or scientific coordinates (#4703)

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2866,50 +2866,60 @@ class Drawing(bonsai.core.tool.Drawing):
         def finalize_dxf():
             doc.saveas(dxf_filepath)
 
-        drawing = svg.findall(f"{SVG}g[@{IFC}name]")
-        if not drawing:
+        drawings = svg.findall(f"{SVG}g[@{IFC}name]")
+        if not drawings:
             finalize_dxf()
             return
-        drawing = drawing[0]
 
-        NUMBER = r"-?\d+\.?\d+"
+        # A full SVG number: optional sign, integer and/or fractional part, optional
+        # scientific-notation exponent. The IfcOpenShell SVG serializer prints coordinates
+        # with std::setprecision(max_digits10) and default float formatting, so a coordinate
+        # can be a bare integer ("5"), a long float ("199.99999999999997"), or scientific
+        # notation for near-zero values ("1.5e-13"). The previous pattern (-?\d+\.?\d+) failed
+        # on single-digit integers and split scientific values into two tokens, silently
+        # dropping or scrambling whole polylines, which shows up as misplaced/missing geometry
+        # in the exported DXF. See #4703.
+        NUMBER = r"[-+]?(?:\d*\.\d+|\d+\.?\d*)(?:[eE][-+]?\d+)?"
         COORD = rf"{NUMBER},{NUMBER}"
         POLYLINE_PATTERN = rf"M{COORD} (?:L{COORD} ?)+Z? ?"
         MULTI_POLYLINE_PATTERN = rf"^({POLYLINE_PATTERN})+$"
 
-        for element_g in drawing.findall(f"{SVG}g"):
-            paths = element_g.findall(f"{SVG}path")
+        # A drawing SVG may contain more than one named group (e.g. a section that cuts
+        # through several storeys). Export all of them, not just the first.
+        for drawing in drawings:
+            for element_g in drawing.findall(f"{SVG}g"):
+                paths = element_g.findall(f"{SVG}path")
 
-            for path in paths:
-                # For some reason `<path/>` without "d" attribute can occur too. See #6871.
-                # It's unclear whether this issue is still present with the updated ifcopenshell core,
-                # but adding this fix for now. Could be reveted later.
-                if "d" not in path.attrib:
-                    continue
-                path = path.attrib["d"]
+                for path in paths:
+                    # For some reason `<path/>` without "d" attribute can occur too. See #6871.
+                    # It's unclear whether this issue is still present with the updated ifcopenshell core,
+                    # but adding this fix for now. Could be reveted later.
+                    if "d" not in path.attrib:
+                        continue
+                    path = path.attrib["d"]
 
-                if not re.match(MULTI_POLYLINE_PATTERN, path):
-                    # print(f'Path "{path}" doesn\'t match expected pattern {MULTI_POLYLINE_PATTERN}')
-                    continue
+                    if not re.match(MULTI_POLYLINE_PATTERN, path):
+                        # print(f'Path "{path}" doesn\'t match expected pattern {MULTI_POLYLINE_PATTERN}')
+                        continue
 
-                for polyline_path in re.findall(POLYLINE_PATTERN, path):
-                    points = re.findall(rf"{NUMBER}", polyline_path)
-                    points = [float(p) for p in points]
-                    POINT_SIZE = 2
+                    for polyline_path in re.findall(POLYLINE_PATTERN, path):
+                        points = re.findall(rf"{NUMBER}", polyline_path)
+                        points = [float(p) for p in points]
+                        POINT_SIZE = 2
 
-                    grouped_points = []
-                    for i in range(0, len(points), POINT_SIZE):
-                        point = points[i : i + POINT_SIZE]
-                        point[1] *= -1
-                        grouped_points.append(point)
-                    points = grouped_points
+                        grouped_points = []
+                        for i in range(0, len(points), POINT_SIZE):
+                            point = points[i : i + POINT_SIZE]
+                            point[1] *= -1
+                            grouped_points.append(point)
+                        points = grouped_points
 
-                    # Z marks closed polylines
-                    is_closed_polyline = polyline_path.rstrip().endswith("Z")
-                    if is_closed_polyline or len(points) > 2:
-                        msp.add_lwpolyline(points, close=is_closed_polyline)
-                    else:  # LINE
-                        msp.add_line(*points)
+                        # Z marks closed polylines
+                        is_closed_polyline = polyline_path.rstrip().endswith("Z")
+                        if is_closed_polyline or len(points) > 2:
+                            msp.add_lwpolyline(points, close=is_closed_polyline)
+                        else:  # LINE
+                            msp.add_line(*points)
 
         finalize_dxf()
 


### PR DESCRIPTION
Fixes #4703.

`convert_svg_to_dxf` parsed path coordinates with `-?\d+\.?\d+`, which fails on single-digit integers and splits scientific-notation values into two tokens. Since the IfcOpenShell SVG serializer prints doubles with `setprecision(max_digits10)` + default formatting, both forms occur in real drawings (a vertex exactly on an integer millimetre, a near-zero value like `1.5e-13`), so whole polylines were silently dropped or their points scrambled in the exported DXF, which reads as "misplaced" in a CAD app while a generic converter (the reporter's exdxf) looked fine.

Replaced with a full SVG-number regex (sign, integer/fraction, optional exponent) and made the exporter iterate every named drawing group instead of only the first (a section can cut several storeys; the old `[0]` dropped the rest).

Verified: clean-decimal and 17-digit-float paths tokenize identically (no regression); a rectangle with a scientific-notation edge and one with a single-digit-integer edge, previously dropped entirely, now export at correct, Y-flipped positions matching the SVG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
