### PR TITLE
Bonsai: stop emitting a trailing segment on an open arc curve (#7786)

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2640,6 +2640,9 @@ class Model(bonsai.core.tool.Model):
                         ):
                             segments.append(tmp.createIfcArcIndex([i + 1, i + 2, i + 3]))
                             i += 2
+                        elif i + 1 == total_verts and not is_closed:
+                            # Final vertex of an open curve has no outgoing segment
+                            break
                         else:
                             segments.append(tmp.createIfcLineIndex([i + 1, i + 2]))
                             i += 1


### PR DESCRIPTION
Closes #7786.

`auto_detect_curves` builds the `IfcArcIndex`/`IfcLineIndex` segment list for a curve. Its loop emitted a trailing `IfcLineIndex` for the final vertex unconditionally. For a closed loop that segment is intentional and later rewritten to close the loop, but for an open curve (a line annotation) it referenced a vertex index that does not exist. So turning a segment of an open line into a two point or three point arc produced an `IfcIndexedPolyCurve` whose last segment was out of range (for example `IfcArcIndex((1,2,3))` followed by `IfcLineIndex((3,4))` with only three points). OCCT could not build it, the re-imported mesh came back empty, and the arc annotation vanished.

This breaks on the final vertex of an open curve so no trailing segment is emitted. Closed loops are unaffected, since the branch is skipped when `is_closed`.

Verified live in headless Blender 5.1.2 (line annotation, subdivide, move the middle vertex, set_arc_index, confirm): before, the segments were `(IfcArcIndex((1,2,3)), IfcLineIndex((3,4)))` and import returned an empty mesh (verts 0); after, `(IfcArcIndex((1,2,3)),)` and import returns the arc (verts 10). Regression checks pass for an open curve with a mid arc (the trailing line is preserved), a closed loop with an arc (still closes), and an open pure arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
