### PR TITLE
Bonsai: make the "has openings" representation error actionable (#8108)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -581,7 +581,11 @@ class UpdateRepresentation(bpy.types.Operator, tool.Ifc.Operator):
         if has_openings and not self.apply_openings:
             # Meshlike things with openings can only be updated without openings applied.
             if self.from_ui:
-                self.report({"ERROR"}, f"Object '{obj.name}' has openings - representation cannot be updated.")
+                self.report(
+                    {"ERROR"},
+                    f"Object '{obj.name}' has openings. "
+                    "ALT+click the button to bake the openings into the new representation.",
+                )
             return
 
         if not product.is_a("IfcGridAxis"):


### PR DESCRIPTION
Fixes #8108.

Converting a wall's representation to a parametric extrusion via *Geometry and Materials → Representation Utilities → Convert to … Extrusion …* failed on any element that has openings with `Object '<name>' has openings - representation cannot be updated.` and stopped, giving the user no way forward.

The guard in `UpdateRepresentation._execute` is correct (the reported wall `34kxOHF3tb73HULWLfLeTT` genuinely has two `IfcRelVoidsElement` openings, each with a real `Body`/`SweptSolid` `IfcExtrudedAreaSolid`), but the operator already supports an ALT+click path (`apply_openings=True`) that bakes openings into the new representation, and the message never surfaced it. This makes the message point at that path, as @Gorgious56 requested in the issue thread.

No logic change. Message only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
