### PR TITLE
Bonsai: keep holes when creating an annotation Fill Area (#6315)

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2249,12 +2249,12 @@ class Model(bonsai.core.tool.Model):
         result = cls.auto_detect_profiles(obj, mesh)
         fill_area = None
         if isinstance(result, dict) and (profile_def := result["profile_def"]):
-            if profile_def.is_a("IfcArbitraryClosedProfileDef"):
-                fill_area = result["ifc_file"].createIfcAnnotationFillArea(profile_def.OuterCurve)
-            elif profile_def.is_a("IfcArbitraryProfileDefWithVoids"):
+            if profile_def.is_a("IfcArbitraryProfileDefWithVoids"):
                 fill_area = result["ifc_file"].createIfcAnnotationFillArea(
                     profile_def.OuterCurve, profile_def.InnerCurves
                 )
+            elif profile_def.is_a("IfcArbitraryClosedProfileDef"):
+                fill_area = result["ifc_file"].createIfcAnnotationFillArea(profile_def.OuterCurve)
             if fill_area:
                 return {"ifc_file": result["ifc_file"], "annotation_fill_area": fill_area}
 


### PR DESCRIPTION
Closes #6315.

`auto_detect_annotation_fill_area` tested `IfcArbitraryClosedProfileDef` before its subtype `IfcArbitraryProfileDefWithVoids`. Since a voided profile is a subtype and `is_a("IfcArbitraryClosedProfileDef")` returns True for it, a box in a box mesh, which `auto_detect_profiles` correctly turns into an `IfcArbitraryProfileDefWithVoids`, matched the base branch and the FillArea was built from the `OuterCurve` only, silently dropping the inner loop. That is why the hole could not be created.

This tests the more specific voided type first so the inner curves are passed to `IfcAnnotationFillArea`.

Verified live in headless Blender 5.1.2 running `export_annotation_fill_area` on an outer box containing an inner box: before, `InnerBoundaries` was None (hole lost); after, `InnerBoundaries` is a `IfcIndexedPolyCurve` (hole preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
