### PR TITLE
Bonsai: store the drawing camera outside the Body context so viewers don't show boxes (#4800)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -966,6 +966,17 @@ class CreateDrawing(bpy.types.Operator):
             self.serialiser.setFile(ifc)
             drawing_elements = tool.Drawing.get_drawing_elements(self.camera_element, ifc_file=ifc)
 
+            # The camera defines the drawing's view crop, it is not a drawn
+            # element. Keep it out of the context-specific linework passes below
+            # and instead always feed it to the serialiser through the
+            # context-agnostic iterator further down, so the crop/frustum is
+            # built regardless of which representation context the camera lives
+            # in. Otherwise a camera stored outside the Body context (see #4800)
+            # would never reach the serialiser and the whole drawing would come
+            # out empty.
+            if tool.Ifc.get() == ifc:
+                drawing_elements.discard(self.camera_element)
+
             if self.cprops.fill_mode == "SHAPELY":
                 for element in drawing_elements.copy():
                     if element.is_a("IfcAnnotation"):
@@ -983,9 +994,11 @@ class CreateDrawing(bpy.types.Operator):
             self.serialize_contexts_elements(ifc, tree, contexts, "body", drawing_elements, target_view, link_matrix)
             self.serialize_contexts_elements(ifc, tree, contexts, "annotation", drawing_elements, target_view, link_matrix)
 
-            if tool.Ifc.get() == ifc and self.camera_element not in drawing_elements:
+            if tool.Ifc.get() == ifc:
                 with profile("Camera element"):
-                    # The camera must always be included, regardless of any include/exclude filters.
+                    # The camera must always be included, regardless of any include/exclude filters
+                    # and regardless of its representation context (see #4800). The default settings
+                    # here impose no context filter, so the camera's crop geometry is always built.
                     geom_settings = ifcopenshell.geom.settings()
                     geom_settings.set("iterator-output", ifcopenshell.ifcopenshell_wrapper.NATIVE)
                     it = ifcopenshell.geom.iterator(geom_settings, ifc, include=[self.camera_element])

--- a/src/bonsai/bonsai/core/drawing.py
+++ b/src/bonsai/bonsai/core/drawing.py
@@ -299,7 +299,7 @@ def add_drawing(
         ifc_class="IfcAnnotation",
         predefined_type="DRAWING",
         should_add_representation=True,
-        context=drawing.get_body_context(),
+        context=drawing.get_drawing_camera_context(),
         ifc_representation_class=None,
     )
     

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -370,6 +370,8 @@ class Drawing:
     def get_assigned_product(cls, element): pass
     def get_assigned_product_workaround(cls, element): pass
     def get_body_context(cls): pass
+    def get_drawing_camera_context(cls): pass
+    def get_drawing_camera_representation(cls, drawing): pass
     def get_default_drawing_path(cls, name): pass
     def get_default_drawing_resource_path(cls, resource): pass
     def get_default_layout_path(cls, identification, name): pass

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -708,6 +708,49 @@ class Drawing(bonsai.core.tool.Drawing):
     def get_body_context(cls) -> ifcopenshell.entity_instance:
         return ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
 
+    # Context the drawing camera's view volume is stored in. It must NOT be the
+    # Model/Body context: viewers (Solibri and others) render the camera's solid
+    # there as a box floating over the model. See #4800. "Clearance" keeps the
+    # camera out of the Body render path and out of the drawing annotation
+    # serialization path, while still routing through the camera-solid builder
+    # (add_representation dispatches Clearance to create_variable_representation)
+    # so the crop volume round-trips through the geometry kernel unchanged.
+    DRAWING_CAMERA_CONTEXT = ("Model", "Clearance", "MODEL_VIEW")
+
+    @classmethod
+    def get_drawing_camera_context(cls) -> ifcopenshell.entity_instance:
+        ifc_file = tool.Ifc.get()
+        context_type, context_identifier, target_view = cls.DRAWING_CAMERA_CONTEXT
+        context = ifcopenshell.util.representation.get_context(
+            ifc_file, context_type, context_identifier, target_view
+        )
+        if context is None:
+            parent = ifcopenshell.util.representation.get_context(ifc_file, context_type)
+            if parent is None:
+                parent = ifcopenshell.api.context.add_context(ifc_file, context_type=context_type)
+            context = ifcopenshell.api.context.add_context(
+                ifc_file,
+                context_type=context_type,
+                context_identifier=context_identifier,
+                target_view=target_view,
+                parent=parent,
+            )
+        return context
+
+    @classmethod
+    def get_drawing_camera_representation(
+        cls, drawing: ifcopenshell.entity_instance
+    ) -> Union[ifcopenshell.entity_instance, None]:
+        # New drawings keep the camera view volume in the dedicated context
+        # (see #4800). Drawings created before that change keep it in Model/Body,
+        # so fall back to Body for backwards compatibility.
+        representation = ifcopenshell.util.representation.get_representation(drawing, *cls.DRAWING_CAMERA_CONTEXT)
+        if representation is None:
+            representation = ifcopenshell.util.representation.get_representation(
+                drawing, "Model", "Body", "MODEL_VIEW"
+            )
+        return representation
+
     @classmethod
     def get_document_uri(
         cls, document: ifcopenshell.entity_instance, description: Optional[str] = None
@@ -996,7 +1039,7 @@ class Drawing(bonsai.core.tool.Drawing):
     def import_drawing(cls, drawing: ifcopenshell.entity_instance) -> bpy.types.Object:
         settings = ifcopenshell.geom.settings()
 
-        representation = ifcopenshell.util.representation.get_representation(drawing, "Model", "Body", "MODEL_VIEW")
+        representation = cls.get_drawing_camera_representation(drawing)
         assert representation
 
         shape = ifcopenshell.geom.create_shape(settings, drawing)
@@ -1018,7 +1061,7 @@ class Drawing(bonsai.core.tool.Drawing):
     def import_temporary_drawing_camera(cls, drawing: ifcopenshell.entity_instance) -> bpy.types.Object:
         settings = ifcopenshell.geom.settings()
 
-        representation = ifcopenshell.util.representation.get_representation(drawing, "Model", "Body", "MODEL_VIEW")
+        representation = cls.get_drawing_camera_representation(drawing)
         assert representation
 
         shape = ifcopenshell.geom.create_shape(settings, drawing)

--- a/src/bonsai/test/core/test_drawing.py
+++ b/src/bonsai/test/core/test_drawing.py
@@ -338,7 +338,7 @@ class TestAddDrawing:
         drawing.ensure_unique_drawing_name("drawing_name").should_be_called().will_return("name")
         drawing.generate_drawing_matrix("target_view", "location_hint").should_be_called().will_return("matrix")
         drawing.create_camera("name", "matrix", "location_hint", "target_view").should_be_called().will_return("obj")
-        drawing.get_body_context().should_be_called().will_return("context")
+        drawing.get_drawing_camera_context().should_be_called().will_return("context")
         drawing.run_root_assign_class(
             obj="obj",
             ifc_class="IfcAnnotation",


### PR DESCRIPTION
Fixes #4800.

Drawing cameras (`IfcAnnotation`/`DRAWING`) had their view-volume CSG solid created in `Model/Body/MODEL_VIEW`; IFC viewers like Solibri render Body-context solids, so the drawing "views" show up as boxes over the model.

To answer @Moult's old question: no C++ hardcodes the Body context for the camera. The kernel/serializers are context-driven via settings; the Body coupling was purely Python, one writer (`core/drawing.py`) and two readers.

This moves the camera's crop-volume solid to a dedicated `Model/Clearance/MODEL_VIEW` context. `Clearance` is a non-Body identifier viewers skip, and it's one of the identifiers `add_representation` routes to `create_variable_representation`, so the camera block/pyramid is built and rebuilt by the kernel unchanged, unlike `Box`, which becomes an un-rebuildable `IfcBoundingBox` and breaks the camera round-trip. It also stays out of the drawing SVG serialization (which only iterates Body and Annotation contexts). Readers resolve via a new `get_drawing_camera_representation` that falls back to `Model/Body` so drawings authored by older Bonsai still open.

Verified headless (Blender 5.1.2): new drawings land in Clearance (not Body), reimport/rebuild works and survives save/reopen, and legacy Body cameras still import via the fallback. No C++ change needed.

Scope: existing files aren't migrated (the camera moves to Clearance only when a drawing is recreated); a migration pass could be added if wanted. Happy to swap `Clearance` for a purpose-named context if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
