### PR TITLE
Bonsai: fix "Instance not found" crash when removing a stale presentation layer

### DIFF
--- a/src/bonsai/bonsai/bim/module/layer/operator.py
+++ b/src/bonsai/bonsai/bim/module/layer/operator.py
@@ -16,9 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import bpy
+import ifcopenshell
 import ifcopenshell.api.layer
 import ifcopenshell.util.element
 
@@ -33,6 +36,28 @@ def get_active_mesh(context: bpy.types.Context, mesh_name: str) -> bpy.types.Mes
         assert (obj := context.active_object)
         assert isinstance(item_mesh := obj.data, bpy.types.Mesh)
     return item_mesh
+
+
+def resolve_layer(
+    operator: bpy.types.Operator, ifc_file: ifcopenshell.file, layer_id: int
+) -> ifcopenshell.entity_instance | None:
+    """Resolve a layer id supplied by the UI to a live entity.
+
+    UI buttons bake the layer id at draw time, so a queued or double click can
+    still target an ``IfcPresentationLayerAssignment`` that another operator has
+    already removed. Rather than let ``by_id`` raise ``Instance #N not found``,
+    reload the layer list so the stale row disappears, warn the user, and return
+    ``None`` so the caller aborts without touching a deleted entity.
+    """
+    try:
+        layer = ifc_file.by_id(layer_id)
+    except RuntimeError:
+        layer = None
+    if layer is None or not layer.is_a("IfcPresentationLayerAssignment"):
+        bpy.ops.bim.load_layers()
+        operator.report({"WARNING"}, "Presentation layer no longer exists, the layer list has been refreshed.")
+        return None
+    return layer
 
 
 class LoadLayers(bpy.types.Operator):
@@ -82,8 +107,12 @@ class EnableEditingLayer(bpy.types.Operator):
 
     def execute(self, context):
         props = tool.Layer.get_layer_props()
+        ifc_file = tool.Ifc.get()
+        layer = resolve_layer(self, ifc_file, self.layer)
+        if layer is None:
+            return {"CANCELLED"}
         props.layer_attributes.clear()
-        bonsai.bim.helper.import_attributes(tool.Ifc.get().by_id(self.layer), props.layer_attributes)
+        bonsai.bim.helper.import_attributes(layer, props.layer_attributes)
         props.active_layer_id = self.layer
         return {"FINISHED"}
 
@@ -142,7 +171,10 @@ class RemovePresentationLayer(bpy.types.Operator, tool.Ifc.Operator):
 
     def _execute(self, context):
         ifc_file = tool.Ifc.get()
-        ifcopenshell.api.layer.remove_layer(ifc_file, layer=ifc_file.by_id(self.layer))
+        layer = resolve_layer(self, ifc_file, self.layer)
+        if layer is None:
+            return {"CANCELLED"}
+        ifcopenshell.api.layer.remove_layer(ifc_file, layer=layer)
         bpy.ops.bim.load_layers()
         return {"FINISHED"}
 
@@ -162,10 +194,13 @@ class AssignPresentationLayer(bpy.types.Operator, tool.Ifc.Operator):
     def _execute(self, context):
         item = get_active_mesh(context, self.item)
         ifc_file = tool.Ifc.get()
+        layer = resolve_layer(self, ifc_file, self.layer)
+        if layer is None:
+            return {"CANCELLED"}
         ifcopenshell.api.layer.assign_layer(
             ifc_file,
             items=[ifc_file.by_id(tool.Geometry.get_mesh_props(item).ifc_definition_id)],
-            layer=ifc_file.by_id(self.layer),
+            layer=layer,
         )
         return {"FINISHED"}
 
@@ -185,9 +220,12 @@ class UnassignPresentationLayer(bpy.types.Operator, tool.Ifc.Operator):
     def _execute(self, context):
         item = get_active_mesh(context, self.item)
         ifc_file = tool.Ifc.get()
+        layer = resolve_layer(self, ifc_file, self.layer)
+        if layer is None:
+            return {"CANCELLED"}
         representation = tool.Geometry.get_data_representation(item)
         assert representation
-        ifcopenshell.api.layer.unassign_layer(ifc_file, items=[representation], layer=ifc_file.by_id(self.layer))
+        ifcopenshell.api.layer.unassign_layer(ifc_file, items=[representation], layer=layer)
         return {"FINISHED"}
 
 
@@ -201,7 +239,11 @@ class SelectLayerProducts(bpy.types.Operator):
         layer: int
 
     def execute(self, context):
-        elements = ifcopenshell.util.element.get_elements_by_layer(tool.Ifc.get(), tool.Ifc.get().by_id(self.layer))
+        ifc_file = tool.Ifc.get()
+        layer = resolve_layer(self, ifc_file, self.layer)
+        if layer is None:
+            return {"CANCELLED"}
+        elements = ifcopenshell.util.element.get_elements_by_layer(ifc_file, layer)
         for obj in context.visible_objects:
             obj.select_set(False)
             element = tool.Ifc.get_entity(obj)
@@ -222,9 +264,14 @@ class SelectLayerInLayerUI(bpy.types.Operator):
     def execute(self, context):
         props = tool.Layer.get_layer_props()
         ifc_file = tool.Ifc.get()
-        layer = ifc_file.by_id(self.layer_id)
+        layer = resolve_layer(self, ifc_file, self.layer_id)
+        if layer is None:
+            return {"CANCELLED"}
         bpy.ops.bim.load_layers()
-        props.active_layer_index = next((i for i, m in enumerate(props.layers) if m.ifc_definition_id == self.layer_id))
+        index = next((i for i, m in enumerate(props.layers) if m.ifc_definition_id == self.layer_id), None)
+        if index is None:
+            return {"CANCELLED"}
+        props.active_layer_index = index
         self.report(
             {"INFO"},
             f"Layer '{layer.Name or 'Unnamed'}' is selected in Layers UI.",


### PR DESCRIPTION
Reported by @Vanuan in #4934. Removing a presentation layer after clicking the layer icons in sequence could raise RuntimeError: Instance #xxxx not found.

Root cause: the layer list draws from props.layers and bakes each layer's IfcPresentationLayerAssignment id into its row buttons at draw time. The remove/assign/unassign/enable/select operators then called ifc_file.by_id(self.layer) with no validation. Presentation layers are removed automatically once they have no assigned items left (an IfcPresentationLayerAssignment must keep at least one item to stay schema valid), so unassigning the last item deletes the layer. If that baked id reaches an operator after the entity is gone (queued clicks, or a redraw that has not yet reloaded the list), by_id raises "Instance #N not found" and the operator crashes.

Fix: a shared resolve_layer guard resolves the UI supplied id against current state. If the id no longer references a presentation layer it reloads the layer list so the stale row disappears, warns the user and returns None so the operator cancels cleanly. All operators that take a layer id from the UI now go through it. Normal behaviour is unchanged: removing an existing layer still works and the active selection stays sensible.

Verified in a live Blender session across the paths from the report:
- Stale id sequence: assign a layer to an object, unassign so the layer is emptied and auto removed, then assign again on the same id. Before this fix that raised RuntimeError: Instance #N not found; now the operator reports "Presentation layer no longer exists, the layer list has been refreshed" and cancels cleanly with no traceback.
- Rapid repeated assign and unassign across several objects: no crash.
- IfcPresentationLayerWithStyle layers (the on, frozen and blocked icons from the original report): no crash, and a layer assigned to a single item is correctly removed when that item is unassigned.
black, ruff and ty are clean on the changed file.

Fixes #4934

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
