### PR TITLE
ifc5d: add base-quantity rule for IfcGeographicElement (#6508)

### DIFF
--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
@@ -326,6 +326,16 @@
                     "Width": null
                 }
             },
+            "IfcGeographicElement": {
+                "EQto_GeographicElementBaseQuantities": {
+                    "Depth": "net_get_z",
+                    "GrossArea": "gross_get_footprint_area",
+                    "GrossVolume": "gross_get_volume",
+                    "NetArea": "net_get_footprint_area",
+                    "NetVolume": "net_get_volume",
+                    "Perimeter": "net_get_footprint_perimeter"
+                }
+            },
             "IfcHeatExchanger": {
                 "Qto_HeatExchangerBaseQuantities": {
                     "GrossWeight": null

--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantitiesBlender.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantitiesBlender.json
@@ -326,6 +326,16 @@
                     "Width": "get_width"
                 }
             },
+            "IfcGeographicElement": {
+                "EQto_GeographicElementBaseQuantities": {
+                    "Depth": "get_height",
+                    "GrossArea": "get_gross_footprint_area",
+                    "GrossVolume": "get_gross_volume",
+                    "NetArea": "get_net_footprint_area",
+                    "NetVolume": "get_net_volume",
+                    "Perimeter": "get_gross_perimeter"
+                }
+            },
             "IfcHeatExchanger": {
                 "Qto_HeatExchangerBaseQuantities": {
                     "GrossWeight": null

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
@@ -371,6 +371,16 @@
                     "Width": null
                 }
             },
+            "IfcGeographicElement + IfcGeographicElementType": {
+                "EQto_GeographicElementBaseQuantities": {
+                    "Depth": "net_get_z",
+                    "GrossArea": "gross_get_footprint_area",
+                    "GrossVolume": "gross_get_volume",
+                    "NetArea": "net_get_footprint_area",
+                    "NetVolume": "net_get_volume",
+                    "Perimeter": "net_get_footprint_perimeter"
+                }
+            },
             "IfcGeotechnicalStratum": {
                 "Qto_ArealStratumBaseQuantities": {
                     "Area": null,

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
@@ -371,6 +371,16 @@
                     "Width": "get_width"
                 }
             },
+            "IfcGeographicElement + IfcGeographicElementType": {
+                "EQto_GeographicElementBaseQuantities": {
+                    "Depth": "get_height",
+                    "GrossArea": "get_gross_footprint_area",
+                    "GrossVolume": "get_gross_volume",
+                    "NetArea": "get_net_footprint_area",
+                    "NetVolume": "get_net_volume",
+                    "Perimeter": "get_gross_perimeter"
+                }
+            },
             "IfcGeotechnicalStratum": {
                 "Qto_ArealStratumBaseQuantities": {
                     "Area": null,


### PR DESCRIPTION
IfcGeographicElement was reported as "not quantified" because neither IFC4 nor IFC4.3 defines a base-quantity set for it and ifc5d had no rule. Following the discussion (thanks @theoryshaw for the report, @Andrej730 for proposing the custom EQto, @maxfb87 and @steverugi for the property review), this adds a Bonsai-custom EQto_GeographicElementBaseQuantities to the four ifc5d rule files (IfcOpenShell + Blender engines, IFC4 + IFC4X3), mirroring the existing IfcSlab mapping.

Quantities: Depth, GrossArea, GrossVolume, NetArea, NetVolume, Perimeter (steverugi's YES list). Length and Width are omitted as not standardisable.

Maintainers: please confirm the final property list. The thread converged on the custom EQto approach but the exact set was not formally locked, so I implemented steverugi's wishlist and am happy to adjust.

Verified on a synthetic IFC4X3 IfcGeographicElement (4x2x1 box): before, no quantities; after, GrossArea/NetArea 8.0, GrossVolume/NetVolume 8.0, Depth 1.0, Perimeter 12.0, with correct IfcQuantityArea/Volume/Length types and a clean ifcopenshell.validate.

Follow-up (not in this PR): a matching EQto_GeographicElementBaseQuantities pset template under src/bonsai/bonsai/bim/data/pset/ would surface the set in Bonsai's pset picker.

Fixes #6508

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
