### PR TITLE
Bonsai: fix crash linking a fresh IFC with Use Cache off (#8350)

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1538,10 +1538,13 @@ class LoadLink(bpy.types.Operator, tool.Ifc.Operator):
         json_filepath = self.filepath_.with_suffix(".ifc.cache.json")
 
         def should_clear_cache() -> bool:
-            if not self.use_cache:
-                return True
+            # Nothing to clear if the cache file was never created (e.g. a
+            # fresh link). Check this first so os.remove below is never
+            # called on a non-existent path, regardless of use_cache.
             if not blend_filepath.exists():
                 return False
+            if not self.use_cache:
+                return True
             data = json.loads(json_filepath.read_text())
             # Empty 'query' - model loaded without custom query.
             # Missing 'query' - model was loaded before custom queries were introduced in Bonsai.


### PR DESCRIPTION
Fixes #8350.

Link IFC with "Use Cache" unchecked crashes with `FileNotFoundError` in `LoadLink.link_ifc` when no `.ifc.cache.blend` exists yet (a fresh link):
```
File ".../bim/module/project/operator.py", line 1552, in link_ifc
    os.remove(blend_filepath)
FileNotFoundError: [WinError 2] The system cannot find the file specified: '...BC002.ifc.cache.blend'
```
(The crash is in the cache handling, not the query, the query in the title just tends to accompany a Use-Cache-off link.)

Regression from `35e3d9c42`, which refactored the cache-clear guard from `if not self.use_cache and blend_filepath.exists()` into a `should_clear_cache()` helper but dropped the existence check on the `not use_cache` path, so `os.remove()` ran on a non-existent file.

This checks `blend_filepath.exists()` first in `should_clear_cache()`, so the remove is never attempted when there's nothing to clear, while keeping the query-mismatch cache invalidation from `35e3d9c42` intact.

Verified: the exact scenario (fresh link, cache off, with query) no longer raises; existing-cache clearing on `use_cache=False`, query-mismatch, and query-match paths all behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
