### PR TITLE
ifcfm: convert COBie Coordinate space points to project units (#5926)

### DIFF
--- a/src/ifcfm/ifcfm/cobie24.py
+++ b/src/ifcfm/ifcfm/cobie24.py
@@ -28,6 +28,7 @@ import ifcopenshell.util.fm
 import ifcopenshell.util.placement
 import ifcopenshell.util.shape
 import ifcopenshell.util.system
+import ifcopenshell.util.unit
 from ifcopenshell.util.shape_builder import np_matrix_to_euler
 
 # The original BIMServer plugin has a function called ifcToCOBie:
@@ -920,6 +921,11 @@ def get_coordinate_data_(element: ifcopenshell.entity_instance) -> Generator[dic
     verts = ifcopenshell.util.shape.get_shape_vertices(shape, shape.geometry)
     categories = ("box-lowerleft", "box-upperright")
     bbox = ifcopenshell.util.shape.get_bbox(verts)
+    # Geometry vertices are in SI metres, but Floor rows use the raw placement in
+    # project length units. Convert space points to project units so the whole
+    # Coordinate sheet is consistent with the Facility LinearUnits.
+    unit_scale = ifcopenshell.util.unit.calculate_unit_scale(element.file)
+    bbox = [point / unit_scale for point in bbox]
     base_data = base_data | {
         "Category": "point",
         "SheetName": "Space",


### PR DESCRIPTION
Relates to #5926.

While looking into the reported missing COBie tabs, I found a real correctness bug in the Coordinate sheet. Floor rows use `get_local_placement`, whose values are in the project length unit, but Space rows come from `ifcopenshell.geom.create_shape`, whose vertices are in SI metres, and the space branch never scaled them back. So on a non metre model (for example millimetres) the Coordinate sheet mixed units a thousandfold apart and disagreed with the Facility sheet's declared LinearUnits.

This scales the space bounding box by the project unit scale so the whole Coordinate sheet is consistent. A metre model is unchanged since the scale is 1.

Verified in Python: on a millimetre model, before, Floor was (10000, 20000, 3500) mm while the Space lower left was (-1.0, -0.5, 0.0) metres; after, the Space lower left is (-1000, -500, 0) mm, consistent with the Floor row and with Facility LinearUnits = millimeters. A metre model is unchanged.

Note on the original issue: the missing tabs themselves are not a data drop bug. Coordinate is already implemented in cobie24 (the reporter's 15 tab result matches the cobie24legacy preset or a pre March 2026 build), and Instruction, Impact, Issue and PickLists have no established IFC to COBie source mapping, so they are legitimately blank rather than dropped. Adding those as fixed template sheets would be a separate feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
