### PR TITLE
win/msys2: make the OpenCOLLADA dependency build skippable via COLLADA_SUPPORT (#6568)

### DIFF
--- a/win/build-deps.sh
+++ b/win/build-deps.sh
@@ -59,28 +59,38 @@ function git_clone_and_checkout_revision {
     popd
 }
 
-# Use a fixed revision in order to prevent introducing breaking changes
-git_clone_and_checkout_revision https://github.com/KhronosGroup/OpenCOLLADA.git "$DEPS_DIR/OpenCOLLADA" \
-    064a60b65c2c31b94f013820856bc84fb1937cc6
-pushd "$DEPS_DIR/OpenCOLLADA"
-[ -d $BUILD_DIR ] || mkdir -p $BUILD_DIR
-pushd $BUILD_DIR
-cmake .. -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR/OpenCOLLADA"
-make -j$IFCOS_NUM_BUILD_PROCS
-make install
-popd 
+# COLLADA support is optional. OpenCOLLADA is unmaintained (last updated in 2018)
+# and frequently fails to build on recent MinGW/ucrt toolchains (see issue #6568).
+# Set COLLADA_SUPPORT=0 to skip building it. IfcConvert still supports glTF output.
+# Pass the same COLLADA_SUPPORT value to run-cmake.sh so IfcOpenShell is configured
+# with -DCOLLADA_SUPPORT=OFF and does not look for the missing OpenCOLLADA library.
+COLLADA_SUPPORT="${COLLADA_SUPPORT:-1}"
+if [ "$COLLADA_SUPPORT" != "0" ] && [ "$COLLADA_SUPPORT" != "OFF" ] && [ "$COLLADA_SUPPORT" != "off" ]; then
+    # Use a fixed revision in order to prevent introducing breaking changes
+    git_clone_and_checkout_revision https://github.com/KhronosGroup/OpenCOLLADA.git "$DEPS_DIR/OpenCOLLADA" \
+        064a60b65c2c31b94f013820856bc84fb1937cc6
+    pushd "$DEPS_DIR/OpenCOLLADA"
+    [ -d $BUILD_DIR ] || mkdir -p $BUILD_DIR
+    pushd $BUILD_DIR
+    cmake .. -G "MSYS Makefiles" -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR/OpenCOLLADA"
+    make -j$IFCOS_NUM_BUILD_PROCS
+    make install
+    popd
+    popd
+else
+    echo "Skipping OpenCOLLADA build (COLLADA_SUPPORT=$COLLADA_SUPPORT). Configure IfcOpenShell with -DCOLLADA_SUPPORT=OFF."
+fi
 
 git_clone_or_pull https://github.com/tpaviot/oce.git "$DEPS_DIR/oce"
 git_clone_or_pull https://github.com/QbProg/oce-win-bundle.git "$DEPS_DIR/oce/oce-win-bundle"
 pushd "$DEPS_DIR/oce"
 [ -d $BUILD_DIR ] || mkdir -p $BUILD_DIR
 pushd $BUILD_DIR
-# -DOCE_BUILD_SHARED_LIB=0 
+# -DOCE_BUILD_SHARED_LIB=0
 cmake .. -G "MSYS Makefiles" -DOCE_INSTALL_PREFIX="$INSTALL_DIR/oce" -DOCE_TESTING=0
 make -j$IFCOS_NUM_BUILD_PROCS
 make install
-popd 
-
+popd
 popd
 
 echo IfcOpenShell dependencies installed and built

--- a/win/run-cmake.sh
+++ b/win/run-cmake.sh
@@ -26,6 +26,14 @@ BUILD_DIR=../build-msys
 
 CMAKE_INSTALL_PREFIX=../installed-msys
 
+# Keep this in sync with build-deps.sh: when COLLADA_SUPPORT=0 OpenCOLLADA is not
+# built, so configure IfcOpenShell without it (IfcConvert still supports glTF).
+COLLADA_SUPPORT="${COLLADA_SUPPORT:-1}"
+COLLADA_CMAKE_ARGS=""
+if [ "$COLLADA_SUPPORT" = "0" ] || [ "$COLLADA_SUPPORT" = "OFF" ] || [ "$COLLADA_SUPPORT" = "off" ]; then
+    COLLADA_CMAKE_ARGS="-DCOLLADA_SUPPORT=OFF"
+fi
+
 pushd $BUILD_DIR
 
 # PYTHON_INCLUDE_DIR=/mingw64/include/python2.7 \
@@ -35,6 +43,6 @@ OCC_LIBRARY_DIR=`pwd`/../deps-msys-installed/oce/Win64/lib/ \
 OPENCOLLADA_INCLUDE_DIR=`pwd`/../deps-msys-installed/OpenCOLLADA/include/opencollada/ \
 OPENCOLLADA_LIBRARY_DIR=`pwd`/../deps-msys-installed/OpenCOLLADA/lib/opencollada/ \
 cmake -G "MSYS Makefiles" ../cmake -DSWIG_DIR=/usr/bin -DCMAKE_INSTALL_PREFIX=$CMAKE_INSTALL_PREFIX \
-    -DCMAKE_MAKE_PROGRAM=/mingw64/bin/mingw32-make.exe $@
+    -DCMAKE_MAKE_PROGRAM=/mingw64/bin/mingw32-make.exe $COLLADA_CMAKE_ARGS $@
 
 popd


### PR DESCRIPTION
Addresses #6568.

MSys2/MinGW builds fail inside the bundled **OpenCOLLADA** dependency (`int64_t does not name a type`, `InterlockedCompareExchangePointer` pointer cast). OpenCOLLADA is unmaintained since 2018, and IfcConvert already has glTF as the modern replacement, so the right fix is to let people build without Collada.

Collada is **already optional at the cmake level** (`cmake/CMakeLists.txt` `option(COLLADA_SUPPORT ... ON)`, the `ColladaSerializer` and IfcConvert `.dae` option are fully guarded by `WITH_OPENCOLLADA`). But the MSys2 helper `win/build-deps.sh` clones and builds OpenCOLLADA **unconditionally**, before cmake runs, so the user hits the OpenCOLLADA compile wall and the optional flag is never reached.

This gates the OpenCOLLADA dependency build behind a `COLLADA_SUPPORT` env var:
- `win/build-deps.sh`: only clones/builds OpenCOLLADA when `COLLADA_SUPPORT` is not `0/OFF/off` (default `1` preserves current behavior). Made the OpenCOLLADA/oce blocks self-contained pushd/popd.
- `win/run-cmake.sh`: forwards `-DCOLLADA_SUPPORT=OFF` when disabled, so the dep build and the IfcOpenShell configure stay consistent.

MinGW users can then run `COLLADA_SUPPORT=0 ./build-deps.sh && COLLADA_SUPPORT=0 ./run-cmake.sh` and get a working IfcConvert (with glTF) instead of the broken dependency.

**Verification (honest):** I'm on macOS and cannot reproduce a Windows MinGW/ucrt build, so the full `COLLADA_SUPPORT=0` MSys2 build is proposed, not compiled. What is verified: the cmake option and `WITH_OPENCOLLADA` guards exist on v0.8.0; both edited scripts pass `bash -n`; the toggle truth table (unset/1/0/OFF/off) and pushd/popd balance check out.

For anyone who still needs Collada on MinGW, the two trace errors are fixable in OpenCOLLADA directly: add `#include <cstdint>` to `common/libBuffer/include/CommonFWriteBufferFlusher.h`, and cast the first arg in `Externals/LibXML/threads.c:452` to `(void* volatile*)`. That could be wired as a `win/patches/opencollada_mingw.patch` applied in `build-deps.sh` (the way `nix/patches/opencollada/` works) if maintainers prefer keeping Collada buildable there; I left it out since the skip toggle already unblocks the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
