### PR TITLE
Bonsai: fix deleting IfcIndexedPolyCurve from a GeometricSet representation

### DIFF
--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1775,7 +1775,7 @@ class Geometry(bonsai.core.tool.Geometry):
                 else:
                     representation = inverse
             elif inverse.is_a("IfcGeometricSet"):
-                # The item is aggregated via .Elements and must be pulled out or it reappears (#6591).
+                # item sits in the set's .Elements; pull it out or it reappears on reload (#6591)
                 geometric_sets.append(inverse)
             elif inverse.is_a("IfcBooleanResult"):
                 if inverse.SecondOperand == representation_item:
@@ -1819,7 +1819,7 @@ class Geometry(bonsai.core.tool.Geometry):
             if new_elements:
                 geometric_set.Elements = new_elements
             else:
-                # Removing the set's last element is invalid, so drop the whole set.
+                # dropping the last element is invalid, so remove the whole set
                 cls.remove_representation_item(geometric_set, element)
                 return
 

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1766,6 +1766,7 @@ class Geometry(bonsai.core.tool.Geometry):
         [consider_inverses.append(texture := t) for t in getattr(representation_item, "HasTextures", [])]
 
         representation = None
+        geometric_sets: list[ifcopenshell.entity_instance] = []
         boolean_results_to_remove: set[ifcopenshell.entity_instance] = set()
         for inverse in ifc_file.get_inverse(representation_item):
             if inverse.is_a("IfcShapeRepresentation"):
@@ -1773,6 +1774,12 @@ class Geometry(bonsai.core.tool.Geometry):
                     shape_aspects.append(inverse.OfShapeAspect[0])
                 else:
                     representation = inverse
+            elif inverse.is_a("IfcGeometricSet"):
+                # IfcGeometricSet/IfcGeometricCurveSet aggregate their items via
+                # .Elements and sit between the item and the IfcShapeRepresentation.
+                # The item must be pulled out of the set for a deletion to stick,
+                # otherwise the set keeps referencing it and it reappears (see #6591).
+                geometric_sets.append(inverse)
             elif inverse.is_a("IfcBooleanResult"):
                 if inverse.SecondOperand == representation_item:
                     other_operand = inverse.FirstOperand
@@ -1809,6 +1816,17 @@ class Geometry(bonsai.core.tool.Geometry):
             if not new_items:
                 return
             representation.Items = new_items
+
+        for geometric_set in geometric_sets:
+            new_elements = tuple(e for e in geometric_set.Elements if e != representation_item)
+            if new_elements:
+                geometric_set.Elements = new_elements
+            else:
+                # Removing the last element would make the set invalid, so remove
+                # the whole set instead, which cascades to this item.
+                cls.remove_representation_item(geometric_set, element)
+                return
+
         also_consider = list(consider_inverses)
         ifcopenshell.util.element.remove_deep2(ifc_file, representation_item, also_consider=also_consider)
 

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1775,10 +1775,7 @@ class Geometry(bonsai.core.tool.Geometry):
                 else:
                     representation = inverse
             elif inverse.is_a("IfcGeometricSet"):
-                # IfcGeometricSet/IfcGeometricCurveSet aggregate their items via
-                # .Elements and sit between the item and the IfcShapeRepresentation.
-                # The item must be pulled out of the set for a deletion to stick,
-                # otherwise the set keeps referencing it and it reappears (see #6591).
+                # The item is aggregated via .Elements and must be pulled out or it reappears (#6591).
                 geometric_sets.append(inverse)
             elif inverse.is_a("IfcBooleanResult"):
                 if inverse.SecondOperand == representation_item:
@@ -1822,8 +1819,7 @@ class Geometry(bonsai.core.tool.Geometry):
             if new_elements:
                 geometric_set.Elements = new_elements
             else:
-                # Removing the last element would make the set invalid, so remove
-                # the whole set instead, which cascades to this item.
+                # Removing the set's last element is invalid, so drop the whole set.
                 cls.remove_representation_item(geometric_set, element)
                 return
 


### PR DESCRIPTION
Deleting a representation item that lives inside an IfcGeometricSet (for example an IfcIndexedPolyCurve inside an IfcGeometricCurveSet of a Plan/Body/PLAN_VIEW representation) did not persist: the item was visually removed in item edit mode but returned on exiting edit mode.

Root cause: Geometry.remove_representation_item resolved the containing representation only when the item's inverse was an IfcShapeRepresentation (or IfcBooleanResult). For items nested in an IfcGeometricSet the inverse is the set itself, so the item was never detached and remove_deep2 could not delete it while the set still referenced it. It was re-imported on reload.

Fix: also handle IfcGeometricSet inverses by removing the item from .Elements. If that would empty the set, remove the whole set instead, which cascades to the item.

Verified against the reporter's prova.ifc: the targeted IfcIndexedPolyCurve is removed from the IfcGeometricCurveSet and stays removed after the product representation is re-resolved. Also confirmed in a live Blender session (deleting a curve from the basin's plan symbol now persists), with the 3D model-view representation untouched and a clean ifcopenshell.validate.

Thanks to @carlopav for the clear steps and the sample file.

Fixes #6591

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
