### PR TITLE
serializers: glTF baseColorFactor should be the surface colour, not diffuse*factor (#2509)

### DIFF
--- a/src/serializers/GltfSerializer.cpp
+++ b/src/serializers/GltfSerializer.cpp
@@ -99,9 +99,15 @@ int GltfSerializer::writeMaterial(const ifcopenshell::geometry::taxonomy::style:
 
 	std::array<double, 4> base;
 	base.fill(1.0);
-	if (style->get_color()) {
+	// glTF's baseColorFactor is the base/albedo colour. IfcSurfaceStyleRendering's
+	// DiffuseColour is a reflectance factor that the mapping pre-multiplies into the
+	// diffuse colour (surface * factor); baking that product into baseColorFactor
+	// darkens the model compared to what PBR viewers show (#2509). Prefer the pure
+	// SurfaceColour as the albedo, falling back to the diffuse colour when absent.
+	const auto& base_color = style->surface ? style->surface : style->get_color();
+	if (base_color) {
 		for (int i = 0; i < 3; ++i) {
-			base[i] = style->get_color().ccomponents()(i);
+			base[i] = base_color.ccomponents()(i);
 		}
 	}
 	if (style->transparency == style->transparency) {


### PR DESCRIPTION
Fixes #2509.

## Problem

glb output is noticeably darker than every PBR viewer shows when an `IfcSurfaceStyleRendering` sets a `DiffuseColour`.

`GltfSerializer::writeMaterial` took `baseColorFactor` from `style->get_color()`, which returns the taxonomy `diffuse` colour. The mapping pre-multiplies the IFC SurfaceColour by the DiffuseColour reflectance factor into `diffuse` (`mapping.cpp`), so glTF received `surface * factor`, a darkened albedo.

## Fix

glTF's `baseColorFactor` is the base/albedo colour, and viewers apply their own lighting on top. Use the pure `SurfaceColour` as the albedo, falling back to the diffuse colour when no surface colour is present:

```cpp
const auto& base_color = style->surface ? style->surface : style->get_color();
```

Transparency and specular handling are untouched.

## Verification

Reproduced the issue's style with the current 0.8 mapping: the old path gave `diffuse = (0.381, 0.36, 0.335)` (the dark value reported), while `surface = (0.847, 0.8, 0.745)`. The fix writes `baseColorFactor = [0.847, 0.8, 0.745, 1.0]`, matching other viewers. Not compile-tested locally (no kernel build); the explicit-`operator bool` conditional is standard-legal and CI's `build-ifcopenshell` compile-checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)