### PR TITLE
examples: fix missing OpenCASCADE includes on MSVC x64 (#7822)

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -92,6 +92,23 @@ build_example(IfcParseExamples ${schema})
 if(WITH_OPENCASCADE)
     build_example(IfcOpenHouse ${schema} geometry_serializer)
     build_example(IfcAdvancedHouse ${schema} geometry_serializer)
+
+    # IfcOpenHouse and IfcAdvancedHouse include OpenCASCADE headers directly
+    # (TColgp_Array2OfPnt.hxx, Geom_BSplineSurface.hxx, ...). Transitive
+    # propagation of the OCC include directories through geometry_serializer is
+    # not reliable on every generator (see issue #7822 on MSVC x64), so add them
+    # explicitly. FindOpenCASCADE sets OCC_INCLUDE_DIR when the include/library
+    # dirs are provided, or OpenCASCADE_INCLUDE_DIR when discovered via config.
+    if(OCC_INCLUDE_DIR)
+        set(_occ_example_includes ${OCC_INCLUDE_DIR})
+    else()
+        set(_occ_example_includes ${OpenCASCADE_INCLUDE_DIR})
+    endif()
+    if(_occ_example_includes)
+        target_include_directories(IfcOpenHouse PRIVATE ${_occ_example_includes})
+        target_include_directories(IfcAdvancedHouse PRIVATE ${_occ_example_includes})
+    endif()
+    unset(_occ_example_includes)
 endif()
 
 if("4x3_add2" IN_LIST SCHEMA_VERSIONS)


### PR DESCRIPTION
Fixes #7822.

## Problem

On the Visual Studio generator (MSVC x64), the `IfcOpenHouse` and `IfcAdvancedHouse` examples fail to compile with missing OpenCASCADE headers (`TColgp_Array2OfPnt.hxx`, `Geom_BSplineSurface.hxx`, and similar). The headers are included by the examples directly and exist on disk in `OCC_INCLUDE_DIR`, but the include directory does not reach the example project files.

## Cause

The examples only link `geometry_serializer`, and the OCC include directories are meant to propagate transitively through `geometry_serializer` to its `geometry_serializer_ifc${schema}` OBJECT library to `OpenCASCADE_INTERFACE`. That second-order transitive propagation through an OBJECT library is not reliable on the Visual Studio generator, so the compiler never gets the OCC include path.

## Fix

Add the OCC include directories explicitly to the two OpenCASCADE examples with `target_include_directories(... PRIVATE)`, using `OCC_INCLUDE_DIR` (set by FindOpenCASCADE when include/lib dirs are provided, the usual Windows path) or `OpenCASCADE_INCLUDE_DIR` (config-discovery path). It is guarded so it is a no-op in the standalone-project case, where includes come from the exported interface targets. Linking is unchanged (it already flows through `geometry_serializer`); this is a compile-only fix.

## Verification

Reasoned from the CMake dependency graph; I do not have a Windows/MSVC build to confirm the vcxproj now carries the include path, and CI does not compile the examples, so this is not build-verified. The change is additive and guarded, so it cannot affect the library build or the standalone-package path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)