### PR TITLE
Bonsai: unlock IfcGridAxis in IFC4X3 so gridlines are editable (#7800)

### DIFF
--- a/src/bonsai/bonsai/bim/module/spatial/prop.py
+++ b/src/bonsai/bonsai/bim/module/spatial/prop.py
@@ -128,7 +128,7 @@ def update_grid_is_locked(self: "BIMGridProperties", context: bpy.types.Context)
     if tool.Ifc.get().schema in ("IFC2X3", "IFC4"):
         elements = tool.Ifc.get().by_type("IfcGrid") + tool.Ifc.get().by_type("IfcGridAxis")
     else:
-        elements = tool.Ifc.get().by_type("IfcPositioningElement")
+        elements = tool.Ifc.get().by_type("IfcPositioningElement") + tool.Ifc.get().by_type("IfcGridAxis")
     for element in elements:
         if obj := tool.Ifc.get_object(element):
             if self.is_locked:


### PR DESCRIPTION
Closes #7800.

Grid axis objects are locked on load (the is_locked default, "Prevent all grids and grid axes from being edited"). Toggling the grid padlock runs `update_grid_is_locked`, which for IFC2X3 and IFC4 collects `IfcGrid` and `IfcGridAxis` and clears their lock, but for IFC4X3 collected only `IfcPositioningElement`. `IfcGridAxis` is not a positioning element in any schema, so in IFC4X3 the axis objects were never unlocked, their Blender `lock_location` stayed `(True, True, True)`, and the gridline could not be moved with G. The reporter's Transform panel padlock workaround was manually clearing that lock.

This adds `IfcGridAxis` to the IFC4X3 element list, matching the IFC4 branch. `IfcGrid` is already covered there since it subtypes `IfcPositioningElement` in IFC4X3.

Verified live in headless Blender 5.1.2: in IFC4X3, after the panel unlock the axis lock_location was still (True, True, True) before the fix and is (False, False, False) after, matching IFC4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
