### PR TITLE
Bonsai: guard curve edit-mode for non-annotation curves, keep annotation curves editable (#4813, #5025)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -2329,6 +2329,16 @@ class OverrideModeSetEdit(bpy.types.Operator, tool.Ifc.Operator):
                 self.enable_edit_mode(context)
             elif tool.Blender.Modifier.try_applying_edit_mode(obj, element):
                 pass
+            elif obj.type == "CURVE" and not element.is_a("IfcAnnotation"):
+                # Swept disk solids (e.g. rebars, or tubes modelled without separate
+                # elbow elements) are loaded as native Blender curves that carry no
+                # mesh item ids, so they can't enter the mesh-based item editing mode.
+                # Decline gracefully instead of crashing inside
+                # import_representation_items (see #4813). Curve annotations
+                # (dimensions, leaders) are also curves but DO carry item ids, so they
+                # must stay editable and are deliberately excluded here (see #5025).
+                self.report({"INFO"}, "Editing this curve representation is not supported yet.")
+                obj.select_set(False)
             else:
                 bpy.ops.bim.import_representation_items()
         elif tool.Geometry.is_representation_item(obj):


### PR DESCRIPTION
Fixes #4813. Fixes #5025.

Native `IfcSweptDiskSolid` representations (including `IfcSweptDiskSolidPolygonal`, used for rebars and for tubes modelled without separate elbow elements) load as Blender curve objects. Entering edit mode routed them through `OverrideModeSetEdit.handle_single_object` into the mesh-only `bim.import_representation_items`, which hit `assert False, "Unexpected mesh type."` because a curve carries none of the `ios_*_item_ids` mesh attributes (#4813).

Declining **all** curves would fix that crash but regress #5025: curve-based annotations (dimensions, leaders) also load as curves, but they carry `ios_edges_item_ids` and are edited via item mode, so they must stay editable. This narrows the guard to **non-annotation** curves, so swept disk solids decline gracefully while annotation curves keep falling through to editing.

Verified headless across annotation and swept-disk fixtures: annotation curve → enters item mode; swept disk solid → declines cleanly, no crash; a plain mesh is unaffected.

Scope: does not restore curve-native (control-point) editing of swept disk solids (there's no curve→`IfcSweptDiskSolid` save-back path); that's a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
