### PR TITLE
Bonsai: fix wrong duplicated geometry for type mapped elements (#7487, #7996)

### DIFF
--- a/src/bonsai/bonsai/core/root.py
+++ b/src/bonsai/bonsai/core/root.py
@@ -45,7 +45,16 @@ def copy_class(
     new = ifc.run("root.copy_class", product=element)
     ifc.link(new, obj)
     relating_type = root.get_element_type(new)
-    if relating_type and root.does_type_have_representations(relating_type):
+    # Only remap the type's geometry when the occurrence actually derives its
+    # body from the type. If the occurrence carries its own authored geometry
+    # (has_independent_representation), keep and copy that: some exporters emit
+    # one RepresentationMap per occurrence on the shared type, so remapping
+    # would graft every sibling's geometry onto the copy (issue #7487).
+    if (
+        relating_type
+        and root.does_type_have_representations(relating_type)
+        and not root.has_independent_representation(element)
+    ):
         ifc.run("type.map_type_representations", related_object=new, relating_type=relating_type)
         root.link_object_data(ifc.get_object(relating_type), obj)
     elif representation:

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -897,6 +897,7 @@ class Root:
     def assign_body_styles(cls, element, obj): pass
     def copy_representation(cls, source, dest): pass
     def does_type_have_representations(cls, element): pass
+    def has_independent_representation(cls, element): pass
     def get_default_container(cls): pass
     def get_element_representation(cls, element, context): pass
     def get_element_type(cls, element): pass

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2714,7 +2714,18 @@ class Geometry(bonsai.core.tool.Geometry):
             # immediately shows the unclipped geometry; otherwise the user
             # sees a stale mesh until they Shift+G, which is easy to miss.
             if new.is_a("IfcWall"):
-                if tool.Model.strip_underside_booleans(new):
+                wall_type = tool.Root.get_element_type(new)
+                if wall_type and tool.Root.does_type_have_representations(wall_type):
+                    # Imported wall whose body is authored and backed by
+                    # type representation maps (e.g. ArchiCAD SweptSolid
+                    # walls), not generated from a Bonsai layer-set + axis.
+                    # regenerate_wall would discard the authored profile
+                    # (roof clips, per-wall heights) and collapse the
+                    # duplicate onto a default extrusion, so the copy pokes
+                    # through the roof. Keep the deep-copied body, exactly
+                    # like every other imported element (issue #7487).
+                    pass
+                elif tool.Model.strip_underside_booleans(new):
                     tool.Model.reload_body_representation(new_obj)
                 # HasOpenings rels don't follow object duplication, so
                 # the duplicate's body must rebuild to match its current

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2742,13 +2742,18 @@ class Geometry(bonsai.core.tool.Geometry):
         """Recalculate new IfcWall duplicates that just received an
         ``IfcRelConnectsPathElements``. The in-loop ``regenerate_wall`` runs
         before ``recreate_connections``, so wall body geometry doesn't reflect
-        the junction until this second pass."""
+        the junction until this second pass. Walls backed by type
+        representation maps are authored, not layer-set generated, so they are
+        excluded here for the same reason they skip ``regenerate_wall``."""
         walls_to_recalc: list[bpy.types.Object] = []
         for new_list in old_to_new.values():
             for new_entity in new_list:
                 if not new_entity.is_a("IfcWall"):
                     continue
                 if not (getattr(new_entity, "ConnectedTo", None) or getattr(new_entity, "ConnectedFrom", None)):
+                    continue
+                wall_type = tool.Root.get_element_type(new_entity)
+                if wall_type and tool.Root.does_type_have_representations(wall_type):
                     continue
                 new_obj = tool.Ifc.get_object(new_entity)
                 if new_obj is not None:

--- a/src/bonsai/bonsai/tool/root.py
+++ b/src/bonsai/bonsai/tool/root.py
@@ -122,6 +122,28 @@ class Root(bonsai.core.tool.Root):
         return bool(element.RepresentationMaps)
 
     @classmethod
+    def has_independent_representation(cls, element: ifcopenshell.entity_instance) -> bool:
+        """``True`` if the element carries its own geometry inline rather than
+        deriving it from its type's representation maps.
+
+        A type occurrence that maps its type's geometry stores only
+        ``IfcMappedItem`` items pointing at the type's ``IfcRepresentationMap``\\ s.
+        An occurrence with an authored body (e.g. an imported ArchiCAD
+        ``SweptSolid`` wall) stores the geometry directly. Duplicating the
+        latter must copy that inline geometry, not remap the type: some
+        exporters emit a distinct ``RepresentationMap`` per occurrence on the
+        shared type, so remapping would graft every sibling occurrence's
+        geometry onto the copy (issue #7487)."""
+        representation = getattr(element, "Representation", None)
+        if not representation:
+            return False
+        for rep in representation.Representations:
+            for item in rep.Items:
+                if not item.is_a("IfcMappedItem"):
+                    return True
+        return False
+
+    @classmethod
     def get_decomposition_relationships(
         cls, objs: list[bpy.types.Object]
     ) -> dict[ifcopenshell.entity_instance, dict[str, Any]]:

--- a/src/bonsai/test/core/test_root.py
+++ b/src/bonsai/test/core/test_root.py
@@ -34,9 +34,37 @@ class TestCopyClass:
         ifc.link("element", "obj").should_be_called()
         root.get_element_type("element").should_be_called().will_return("type")
         root.does_type_have_representations("type").should_be_called().will_return(True)
+        root.has_independent_representation("original_element").should_be_called().will_return(False)
         ifc.run("type.map_type_representations", related_object="element", relating_type="type").should_be_called()
         ifc.get_object("type").should_be_called().will_return("type_obj")
         root.link_object_data("type_obj", "obj").should_be_called()
+        collector.assign("obj").should_be_called()
+        subject.copy_class(ifc, collector, geometry, root, obj="obj")
+
+    def test_copy_keeps_authored_geometry_when_occurrence_has_independent_representation(
+        self, ifc, collector, geometry, root
+    ):
+        # Some exporters (e.g. ArchiCAD) give a type one IfcRepresentationMap
+        # per occurrence, so an occurrence with its own authored body must
+        # copy that body instead of being remapped onto a sibling's geometry
+        # (issue #7487, issue #7996).
+        ifc.get_entity("obj").should_be_called().will_return("original_element")
+        root.is_element_a("original_element", "IfcRelSpaceBoundary").should_be_called().will_return(False)
+        root.get_object_representation("obj").should_be_called().will_return("representation")
+        ifc.run("root.copy_class", product="original_element").should_be_called().will_return("element")
+        ifc.link("element", "obj").should_be_called()
+        root.get_element_type("element").should_be_called().will_return("type")
+        root.does_type_have_representations("type").should_be_called().will_return(True)
+        root.has_independent_representation("original_element").should_be_called().will_return(True)
+        root.copy_representation("original_element", "element").should_be_called().will_return("copied_entities")
+        geometry.copy_data_links("data", "copied_entities").should_be_called()
+        geometry.change_object_data("obj", "data", is_global=True).should_be_called()
+        geometry.duplicate_object_data("obj").should_be_called().will_return("data")
+        ifc.get_entity("data").should_be_called().will_return("new_representation")
+        geometry.get_representation_name("new_representation").should_be_called().will_return("name")
+        geometry.rename_object("data", "name").should_be_called()
+        root.has_material_styles("element").should_be_called().will_return(False)
+        root.assign_body_styles("element", "obj").should_be_called()
         collector.assign("obj").should_be_called()
         subject.copy_class(ifc, collector, geometry, root, obj="obj")
 

--- a/src/bonsai/test/tool/test_geometry.py
+++ b/src/bonsai/test/tool/test_geometry.py
@@ -758,3 +758,41 @@ class TestApplyItemIdsAsVertexGroups(NewFile):
                 vert = verts[vi]
                 groups = [g.group for g in vert.groups]
                 assert groups == [ios_item_ids_unique[i]]
+
+
+class TestRecalculateWallsWithNewConnections(NewFile):
+    def create_connected_wall(self, ifc: ifcopenshell.file, type_has_maps: bool) -> ifcopenshell.entity_instance:
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        wall_type = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWallType")
+        ifcopenshell.api.type.assign_type(ifc, related_objects=[wall], relating_type=wall_type)
+        if type_has_maps:
+            wall_type.RepresentationMaps = [ifc.createIfcRepresentationMap()]
+        other = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        ifc.create_entity("IfcRelConnectsPathElements", RelatingElement=wall, RelatedElement=other)
+        obj = bpy.data.objects.new("Wall", bpy.data.meshes.new("Mesh"))
+        tool.Ifc.link(wall, obj)
+        return wall
+
+    def recalculated_walls(self, wall: ifcopenshell.entity_instance) -> list[bpy.types.Object]:
+        recalculated: list[bpy.types.Object] = []
+        original = tool.Model.recalculate_walls
+        tool.Model.recalculate_walls = lambda objs: recalculated.extend(objs)
+        try:
+            subject._recalculate_walls_with_new_connections({wall: [wall]})
+        finally:
+            tool.Model.recalculate_walls = original
+        return recalculated
+
+    def test_a_wall_generated_from_a_layer_set_is_recalculated(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        wall = self.create_connected_wall(ifc, type_has_maps=False)
+        assert self.recalculated_walls(wall) == [tool.Ifc.get_object(wall)]
+
+    def test_a_wall_backed_by_type_representation_maps_keeps_its_authored_body(self):
+        # Recalculating rebuilds the body from a layer set and axis, which
+        # discards authored geometry such as ArchiCAD roof clips (issue #7487).
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        wall = self.create_connected_wall(ifc, type_has_maps=True)
+        assert self.recalculated_walls(wall) == []


### PR DESCRIPTION
Selecting the whole AC20-FZK-Haus sample and pressing Shift+D (IFC Duplicate Objects) produced walls of the wrong size that poked through the roof. Other elements were affected too: roof slabs came out with extra representations and windows looked wrong. @sboddy earlier noted on the thread that the duplicates all shared the same representation, which this confirms.

Root cause. This file is an ArchiCAD export whose element types carry one IfcRepresentationMap per occurrence (WallType 0.24 has 5 maps for its 5 walls, WallType 0.3 has 8 maps for its 8 walls).

1. copy_class remapped type geometry whenever the type had any representation maps. type.map_type_representations deletes the occurrence's own copied body and adds one mapped body per type map, so each duplicate accumulated every sibling occurrence's geometry and displayed the wrong one.
2. The wall branch of duplicate_ifc_objects additionally ran regenerate_wall on these authored walls, rebuilding the body from a Bonsai layer set and axis and throwing away the authored roof clips and per wall heights, collapsing the copy onto a default extrusion.

Both defects had to be fixed, neither alone is sufficient.

Fix.
- Add Root.has_independent_representation: true when an element stores geometry inline rather than via IfcMappedItems from its type.
- copy_class only remaps type geometry when the occurrence does not have its own authored representation. Authored occurrences copy their body instead.
- The wall duplicate branch keeps the deep copied body (no regenerate_wall) for walls backed by type representation maps, native Bonsai walls still regenerate.

Verification for #7487. Headless duplicate of the full FZK Haus: all 13 duplicated walls now match their source dimensions exactly (including the roof clipped gables), and every duplicated wall, window, door, slab, railing and stair has exactly one Body representation. A native Bonsai parametric wall still duplicates through the regenerate path unchanged. Black, Ruff and ty are clean on the changed files.

## Also fixes #7996

@PahlawanJoey reported steel beams disappearing when duplicating floor slabs that carry embedded lifting anchors (IfcBeam), using the IFC Duplicate Objects operator. @theoryshaw could not reproduce in April, and the thread correctly narrowed this down to a fork: Blender's native Shift+D duplicate leaves IFC-less meshes that vanish on reload (expected, not a bug), versus Bonsai's own IFC Duplicate Objects operator. Joey has since confirmed on a current daily build that it is specifically the IFC Duplicate Objects path, and supplied two reproduction files.

This is the same root cause as #7487, on different geometry. Both files are IFC2X3 exports where each beam type again carries one RepresentationMap per occurrence (a distinct steel angle-iron or rebar profile per lifting anchor), while most individual beams keep their own authored Brep body instead of using the type's map.

Reproduced live in headless Blender on both files Joey attached:

- `Debug_Duplicated.ifc`: 72 IfcBeam, 16 of them with an authored Brep body (28 to 64 vertices, matching real angle-iron and round-bar profiles) despite their type having RepresentationMaps. Before this fix, duplicating any of those 16 beams replaced their authored body with the type's unrelated shared map (8 or 12 vertices, a generic straight segment), saved and reload confirmed the substitution in the file. After this fix, duplicates keep the authored body (matching vertex counts) as `IfcFacetedBrep`, not `IfcMappedItem`.
- `2502293-235-1TC-ISO.ifc`: same pattern, 2 of 6 beams have an authored body against a typed RepresentationMap. Same before/after result.

The beam entity itself was never removed in either file, in every reproduction the duplicate ended up with a representation, just the wrong one (the type's shared map instead of its own authored shape). Depending on where that generic shape lands relative to the anchor's real bent geometry, it can end up flush with or inside the slab it is anchored to, which is what reads as "disappeared" in the viewport, matching the screenshots on the issue.

Added a regression test (`test/core/test_root.py::TestCopyClass::test_copy_keeps_authored_geometry_when_occurrence_has_independent_representation`) using this exact independent-representation pattern. It fails against the pre-fix `copy_class` and passes with this fix. The existing `test_copy_with_new_geometry_derived_from_the_type` test was missing the `has_independent_representation` mock added by this PR and has been updated to match.

Full `test/core` suite (391 tests, no Blender required): all pass before and after this addition.

Fixes #7487
Fixes #7996

This PR contains AI-generated code (Claude Code), reviewed and verified by Petru Conduraru before every push.
