### PR TITLE
Bonsai: keep user linked collections when writing the metadata blend (#7978)

### DIFF
--- a/src/bonsai/bonsai/bim/operator.py
+++ b/src/bonsai/bonsai/bim/operator.py
@@ -290,9 +290,12 @@ for collection in list(bpy.data.collections):
     if collection.name.startswith('IfcProject'):
         bpy.data.collections.remove(collection, do_unlink=True)
 
-# 4.1 Remove all collections from linked libraries (they will be recreated by bonsai)
+# 4.1 Remove Bonsai linked-model collections (they will be recreated by bonsai on load).
+# These always carry "IfcProject" in their name (see LinkIfc.link_blend). User collections
+# linked via File > Link have no IFC record, so removing them here would strip the instance
+# and leave a bare empty on reload; they must be preserved.
 for collection in list(bpy.data.collections):
-    if collection.library:
+    if collection.library and 'IfcProject' in collection.name:
         bpy.data.collections.remove(collection, do_unlink=True)
 
 # 4.2. Remove all empty objects that are collection instances for linked models


### PR DESCRIPTION
Closes #7978.

Saving the project with the save-metadata-blend preference on runs a background cleanup script that strips IFC geometry before writing the `.metadata.blend`. Step 4.1 removed every library linked collection, on the assumption that Bonsai recreates them. That is only true for Bonsai managed IFC models, whose collections always carry `IfcProject` in their name (see `LinkIfc.link_blend`). A collection the user linked via `File > Link` has no IFC record, so removing it cleared the instance empty's `instance_collection` pointer and left a bare empty on reload, which is the reported "linked collection replaced by empty object".

This scopes the removal to collections whose name contains `IfcProject`, matching the filter Bonsai already uses when linking IFC models, so user linked collections are preserved.

Verified live in headless Blender 5.1.2: with a user "Blue Cube" collection linked via File > Link, before the fix the reopened metadata blend had the empty with `instance_collection = None`; after the fix the linked collection instance and its library are fully preserved.

Scope note: there is a separate pre-existing case where a user object placed inside an IFC managed spatial collection is purged entirely by the later orphan purge. That total-loss path predates this code and needs a broader change, so it is left out of this minimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
