### PR TITLE
ifcgeom: use the real extrusion depth for IfcSurfaceOfLinearExtrusion (#8013)

### DIFF
--- a/src/ifcgeom/mapping/IfcSurfaceOfLinearExtrusion.cpp
+++ b/src/ifcgeom/mapping/IfcSurfaceOfLinearExtrusion.cpp
@@ -35,6 +35,6 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcSurfaceOfLinearExtrusion* in
 		matrix,
 		map(inst->SweptCurve()),
 		taxonomy::cast<taxonomy::direction3>(map(inst->ExtrudedDirection())),
-		std::numeric_limits<double>::infinity()
+		inst->Depth() * length_unit_
 	);
 }


### PR DESCRIPTION
Closes #8013.

The IfcSurfaceOfLinearExtrusion mapping passed `std::numeric_limits<double>::infinity()` as the extrusion depth and never read `inst->Depth()` (3.0 in the sample file). The kernel then built the prism with an infinite translation vector, so the surface had unbounded extent and the bounding box and BRepMesh tessellation iterated over an unbounded domain and never terminated, which is the reported freeze on load.

This reads `inst->Depth() * length_unit_` instead, the same pattern the sibling `IfcExtrudedAreaSolid` and `IfcExtrudedAreaSolidTapered` mappers already use.

Verification: the hang is live reproduced (create_shape on the sample product runs past a 30 s hard timeout and is killed). The after state needs a kernel build to run, so it is not build tested, but a finite depth yields a finite prism and the change mirrors the proven sibling mappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
