### PR TITLE
Bonsai: expose 2-Point Arc resolution in redo panel (#7233)

### DIFF
--- a/src/bonsai/bonsai/bim/module/cad/workspace.py
+++ b/src/bonsai/bonsai/bim/module/cad/workspace.py
@@ -245,6 +245,9 @@ class CadHotkey(bpy.types.Operator):
             if tool.Geometry.is_profile_object_active():
                 row = self.layout.row()
                 row.prop(props, "radius")
+            else:
+                row = self.layout.row()
+                row.prop(props, "resolution")
 
         elif self.hotkey == "S_F":
             if not tool.Geometry.is_profile_object_active():
@@ -281,7 +284,7 @@ class CadHotkey(bpy.types.Operator):
         if tool.Geometry.is_profile_object_active():
             bpy.ops.bim.add_ifccircle(radius=self.props.radius)
         else:
-            bpy.ops.bim.cad_arc_from_2_points()
+            bpy.ops.bim.cad_arc_from_2_points(resolution=self.props.resolution)
 
     def hotkey_S_E(self):
         bpy.ops.bim.cad_trim_extend()


### PR DESCRIPTION
Fixes #7233.

The S_C (2-Point Arc) redo panel drew no property for non profile meshes, so the bottom left options box appeared empty. Mirror the working 3-Point Arc branch: draw the resolution property and pass it to cad_arc_from_2_points. The arc geometry itself is correct per the maintainer; this is the UI and parameter threading defect.

Verified live in headless Blender: the non profile redo panel goes from empty to showing the resolution property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)