### PR TITLE
Bonsai: fail gracefully when the sheet PDF/DXF conversion command is missing or fails (#4822)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -22,7 +22,6 @@ import logging
 import multiprocessing
 import os
 import shutil
-import subprocess
 import time
 from math import radians
 from pathlib import Path
@@ -981,7 +980,9 @@ class CreateDrawing(bpy.types.Operator):
             # Specifically for PLAN_VIEW and REFLECTED_PLAN_VIEW, any Plan context is also prioritised.
             contexts = self.get_linework_contexts(ifc, target_view)
             self.serialize_contexts_elements(ifc, tree, contexts, "body", drawing_elements, target_view, link_matrix)
-            self.serialize_contexts_elements(ifc, tree, contexts, "annotation", drawing_elements, target_view, link_matrix)
+            self.serialize_contexts_elements(
+                ifc, tree, contexts, "annotation", drawing_elements, target_view, link_matrix
+            )
 
             if tool.Ifc.get() == ifc and self.camera_element not in drawing_elements:
                 with profile("Camera element"):
@@ -2081,48 +2082,6 @@ class CreateSheets(bpy.types.Operator, tool.Ifc.Operator):
             self.open_viewer = True
         return self.execute(context)
 
-    def run_conversion_commands(
-        self, command_json: str, replacements: dict[str, str], setting_name: str
-    ) -> bool:
-        """Run the user-configured SVG conversion commands.
-
-        Returns True on success. On a misconfigured command (bad JSON, missing
-        program, or non-zero exit code) it reports a clear, actionable error that
-        names the failing command and the Bonsai preference to fix, and returns
-        False instead of letting a raw traceback surface. See issue #4822.
-        """
-        try:
-            commands = json.loads(command_json)
-        except json.JSONDecodeError as e:
-            self.report(
-                {"ERROR"},
-                f'The "{setting_name}" Bonsai preference is not valid JSON ({e}). '
-                'It should look like [["inkscape", "svg", "-o", "pdf"]].',
-            )
-            return False
-        for command in commands:
-            command[0] = shutil.which(command[0]) or command[0]
-            try:
-                subprocess.run([replacements.get(c, c) for c in command], check=True)
-            except FileNotFoundError:
-                self.report(
-                    {"ERROR"},
-                    f'Could not run "{command[0]}" set in the "{setting_name}" Bonsai preference. '
-                    "The program was not found. Check that it is installed and on your PATH "
-                    '(on Windows you may need "inkscape.exe" instead of "inkscape"), '
-                    "then update the command in the Bonsai add-on preferences.",
-                )
-                return False
-            except subprocess.CalledProcessError as e:
-                self.report(
-                    {"ERROR"},
-                    f'The command "{command[0]}" set in the "{setting_name}" Bonsai preference '
-                    f"failed with exit code {e.returncode}. See the system console for details, "
-                    "then check the command in the Bonsai add-on preferences.",
-                )
-                return False
-        return True
-
     def _execute(self, context):
         scene = context.scene
         props = tool.Drawing.get_document_props()
@@ -2188,13 +2147,19 @@ class CreateSheets(bpy.types.Operator, tool.Ifc.Operator):
             if svg2pdf_command:
                 # With great power comes great responsibility. Example:
                 # [["inkscape", "svg", "-o", "pdf"]]
-                if not self.run_conversion_commands(svg2pdf_command, replacements, "svg2pdf_command"):
+                try:
+                    core.run_conversion_command(tool.Drawing, svg2pdf_command, replacements, "svg2pdf_command")
+                except core.ConversionCommandError as e:
+                    self.report({"ERROR"}, str(e))
                     return {"CANCELLED"}
 
             if svg2dxf_command:
                 # With great power comes great responsibility. Example:
                 # [["inkscape", "svg", "-o", "eps"], ["pstoedit", "-dt", "-f", "dxf:-polyaslines -mm", "eps", "dxf", "-psarg", "-dNOSAFER"]]
-                if not self.run_conversion_commands(svg2dxf_command, replacements, "svg2dxf_command"):
+                try:
+                    core.run_conversion_command(tool.Drawing, svg2dxf_command, replacements, "svg2dxf_command")
+                except core.ConversionCommandError as e:
+                    self.report({"ERROR"}, str(e))
                     return {"CANCELLED"}
 
             if self.open_viewer:

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2081,6 +2081,48 @@ class CreateSheets(bpy.types.Operator, tool.Ifc.Operator):
             self.open_viewer = True
         return self.execute(context)
 
+    def run_conversion_commands(
+        self, command_json: str, replacements: dict[str, str], setting_name: str
+    ) -> bool:
+        """Run the user-configured SVG conversion commands.
+
+        Returns True on success. On a misconfigured command (bad JSON, missing
+        program, or non-zero exit code) it reports a clear, actionable error that
+        names the failing command and the Bonsai preference to fix, and returns
+        False instead of letting a raw traceback surface. See issue #4822.
+        """
+        try:
+            commands = json.loads(command_json)
+        except json.JSONDecodeError as e:
+            self.report(
+                {"ERROR"},
+                f'The "{setting_name}" Bonsai preference is not valid JSON ({e}). '
+                'It should look like [["inkscape", "svg", "-o", "pdf"]].',
+            )
+            return False
+        for command in commands:
+            command[0] = shutil.which(command[0]) or command[0]
+            try:
+                subprocess.run([replacements.get(c, c) for c in command], check=True)
+            except FileNotFoundError:
+                self.report(
+                    {"ERROR"},
+                    f'Could not run "{command[0]}" set in the "{setting_name}" Bonsai preference. '
+                    "The program was not found. Check that it is installed and on your PATH "
+                    '(on Windows you may need "inkscape.exe" instead of "inkscape"), '
+                    "then update the command in the Bonsai add-on preferences.",
+                )
+                return False
+            except subprocess.CalledProcessError as e:
+                self.report(
+                    {"ERROR"},
+                    f'The command "{command[0]}" set in the "{setting_name}" Bonsai preference '
+                    f"failed with exit code {e.returncode}. See the system console for details, "
+                    "then check the command in the Bonsai add-on preferences.",
+                )
+                return False
+        return True
+
     def _execute(self, context):
         scene = context.scene
         props = tool.Drawing.get_document_props()
@@ -2146,17 +2188,14 @@ class CreateSheets(bpy.types.Operator, tool.Ifc.Operator):
             if svg2pdf_command:
                 # With great power comes great responsibility. Example:
                 # [["inkscape", "svg", "-o", "pdf"]]
-                commands = json.loads(svg2pdf_command)
-                for command in commands:
-                    subprocess.run([replacements.get(c, c) for c in command])
+                if not self.run_conversion_commands(svg2pdf_command, replacements, "svg2pdf_command"):
+                    return {"CANCELLED"}
 
             if svg2dxf_command:
                 # With great power comes great responsibility. Example:
                 # [["inkscape", "svg", "-o", "eps"], ["pstoedit", "-dt", "-f", "dxf:-polyaslines -mm", "eps", "dxf", "-psarg", "-dNOSAFER"]]
-                commands = json.loads(svg2dxf_command)
-                for command in commands:
-                    command[0] = shutil.which(command[0]) or command[0]
-                    subprocess.run([replacements.get(c, c) for c in command])
+                if not self.run_conversion_commands(svg2dxf_command, replacements, "svg2dxf_command"):
+                    return {"CANCELLED"}
 
             if self.open_viewer:
                 if svg2pdf_command:

--- a/src/bonsai/bonsai/core/drawing.py
+++ b/src/bonsai/bonsai/core/drawing.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
@@ -302,23 +304,25 @@ def add_drawing(
         context=drawing.get_body_context(),
         ifc_representation_class=None,
     )
-    
+
     drawings_parent_group = None
     for group in ifc.get().by_type("IfcGroup"):
         if group.Name == "DRAWINGS" and group.ObjectType == "DRAWINGS":
             drawings_parent_group = group
             break
-    
+
     if not drawings_parent_group:
         drawings_parent_group = ifc.run("group.add_group")
-        ifc.run("group.edit_group", group=drawings_parent_group, attributes={"Name": "DRAWINGS", "ObjectType": "DRAWINGS"})
-    
+        ifc.run(
+            "group.edit_group", group=drawings_parent_group, attributes={"Name": "DRAWINGS", "ObjectType": "DRAWINGS"}
+        )
+
     group = ifc.run("group.add_group")
     ifc.run("group.edit_group", group=group, attributes={"Name": drawing_name, "ObjectType": "DRAWING"})
     ifc.run("group.assign_group", group=group, products=[element])
-    
+
     ifc.run("group.assign_group", group=drawings_parent_group, products=[group])
-    
+
     collector.assign(camera)
     pset = ifc.run("pset.add_pset", product=element, name="EPset_Drawing")
     if drawing.get_unit_system() == "METRIC":
@@ -355,7 +359,7 @@ def add_drawing(
         if document.Name == "DRAWINGS" and document.Scope == "DRAWINGS":
             drawings_parent_document = document
             break
-    
+
     if not drawings_parent_document:
         drawings_parent_document = ifc.run("document.add_information")
         if ifc.get_schema() == "IFC2X3":
@@ -363,7 +367,7 @@ def add_drawing(
         else:
             attributes = {"Identification": "DRAWINGS", "Name": "DRAWINGS", "Scope": "DRAWINGS"}
         ifc.run("document.edit_information", information=drawings_parent_document, attributes=attributes)
-    
+
     information = ifc.run("document.add_information", parent=drawings_parent_document)
     uri = drawing.get_default_drawing_path(drawing_name)
     reference = ifc.run("document.add_reference", information=information)
@@ -392,17 +396,19 @@ def duplicate_drawing(
     drawing_tool.set_name(new_drawing, drawing_name)
     group = drawing_tool.get_drawing_group(new_drawing)
     ifc.run("group.unassign_group", group=group, products=[new_drawing])
-    
+
     drawings_parent_group = None
     for parent_group in ifc.get().by_type("IfcGroup"):
         if parent_group.Name == "DRAWINGS" and parent_group.ObjectType == "DRAWINGS":
             drawings_parent_group = parent_group
             break
-    
+
     if not drawings_parent_group:
         drawings_parent_group = ifc.run("group.add_group")
-        ifc.run("group.edit_group", group=drawings_parent_group, attributes={"Name": "DRAWINGS", "ObjectType": "DRAWINGS"})
-    
+        ifc.run(
+            "group.edit_group", group=drawings_parent_group, attributes={"Name": "DRAWINGS", "ObjectType": "DRAWINGS"}
+        )
+
     new_group = ifc.run("group.add_group")
     ifc.run("group.edit_group", group=new_group, attributes={"Name": drawing_name, "ObjectType": "DRAWING"})
     ifc.run("group.assign_group", group=new_group, products=[new_drawing])
@@ -427,7 +433,7 @@ def duplicate_drawing(
         if document.Name == "DRAWINGS" and document.Scope == "DRAWINGS":
             drawings_parent_document = document
             break
-    
+
     if not drawings_parent_document:
         drawings_parent_document = ifc.run("document.add_information")
         if ifc.get_schema() == "IFC2X3":
@@ -645,3 +651,38 @@ def activate_drawing_view(
     blender.activate_camera(camera)
     drawing_tool.isolate_camera_collection(camera)
     drawing_tool.activate_drawing(camera)
+
+
+def run_conversion_command(
+    drawing: type[tool.Drawing], command_json: str, replacements: dict[str, str], setting_name: str
+) -> None:
+    """Run a user-configured SVG conversion command, such as svg2pdf_command.
+
+    :raises ConversionCommandError: if the command is not valid JSON, the
+        configured program cannot be found, or the command exits with a
+        non-zero status.
+    """
+    try:
+        drawing.run_conversion_command(command_json, replacements)
+    except json.JSONDecodeError as e:
+        raise ConversionCommandError(
+            f'The "{setting_name}" Bonsai preference is not valid JSON ({e}). '
+            'It should look like [["inkscape", "svg", "-o", "pdf"]].'
+        )
+    except FileNotFoundError as e:
+        raise ConversionCommandError(
+            f'Could not run "{e.filename}" set in the "{setting_name}" Bonsai preference. '
+            "The program was not found. Check that it is installed and on your PATH "
+            '(on Windows you may need "inkscape.exe" instead of "inkscape"), '
+            "then update the command in the Bonsai add-on preferences."
+        )
+    except subprocess.CalledProcessError as e:
+        raise ConversionCommandError(
+            f'The command "{e.cmd[0]}" set in the "{setting_name}" Bonsai preference '
+            f"failed with exit code {e.returncode}. See the system console for details, "
+            "then check the command in the Bonsai add-on preferences."
+        )
+
+
+class ConversionCommandError(Exception):
+    pass

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1282,6 +1282,19 @@ class Drawing(bonsai.core.tool.Drawing):
                 subprocess.call(("xdg-open", path))
 
     @classmethod
+    def run_conversion_command(cls, command_json: str, replacements: dict[str, str]) -> None:
+        """Run a JSON-configured SVG conversion command such as svg2pdf_command.
+
+        :raises json.JSONDecodeError: if ``command_json`` is not valid JSON.
+        :raises FileNotFoundError: if a configured program cannot be found.
+        :raises subprocess.CalledProcessError: if a command exits non-zero.
+        """
+        commands = json.loads(command_json)
+        for command in commands:
+            command[0] = shutil.which(command[0]) or command[0]
+            subprocess.run([replacements.get(c, c) for c in command], check=True)
+
+    @classmethod
     def open_spreadsheet(cls, uri: str) -> None:
         cls.open_with_user_command(tool.Blender.get_addon_preferences().spreadsheet_command, uri)
 

--- a/src/bonsai/test/core/test_drawing.py
+++ b/src/bonsai/test/core/test_drawing.py
@@ -16,6 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+
 import bonsai.core.drawing as subject
 from test.core.bootstrap import Prophecy, blender, collector, drawing, geometry, ifc
 
@@ -600,3 +606,31 @@ class TestAddAnnotation:
             relating_type="element_type",
             enable_editing=True,
         )
+
+
+class TestRunConversionCommand:
+    """See issue #4822: a misconfigured svg2pdf/svg2dxf command must raise a
+    catchable ConversionCommandError instead of an uncaught traceback."""
+
+    def test_bad_json_raises_conversion_command_error(self):
+        drawing_tool = Mock()
+        drawing_tool.run_conversion_command.side_effect = json.JSONDecodeError("Expecting value", "not json", 0)
+        with pytest.raises(subject.ConversionCommandError, match="svg2pdf_command"):
+            subject.run_conversion_command(drawing_tool, "not json", {}, "svg2pdf_command")
+
+    def test_missing_program_raises_conversion_command_error(self):
+        drawing_tool = Mock()
+        drawing_tool.run_conversion_command.side_effect = FileNotFoundError(2, "No such file or directory", "inkscape")
+        with pytest.raises(subject.ConversionCommandError, match="inkscape"):
+            subject.run_conversion_command(drawing_tool, "[]", {}, "svg2pdf_command")
+
+    def test_nonzero_exit_raises_conversion_command_error(self):
+        drawing_tool = Mock()
+        drawing_tool.run_conversion_command.side_effect = subprocess.CalledProcessError(1, ["inkscape", "svg"])
+        with pytest.raises(subject.ConversionCommandError, match="exit code 1"):
+            subject.run_conversion_command(drawing_tool, "[]", {}, "svg2pdf_command")
+
+    def test_success_does_not_raise(self):
+        drawing_tool = Mock()
+        subject.run_conversion_command(drawing_tool, "[]", {"svg": "a.svg"}, "svg2pdf_command")
+        drawing_tool.run_conversion_command.assert_called_once_with("[]", {"svg": "a.svg"})


### PR DESCRIPTION
Fixes #4822.

Printing sheets runs the user-configured `svg2pdf_command` / `svg2dxf_command` conversion commands (e.g. inkscape) via `subprocess`. When the program is not installed, not on PATH, uses old syntax, or the preference holds malformed JSON, the error bubbled up as an uncaught traceback. That is the config problem the reporter hit, and @aothms diagnosed it on the issue as a misconfigured `svg2pdf_command` preference.

### Updated to use a catchable exception, per @Moult's request on the issue

@Moult reopened #4822 asking specifically for this:

> I think this should be a catchable exception though, now that we're starting to introduce proper exception handling...

The first version of this PR caught the stdlib exceptions inline in the operator and reported an error. That stopped the traceback but did not give callers anything to catch, so it did not answer the request. It now follows the convention already established elsewhere in Bonsai, for example `SpaceGenerationError` (defined in `core/spatial.py`, raised in `core/spatial.py`, caught in `bim/module/model/space.py`), alongside `IncompatibleAggregateError`, `RequireTwoWallsError` and `IncompatibleRepresentationError`:

- `tool/drawing.py` gains `Drawing.run_conversion_command()`, which does the subprocess work and lets `json.JSONDecodeError`, `FileNotFoundError` and `subprocess.CalledProcessError` propagate.
- `core/drawing.py` gains `ConversionCommandError` and `run_conversion_command()`, which catches those three and re-raises with a message naming the failing command and the Bonsai preference to fix.
- `CreateSheets._execute` catches `core.ConversionCommandError`, reports it, and cancels.

The successful path is unchanged. Scope is limited to the sheet-conversion calls in `CreateSheets`.

### Before and after

Before: `subprocess.run(["inkscape-not-installed", ...])` raised an uncaught `FileNotFoundError`. `IfcStore.execute_ifc_operator` logs and re-raises, so Blender showed a raw traceback.

After: `ConversionCommandError: Could not run "inkscape-not-installed" set in the "svg2pdf_command" Bonsai preference...`, reported as an operator error, and catchable by any caller.

### Tests

`test/core/test_drawing.py` adds `TestRunConversionCommand` with four cases: malformed JSON, missing program, non-zero exit, and success.

```
pytest test/core -o addopts=""
387 passed
```

Two failures in `TestAddDrawing` / `TestDuplicateDrawing` are pre-existing (`Interface 'bonsai.core.tool.Ifc' has no attribute 'by_type'`), confirmed by stashing this change out and reproducing them identically on the unmodified branch.

Generated with the assistance of an AI coding tool.
