### PR TITLE
serializers: use mesher-linear-deflection for polygonal HLR drawings (#7162)

### DIFF
--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -1212,7 +1212,7 @@ void SvgSerializer::write(const geometry_data& data) {
 					if (storey) {
 						auto it = storey_hlr.find(storey);
 						if (it == storey_hlr.end()) {
-							it = storey_hlr.insert({ storey, hlr_t(logger_, use_prefiltering_, use_hlr_poly_, segment_projection_, projection_plane) }).first;
+							it = storey_hlr.insert({ storey, hlr_t(logger_, use_prefiltering_, use_hlr_poly_, segment_projection_, geometry_settings().get<ifcopenshell::geometry::settings::MesherLinearDeflection>().get(), projection_plane) }).first;
 						}
 						it->second.add(*compound_to_hlr, data.product);
 					} else {
@@ -2079,7 +2079,7 @@ void SvgSerializer::finalize() {
 
 			// @todo do we have always have pln here?
 			if (use_hlr && pln) {
-				hlr = new hlr_t(logger_, use_prefiltering_, use_hlr_poly_, segment_projection_, *pln);
+				hlr = new hlr_t(logger_, use_prefiltering_, use_hlr_poly_, segment_projection_, geometry_settings().get<ifcopenshell::geometry::settings::MesherLinearDeflection>().get(), *pln);
 			}
 
 			section_data_ = std::vector<section_data>{ sd };

--- a/src/serializers/SvgSerializer.h
+++ b/src/serializers/SvgSerializer.h
@@ -152,11 +152,14 @@ typedef boost::variant<
 namespace {
 	class hlr_writer {
 		const TopoDS_Shape& shape_;
+		double linear_deflection_;
 
 	public:
 		typedef void result_type;
 
-		hlr_writer(const TopoDS_Shape& shape) : shape_(shape)
+		hlr_writer(const TopoDS_Shape& shape, double linear_deflection)
+			: shape_(shape)
+			, linear_deflection_(linear_deflection)
 		{}
 
 		void operator()(boost::blank&) const {
@@ -168,7 +171,10 @@ namespace {
 		}
 
 		void operator()(opencascade::handle<HLRBRep_PolyAlgo>& algo) const {
-			BRepMesh_IncrementalMesh(shape_, 0.10);
+			// Mesh the shape prior to polygonal HLR. Respect the configured
+			// mesher-linear-deflection so that curved edges (e.g. circular
+			// profiles) are not projected as coarse low-segment polygons. See #7162.
+			BRepMesh_IncrementalMesh(shape_, linear_deflection_);
 			algo->Load(shape_);
 		}
 	};
@@ -362,6 +368,7 @@ namespace {
 		bool use_prefiltering_;
 		bool use_hlr_poly_;
 		bool segment_projection_;
+		double linear_deflection_;
 		gp_Ax1 view_direction_;
 		HLRAlgo_Projector projector_;
 
@@ -372,11 +379,12 @@ namespace {
 
 	public:
 
-		prefiltered_hlr(Logger& logger, bool use_prefiltering, bool use_hlr_poly, bool segment_projection, const gp_Pln& view_direction)
+		prefiltered_hlr(Logger& logger, bool use_prefiltering, bool use_hlr_poly, bool segment_projection, double linear_deflection, const gp_Pln& view_direction)
 			: logger_(logger)
 			, use_prefiltering_(use_prefiltering)
 			, use_hlr_poly_(use_hlr_poly)
 			, segment_projection_(segment_projection)
+			, linear_deflection_(linear_deflection)
 			// @nb negative z in accordance with occt projector convention (and opengl)
 			, view_direction_(view_direction.Axis())
 		{
@@ -514,7 +522,7 @@ namespace {
 			size_t n_included = 0;
 			for (auto it = items_.begin(); it != items_.end(); ++it) {
 				if (!use_prefiltering_ || !is_obscured_(&it->second)) {
-					hlr_writer vis(it->second);
+					hlr_writer vis(it->second, linear_deflection_);
 					boost::apply_visitor(vis, engine_);
 					n_included++;
 				}


### PR DESCRIPTION
Closes #7162.

Bonsai's drawing operator uses the polygonal HLR projection path (`setUseHlrPoly(True)`). That path meshes the solid before projection with a hardcoded `BRepMesh_IncrementalMesh(shape_, 0.10)` in `hlr_writer`. A 0.10 model unit (100mm) deflection tessellates curved profiles into coarse low segment polygons, and `mesher-linear-deflection` was ignored on this path, so a round column or pipe section printed as a faceted polygon. The exact HLR path and the section cut path (`GCPnts_QuasiUniformDeflection`) already honor the setting.

This threads the configured `MesherLinearDeflection` into the polygonal HLR mesher instead of the constant, matching the precedent already used for the section cut in the same file.

Verification: reproduced live that the polygonal path is frozen regardless of the geometry settings (a round r=0.05m column projects as a coarse polygon and lowering mesher-linear-deflection has no effect), while the exact path already responds to it. The change is a one constant swap threaded through the hlr constructors, type consistent with the existing `geometry_settings().get<MesherLinearDeflection>().get()` call in the same translation unit. It requires an OCCT rebuild to run, so it is not build tested; happy to confirm segment counts on a built wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
