### PR TITLE
ifcgeom: clone mapped items before in place mutation to fix nondeterministic multithreaded geometry (#8050)

### DIFF
--- a/src/ifcgeom/mapping/IfcCompositeCurve.cpp
+++ b/src/ifcgeom/mapping/IfcCompositeCurve.cpp
@@ -53,6 +53,9 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcCompositeCurve* inst) {
 			auto crv = map(segment->as<IfcSchema::IfcCompositeCurveSegment>()->ParentCurve());
 			if (crv) {
 				if (!segment->as<IfcSchema::IfcCompositeCurveSegment>()->SameSense()) {
+					// Clone before reversing so we do not corrupt the shared cached
+					// curve that map() may return for other segments.
+					crv.reset(crv->clone_());
 					crv->reverse();
 				}
 				if (crv->kind() == taxonomy::EDGE) {

--- a/src/ifcgeom/mapping/IfcEdge.cpp
+++ b/src/ifcgeom/mapping/IfcEdge.cpp
@@ -43,6 +43,9 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcEdge* inst) {
 		auto basis = map(inst->as<IfcSchema::IfcEdgeCurve>()->EdgeGeometry());
 		auto loop = taxonomy::dcast<taxonomy::loop>(basis);
 		if (loop && loop->children.size() == 1) {
+			// Clone before mutating so calculate_linear_edge_curves does not write
+			// into the child edges of the shared cached loop returned by map().
+			loop.reset(loop->clone_());
 			loop->calculate_linear_edge_curves();
 			basis = loop->children[0]->basis;
 		}

--- a/src/ifcgeom/mapping/IfcFace.cpp
+++ b/src/ifcgeom/mapping/IfcFace.cpp
@@ -26,18 +26,14 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcFace* inst) {
 	auto bounds = inst->Bounds();
 	for (auto& bound : *bounds) {
 		if (auto r = taxonomy::cast<taxonomy::loop>(map(bound->Bound()))) {
+			// Clone before mutating so we do not corrupt the shared cached loop
+			// that map() may return for other faces referencing the same bound.
+			r.reset(r->clone_());
 			if (!bound->Orientation()) {
 				r->reverse();
 			}
 			// @todo check why loop sets external to true initially
 			r->external = bound->declaration().is(IfcSchema::IfcFaceOuterBound::Class());
-			/*
-			// Make a copy in case we need immutability later for e.g. caching
-			auto s = r->clone();
-			((taxonomy::loop*)s)->external = true;
-			delete r;
-			r = s;
-			*/
 			face->children.push_back(r);
 		}
 	}


### PR DESCRIPTION
Fixes #8050.

The geometry iterator produced nondeterministic output under multithreading (elements intermittently missing or with different vertex counts between runs; single threaded is fine).

## Root cause

The mapping cache returns the same shared taxonomy item on a cache hit (`mapping::map()` returns the identical `shared_ptr`), and several `map_impl` handlers mutate a `map()` result in place without cloning first. That shared item is reused across the representations a worker processes, and across workers, so the in place write corrupts it. Because task distribution to workers is scheduler dependent, the corruption varies run to run.

## Fix

Clone before mutating at every site that writes into a `map()` result, matching the idiom already used in `IfcOrientedEdge`, `IfcDerivedProfileDef` and `IfcArbitraryOpenProfileDef`:

- `IfcFace.cpp`: clone the mapped loop before `reverse()` and setting `external`.
- `IfcCompositeCurve.cpp`: clone the mapped ParentCurve before `reverse()`.
- `IfcEdge.cpp`: clone the mapped loop before `calculate_linear_edge_curves()` writes into its child edges.

A full audit of every `map()` result mutation in `src/ifcgeom/mapping` is included; the sites that only read or store the result are left unchanged. Because `clone_()` deep clones children, the mutations that reach into child edges are also contained.

This fixes the race at the mutation site and keeps the mapping cache enabled, so the earlier approach of disabling the worker cache is no longer needed.

## Verification

Correctness is argued by equivalence with the existing clone before mutate idiom: after the change no cached shared item is ever mutated, so no two readers can observe each other's writes regardless of thread scheduling. A multithreaded before and after on a compiled kernel was not re run in this iteration, so I am happy to run the dental_clinic comparison again on a build if you want the empirical confirmation as well.
