### PR TITLE
Fix BCF 2.1 viewpoint and snapshot file names

### DIFF
--- a/src/bcf/bcf/v2/topic.py
+++ b/src/bcf/bcf/v2/topic.py
@@ -271,11 +271,21 @@ class TopicHandler:
     def add_visinfo_handler(
         self, new_viewpoint: VisualizationInfoHandler, snapshot_filename: Optional[str] = None
     ) -> mdl.ViewPoint:
-        self.viewpoints[new_viewpoint.guid + ".bcfv"] = new_viewpoint
+        # The BCF 2.1 schema requires one viewpoint to be named "viewpoint.bcfv" (and its
+        # snapshot "snapshot.png"), even when a topic holds multiple viewpoints. Other tools
+        # (e.g. BimCollab) rely on these fixed names to load the topic's primary viewpoint.
+        # Use the fixed names for the first viewpoint and fall back to guid based names for
+        # any additional ones. See https://github.com/buildingSMART/BCF-XML/tree/release_2_1.
+        guid = new_viewpoint.guid
+        is_primary = "viewpoint.bcfv" not in self.viewpoints
+        viewpoint_filename = "viewpoint.bcfv" if is_primary else f"{guid}.bcfv"
+        if snapshot_filename is None and new_viewpoint.snapshot is not None:
+            snapshot_filename = "snapshot.png" if is_primary else f"{guid}.png"
+        self.viewpoints[viewpoint_filename] = new_viewpoint
         viewpoint = mdl.ViewPoint(
-            viewpoint=new_viewpoint.guid + ".bcfv",
+            viewpoint=viewpoint_filename,
             snapshot=snapshot_filename,
-            guid=new_viewpoint.guid,
+            guid=guid,
         )
         self.markup.viewpoints.append(viewpoint)
         return viewpoint

--- a/src/bcf/tests/v2/test_bcf_xml.py
+++ b/src/bcf/tests/v2/test_bcf_xml.py
@@ -1,6 +1,7 @@
 """BCF XML tests."""
 
 import uuid
+import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -110,6 +111,45 @@ def test_massive_bcf(xml_handler) -> None:
     with TemporaryDirectory() as tmp_dir:
         file_path = Path(tmp_dir) / "test.bcf"
         bcf.save(file_path)
+
+
+# 1x1 transparent PNG, used to attach a snapshot to a viewpoint.
+BLANK_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDAT\x08\xd7c\x90\x8a"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _make_visinfo(xml_handler):
+    vi = mdl.VisualizationInfo(
+        guid=str(uuid.uuid4()),
+        components=build_components(str(uuid.uuid4())),
+        perspective_camera=build_camera_from_vectors([1, 2, 3], [0, 1, 0], [0, 0, 1]),
+    )
+    return VisualizationInfoHandler(visualization_info=vi, snapshot=BLANK_PNG, xml_handler=xml_handler)
+
+
+def test_bcf21_viewpoint_and_snapshot_filenames(xml_handler, build_sample) -> None:
+    """BCF 2.1 requires the primary viewpoint/snapshot to be named viewpoint.bcfv/snapshot.png (issue #7152)."""
+    bcf, th = build_sample
+    primary = th.add_visinfo_handler(_make_visinfo(xml_handler))
+    assert primary.viewpoint == "viewpoint.bcfv"
+    assert primary.snapshot == "snapshot.png"
+
+    # Additional viewpoints keep guid based names so only one viewpoint.bcfv exists.
+    extra_handler = _make_visinfo(xml_handler)
+    extra = th.add_visinfo_handler(extra_handler)
+    assert extra.viewpoint == f"{extra_handler.guid}.bcfv"
+    assert extra.snapshot == f"{extra_handler.guid}.png"
+
+    with TemporaryDirectory() as tmp_dir:
+        file_path = Path(tmp_dir) / "test.bcf"
+        bcf.save(file_path)
+        with zipfile.ZipFile(file_path) as zf:
+            names = zf.namelist()
+    assert f"{th.guid}/viewpoint.bcfv" in names
+    assert f"{th.guid}/snapshot.png" in names
 
 
 def test_equality_with_wrong_object(build_sample) -> None:

--- a/src/bcf/tests/v2/test_ifcclash_api.py
+++ b/src/bcf/tests/v2/test_ifcclash_api.py
@@ -15,7 +15,8 @@ def test_create_clash_set_bcf() -> None:
     assert len(topic.viewpoints) == 1
     guid, vi_handler = next((k, v) for k, v in topic.viewpoints.items())
     v_info = vi_handler.visualization_info
-    assert f"{v_info.guid}.bcfv" == guid
+    # BCF 2.1 requires the primary viewpoint to be named "viewpoint.bcfv" (see issue #7152).
+    assert guid == "viewpoint.bcfv"
     components = v_info.components.selection.component
     assert {c.ifc_guid for c in components} == {"firstId", "secondId"}
     camera = v_info.perspective_camera


### PR DESCRIPTION
BCF 2.1 requires the primary viewpoint of a topic to be named exactly viewpoint.bcfv and its snapshot snapshot.png, even when the topic holds multiple viewpoints. The v2 writer named every viewpoint <guid>.bcfv, which is the BCF 3.0 convention. Other tools (for example BimCollab Zoom) rely on the fixed 2.1 names and could not open the topic's primary viewpoint, breaking interoperability.

This changes bcf/v2/topic.py so the first viewpoint added to a topic is named viewpoint.bcfv, and when the handler carries snapshot bytes without an explicit filename the snapshot defaults to snapshot.png. Additional viewpoints keep guid based names, so exactly one viewpoint.bcfv exists per topic. BCF 3.0 output is untouched.

Thanks to @sanzoghenzo for reporting and diagnosing the exact 2.1 schema constraint, and for the reference workaround.

Testing: the full bcf test suite passes (26 tests), including a new regression test that inspects the written .bcf zip for viewpoint.bcfv and snapshot.png and round-trips the file.

Fixes #7152

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
