### PR TITLE
Bonsai: persist a drawing camera size edit, without calling an operator from a property callback (#8034)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -55,6 +55,7 @@ diagram_scales_enum = []
 def purge():
     global diagram_scales_enum
     diagram_scales_enum = []
+    _cancel_pending_camera_representation_persist()
 
 
 def update_target_view_doc(self: "DocProperties", context: bpy.types.Context) -> None:
@@ -471,6 +472,47 @@ class DocProperties(PropertyGroup):
         return tool.Drawing.get_drawing_target_view(active_drawing)
 
 
+_pending_camera_representation_persist: Union[Callable[[], None], None] = None
+_CAMERA_REPRESENTATION_PERSIST_DEBOUNCE = 0.5
+
+
+def _schedule_camera_representation_persist(camera_name: str) -> None:
+    """(Re)schedule a deferred ``bim.update_representation`` for ``camera_name``.
+
+    Called only from a PropertyGroup ``update=`` callback, which fires
+    synchronously mid property-write and must not call ``bpy.ops`` there
+    (see ``update_width_height``). Each call cancels any pending timer and
+    registers a fresh one, so a burst of ticks from a slider drag collapses
+    into a single deferred call once the debounce window of quiet elapses,
+    handed to Blender's main loop where operators are legal.
+    """
+    global _pending_camera_representation_persist
+    if _pending_camera_representation_persist is not None and bpy.app.timers.is_registered(
+        _pending_camera_representation_persist
+    ):
+        bpy.app.timers.unregister(_pending_camera_representation_persist)
+
+    def _do_persist() -> None:
+        global _pending_camera_representation_persist
+        _pending_camera_representation_persist = None
+        obj = bpy.data.objects.get(camera_name)
+        if obj is None or not tool.Ifc.get_entity(obj):
+            return None
+        bpy.ops.bim.update_representation(obj=obj.name, ifc_representation_class="")
+        return None
+
+    _pending_camera_representation_persist = _do_persist
+    bpy.app.timers.register(_do_persist, first_interval=_CAMERA_REPRESENTATION_PERSIST_DEBOUNCE)
+
+
+def _cancel_pending_camera_representation_persist() -> None:
+    global _pending_camera_representation_persist
+    pending = _pending_camera_representation_persist
+    if pending is not None and bpy.app.timers.is_registered(pending):
+        bpy.app.timers.unregister(pending)
+    _pending_camera_representation_persist = None
+
+
 def update_width_height(self: "BIMCameraProperties", context: bpy.types.Context) -> None:
     self.update_camera_resolution()
     if not self.update_props:
@@ -480,10 +522,16 @@ def update_width_height(self: "BIMCameraProperties", context: bpy.types.Context)
         return
     if not tool.Ifc.get_entity(camera):
         return
-    # Persist the new camera size into the drawing's IFC representation immediately,
-    # so it round-trips without needing to re-activate the drawing.
+    # Stage the new camera size into `representation` immediately (cheap,
+    # touches only this data-block's own property, same as the sibling
+    # update_diagram_scale/update_is_nts callbacks). Persisting it into the
+    # IFC representation itself needs bim.update_representation, which is
+    # unsafe to call from here directly: this callback runs mid property-write,
+    # and the operator can swap out this very camera's data-block (see
+    # tool.Geometry.change_data), so calling it inline would touch data being
+    # written under us. Debounce and defer that part instead.
     if self.update_representation(camera.matrix_world):
-        bpy.ops.bim.update_representation(obj=camera.name, ifc_representation_class="")
+        _schedule_camera_representation_persist(camera.name)
 
 
 def update_camera_type(self: "BIMCameraProperties", context: bpy.types.Context) -> None:

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -473,6 +473,17 @@ class DocProperties(PropertyGroup):
 
 def update_width_height(self: "BIMCameraProperties", context: bpy.types.Context) -> None:
     self.update_camera_resolution()
+    if not self.update_props:
+        return
+    assert context.scene
+    if not (camera := context.scene.camera) or camera.data != self.id_data:
+        return
+    if not tool.Ifc.get_entity(camera):
+        return
+    # Persist the new camera size into the drawing's IFC representation immediately,
+    # so it round-trips without needing to re-activate the drawing.
+    if self.update_representation(camera.matrix_world):
+        bpy.ops.bim.update_representation(obj=camera.name, ifc_representation_class="")
 
 
 def update_camera_type(self: "BIMCameraProperties", context: bpy.types.Context) -> None:


### PR DESCRIPTION
Fixes #8034.

Editing a drawing camera's Width or Height should persist into the IFC representation rather than being lost. That goal is unchanged; the mechanism has been reworked because the original one was unsafe.

### Why it was reworked

The first version called `bpy.ops.bim.update_representation(...)` directly from the property update callback. Blender's API documentation is explicit that this is not permitted:

> Access to these properties might happen in threaded context, on a per-data-block level. This has to be carefully considered when using accessors or update callbacks. Typically, these callbacks should not affect any other data that the one owned by their data-block.

`bim.update_representation` calls `object.mode_set`, iterates `selected_objects`, and previously recreated the camera's own `Camera` data-block. All of that is "other data".

There is evidence this was reaching users. On #9031 a reporter running BonsaiPR `0.8.6-alpha260728`, a daily build in which this PR is listed as merged, hit a Blender crash while dragging Width and Height, with a stack of `bpy_prop_update_fn -> operator call -> depsgraph flush`. That is this shape exactly. **It was not reproduced, so the link is strongly indicated rather than proven**, but the pattern is unsafe regardless.

### The mechanism now

Bonsai already solves this elsewhere, and this follows that precedent rather than inventing one. `tool/clip_box.py`'s `schedule_refresh()` documents it:

> PropertyGroup `update=` callbacks must not call `bpy.ops`... Deferring via a 0-delay timer hands the refresh to Blender's main loop, where operators are legal.

So:

* the JSON `representation` snapshot is still staged **synchronously** in the callback, which is safe since it only touches data the block owns
* the `bim.update_representation` call is handed to a **debounced `bpy.app.timers` callback**, cancel-and-reschedule on each tick, mirroring `_schedule_cap_rebuild`

A useful side effect: a slider drag no longer writes to IFC on every tick, only once after the drag settles. The original version wrote dozens of times per gesture.

### Relation to #9087

Complementary rather than overlapping. #9087 stops `Loader.create_camera` recreating the camera data-block on every reimport, which removes the use-after-free trigger. This PR stops the callback calling an operator from a context where that is not allowed in the first place. Both are needed; neither subsumes the other, and their diffs do not overlap.

### Verified

Live in headless Blender, scratch profile, real profile untouched:

* setting `width`/`height` no longer calls `bim.update_representation` synchronously, confirmed by the IFC block item id being unchanged immediately after the property write
* firing the debounced timer does call it and does change the block item
* after save and reload, `IfcBlock` reads `XLength=123.0`, `YLength` approximately `76.998`, so the edit round-trips (the sub-millimetre difference is the pre-existing rounding noted on the original PR)

```
pytest test/core
383 passed
```

Two pre-existing failures in `test_drawing.py` are unrelated to `prop.py`, confirmed unchanged before and after.

Generated with the assistance of an AI coding tool.
