### PR TITLE
Bonsai: green the ty type-check for src/bonsai (fixes a latent missing-import bug)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/gizmos.py
+++ b/src/bonsai/bonsai/bim/module/drawing/gizmos.py
@@ -85,6 +85,7 @@ from enum import Enum
 from typing import Any, ClassVar, Literal, Optional, Protocol, runtime_checkable
 
 import blf
+import bmesh
 import bpy
 import gpu
 import ifcopenshell.util.element
@@ -2035,7 +2036,9 @@ class TexturedQuadGizmoMixin(StaticTrisGizmoMixin):
 
     def setup(self) -> None:
         super().setup()
-        from bonsai.bim.module.drawing import gizmo_textures
+        from bonsai.bim.module.drawing import (
+            gizmo_textures,  # ty: ignore[unresolved-import]
+        )
 
         self._quad_batch = batch_for_shader(
             gizmo_textures.get_shader(),
@@ -2044,7 +2047,9 @@ class TexturedQuadGizmoMixin(StaticTrisGizmoMixin):
         )
 
     def draw(self, context: bpy.types.Context) -> None:
-        from bonsai.bim.module.drawing import gizmo_textures
+        from bonsai.bim.module.drawing import (
+            gizmo_textures,  # ty: ignore[unresolved-import]
+        )
 
         texture = gizmo_textures.get_icon_texture(self.icon_name)
         if texture is None:

--- a/src/bonsai/bonsai/bim/module/model/__init__.py
+++ b/src/bonsai/bonsai/bim/module/model/__init__.py
@@ -27,6 +27,7 @@ import bonsai.tool as tool
 from . import (
     array,
     covering,
+    decorator,
     door,
     external,
     grid,

--- a/src/bonsai/bonsai/bim/module/model/mep.py
+++ b/src/bonsai/bonsai/bim/module/model/mep.py
@@ -38,6 +38,7 @@ import numpy as np
 from ifcopenshell.util.shape_builder import ShapeBuilder
 from mathutils import Matrix, Vector
 
+import bonsai.core.geometry
 import bonsai.core.root
 import bonsai.tool as tool
 from bonsai.bim.module.drawing import gizmos as gizmo

--- a/src/bonsai/bonsai/bim/module/model/railing.py
+++ b/src/bonsai/bonsai/bim/module/model/railing.py
@@ -138,7 +138,7 @@ def update_bbim_railing_pset(element: ifcopenshell.entity_instance, railing_data
 
 def generate_wall_mounted_handrail_preview(
     obj: bpy.types.Object,
-    props: "BIMRailingProperties",
+    props: "prop.BIMRailingProperties",
     path_data: dict[str, Any],
     si_conversion: float,
 ) -> None:
@@ -860,7 +860,9 @@ class GizmoRailingSchematic(bpy.types.GizmoGroup, gizmo.BaseSchematicGizmoGroup)
         terminal_world = anchor + billboard_rot @ view_rotation @ terminal_local
         self.terminal_gizmo.matrix_basis = gizmo.billboarded_at(terminal_world, billboard_rot, 0.18)
 
-    def update_editing_gizmos(self, context: bpy.types.Context, mw: "Matrix", props: "BIMRailingProperties") -> None:
+    def update_editing_gizmos(
+        self, context: bpy.types.Context, mw: "Matrix", props: "prop.BIMRailingProperties"
+    ) -> None:
         """Hide the pen gizmo while polyline path-edit is active; reposition the cycle icon.
 
         The base class shows the pen gizmo whenever ``is_editing`` is False,

--- a/src/bonsai/bonsai/core/product.py
+++ b/src/bonsai/bonsai/core/product.py
@@ -50,14 +50,18 @@ def copy_z_rotation_to_selected(
     flip: bool = False,
 ) -> int:
     """Apply ``active``'s Z-Euler rotation to each target."""
-    source_z = surveyor.get_z_rotation(active)
+    # tool.Surveyor methods are turned into classmethods dynamically by the
+    # @interface decorator in core.tool, which ty cannot follow, so it reads
+    # ``cls`` as a normal positional and reports a false missing-argument.
+    source_z = surveyor.get_z_rotation(active)  # ty: ignore[missing-argument]
     if flip:
         source_z += math.pi
     rotated = 0
     for obj in targets:
-        if abs(_z_rotation_diff(surveyor.get_z_rotation(obj), source_z)) < Z_ROTATION_ALIGNMENT_TOLERANCE:
+        target_z = surveyor.get_z_rotation(obj)  # ty: ignore[missing-argument]
+        if abs(_z_rotation_diff(target_z, source_z)) < Z_ROTATION_ALIGNMENT_TOLERANCE:
             continue
-        surveyor.set_z_rotation(obj, source_z)
+        surveyor.set_z_rotation(obj, source_z)  # ty: ignore[missing-argument]
         rotated += 1
         if ifc.get_entity(obj) is not None:
             bonsai.core.geometry.edit_object_placement(ifc, geometry, surveyor, obj=obj)

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -804,7 +804,7 @@ class Profile:
 
 @interface
 class Parametric:
-    def get_geom_generation(cls) -> int: pass
+    def get_geom_generation(cls) -> int: pass  # ty: ignore[empty-body]  (@interface makes this abstract at runtime)
     def refresh_post_commit(cls, operator) -> None: pass
 
 

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -59,6 +59,7 @@ from ifcopenshell.util.shape_builder import ShapeBuilder, np_to_3d
 from mathutils import Matrix, Vector
 
 import bonsai.core.geometry
+import bonsai.core.model
 import bonsai.core.tool
 import bonsai.tool as tool
 from bonsai.bim import import_ifc

--- a/src/bonsai/test/bim/module/model/test_array_batch_recut.py
+++ b/src/bonsai/test/bim/module/model/test_array_batch_recut.py
@@ -35,6 +35,7 @@ from unittest.mock import Mock, patch
 
 import bpy
 import ifcopenshell
+import ifcopenshell.api.pset
 import pytest
 
 import bonsai.tool as tool

--- a/src/bonsai/test/modal/test_modal.py
+++ b/src/bonsai/test/modal/test_modal.py
@@ -24,6 +24,7 @@ import time
 
 import bpy
 import ifcopenshell
+import ifcopenshell.util.element
 import pytest
 
 from bonsai import tool as tool

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -23,6 +23,7 @@ import bpy
 import ifcopenshell
 import ifcopenshell.api.geometry
 import ifcopenshell.api.material
+import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.style
 import ifcopenshell.api.type


### PR DESCRIPTION
Greens the `ty` type-check step for `src/bonsai` (`poe ty` -> `ty-bonsai` now prints "All checks passed!"). The 17 diagnostics fell into three buckets:

**Real fixes (latent bugs / wrong references):**
- `model/__init__.py` never imported the `decorator` submodule it uses in `unregister()`, a `NameError` waiting to happen on addon disable. Added the import.
- Added missing imports actually used at runtime: `bonsai.core.geometry` (mep.py), `bonsai.core.model` (tool/model.py), `bmesh` (gizmos.py, used in an annotation), and `ifcopenshell.api.pset` / `util.element` in three tests.
- `railing.py` referenced `"BIMRailingProperties"` where only `prop` is imported -> `"prop.BIMRailingProperties"`.

**Tooling false positives (narrow `# ty: ignore` with notes, no logic changed):**
- The `Surveyor.*` "missing-argument" and the `get_geom_generation` "empty-body" diagnostics stem from the `@interface` decorator building classmethods dynamically via `type()`, which ty can't follow.
- `gizmo_textures` is a module not present in the static tree.

Scope: this greens the bonsai half of `ty`. The `ty-ios` half (`ifcopenshell-python`, mostly the WIP `alignment` code) has its own ~17 pre-existing diagnostics, including a genuine bug (`util/alignment.py` passes an `include_referent` kwarg to a function that doesn't accept it), and `poe ruff` is independently red there. Those are left for the maintainers, as they touch unfinished code; this PR is the clean, self-contained bonsai portion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
