### PR TITLE
Bonsai: fix creating IfcSpaceType from the Type Manager / Multi Object Tool

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/data.py
+++ b/src/bonsai/bonsai/bim/module/root/data.py
@@ -72,9 +72,7 @@ class IfcClassData:
         declarations = ifcopenshell.util.schema.get_subtypes(declaration)
         names = [d.name() for d in declarations]
         if ifc_product == "IfcElementType":
-            names.append("IfcTypeProduct")
-            if tool.Ifc.get_schema() in ("IFC2X3", "IFC4"):
-                names.extend(("IfcDoorStyle", "IfcWindowStyle"))
+            names.extend(tool.Root.get_element_type_extra_classes(tool.Ifc.get_schema()))
         if ifc_product == "IfcElement":
             entity = tool.Ifc.schema().declaration_by_name("IfcFeatureElement").as_entity()
             assert entity

--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -510,10 +510,14 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
                 props.representation_template = "OBJ"
                 props.representation_obj = obj
         # For convenience, preselect IFC class
-        if self.ifc_product:
-            props.ifc_product = self.ifc_product
         if self.ifc_class:
+            # The ifc_class enum is built from the subtypes of ifc_product, so the product must be
+            # consistent with the class. Callers may pass a hardcoded product (e.g. IfcElementType) that
+            # does not contain the class (e.g. IfcSpaceType), which would raise a TypeError here. #7204
+            props.ifc_product = tool.Root.get_add_element_product(self.ifc_class, self.ifc_product)
             props.ifc_class = self.ifc_class
+        elif self.ifc_product:
+            props.ifc_product = self.ifc_product
         if self.skip_dialog:
             return self.execute(context)
         return context.window_manager.invoke_props_dialog(self)

--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -55,17 +55,12 @@ class EnableReassignClass(bpy.types.Operator):
         ifc_class = element.is_a()
         props = tool.Blender.get_object_bim_props(obj)
         props.is_reassigning_class = True
-        ifc_products = tool.Root.get_ifc_products()
-        schema = tool.Ifc.schema()
-        declaration = schema.declaration_by_name(ifc_class)
-        for ifc_product in ifc_products:
-            if ifcopenshell.util.schema.is_a(declaration, ifc_product):
-                rprops.ifc_product = ifc_product
-                break
-        else:
+        ifc_product = tool.Root.get_add_element_product(ifc_class)
+        if not ifc_product:
             self.report({"ERROR"}, f"Couldn't find matching IFC product for the selected object: '{element}'.")
             props.is_reassigning_class = False
             return {"CANCELLED"}
+        rprops.ifc_product = ifc_product
 
         element = self.file.by_id(tool.Blender.get_ifc_definition_id(obj))
         rprops.ifc_class = element.is_a()

--- a/src/bonsai/bonsai/tool/root.py
+++ b/src/bonsai/bonsai/tool/root.py
@@ -490,6 +490,22 @@ class Root(bonsai.core.tool.Root):
         return products
 
     @classmethod
+    def get_element_type_extra_classes(cls, schema: str) -> tuple[str, ...]:
+        """Classes offered under the ``IfcElementType`` product that are not schema subtypes of it.
+
+        Single source of truth shared by the Type Manager enum (see
+        ``bonsai.bim.module.root.data.IfcClassData.ifc_classes``) and :func:`get_add_element_product`, so
+        the two cannot drift. ``IfcDoorStyle`` / ``IfcWindowStyle`` only exist in IFC2X3 and IFC4, so they
+        are only offered there; ``IfcTypeProduct`` exists in every schema.
+
+        :param schema: Schema identifier, e.g. ``tool.Ifc.get_schema()``.
+        """
+        classes = ["IfcTypeProduct"]
+        if schema in ("IFC2X3", "IFC4"):
+            classes.extend(("IfcDoorStyle", "IfcWindowStyle"))
+        return tuple(classes)
+
+    @classmethod
     def get_add_element_product(cls, ifc_class: str, fallback_product: str = "") -> str:
         """Return the ``ifc_product`` category (see :func:`get_ifc_products`) the ``ifc_class`` belongs to.
 
@@ -503,8 +519,9 @@ class Root(bonsai.core.tool.Root):
         :param fallback_product: Product to keep when it already contains ``ifc_class``, or to return when
             no better match is found.
         """
+        schema = tool.Ifc.get_schema()
         # Classes offered under the IfcElementType product that are not schema subtypes of it.
-        if ifc_class in ("IfcTypeProduct", "IfcDoorStyle", "IfcWindowStyle"):
+        if ifc_class in cls.get_element_type_extra_classes(schema):
             return "IfcElementType"
         declaration = tool.Ifc.schema().declaration_by_name(ifc_class)
         if fallback_product and ifcopenshell.util.schema.is_a(declaration, fallback_product):

--- a/src/bonsai/bonsai/tool/root.py
+++ b/src/bonsai/bonsai/tool/root.py
@@ -29,6 +29,7 @@ import ifcopenshell.api.style
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
 import ifcopenshell.util.representation
+import ifcopenshell.util.schema
 
 import bonsai.core.aggregate
 import bonsai.core.geometry
@@ -487,3 +488,28 @@ class Root(bonsai.core.tool.Root):
                 "IfcRelSpaceBoundary",
             )
         return products
+
+    @classmethod
+    def get_add_element_product(cls, ifc_class: str, fallback_product: str = "") -> str:
+        """Return the ``ifc_product`` category (see :func:`get_ifc_products`) the ``ifc_class`` belongs to.
+
+        ``bim.add_element`` builds its ``ifc_class`` enum from the subtypes of the selected
+        ``ifc_product``, so the product must be consistent with the class. Some classes are offered in
+        the Type Manager but are not subtypes of ``IfcElementType`` (e.g. ``IfcSpaceType``, which is an
+        ``IfcSpatialElementType``); passing a hardcoded product for those raises a ``TypeError`` when the
+        class is assigned to the enum. See https://github.com/IfcOpenShell/IfcOpenShell/issues/7204.
+
+        :param ifc_class: The IFC class that will be assigned to ``props.ifc_class``.
+        :param fallback_product: Product to keep when it already contains ``ifc_class``, or to return when
+            no better match is found.
+        """
+        # Classes offered under the IfcElementType product that are not schema subtypes of it.
+        if ifc_class in ("IfcTypeProduct", "IfcDoorStyle", "IfcWindowStyle"):
+            return "IfcElementType"
+        declaration = tool.Ifc.schema().declaration_by_name(ifc_class)
+        if fallback_product and ifcopenshell.util.schema.is_a(declaration, fallback_product):
+            return fallback_product
+        for product in cls.get_ifc_products():
+            if ifcopenshell.util.schema.is_a(declaration, product):
+                return product
+        return fallback_product

--- a/src/bonsai/test/tool/test_root.py
+++ b/src/bonsai/test/tool/test_root.py
@@ -70,6 +70,49 @@ class TestDoesTypeHaveRepresentations(NewFile):
         assert subject.does_type_have_representations(element) is True
 
 
+class TestGetElementTypeExtraClasses(NewFile):
+    def test_ifc_type_product_is_offered_in_every_schema(self):
+        for schema in ("IFC2X3", "IFC4", "IFC4X3"):
+            assert "IfcTypeProduct" in subject.get_element_type_extra_classes(schema)
+
+    def test_door_and_window_styles_are_only_offered_in_ifc2x3_and_ifc4(self):
+        for schema in ("IFC2X3", "IFC4"):
+            extra = subject.get_element_type_extra_classes(schema)
+            assert "IfcDoorStyle" in extra
+            assert "IfcWindowStyle" in extra
+        # IfcDoorStyle/IfcWindowStyle do not exist in IFC4X3 and must not be offered there.
+        extra = subject.get_element_type_extra_classes("IFC4X3")
+        assert "IfcDoorStyle" not in extra
+        assert "IfcWindowStyle" not in extra
+
+
+class TestGetAddElementProduct(NewFile):
+    def test_ifc_space_type_resolves_to_spatial_element_type(self):
+        # Regression for #7204: IfcSpaceType is an IfcSpatialElementType, not an IfcElementType, so a
+        # hardcoded IfcElementType product would raise a TypeError when assigning the ifc_class enum.
+        tool.Ifc.set(ifcopenshell.file(schema="IFC4"))
+        assert subject.get_add_element_product("IfcSpaceType", "IfcElementType") == "IfcSpatialElementType"
+
+    def test_normal_element_type_resolves_to_element_type(self):
+        tool.Ifc.set(ifcopenshell.file(schema="IFC4"))
+        assert subject.get_add_element_product("IfcWallType", "IfcElementType") == "IfcElementType"
+
+    def test_special_cases_resolve_to_element_type(self):
+        for schema in ("IFC2X3", "IFC4"):
+            tool.Ifc.set(ifcopenshell.file(schema=schema))
+            for ifc_class in ("IfcTypeProduct", "IfcDoorStyle", "IfcWindowStyle"):
+                assert subject.get_add_element_product(ifc_class, "IfcElementType") == "IfcElementType"
+
+    def test_schema_guard_is_honoured_on_ifc4x3(self):
+        # IfcDoorStyle/IfcWindowStyle do not exist in IFC4X3, so they must not be special-cased there,
+        # while IfcTypeProduct is still offered under IfcElementType.
+        tool.Ifc.set(ifcopenshell.file(schema="IFC4X3"))
+        extra = subject.get_element_type_extra_classes(tool.Ifc.get_schema())
+        assert "IfcDoorStyle" not in extra
+        assert "IfcWindowStyle" not in extra
+        assert subject.get_add_element_product("IfcTypeProduct", "IfcElementType") == "IfcElementType"
+
+
 class TestGetDecompositionRelationships(NewFile):
     def test_run(self):
         ifc = ifcopenshell.file()


### PR DESCRIPTION
Reported by @CyrilWaechter in #7204.

Creating a new IfcSpaceType (select an IfcSpaceType, open the Multi Object Tool, launch the Type Manager, press Create New Type) failed with:

    TypeError: bpy_struct: item.attr = val: enum "IfcSpaceType" not found in (...)

The Type Manager intentionally lists IfcSpaceType as a creatable type, but the "Create New Type" buttons invoke bim.add_element with a hardcoded ifc_product of "IfcElementType". In AddElement._invoke, setting ifc_product rebuilds the ifc_class enum from that product's subtypes. IfcSpaceType is an IfcSpatialElementType, not an IfcElementType, so it is missing from the enum and assigning it raises TypeError.

Fix this centrally in the operator: derive the correct ifc_product from the class before assigning the enum, via a new tool.Root.get_add_element_product helper. The helper keeps the caller's product when it already contains the class, special-cases the classes offered under IfcElementType that are not schema subtypes of it (IfcTypeProduct, IfcDoorStyle, IfcWindowStyle), and otherwise picks the product whose subtypes contain the class. This protects both Create New Type buttons and any other caller.

Verified by driving the schema/enum logic and creation directly: before, the enum assignment raises the reported TypeError; after, the derived product is IfcSpatialElementType, the enum contains IfcSpaceType, the entity is created, and ifcopenshell.validate is clean.

Fixes #7204

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
