### PR TITLE
Bonsai: show IfcTextLiteralWithExtent attached to the parent context (#6479)

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -420,6 +420,18 @@ class Drawing(bonsai.core.tool.Drawing):
             element, "Plan", "Annotation"
         ) or ifcopenshell.util.representation.get_representation(element, "Model", "Annotation")
         if not rep:
+            # Some files attach the Annotation representation directly to the
+            # parent Model or Plan context instead of an Annotation subcontext,
+            # so fall back to matching by RepresentationIdentifier.
+            rep = next(
+                (
+                    r
+                    for r in ifcopenshell.util.representation.get_representations_iter(element)
+                    if r.RepresentationIdentifier == "Annotation"
+                ),
+                None,
+            )
+        if not rep:
             return None
 
         rep = tool.Geometry.resolve_mapped_representation(rep)


### PR DESCRIPTION
Closes #6479.

`get_annotation_representation` only looked up the Annotation subcontext, so a text literal whose `IfcShapeRepresentation` is attached directly to the Model or Plan context (a valid file layout) returned no representation and the label drew empty. This adds a fallback that matches the element's representations by `RepresentationIdentifier == "Annotation"` when the subcontext lookup finds nothing.

Verified live in headless Blender 5.1.2 on the reporter's sample: before, `get_text_literal` returned an empty list; after, the literal text is found and handed to the TextDecorator. The GPU viewport draw handler cannot run headless, so the last visual step is confirmed at the data level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
