### PR TITLE
Bonsai: preserve half space cuts when duplicating an element (#7533)

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -1028,6 +1028,30 @@ class Model(bonsai.core.tool.Model):
             ifcopenshell.api.pset.remove_pset(tool.Ifc.get(), product=element, pset=pset)
 
     @classmethod
+    def remap_manual_booleans(
+        cls, element: ifcopenshell.entity_instance, id_map: dict[int, ifcopenshell.entity_instance]
+    ) -> None:
+        """Repoint ``element``'s 'BBIM_Boolean' pset onto freshly copied booleans.
+
+        When an element is duplicated the pset is copied verbatim, so its ids
+        still refer to the source's booleans while the copy owns brand new
+        boolean entities from the deep-copied representation. ``id_map`` is the
+        source-id to new-entity mapping produced by the representation copy;
+        replace every stored id that was copied with the id of its new entity so
+        the copy tracks its own manual booleans.
+        """
+        pset_data = ifcopenshell.util.element.get_pset(element, "BBIM_Boolean")
+        if not pset_data:
+            return
+        stored_ids = json.loads(pset_data["Data"])
+        remapped = [id_map[i].id() if i in id_map else i for i in stored_ids]
+        if remapped == stored_ids:
+            return
+        pset = tool.Ifc.get().by_id(pset_data["id"])
+        data = tool.Ifc.get().createIfcText(json.dumps(remapped))
+        ifcopenshell.api.pset.edit_pset(tool.Ifc.get(), pset=pset, properties={"Data": data})
+
+    @classmethod
     def get_flow_segment_axis(cls, obj: bpy.types.Object) -> tuple[Vector, Vector]:
         z_values = [v[2] for v in obj.bound_box]
         return (obj.matrix_world @ Vector((0, 0, min(z_values))), obj.matrix_world @ Vector((0, 0, max(z_values))))

--- a/src/bonsai/bonsai/tool/root.py
+++ b/src/bonsai/bonsai/tool/root.py
@@ -102,6 +102,9 @@ class Root(bonsai.core.tool.Root):
                 exclude_callback=exclude_callback,
                 copied_entities=copied_entities,
             )
+            # The copied BBIM_Boolean pset still tracks the source's booleans;
+            # repoint it at the copy's freshly duplicated booleans.
+            tool.Model.remap_manual_booleans(dest, copied_entities)
         elif dest.is_a("IfcTypeProduct"):
             if not source.RepresentationMaps:
                 return copied_entities


### PR DESCRIPTION
Closes #7533.

Duplicating an element copies its `BBIM_Boolean` pset verbatim, so the copy's pset still holds the source's boolean ids, while `copy_representation` deep copies the representation and mints brand new boolean entities on the copy. The copy therefore tracks ids that are not in its own chain, the `strip_underside_booleans` hook then removes the stale pset, and on the next body regeneration `get_manual_booleans` returns empty and the duplicate loses its manual cut.

This adds `Model.remap_manual_booleans` and calls it from `copy_representation`, the single point where both the copied element and the old to new id map exist. Genuine tessellated slab trim booleans are still stripped as before; only manual CSG cuts are repointed.

Verified live in headless Blender 5.1.2: before, the duplicate lost its cut on the next regen; after, it keeps and tracks its own booleans through a save and reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
