### PR TITLE
ifcgeom: guard IfcGeom::serialise against null OCCT handles (#4926)

### DIFF
--- a/src/ifcgeom/Serialization/schema/Serialization.cpp
+++ b/src/ifcgeom/Serialization/schema/Serialization.cpp
@@ -111,6 +111,12 @@ namespace {
 
 template <>
 int convert_to_ifc(const opencascade::handle<Geom_Curve>& c, IfcSchema::IfcCurve*& curve, bool advanced) {
+	// Guard against a null curve handle. BRep_Tool::Curve() returns a null handle for
+	// edges without a 3D curve (e.g. the degenerate pole edges of a sphere), and
+	// dereferencing it via ->DynamicType() below would crash. See #4926.
+	if (c.IsNull()) {
+		return 0;
+	}
 	if (c->DynamicType() == STANDARD_TYPE(Geom_TrimmedCurve)) {
         opencascade::handle<Geom_TrimmedCurve> trim = opencascade::handle<Geom_TrimmedCurve>::DownCast(c);
 		const opencascade::handle<Geom_Curve> basis = trim->BasisCurve();
@@ -279,6 +285,10 @@ int convert_to_ifc(const opencascade::handle<Geom_Curve>& c, IfcSchema::IfcCurve
 
 template <>
 int convert_to_ifc(const opencascade::handle<Geom_Surface>& s, IfcSchema::IfcSurface*& surface, bool advanced) {
+	// Guard against a null surface handle before dereferencing via ->DynamicType(). See #4926.
+	if (s.IsNull()) {
+		return 0;
+	}
 	if (s->DynamicType() == STANDARD_TYPE(Geom_Plane)) {
 		opencascade::handle<Geom_Plane> plane = opencascade::handle<Geom_Plane>::DownCast(s);
 		IfcSchema::IfcAxis2Placement3D* place;
@@ -527,6 +537,12 @@ int convert_to_ifc(const TopoDS_Wire& wire, IfcSchema::IfcLoop*& loop, bool adva
 template <>
 int convert_to_ifc(const TopoDS_Face& f, IfcSchema::IfcFace*& face, bool advanced) {
 	opencascade::handle<Geom_Surface> surf = BRep_Tool::Surface(f);
+	// A face may lack an underlying geometric surface (e.g. a purely triangulated face),
+	// in which case BRep_Tool::Surface() returns a null handle. Skip it gracefully rather
+	// than crashing on the surf->DynamicType() dereference further down. See #4926.
+	if (surf.IsNull()) {
+		return 0;
+	}
 	TopExp_Explorer exp(f, TopAbs_WIRE);
 	IfcSchema::IfcFaceBound::list::ptr bounds(new IfcSchema::IfcFaceBound::list);
 	int index = 0;


### PR DESCRIPTION
Addresses #4926.

## Problem

`IfcGeom::serialise()` (raw TopoDS to `IfcProductDefinitionShape`) could crash when serialising curved shapes (sphere, cylinder). Three converters in `Serialization.cpp` dereference OCCT handles via `->DynamicType()` without checking for null:

- `convert_to_ifc(Geom_Curve)` — `BRep_Tool::Curve()` returns a null handle for edges with no 3D curve (for example the degenerate pole edges of a sphere).
- `convert_to_ifc(Geom_Surface)` — no null check before `s->DynamicType()`.
- `convert_to_ifc(TopoDS_Face)` — `BRep_Tool::Surface(f)` returns null for a face with no underlying geometric surface (a purely triangulated face), then `surf->DynamicType()` dereferences it.

## Fix

Add `IsNull()` early returns at each of the three sites, skipping the curve/surface/face gracefully (return 0), the same way `serialise` already handles unsupported geometry. These are pure additive null checks, so shapes that serialise correctly today are unaffected.

## Verification and honesty note

The current tree already has partial `IsNull()` guards at the wire/edge level (added after this issue was filed), and I could not force a hard crash on the prebuilt 0.8.6 wheel (a cylinder fails earlier at the mapping stage with a graceful error, and a sphere serialises to a null result), so I could not binary-reproduce the reporter's original segfault. These three guards close the remaining unguarded `->DynamicType()` derefs on exactly the path the issue names. Not runtime-verified against a local kernel build; compilation is covered by CI's `build-ifcopenshell`. Framed as hardening rather than a claimed fix; maintainers can confirm against the original file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)