### PR TITLE
ifcopenshell: order wall path cuts along the edge before stitching (#7827)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/regenerate_wall_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/regenerate_wall_representation.py
@@ -286,6 +286,10 @@ class Regenerator:
                 if self.minpath_points:
                     self.minpath_points[0] = list(reversed(self.minpath_points[0]))
 
+            # Stitch multiple path cuts in the order they are met along each edge
+            self.maxpath_points.sort(key=lambda seg: min(p[0] for p in seg))
+            self.minpath_points.sort(key=lambda seg: min(p[0] for p in seg), reverse=True)
+
             while True:
                 # Draw each profile as clockwise starting from (minx, miny)
                 start_split = next(split_points, None)


### PR DESCRIPTION
Closes #7827.

`Regenerator.regenerate` stitched the wall path cut notches (`maxpath_points` on the +Y edge, `minpath_points` on the -Y edge) into the profile in the order the joins were processed, not the order they are met while walking the edge. With one ATPATH junction this is fine, but with two junctions on the same wall path the second notch was appended after the first regardless of its position, so walking the edge jumped backward in x and produced a self intersecting polygon that visually deformed the pre existing, unrelated joint. This is the "extending one wall deforms another wall's joint" report.

This sorts the notch lists along the edge before assembly (`maxpath` ascending, `minpath` descending by x). A single junction wall is unchanged, since the sort is a no op on one element, so the common case does not regress.

Verified live in headless Blender 5.1.2 on the reporter's sample. The top edge x sequence went from `0, 4.68, 5.23, 2.763, 2.963, 8.781` (backward jump, deformed joint) to `0, 2.763, 2.963, 4.68, 5.23, 8.781` (monotonic, both notches intact). The single junction baseline profile is byte identical before and after.

Note: PR #7892 targets the same issue but changes an unrelated `split_points` bounds check that does not affect this geometry, so it does not resolve #7827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
