### PR TITLE
Bonsai: fix IFC4X3 IfcAnnotation PredefinedType vs ObjectType handling

### DIFF
--- a/src/bonsai/bonsai/core/drawing.py
+++ b/src/bonsai/bonsai/core/drawing.py
@@ -547,6 +547,7 @@ def add_annotation(
             context=context,
             ifc_representation_class=drawing_tool.get_ifc_representation_class(object_type),
         )
+        drawing_tool.setup_annotation_object_type(element, object_type)
         if relating_type:
             drawing_tool.run_type_assign_type(element=element, relating_type=relating_type)
         ifc.run("group.assign_group", group=drawing_tool.get_drawing_group(drawing), products=[element])

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -417,6 +417,7 @@ class Drawing:
     def set_drawing_collection_name(cls, drawing, collection): pass
     def set_name(cls, element, name): pass
     def setup_annotation_object(cls, obj, object_type): pass
+    def setup_annotation_object_type(cls, element, object_type): pass
     def setup_shading_styles_path(cls, resource_path): pass
     def show_decorations(cls): pass
     def sync_object_placement(cls, obj): pass

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1316,6 +1316,25 @@ class Drawing(bonsai.core.tool.Drawing):
         )
 
     @classmethod
+    def setup_annotation_object_type(cls, element: ifcopenshell.entity_instance, object_type: str) -> None:
+        """Store the Bonsai annotation kind in ObjectType and keep it schema consistent.
+
+        Bonsai identifies annotation kinds (TEXT, SYMBOL, DIMENSION, ...) through
+        ``IfcAnnotation.ObjectType``. In IFC4X3, ``IfcAnnotation`` gained a
+        ``PredefinedType`` (``IfcAnnotationTypeEnum``) whose members ``TEXT``,
+        ``SYMBOL`` and ``DIMENSION`` collide with those object types, so
+        ``root.create_entity`` stores the kind in ``PredefinedType`` and leaves
+        ``ObjectType`` empty. That breaks every downstream lookup keyed on
+        ``ObjectType``. Normalise so ``ObjectType`` always carries the kind and,
+        when the schema has a ``PredefinedType``, set it to ``USERDEFINED`` so the
+        schema WHERE rule (ObjectType present iff USERDEFINED) stays satisfied.
+        """
+        if element.ObjectType != object_type:
+            element.ObjectType = object_type
+        if hasattr(element, "PredefinedType") and element.PredefinedType != "USERDEFINED":
+            element.PredefinedType = "USERDEFINED"
+
+    @classmethod
     def run_type_assign_type(cls, element: ifcopenshell.entity_instance, relating_type: ifcopenshell.entity_instance):
         return bonsai.core.type.assign_type(tool.Ifc, tool.Model, tool.Type, element=element, type=relating_type)
 

--- a/src/ifcopenshell-python/ifcopenshell/api/attribute/edit_attributes.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/attribute/edit_attributes.py
@@ -72,8 +72,11 @@ def edit_attributes(file: ifcopenshell.file, product: ifcopenshell.entity_instan
 
         elif (object_type := getattr_safe(product, "ObjectType")) is not ...:
             relating_type = ifcopenshell.util.element.get_type(product)
+            # The relating type may be a type product that has no PredefinedType
+            # attribute at all (e.g. IfcFurnishingElementType), so access it safely.
+            relating_type_predefined_type = getattr_safe(relating_type, "PredefinedType") if relating_type else ...
             # Allow for None due to https://github.com/buildingSMART/IFC4.3.x-development/issues/818
-            if relating_type and relating_type.PredefinedType not in ("NOTDEFINED", None):
+            if relating_type and relating_type_predefined_type not in ("NOTDEFINED", None, ...):
                 product.ObjectType = None
                 product.PredefinedType = None
             elif object_type is None and predefined_type == "USERDEFINED":


### PR DESCRIPTION
In IFC4X3, IfcAnnotation gained a PredefinedType (IfcAnnotationTypeEnum) that IFC4 and IFC4x0 do not have. Thanks to @jes-r for the detailed report in #5314. This caused two problems when creating and editing annotations in an IFC4X3 project.

Crash on save. attribute.edit_attributes accessed relating_type.PredefinedType directly. Several concrete IfcTypeProduct subtypes (IfcFurnishingElementType, IfcBuiltElementType, IfcDeepFoundationType, IfcCivilElementType, IfcDistributionElementType) have no PredefinedType attribute at all, so saving attributes on a typed IFC4X3 annotation raised "AttributeError: ... has no attribute 'PredefinedType'". This path is IFC4X3 only, because in IFC4 the annotation has no PredefinedType and the block is skipped. It now reads the value through the existing getattr_safe helper and treats a missing attribute like None.

Empty ObjectType on placement. Bonsai identifies annotation kinds through IfcAnnotation.ObjectType, but the object types TEXT, SYMBOL and DIMENSION collide with IfcAnnotationTypeEnum members, so root.create_entity stored the kind in PredefinedType and left ObjectType empty. The symbol or text label then did not render and the user had to type the kind into ObjectType by hand. New annotations are now normalised so ObjectType carries the kind and, when the schema has PredefinedType, it is set to USERDEFINED. That satisfies the schema WHERE rule (ObjectType present iff USERDEFINED) and keeps every ObjectType based lookup working, matching the IFC4 behaviour.

Verified at the ifcopenshell level: the edit_attributes call from the report no longer raises and produces a schema valid annotation (ifcopenshell.validate clean), the case of an annotation typed by a type with a concrete PredefinedType still clears both attributes, and IFC4 and IFC4X3 annotation creation yields a consistent ObjectType for all kinds. Black and Ruff are clean on the changed lines. Verified at the handler and API level, not through a live GUI click through.

Fixes #5314

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
