### PR TITLE
Bonsai: draw text-only leaders instead of crashing the decoration pass (#7655)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -920,8 +920,14 @@ class LeaderDecorator(BaseDecorator):
         return (obj.matrix_world @ spline_points[0].co).to_3d()
 
     def decorate(self, context, obj):
-        self.draw_arrow(context, obj)
-        self.draw_text(context, obj, self.get_spline_end(obj))
+        # A text leader can lose its leader curve and keep only the text literal, leaving an empty object.
+        # Without a curve there is no arrow to draw and no spline to anchor the text, so fall back to the
+        # origin like a plain text annotation instead of raising and aborting every following decoration.
+        if isinstance(obj.data, bpy.types.Curve) and obj.data.splines:
+            self.draw_arrow(context, obj)
+            self.draw_text(context, obj, self.get_spline_end(obj))
+        else:
+            self.draw_text(context, obj)
 
 
 class RadiusDecorator(BaseDecorator):


### PR DESCRIPTION
Fixes #7655.

A TEXT_LEADER annotation whose representation lost its leader curve imports as an empty object. LeaderDecorator.decorate went straight to draw_arrow, whose get_path_geom dereferenced obj.data.splines on None and raised, which aborted the whole DecorationsHandler pass so no later annotation drew its text. Fall back to drawing the text at the annotation origin when there is no curve, matching TextDecorator.

Verified live in headless Blender: the offending annotation imports as an empty object and now takes the text only path instead of raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)