### PR TITLE
Quantify doors and windows from IFC attributes on both take-off engines (supersedes #4537)

### DIFF
--- a/src/bonsai/bonsai/bim/module/qto/calculator.py
+++ b/src/bonsai/bonsai/bim/module/qto/calculator.py
@@ -25,6 +25,7 @@ import ifc5d.qto
 import ifcopenshell
 import ifcopenshell.geom
 import ifcopenshell.util.element
+import ifcopenshell.util.unit
 import mathutils
 from mathutils import Matrix, Vector
 from mathutils.bvhtree import BVHTree
@@ -518,6 +519,136 @@ def get_side_area(o: bpy.types.Object) -> float:
     y = get_y(o)
     z = get_z(o)
     return max(x * z, y * z)
+
+
+# A quantity target is either a Blender object, the IFC element itself (used when
+# the element has no Blender object, e.g. a door/window whose mapped body
+# representation never produced a standalone mesh), or None.
+QtoTarget = Union[bpy.types.Object, ifcopenshell.entity_instance, None]
+
+
+def _resolve_element(o: QtoTarget) -> Union[ifcopenshell.entity_instance, None]:
+    """Resolve the IFC element from a quantity target.
+
+    The target may already be an IFC element (no Blender object case) or a
+    Blender object whose element is looked up, or None.
+    """
+    if o is None:
+        return None
+    if isinstance(o, ifcopenshell.entity_instance):
+        return o
+    return tool.Ifc.get_entity(o)
+
+
+def _resolve_object(o: QtoTarget) -> Union[bpy.types.Object, None]:
+    """Return the Blender object from a quantity target, or None.
+
+    When the target is the IFC element itself there is no object, so geometry
+    based fallbacks must be skipped.
+    """
+    if o is None or isinstance(o, ifcopenshell.entity_instance):
+        return None
+    return o
+
+
+def _get_overall_dimensions(o: QtoTarget) -> tuple[Union[float, None], Union[float, None]]:
+    """Return an element's ``(OverallWidth, OverallHeight)`` in SI metres.
+
+    Reads the ``OverallWidth`` / ``OverallHeight`` attributes of the underlying
+    IfcDoor/IfcWindow (or any element exposing them) and rescales them from
+    project units to SI metres so the result matches the bounding-box based
+    calculators. Works whether the target is a Blender object or the IFC element
+    itself, so it can quantify a door/window that has no Blender object. Missing
+    attributes are returned as ``None``.
+    """
+    element = _resolve_element(o)
+    if element is None:
+        return None, None
+    width = getattr(element, "OverallWidth", None)
+    height = getattr(element, "OverallHeight", None)
+    if width is None and height is None:
+        return None, None
+    unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
+    if width is not None:
+        width *= unit_scale
+    if height is not None:
+        height *= unit_scale
+    return width, height
+
+
+def get_overall_width(o: QtoTarget) -> Union[float, None]:
+    """Width of a door or window from its ``OverallWidth`` attribute.
+
+    Matches the buildingSMART Qto_Door/WindowBaseQuantities "Width" (nominal
+    width of the outer lining). Falls back to the bounding box X dimension when
+    the attribute is not set and a Blender object is available, otherwise returns
+    ``None``.
+
+    :param o: Blender Object or IFC element
+    :return float: Overall width
+    """
+    width, _ = _get_overall_dimensions(o)
+    if width is not None:
+        return width
+    obj = _resolve_object(o)
+    return get_x(obj) if obj is not None else None
+
+
+def get_overall_height(o: QtoTarget) -> Union[float, None]:
+    """Height of a door or window from its ``OverallHeight`` attribute.
+
+    Matches the buildingSMART Qto_Door/WindowBaseQuantities "Height" (nominal
+    height of the outer lining). Falls back to the bounding box Z dimension when
+    the attribute is not set and a Blender object is available, otherwise returns
+    ``None``.
+
+    :param o: Blender Object or IFC element
+    :return float: Overall height
+    """
+    _, height = _get_overall_dimensions(o)
+    if height is not None:
+        return height
+    obj = _resolve_object(o)
+    return get_height(obj) if obj is not None else None
+
+
+def get_lining_area(o: QtoTarget) -> Union[float, None]:
+    """Outer lining area of a door or window (``OverallWidth * OverallHeight``).
+
+    Matches the buildingSMART Qto_Door/WindowBaseQuantities "Area" (total area
+    of the outer lining). Unlike the bounding-box or mesh-face calculators this
+    does not overshoot for doors whose lining or threshold extends past the
+    nominal opening. Falls back to :func:`get_side_area` when the
+    OverallWidth/OverallHeight attributes are not set and a Blender object is
+    available, otherwise returns ``None``.
+
+    :param o: Blender Object or IFC element
+    :return float: Lining area
+    """
+    width, height = _get_overall_dimensions(o)
+    if width is not None and height is not None:
+        return width * height
+    obj = _resolve_object(o)
+    return get_side_area(obj) if obj is not None else None
+
+
+def get_lining_perimeter(o: QtoTarget) -> Union[float, None]:
+    """Outer lining perimeter of a door or window (``2 * (width + height)``).
+
+    Matches the buildingSMART Qto_Door/WindowBaseQuantities "Perimeter"
+    (perimeter of the outer lining). Falls back to
+    :func:`get_rectangular_perimeter` when the OverallWidth/OverallHeight
+    attributes are not set and a Blender object is available, otherwise returns
+    ``None``.
+
+    :param o: Blender Object or IFC element
+    :return float: Lining perimeter
+    """
+    width, height = _get_overall_dimensions(o)
+    if width is not None and height is not None:
+        return (width + height) * 2
+    obj = _resolve_object(o)
+    return get_rectangular_perimeter(obj) if obj is not None else None
 
 
 def get_cross_section_area(obj: bpy.types.Object) -> float:

--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
@@ -217,10 +217,10 @@
             },
             "IfcDoor": {
                 "Qto_DoorBaseQuantities": {
-                    "Area": null,
-                    "Height": null,
-                    "Perimeter": null,
-                    "Width": null
+                    "Area": "get_lining_area",
+                    "Height": "get_overall_height",
+                    "Perimeter": "get_lining_perimeter",
+                    "Width": "get_overall_width"
                 }
             },
             "IfcDuctFitting": {
@@ -626,10 +626,10 @@
             },
             "IfcWindow": {
                 "Qto_WindowBaseQuantities": {
-                    "Area": "net_get_max_side_area",
-                    "Height": "net_get_z",
-                    "Perimeter": null,
-                    "Width": "net_get_x"
+                    "Area": "get_lining_area",
+                    "Height": "get_overall_height",
+                    "Perimeter": "get_lining_perimeter",
+                    "Width": "get_overall_width"
                 }
             }
         }

--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantitiesBlender.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantitiesBlender.json
@@ -217,10 +217,10 @@
             },
             "IfcDoor": {
                 "Qto_DoorBaseQuantities": {
-                    "Area": "get_net_side_area",
-                    "Height": "get_height",
-                    "Perimeter": "get_rectangular_perimeter",
-                    "Width": "get_x"
+                    "Area": "get_lining_area",
+                    "Height": "get_overall_height",
+                    "Perimeter": "get_lining_perimeter",
+                    "Width": "get_overall_width"
                 }
             },
             "IfcDuctFitting": {
@@ -626,10 +626,10 @@
             },
             "IfcWindow": {
                 "Qto_WindowBaseQuantities": {
-                    "Area": "get_net_side_area",
-                    "Height": "get_height",
-                    "Perimeter": "get_rectangular_perimeter",
-                    "Width": "get_x"
+                    "Area": "get_lining_area",
+                    "Height": "get_overall_height",
+                    "Perimeter": "get_lining_perimeter",
+                    "Width": "get_overall_width"
                 }
             }
         }

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
@@ -234,10 +234,10 @@
             },
             "IfcDoor + IfcDoorType": {
                 "Qto_DoorBaseQuantities": {
-                    "Area": null,
-                    "Height": null,
-                    "Perimeter": null,
-                    "Width": null
+                    "Area": "get_lining_area",
+                    "Height": "get_overall_height",
+                    "Perimeter": "get_lining_perimeter",
+                    "Width": "get_overall_width"
                 }
             },
             "IfcDuctFitting + IfcDuctFittingType": {
@@ -789,10 +789,10 @@
             },
             "IfcWindow + IfcWindowType": {
                 "Qto_WindowBaseQuantities": {
-                    "Area": "net_get_max_side_area",
-                    "Height": "net_get_z",
-                    "Perimeter": null,
-                    "Width": "net_get_x"
+                    "Area": "get_lining_area",
+                    "Height": "get_overall_height",
+                    "Perimeter": "get_lining_perimeter",
+                    "Width": "get_overall_width"
                 }
             }
         }

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
@@ -234,10 +234,10 @@
             },
             "IfcDoor + IfcDoorType": {
                 "Qto_DoorBaseQuantities": {
-                    "Area": "get_net_side_area",
-                    "Height": "get_height",
-                    "Perimeter": "get_rectangular_perimeter",
-                    "Width": "get_x"
+                    "Area": "get_lining_area",
+                    "Height": "get_overall_height",
+                    "Perimeter": "get_lining_perimeter",
+                    "Width": "get_overall_width"
                 }
             },
             "IfcDuctFitting + IfcDuctFittingType": {
@@ -789,10 +789,10 @@
             },
             "IfcWindow + IfcWindowType": {
                 "Qto_WindowBaseQuantities": {
-                    "Area": "get_net_side_area",
-                    "Height": "get_height",
-                    "Perimeter": "get_rectangular_perimeter",
-                    "Width": "get_length"
+                    "Area": "get_lining_area",
+                    "Height": "get_overall_height",
+                    "Perimeter": "get_lining_perimeter",
+                    "Width": "get_overall_width"
                 }
             }
         }

--- a/src/ifc5d/ifc5d/qto.py
+++ b/src/ifc5d/ifc5d/qto.py
@@ -342,6 +342,28 @@ class IfcOpenShell(QtoCalculator):
         "get_footing_height",
     )
 
+    # Attribute based calculators. Unlike the geometry calculators above these
+    # read values straight off the IFC element (e.g. IfcDoor/IfcWindow
+    # OverallWidth/OverallHeight) and need no geometry, so they quantify elements
+    # whose body representation is mapped, missing, or otherwise not meshed.
+    attribute_functions = {
+        "get_overall_width": Function(
+            "IfcLengthMeasure", "Overall Width", "The door/window OverallWidth attribute (nominal outer lining width)"
+        ),
+        "get_overall_height": Function(
+            "IfcLengthMeasure",
+            "Overall Height",
+            "The door/window OverallHeight attribute (nominal outer lining height)",
+        ),
+        "get_lining_area": Function(
+            "IfcAreaMeasure", "Lining Area", "The door/window outer lining area (OverallWidth * OverallHeight)"
+        ),
+        "get_lining_perimeter": Function(
+            "IfcLengthMeasure", "Lining Perimeter", "The door/window outer lining perimeter (2 * (width + height))"
+        ),
+    }
+    functions.update(attribute_functions)
+
     internal_functions = (
         "get_segment_length",
         "get_weight",
@@ -350,6 +372,58 @@ class IfcOpenShell(QtoCalculator):
         "get_opening_depth",
         "get_opening_area",
     ) + footing_functions
+
+    @classmethod
+    def _overall_dimensions(
+        cls, element: ifcopenshell.entity_instance
+    ) -> tuple[Union[float, None], Union[float, None]]:
+        """Return ``(OverallWidth, OverallHeight)`` of an element in SI metres.
+
+        Reads the attributes directly and rescales them from project units to SI
+        so the result is consistent with the geometry based calculators. Missing
+        attributes are returned as ``None``.
+        """
+        width = getattr(element, "OverallWidth", None)
+        height = getattr(element, "OverallHeight", None)
+        if width is not None:
+            width *= cls.unit_scale
+        if height is not None:
+            height *= cls.unit_scale
+        return width, height
+
+    @classmethod
+    def get_overall_width(cls, element: ifcopenshell.entity_instance) -> Union[float, None]:
+        """Door/window width from ``OverallWidth`` (SI metres), or ``None`` if unset."""
+        width, _ = cls._overall_dimensions(element)
+        return width
+
+    @classmethod
+    def get_overall_height(cls, element: ifcopenshell.entity_instance) -> Union[float, None]:
+        """Door/window height from ``OverallHeight`` (SI metres), or ``None`` if unset."""
+        _, height = cls._overall_dimensions(element)
+        return height
+
+    @classmethod
+    def get_lining_area(cls, element: ifcopenshell.entity_instance) -> Union[float, None]:
+        """Door/window outer lining area ``OverallWidth * OverallHeight`` (SI m2).
+
+        Returns ``None`` when either attribute is unset.
+        """
+        width, height = cls._overall_dimensions(element)
+        if width is None or height is None:
+            return None
+        return width * height
+
+    @classmethod
+    def get_lining_perimeter(cls, element: ifcopenshell.entity_instance) -> Union[float, None]:
+        """Door/window outer lining perimeter ``2 * (width + height)`` (SI metres).
+
+        Returns ``None`` when either attribute is unset.
+        """
+        width, height = cls._overall_dimensions(element)
+        if width is None or height is None:
+            return None
+        return (width + height) * 2
 
     @classmethod
     def calculate(cls, ifc_file, elements, qtos, results):
@@ -362,10 +436,16 @@ class IfcOpenShell(QtoCalculator):
 
         gross_qtos: QtosFormulas = {}
         net_qtos: QtosFormulas = {}
+        attribute_qtos: QtosFormulas = {}
 
         for name, quantities in qtos.items():
             for quantity, formula in quantities.items():
                 if not formula:
+                    continue
+                # Attribute based formulas are computed from the element directly
+                # and need no geometry, so keep them out of the iterator tasks.
+                if formula in cls.attribute_functions:
+                    attribute_qtos.setdefault(name, {})[quantity] = formula
                     continue
                 gross_or_net_qtos = gross_qtos if formula.startswith("gross_") else net_qtos
                 if formula.endswith(cls.internal_functions):
@@ -388,6 +468,17 @@ class IfcOpenShell(QtoCalculator):
                 tasks.append((iterator, net_qtos))
 
         cls.unit_converter = SI2ProjectUnitConverter(ifc_file)
+
+        # Attribute based quantities: compute straight from the element, no
+        # geometry required, so mapped/unmeshed doors and windows still quantify.
+        for element in elements:
+            for name, quantities in attribute_qtos.items():
+                for quantity, formula in quantities.items():
+                    value = getattr(cls, formula)(element)
+                    if value is None:
+                        continue
+                    value = cls.unit_converter.convert(value, cls.attribute_functions[formula].measure)
+                    results.setdefault(element, {}).setdefault(name, {})[quantity] = value
 
         for iterator, qtos_ in tasks:
             if iterator.initialize():
@@ -604,6 +695,9 @@ class Blender(QtoCalculator):
         "get_length": Function("IfcLengthMeasure", "Length", ""),
         "get_opening_depth": Function("IfcLengthMeasure", "Opening Depth", ""),
         "get_opening_height": Function("IfcLengthMeasure", "Opening Height", ""),
+        "get_overall_height": Function("IfcLengthMeasure", "Overall Height", ""),
+        "get_overall_width": Function("IfcLengthMeasure", "Overall Width", ""),
+        "get_lining_perimeter": Function("IfcLengthMeasure", "Lining Perimeter", ""),
         "get_rectangular_perimeter": Function("IfcLengthMeasure", "Rectangular Perimeter", ""),
         "get_stair_length": Function("IfcLengthMeasure", "Stair Length", ""),
         "get_width": Function("IfcLengthMeasure", "Width", ""),
@@ -620,6 +714,8 @@ class Blender(QtoCalculator):
         "get_gross_stair_area": Function("IfcAreaMeasure", "Gross Stair Area", ""),
         "get_gross_surface_area": Function("IfcAreaMeasure", "Gross Surface Area", ""),
         "get_gross_top_area": Function("IfcAreaMeasure", "Gross Top Area", ""),
+        "get_lining_area": Function("IfcAreaMeasure", "Lining Area", ""),
+        "get_side_area": Function("IfcAreaMeasure", "Side Area", ""),
         "get_net_ceiling_area": Function("IfcAreaMeasure", "Net Ceiling Area", ""),
         "get_net_floor_area": Function("IfcAreaMeasure", "Net Floor Area", ""),
         "get_net_footprint_area": Function("IfcAreaMeasure", "Net Footprint Area", ""),
@@ -667,8 +763,13 @@ class Blender(QtoCalculator):
 
         for element in elements:
             obj = tool.Ifc.get_object(element)
-            if not obj or obj.type != "MESH":
-                continue
+            # When the element has no Blender object (e.g. a door/window whose
+            # mapped body representation never produced a standalone mesh),
+            # attribute-based calculators can still quantify it from the IFC
+            # element directly. Pass the element itself as the calculation target
+            # in that case; geometry-only calculators raise on a non-object and
+            # are skipped below, so nothing crashes.
+            target = obj if obj is not None else element
             element_results = results.setdefault(element, {})
             for name, quantities in qtos.items():
                 qto_results = element_results.setdefault(name, {})
@@ -677,10 +778,19 @@ class Blender(QtoCalculator):
                         continue
                     if not (formula_function := formula_functions.get(formula)):
                         formula_function = formula_functions[formula] = getattr(calculator, formula)
-                    if (value := formula_function(obj)) is not None:
+                    # A calculator may raise on geometry it cannot handle (a
+                    # non-MESH object, or the element itself when there is no
+                    # object). Skip that quantity rather than aborting the whole
+                    # take-off.
+                    try:
+                        value = formula_function(target)
+                    except Exception:
+                        value = None
+                    if value is not None:
                         qto_results[quantity] = unit_converter.convert(value, Blender.functions[formula].measure)
-                if qto_results:
-                    element_results[name] = qto_results
+                # Avoid leaving an empty qset behind if nothing was calculated.
+                if not qto_results:
+                    del element_results[name]
             # Avoid adding empty qsets if nothing was calculated.
             if not element_results:
                 del results[element]


### PR DESCRIPTION
Reported in #4537 by @daniels0401: door and window surface areas are wrong. Running Perform Quantity Take-off on a real Bonsai IfcDoor also reported it "not quantified", producing no Qto_DoorBaseQuantities, while a comparable IfcWindow quantified fine. The door/window base quantities (Area, Width, Height, Perimeter) come from OverallWidth/OverallHeight and need no geometry, so the door should always quantify. This PR supersedes #4537.

Two root causes, both fixed:

1. Blender engine. Blender.calculate skipped any element whose tool.Ifc.get_object returned None, so a door with no Blender object (its body did not load a mesh, the object was removed, or the element came from a partially loaded/linked file) was dropped before any calculator ran. It now uses the IFC element itself as the calculation target when there is no object. The door/window attribute calculators accept a Blender object, an IFC element, or None, and only fall back to geometry when a real object is available. Geometry-only calculators raise on a non-object and are caught, so nothing crashes and every other element behaves exactly as before.

2. IfcOpenShell engine (the more common path). Its rule sets had the door quantities fully null and the window Area as an inflated max-side bounding box with a null perimeter. This PR adds attribute based calculators (get_lining_area = OverallWidth * OverallHeight, get_overall_width, get_overall_height, get_lining_perimeter = 2 * (width + height)), rescaled from project units to SI, requiring no geometry, and points IfcDoor/IfcWindow in both IFC4QtoBaseQuantities.json and IFC4X3QtoBaseQuantities.json at them, including the previously missing Perimeter.

This produces the complete Qto_Door/WindowBaseQuantities set (Width, Height, Perimeter, Area) that buildingSMART defines for the outer lining.

Verification, driven headless:
- Real door (OverallWidth 0.9, OverallHeight 2.0), both engines, with and without a Blender object: Area 1.80, Width 0.9, Height 2.0, Perimeter 5.8.
- 0.6 by 0.9 window on the IfcOpenShell engine: Area 0.54, Perimeter 3.0 (previously inflated / null); correct scaling in millimetre files.
- Wall/beam/slab geometry quantities unchanged; ifcopenshell.validate clean on written quantities.
- Confirmed in a live Blender session against a real door.

Fixes #4537

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
