### PR TITLE
Fix #7092: copy independent profile defs when duplicating a material profile set

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/material/copy_material.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/material/copy_material.py
@@ -17,6 +17,7 @@
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
 import ifcopenshell
+import ifcopenshell.api.profile
 import ifcopenshell.util.element
 
 
@@ -26,8 +27,9 @@ def copy_material(file: ifcopenshell.file, material: ifcopenshell.entity_instanc
     All material psets and styles are copied. The copied material is not
     associated to any elements.
 
-    If a material set is copied, the set items are also copied. However the
-    underlying materials (and profiles) used within the set items are reused.
+    If a material set is copied, the set items are also copied. The underlying
+    materials used within the set items are reused, but profile definitions are
+    copied so each set may be edited independently.
 
     If a material is associated with a presentation style, that presentation
     style is reused.
@@ -63,7 +65,10 @@ def copy_material(file: ifcopenshell.file, material: ifcopenshell.entity_instanc
         new.MaterialProfiles = [copy_material(file, i) for i in material.MaterialProfiles]
         return new
     elif material.is_a("IfcMaterialProfile"):
-        return _copy_material_with_inverses(file, material)
+        new = _copy_material_with_inverses(file, material)
+        if new.Profile:
+            new.Profile = ifcopenshell.api.profile.copy_profile(file, new.Profile)
+        return new
     elif material.is_a("IfcMaterialList"):
         return _copy_material_with_inverses(file, material)
     else:

--- a/src/ifcopenshell-python/test/api/material/test_copy_material.py
+++ b/src/ifcopenshell-python/test/api/material/test_copy_material.py
@@ -131,11 +131,11 @@ class TestCopyMaterial(test.bootstrap.IFC4):
         assert new.Name == "Foo"
         assert new.MaterialProfiles[0] != item
         assert new.MaterialProfiles[0].Material == material
-        assert new.MaterialProfiles[0].Profile == profile
+        assert new.MaterialProfiles[0].Profile != profile
         assert len(self.file.by_type("IfcMaterialProfileSet")) == 2
         assert len(self.file.by_type("IfcMaterialProfile")) == 2
         assert len(self.file.by_type("IfcMaterial")) == 1
-        assert len(self.file.by_type("IfcProfileDef")) == 1
+        assert len(self.file.by_type("IfcProfileDef")) == 2
 
     def test_copy_a_material_list(self):
         material = ifcopenshell.api.material.add_material(self.file, name="CON01")


### PR DESCRIPTION
Fixes #7092.

copy_material shared the underlying IfcProfileDef between a material profile set and its copy, so duplicating a profile based type left both types pointing at the same cross section. Editing one type's profile then changed the other. Copy the profile definition (keeping the shared IfcMaterial) so each set can be edited independently.

Verified with real ifcopenshell through the copy_class path Bonsai uses: the duplicate now has a distinct profile, the material stays shared, and the existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)