### PR TITLE
util.representation: recover wall length from a rectangle profile body (#8011)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/representation.py
@@ -511,8 +511,18 @@ def get_reference_line(wall: ifcopenshell.entity_instance, fallback_length: floa
         for extrusion in extrusions:
             profile = extrusion.SweptArea
             curve = getattr(profile, "OuterCurve", None)
-            if not curve:
-                continue
+            if curve is None:
+                # Parametric rectangle profiles (IfcRectangleProfileDef and its
+                # subtypes) have no OuterCurve but a plain XDim centred on the
+                # profile Position. Walls authored by other software commonly use
+                # them, so recover the length here rather than falling back to the
+                # 1m default.
+                if profile.is_a("IfcRectangleProfileDef"):
+                    half_x = profile.XDim / 2
+                    center_x = profile.Position.Location.Coordinates[0] if profile.Position else 0.0
+                    x = [center_x - half_x, center_x + half_x]
+                else:
+                    continue
             elif curve.is_a("IfcPolyline"):
                 x = [p[0][0] for p in curve.Points]
             elif curve.is_a("IfcIndexedPolyCurve"):


### PR DESCRIPTION
Closes #8011.

Editing a wall's height regenerates its body through `regenerate_wall_representation`, which recovers the wall length via `get_reference_line`. That function reads the length from the Axis representation, then from the base extrusion profile's `OuterCurve`, and otherwise falls back to a 1m default. Walls authored by other software commonly have no Axis representation and a body built from a parametric `IfcRectangleProfileDef`, which has no `OuterCurve`, so the recovery fell through to 1m and a 3000mm wall was rebuilt at 1000mm on the first edit.

This recovers the X extent from `IfcRectangleProfileDef` and its subtypes using `XDim` centred on the profile `Position`. It reads the wall's own base extrusion, not the object bounding box, so a wall joined or unioned to others still recovers its authored length. That avoids the union breaking concern raised in the thread against the bounding box idea. Native Bonsai walls carry an Axis representation and take the earlier branch, so they are unchanged.

Verified live in headless Blender 5.1.2 on a foreign style wall (3000mm rectangle profile body, no Axis rep): before, get_reference_line returned the 1m fallback and the wall rebuilt at 1000mm; after, it returns 3000mm and the wall stays 3000mm. A wall with an Axis polyline still returns its axis length (5000mm), confirming native walls are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
