### PR TITLE
Clean up orphaned relationships after removing elements (IfcMechanicalFastener and others)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/root/remove_product.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/root/remove_product.py
@@ -162,12 +162,25 @@ def remove_product(file: ifcopenshell.file, product: ifcopenshell.entity_instanc
                 file.remove(inverse)
                 if history:
                     ifcopenshell.util.element.remove_deep2(file, history)
+        elif inverse.is_a("IfcRelReferencedInSpatialStructure"):
+            if inverse.RelatingStructure == product or len(inverse.RelatedElements) == 1:
+                history = inverse.OwnerHistory
+                file.remove(inverse)
+                if history:
+                    ifcopenshell.util.element.remove_deep2(file, history)
         elif inverse.is_a("IfcRelConnectsElements"):
             if inverse.is_a("IfcRelConnectsWithRealizingElements"):
                 if product not in (inverse.RelatingElement, inverse.RelatedElement) and any(
                     el for el in inverse.RealizingElements if el != product
                 ):
                     continue
+            history = inverse.OwnerHistory
+            file.remove(inverse)
+            if history:
+                ifcopenshell.util.element.remove_deep2(file, history)
+        elif inverse.is_a("IfcRelInterferesElements"):
+            # Both RelatingElement and RelatedElement are mandatory, so the
+            # relationship is meaningless once either participant is removed.
             history = inverse.OwnerHistory
             file.remove(inverse)
             if history:
@@ -202,6 +215,25 @@ def remove_product(file: ifcopenshell.file, product: ifcopenshell.entity_instanc
                 if history:
                     ifcopenshell.util.element.remove_deep2(file, history)
             elif len(inverse.RelatedObjects) == 1:
+                history = inverse.OwnerHistory
+                file.remove(inverse)
+                if history:
+                    ifcopenshell.util.element.remove_deep2(file, history)
+        elif inverse.is_a("IfcRelAssigns"):
+            # Covers the remaining IfcRelAssignsTo* subtypes (process, control,
+            # actor, resource). Only remove the relationship when the product is
+            # its sole related object, otherwise file.remove drops the product
+            # from RelatedObjects and the relationship stays valid.
+            if len(inverse.RelatedObjects) == 1:
+                history = inverse.OwnerHistory
+                file.remove(inverse)
+                if history:
+                    ifcopenshell.util.element.remove_deep2(file, history)
+        elif inverse.is_a("IfcRelAssociates"):
+            # IfcRelAssociatesMaterial is handled above. Other associations
+            # (classification, document, library, constraint, approval) would
+            # otherwise be left with an empty mandatory RelatedObjects set.
+            if len(inverse.RelatedObjects) == 1:
                 history = inverse.OwnerHistory
                 file.remove(inverse)
                 if history:

--- a/src/ifcopenshell-python/test/api/root/test_remove_product.py
+++ b/src/ifcopenshell-python/test/api/root/test_remove_product.py
@@ -464,6 +464,80 @@ class TestRemoveProduct(test.bootstrap.IFC4):
         ifcopenshell.api.root.remove_product(self.file, product=flow_element)
         assert not self.file.by_type("IfcRelFlowControlElements")
 
+    def test_removing_orphaned_classification_associations(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcMechanicalFastener")
+        classification = self.file.create_entity("IfcClassification", Name="Uniclass")
+        reference = self.file.create_entity(
+            "IfcClassificationReference", ReferencedSource=classification, Identification="Pr_20"
+        )
+        self.file.create_entity(
+            "IfcRelAssociatesClassification",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedObjects=[element],
+            RelatingClassification=reference,
+        )
+        ifcopenshell.api.root.remove_product(self.file, product=element)
+        assert not self.file.by_type("IfcRelAssociatesClassification")
+
+    def test_keeping_shared_classification_associations(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcMechanicalFastener")
+        other = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        classification = self.file.create_entity("IfcClassification", Name="Uniclass")
+        reference = self.file.create_entity(
+            "IfcClassificationReference", ReferencedSource=classification, Identification="Pr_20"
+        )
+        self.file.create_entity(
+            "IfcRelAssociatesClassification",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedObjects=[element, other],
+            RelatingClassification=reference,
+        )
+        ifcopenshell.api.root.remove_product(self.file, product=element)
+        assert len(self.file.by_type("IfcRelAssociatesClassification")) == 1
+        assert self.file.by_type("IfcRelAssociatesClassification")[0].RelatedObjects == (other,)
+
+    def test_removing_orphaned_process_assignments(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcMechanicalFastener")
+        task = self.file.create_entity("IfcTask", GlobalId=ifcopenshell.guid.new())
+        self.file.create_entity(
+            "IfcRelAssignsToProcess",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedObjects=[element],
+            RelatingProcess=task,
+        )
+        ifcopenshell.api.root.remove_product(self.file, product=element)
+        assert not self.file.by_type("IfcRelAssignsToProcess")
+
+    def test_removing_referenced_spatial_structure_relationships(self):
+        # IfcRelReferencedInSpatialStructure was introduced in IFC4.
+        if self.file.schema == "IFC2X3":
+            return
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcMechanicalFastener")
+        storey = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        self.file.create_entity(
+            "IfcRelReferencedInSpatialStructure",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedElements=[element],
+            RelatingStructure=storey,
+        )
+        ifcopenshell.api.root.remove_product(self.file, product=element)
+        assert not self.file.by_type("IfcRelReferencedInSpatialStructure")
+
+    def test_removing_interference_relationships(self):
+        # IfcRelInterferesElements was introduced in IFC4.
+        if self.file.schema == "IFC2X3":
+            return
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcMechanicalFastener")
+        other = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBeam")
+        self.file.create_entity(
+            "IfcRelInterferesElements",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatingElement=element,
+            RelatedElement=other,
+        )
+        ifcopenshell.api.root.remove_product(self.file, product=element)
+        assert not self.file.by_type("IfcRelInterferesElements")
+
 
 class TestRemoveProductIFC2X3(TestRemoveProduct, test.bootstrap.IFC2X3):
     pass


### PR DESCRIPTION
Reported by @MorselliCERN in #6153: deleting IfcMechanicalFastener bolt assemblies and then saving produced an invalid file.

Root cause: ifcopenshell.api.root.remove_product did not handle several relationship types. When the removed product was the sole participant, the final file.remove left a degenerate relationship behind: an empty mandatory SET (IfcRelAssociates* other than material, IfcRelAssignsTo* other than group/product, IfcRelReferencedInSpatialStructure) or a null mandatory reference (IfcRelInterferesElements). These are common on structural fasteners (classification marks, spatial references, clash/interference, 4D task assignments) and produce invalid IFC.

Fix: add handlers for these relationship types so removal cleans them up. Shared relationships are kept, with the product removed from the set.

Tests: 5 new cases in test_remove_product.py (IFC4-only ones guarded for IFC2X3); full suite passes (74). Black/Ruff/ty clean.

Honest note: the reporter's sample files were shared privately (via ifcopenshell.org/upload) and were not available to me, so I could not reproduce their exact save-error string. This fixes the reproducible orphaned-invalid-relationship defect on the fastener-removal path, which is the most defensible root cause matching the report. @MorselliCERN, if you can retest your model on a build including this, or reshare the file, we can confirm it is the same error.

Fixes #6153

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
