### PR TITLE
fix(bonsai): stop unusual metric length units from crashing format_distance

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/helper.py
+++ b/src/bonsai/bonsai/bim/module/drawing/helper.py
@@ -196,7 +196,10 @@ def format_distance(
                 "CENTIMETRE": "CENTIMETERS",
                 "MILLIMETRE": "MILLIMETERS",
             }
-            unit_length = unit_length_mapping[unit_length]
+            # Any valid IFC SI length unit that has no dedicated formatting branch
+            # below (for example KILOMETRE or MICROMETRE) falls through to the
+            # adaptive metric formatting instead of raising a KeyError.
+            unit_length = unit_length_mapping.get(unit_length, unit_length)
         # For now we only format area in IFC Units
         if area_unit := ifcopenshell.util.unit.get_project_unit(tool.Ifc.get(), "AREAUNIT"):
             area_unit_symbol = " " + ifcopenshell.util.unit.get_unit_symbol(area_unit)


### PR DESCRIPTION
Reported by @sboddy in #7102.

The New Project Wizard uses Blender's native length-unit dropdown, which offers Kilometre and Micrometre for metric projects. Selecting one and then drawing a wall crashed:

    File ".../bonsai/bim/module/drawing/helper.py", line 159, in format_distance
      unit_length = unit_length_mapping[unit_length]
    KeyError: 'KILOMETRE'

`format_distance` derives the active IFC length unit name (including any SI Prefix, giving names like KILOMETRE or MICROMETRE) and looked it up in a hardcoded dict with a direct subscript. That dict only covers FOOT, INCH, METRE, DECIMETRE, CENTIMETRE and MILLIMETRE, so any other valid IFC SI length unit raised a KeyError. This affects the wizard, but also any IFC file authored elsewhere that legitimately uses these units, so the fix belongs in the downstream handling rather than in the offered list.

The metric formatter already has an adaptive fallback branch for any unit it does not handle explicitly. Switching the lookup to `dict.get` with the raw unit name as the fallback lets kilometre, micrometre and any other unmapped SI length unit reach that branch and format correctly instead of crashing. The known units are unaffected.

Verified in Blender 5.1.2 by building IFC files with each SI length unit and calling `format_distance` directly. Before, KILOMETRE and MICROMETRE raised KeyError; after, they return a valid metric string. METRE, MILLIMETRE and CENTIMETRE output is unchanged.

Fixes #7102

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
