### PR TITLE
ifcgeom: fix 'Failed to join curve segments' on zero-span trimmed conics (#6912)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/loop.cpp
+++ b/src/ifcgeom/kernels/opencascade/loop.cpp
@@ -168,7 +168,16 @@ namespace {
 					auto v1 = boost::get<double>(e_start);
 					auto v2 = boost::get<double>(e_end);
 
-					if (is_conic && ALMOST_THE_SAME(fmod(v2 - v1, M_PI * 2.), 0.)) {
+					if (is_conic && ALMOST_THE_SAME(v1, v2)) {
+						// A zero-span parameter trim (e.g. an IfcTrimmedCurve trimmed
+						// from 0 to 0) is a degenerate segment, not a full revolution.
+						// The modulo-2pi test below cannot tell the two apart (fmod(0)
+						// == 0), so without this guard a spurious full conic edge would
+						// be emitted, inserting a closed circle into the wire and
+						// breaking curve joining (#6912). Signal a degenerate segment so
+						// the caller can skip it.
+						throw std::runtime_error("Degenerate zero-span trimmed conic segment");
+					} else if (is_conic && ALMOST_THE_SAME(fmod(v2 - v1, M_PI * 2.), 0.)) {
 						E = BRepBuilderAPI_MakeEdge(curve).Edge();
 					} else {
 						E = BRepBuilderAPI_MakeEdge(curve, v1, v2).Edge();


### PR DESCRIPTION
Fixes #6912.

## Problem

Some IFC files (seen from Tekla exports) contain an `IfcCompositeCurve` with a degenerate segment: a parameter-trimmed conic trimmed from parameter 0 to 0, i.e. a zero-length arc. Converting these fails with:

```
GEO 212  Internal error, inconsistent wire segments
GEO 214  Failed to join curve segments
```

In `src/ifcgeom/kernels/opencascade/loop.cpp`, the conic branch decides whether a trimmed conic is a full revolution with:

```cpp
if (is_conic && ALMOST_THE_SAME(fmod(v2 - v1, M_PI * 2.), 0.))
```

A zero span (`v1 == v2 == 0`) also satisfies this, because `fmod(0, 2*PI) == 0`. So instead of a degenerate segment it emitted `BRepBuilderAPI_MakeEdge(curve).Edge()`, a **complete circle**. That closed circle cannot be joined to its neighbours, breaking the wire.

## Fix

Detect the zero-span case explicitly (`is_conic && ALMOST_THE_SAME(v1, v2)`) and throw. The per-segment loop in `convert()` already wraps `convert_curve(segment)` in `try { } catch (...) { continue; }`, so the degenerate segment is simply skipped and the remaining valid segments assemble into a clean wire. A genuine full circle has `v2 - v1` close to `2*PI`, far from the tolerance, and is untouched.

## Verification

- Traced end to end on the issue's reduced sample: segment `#1292 = IfcTrimmedCurve(#1291, PARAMETERVALUE(0.), PARAMETERVALUE(0.))` on a circle of radius ~96924.79, confirming the 0 to 0 trim that produced the spurious full circle.
- No new includes needed; `std::runtime_error`, `M_PI`, `fmod`, `ALMOST_THE_SAME` are already used in the file.
- Compilation covered by CI's `build-ifcopenshell`. No local kernel build available, so the joined-wire outcome rests on the traced root cause and the existing skip-on-throw path rather than a rendered result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)