### PR TITLE
Bonsai: baseline half space item placements so item edits keep all cuts (#7737)

### DIFF
--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2259,6 +2259,10 @@ class Geometry(bonsai.core.tool.Geometry):
 
                 obj.matrix_world = item_matrix
                 obj.data.transform(transformation_i)
+
+        # Baseline movable items (swept solids and half spaces) so is_moved is
+        # accurate and sync_item_positions leaves untouched placements alone.
+        if cls.is_movable(item):
             cls.record_object_position(obj)
 
         # ADD THIS AT THE END - Store initial vertex order for annotations


### PR DESCRIPTION
Fixes #7737.

import_item recorded the placement checksum only for swept area solids, so half space item objects had no checksum and Ifc.is_moved returned True for them by default. sync_item_positions then regenerated every half space placement on any item mode change, and for rotated elements that regeneration altered a plane enough that OCCT dropped one boolean cut, turning a quarter cylinder into a half cylinder. Record the baseline for all movable items.

Verified live in headless Blender 5.1.2: all four rotated cylinders keep their quarter geometry through an item edit and exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)