### PR TITLE
ifcclash: fail gracefully when scikit-learn is missing for smart grouping (#4128)

### DIFF
--- a/src/bonsai/bonsai/bim/module/clash/operator.py
+++ b/src/bonsai/bonsai/bim/module/clash/operator.py
@@ -482,7 +482,11 @@ class SmartClashGroup(bpy.types.Operator):
 
         # execute the smart grouping
         save_path = bpy.path.ensure_ext(props.smart_grouped_clashes_path, ".json")
-        smart_grouped_clashes = ifc_clasher.smart_group_clashes(clash_sets, props.smart_clash_grouping_max_distance)
+        try:
+            smart_grouped_clashes = ifc_clasher.smart_group_clashes(clash_sets, props.smart_clash_grouping_max_distance)
+        except ImportError as e:
+            self.report({"ERROR"}, str(e))
+            return {"CANCELLED"}
 
         # save smart_groups to json
         with open(save_path, "w") as f:

--- a/src/ifcclash/ifcclash/ifcclash.py
+++ b/src/ifcclash/ifcclash/ifcclash.py
@@ -260,7 +260,13 @@ class Clasher:
     def smart_group_clashes(self, clash_sets: list[ClashSet], max_clustering_distance: float):
         from collections import defaultdict
 
-        from sklearn.cluster import OPTICS
+        try:
+            from sklearn.cluster import OPTICS
+        except ImportError as e:
+            raise ImportError(
+                "Smart clash grouping requires scikit-learn (and its dependencies scipy, numpy, "
+                "joblib, threadpoolctl). Install it with `pip install scikit-learn` to use this feature."
+            ) from e
 
         count_of_input_clashes = 0
         count_of_clash_sets = 0


### PR DESCRIPTION
Fixes #4128.

Using "Smart Group Clashes" without scikit-learn installed crashed with a raw `ModuleNotFoundError`. Smart grouping uses scikit-learn's `OPTICS` clusterer (`ifcclash.py`, `smart_group_clashes()`), and scikit-learn (plus scipy/numpy/joblib/threadpoolctl) is a heavy, undeclared optional dependency that is frequently absent.

## Change
- `ifcclash.py`: the lazy `from sklearn.cluster import OPTICS` is wrapped in `try/except ImportError`, re-raising a clear message telling the user which packages are needed and how to install them (`pip install scikit-learn`).
- Bonsai `SmartClashGroup` operator: catches `ImportError` and reports it via `self.report({"ERROR"}, ...)`, returning `{"CANCELLED"}` instead of surfacing a traceback.

## Scope
Graceful handling only. Does not add scikit-learn as a hard dependency, and does not touch the clash algorithm or the collision backend, the trimesh/pyembree/fcpw/cgal backend-replacement discussion in the issue is left for its own effort. Behavior is identical when scikit-learn is installed.

## Testing
With scikit-learn absent: the module still imports, and invoking smart grouping now yields the clear message instead of a traceback. The sklearn-present path is unchanged (verified by injecting a stub `OPTICS`). Black and Ruff pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
