### PR TITLE
svg: guard HLR stages so one failing element or projection does not abort the drawing (#3971)

### DIFF
--- a/src/serializers/SvgSerializer.h
+++ b/src/serializers/SvgSerializer.h
@@ -38,6 +38,7 @@
 #include <gp_Pln.hxx>
 #include <Bnd_Box.hxx>
 #include <Standard_Version.hxx>
+#include <Standard_Failure.hxx>
 #include <BRep_Builder.hxx>
 #include <HLRBRep_PolyHLRToShape.hxx>
 #include <BRepTopAdaptor_FClass2d.hxx>
@@ -385,6 +386,16 @@ namespace {
 
 		Logger& logger_;
 
+		// Characterise an OpenCASCADE failure for the log so the cause is actionable
+		// instead of an opaque "unknown error". OCCT throws Standard_Failure, which on
+		// some OCCT builds does not derive from std::exception, hence the dedicated
+		// overload. See #3971.
+		static std::string describe_occt_failure(const Standard_Failure& e) {
+			std::string type = e.DynamicType() ? e.DynamicType()->Name() : "Standard_Failure";
+			const char* msg = e.GetMessageString();
+			return type + (msg && *msg ? std::string(": ") + msg : std::string());
+		}
+
 	public:
 
 		prefiltered_hlr(Logger& logger, bool use_prefiltering, bool use_hlr_poly, bool segment_projection, const gp_Pln& view_direction)
@@ -472,13 +483,21 @@ namespace {
 			gp_Dir D;
 
 			// The prefiltering analysis below (manifold test, face classification) runs OCCT
-			// routines that can throw on an unclean mesh. If building the filtered compound
-			// fails, fall back to adding the shape unfiltered so a single bad element cannot
-			// abort the drawing during HLR accumulation. See #3971.
+			// routines that can throw. If building the filtered compound fails, fall back to
+			// adding the shape unfiltered so a single failing element cannot abort the drawing
+			// during HLR accumulation. Skip and warn with an error code so a Python consumer
+			// can conditionally raise. See #3971.
 			bool is_manifold = false;
 			try {
 				is_manifold = IfcGeom::util::is_manifold(s);
+			} catch (const Standard_Failure& e) {
+				logger_.Notice("SER", 36, "Manifold test failed, treating element as non-manifold: " + describe_occt_failure(e), product);
+				is_manifold = false;
+			} catch (const std::exception& e) {
+				logger_.Notice("SER", 36, e, product);
+				is_manifold = false;
 			} catch (...) {
+				logger_.Notice("SER", 36, "Manifold test failed for element, treating as non-manifold", product);
 				is_manifold = false;
 			}
 
@@ -512,12 +531,16 @@ namespace {
 					logger_.Notice("SER", 34, "Included " + std::to_string(n_faces_included) + " faces out of " + std::to_string(n_total) + " after prefiltering");
 
 					it = items_.insert(items_.end(), { product, C });
+				} catch (const Standard_Failure& e) {
+					logger_.Warning("SER", 37, "Prefilter face analysis failed, element added unfiltered to hidden line removal: " + describe_occt_failure(e), product);
+					items_.insert(items_.end(), { product, s });
+					return;
 				} catch (const std::exception& e) {
-					logger_.Warning("SER", 36, e, product);
+					logger_.Warning("SER", 37, e, product);
 					items_.insert(items_.end(), { product, s });
 					return;
 				} catch (...) {
-					logger_.Warning("SER", 36, "Element added unfiltered to hidden line removal due to an unclean mesh", product);
+					logger_.Warning("SER", 37, "Prefilter face analysis failed, element added unfiltered to hidden line removal", product);
 					items_.insert(items_.end(), { product, s });
 					return;
 				}
@@ -554,8 +577,12 @@ namespace {
 							}
 						}
 					}
+				} catch (const Standard_Failure& e) {
+					logger_.Notice("SER", 38, "Incomplete obscuration prefiltering cache for element: " + describe_occt_failure(e), product);
+				} catch (const std::exception& e) {
+					logger_.Notice("SER", 38, e, product);
 				} catch (...) {
-					logger_.Notice("SER", 34, "Incomplete prefiltering cache for element due to an unclean mesh");
+					logger_.Notice("SER", 38, "Incomplete obscuration prefiltering cache for element", product);
 				}
 			} else {
 				items_.insert(items_.end(), { product, s });
@@ -565,20 +592,21 @@ namespace {
 		std::list<std::tuple<const IfcUtil::IfcBaseEntity*, std::string, TopoDS_Shape>> build() {
 			size_t n_included = 0;
 			for (auto it = items_.begin(); it != items_.end(); ++it) {
-				// An unclean mesh (self-intersections, degeneracies, ...) can make the
-				// underlying OCCT routines (obscuration test, HLRBRep_Algo::Add / BRepMesh /
-				// Load) throw. Skip the offending element with a warning rather than aborting
-				// the whole drawing. See #3971.
+				// The per-element OCCT routines (obscuration test, HLRBRep_Algo::Add /
+				// BRepMesh / Load) can throw on some inputs. Skip the offending element with
+				// a warning and an error code rather than aborting the whole drawing. See #3971.
 				try {
 					if (!use_prefiltering_ || !is_obscured_(&it->second)) {
 						hlr_writer vis(it->second);
 						boost::apply_visitor(vis, engine_);
 						n_included++;
 					}
+				} catch (const Standard_Failure& e) {
+					logger_.Warning("SER", 39, "Element skipped in hidden line removal: " + describe_occt_failure(e), it->first);
 				} catch (const std::exception& e) {
-					logger_.Warning("SER", 36, e, it->first);
+					logger_.Warning("SER", 39, e, it->first);
 				} catch (...) {
-					logger_.Warning("SER", 36, "Element skipped in hidden line removal due to an unclean mesh", it->first);
+					logger_.Warning("SER", 39, "Element skipped in hidden line removal", it->first);
 				}
 			}
 			if (use_prefiltering_) {
@@ -590,17 +618,24 @@ namespace {
 				vis.set_product_shape(&items_);
 			}
 			vis.set_classified_shapes(&classified_items_);
-			// The projection pass (HLRBRep_Algo::Update/Hide or the poly equivalent) can also
-			// throw on unclean accumulated input. Keep the drawing alive by emitting no
-			// projected linework for this drawing instead of propagating the failure out of
-			// finalize(). See #3971.
+			// The projection pass (HLRBRep_Algo::Update/Hide or the poly HLR equivalent) runs
+			// over the whole accumulated compound at once, so it has no per-element
+			// granularity. On the Monica_Residence model this is where OCCT throws
+			// Standard_OutOfRange ("NCollection_Array1::ChangeValue") deep in the poly HLR
+			// projector even though the input mesh is topologically clean. Keep the drawing
+			// alive by emitting no projected linework for it instead of propagating the
+			// failure out of finalize(). Logged at ERROR with a code so a Python consumer can
+			// conditionally raise. See #3971.
 			try {
 				return boost::apply_visitor(vis, engine_);
+			} catch (const Standard_Failure& e) {
+				logger_.Error("SER", 40, "Projected hidden line removal failed, drawing rendered without projected linework: " + describe_occt_failure(e));
+				return {};
 			} catch (const std::exception& e) {
-				logger_.Error("SER", 37, e);
+				logger_.Error("SER", 40, e);
 				return {};
 			} catch (...) {
-				logger_.Error("SER", 37, "Projected linework skipped for this drawing due to an unclean mesh");
+				logger_.Error("SER", 40, "Projected hidden line removal failed, drawing rendered without projected linework");
 				return {};
 			}
 		}

--- a/src/serializers/SvgSerializer.h
+++ b/src/serializers/SvgSerializer.h
@@ -471,41 +471,66 @@ namespace {
 			gp_Vec V;
 			gp_Dir D;
 
-			if (IfcGeom::util::is_manifold(s)) {
-				size_t n_faces_included = 0, n_total = 0;
-				{
-					TopExp_Explorer exp(s, TopAbs_FACE);
-					for (; exp.More(); exp.Next(), n_total++) {
-						const auto& face = TopoDS::Face(exp.Current());
-						if (BRep_Tool::Surface(face)->DynamicType() == STANDARD_TYPE(Geom_Plane)) {
-							BRepGProp_Face prop(face);
+			// The prefiltering analysis below (manifold test, face classification) runs OCCT
+			// routines that can throw on an unclean mesh. If building the filtered compound
+			// fails, fall back to adding the shape unfiltered so a single bad element cannot
+			// abort the drawing during HLR accumulation. See #3971.
+			bool is_manifold = false;
+			try {
+				is_manifold = IfcGeom::util::is_manifold(s);
+			} catch (...) {
+				is_manifold = false;
+			}
 
-							prop.Normal(0., 0., P, V);
-							if (V.SquareMagnitude() > 1.e-9) {
-								D = V;
-								// keep only front-facing
-								if (D.Dot(view_direction_.Direction()) > 1.e-3) {
-									BB.Add(C, face);
-									n_faces_included++;
+			std::list<std::pair<const IfcUtil::IfcBaseEntity*, TopoDS_Shape>>::iterator it;
+			if (is_manifold) {
+				try {
+					size_t n_faces_included = 0, n_total = 0;
+					{
+						TopExp_Explorer exp(s, TopAbs_FACE);
+						for (; exp.More(); exp.Next(), n_total++) {
+							const auto& face = TopoDS::Face(exp.Current());
+							if (BRep_Tool::Surface(face)->DynamicType() == STANDARD_TYPE(Geom_Plane)) {
+								BRepGProp_Face prop(face);
+
+								prop.Normal(0., 0., P, V);
+								if (V.SquareMagnitude() > 1.e-9) {
+									D = V;
+									// keep only front-facing
+									if (D.Dot(view_direction_.Direction()) > 1.e-3) {
+										BB.Add(C, face);
+										n_faces_included++;
+									}
 								}
+							} else {
+								BB.Add(C, face);
+								n_faces_included++;
 							}
-						} else {
-							BB.Add(C, face);
-							n_faces_included++;
 						}
 					}
+
+					logger_.Notice("SER", 34, "Included " + std::to_string(n_faces_included) + " faces out of " + std::to_string(n_total) + " after prefiltering");
+
+					it = items_.insert(items_.end(), { product, C });
+				} catch (const std::exception& e) {
+					logger_.Warning("SER", 36, e, product);
+					items_.insert(items_.end(), { product, s });
+					return;
+				} catch (...) {
+					logger_.Warning("SER", 36, "Element added unfiltered to hidden line removal due to an unclean mesh", product);
+					items_.insert(items_.end(), { product, s });
+					return;
 				}
 
-				logger_.Notice("SER", 34, "Included " + std::to_string(n_faces_included) + " faces out of " + std::to_string(n_total) + " after prefiltering");
-
-				auto it = items_.insert(items_.end(), { product, C });
-
-				{
+				// Best-effort large-orthogonal-face cache used for obscuration prefiltering.
+				// The shape is already accumulated above, so on failure just abandon the
+				// remaining cache entries rather than losing the element. See #3971.
+				try {
 					TopExp_Explorer exp(C, TopAbs_FACE);
 					for (; exp.More(); exp.Next()) {
 						const auto& face = TopoDS::Face(exp.Current());
 						if (BRep_Tool::Surface(face)->DynamicType() == STANDARD_TYPE(Geom_Plane)) {
-							
+
 							// find large faces orthogonal to view dir
 							BRepGProp_Face prop(face);
 							prop.Normal(0., 0., P, V);
@@ -529,6 +554,8 @@ namespace {
 							}
 						}
 					}
+				} catch (...) {
+					logger_.Notice("SER", 34, "Incomplete prefiltering cache for element due to an unclean mesh");
 				}
 			} else {
 				items_.insert(items_.end(), { product, s });
@@ -538,10 +565,20 @@ namespace {
 		std::list<std::tuple<const IfcUtil::IfcBaseEntity*, std::string, TopoDS_Shape>> build() {
 			size_t n_included = 0;
 			for (auto it = items_.begin(); it != items_.end(); ++it) {
-				if (!use_prefiltering_ || !is_obscured_(&it->second)) {
-					hlr_writer vis(it->second);
-					boost::apply_visitor(vis, engine_);
-					n_included++;
+				// An unclean mesh (self-intersections, degeneracies, ...) can make the
+				// underlying OCCT routines (obscuration test, HLRBRep_Algo::Add / BRepMesh /
+				// Load) throw. Skip the offending element with a warning rather than aborting
+				// the whole drawing. See #3971.
+				try {
+					if (!use_prefiltering_ || !is_obscured_(&it->second)) {
+						hlr_writer vis(it->second);
+						boost::apply_visitor(vis, engine_);
+						n_included++;
+					}
+				} catch (const std::exception& e) {
+					logger_.Warning("SER", 36, e, it->first);
+				} catch (...) {
+					logger_.Warning("SER", 36, "Element skipped in hidden line removal due to an unclean mesh", it->first);
 				}
 			}
 			if (use_prefiltering_) {
@@ -553,7 +590,19 @@ namespace {
 				vis.set_product_shape(&items_);
 			}
 			vis.set_classified_shapes(&classified_items_);
-			return boost::apply_visitor(vis, engine_);
+			// The projection pass (HLRBRep_Algo::Update/Hide or the poly equivalent) can also
+			// throw on unclean accumulated input. Keep the drawing alive by emitting no
+			// projected linework for this drawing instead of propagating the failure out of
+			// finalize(). See #3971.
+			try {
+				return boost::apply_visitor(vis, engine_);
+			} catch (const std::exception& e) {
+				logger_.Error("SER", 37, e);
+				return {};
+			} catch (...) {
+				logger_.Error("SER", 37, "Projected linework skipped for this drawing due to an unclean mesh");
+				return {};
+			}
 		}
 	};
 }


### PR DESCRIPTION
## Summary
The SVG serializer ran the OpenCASCADE hidden-line-removal routines in `prefiltered_hlr` with no exception handling, so a single failing element or a failing projection aborted the whole drawing. `finalize()` propagated a bare `Standard_Failure` that the Python wrapper reported as the opaque `RuntimeError: An unknown error occurred`. On the issue's Monica_Residence model, 17 drawings failed this way.

## Root cause
Characterized on that model: OCCT throws `Standard_OutOfRange` (`NCollection_Array1::ChangeValue`) in the poly HLR projection pass (`HLRBRep_PolyAlgo` / `PolyHLRToShape`), reached from `finalize()` via `build()`, even though the input mesh is topologically clean. It is an internal out-of-range in the projector, not a repairable mesh defect. The projection runs over the whole accumulated compound at once, so it has no per-element granularity.

## Change
Per @aothms's guidance (skip in C++, let Python conditionally raise): guard each HLR stage (manifold test, prefilter face analysis, obscuration cache, per-element accumulation, projection) and on failure skip that unit while emitting a message through the non-static logger with a distinct SER error code (36 to 40) and the offending product where known. The projection failure is logged at ERROR (SER40) so a Python consumer can key on the code and raise. The catch sites handle `Standard_Failure` explicitly and report its `DynamicType` and `GetMessageString`, because on this OCCT build `Standard_Failure` does not derive from `std::exception`; a plain `catch (std::exception&)` would never see it and the log would stay generic.

## Verification
On Monica_Residence: drawings that threw now finalize (SOUTH ELEVATION, SECTION - EAST, SECTION - NORTH complete; each logs SER40 with the OCCT detail), a clean drawing (NORTH ELEVATION) is byte-identical to the unguarded output, and no exception leaves `finalize()`.

Fixes #3971

🤖 Generated with [Claude Code](https://claude.com/claude-code)
