### PR TITLE
Bonsai: give Create Element and Annotation tools stable toolbar-popup shortcuts (#4694)

### DIFF
--- a/src/bonsai/bonsai/bim/__init__.py
+++ b/src/bonsai/bonsai/bim/__init__.py
@@ -300,6 +300,22 @@ def register():
         kmi = km.keymap_items.new("bim.switch_tab", "TAB", "PRESS", ctrl=True)
         addon_keymaps.append((km, kmi))
 
+        # Give the "Create Element" and "Annotation" workspace tools their own stable
+        # activation keys in the toolbar popup (Shift+Space). Without an explicit key,
+        # Blender assigns these tools number keys based on their position in the toolbar,
+        # and that position moves as the active tool changes. The same key then flip-flops
+        # between the two tools, making the shortcuts unpredictable (see #4694). This mirrors
+        # Blender's own "Toolbar Popup" keymap, where builtin tools get fixed letters.
+        km = wm.keyconfigs.addon.keymaps.new(
+            name="Toolbar Popup", space_type="EMPTY", region_type="TEMPORARY"
+        )
+        kmi = km.keymap_items.new("wm.tool_set_by_id", "C", "PRESS")
+        kmi.properties.name = "bim.bim_tool"
+        addon_keymaps.append((km, kmi))
+        kmi = km.keymap_items.new("wm.tool_set_by_id", "A", "PRESS")
+        kmi.properties.name = "bim.annotation_tool"
+        addon_keymaps.append((km, kmi))
+
     global icons
 
     icons_dir = os.path.join(cwd, "data", "icons")


### PR DESCRIPTION
Fixes #4694.

"Create Element" (`bim.bim_tool`) and "Annotation" (`bim.annotation_tool`) had no explicit activation shortcut. Blender's toolbar popup then auto-assigned them number keys based on toolbar position, and since that position moves as the active tool changes, the same key flip-flopped between the two tools, which is the unpredictable behaviour reported.

This registers a "Toolbar Popup" keymap giving each tool a stable, distinct key (`C` for Create Element, `A` for Annotation), mirroring Blender's own default popup keymap for builtin tools (cursor→`SPACE`, select→`W`, transform→`T`, measure→`M`; `C`/`A` are free). Popup-only (`TEMPORARY`), so no new global viewport shortcut and no clash; cleaned up via the existing `addon_keymaps` unregister loop.

Verified in Blender 5.1.2: before the change a one-slot toolbar reflow moves `bim.bim_tool` onto `bim.annotation_tool`'s former key; after it, each tool keeps a stable, distinct accelerator that survives the reflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
