### PR TITLE
Bonsai: deterministic annotation order in generated drawing SVGs (#6608)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1704,6 +1704,12 @@ class CreateDrawing(bpy.types.Operator):
             key=lambda a: (
                 tool.Drawing.get_annotation_z_index(a),
                 1 if ifcopenshell.util.element.get_predefined_type(a) == "TEXT" else 0,
+                # Deterministic tiebreaker so equal-priority annotations keep a
+                # stable order across sessions. Without it the order comes from
+                # the set union above, which depends on entity hashes (and thus
+                # the file pointer), shuffling annotations between Blender
+                # restarts. See #6608.
+                a.id(),
             ),
         )
 


### PR DESCRIPTION
Closes #6608.

`generate_annotation` built the annotation list from a set union and sorted it by ZIndex and TEXT-ness only. Annotations that tied on that key kept set iteration order, which follows entity hash (step id plus the process memory address), so the order of tied annotations (for example a label and its background fill) shuffled between Blender restarts and flipped their draw order.

This adds the stable IFC step id as a final tiebreaker so the order is total and session independent. Behavior preserving, no z-layer semantics changed.

Verified across repeated process runs: tied annotations now keep an identical order every run. Note the touched file has pre-existing formatting unrelated to this change; the added lines are black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
