### PR TITLE
Bonsai: stop shifting an IfcSpace by the container elevation on Regen (#6405)

### DIFF
--- a/src/bonsai/bonsai/core/spatial.py
+++ b/src/bonsai/bonsai/core/spatial.py
@@ -221,8 +221,11 @@ def generate_space(
             assert space_polygon
 
     if element and element.is_a("IfcSpace"):
+        # The existing space object is already at its correct elevation, and
+        # set_space_representation_from_polygon rebuilds the geometry in place.
+        # Re-applying the object's own elevation here would shift it by the
+        # container elevation (see #6405).
         spatial.set_space_representation_from_polygon(active_obj, element, space_polygon, h, polygon_is_si=True)
-        spatial.translate_obj_to_z_location(active_obj, z)
     else:
         if relating_type:
             name = model.generate_occurrence_name(relating_type, "IfcSpace")


### PR DESCRIPTION
Closes #6405.

`generate_space` handles two cases. In the existing-space branch (the Regen path) it called `set_space_representation_from_polygon`, which rebuilds the space geometry in place at the correct elevation, and then `translate_obj_to_z_location(active_obj, z)`, where `z` is the object's own current world bottom from `get_x_y_z_h_mat_from_obj`. That re-applies the object's elevation on top of itself, so every Regen shifted the space up by the container storey elevation. The reporter's older build showed it dropping to 0 instead, but it is the same root cause: Regen re-applying the object's own elevation.

This removes the `translate_obj_to_z_location` call in the existing-space branch. The creation branch and `generate_spaces_from_walls` still use it, since a fresh object starts at z=0 and must be lifted to the container elevation.

Verified live in headless Blender 5.1.2: a space in a storey at elevation 3m, correct bottom z=3.0. Before, one Regen moved it to z=6.0; after, it stays at z=3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
