### PR TITLE
serializers: export property sets held in an IfcPropertySetDefinitionSet to XML (#6330)

### DIFF
--- a/src/serializers/schema_dependent/XmlSerializer.cpp
+++ b/src/serializers/schema_dependent/XmlSerializer.cpp
@@ -305,7 +305,7 @@ ptree* descend(Logger& logger, ifcopenshell::geometry::abstract_mapping* mapping
 			<IfcSchema::IfcObject, IfcSchema::IfcRelDefinesByProperties, IfcSchema::IfcPropertySetDefinition>
 			(logger, object, &IfcSchema::IfcObject::IsDefinedBy, &IfcSchema::IfcRelDefinesByProperties::RelatingPropertyDefinition);
 
-#ifdef SCHEMAS_HAS_IfcPropertySetDefinitionSet
+#ifdef SCHEMA_HAS_IfcPropertySetDefinitionSet
 		aggregate_of<IfcSchema::IfcPropertySetDefinitionSet>::ptr property_set_sets = get_related
 			<IfcSchema::IfcObject, IfcSchema::IfcRelDefinesByProperties, IfcSchema::IfcPropertySetDefinitionSet>
 			(logger, object, &IfcSchema::IfcObject::IsDefinedBy, &IfcSchema::IfcRelDefinesByProperties::RelatingPropertyDefinition);


### PR DESCRIPTION
Fixes #6330.

## Problem

When an object's `RelatingPropertyDefinition` is an `IfcPropertySetDefinitionSet` (a set that groups several property sets), the XML serializer emitted a blank/empty class instead of the contained property sets.

## Cause

`XmlSerializer.cpp` already has a block that expands such a set into its member `IfcPropertySetDefinition`s, but it is guarded by:

```cpp
#ifdef SCHEMAS_HAS_IfcPropertySetDefinitionSet
```

The macro the schema generator actually emits is `SCHEMA_HAS_IfcPropertySetDefinitionSet` (singular). The plural spelling is not defined anywhere in the tree (confirmed: 11 headers define the singular form, zero use the plural), so the whole block was dead code.

## Fix

Correct the guard to `SCHEMA_HAS_IfcPropertySetDefinitionSet`. The inner code (get the related sets, cast through the aggregate conversion operator, push each contained pset) is type-correct as written and needs no other change.

## Verification

The parse layer already populates these nested sets: they are readable from Python via `util.element` (PR #8418), which is only possible when parsing fills the set's aggregate. Enabling this serializer block completes the equivalent C++ XML path. Not runtime-tested (no local build); compilation across schemas is covered by CI's `build-ifcopenshell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)