### PR TITLE
fix(bonsai): add door geometry to an object with no mesh data (#7117)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/door.py
+++ b/src/bonsai/bonsai/bim/module/model/door.py
@@ -538,6 +538,14 @@ class AddDoor(bpy.types.Operator, tool.Ifc.Operator):
     def add_door_on_object(self, obj: bpy.types.Object) -> None:
         element = tool.Ifc.get_entity(obj)
         assert element
+        # A door element may be assigned to a Blender empty (for example an
+        # IfcDoorType created by assigning the class to an empty). An empty has
+        # no mesh data and cannot hold the parametric door representation, which
+        # later fails in replace_object_ifc_representation. Recreate it as a mesh
+        # object first so the geometry can be attached. See #7117.
+        if not isinstance(obj.data, bpy.types.Mesh):
+            obj = tool.Geometry.recreate_object_with_data(obj, bpy.data.meshes.new(obj.name))
+            tool.Blender.set_active_object(obj)
         props = tool.Model.get_door_props(obj)
 
         tool.Blender.get_addon_preferences().default_parameters.door.copy_to(props)


### PR DESCRIPTION
Reported by @shahn in #7117.

Creating a door type from a Blender empty and adding parametric geometry crashed:

    File ".../bonsai/tool/model.py", in replace_object_ifc_representation
        assert isinstance(mesh, bpy.types.Mesh)
    AssertionError

When you assign IfcDoorType to a Blender empty and then add parametric door geometry, `add_door_on_object` runs on an object whose `obj.data` is None. It then calls `replace_object_ifc_representation`, which requires a Mesh, so the assert fails. IfcDoorType is eligible for the door modifier, so this is a valid user action, the object simply never received a mesh to hold the representation.

An empty cannot be turned into a mesh object by assigning `.data`, so the object is recreated with a fresh mesh using the existing `Geometry.recreate_object_with_data` helper before the door representation is built.

Verified in Blender 5.1.2 headless by driving the operator path (create project, add empty, assign IfcDoorType, add door): before the change it reproduces the reported AssertionError, after the change the object becomes a mesh, the IfcDoorType gets its Profile, Body and Plan representation maps, and valid door geometry is produced. Verified at the operator level, not through a live GUI session.

Fixes #7117

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
