### PR TITLE
Bonsai: numpad decimal key inserts a dot in modal inputs, matching Blender (#8262)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/gizmos.py
+++ b/src/bonsai/bonsai/bim/module/drawing/gizmos.py
@@ -158,6 +158,29 @@ _SPECIAL = {"=", " "}  # Formula prefix, spaces
 
 NUMERIC_INPUT_CHARS = _DIGITS | _OPERATORS | _METRIC_UNITS | _IMPERIAL_UNITS | _SPECIAL
 
+# The numpad decimal key emits ',' rather than '.' on some OS keyboard layouts
+# (e.g. German/QWERTZ). Blender's native number fields still insert a decimal
+# point for that physical key, so we mirror that here. See issue #8262.
+_NUMPAD_DECIMAL_TYPES = {"NUMPAD_PERIOD", "NUMPAD_COMMA"}
+
+
+def resolve_numeric_input_char(event: bpy.types.Event) -> str | None:
+    """Return the character a keystroke contributes to a numeric input field,
+    or ``None`` if the key is not numeric input.
+
+    The numpad decimal key always contributes ``.`` regardless of the OS
+    character it emits, matching Blender's native field behaviour. This keeps
+    Bonsai's custom modal input consistent with the rest of Blender instead of
+    silently dropping a comma (which turned ``9,8`` into ``98``). See #8262.
+    """
+    if event.value != "PRESS":
+        return None
+    if event.type in _NUMPAD_DECIMAL_TYPES:
+        return "."
+    if event.ascii and event.ascii.lower() in NUMERIC_INPUT_CHARS:
+        return event.ascii
+    return None
+
 
 def _is_transform_modal_active(context) -> bool:
     """Module-local alias for ``tool.Blender.is_transform_modal_active``.
@@ -2704,8 +2727,9 @@ class BIM_OT_gizmo_value_input(bpy.types.Operator):
     def modal(self, context, event):
         kb = self._keyboard_input
 
-        if event.value == "PRESS" and event.ascii and event.ascii.lower() in NUMERIC_INPUT_CHARS:
-            kb.characters.append(event.ascii)
+        input_char = resolve_numeric_input_char(event)
+        if input_char is not None:
+            kb.characters.append(input_char)
             kb.is_active = True
             kb.parse()
             self._apply_value()
@@ -3072,8 +3096,9 @@ class GizmoMovable(bpy.types.Gizmo):
         """Handle keyboard numeric input."""
         kb = self.keyboard_input
 
-        if event.value == "PRESS" and event.ascii and event.ascii.lower() in NUMERIC_INPUT_CHARS:
-            kb.characters.append(event.ascii)
+        input_char = resolve_numeric_input_char(event)
+        if input_char is not None:
+            kb.characters.append(input_char)
             kb.is_active = True
             kb.parse()
             self._apply_keyboard_value()

--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -221,6 +221,14 @@ class PolylineOperator:
 
     def handle_keyboard_input(self, context: bpy.types.Context, event: bpy.types.Event) -> None:
 
+        # The numpad decimal key emits ',' on some OS layouts (e.g. German), which
+        # is not in ``number_options`` and was silently dropped, turning ``9,8``
+        # into ``98``. Blender's native fields insert a decimal point for that
+        # physical key, so mirror that behaviour. See issue #8262.
+        input_char = (
+            "." if (event.value == "PRESS" and event.type in {"NUMPAD_PERIOD", "NUMPAD_COMMA"}) else event.ascii
+        )
+
         if self.tool_state.is_input_on and event.value == "PRESS" and event.type == "TAB":
             self.recalculate_inputs(context)
             index = self.input_options.index(self.input_type)
@@ -250,7 +258,7 @@ class PolylineOperator:
             PolylineDecorator.update(event, self.tool_state, self.input_ui, self.snapping_points[0])
             tool.Blender.update_viewport()
 
-        if not self.tool_state.is_input_on and event.ascii in self.number_options:
+        if not self.tool_state.is_input_on and input_char in self.number_options:
             self.recalculate_inputs(context)
             self.tool_state.mode = "Edit"
             self.tool_state.is_input_on = True
@@ -270,8 +278,8 @@ class PolylineOperator:
             tool.Blender.update_viewport()
 
         if self.input_type in self.input_options:
-            if (event.ascii in self.number_options) or (event.value == "RELEASE" and event.type == "BACK_SPACE"):
-                if not self.tool_state.mode == "Edit" and not (event.ascii == "=" or event.type == "BACK_SPACE"):
+            if (input_char in self.number_options) or (event.value == "RELEASE" and event.type == "BACK_SPACE"):
+                if not self.tool_state.mode == "Edit" and not (input_char == "=" or event.type == "BACK_SPACE"):
                     self.number_input = []
 
                 if event.type == "BACK_SPACE":
@@ -279,13 +287,13 @@ class PolylineOperator:
                         self.number_input = []
                     else:
                         self.number_input.pop(-1)
-                elif event.ascii == "=":
+                elif input_char == "=":
                     if self.number_input and self.number_input[0] == "=":
                         self.number_input.pop(0)
                     else:
                         self.number_input.insert(0, "=")
                 else:
-                    self.number_input.append(event.ascii)
+                    self.number_input.append(input_char)
 
                 if not self.number_input:
                     self.number_output = "0"


### PR DESCRIPTION
Fixes #8262.

**Problem.** Bonsai's own modal numeric input (the parametric value gizmo, click-to-type gizmo, and the polyline/measure dimension field used when editing a wall's length) accumulated keystrokes from `event.ascii` and only accepted a fixed allow-list containing `.` but not `,`. On layouts where the numpad decimal key emits `,` (German/QWERTZ), that keystroke was silently dropped: `9` `[numpad .]` `8` produced `98` instead of `9.8`, a silent 10x error. Native Blender number fields are unaffected because they key off the physical numpad key, not the emitted character.

**Fix.** In the modal keystroke layer, map the numpad decimal key (`NUMPAD_PERIOD`/`NUMPAD_COMMA`) to `.` regardless of the emitted character, matching Blender's native behaviour. `gizmos.py` gets a small shared helper `resolve_numeric_input_char`; `polyline.py` normalises the key at the top of its handler. The number grammar is untouched, no locale comma decimal separator is introduced, and a typed literal comma is still not accepted as a decimal separator (the approach in the now-closed #8270, which @aothms asked us not to take). Nothing downstream (formulas, CSV, schedules, display formatting) changes.

**Scope.** Three Bonsai-owned custom modal inputs. Native `FloatProperty` fields (window/door parametric controls, N-panel) were never affected and are untouched.

**Verify.** German numpad `9` `[.]` `8` → `9.8`; US top-row `9.8` unchanged; integer `42` unchanged; typed top-row comma still rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
