### PR TITLE
IfcGeomTree: keep clash_intersection_many results in set_a, set_b order (#5357)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
+++ b/src/ifcgeom/kernels/opencascade/IfcGeomTree.h
@@ -1109,6 +1109,12 @@ namespace IfcGeom {
                                 is_manifold = true;
                                 clash intersection = test_intersection(task.b, task.a, tolerance, check_all);
                                 if (intersection.clash_type != -1) {
+                                    // test_intersection() was called with the arguments swapped in
+                                    // order to test whether task.b protrudes into task.a, so it
+                                    // reports .a and .b in swapped order. Restore the canonical
+                                    // order so that result.a always refers to an element of set_a
+                                    // and result.b to an element of set_b.
+                                    std::swap(intersection.a, intersection.b);
                                     // Replace the clash result if any of these criteria apply:
                                     // - We don't have a clash yet
                                     // - Our previous clash is piercing, and our new one is a protrusion


### PR DESCRIPTION
Closes #5357.

`clash_intersection_many` runs a protrusion pass that calls `test_intersection(task.b, task.a, ...)` with its arguments swapped, because protrusion is directional and this pass tests whether the set_b element protrudes into the set_a element. `test_intersection` always stamps its first argument as `.a` and its second as `.b`, so the clash it returns has `.a` and `.b` swapped relative to the `set_a`/`set_b` the caller passed. When this pass produces the adopted result (for example the set_b element protrudes deeper, or is the only manifold one), the reported clash comes out flipped, so `result.a` is a set_b element (the `IfcSpace` in the report) instead of the wall or slab.

This swaps `intersection.a` and `intersection.b` back to canonical order right after the directional call, so `result.a` always refers to a set_a element and `result.b` to a set_b element. `distance` and `clash_type` are unaffected. `ifcquery/clash.py`, which reports `result.b` as the other element, relied on this order and is corrected by the same change.

Verification: the flip is live reproduced with a known-answer case (a small IfcSpace embedded in a larger IfcWall returns `result.a = IfcSpace` before the fix). The one line kernel change itself is not build tested, since it needs an OpenCascade rebuild. Happy to run the before and after on a build if you want that confirmation too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
