### PR TITLE
serializers: emit a stable id for nested materials in XML (#5109)

### DIFF
--- a/src/serializers/schema_dependent/XmlSerializer.cpp
+++ b/src/serializers/schema_dependent/XmlSerializer.cpp
@@ -822,6 +822,7 @@ void POSTFIX_SCHEMA(XmlSerializer)::finalize() {
 				IfcSchema::IfcMaterialLayer::list::ptr ls = layerset->MaterialLayers();
 				for (IfcSchema::IfcMaterialLayer::list::it jt = ls->begin(); jt != ls->end(); ++jt) {
 					ptree subnode;
+					subnode.put("<xmlattr>.id", qualify_unrooted_instance(*jt));
 					if ((*jt)->Material()) {
 						subnode.put("<xmlattr>.Name", (*jt)->Material()->Name());
 					}
@@ -831,6 +832,7 @@ void POSTFIX_SCHEMA(XmlSerializer)::finalize() {
 				IfcSchema::IfcMaterial::list::ptr mats = mat->as<IfcSchema::IfcMaterialList>()->Materials();
 				for (IfcSchema::IfcMaterial::list::it jt = mats->begin(); jt != mats->end(); ++jt) {
 					ptree subnode;
+					subnode.put("<xmlattr>.id", qualify_unrooted_instance(*jt));
 					format_entity_instance(logger_, mapping_, *jt, subnode, node);
 				}
 			}


### PR DESCRIPTION
Fixes #5109.

## Problem

Converting IFC to XML loses material identity: materials nested inside an `IfcMaterialList`, and the `IfcMaterialLayer`s inside an `IfcMaterialLayerSet`, were emitted with no `id` attribute. Because `IfcMaterial`/`IfcMaterialLayer` are unrooted (no GlobalId), several distinct materials (for example multiple `Metal`/`Wood` entries) came out as indistinguishable duplicate nodes with no way to reference them.

## Fix

The top-level material node already receives a stable id via `qualify_unrooted_instance(mat)`. Apply the same STEP-id-derived scheme to the nested `IfcMaterial` and `IfcMaterialLayer` child nodes (two lines), so each nested material is identifiable and referenceable, consistent with how the serializer already ids unrooted instances and its per-product `xlink:href` links.

## Verification

`qualify_unrooted_instance` is already called in `finalize()` (line 813), so it is in scope and correctly typed, and both iterands are entity instances, so the calls are well-formed. Not runtime-tested (no local build); compilation is covered by CI's `build-ifcopenshell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)