### PR TITLE
ifcgeom: import IfcRightCircularCylinder CSG geometry (#6742)

### DIFF
--- a/src/ifcgeom/mapping/IfcRightCircularCylinder.cpp
+++ b/src/ifcgeom/mapping/IfcRightCircularCylinder.cpp
@@ -21,21 +21,41 @@
 #define mapping POSTFIX_SCHEMA(mapping)
 using namespace ifcopenshell::geometry;
 
-taxonomy::ptr mapping::map_impl(const IfcSchema::IfcRightCircularCylinder* inst) {
-	// @todo
-	return nullptr;
-	/*
+#include <boost/math/constants/constants.hpp>
 
+taxonomy::ptr mapping::map_impl(const IfcSchema::IfcRightCircularCylinder* inst) {
 	const double r = inst->Radius() * length_unit_;
 	const double h = inst->Height() * length_unit_;
 
-	BRepPrimAPI_MakeCylinder builder(r, h);
-	gp_Trsf trsf;
-	IfcGeom::Kernel::convert(inst->Position(),trsf);
-	
-	// IfcCsgPrimitive3D.Position has unit scale factor
-	shape = builder.Solid().Moved(trsf);
+	const double precision = settings_.get<settings::Precision>().get();
+	if (r < precision || h < precision) {
+		logger_.Message(Logger::LOG_ERROR, "GEO", 89, "Non-positive radius or height encountered for:", inst);
+		return nullptr;
+	}
 
-	return true;
-	*/
+	// A right circular cylinder is a disk of radius r extruded by its height h
+	// along the local +Z axis. Build the disk as a single circular loop face,
+	// mirroring IfcCircleProfileDef, then wrap it in a taxonomy::extrusion so
+	// both geometry kernels handle it through the ordinary swept-solid path.
+	auto circle = taxonomy::make<taxonomy::circle>();
+	circle->radius = r;
+	circle->matrix = taxonomy::make<taxonomy::matrix4>();
+
+	auto edge = taxonomy::make<taxonomy::edge>();
+	edge->basis = circle;
+	edge->start = 0.;
+	edge->end = 2 * boost::math::constants::pi<double>();
+
+	auto loop = taxonomy::make<taxonomy::loop>();
+	loop->children = { edge };
+	loop->external = true;
+
+	auto face = taxonomy::make<taxonomy::face>();
+	face->children.push_back(loop);
+
+	// IfcCsgPrimitive3D.Position places the whole solid; map() applies the unit scale.
+	auto matrix = taxonomy::cast<taxonomy::matrix4>(map(inst->Position()));
+	auto direction = taxonomy::make<taxonomy::direction3>(0, 0, 1);
+
+	return taxonomy::make<taxonomy::extrusion>(matrix, face, direction, h);
 }


### PR DESCRIPTION
Fixes #6742.

## Problem

A file whose representation uses an `IfcRightCircularCylinder` (CSG primitive) imports with no geometry. On the sample from the issue the product fails outright:

```
RuntimeError: Failed to process shape. Product: #40=IfcBuildingElementProxy(...)
```

The cause is that `src/ifcgeom/mapping/IfcRightCircularCylinder.cpp` was still a stub: `map_impl` returned `nullptr` with a `// @todo`, so the CSG solid had no basis geometry.

## Fix

Map the cylinder the same way a circular column is built: a disk face of the given radius (a single circular loop, mirroring `IfcCircleProfileDef`) wrapped in a `taxonomy::extrusion` along the local +Z axis by the cylinder height. This routes through the ordinary swept-solid path, so both the OpenCascade and CGAL kernels handle it with no primitive-specific code.

`IfcCsgPrimitive3D.Position` places the whole solid, with `map()` applying the unit scale, consistent with the already-working `IfcBlock` and `IfcSphere` mappings. Non-positive radius or height is rejected with the standard GEO log message.

## Verification

- Root cause and the empty-geometry failure reproduced on the issue's sample (`IFCRIGHTCIRCULARCYLINDER(#36,0.45,1.)`), which currently raises `Failed to process shape`.
- The construction mirrors `IfcCircleProfileDef` (disk face) and `IfcExtrudedAreaSolid` (extrusion wrapper) exactly, both known-good paths.
- Compilation is covered by CI's `build-ifcopenshell` job. I was not able to run the compiled kernel against the sample locally (no local kernel build), so runtime output is argued from the shared code path rather than binary-tested; happy to iterate if a maintainer spots anything.

The sibling `IfcRightCircularCone` mapping is still a stub; a cone needs a tapered/revolved solid rather than a straight extrusion, so I left it out of this change to keep the fix tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)