### PR TITLE
serializers: fix empty-optional dereference in glTF finalize (separate Z-up node)

### DIFF
--- a/src/serializers/GltfSerializer.cpp
+++ b/src/serializers/GltfSerializer.cpp
@@ -440,7 +440,7 @@ void GltfSerializer::finalize() {
 	}
 
 	if (z_up_transform_) {
-        (*ecef_transform_)["children"] = roots_;
+        (*z_up_transform_)["children"] = roots_;
 	}
 
 	tmp_fstream1_.close();


### PR DESCRIPTION
## Problem

In `GltfSerializer::finalize()`, three parallel blocks attach the scene roots to their wrapper transform nodes. The `north_rotation_` and `ecef_transform_` blocks dereference their own optional, but the third block is a copy-paste slip: it is guarded by `if (z_up_transform_)` yet dereferences `(*ecef_transform_)`.

These are `boost::optional<json>` (`GltfSerializer.h`). When a separate Z-up node is requested (`SeparateZUpNode`) without ECEF export (`WriteGltfEcef`), `ecef_transform_` is empty, so `operator*` on it is undefined behavior (reads an uninitialized `json`, then writes `["children"]` into it).

## Fix

One token: align the dereference with its guard so the body uses `z_up_transform_`, matching the two blocks above it.

```diff
 if (z_up_transform_) {
-    (*ecef_transform_)["children"] = roots_;
+    (*z_up_transform_)["children"] = roots_;
 }
```

## Notes

The Z-up node already has its children set and is pushed earlier in the function, so this trailing assignment is effectively redundant; the practical effect of the change is removing the latent UB, not altering valid output. Found by reading the serializer (no linked issue). Compilation is covered by CI's `build-ifcopenshell`; I have no local kernel build, so this is a static-analysis fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)