### PR TITLE
Bonsai: persist CSV attributes when saving a spreadsheet search (#3950)

### DIFF
--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -890,7 +890,23 @@ class SaveSearch(Operator, tool.Ifc.Operator):
             self.report({"ERROR"}, "Error occurred trying save search.")
             return
 
-        description = json.dumps({"type": "BBIM_Search", "query": query, "filter_structure": filter_structure})
+        description_data = {"type": "BBIM_Search", "query": query, "filter_structure": filter_structure}
+        if self.module == "csv":
+            csv_props = tool.Blender.get_csv_props()
+            description_data["csv_attributes"] = [
+                {
+                    "name": a.name,
+                    "header": a.header,
+                    "sort": a.sort,
+                    "group": a.group,
+                    "varies_value": a.varies_value,
+                    "summary": a.summary,
+                    "formatting": a.formatting,
+                }
+                for a in csv_props.csv_attributes
+            ]
+
+        description = json.dumps(description_data)
         ifc_file = tool.Ifc.get()
         group = next(
             (
@@ -937,6 +953,14 @@ class LoadSearch(Operator, tool.Ifc.Operator):
             tool.Search.import_filter_structure(group_data["filter_structure"], filter_groups)
         else:
             tool.Search.import_filter_query(tool.Search.get_group_query(group), filter_groups)
+
+        if self.module == "csv" and group_data and "csv_attributes" in group_data:
+            csv_props = tool.Blender.get_csv_props()
+            csv_props.csv_attributes.clear()
+            for attribute in group_data["csv_attributes"]:
+                new = csv_props.csv_attributes.add()
+                for prop in ["name", "header", "sort", "group", "varies_value", "summary", "formatting"]:
+                    setattr(new, prop, attribute[prop])
 
     def draw(self, context):
         assert self.layout


### PR DESCRIPTION
Closes #3950.

`SaveSearch` serialized only `type`, `query` and `filter_structure` into the saved IfcGroup Description. It is a generic operator shared across modules, so the CSV specific `csv_attributes` (the columns, sort, group, summary and formatting configured for a spreadsheet) were never persisted, and `LoadSearch` never restored them. So saving a CSV search kept the filter but dropped all of the column configuration, and it could not be reloaded from the IFC. Moult confirmed this as a genuine missing capability in the thread.

When the operator module is `csv`, this saves `csv_attributes` into the description and restores them on load. It is guarded by `self.module == "csv"`, so the search, diff, drawing and clash modules are untouched, and it mirrors the existing serialization style used elsewhere in the CSV module.

Verified live in headless Blender 5.1.2: before, the saved group had keys `type, query, filter_structure` and the attributes came back empty on load; after, `csv_attributes` is serialized with all fields and, after clearing and reloading, the columns are fully restored (name, header, sort, group, varies_value, summary, formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
