### PR TITLE
util.placement: tolerate null direction ratios in get_axis2placement (#5113)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/placement.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/placement.py
@@ -62,8 +62,8 @@ def get_axis2placement(placement: ifcopenshell.entity_instance) -> MatrixType:
     """
     ifc_class = placement.is_a()
     if ifc_class in ("IfcAxis2Placement3D", "IfcAxis2PlacementLinear"):
-        z = np.array(placement.Axis.DirectionRatios if placement.Axis else (0, 0, 1))
-        x = np.array(placement.RefDirection.DirectionRatios if placement.RefDirection else (1, 0, 0))
+        z = np.array((placement.Axis and placement.Axis.DirectionRatios) or (0, 0, 1))
+        x = np.array((placement.RefDirection and placement.RefDirection.DirectionRatios) or (1, 0, 0))
         location = placement.Location
         if coordinates := getattr(location, "Coordinates", None):
             o = coordinates
@@ -76,7 +76,7 @@ def get_axis2placement(placement: ifcopenshell.entity_instance) -> MatrixType:
             return np.array(shape.matrix).reshape((4, 4), order="F")
     elif ifc_class == "IfcAxis2Placement2D":
         z = np.array((0, 0, 1))
-        if placement.RefDirection:
+        if placement.RefDirection and placement.RefDirection.DirectionRatios:
             x = np.array(placement.RefDirection.DirectionRatios)
             x.resize(3)
         else:
@@ -85,7 +85,7 @@ def get_axis2placement(placement: ifcopenshell.entity_instance) -> MatrixType:
 
     elif ifc_class == "IfcAxis1Placement":
         axis = placement.Axis
-        z = np.array(axis.DirectionRatios if axis else (0, 0, 1))
+        z = np.array((axis and axis.DirectionRatios) or (0, 0, 1))
         x = np.array((1, 0, 0))
         o = placement.Location.Coordinates
 

--- a/src/ifcopenshell-python/test/util/test_placement.py
+++ b/src/ifcopenshell-python/test/util/test_placement.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
 import ifcopenshell.util.placement as subject
 import test.bootstrap
 
@@ -40,3 +41,43 @@ class TestGetStoreyElevationIFC4(test.bootstrap.IFC4):
         assert subject.get_storey_elevation(storey) == 0.0
         building = self.file.createIfcBuilding()
         assert subject.get_storey_elevation(building) == 0.0
+
+
+class TestGetAxis2PlacementIFC4(test.bootstrap.IFC4):
+    def test_getting_a_valid_placement(self):
+        placement = self.file.createIfcAxis2Placement3D(
+            self.file.createIfcCartesianPoint((1.0, 2.0, 3.0)),
+            self.file.createIfcDirection((0.0, 0.0, 1.0)),
+            self.file.createIfcDirection((1.0, 0.0, 0.0)),
+        )
+        matrix = subject.get_axis2placement(placement)
+        assert np.allclose(matrix[:, 3], (1.0, 2.0, 3.0, 1.0))
+
+    def test_missing_axis_and_ref_direction_falls_back_to_defaults(self):
+        placement = self.file.createIfcAxis2Placement3D(
+            self.file.createIfcCartesianPoint((0.0, 0.0, 0.0))
+        )
+        assert np.allclose(subject.get_axis2placement(placement), np.eye(4))
+
+    def test_null_direction_ratios_falls_back_to_defaults(self):
+        # Axis and RefDirection entities exist but their DirectionRatios are null.
+        placement = self.file.createIfcAxis2Placement3D(
+            self.file.createIfcCartesianPoint((0.0, 0.0, 0.0)),
+            self.file.createIfcDirection(),
+            self.file.createIfcDirection(),
+        )
+        assert np.allclose(subject.get_axis2placement(placement), np.eye(4))
+
+    def test_axis1_null_direction_ratios_falls_back_to_defaults(self):
+        placement = self.file.createIfcAxis1Placement(
+            self.file.createIfcCartesianPoint((0.0, 0.0, 0.0)),
+            self.file.createIfcDirection(),
+        )
+        assert np.allclose(subject.get_axis2placement(placement), np.eye(4))
+
+    def test_2d_null_ref_direction_ratios_falls_back_to_defaults(self):
+        placement = self.file.createIfcAxis2Placement2D(
+            self.file.createIfcCartesianPoint((0.0, 0.0)),
+            self.file.createIfcDirection(),
+        )
+        assert np.allclose(subject.get_axis2placement(placement), np.eye(4))


### PR DESCRIPTION
Related to #5113.

While investigating #5113 (files with null `IfcAxis2Placement3D` components) I found that on current 0.8.x the exact `IFCAXIS2PLACEMENT3D($,$,$)` from that issue already loads without error, the C++ kernel tolerates the fully-null placement now. But a closely related null-placement case still crashes in the Python util: when an `Axis` or `RefDirection` entity exists but its `DirectionRatios` attribute is null (`IFCDIRECTION()`), `get_axis2placement` throws an opaque `TypeError: unsupported operand type(s) for *: 'NoneType' and 'NoneType'`, because the guard only checked whether the direction entity was present, not whether it carried ratios, so `np.array(None)` flowed into the matrix math. Affects `IfcAxis2Placement3D`, `IfcAxis2Placement2D`, and `IfcAxis1Placement`.

This falls back to the schema default axes (Z = 0,0,1, X = 1,0,0) when the ratios are absent, matching the existing handling of a missing `Axis`/`RefDirection`. Adds regression tests for the null-placement family (`test/util/test_placement.py`, 8 pass). No fabricated transform, pure schema defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
