### PR TITLE
Bonsai: sync material_type when selecting a material set in the Materials UI (#6681)

### DIFF
--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -999,6 +999,9 @@ class SelectMaterialInMaterialsUI(bpy.types.Operator):
                 material = material.ForLayerSet
             material_id = material.id()
 
+        # Keep the materials UI in sync so the list, header and per-type
+        # operators match the material class we are about to load.
+        props.material_type = material_class
         core.load_materials(tool.Material, material_class)
 
         def get_material_item() -> Union[tuple[int, bpy.types.PropertyGroup], None]:


### PR DESCRIPTION
Closes #6681.

`bim.material_ui_select` resolves a usage down to its set (`ForProfileSet` / `ForLayerSet`) and calls `load_materials` to populate `props.materials`, but it never updated `props.material_type`. The Materials UI treats `props.material_type` as the source of truth: the panel header, the per type operator row, and the list item drawing all branch on it, and the import button loads off it. So after clicking the zoom icon for a profile or layer based element, the list held the set but `material_type` stayed `IfcMaterial`, leaving the panel rendering IfcMaterial operators and rows over a profile or layer set. This affected both the `IfcMaterialProfileSetUsage` and `IfcMaterialLayerSetUsage` variants.

This sets `props.material_type` to the resolved material class before loading. `material_class` is always a valid `material_type` enum value, so it is correct for the direct material path as well.

Verified live in headless Blender 5.1.2 with a profile based IfcBeam (IfcMaterialProfileSetUsage) and a layer based IfcWall (IfcMaterialLayerSetUsage): before, both left `material_type = IfcMaterial`; after, they set `IfcMaterialProfileSet` and `IfcMaterialLayerSet` respectively, and the selection index still matches the target set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
