### PR TITLE
IfcConvert: report an error instead of failing silently on an unwritable output path (#438)

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -885,6 +885,7 @@ int main(int argc, char** argv) {
 	}
 
 	if (!serializer->ready()) {
+		logger.Error("SYS", 25, "Unable to open output file '" + IfcUtil::path::to_utf8(output_filename) + "' for writing; check that the directory exists and is writable");
 		IfcUtil::path::delete_file(IfcUtil::path::to_utf8(output_temp_filename));
 		write_log(!quiet);
 		return EXIT_FAILURE;


### PR DESCRIPTION
Fixes #438.

## Problem

Running `IfcConvert` with an output file in a directory that does not exist (or is not writable) exits with a failure code but prints nothing, so there is no indication of what went wrong.

The serializer's `ready()` check already correctly returns `false` when the output stream cannot be opened, but the handler deleted the temp file and returned `EXIT_FAILURE` with no log message:

```cpp
if (!serializer->ready()) {
    IfcUtil::path::delete_file(IfcUtil::path::to_utf8(output_temp_filename));
    write_log(!quiet);
    return EXIT_FAILURE;
}
```

## Fix

Emit a `SYS` error naming the output file before returning, mirroring the existing "Unable to open output file for writing" reporting used elsewhere in the same file. No behavior change beyond the added diagnostic.

## Verification

Static change; the `ready()` machinery and the failure path are unchanged, only a `logger.Error(...)` is added ahead of the existing cleanup. Compilation is covered by CI's `build-ifcopenshell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)