### PR TITLE
Bonsai: fix "Save Pset As Template" on IFC4X3 custom psets

### DIFF
--- a/src/bonsai/bonsai/tool/pset_template.py
+++ b/src/bonsai/bonsai/tool/pset_template.py
@@ -72,9 +72,12 @@ class PsetTemplate(bonsai.core.tool.PsetTemplate):
                 if prop.Name in added_prop_names:
                     continue
                 added_prop_names.add(prop.Name)
-                # IFC4X3 renamed IfcProperty.Description to IfcProperty.Specification,
-                # so read whichever attribute the current schema provides.
-                description = getattr(prop, "Description", None) or getattr(prop, "Specification", None)
+                # IFC4X3 renamed IfcProperty.Description to IfcProperty.Specification.
+                # Access it positionally instead of by name: in both IFC4 and IFC4X3,
+                # IfcProperty's second attribute (index 1, after Name) is this
+                # description/specification field, so the EXPRESS attribute position
+                # is stable across schema versions even though the name isn't.
+                description = prop[1]
                 ifcopenshell.api.pset_template.add_prop_template(
                     template_file,
                     pset_template,

--- a/src/bonsai/bonsai/tool/pset_template.py
+++ b/src/bonsai/bonsai/tool/pset_template.py
@@ -72,11 +72,14 @@ class PsetTemplate(bonsai.core.tool.PsetTemplate):
                 if prop.Name in added_prop_names:
                     continue
                 added_prop_names.add(prop.Name)
+                # IFC4X3 renamed IfcProperty.Description to IfcProperty.Specification,
+                # so read whichever attribute the current schema provides.
+                description = getattr(prop, "Description", None) or getattr(prop, "Specification", None)
                 ifcopenshell.api.pset_template.add_prop_template(
                     template_file,
                     pset_template,
                     name=prop.Name,
-                    description=prop.Description,
+                    description=description,
                     primary_measure_type=prop.NominalValue.is_a(),
                 )
         return pset_template


### PR DESCRIPTION
Saving a custom property set as a template failed on IFC4X3 models with:

    AttributeError: entity instance of type 'IFC4X3_ADD2.IfcPropertySingleValue' has no attribute 'Description'

IFC4X3 renamed IfcProperty.Description to IfcProperty.Specification. PsetTemplate.add_pset_as_template hard-coded prop.Description, so every attempt to save a custom pset as a template on an IFC4x3 project raised and the template was never written. It now reads whichever attribute the current schema exposes, so the flow works on IFC2X3/IFC4 (Description) and IFC4X3 (Specification) alike.

Verified end to end: creating a custom pset on an IFC4X3 wall and saving it as a template now produces a valid IfcPropertySetTemplate with the property names and measure types preserved, and ifcopenshell.validate reports no issues. Also confirmed in a live Blender session.

Thanks to @NickNunes26 for the report.

Fixes #7112

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
