### PR TITLE
ifcgeom: don't segfault on null/empty boolean operands (#1366)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/boolean_result.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_result.cpp
@@ -178,7 +178,9 @@ bool OpenCascadeKernel::convert_impl(const taxonomy::boolean_result::ptr br, Con
 		}
 		r = C;
 	} else {
-		if (br->operation != taxonomy::boolean_result::SUBTRACTION && a.IsNull()) {
+		if (br->operation != taxonomy::boolean_result::SUBTRACTION && a.IsNull() && !b.IsEmpty()) {
+			// #1366 guard b.First() against an empty operand list, which would
+			// otherwise dereference a null shape and crash.
 			a = b.First();
 			b.RemoveFirst();
 		}

--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -874,6 +874,30 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 	return true;
 	*/
 
+	// #1366 Guard against null or empty operands before they reach OCCT.
+	// An operand that is null or carries no faces makes downstream OCCT
+	// routines (unify, the pave filler, shape healing) dereference a null
+	// shape and crash with a segfault rather than a catchable exception.
+	// A null/empty first operand cannot yield a meaningful result, and a
+	// null/empty tool contributes nothing to any boolean, so drop it.
+	if (a_input.IsNull() || count(a_input, TopAbs_FACE) == 0) {
+		Logger::Root().Warning("GEO", 155, "Empty or null first operand, skipping boolean operation");
+		result = a_input;
+		return !a_input.IsNull();
+	}
+
+	NCollection_List<TopoDS_Shape> b_input_filtered;
+	{
+		NCollection_List<TopoDS_Shape>::Iterator it(b_input);
+		for (; it.More(); it.Next()) {
+			if (!it.Value().IsNull() && count(it.Value(), TopAbs_FACE) > 0) {
+				b_input_filtered.Append(it.Value());
+			} else {
+				Logger::Root().Warning("GEO", 156, "Skipping empty or null operand in boolean operation");
+			}
+		}
+	}
+
 	// @todo, it does seem a bit odd, we first triangulate non-planar faces
 	// to later unify them again. Can we make this a bit more intelligent?
 	TopoDS_Shape a;
@@ -893,7 +917,7 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 		);
 
 		{
-			NCollection_List<TopoDS_Shape>::Iterator it(b_input);
+			NCollection_List<TopoDS_Shape>::Iterator it(b_input_filtered);
 			for (; it.More(); it.Next()) {
 				b.Append(unify(it.Value(), fuzziness));
 				Logger::Root().Message(
@@ -907,7 +931,7 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 		}
 	} else {
 		a = a_input;
-		b = b_input;
+		b = b_input_filtered;
 	}
 
 	bool is_2d = count(a, TopAbs_FACE) > 0 && count(a, TopAbs_SHELL) == 0;


### PR DESCRIPTION
Fixes #1366.

## Problem

A CSG boolean difference from ArchiCAD segfaults. The model subtracts a chain of `IfcFacetedBrep` operands from a base solid, and ArchiCAD faceted breps routinely convert to null or face-less shapes. Such an operand flows unguarded into `IfcGeom::util::boolean_operation`, where OCCT routines (`unify`, the pave filler, `ShapeFix_Shape`) dereference the null/empty shape and crash with a SIGSEGV rather than throwing a `Standard_Failure` that `handle_occt_exception` could catch.

## Fix

In `boolean_operation`:
- If the first operand is null or has no faces, log a warning and return it (nothing can be built on it).
- Filter out null / face-less tool operands before they reach `unify()` and the OCCT builder.

When filtering removes every tool operand, the pre-existing `b.Extent() == 0` guard ("No other operands remaining, using first operand", GEO 132) returns the first operand, exactly as it already does when the subtraction-elimination passes empty the list. So this reuses established behavior and does not change the result of any boolean with valid operands (valid operands carry faces and are kept). Empty operands contribute nothing to a CUT or FUSE.

Also hardens the `a = b.First()` union path in `boolean_result.cpp` against an empty operand list.

## Verification

Root cause reasoned from the operand chain and the OCCT call path; not runtime-verified, as there is no local kernel build and the exact crashing OCCT frame needs a debugger. The change is defensive and routes degenerate operands into an existing, tested code path, so valid geometry is unaffected. Compilation is covered by CI's `build-ifcopenshell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)