### PR TITLE
fix(ifc5d): correct swapped Width and Depth in Qto_SlabBaseQuantities

### DIFF
--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
@@ -507,7 +507,7 @@
             },
             "IfcSlab": {
                 "Qto_SlabBaseQuantities": {
-                    "Depth": "net_get_z",
+                    "Depth": "net_get_y",
                     "GrossArea": "gross_get_footprint_area",
                     "GrossVolume": "gross_get_volume",
                     "GrossWeight": "gross_get_weight",
@@ -516,7 +516,7 @@
                     "NetVolume": "net_get_volume",
                     "NetWeight": "net_get_weight",
                     "Perimeter": "net_get_footprint_perimeter",
-                    "Width": "net_get_y"
+                    "Width": "net_get_z"
                 }
             },
             "IfcSolarDevice": {

--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantitiesBlender.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantitiesBlender.json
@@ -507,7 +507,7 @@
             },
             "IfcSlab": {
                 "Qto_SlabBaseQuantities": {
-                    "Depth": "get_height",
+                    "Depth": "get_width",
                     "GrossArea": "get_gross_footprint_area",
                     "GrossVolume": "get_gross_volume",
                     "GrossWeight": "get_gross_weight",
@@ -516,7 +516,7 @@
                     "NetVolume": "get_net_volume",
                     "NetWeight": "get_net_weight",
                     "Perimeter": "get_gross_perimeter",
-                    "Width": "get_width"
+                    "Width": "get_height"
                 }
             },
             "IfcSolarDevice": {

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
@@ -643,7 +643,7 @@
             },
             "IfcSlab + IfcSlabType": {
                 "Qto_SlabBaseQuantities": {
-                    "Depth": "net_get_z",
+                    "Depth": "net_get_y",
                     "GrossArea": "gross_get_footprint_area",
                     "GrossVolume": "gross_get_volume",
                     "GrossWeight": "gross_get_weight",
@@ -652,7 +652,7 @@
                     "NetVolume": "net_get_volume",
                     "NetWeight": "net_get_weight",
                     "Perimeter": "net_get_footprint_perimeter",
-                    "Width": "net_get_y"
+                    "Width": "net_get_z"
                 }
             },
             "IfcSolarDevice + IfcSolarDeviceType": {

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
@@ -643,7 +643,7 @@
             },
             "IfcSlab + IfcSlabType": {
                 "Qto_SlabBaseQuantities": {
-                    "Depth": "get_height",
+                    "Depth": "get_width",
                     "GrossArea": "get_gross_footprint_area",
                     "GrossVolume": "get_gross_volume",
                     "GrossWeight": "get_gross_weight",
@@ -652,7 +652,7 @@
                     "NetVolume": "get_net_volume",
                     "NetWeight": "get_net_weight",
                     "Perimeter": "get_gross_perimeter",
-                    "Width": "get_width"
+                    "Width": "get_height"
                 }
             },
             "IfcSolarDevice + IfcSolarDeviceType": {


### PR DESCRIPTION
The base quantity rule files assigned the slab Width and Depth the wrong way around versus the buildingSMART definition of Qto_SlabBaseQuantities.

Per the IFC4x3 spec:
- Width is the width of the object, only given if it has constant thickness (prismatic). This is the slab thickness.
- Depth is one direction of the non-projected footprint area.
- Length is the other footprint direction.

The rule files mapped Depth to the vertical thickness and Width to a horizontal footprint dimension, so the two values came out swapped. This affected both calculators and both schemas:
- IFC4QtoBaseQuantities.json and IFC4X3QtoBaseQuantities.json (IfcOpenShell): Depth net_get_z, Width net_get_y
- IFC4QtoBaseQuantitiesBlender.json and IFC4X3QtoBaseQuantitiesBlender.json (Blender): Depth get_height, Width get_width

The fix swaps the Depth and Width formulas in all four files. Length is unchanged.

Verified with a rectangular slab of footprint 5.0 by 3.0 and thickness 0.2, run through the IfcOpenShell calculator:
- before: Width 3.0, Depth 0.2
- after:  Width 0.2, Depth 3.0
Length stayed 5.0.

The Blender calculator path was verified by inspection: get_height returns the local Z extent (thickness) and get_width returns the smaller of the two horizontal extents, so the same swap applies. It was not driven through a live Blender session. Testing covered a single axis-aligned rectangular slab.

Thanks to @IO10101 for the report and @steverugi for the spec discussion.

Fixes #8053

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
