### PR TITLE
util.element: read property sets inside an IfcPropertySetDefinitionSet (#6330)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/element.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/element.py
@@ -112,8 +112,14 @@ def get_pset(
         for relationship in is_defined_by:
             if relationship.is_a("IfcRelDefinesByProperties"):
                 definition = relationship.RelatingPropertyDefinition
-                if definition.Name == name:
-                    pset = definition
+                # IfcPropertySetDefinitionSet is a defined type wrapping a list
+                # of property set definitions, so unpack it into its members.
+                if definition.is_a("IfcPropertySetDefinitionSet"):
+                    definitions = definition.wrappedValue
+                else:
+                    definitions = (definition,)
+                pset = next((d for d in definitions if d.Name == name), None)
+                if pset:
                     break
 
     if pset:
@@ -221,15 +227,22 @@ def get_psets(
         for relationship in is_defined_by:
             if relationship.is_a("IfcRelDefinesByProperties"):
                 definition = relationship.RelatingPropertyDefinition
-                if (
-                    psets_only
-                    and not definition.is_a("IfcPropertySet")
-                    and not definition.is_a("IfcPreDefinedPropertySet")
-                ):
-                    continue
-                if qtos_only and not definition.is_a("IfcElementQuantity"):
-                    continue
-                psets.setdefault(definition.Name, {}).update(get_property_definition(definition, verbose=verbose))
+                # IfcPropertySetDefinitionSet is a defined type wrapping a list
+                # of property set definitions, so unpack it into its members.
+                if definition.is_a("IfcPropertySetDefinitionSet"):
+                    definitions = definition.wrappedValue
+                else:
+                    definitions = (definition,)
+                for definition in definitions:
+                    if (
+                        psets_only
+                        and not definition.is_a("IfcPropertySet")
+                        and not definition.is_a("IfcPreDefinedPropertySet")
+                    ):
+                        continue
+                    if qtos_only and not definition.is_a("IfcElementQuantity"):
+                        continue
+                    psets.setdefault(definition.Name, {}).update(get_property_definition(definition, verbose=verbose))
     return psets
 
 


### PR DESCRIPTION
Closes #6330.

`get_pset` and `get_psets` assumed `RelatingPropertyDefinition` is a single property definition and read `definition.Name` directly. When it is an `IfcPropertySetDefinitionSet` (a defined type wrapping a list of property set definitions) that attribute access raised `AttributeError`, so an element whose psets are grouped in a set returned none of them.

This unpacks `IfcPropertySetDefinitionSet` into its members in both loops. Single definitions and the `psets_only` and `qtos_only` filters are unchanged. The C++ parser side was already fixed by @aothms; this repairs the remaining Python read path.

Verified in Python on the reporter's file: before, both calls raised and the members were inaccessible; after, `PSet_1` and `PSet_2` read correctly alongside the regular psets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
