### PR TITLE
Bonsai: keep half space solids when regenerating a profile element (#7640)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -482,7 +482,9 @@ class DumbProfileJoiner:
             if clipping["operand_type"] == "IfcHalfSpaceSolid":
                 clipping["matrix"] = new_matrix @ clipping["matrix"]
 
-        self.clippings.extend(tool.Model.get_manual_booleans(element))
+        manual_booleans = tool.Model.get_manual_booleans(element)
+        manual_boolean_ids = [b.id() for b in manual_booleans]
+        self.clippings.extend(manual_booleans)
 
         depth = (self.body[1] - self.body[0]).length
 
@@ -534,6 +536,16 @@ class DumbProfileJoiner:
             bonsai.core.geometry.remove_representation(tool.Ifc, tool.Geometry, obj=obj, representation=old_body)
         else:
             ifcopenshell.api.geometry.assign_representation(tool.Ifc.get(), product=element, representation=new_body)
+
+        # Re-applying the manual booleans through add_profile_representation created
+        # fresh IfcBooleanResults, so the BBIM_Boolean pset still references the ids of
+        # the now-removed originals. Repoint it at the rebuilt booleans so the next
+        # regeneration still recognises them, otherwise the manual half space solids
+        # are silently dropped on the following profile edit.
+        if manual_boolean_ids:
+            new_booleans = tool.Model.get_booleans(representation=new_body)
+            tool.Model.unmark_manual_booleans(element, manual_boolean_ids)
+            tool.Model.mark_manual_booleans(element, new_booleans[-len(manual_boolean_ids) :])
 
         previous_matrix = obj.matrix_world.copy()
         previous_origin = obj.location.copy()


### PR DESCRIPTION
Closes #7640.

`recreate_profile` rebuilds the body and re-applies the manual booleans (half space cuts tracked by id in the `BBIM_Boolean` pset) as new `IfcBooleanResult` entities, then removes the old body. It never repointed the pset, so the tracked ids referred to deleted entities. The next regeneration matched none of them and dropped every manual half space solid, which is why editing then renaming a profile lost the cuts.

This repoints the `BBIM_Boolean` pset to the freshly created boolean ids after the new body is assigned.

Verified live in headless Blender 5.1.2: before, renaming went from 2 half space cuts to 0; after, they survive the rename and a save/reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
