### PR TITLE
Fix #7125: search_in_dictionary honours related_ifc_entity via Dictionary/Classes

### DIFF
--- a/src/bsdd/bsdd.py
+++ b/src/bsdd/bsdd.py
@@ -902,6 +902,31 @@ class Client:
         This version uses new naming and returns one Dictionary instead of a list with always one Dictionary.
         This API replaces SearchList.
         """
+        # The SearchInDictionary endpoint ignores RelatedIfcEntity server side and always returns zero
+        # Classes, so route IFC entity filtering through Dictionary/Classes, which honours it, and reshape
+        # the reply into the SearchInDictionary contract.
+        if related_ifc_entity:
+            classes = self.get_classes(
+                dictionary_uri=dictionary_uri,
+                use_nested_classes=False,
+                class_type="",
+                search_text=search_text,
+                related_ifc_entity=related_ifc_entity,
+                language_code=language_code,
+                version=version,
+                offset=offset,
+                limit=limit,
+            )
+            return {
+                "dictionary": {
+                    "name": classes.get("name", ""),
+                    "uri": classes.get("uri", ""),
+                    "classes": classes.get("classes", []),
+                },
+                "totalCount": classes.get("classesTotalCount", 0),
+                "offset": classes.get("classesOffset", 0),
+                "count": classes.get("classesCount", 0),
+            }
         endpoint = f"SearchInDictionary/v{version}"
         params = {
             "DictionaryUri": dictionary_uri,


### PR DESCRIPTION
Fixes #7125.

The bSDD SearchInDictionary endpoint ignores its RelatedIfcEntity parameter server side and returns zero Classes for every value, so passing related_ifc_entity always yielded an empty result. Route the IFC entity filter through the Dictionary/Classes endpoint, which honours it, and reshape the reply into the SearchInDictionary contract. The path without related_ifc_entity is unchanged.

Verified live against the bSDD API: IfcWall goes from 0 to real results, the no argument path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)