### PR TITLE
IfcParse: free simple type instances created after load (#8070)

### DIFF
--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -2170,8 +2170,15 @@ IfcUtil::IfcBaseClass* IfcFile::addEntity(IfcUtil::IfcBaseClass* entity, int id)
         // rocksdb instances are assumed to be create with file.create();
         std::visit([new_entity](auto& m) {
             if constexpr (std::is_same_v<std::decay_t<decltype(m)>, impl::in_memory_file_storage>) {
-                // @todo not freed yet
                 m.tbyid_.insert({ new_entity->identity(), new_entity });
+                // #8070: take ownership of this freshly created non-entity (simple type)
+                // instance so that it is freed together with the file. tbyid_ is only a
+                // non-owning lookup index; read_simple_type_instances is the owner, matching
+                // how simple type instances read from a file are retained. This branch is only
+                // reached for instances with file_ == nullptr, so they are never already owned
+                // by read_simple_type_instances (avoiding a double free), and re-adds of the
+                // same instance return early via the file_ == this path above.
+                m.read_simple_type_instances.emplace_back(new_entity);
             }
         }, storage_);
     }


### PR DESCRIPTION
Closes #8070.

Non-entity (simple type) instances created after a file is loaded are inserted into `in_memory_file_storage.tbyid_`, a map of raw owning pointers that no destructor ever frees (the `IfcFile` destructor deletes only `byid_` pointees). So every simple type value handed to the file after load, for example `prop.NominalValue = f.create_entity("IfcLabel", ...)`, leaks.

This takes ownership of the freshly created non-entity into `read_simple_type_instances`, the vector that already owns simple types read from a file, leaving `tbyid_` as a pure non-owning index. The branch is only reached for instances with `file_ == nullptr`, so they are never already owned there, and re-adds return early via the `file_ == this` path, so ownership is registered exactly once and there is no double free.

Verification: the leak is live reproduced in Python (RSS grows about 56 MB over 20 iterations for simple type values, flat for entity values). The one line ownership fix itself is not build tested, since it needs a full kernel build. Happy to run the empirical before and after on a build if you want that confirmation too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
