### PR TITLE
ifcgeom: emit mtllib in OBJ output so materials are linked (#4846)

### DIFF
--- a/src/ifcgeom/GeometrySerializer.h
+++ b/src/ifcgeom/GeometrySerializer.h
@@ -114,6 +114,7 @@ public:
 
 	stream_or_filename(const std::string& fn)
 		: ofs_(new std::ofstream(IfcUtil::path::from_utf8(fn).c_str()))
+		, filename_(fn)
 		, stream(*ofs_)
 	{}
 


### PR DESCRIPTION
Fixes #4846.

## Problem

Converting to OBJ produces a `.mtl` file with the correct materials, but the `.obj` never references it, so viewers show no materials.

`WavefrontObjSerializer` emits the `mtllib` line only when `mtl_stream.filename()` is set:

```cpp
if (mtl_stream.filename()) {
    std::string mtl_basename = *mtl_stream.filename();
    ...
}
```

But `stream_or_filename`'s filename constructor (`GeometrySerializer.h`) opened the `ofstream` without ever assigning `filename_`, so `filename()` always returned an empty optional. The `mtllib` line was therefore dead code for every file-based OBJ export.

## Fix

Store the filename in the constructor:

```cpp
stream_or_filename(const std::string& fn)
    : ofs_(new std::ofstream(...))
    , filename_(fn)
    , stream(*ofs_)
{}
```

The in-memory (`ostringstream`) constructor still leaves `filename_` empty, and `filename()` is read only by the OBJ serializer's `mtllib` guard, so nothing else changes.

## Verification

Confirmed on the issue sample with the current build: the `.mtl` contained the `newmtl` entry and the `.obj` had `usemtl` but zero `mtllib` lines. The `filename()` accessor is used at exactly one site (the OBJ `mtllib` guard), so this restores the reference with no other behavioral change. Not compile-tested locally; CI's `build-ifcopenshell` compile-checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)