### PR TITLE
ifcopenshell: stamp new file headers with the current package version (#6678)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/file.py
+++ b/src/ifcopenshell-python/ifcopenshell/file.py
@@ -625,6 +625,15 @@ class file:
         self.future = []
         self.transaction: Optional[Transaction] = None
 
+        if f is None:
+            # The C++ core stamps the header with its own compiled version
+            # constant, which may lag behind the released Python package (see
+            # issue #6678). Overwrite it here so a newly created file always
+            # reports the current ifcopenshell version.
+            file_name = self.header.file_name
+            file_name.preprocessor_version = "IfcOpenShell {}".format(ifcopenshell.version)
+            file_name.originating_system = "IfcOpenShell {}".format(ifcopenshell.version)
+
         # we store a tuple of C++ file pointer address and creation time stamp so that
         # when memory addresses get recycled we do not run into collisions when the
         # address is used as a cache key.


### PR DESCRIPTION
Closes #6678.

A newly created file took its `FILE_NAME` `preprocessor_version` and `originating_system` from the C++ core compiled version constant, which lags the released Python package (wheels shipped 0.8.2 still wrote 0.8.0) and carries a commit hash on stamped builds. New files now use `ifcopenshell.version`, the same authoritative value `create_file.py` already applies, guarded by `f is None` so files opened from disk keep their original stamps.

Verified in Python: a fresh file writes the real version, and a file created with a custom `preprocessor_version`, written and reopened, keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
