### PR TITLE
Bonsai: compute earthworks base quantities in ifc5d take-off (#6325)

### DIFF
--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
@@ -265,21 +265,21 @@
             },
             "IfcEarthworksCut": {
                 "Qto_EarthworksCutBaseQuantities": {
-                    "Depth": null,
-                    "Length": null,
+                    "Depth": "net_get_z",
+                    "Length": "net_get_x",
                     "LooseVolume": null,
-                    "UndisturbedVolume": null,
+                    "UndisturbedVolume": "net_get_volume",
                     "Weight": null,
-                    "Width": null
+                    "Width": "net_get_y"
                 }
             },
             "IfcEarthworksFill": {
                 "Qto_EarthworksFillBaseQuantities": {
-                    "CompactedVolume": null,
-                    "Depth": null,
-                    "Length": null,
+                    "CompactedVolume": "net_get_volume",
+                    "Depth": "net_get_z",
+                    "Length": "net_get_x",
                     "LooseVolume": null,
-                    "Width": null
+                    "Width": "net_get_y"
                 }
             },
             "IfcElectricAppliance + IfcElectricApplianceType": {
@@ -585,11 +585,11 @@
             },
             "IfcReinforcedSoil": {
                 "Qto_ReinforcedSoilBaseQuantities": {
-                    "Area": null,
-                    "Depth": null,
-                    "Length": null,
-                    "Volume": null,
-                    "Width": null
+                    "Area": "net_get_footprint_area",
+                    "Depth": "net_get_z",
+                    "Length": "net_get_x",
+                    "Volume": "net_get_volume",
+                    "Width": "net_get_y"
                 }
             },
             "IfcReinforcingElement + IfcReinforcingElementType": {

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
@@ -585,11 +585,11 @@
             },
             "IfcReinforcedSoil": {
                 "Qto_ReinforcedSoilBaseQuantities": {
-                    "Area": null,
-                    "Depth": null,
-                    "Length": null,
-                    "Volume": null,
-                    "Width": null
+                    "Area": "get_net_footprint_area",
+                    "Depth": "get_height",
+                    "Length": "get_length",
+                    "Volume": "get_net_volume",
+                    "Width": "get_width"
                 }
             },
             "IfcReinforcingElement + IfcReinforcingElementType": {


### PR DESCRIPTION
Fixes #6325.

The ifcopenshell take-off engine left every Qto_EarthworksFillBaseQuantities value null, so Bonsai added the qset with no numbers on IFC4X3 models. Map the geometrically derivable quantities using the slab axis convention: Length on local X, Width on local Y, Depth on local Z, and the net solid volume as the compacted (Fill) or undisturbed (Cut) volume. LooseVolume and Weight stay unmapped because they need soil bulking and density factors absent from geometry. Bring IfcEarthworksCut to parity with the Blender engine and wire IfcReinforcedSoil on both engines.

Verified on a non square element (3.0 x 1.0 x 0.5): Length, Width, Depth and Volume correct and not swapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)