### PR TITLE
Import IfcSurfaceFeature road markings by following IfcRelAdheresToElement (#8375)

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1294,6 +1294,11 @@ class LoadProjectElements(bpy.types.Operator):
             if element.IsDecomposedBy:
                 for subelement in element.IsDecomposedBy[0].RelatedObjects:
                     decomposed_elements.add(subelement)
+            # IfcSurfaceFeature (e.g. road markings) adhere to a host element
+            # via IfcRelAdheresToElement, a [1:1] hierarchical relationship in
+            # the same family as aggregation, containment and nesting (IFC4.3).
+            for rel in getattr(element, "HasSurfaceFeatures", ()):
+                decomposed_elements.update(rel.RelatedSurfaceFeatures)
         if decomposed_elements:
             self.append_decomposed_elements(decomposed_elements)
         elements.update(decomposed_elements)

--- a/src/ifcopenshell-python/ifcopenshell/util/element.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/element.py
@@ -1125,7 +1125,8 @@ def get_decomposition(element: ifcopenshell.entity_instance, is_recursive=True) 
     """
     Retrieves all subelements of an element based on the spatial decomposition
     hierarchy. This includes all subspaces and elements contained in subspaces,
-    parts of an aggregate, all openings, and all fills of any openings.
+    parts of an aggregate, all openings, all fills of any openings, and any
+    surface features adhering to an element (IFC4.3 and above).
 
     :param element: The IFC element
     :return: The decomposition of the element
@@ -1159,6 +1160,10 @@ def get_decomposition(element: ifcopenshell.entity_instance, is_recursive=True) 
             results.add(related)
         for rel in getattr(element, "IsNestedBy", []):
             related = rel.RelatedObjects
+            queue.extend(related)
+            results.update(related)
+        for rel in getattr(element, "HasSurfaceFeatures", []):
+            related = rel.RelatedSurfaceFeatures
             queue.extend(related)
             results.update(related)
         if not is_recursive:
@@ -1251,6 +1256,8 @@ def get_parent(
     - Nesting: components are attached to a host parent
     - Filling: the physical element fills an opening, such as a window filling a hole
     - Voiding: the opening voids another physical element, such as a hole in a wall
+    - Adherence: a surface feature adheres to a host element, such as a road
+      marking adhering to a road course (IFC4.3 and above)
 
     :param element: Any physical or spatial element in the tree
     :param ifc_class: Optionally filter the type of parent you're after. For
@@ -1270,6 +1277,7 @@ def get_parent(
         or get_nest(element)
         or get_filled_void(element)
         or get_voided_element(element)
+        or get_adhered_element(element)
     )
 
     if not ifc_class:
@@ -1319,6 +1327,28 @@ def get_voided_element(element: ifcopenshell.entity_instance) -> Union[ifcopensh
     """
     if rel := getattr(element, "VoidsElements", None):
         return rel[0].RelatingBuildingElement
+
+
+def get_adhered_element(element: ifcopenshell.entity_instance) -> Union[ifcopenshell.entity_instance, None]:
+    """If the element is a surface feature, get the element it adheres to
+
+    In IFC4.3 an IfcSurfaceFeature (such as a road marking) adheres to a host
+    element through the IfcRelAdheresToElement relationship. This is a [1:1]
+    cardinality hierarchical relationship, in the same family as aggregation,
+    containment and nesting.
+
+    :param element: The IfcSurfaceFeature
+    :return: The host element that the surface feature adheres to
+
+    Example:
+
+    .. code:: python
+
+        marking = file.by_type("IfcSurfaceFeature")[0]
+        host = ifcopenshell.util.element.get_adhered_element(marking)
+    """
+    if rel := getattr(element, "AdheresToElement", None):
+        return rel[0].RelatingElement
 
 
 def get_aggregate(element: ifcopenshell.entity_instance) -> Union[ifcopenshell.entity_instance, None]:
@@ -1412,6 +1442,29 @@ def get_contained(element: ifcopenshell.entity_instance) -> list[ifcopenshell.en
     if contains_elements := getattr(element, "ContainsElements", ()):
         for rel in contains_elements:
             objects.extend(rel.RelatedElements)
+    return objects
+
+
+def get_surface_features(element: ifcopenshell.entity_instance) -> list[ifcopenshell.entity_instance]:
+    """Retrieves the surface features that adhere to an element.
+
+    In IFC4.3 an IfcSurfaceFeature (such as a road marking) adheres to a host
+    element through the IfcRelAdheresToElement relationship.
+
+    :param element: The IFC element
+    :return: The surface features adhering to the element
+
+    Example:
+
+    .. code:: python
+
+        element = file.by_type("IfcCourse")[0]
+        markings = ifcopenshell.util.element.get_surface_features(element)
+    """
+    objects: list[ifcopenshell.entity_instance] = []
+    if has_surface_features := getattr(element, "HasSurfaceFeatures", ()):
+        for rel in has_surface_features:
+            objects.extend(rel.RelatedSurfaceFeatures)
     return objects
 
 


### PR DESCRIPTION
## Problem
On the Viadotto Acerno IFC4X3 bridge model (#8375), road markings modelled as IfcSurfaceFeature go missing on Bonsai import. Thanks to @aothms for the lead: IfcSurfaceFeature adheres to its host via IfcRelAdheresToElement (host inverse HasSurfaceFeatures, feature attribute AdheresToElement), which in IFC4.3 is a [1:1] cardinality hierarchical relationship in the same family as IfcRelAggregates, IfcRelContainedInSpatialStructure and IfcRelNests. The importer and the ifcopenshell spatial traversal never followed it.

## Root cause
ifcopenshell.util.element.get_parent (the canonical spatial resolver) walked containment, aggregation, nesting, filling and voiding, but not adherence, so a surface feature had no resolvable parent and get_container returned None. On import the features fell into the Unsorted collection, and in DECOMPOSITION filter mode (which followed only IsDecomposedBy) they were dropped outright.

## Fix
Treat IfcRelAdheresToElement as a first-class hierarchical relationship:
- util.element: add get_adhered_element (feature to host) into the get_parent chain, walk HasSurfaceFeatures in get_decomposition, and add a get_surface_features helper mirroring get_parts/get_contained.
- Bonsai project operator: follow HasSurfaceFeatures in the DECOMPOSITION filter path.

Handled generally via getattr guards (no-op on IFC2X3/IFC4), no per-file special-casing.

## Evidence (sample model, 3 IfcSurfaceFeature on an IfcCourse host)
- Before: features import into the Unsorted collection; DECOMPOSITION filter collects 0/3.
- After: get_container(feature) resolves to the host's IfcRoadPart; a headless import places all 3 features in the host's 'IfcRoadPart/Road Carriageway' collection; DECOMPOSITION filter collects 3/3.

Verified at the traversal level headlessly, not via a live GUI click through. Black, Ruff and ty clean on the changed lines.

Fixes #8375

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
