### PR TITLE
Bonsai: apply the drawing Include filter to IfcSpace elements (#4785)

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2390,7 +2390,22 @@ class Drawing(bonsai.core.tool.Drawing):
         elements = cls.get_elements_in_camera_view(
             tool.Ifc.get_object(drawing), [tool.Ifc.get_object(e) for e in ifc_file.by_type("IfcSpace")]
         )
-        # NOTE: EPset_Drawing.Include is not used to avoid adding other elements besides spaces
+        # Apply the Include filter to spaces so they honour EPset_Drawing.Include
+        # like every other element (see #4785). Intersecting only ever narrows the
+        # space set, so it cannot pull in non-space elements.
+        include = pset.get("Include", None)
+        if include:
+            try:
+                data = json.loads(include)
+                if isinstance(data, dict) and "filter_structure" in data:
+                    include_elements = tool.Search.execute_filter_groups_from_json(data, ifc_file)
+                elif isinstance(data, dict) and "query" in data:
+                    include_elements = ifcopenshell.util.selector.filter_elements(ifc_file, data["query"])
+                else:
+                    include_elements = ifcopenshell.util.selector.filter_elements(ifc_file, include)
+            except (json.JSONDecodeError, ValueError):
+                include_elements = ifcopenshell.util.selector.filter_elements(ifc_file, include)
+            elements &= include_elements
         exclude = pset.get("Exclude", None)
         if exclude:
             try:


### PR DESCRIPTION
Fixes #4785.

`IfcSpace` elements ignored the drawing's `EPset_Drawing.Include` filter. Spaces are selected in `Drawing.get_drawing_spaces()` (used by both SVG generation and viewport activation), which collected every space in the camera view and applied only `Exclude`, skipping `Include` entirely (there was even a comment saying Include was skipped on purpose).

This applies the `Include` filter to spaces too, reusing the same query parsing as `get_drawing_elements` (filter_structure / query dict / plain query string). Intersecting the in-view spaces with the Include results only narrows the set, so no non-space elements can be introduced.

Behaviour: with no `Include`, spaces are unchanged; with an `Include` naming spaces, only matching spaces appear; with an `Include` naming only non-space classes, spaces are correctly dropped. `Exclude` is unchanged and composes with `Include`.

Scope: spaces only. `IfcAnnotation` (also mentioned in the issue) is left as-is because a drawing's own annotations are added deliberately and unconditionally; making them honour `Include` would hide them in normal use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
