### PR TITLE
ifcgeom: keep cant twist in IfcSectionedSurface via IfcAxis2PlacementLinear (#8116)

### DIFF
--- a/src/ifcgeom/mapping/IfcAxis2PlacementLinear.cpp
+++ b/src/ifcgeom/mapping/IfcAxis2PlacementLinear.cpp
@@ -49,31 +49,31 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcAxis2PlacementLinear* inst) 
 	}
 	*/
 
-    if (hasAxis && !hasRef) {
+    // When Axis and/or RefDirection are omitted they default to the orientation
+    // of the reference curve at the placement location:
+    //   - Axis (local Z) defaults to the curve normal,  m.col(2)
+    //   - RefDirection (local X) defaults to the curve tangent, m.col(0)
+    // Taking the curve normal (rather than recomputing an axis from the global
+    // Z direction) preserves the cant / superelevation twist that is baked into
+    // the linear placement frame, so skewed / rotated sections are swept in
+    // their correct frame. See issue #8116.
+    if (hasAxis) {
         taxonomy::direction3::ptr a = taxonomy::cast<taxonomy::direction3>(map(inst->Axis()));
         axis = *a->components_;
-
-        refDirection = m->components().col(0).head<3>(); // RefDirection is the curve tangent when omitted
-        // refDirection is not necessarily orthogonal to axis.
-        // axis.cross(refDirection) gives y. y.cross(axis) gives x=refDirection
-        refDirection = axis.cross(refDirection).cross(axis);
-    } else if (!hasAxis && hasRef) {
-        taxonomy::direction3::ptr r = taxonomy::cast<taxonomy::direction3>(map(inst->RefDirection()));
-        refDirection = *r->components_;
-        Eigen::Vector3d up(0, 0, 1);
-        axis = refDirection.cross(up.cross(refDirection));
-    } else if (!hasAxis && !hasRef) {
-        refDirection = m->components().col(0).head<3>(); // RefDirection is the curve tangent when omitted
-        Eigen::Vector3d up(0, 0, 1);
-        axis = refDirection.cross(up.cross(refDirection));
     } else {
-        taxonomy::direction3::ptr a = taxonomy::cast<taxonomy::direction3>(map(inst->Axis()));
-        axis = *a->components_;
+        axis = m->components().col(2).head<3>(); // Axis is the curve normal when omitted
+    }
 
+    if (hasRef) {
         taxonomy::direction3::ptr r = taxonomy::cast<taxonomy::direction3>(map(inst->RefDirection()));
         refDirection = *r->components_;
-        refDirection = axis.cross(refDirection).cross(axis); // refDirection needs to be orthogonal to axis
+    } else {
+        refDirection = m->components().col(0).head<3>(); // RefDirection is the curve tangent when omitted
     }
+
+    // refDirection is not necessarily orthogonal to axis:
+    // axis.cross(refDirection) gives y. y.cross(axis) gives x = refDirection.
+    refDirection = axis.cross(refDirection).cross(axis);
 
     // axis and refDirection need to be orthogonal
     return taxonomy::make<taxonomy::matrix4>(o, axis, refDirection);


### PR DESCRIPTION
Fixes #8116.

## Problem

An `IfcSectionedSurface` swept along a canted (superelevated) alignment renders without any cross-section twist: the end view never rotates, so cant/superelevation is lost.

The directrix frame carries the correct twist, but `IfcAxis2PlacementLinear` throws it away. When `Axis` (and/or `RefDirection`) are omitted, the old code recomputed the local Z axis from the global up vector:

```cpp
Eigen::Vector3d up(0, 0, 1);
axis = refDirection.cross(up.cross(refDirection));
```

That forces the placement into a world-vertical plane and discards the cant rotation baked into the reference-curve normal.

## Fix

Per the schema, an omitted `Axis` defaults to the reference-curve normal and an omitted `RefDirection` to the reference-curve tangent. Take those directly from the incoming curve frame (`m.col(2)` and `m.col(0)`) instead of rebuilding the axis from global Z, then orthogonalize `RefDirection` against `Axis` as before.

The four original branches are unified into "default Axis to curve normal, default RefDirection to curve tangent". The cases where `Axis` is given explicitly (Axis-only and Axis+RefDirection) are behaviourally unchanged; only the two omitted-`Axis` branches change, which are exactly the ones that dropped the cant.

## Verification

- Traced against the issue sample: `IFCAXIS2PLACEMENTLINEAR(#pbde,$,$)` (both omitted) on an `IfcSegmentedReferenceCurve` directrix with cant. With the curve normal as `Axis`, `make_loft`'s frame remap yields the correct (lateral, up-canted, tangent) sweep frame.
- Matches the direction of the reporter's own proposed patch, and the reporter attached a before/after image confirming the visual result.
- Compilation is covered by CI's `build-ifcopenshell`. I do not have a local kernel build, so this is validated by static frame tracing rather than a rendered image; happy to iterate if a maintainer spots anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)