### PR TITLE
ifcgeom: bounding-box broad-phase for the wire self-intersection check (#5999)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/wire_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/wire_utils.cpp
@@ -420,6 +420,19 @@ bool IfcGeom::util::wire_intersections(const TopoDS_Wire& wire, NCollection_List
 
 	bool intersected = false;
 
+	// Precompute a bounding box per edge (enlarged by the intersection tolerance)
+	// so the expensive GeomAPI_ExtremaCurveCurve test below can be skipped for edge
+	// pairs whose extents do not come close to overlapping. On advanced b-rep models
+	// (see issue #5999) the exhaustive O(n^2) extrema computation over curved edges
+	// dominates runtime; this broad-phase prune mirrors the box filtering already
+	// used for the n > 64 tree path and does not change the set of reported
+	// intersections (disjoint boxes cannot contain a qualifying crossing).
+	std::vector<Bnd_Box> edge_boxes(n);
+	for (int e = 0; e < n; ++e) {
+		BRepBndLib::Add(wd->Edge(e + 1), edge_boxes[e]);
+		edge_boxes[e].Enlarge(eps);
+	}
+
 	// tfk: Extrema on infinite curves proved to be more robust.
 	// TopoDS_Face face = BRepBuilderAPI_MakeFace(wire, true).Face();
 	// ShapeAnalysis_Wire saw(wd, face, getValue(GV_PRECISION));
@@ -451,6 +464,13 @@ bool IfcGeom::util::wire_intersections(const TopoDS_Wire& wire, NCollection_List
 
 			// Only check non-consecutive edges
 			if (i == n - 1 && j == 0) continue;
+
+			// Broad-phase prune: if the edge extents (already padded by eps) are
+			// disjoint the curves cannot yield a qualifying intersection, so skip
+			// the costly extrema computation.
+			if (edge_boxes[i].IsOut(edge_boxes[j])) {
+				continue;
+			}
 
 			double u11, u12, u21, u22, U1, U2;
 			GeomAPI_ExtremaCurveCurve ecc(


### PR DESCRIPTION
Fixes #5999.

## Problem

On advanced b-rep / DTV models, importing is slow, bisected to the reintroduction of the wire self-intersection check. In `wire_intersections()`, wires with `n <= 64` edges run an exhaustive O(n^2) inner loop, and each pair constructs a `GeomAPI_ExtremaCurveCurve` over the underlying (often NURBS) curves. That extrema computation dominates. The `n > 64` path already prunes with a bounding-box broad-phase via the spatial tree; the small-n path had no broad-phase at all.

## Fix

Precompute one `Bnd_Box` per edge, enlarged by the intersection tolerance `eps` (the same padding the tree path uses), and `continue` before the extrema construction when two edges' padded boxes are disjoint (`IsOut`). Disjoint eps-padded boxes cannot contain a qualifying crossing, so the set of detected self-intersections is identical; only the cost of the far-apart pairs is removed.

## Verification

Correctness mirrors the already-accepted box filtering of the `n > 64` branch. `Bnd_Box` and `BRepBndLib` are already used in this file, so no new includes. Not perf/build-tested (no local kernel build); compilation is covered by CI's `build-ifcopenshell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)