### PR TITLE
ifcgeom: fix IfcSurfaceCurveSweptAreaSolid misplaced far from origin (#4848)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/sweep_along_curve.cpp
+++ b/src/ifcgeom/kernels/opencascade/sweep_along_curve.cpp
@@ -128,7 +128,12 @@ bool OpenCascadeKernel::convert(const taxonomy::sweep_along_curve::ptr scs, Topo
         }
     }
 	
-	auto w = convert_curve(scs->curve);
+	// Build the wire from curve, which is the directrix offset toward the origin
+	// when applied_temporary_offset is set. Using scs->curve here left the wire
+	// far from the origin yet still translated the result back by +mean, which
+	// misplaced sweeps far from the origin (#4848). When no offset is applied
+	// curve aliases scs->curve, so near-origin geometry is unaffected.
+	auto w = convert_curve(curve);
 	if (w.which() != 2) {
 		Logger::Root().Error("UNS", 9, "Unsupported directrix");
 		return false;


### PR DESCRIPTION
Fixes #4848.

## Problem

`IfcSurfaceCurveSweptAreaSolid` geometry regressed in 0.8: on georeferenced models, swept solids that sit far from the origin (parapets, etc.) go missing or are visibly misplaced. Models near the local origin are fine, which is why it reads as an intermittent regression (0.7 had no offset logic at all).

## Cause

`sweep_along_curve.cpp` offsets the directrix toward the origin when it is far away, to keep OCCT numerically stable:

```cpp
auto curve = scs->curve;
...
if (mean.norm() > 1.e2) {
    curve = ...clone with points shifted by -mean;
    applied_temporary_offset = true;
}
...
auto w = convert_curve(scs->curve);   // <- builds the wire from the ORIGINAL
...
if (applied_temporary_offset) {
    result.Move(+mean);               // but still translates the result back
}
```

The wire was built from `scs->curve` (the un-offset original) rather than the offset `curve`. So the offset never took effect, and the finished solid was translated by `+mean` away from its correct position.

## Fix

Build the wire from `curve`. When no offset is applied, `curve` aliases `scs->curve`, so near-origin geometry is byte-for-byte unchanged; only the far-from-origin path (currently broken) is corrected, and it now also gets the intended numerical benefit of sweeping near the origin.

## Verification

Root cause confirmed by reading: the offset `curve`, the `applied_temporary_offset` flag, and the `+mean` translate-back all line up, and line 131 was the one place still using the original. Not runtime-tested (no local kernel build); compilation is covered by CI's `build-ifcopenshell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)