### PR TITLE
Bonsai: fail gracefully when a drawing has no camera geometry (#6613)

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -989,6 +989,24 @@ class Drawing(bonsai.core.tool.Drawing):
             mat[1][1] *= -1
         return mat
 
+    @classmethod
+    def get_camera_representation(cls, drawing: ifcopenshell.entity_instance) -> ifcopenshell.entity_instance:
+        """Get the camera view box representation used to build the drawing camera.
+
+        A drawing camera is a Model/Body/MODEL_VIEW box. Some files store the box
+        under a different context, so we fall back to any genuine Body representation,
+        but never to an annotation or text representation, which is not a camera.
+        """
+        representation = ifcopenshell.util.representation.get_representation(drawing, "Model", "Body", "MODEL_VIEW")
+        if representation is None:
+            for r in ifcopenshell.util.representation.get_representations_iter(drawing):
+                if ifcopenshell.util.representation.resolve_representation(r).RepresentationIdentifier == "Body":
+                    representation = r
+                    break
+        if representation is None:
+            raise ValueError(f"Drawing {drawing.Name!r} has no camera representation and cannot be opened.")
+        return representation
+
     # NOTE: EPsetDrawing pset is completely synced with BIMCameraProperties
     # but BIMCameraProperties are only synced with EPsetDrawing at drawing import
     # therefore camera props can differ from pset if the user changed them from pset.
@@ -996,10 +1014,12 @@ class Drawing(bonsai.core.tool.Drawing):
     def import_drawing(cls, drawing: ifcopenshell.entity_instance) -> bpy.types.Object:
         settings = ifcopenshell.geom.settings()
 
-        representation = ifcopenshell.util.representation.get_representation(drawing, "Model", "Body", "MODEL_VIEW")
-        assert representation
+        representation = cls.get_camera_representation(drawing)
 
-        shape = ifcopenshell.geom.create_shape(settings, drawing)
+        try:
+            shape = ifcopenshell.geom.create_shape(settings, drawing)
+        except RuntimeError as e:
+            raise ValueError(f"Drawing {drawing.Name!r} camera geometry could not be built and cannot be opened.") from e
         camera = tool.Loader.create_camera(drawing, representation, shape)
         tool.Loader.link_mesh(shape, camera)
         obj = bpy.data.objects.new(tool.Loader.get_name(drawing), camera)
@@ -1018,10 +1038,12 @@ class Drawing(bonsai.core.tool.Drawing):
     def import_temporary_drawing_camera(cls, drawing: ifcopenshell.entity_instance) -> bpy.types.Object:
         settings = ifcopenshell.geom.settings()
 
-        representation = ifcopenshell.util.representation.get_representation(drawing, "Model", "Body", "MODEL_VIEW")
-        assert representation
+        representation = cls.get_camera_representation(drawing)
 
-        shape = ifcopenshell.geom.create_shape(settings, drawing)
+        try:
+            shape = ifcopenshell.geom.create_shape(settings, drawing)
+        except RuntimeError as e:
+            raise ValueError(f"Drawing {drawing.Name!r} camera geometry could not be built and cannot be opened.") from e
         camera = tool.Loader.create_camera(drawing, representation, shape)
         if obj := bpy.data.objects.get("TemporaryDrawingCamera"):
             obj.data = camera


### PR DESCRIPTION
Closes #6613.

`import_drawing` and `import_temporary_drawing_camera` looked up the drawing camera box with a strict `get_representation(drawing, "Model", "Body", "MODEL_VIEW")` followed by a bare `assert representation`. A drawing whose camera box is stored in a different context, or a drawing that has no camera geometry at all, returned `None` and crashed with `AssertionError`, which blocked opening the file.

This adds `get_camera_representation`: it keeps the Model/Body/MODEL_VIEW lookup, then falls back only to a genuine `Body` representation (resolving a MappedRepresentation to its source), never to an annotation or text representation, since those are not a camera. If nothing qualifies it raises a clear `ValueError` naming the drawing. It also wraps `create_shape` so geometry that cannot be built raises the same clear `ValueError` instead of an opaque `RuntimeError`. Bonsai operators surface a `ValueError` as a clean message, so the file opens and the rest of the drawings are unaffected.

Verified live in headless Blender 5.1.2 against the reporter's actual file. It contains one drawing whose only representation is a 2D text annotation (`IfcTextLiteralWithExtent`, context Model/Annotation/MODEL_VIEW) with no camera box. Before: 52 drawings import and that one throws `AssertionError`. After: the 52 still import cleanly and that one fails with `Drawing 'SITE PLAN - 3RD FLOOR' has no camera representation and cannot be opened.` (0 AssertionError, 0 RuntimeError).

Note: this makes the failure graceful and unblocks the file. That specific drawing genuinely has no camera geometry and so cannot be rendered as a drawing view; why it was authored without a camera box is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
