### PR TITLE
Bonsai: resolve sheet drawing via document Location instead of fuzzy name match

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2398,6 +2398,10 @@ class ActivateDrawingBase(tool.Ifc.Operator):
                 tool.Drawing.import_annotations_in_group(tool.Drawing.get_drawing_group(selected_drawing))
             return {"FINISHED"}
 
+        if not self.drawing:
+            self.report({"WARNING"}, "No drawing is associated with this sheet item.")
+            return {"CANCELLED"}
+
         drawing = tool.Ifc.get().by_id(self.drawing)
         dprops = tool.Drawing.get_document_props()
 
@@ -2505,6 +2509,20 @@ class ActivateDrawingFromSheet(bpy.types.Operator, ActivateDrawingBase):
             cls.poll_message_set("No drawing selected.")
             return False
         return True
+
+    def invoke(self, context, event) -> set["rna_enums.OperatorReturnItems"]:
+        # Resolve the drawing from the active sheet item here (once per click) rather than in the
+        # Sheets panel's draw(): draw() runs on every redraw, and get_drawing_from_sheet_reference()
+        # scans all IfcAnnotation entities, which noticeably lagged the panel on large models.
+        active_sheet = tool.Drawing.get_active_sheet_item(reference_type="DRAWING")
+        if active_sheet:
+            reference = tool.Ifc.get().by_id(active_sheet.ifc_definition_id)
+            drawing = tool.Drawing.get_drawing_from_sheet_reference(reference)
+            if drawing is not None:
+                self.drawing = drawing.id()
+        # Call the base invoke explicitly: in the MRO bpy.types.Operator precedes ActivateDrawingBase,
+        # so super().invoke() could bypass the base's modifier-key handling.
+        return ActivateDrawingBase.invoke(self, context, event)
 
 
 class RemoveDrawing(bpy.types.Operator, tool.Ifc.Operator):

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -483,20 +483,10 @@ class BIM_PT_sheets(Panel):
             op = row3.operator("bim.activate_drawing_from_sheet", icon="OUTLINER_OB_CAMERA", text="")
 
             if active_sheet.reference_type == "DRAWING":
-                drawingnamesvg = active_sheet.name
-                drawingname = drawingnamesvg.split(".svg")[0]
-                ifc_file = tool.Ifc.get()
-                ifc_annotations = ifc_file.by_type("IfcAnnotation")
-                drawingid = None
-                for annotation in ifc_annotations:
-                    if annotation.ObjectType != "DRAWING":
-                        continue
-                    Annotation_Name = annotation.Name.replace(",", "")  # Remove commas
-                    if Annotation_Name == drawingname:
-                        drawingid = annotation.id()
-                        break
-                if drawingid is not None:
-                    op.drawing = drawingid
+                reference = tool.Ifc.get().by_id(active_sheet.ifc_definition_id)
+                drawing = tool.Drawing.get_drawing_from_sheet_reference(reference)
+                if drawing is not None:
+                    op.drawing = drawing.id()
 
             row3.separator(factor=0.5, type="SPACE")
 

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -480,13 +480,11 @@ class BIM_PT_sheets(Panel):
             row3 = row.row(align=True)
             row3.alignment = "RIGHT"
 
-            op = row3.operator("bim.activate_drawing_from_sheet", icon="OUTLINER_OB_CAMERA", text="")
-
-            if active_sheet.reference_type == "DRAWING":
-                reference = tool.Ifc.get().by_id(active_sheet.ifc_definition_id)
-                drawing = tool.Drawing.get_drawing_from_sheet_reference(reference)
-                if drawing is not None:
-                    op.drawing = drawing.id()
+            # The operator resolves the drawing from the active sheet item itself (in invoke), so we
+            # deliberately don't call get_drawing_from_sheet_reference() here: draw() runs on every
+            # redraw and that helper scans all IfcAnnotation entities, which noticeably lagged the
+            # Sheets panel on large models.
+            row3.operator("bim.activate_drawing_from_sheet", icon="OUTLINER_OB_CAMERA", text="")
 
             row3.separator(factor=0.5, type="SPACE")
 

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2827,6 +2827,29 @@ class Drawing(bonsai.core.tool.Drawing):
         return (start - offset).tolist(), (end + offset).tolist()
 
     @classmethod
+    def get_drawing_from_sheet_reference(
+        cls, reference: ifcopenshell.entity_instance
+    ) -> Union[ifcopenshell.entity_instance, None]:
+        """Resolve the drawing IfcAnnotation referenced by a sheet's ``DRAWING`` document reference.
+
+        A sheet reference and the drawing's own document share the exact same ``Location``
+        (see :meth:`get_sheet_references`, the inverse of this lookup), so we match on that
+        instead of reconstructing and comparing the (sanitised) SVG filename or the drawing name.
+        This keeps the resolution correct for drawing names containing commas or any other
+        character stripped by :meth:`sanitise_filename`.
+        """
+        location = reference.Location
+        if not location:
+            return None
+        for drawing in tool.Ifc.get().by_type("IfcAnnotation"):
+            if drawing.ObjectType != "DRAWING":
+                continue
+            document = cls.get_drawing_document(drawing)
+            if document and document.Location == location:
+                return drawing
+        return None
+
+    @classmethod
     def get_sheet_references(cls, drawing: ifcopenshell.entity_instance) -> list[ifcopenshell.entity_instance]:
         sheet_references: list[ifcopenshell.entity_instance] = []
         drawing_reference = cls.get_drawing_document(drawing)


### PR DESCRIPTION
Clicking a drawing inside a sheet in the Sheets panel needs the drawing's IfcAnnotation id to activate it. The code reconstructed the drawing name from the sheet reference's SVG filename and reverse matched it against every `IfcAnnotation.Name`. That filename is produced by `sanitise_filename`, which strips every character outside a safe set, so the reverse match is inherently lossy. Drawing names with a comma (and `#`, parentheses, `@`, `/` and similar) failed to resolve, leaving the local `drawingid` unbound and raising `UnboundLocalError: cannot access local variable 'drawingid'`, collapsing the sheet UI on click and on save.

The merged workaround in d581174 only stripped commas, so any other sanitised character still broke it, and @Moult reopened asking for a proper fix.

Root cause and fix: a sheet's DRAWING `IfcDocumentReference` is created with the same `Location` as the drawing's own document (`get_drawing_document`), and `get_sheet_references` already uses that `Location` equality in the forward direction. `Location` is the real, punctuation independent link. This PR adds `Drawing.get_drawing_from_sheet_reference` (the inverse of `get_sheet_references`) and uses it in `BIM_PT_sheets`, dropping the comma stripping name match entirely. Names with any punctuation now resolve correctly.

Verified against the reporter's sample file (`BreakSheetUi.ifc`): drawing `'PLAN, View'` has document `Location` `drawings/PLAN View.svg`, matching the sheet reference `Location` exactly, and now resolves to the correct id. A synthetic `#` in name case confirms the new resolver succeeds where the old comma only hack returned nothing. Black (120), Ruff and ty are clean on the changed files.

Verified at the resolution logic level against the sample file, not via a live GUI click through in Blender.

Reported by @Slackking1. Initial workaround by @theoryshaw; better fix requested by @Moult.

Fixes #5493

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
