### PR TITLE
Green the ci-lint ty and ruff checks (src/bonsai + ifcopenshell-python)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/gizmos.py
+++ b/src/bonsai/bonsai/bim/module/drawing/gizmos.py
@@ -85,6 +85,7 @@ from enum import Enum
 from typing import Any, ClassVar, Literal, Optional, Protocol, runtime_checkable
 
 import blf
+import bmesh
 import bpy
 import gpu
 import ifcopenshell.util.element
@@ -2035,7 +2036,9 @@ class TexturedQuadGizmoMixin(StaticTrisGizmoMixin):
 
     def setup(self) -> None:
         super().setup()
-        from bonsai.bim.module.drawing import gizmo_textures
+        from bonsai.bim.module.drawing import (
+            gizmo_textures,  # ty: ignore[unresolved-import]
+        )
 
         self._quad_batch = batch_for_shader(
             gizmo_textures.get_shader(),
@@ -2044,7 +2047,9 @@ class TexturedQuadGizmoMixin(StaticTrisGizmoMixin):
         )
 
     def draw(self, context: bpy.types.Context) -> None:
-        from bonsai.bim.module.drawing import gizmo_textures
+        from bonsai.bim.module.drawing import (
+            gizmo_textures,  # ty: ignore[unresolved-import]
+        )
 
         texture = gizmo_textures.get_icon_texture(self.icon_name)
         if texture is None:

--- a/src/bonsai/bonsai/bim/module/model/__init__.py
+++ b/src/bonsai/bonsai/bim/module/model/__init__.py
@@ -27,6 +27,7 @@ import bonsai.tool as tool
 from . import (
     array,
     covering,
+    decorator,
     door,
     external,
     grid,

--- a/src/bonsai/bonsai/bim/module/model/mep.py
+++ b/src/bonsai/bonsai/bim/module/model/mep.py
@@ -38,6 +38,7 @@ import numpy as np
 from ifcopenshell.util.shape_builder import ShapeBuilder
 from mathutils import Matrix, Vector
 
+import bonsai.core.geometry
 import bonsai.core.root
 import bonsai.tool as tool
 from bonsai.bim.module.drawing import gizmos as gizmo

--- a/src/bonsai/bonsai/bim/module/model/railing.py
+++ b/src/bonsai/bonsai/bim/module/model/railing.py
@@ -138,7 +138,7 @@ def update_bbim_railing_pset(element: ifcopenshell.entity_instance, railing_data
 
 def generate_wall_mounted_handrail_preview(
     obj: bpy.types.Object,
-    props: "BIMRailingProperties",
+    props: "prop.BIMRailingProperties",
     path_data: dict[str, Any],
     si_conversion: float,
 ) -> None:
@@ -860,7 +860,9 @@ class GizmoRailingSchematic(bpy.types.GizmoGroup, gizmo.BaseSchematicGizmoGroup)
         terminal_world = anchor + billboard_rot @ view_rotation @ terminal_local
         self.terminal_gizmo.matrix_basis = gizmo.billboarded_at(terminal_world, billboard_rot, 0.18)
 
-    def update_editing_gizmos(self, context: bpy.types.Context, mw: "Matrix", props: "BIMRailingProperties") -> None:
+    def update_editing_gizmos(
+        self, context: bpy.types.Context, mw: "Matrix", props: "prop.BIMRailingProperties"
+    ) -> None:
         """Hide the pen gizmo while polyline path-edit is active; reposition the cycle icon.
 
         The base class shows the pen gizmo whenever ``is_editing`` is False,

--- a/src/bonsai/bonsai/core/product.py
+++ b/src/bonsai/bonsai/core/product.py
@@ -50,14 +50,18 @@ def copy_z_rotation_to_selected(
     flip: bool = False,
 ) -> int:
     """Apply ``active``'s Z-Euler rotation to each target."""
-    source_z = surveyor.get_z_rotation(active)
+    # tool.Surveyor methods are turned into classmethods dynamically by the
+    # @interface decorator in core.tool, which ty cannot follow, so it reads
+    # ``cls`` as a normal positional and reports a false missing-argument.
+    source_z = surveyor.get_z_rotation(active)  # ty: ignore[missing-argument]
     if flip:
         source_z += math.pi
     rotated = 0
     for obj in targets:
-        if abs(_z_rotation_diff(surveyor.get_z_rotation(obj), source_z)) < Z_ROTATION_ALIGNMENT_TOLERANCE:
+        target_z = surveyor.get_z_rotation(obj)  # ty: ignore[missing-argument]
+        if abs(_z_rotation_diff(target_z, source_z)) < Z_ROTATION_ALIGNMENT_TOLERANCE:
             continue
-        surveyor.set_z_rotation(obj, source_z)
+        surveyor.set_z_rotation(obj, source_z)  # ty: ignore[missing-argument]
         rotated += 1
         if ifc.get_entity(obj) is not None:
             bonsai.core.geometry.edit_object_placement(ifc, geometry, surveyor, obj=obj)

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -804,7 +804,7 @@ class Profile:
 
 @interface
 class Parametric:
-    def get_geom_generation(cls) -> int: pass
+    def get_geom_generation(cls) -> int: pass  # ty: ignore[empty-body]  (@interface makes this abstract at runtime)
     def refresh_post_commit(cls, operator) -> None: pass
 
 

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -59,6 +59,7 @@ from ifcopenshell.util.shape_builder import ShapeBuilder, np_to_3d
 from mathutils import Matrix, Vector
 
 import bonsai.core.geometry
+import bonsai.core.model
 import bonsai.core.tool
 import bonsai.tool as tool
 from bonsai.bim import import_ifc

--- a/src/bonsai/test/bim/module/model/test_array_batch_recut.py
+++ b/src/bonsai/test/bim/module/model/test_array_batch_recut.py
@@ -35,6 +35,7 @@ from unittest.mock import Mock, patch
 
 import bpy
 import ifcopenshell
+import ifcopenshell.api.pset
 import pytest
 
 import bonsai.tool as tool

--- a/src/bonsai/test/modal/test_modal.py
+++ b/src/bonsai/test/modal/test_modal.py
@@ -24,6 +24,7 @@ import time
 
 import bpy
 import ifcopenshell
+import ifcopenshell.util.element
 import pytest
 
 from bonsai import tool as tool

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -23,6 +23,7 @@ import bpy
 import ifcopenshell
 import ifcopenshell.api.geometry
 import ifcopenshell.api.material
+import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.style
 import ifcopenshell.api.type

--- a/src/ifcopenshell-python/ifcopenshell/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/__init__.py
@@ -197,7 +197,10 @@ def open(
     if logger is None and (logger_type := getattr(ifcopenshell_wrapper, "logger", None)):
         logger = logger_type.Root()
     if format == ".ifcXML":
-        f = ifcopenshell_wrapper.parse_ifcxml(str(path.absolute()), *((logger,) if logger is not None else ()))
+        f = ifcopenshell_wrapper.parse_ifcxml(
+            str(path.absolute()),
+            *((logger,) if logger is not None else ()),  # ty: ignore[too-many-positional-arguments]
+        )
         if f:
             return file(f)
         raise OSError(f"Failed to parse .ifcXML file from {path}")
@@ -214,7 +217,11 @@ def open(
     if should_stream:
         return stream(path)
     if readonly:  # Temporary conditional see #7131. Remove once newer builds don't segfault on Linux.
-        f = ifcopenshell_wrapper.open(str(path.absolute()), readonly, *((logger,) if logger is not None else ()))
+        f = ifcopenshell_wrapper.open(
+            str(path.absolute()),
+            readonly,
+            *((logger,) if logger is not None else ()),  # ty: ignore[too-many-positional-arguments]
+        )
     elif bypass_types:
         f = ifcopenshell_wrapper.file(
             ifcopenshell_wrapper.uninitialized_tag(), *((logger,) if logger is not None else ())
@@ -231,9 +238,13 @@ def open(
         kwargs = {"mmap": mmap}
         if logger is not None:
             kwargs["logger"] = logger
-        f = ifcopenshell_wrapper.open(str(path.absolute()), **kwargs)  # ty: ignore[unknown-argument]
+        f = ifcopenshell_wrapper.open(str(path.absolute()), **kwargs)
     else:
-        f = ifcopenshell_wrapper.open(str(path.absolute()), False, *((logger,) if logger is not None else ()))
+        f = ifcopenshell_wrapper.open(
+            str(path.absolute()),
+            False,
+            *((logger,) if logger is not None else ()),  # ty: ignore[too-many-positional-arguments]
+        )
     return file(f)
 
 

--- a/src/ifcopenshell-python/ifcopenshell/api/alignment/_add_segment_to_curve.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/alignment/_add_segment_to_curve.py
@@ -22,8 +22,6 @@ import numpy as np
 import ifcopenshell
 import ifcopenshell.api.alignment
 import ifcopenshell.geom
-import ifcopenshell.ifcopenshell_wrapper as ifcopenshell_wrapper
-import ifcopenshell.util.unit
 from ifcopenshell import entity_instance
 from ifcopenshell.api.alignment._get_segment_endpoint import _get_segment_endpoint
 from ifcopenshell.api.alignment._update_zero_length_segment_placement import _update_zero_length_segment_placement

--- a/src/ifcopenshell-python/ifcopenshell/api/alignment/_add_segment_to_layout.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/alignment/_add_segment_to_layout.py
@@ -22,28 +22,11 @@ import numpy as np
 
 import ifcopenshell
 import ifcopenshell.api.alignment
-from ifcopenshell.api.alignment import _map_alignment_cant_segment
 from ifcopenshell.api.alignment._update_zero_length_segment_placement import _update_zero_length_segment_placement
 import ifcopenshell.api.nest
-import ifcopenshell.api.pset
-import ifcopenshell.geom
-import ifcopenshell.util.alignment
-import ifcopenshell.util.unit
-from ifcopenshell import entity_instance, ifcopenshell_wrapper
+from ifcopenshell import entity_instance
 from ifcopenshell.api.alignment._add_segment_to_curve import _add_segment_to_curve
 from ifcopenshell.api.alignment._get_segment_endpoint import _get_segment_endpoint
-from ifcopenshell.api.alignment._get_segment_start_point_label import (
-    _get_segment_start_point_label,
-)
-from ifcopenshell.api.alignment._map_alignment_cant_segment import (
-    _map_alignment_cant_segment,
-)
-from ifcopenshell.api.alignment._map_alignment_horizontal_segment import (
-    _map_alignment_horizontal_segment,
-)
-from ifcopenshell.api.alignment._map_alignment_vertical_segment import (
-    _map_alignment_vertical_segment,
-)
 
 
 def _add_segment_to_layout(

--- a/src/ifcopenshell-python/ifcopenshell/api/alignment/_add_zero_length_segment.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/alignment/_add_zero_length_segment.py
@@ -18,11 +18,7 @@
 
 import ifcopenshell
 import ifcopenshell.api.alignment
-import ifcopenshell.util.alignment
 from ifcopenshell import entity_instance
-from ifcopenshell.api.alignment._get_segment_start_point_label import (
-    _get_segment_start_point_label,
-)
 
 
 def _add_zero_length_segment(file: ifcopenshell.file, layout: entity_instance) -> None:

--- a/src/ifcopenshell-python/ifcopenshell/api/alignment/_get_segment_endpoint.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/alignment/_get_segment_endpoint.py
@@ -18,6 +18,7 @@
 
 
 import ifcopenshell.api.alignment
+import ifcopenshell.geom
 from ifcopenshell import entity_instance, ifcopenshell_wrapper
 from ifcopenshell.api.alignment._map_alignment_segment import _map_alignment_segment
 from typing import Union

--- a/src/ifcopenshell-python/ifcopenshell/api/alignment/add_stationing_referent.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/alignment/add_stationing_referent.py
@@ -16,17 +16,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
 
 import ifcopenshell
 import ifcopenshell.api.alignment
 from ifcopenshell.api.alignment.update_fallback_position import update_fallback_position
 import ifcopenshell.api.pset
-import ifcopenshell.geom
 import ifcopenshell.guid
 import ifcopenshell.util.element
-import ifcopenshell.util.unit
-from ifcopenshell import entity_instance, ifcopenshell_wrapper
+from ifcopenshell import entity_instance
 
 
 def add_stationing_referent(

--- a/src/ifcopenshell-python/ifcopenshell/api/alignment/add_zero_length_segment.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/alignment/add_zero_length_segment.py
@@ -23,18 +23,8 @@ import ifcopenshell.api.alignment
 from ifcopenshell.api.alignment._get_segment_endpoint import _get_segment_endpoint
 from ifcopenshell.api.alignment._update_zero_length_segment_placement import _update_zero_length_segment_placement
 import ifcopenshell.api.nest
-import ifcopenshell.ifcopenshell_wrapper as wrapper
 import ifcopenshell.util.unit
 from ifcopenshell import entity_instance
-from ifcopenshell.api.alignment._get_segment_start_point_label import (
-    _get_segment_start_point_label,
-)
-from ifcopenshell.api.alignment._map_alignment_horizontal_segment import (
-    _map_alignment_horizontal_segment,
-)
-from ifcopenshell.api.alignment._map_alignment_vertical_segment import (
-    _map_alignment_vertical_segment,
-)
 from ifcopenshell.api.alignment._update_curve_segment_transition_code import (
     _update_curve_segment_transition_code,
 )

--- a/src/ifcopenshell-python/ifcopenshell/api/alignment/create_layout_segment.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/alignment/create_layout_segment.py
@@ -21,9 +21,7 @@ from typing import Union
 import numpy as np
 
 import ifcopenshell
-import ifcopenshell.api.alignment
-import ifcopenshell.geom
-from ifcopenshell import entity_instance, ifcopenshell_wrapper
+from ifcopenshell import entity_instance
 from ifcopenshell.api.alignment._add_segment_to_layout import _add_segment_to_layout
 
 

--- a/src/ifcopenshell-python/ifcopenshell/api/alignment/get_curve_segment.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/alignment/get_curve_segment.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import Sequence
 
 from ifcopenshell import entity_instance
 

--- a/src/ifcopenshell-python/ifcopenshell/api/alignment/update_end_point.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/alignment/update_end_point.py
@@ -19,6 +19,7 @@
 import numpy as np
 
 import ifcopenshell
+import ifcopenshell.api.alignment
 import ifcopenshell.util.placement
 from ifcopenshell import entity_instance
 

--- a/src/ifcopenshell-python/ifcopenshell/api/cost/assign_cost_item_quantity.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cost/assign_cost_item_quantity.py
@@ -117,7 +117,7 @@ def assign_cost_item_quantity(
         "products": products or [],
         "prop_name": prop_name,
         "formula": formula,
-        "ifc_class" : ifc_class
+        "ifc_class": ifc_class,
     }
     return usecase.execute()
 
@@ -134,7 +134,7 @@ class Usecase:
                 continue
             self.assign_cost_control(related_object=product, cost_item=self.settings["cost_item"])
             if self.settings["formula"]:
-                tree = ast.parse(self.settings["formula"], mode = "eval")
+                tree = ast.parse(self.settings["formula"], mode="eval")
                 collector = VariableExtractor()
                 collector.visit(tree)
                 variables = collector.variables
@@ -144,10 +144,10 @@ class Usecase:
                     value = getter(product, variable)
 
                 if value is None:
-                        print(
-                            f"WARNING: Variable '{variable}' in product '{product.Name}' "
-                            f"is missing (None). Check Pset/Qset or property name."
-                        )
+                    print(
+                        f"WARNING: Variable '{variable}' in product '{product.Name}' "
+                        f"is missing (None). Check Pset/Qset or property name."
+                    )
                 elif value == 0:
                     print(
                         f"WARNING: Variable '{variable}' in product '{product.Name}' "
@@ -159,7 +159,9 @@ class Usecase:
 
                 new_quantity = None
                 for quantity in self.quantities:
-                    if quantity.Formula == self.settings["formula"] and len(self.settings["products"]) == 1: #Todo improve it
+                    if (
+                        quantity.Formula == self.settings["formula"] and len(self.settings["products"]) == 1
+                    ):  # Todo improve it
                         new_quantity = quantity
                         self.settings["ifc_class"] = quantity.is_a()
                         continue
@@ -184,23 +186,23 @@ class Usecase:
             self.update_cost_item_count()
 
     def get_value_from_pset(
-            self,
-            product:ifcopenshell.entity_instance,
-            v: str,
+        self,
+        product: ifcopenshell.entity_instance,
+        v: str,
     ) -> float:
         pset_name = v.split(".")[0]
         pset = ifcopenshell.util.element.get_pset(product, pset_name)
         pset_property_name = v.split(".")[1]
-        return (pset or {}).get(pset_property_name,None)
+        return (pset or {}).get(pset_property_name, None)
 
     def get_value_from_qset(
-            self,
-            product:ifcopenshell.entity_instance,
-            v: str,
+        self,
+        product: ifcopenshell.entity_instance,
+        v: str,
     ) -> float:
-        qtos = ifcopenshell.util.element.get_psets(product, qtos_only = True)
+        qtos = ifcopenshell.util.element.get_psets(product, qtos_only=True)
         quantities = next(iter(qtos.values()), {})
-        return (quantities or {}).get(v,None)
+        return (quantities or {}).get(v, None)
 
     def assign_cost_control(
         self, related_object: ifcopenshell.entity_instance, cost_item: ifcopenshell.entity_instance
@@ -243,6 +245,7 @@ class Usecase:
                             count += 1
                 quantity[3] = count
 
+
 OPERATORS = {
     ast.Add: operator.add,
     ast.Sub: operator.sub,
@@ -252,17 +255,19 @@ OPERATORS = {
     ast.USub: operator.neg,
 }
 
+
 def build_full_name(node):
-    #used for variables with dots
+    # used for variables with dots
     parts = []
     while isinstance(node, ast.Attribute):
-            parts.append(node.attr)
-            node = node.value
+        parts.append(node.attr)
+        node = node.value
 
     if isinstance(node, ast.Name):
         parts.append(node.id)
 
     return ".".join(reversed(parts))
+
 
 class VariableExtractor(ast.NodeVisitor):
     def __init__(self):
@@ -274,6 +279,7 @@ class VariableExtractor(ast.NodeVisitor):
     def visit_Attribute(self, node):
         self.variables.add(build_full_name(node))
 
+
 class FormulaEvaluator(ast.NodeVisitor):
     def __init__(self, values):
         self.values = values
@@ -281,7 +287,9 @@ class FormulaEvaluator(ast.NodeVisitor):
     def visit_BinOp(self, node):
         left = self.visit(node.left)
         right = self.visit(node.right)
-        return OPERATORS[type(node.op)](left, right)
+        # OPERATORS mixes binary ops with the unary ast.USub (operator.neg); only
+        # binary ops reach this call, so ty's union-based arity check is a false positive.
+        return OPERATORS[type(node.op)](left, right)  # ty: ignore[too-many-positional-arguments]
 
     def visit_Name(self, node):
         return self.values[node.id]

--- a/src/ifcopenshell-python/ifcopenshell/geom/main.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/main.py
@@ -344,10 +344,16 @@ class iterator(ifcopenshell_wrapper.Iterator):
                 include is not None,
                 num_threads,
             )
-            self.this = initializer(*args, *((logger,) if logger is not None else ()))
+            self.this = initializer(
+                *args,
+                *((logger,) if logger is not None else ()),  # ty: ignore[too-many-positional-arguments]
+            )
         else:
             args = (geometry_library, self.settings, file_or_filename, num_threads)
-            self.this = ifcopenshell_wrapper.construct_iterator(*args, *((logger,) if logger is not None else ()))
+            self.this = ifcopenshell_wrapper.construct_iterator(
+                *args,
+                *((logger,) if logger is not None else ()),  # ty: ignore[too-many-positional-arguments]
+            )
 
     if has_occ:
 

--- a/src/ifcopenshell-python/ifcopenshell/util/alignment.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/alignment.py
@@ -56,7 +56,7 @@ def append_zero_length_segments(file: ifcopenshell.file) -> ifcopenshell.file:
     for alignment in alignments:
         layouts = ifcopenshell.api.alignment.get_alignment_layouts(alignment)
         for layout in layouts:
-            ifcopenshell.api.alignment.add_zero_length_segment(patched_file, layout, include_referent=False)
+            ifcopenshell.api.alignment.add_zero_length_segment(patched_file, layout)
             curve = ifcopenshell.api.alignment.get_layout_curve(layout)
             if curve:
                 ifcopenshell.api.alignment.add_zero_length_segment(patched_file, curve)

--- a/src/ifcopenshell-python/test/api/alignment/test_create_representation.py
+++ b/src/ifcopenshell-python/test/api/alignment/test_create_representation.py
@@ -21,9 +21,12 @@ import math
 
 import pytest
 import ifcopenshell
+import ifcopenshell.api.aggregate
 import ifcopenshell.api.alignment
+import ifcopenshell.api.context
+import ifcopenshell.api.spatial
 import ifcopenshell.api.unit
-import numpy as np
+import ifcopenshell.util.unit
 
 
 def test_create_representation():


### PR DESCRIPTION
## What this does

Greens the `ci-lint / lint-formatting` job's **`ty` type-check** and **`ruff`** steps, which are both currently red on `v0.8.0`.

A note on why the ty problem was bigger than it looked: `poe ty` runs `ty-bonsai` and then `ty-ios`, and poe aborts on the first failing subtask. So while `ty-bonsai` was failing, `ty-ios` never ran and its diagnostics were invisible. Fixing `src/bonsai` (17 diagnostics) unmasks 17 more in `src/ifcopenshell-python`. Both are addressed here.

After this PR: `poe ty` (bonsai + ios) passes, and `poe ruff` passes repo-wide. **Black is not touched here** — it is red for a separate set of ~16 files handled by #8362. Both PRs are needed for the job to go fully green.

## Changes, grouped honestly

**Safe missing imports** (code relied on transitive imports, or a name was outright undefined):
- `bonsai/bim/module/model/mep.py`: `import bonsai.core.geometry`
- `bonsai/tool/model.py`: `import bonsai.core.model`
- `bonsai/bim/module/drawing/gizmos.py`: `import bmesh` (used only in an annotation)
- three `src/bonsai` test files: `ifcopenshell.api.pset` / `ifcopenshell.util.element`
- `api/alignment/_get_segment_endpoint.py`: `import ifcopenshell.geom`
- `api/alignment/update_end_point.py`: `import ifcopenshell.api.alignment`
- `test/api/alignment/test_create_representation.py`: `ifcopenshell.api.{aggregate,context,spatial}` and `ifcopenshell.util.unit`

**Annotation fix**
- `bonsai/bim/module/model/railing.py`: `"BIMRailingProperties"` → `"prop.BIMRailingProperties"` (only `prop` is imported in that module).

**Ruff `unused-import` cleanup** (all in the WIP `api/alignment` code): removed leftover unused imports via `ruff check --fix`. No behaviour change.

**Narrow `# ty: ignore` for genuine tooling false positives** (no rule disabled globally, no runtime behaviour changed):
- `core/product.py`, `core/tool.py`: the `@interface` decorator in `core/tool.py` builds classmethods dynamically via `type()`, which ty cannot follow. It reports false `missing-argument` on `Surveyor.*` calls and a false `empty-body` on `get_geom_generation`. Suppressed with notes.
- `bonsai/bim/module/drawing/gizmos.py`: `gizmo_textures` is provided at runtime and is not in the static tree.
- `ifcopenshell/__init__.py`, `geom/main.py`: calls into the compiled `ifcopenshell_wrapper` pass an optional trailing `logger`, but the hand-maintained `ifcopenshell_wrapper.pyi` stub omits it, so ty reports `too-many-positional-arguments`. Suppressed at the call sites, matching the `# ty: ignore` pattern already present in `__init__.py`. **The real fix is to add the optional `logger` parameter to those stub signatures** — left to the maintainers since the stub is validated by `util/scripts/validate_stub.py`. Also removed one now-unused `# ty: ignore[unknown-argument]`.
- `api/cost/assign_cost_item_quantity.py`: `OPERATORS` maps binary ast ops plus the unary `ast.USub` (`operator.neg`); only binary ops reach the 2-arg call in `visit_BinOp`, so ty's union-based arity check is a false positive. Suppressed.

## Two real bugs found and fixed — please sanity-check

Both are runtime crashes on reachable paths; each fix is the single unambiguous correction, not a guess.

1. **`bonsai/bim/module/model/__init__.py`** used `decorator.MEPSystemPathDecorator.uninstall()` / `WallSystemPathDecorator.uninstall()` in `unregister()`, but never imported the `decorator` submodule → `NameError` on addon disable / Blender shutdown. Added the missing sibling import.
2. **`ifcopenshell/util/alignment.py`** called `add_zero_length_segment(patched_file, layout, include_referent=False)`, but `add_zero_length_segment(file, layout)` has no such parameter → `TypeError`, reachable through the `AddZeroLengthSegmentToAlignment` ifcpatch recipe. Removed the bogus keyword to match the correct sibling call on the next line. If `include_referent` was actually intended as an API parameter, the correct fix is yours to make in the API instead.

## Verification

- `poe ty` → passes (bonsai + ios)
- `poe ruff` → passes repo-wide
- `black` → clean on every file this PR touches (`assign_cost_item_quantity.py` was already black-dirty and is reformatted here; that one file overlaps #8362)
- `python -m compileall` → clean on all changed `ifcopenshell-python` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
