### PR TITLE
ifcparse: don't segfault on truncated / fuzzed STEP files (#6750)

### DIFF
--- a/src/ifcparse/IfcFile.cpp
+++ b/src/ifcparse/IfcFile.cpp
@@ -9,6 +9,7 @@
 
 #include <fstream>
 #include <memory>
+#include <stdexcept>
 #include <utility>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -722,6 +723,14 @@ std::optional<std::tuple<size_t, const IfcParse::declaration*, IfcEntityInstance
                 logger_.get().Message(Logger::LOG_ERROR, "SYN", 3, std::string(ex.what()) + " at offset " + std::to_string(token_stream_[2].startPos));
                 current_id = 0;
                 goto advance;
+            } catch (const std::out_of_range&) {
+                // #6750 A malformed keyword / entity name containing a stray
+                // apostrophe makes the character decoder scan past the end of the
+                // buffer, which surfaces as std::out_of_range from the reader.
+                // Recover instead of letting it escape and crash the process.
+                logger_.get().Message(Logger::LOG_ERROR, "SYN", 3, "Premature end of file while reading entity name at offset " + std::to_string(token_stream_[2].startPos));
+                current_id = 0;
+                goto advance;
             }
 
             if (entity_type->as_entity() == nullptr) {
@@ -746,6 +755,16 @@ std::optional<std::tuple<size_t, const IfcParse::declaration*, IfcEntityInstance
             } catch (const IfcInvalidTokenException& e) {
                 good_ = file_open_status::INVALID_SYNTAX;
                 logger_.get().Error("SYN", 5, e);
+                break;
+            } catch (const std::out_of_range&) {
+                // #6750 Premature end of file while reading an instance's
+                // attributes, e.g. an unterminated string literal ('...) or an
+                // attribute value containing a stray apostrophe that sends the
+                // character decoder scanning past the end of the buffer. Treat as
+                // a syntax error and stop rather than letting the exception escape
+                // readInstance() and crash the process.
+                good_ = file_open_status::INVALID_SYNTAX;
+                logger_.get().Message(Logger::LOG_ERROR, "SYN", 5, "Premature end of file while reading instance #" + std::to_string(current_id));
                 break;
             }
 


### PR DESCRIPTION
Fixes #6750.

## Problem

Opening a truncated or fuzzed IFC file can segfault the whole process (originally surfaced by fuzzing; sample `id_000010` on the issue).

When the STEP character decoder reaches end of file while looking for a closing apostrophe, the bounds-checked `FileReader` backends throw `std::out_of_range`. This happens on:

- an unterminated string literal, e.g. `IFCPROJECT('abc,...` with no closing quote, and
- a keyword or GlobalId whose opening quote was corrupted into a stray byte, e.g. `IFCPROJECT(ABC',...`.

That `std::out_of_range` is not derived from `IfcException` or `IfcInvalidTokenException`, so it slipped past both handlers in `InstanceStreamer::readInstance()` and propagated out of the parser, crashing the process.

## Fix

Add `catch (const std::out_of_range&)` at the two DATA-section sites that materialize token text (reading the entity name, and reading an instance's attributes). Premature EOF is now logged as a `SYN` syntax error and parsing stops cleanly with `file_open_status::INVALID_SYNTAX`, mirroring the existing tolerance for malformed tokens. Added `#include <stdexcept>`.

## Verification

- Reproduced the crash live on the shipped 0.8.6 wheel with `id_000010`, then minimized to the two independent triggers above. Confirmed the discriminator is exact: if the decoder finds a closing `'` before EOF it loads fine; only reaching true EOF crashes.
- Zero risk to well-formed files: valid strings always terminate before EOF, so the new catches only fire on input that currently crashes. The streaming/paged pre-scan path (which uses `out_of_range` as a need-more-pages signal) is untouched.
- Compilation covered by CI's `build-ifcopenshell`. I could not runtime-exercise the patched binary (no local kernel build; Blender's bundled ifcopenshell is a prebuilt wheel), so the patched-behavior claim rests on the reproduced crash plus the reading of the escape path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)