### PR TITLE
ifctester: normalise scalar IDS values to their XML string form (#7245)

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -86,7 +86,13 @@ class Facet:
         self.passed_entities: set[ifcopenshell.entity_instance] = set()
         self.failures: list[FacetFailure] = []
         for i, name in enumerate(self.parameters):
-            setattr(self, name.replace("@", ""), parameters[i])
+            key = name.replace("@", "")
+            parameter = parameters[i]
+            # An IDS value is always XML text coerced to the model data type, so a scalar
+            # passed through the Python API is normalised to the string it serialises to.
+            if key == "value" and isinstance(parameter, (int, float)):
+                parameter = str(parameter)
+            setattr(self, key, parameter)
 
     def asdict(self, clause_type: str) -> dict[str, Any]:
         results = {}

--- a/src/ifctester/test/test_regression_7245_scalar_value_casting.py
+++ b/src/ifctester/test/test_regression_7245_scalar_value_casting.py
@@ -1,0 +1,59 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression test for #7245.
+
+An IDS value built through the Python API with a raw int or float used to be
+compared directly against the model value, so ``ids.Property(value=1)``
+never matched a model IfcLabel of ``"1"``.
+
+Unlike the other ifctester regression fixes, this defect cannot be
+demonstrated with a minimal .ids/.ifc pair: the IDS schema types
+``simpleValue`` as ``xs:string`` (see ids.xsd), so a value parsed out of an
+.ids file is always already a string. The bug only exists on the Python
+construction path (``Facet.__init__``), which XML-loaded specifications
+never go through (they are built empty and populated via ``Facet.parse``).
+So this test drives the defect through the same Python API the original
+bug report (#7245) used.
+"""
+
+import ifcopenshell
+import ifcopenshell.api.pset
+import ifcopenshell.guid
+
+from ifctester import ids
+
+
+class TestScalarValueCastingRegression:
+    def test_int_value_matches_model_string_property(self):
+        f = ifcopenshell.file()
+        f.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new(), Name="P")
+        wall = f.create_entity("IfcWall", GlobalId=ifcopenshell.guid.new(), Name="Wall1")
+        pset = ifcopenshell.api.pset.add_pset(f, product=wall, name="Foo_Bar")
+        ifcopenshell.api.pset.edit_pset(f, pset=pset, properties={"Foo": "1"})
+
+        spec = ids.Specification(name="numeric value via API")
+        spec.applicability.append(ids.Entity(name="IFCWALL"))
+        spec.requirements.append(ids.Property(baseName="Foo", value=1, propertySet="Foo_Bar", dataType="IFCLABEL"))
+        specs = ids.Ids(title="t")
+        specs.specifications.append(spec)
+        specs.validate(f)
+
+        assert spec.status is True


### PR DESCRIPTION
Fixes #7245.

A property or attribute value built through the Python API with a raw int or float was compared directly against the model value, so an IDS integer never matched a model IfcLabel string. An IDS value is always XML text coerced to the model data type, so the scalar is now stored as the string it serialises to and flows through the existing cast path.

Verified: integer and string equals now pass, not equals still fail, restriction ranges unaffected, full ifctester suite passes (37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)