### PR TITLE
Fix IfcConvert --no-progress being ignored with --threads >= 2 (#1410)

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -951,7 +951,8 @@ int main(int argc, char** argv) {
 		std::vector<double> offset(3);
 
 		IfcGeom::Iterator tmp_context_iterator(ifcopenshell::geometry::kernels::construct(ifc_file, geometry_kernel, geometry_settings, logger), geometry_settings, ifc_file, filter_funcs, num_threads, logger);
-			
+		tmp_context_iterator.suppress_progress(no_progress);
+
 		time_t start, end;
 		time(&start);
 		if (!quiet) logger.Status("Computing bounds...");
@@ -997,7 +998,8 @@ int main(int argc, char** argv) {
 	std::unique_ptr<IfcGeom::Iterator> context_iterator;
 	if (!elems_from_adaptor) {
 		context_iterator.reset(new IfcGeom::Iterator(ifcopenshell::geometry::kernels::construct(ifc_file, geometry_kernel, geometry_settings, logger), geometry_settings, ifc_file, filter_funcs, num_threads, logger));
-	}	
+		context_iterator->suppress_progress(no_progress);
+	}
 
 #if defined(WITH_HDF5) && defined(IFOPSH_WITH_OPENCASCADE)
 	std::unique_ptr<HdfSerializer> cache;

--- a/src/ifcgeom/Iterator.cpp
+++ b/src/ifcgeom/Iterator.cpp
@@ -283,7 +283,7 @@ void IfcGeom::Iterator::process_concurrently() {
 
 	logger_.SetProduct(boost::none);
 
-	if (!terminating_) {
+	if (!terminating_ && !no_progress_) {
 		logger_.Status("\rDone creating geometry (" + boost::lexical_cast<std::string>(all_processed_elements_.size()) +
 			" objects)								");
 	}

--- a/src/ifcgeom/Iterator.h
+++ b/src/ifcgeom/Iterator.h
@@ -126,6 +126,7 @@ namespace IfcGeom {
 		IfcParse::IfcFile* ifc_file;
 		std::vector<filter_t> filters_;
 		int num_threads_;
+		bool no_progress_ = false;
 		std::string geometry_library_;
 		Logger& logger_;
 
@@ -250,6 +251,11 @@ namespace IfcGeom {
 		~Iterator();
 
 		void set_cache(GeometrySerializer* cache) { cache_ = cache; }
+
+		// When set, suppresses the carriage-return status line emitted by the
+		// concurrent (multi-threaded) processing path so that callers passing
+		// --no-progress get consistent output regardless of thread count.
+		void suppress_progress(bool b = true) { no_progress_ = b; }
 
 		std::vector<ifcopenshell::geometry::taxonomy::item::ptr> get_task_items() const {
 			std::vector<ifcopenshell::geometry::taxonomy::item::ptr> items;


### PR DESCRIPTION
IfcConvert --no-progress suppressed progress output with a single thread but not with --threads 2 or more, reported by @Amoki in #1410.

Root cause: the shared serializer loop in IfcConvert gates its progress bar on the no_progress flag, but the multi-threaded geometry path in IfcGeom::Iterator::process_concurrently emitted its own carriage-return "Done creating geometry (N objects)" status line with no such gate. The single-threaded create() path never emits that line, so only threads >= 2 leaked progress output.

Fix: add a suppress_progress setter on IfcGeom::Iterator and gate the concurrent status emission on it. IfcConvert sets it from its existing no_progress flag for both the main iterator and the center-model bounds iterator. Backward compatible: callers that do not set the flag keep the previous behaviour, and single-threaded and progress-on output are unchanged.

Verified by building IfcConvert from this branch and running the three commands from the issue against the patched binary. Before the fix, --threads 2 with --no-progress leaked an extra carriage-return "Done creating geometry" line that --threads 1 did not; after the fix the two thread modes produce the same single-line output, and running without --no-progress still shows the full progress bar.

Fixes #1410

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
