### PR TITLE
ifcgeom: cap wire_intersections recursion to prevent a stack overflow (#622)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/wire_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/wire_utils.cpp
@@ -379,6 +379,30 @@ namespace {
 }
 
 bool IfcGeom::util::wire_intersections(const TopoDS_Wire& wire, NCollection_List<TopoDS_Shape>& wires, const wire_tolerance_settings& settings) {
+	// #622: this function recurses once for every self-intersection loop that it
+	// splits off (see the self-call further down). On a degenerate or pathological
+	// boundary that recursion can run unbounded and overflow the stack. Cap the
+	// depth with a thread_local counter (thread_local because the geometry iterator
+	// may run several kernels concurrently) and bail out gracefully once the cap is
+	// reached, appending the wire unmodified instead of crashing. The RAII guard
+	// keeps the counter correct across every return path, including the throw below.
+	static thread_local int recursion_depth = 0;
+	struct recursion_guard {
+		int& depth;
+		recursion_guard(int& d) : depth(d) { ++depth; }
+		~recursion_guard() { --depth; }
+	} guard(recursion_depth);
+
+	// A single legitimate boundary only needs a handful of splits; the original
+	// report overflowed around the 80th nested call, so a cap well below that keeps
+	// valid input working while preventing the crash.
+	static const int max_recursion_depth = 32;
+	if (recursion_depth > max_recursion_depth) {
+		Logger::Root().Warning("GEO", 328, "Wire intersection resolution exceeded maximum recursion depth; leaving boundary unmodified");
+		wires.Append(wire);
+		return false;
+	}
+
 	double eps = get_wire_intersection_tolerance(settings, wire);
 	double eps_real = settings.precision;
 	


### PR DESCRIPTION
Fixes #622.

## Problem

`wire_intersections()` recurses once for every self-intersection loop it splits off. On a degenerate or self-intersecting boundary that recursion is unbounded and overflows the stack, crashing the process (the reporter hit it around the 80th nested frame on `SampleHouse.ifc`).

## Fix

Add a `thread_local` recursion-depth counter with an RAII guard at the top of the function. Once the depth exceeds 32 it logs a `GEO 328` warning and bails out gracefully by appending the wire unmodified and returning `false`, the same fallback the function already uses for non-closed and `n < 3` wires.

- `thread_local` because the geometry iterator can run several OCCT kernels concurrently, so a shared counter would be wrong.
- The RAII guard keeps the counter correct across every return path, including the existing `throw geometry_exception`.
- No signature or ABI change, so the bounding-box broad-phase added for #5999 later in the same function is untouched.

The cap of 32 sits well below the observed ~80-frame overflow while leaving ample headroom for legitimate multi-loop boundaries.

## Verification

Reasoned against the self-recursive call site and the existing fallback pattern; `Logger::Root().Warning` and the `wires.Append(wire)` fallback both mirror existing usage in this file. Not runtime-tested (no local kernel build); compilation is covered by CI's `build-ifcopenshell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)