### PR TITLE
Bonsai: close IfcPolyline loops by appending the closing edge (#8043)

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -617,7 +617,7 @@ class Model(bonsai.core.tool.Model):
 
             cls.edges.extend([(i, i + 1) for i in range(offset, len(cls.vertices) - 1)])
             if is_closed:
-                cls.edges[-1] = (len(cls.vertices) - 1, offset)  # Close the loop
+                cls.edges.append((len(cls.vertices) - 1, offset))  # Close the loop
 
         elif curve.is_a("IfcCompositeCurve"):
             # This is a first pass incomplete implementation only for simple polylines, and misses many details.


### PR DESCRIPTION
Closes #8043.

`convert_curve_to_mesh` built the edge chain of a polyline with `extend`, then for a closed polyline overwrote the last edge with the closing edge instead of appending it. That discarded the final real segment, so every closed `IfcPolyline` loop came back one edge short and open. On the edit mode round trip the inner void loop of an `IfcArbitraryProfileDefWithVoids` was then lost or misclassified, and the profile was rewritten without its void, collapsing the extrusion to a bounding box.

This appends the closing edge instead, matching the `IfcIndexedPolyCurve` branch which already does this.

Verified live in headless Blender 5.1.2 on the reporter's sample: before, the Tab round trip produced four open (degree-1) vertices and re-exported the profile without its void; after, both loops close and the profile round-trips as `IfcArbitraryProfileDefWithVoids` with its inner void intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
