### PR TITLE
layer: never persist empty (schema-invalid) presentation layers

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -35,6 +35,7 @@ import bpy
 import ifcopenshell
 import ifcopenshell.api.attribute
 import ifcopenshell.api.document
+import ifcopenshell.api.layer
 import ifcopenshell.api.nest
 import ifcopenshell.api.project
 import ifcopenshell.api.root
@@ -2056,6 +2057,14 @@ class ExportIFC(bpy.types.Operator, ExportHelper):
         else:
             if not pprops.should_save_metadata_for_this_file:
                 tool.Project.remove_metadata_document_information()
+
+        # An IfcPresentationLayerAssignment requires AssignedItems SET [1:?], so an
+        # empty layer (e.g. one created but never assigned) is schema invalid and must
+        # not be written to disk. This mirrors unassign_layer, which already drops a
+        # layer once its last item is removed.
+        removed_layers = ifcopenshell.api.layer.remove_empty_layers(tool.Ifc.get())
+        layer_suffix = f" (removed {len(removed_layers)} empty presentation layer(s))" if removed_layers else ""
+        commit_suffix += layer_suffix
 
         ifc_exporter = export_ifc.IfcExporter(settings)
         print("Starting export")

--- a/src/ifcopenshell-python/ifcopenshell/api/layer/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/layer/__init__.py
@@ -30,6 +30,7 @@ from .add_layer import add_layer
 from .add_layer_with_style import add_layer_with_style
 from .assign_layer import assign_layer
 from .edit_layer import edit_layer
+from .remove_empty_layers import remove_empty_layers
 from .remove_layer import remove_layer
 from .unassign_layer import unassign_layer
 
@@ -40,6 +41,7 @@ __all__ = [
     "add_layer_with_style",
     "assign_layer",
     "edit_layer",
+    "remove_empty_layers",
     "remove_layer",
     "unassign_layer",
 ]

--- a/src/ifcopenshell-python/ifcopenshell/api/layer/remove_empty_layers.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/layer/remove_empty_layers.py
@@ -1,0 +1,54 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell
+
+
+def remove_empty_layers(file: ifcopenshell.file) -> list[ifcopenshell.entity_instance]:
+    """Removes presentation layers that have no assigned items
+
+    An ``IfcPresentationLayerAssignment`` requires its ``AssignedItems`` to be
+    a set of at least one item (``SET [1:?]``). A layer with no items is
+    therefore schema invalid and, being empty, has no effect on the model.
+    This can happen when a layer is created but never assigned to any
+    representation item, or when it is otherwise left empty.
+
+    :func:`ifcopenshell.api.layer.unassign_layer` already removes a layer as
+    soon as its last item is unassigned. This function covers the
+    complementary case of a layer that was created empty and never populated,
+    so that it never persists as invalid data.
+
+    :param file: The IFC file.
+    :return: The list of removed IfcPresentationLayerAssignment elements.
+
+    Example:
+
+    .. code:: python
+
+        # A layer created but never assigned is schema invalid.
+        ifcopenshell.api.layer.add_layer(model, name="AI-WALL")
+
+        # Prune it (e.g. right before writing the file to disk).
+        ifcopenshell.api.layer.remove_empty_layers(model)
+    """
+    removed: list[ifcopenshell.entity_instance] = []
+    for layer in file.by_type("IfcPresentationLayerAssignment"):
+        if not layer.AssignedItems:
+            file.remove(layer)
+            removed.append(layer)
+    return removed

--- a/src/ifcopenshell-python/test/api/layer/test_remove_empty_layers.py
+++ b/src/ifcopenshell-python/test/api/layer/test_remove_empty_layers.py
@@ -1,0 +1,52 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2022 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.api.layer
+import test.bootstrap
+
+
+class TestRemoveEmptyLayers(test.bootstrap.IFC4):
+    def test_remove_layer_with_no_assigned_items(self):
+        layer = self.file.createIfcPresentationLayerAssignment()
+        removed = ifcopenshell.api.layer.remove_empty_layers(self.file)
+        assert removed == [layer]
+        assert not self.file.by_type("IfcPresentationLayerAssignment")
+
+    def test_keep_layer_with_assigned_items(self):
+        items = [self.file.createIfcExtrudedAreaSolid() for i in range(2)]
+        layer = self.file.createIfcPresentationLayerAssignment()
+        ifcopenshell.api.layer.assign_layer(self.file, items=items, layer=layer)
+
+        removed = ifcopenshell.api.layer.remove_empty_layers(self.file)
+        assert removed == []
+        assert self.file.by_type("IfcPresentationLayerAssignment") == [layer]
+        assert set(layer.AssignedItems) == set(items)
+
+    def test_only_empty_layers_are_removed(self):
+        items = [self.file.createIfcExtrudedAreaSolid()]
+        populated = self.file.createIfcPresentationLayerAssignment(Name="Good")
+        ifcopenshell.api.layer.assign_layer(self.file, items=items, layer=populated)
+        self.file.createIfcPresentationLayerAssignment(Name="Empty")
+
+        removed = ifcopenshell.api.layer.remove_empty_layers(self.file)
+        assert len(removed) == 1
+        assert self.file.by_type("IfcPresentationLayerAssignment") == [populated]
+
+
+class TestRemoveEmptyLayersIFC2X3(test.bootstrap.IFC2X3, TestRemoveEmptyLayers):
+    pass


### PR DESCRIPTION
### Problem
IfcPresentationLayerAssignment.AssignedItems is a required aggregate SET [1:?] (confirmed via schema introspection in IFC4, IFC4X3 and IFC2X3), so a layer with no assigned items is schema invalid; ifcopenshell.validate flags it with "Attribute not optional".

ifcopenshell.api.layer.add_layer deliberately creates a layer with no items, because Bonsai's add-then-assign workflow populates it afterwards. But a layer that is created and never assigned (or otherwise left empty) stays as an invalid entity and is written to disk verbatim on save. unassign_layer already removes a layer when its last item is unassigned; the create-empty / never-assigned case was the remaining gap.

This is a self-identified data-validity fix (no issue number), found while testing the presentation-layer crash fix (#4934).

### Fix
- Add ifcopenshell.api.layer.remove_empty_layers(file), which removes every IfcPresentationLayerAssignment with no AssignedItems.
- Call it in Bonsai's save (ExportIFC._execute) right before export, and report how many empty layers were dropped.

This mirrors unassign_layer's existing "empty means remove to keep IFC valid" behaviour and applies it at the persistence boundary. The add-then-assign UX is untouched: layers stay empty in memory for the whole editing session, and only truly empty layers are pruned, only at write time.

### Evidence
- Empty layer: validate reports 1 error before, 0 after pruning (IFC4 and IFC4X3), layer removed.
- Normal add-then-assign: nothing removed, layer kept with its items, valid.
- Mixed populated + empty: only the empty one removed, valid.
- New tests in test/api/layer/test_remove_empty_layers.py (IFC4 and IFC2X3).
- Verified in a live Blender session: creating unassigned layers and saving reports "removed N empty presentation layer(s)" and the file stays valid.

### Note
An empty presentation layer cannot be represented in a schema valid file, so it cannot survive a save and reload under any correct fix. An alternative that surfaces validity earlier would be to also assign a new layer to the active object's representation on creation when possible; this PR keeps the change minimal (prune only).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
