### PR TITLE
Bonsai: make renames undoable (#5633)

### DIFF
--- a/src/bonsai/bonsai/bim/handler.py
+++ b/src/bonsai/bonsai/bim/handler.py
@@ -85,7 +85,8 @@ def name_callback(obj: Union[bpy.types.Object, bpy.types.Material], data: str) -
             if props.is_renaming:
                 props.is_renaming = False
                 return
-            tool.Ifc.get().by_id(ifc_definition_id).Name = obj.name
+            with IfcStore.track_transaction_outside_operator("Rename Material"):
+                tool.Ifc.get().by_id(ifc_definition_id).Name = obj.name
             refresh_ui_data()
         return
 
@@ -106,14 +107,16 @@ def name_callback(obj: Union[bpy.types.Object, bpy.types.Material], data: str) -
         object_name = element.is_a() + f"/{element_name}"
         obj.name = object_name  # NOTE: doesn't trigger infinite recursion
 
-    if element.is_a("IfcGridAxis"):
-        element.AxisTag = object_name.split("/")[1]
-        refresh_ui_data()
-
-    if not element.is_a("IfcRoot"):
+    if not element.is_a("IfcGridAxis") and not element.is_a("IfcRoot"):
         return
-    element.Name = element_name
-    if props.collection:
+
+    with IfcStore.track_transaction_outside_operator("Rename"):
+        if element.is_a("IfcGridAxis"):
+            element.AxisTag = object_name.split("/")[1]
+        if element.is_a("IfcRoot"):
+            element.Name = element_name
+
+    if element.is_a("IfcRoot") and props.collection:
         props.collection.name = object_name
     refresh_ui_data()
 

--- a/src/bonsai/bonsai/bim/ifc.py
+++ b/src/bonsai/bonsai/bim/ifc.py
@@ -26,6 +26,7 @@ import traceback
 import uuid
 import zipfile
 from collections.abc import Callable
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Literal, NotRequired, Optional, TypedDict, Union
 
@@ -670,3 +671,41 @@ class IfcStore:
             for transaction in event["operations"]:
                 transaction["commit"](transaction["data"])
             IfcStore.history.append(event)
+
+    @classmethod
+    @contextmanager
+    def track_transaction_outside_operator(cls, name: str):
+        """Make an IFC edit performed outside of a Bonsai operator undoable.
+
+        Edits done in msgbus or property update callbacks (e.g. renaming an
+        object or a material) run outside ``execute_ifc_operator``, so they are
+        never recorded in a transaction and Blender's undo cannot roll them back
+        (issue #5633). Bracketing such an edit in this context manager records it
+        in an IFC transaction, registers rollback/commit callbacks in the undo
+        history and advances ``last_transaction``, so the Blender undo step for
+        the rename reverts the IFC change together with the Blender-side change.
+        """
+        ifc_file = cls.get_file()
+        # No file, or we are already inside an operator transaction (nested edit):
+        # let the edit join the ongoing transaction rather than open a standalone one.
+        if ifc_file is None or ifc_file.transaction is not None:
+            yield
+            return
+        key = str(uuid.uuid4()) + name
+        props = tool.Blender.get_bim_props()
+        props.last_transaction = key
+        cls.last_transaction = key
+        ifc_file.begin_transaction()
+        cls.history.append(TransactionStep(key=key, operations=[]))
+        cls.future = []
+        try:
+            yield
+        finally:
+            ifc_file.end_transaction()
+            cls.history[-1]["operations"].append(
+                Operation(
+                    rollback=cls.get_ifc_file_undo_callback("UNDO"),
+                    commit=cls.get_ifc_file_undo_callback("REDO"),
+                    data=None,
+                )
+            )

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -40,6 +40,7 @@ from mathutils import Matrix
 import bonsai.bim.module.drawing.decoration as decoration
 import bonsai.core.drawing as core
 import bonsai.tool as tool
+from bonsai.bim.ifc import IfcStore
 from bonsai.bim.module.drawing.data import (
     AnnotationData,
     DrawingsData,
@@ -187,7 +188,8 @@ def get_diagram_scales(self: "BIMCameraProperties", context: bpy.types.Context) 
 def update_drawing_name(self: "Drawing", context: bpy.types.Context) -> None:
     if self.ifc_definition_id:
         drawing = tool.Ifc.get().by_id(self.ifc_definition_id)
-        core.update_drawing_name(tool.Ifc, tool.Drawing, drawing=drawing, name=self.name)
+        with IfcStore.track_transaction_outside_operator("Rename Drawing"):
+            core.update_drawing_name(tool.Ifc, tool.Drawing, drawing=drawing, name=self.name)
 
 
 def get_drawing_style_name(self: "DrawingStyle"):
@@ -207,7 +209,8 @@ def set_drawing_style_name(self: "DrawingStyle", new_value: str) -> None:
 
 def update_document_name(self: "Document", context: bpy.types.Context) -> None:
     document = tool.Ifc.get().by_id(self.ifc_definition_id)
-    core.update_document_name(tool.Ifc, tool.Drawing, document=document, name=self.name)
+    with IfcStore.track_transaction_outside_operator("Rename Document"):
+        core.update_document_name(tool.Ifc, tool.Drawing, document=document, name=self.name)
 
 
 def update_has_underlay(self: "BIMCameraProperties", context: bpy.types.Context) -> None:

--- a/src/bonsai/bonsai/bim/module/material/prop.py
+++ b/src/bonsai/bonsai/bim/module/material/prop.py
@@ -30,6 +30,7 @@ from bpy.props import (
 from bpy.types import PropertyGroup
 
 import bonsai.tool as tool
+from bonsai.bim.ifc import IfcStore
 from bonsai.bim.module.classification.data import MaterialClassificationsData
 from bonsai.bim.module.material.data import MaterialsData, ObjectMaterialData
 from bonsai.bim.module.profile.data import ProfileData
@@ -95,10 +96,11 @@ def update_material_name(self: "Material", context: bpy.types.Context) -> None:
     ifc_file = tool.Ifc.get()
     name = self.name
     material = ifc_file.by_id(self.ifc_definition_id)
-    if material.is_a("IfcMaterialLayerSet"):
-        material.LayerSetName = name
-    else:
-        material.Name = name
+    with IfcStore.track_transaction_outside_operator("Rename Material"):
+        if material.is_a("IfcMaterialLayerSet"):
+            material.LayerSetName = name
+        else:
+            material.Name = name
 
 
 def set_material_name(self: "Material", new_category_name: str) -> None:

--- a/src/bonsai/bonsai/bim/module/profile/prop.py
+++ b/src/bonsai/bonsai/bim/module/profile/prop.py
@@ -30,6 +30,7 @@ from bpy.props import (
 from bpy.types import PropertyGroup
 
 import bonsai.tool as tool
+from bonsai.bim.ifc import IfcStore
 from bonsai.bim.module.profile.data import ProfileData
 from bonsai.bim.prop import Attribute
 
@@ -46,7 +47,8 @@ def update_profile_name(self: "Profile", context: bpy.types.Context) -> None:
     profile = tool.Ifc.get_entity_by_id(self.ifc_definition_id)
     if not profile:
         return
-    profile.ProfileName = self.name
+    with IfcStore.track_transaction_outside_operator("Rename Profile"):
+        profile.ProfileName = self.name
     refresh_ui_data()
 
 

--- a/src/bonsai/bonsai/bim/module/style/prop.py
+++ b/src/bonsai/bonsai/bim/module/style/prop.py
@@ -32,6 +32,7 @@ from bpy.props import (
 from bpy.types import PropertyGroup
 
 import bonsai.tool as tool
+from bonsai.bim.ifc import IfcStore
 from bonsai.bim.module.style.data import StylesData
 from bonsai.bim.prop import Attribute, StrProperty
 
@@ -52,7 +53,8 @@ def get_reflectance_methods(self: "BIMStylesProperties", context: bpy.types.Cont
 
 def update_style_name(self: "Style", context: bpy.types.Context) -> None:
     style = tool.Ifc.get().by_id(self.ifc_definition_id)
-    tool.Style.rename_style(style, self.name)
+    with IfcStore.track_transaction_outside_operator("Rename Style"):
+        tool.Style.rename_style(style, self.name)
 
 
 class Style(PropertyGroup):


### PR DESCRIPTION
Closes #5633.

Renames of IFC linked objects and materials are applied in `name_callback`, which runs from a `msgbus` notification (objects) or a property update (materials), outside `execute_ifc_operator`. Only edits inside that operator wrapper are bracketed by `begin_transaction` / `end_transaction` and pushed to the undo history with a fresh `last_transaction` key. Because the rename runs outside it, the `Name` write was never recorded in a transaction and never advanced `last_transaction`. Blender's `undo_post` handler rolls the IFC back off a mismatch between `IfcStore.last_transaction` and the Blender restored `props.last_transaction`, so with neither changed, undo had nothing to revert and the IFC name stayed changed while the Blender object name reverted.

This adds `IfcStore.track_transaction_outside_operator`, a context manager that brackets an edit made in a callback the same way the operator wrapper does: it opens an `ifc_file` transaction, registers the standard undo and redo callbacks in the history, and advances `last_transaction`. It no-ops when there is no file or when already inside an operator transaction, so nested edits just join the ongoing transaction. `name_callback` wraps its IFC writes (material `Name`, object `Name`, grid axis `AxisTag`) in it; the Blender side writes stay outside and are handled by Blender's own undo.

Verified live in headless Blender 5.1.2 through the real `undo_post` / `redo_post` handlers: before, undoing an object rename left `ifc.Name` unchanged; after, undo restores the previous name for both objects and materials and redo re-applies it. `ifc_file.transaction` is None after the callback, and a subsequent real operator runs without tripping the override transaction assert.

Note: the same non transactional pattern exists in a few other update callbacks; this fixes the object and material rename cases from the report and provides the reusable helper the others can adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
