### PR TITLE
ifcparse: strip XML-illegal control characters in escape_xml (#2043, #3074)

### DIFF
--- a/src/ifcparse/IfcUtil.cpp
+++ b/src/ifcparse/IfcUtil.cpp
@@ -187,6 +187,15 @@ void IfcUtil::sanitate_material_name(std::string& str) {
 }
 
 void IfcUtil::escape_xml(std::string& str) {
+    // Strip characters that are illegal in XML 1.0. Control characters other
+    // than tab (0x09), newline (0x0A) and carriage return (0x0D) are not valid
+    // XML 1.0 characters and cannot even be represented as numeric character
+    // references, so they would otherwise make the serialized XML/SVG output
+    // non-well-formed. Bytes belonging to a valid UTF-8 multibyte sequence are
+    // always >= 0x80, so filtering on the low control range leaves them intact.
+    str.erase(std::remove_if(str.begin(), str.end(), [](unsigned char c) {
+        return c < 0x20 && c != '\t' && c != '\n' && c != '\r';
+    }), str.end());
     boost::replace_all(str, "&", "&amp;");
     boost::replace_all(str, "\"", "&quot;");
     boost::replace_all(str, "'", "&apos;");


### PR DESCRIPTION
Fixes #2043. Fixes #3074.

## Problem

An IFC string containing control characters (for example an embedded `0x0B` or `0x07`) produced non-well-formed XML and SVG output, so downstream parsers rejected the file.

`IfcUtil::escape_xml` escaped the five XML metacharacters (`& " ' < >`) but let control bytes `0x00` to `0x1F` (other than tab, newline and carriage return) pass through verbatim. Those characters are illegal in XML 1.0 and cannot be represented even as numeric character references, so there is no way to keep them and stay well-formed.

## Fix

Strip the XML-1.0-illegal control characters before escaping. Bytes belonging to a valid UTF-8 multibyte sequence are always `>= 0x80`, so filtering the low control range never touches real (including non-ASCII) text. Tab, newline and carriage return are preserved.

This is the single shared helper: an audit of the SVG serializer confirmed every text-content and attribute site already routes user-derived strings through `escape_xml` (`:1381, :1555, :1673, :1965, :2173, :2287, :2317`), with the only unescaped writes being numeric coordinates and static markup. So both the XML report (#2043) and the SVG report (#3074) are resolved here. The Collada serializer uses the same helper and benefits too.

## Verification

Logic verified with a standalone check: `A\x0B\x07B\x00\t\n é C` drops `0B/07/00`, keeps tab and newline, and preserves the two-byte UTF-8 `é`. Not build-tested locally (no kernel build); compilation is covered by CI's `build-ifcopenshell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)