### PR TITLE
Bonsai: clear all stale annotation products on linked-aggregate refresh (#4014)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -1633,9 +1633,15 @@ class RefreshLinkedAggregate(bpy.types.Operator, tool.Ifc.Operator):
                 if annotation:
                     bonsai.core.drawing.edit_assigned_product(tool.Ifc, tool.Drawing, obj=annotation, product=product)
                 else:
-                    existing_product = tool.Drawing.get_assigned_product(assignment)
-                    if existing_product != product:
-                        if existing_product:
+                    # Mirror core.drawing.edit_assigned_product: an annotation may have
+                    # accumulated more than one assigned product (see #4014). Clear every
+                    # existing product assignment before assigning the new one, otherwise
+                    # stale products remain and the reassignment silently fails.
+                    existing_products = tool.Drawing.get_assigned_product_workaround(assignment)
+                    if existing_products != [product]:
+                        if product in existing_products:
+                            existing_products.remove(product)
+                        for existing_product in existing_products:
                             ifcopenshell.api.drawing.unassign_product(
                                 ifc_file, relating_product=existing_product, related_object=assignment
                             )


### PR DESCRIPTION
**Fixes the last single-product reassign path for #4014.**

`IfcAnnotation` may hold multiple `IfcRelAssignsToProduct` relations. The main UI reassign path already handles this (unassign all, then assign new). `RefreshLinkedAggregate.assign_to_annotations` still used the singular `get_assigned_product` in its `else` branch (annotation with no loaded Blender object), so on a multi-product annotation it removed only the first product and left the rest, silently failing the reassignment (same class of bug as #4014).

This makes the branch mirror `core.drawing.edit_assigned_product`: clear every existing product assignment, then assign the new one. Single-product behaviour is unchanged.

**Testing:** verified against the reporter's `Monica_Residence.ifc` (30 annotations with 2-3 products). The old branch left stale products; the new branch collapses to the newly assigned product. Single-product control unchanged. Black + Ruff pass.

Scope note: this does not address how annotations accumulate multiple products in the first place (still under investigation via the diagnostic warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
