### PR TITLE
ifcgeom: fix inverted normals on mirrored MappedRepresentations (#806)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/OpenCascadeConversionResult.cpp
+++ b/src/ifcgeom/kernels/opencascade/OpenCascadeConversionResult.cpp
@@ -62,6 +62,16 @@ void ifcopenshell::geometry::OpenCascadeShape::Triangulate(ifcopenshell::geometr
 			m(2, 0), m(2, 1), m(2, 2)
 		);
 	}
+
+	// A mirror (negative determinant) placement reverses the handedness of the
+	// transformed vertex coordinates. The explicit vertex normals below are
+	// rotated by this same 3x3 and therefore stay outward, but the emitted
+	// triangle winding is derived purely from the topological face orientation
+	// and does not know about the mirror. After a mirror the winding would end
+	// up wound opposite to the (correct) normals, which consumers that shade
+	// from winding see as inverted normals (see #806). Reverse the winding in
+	// that case so winding and normals remain consistent.
+	const bool flip_winding = rotation_matrix && rotation_matrix->Determinant() < 0;
 	
 	// When welding vertices, vertex coords will be shared among faces so we need to per-shape set
 	// to keep track of which edges were already emitted.
@@ -171,6 +181,10 @@ void ifcopenshell::geometry::OpenCascadeShape::Triangulate(ifcopenshell::geometr
 				if (face.Orientation() == TopAbs_REVERSED)
 					triangles(i).Get(n3, n2, n1);
 				else triangles(i).Get(n1, n2, n3);
+
+				if (flip_winding) {
+					std::swap(n1, n3);
+				}
 
 				if (dict[n1] == dict[n2] || dict[n2] == dict[n3] || dict[n3] == dict[n1]) {
 					logger.Warning("GEO", 185, "Mesher generated a degenerate triangle, ignoring");


### PR DESCRIPTION
Fixes #806.

## Problem

An element placed through a MappedRepresentation with a mirror (negative-determinant) transform renders with inverted normals (the reporter's case is a toilet mirrored via a `MappedRepresentation` of a SurfaceModel). It shows as back-faces only in viewers and in IfcConvert to `.dae`.

## Cause

In `OpenCascadeConversionResult.cpp::Triangulate`:
- vertices are transformed by the full 4x4 (correctly mirrored),
- explicit vertex normals are rotated by the same mirror-inclusive 3x3 (correctly outward),
- but the emitted triangle **winding** is taken purely from the topological `face.Orientation()` and never consults the transform determinant.

A mirror reverses coordinate handedness, so after mirroring the vertices the emitted index order describes the opposite winding while the normals stay outward. The two disagree, and consumers that shade from winding see inverted normals.

## Fix

Compute `flip_winding = rotation_matrix && rotation_matrix->Determinant() < 0` once, and at the single triangle-emission point reverse the winding (`std::swap(n1, n3)`) when set, leaving the explicit normals untouched. Gated strictly on `det < 0`, so positive-determinant (non-mirrored) placements are byte-for-byte unchanged.

The CGAL kernel derives normals from the post-transform geometry, so its winding and normals are already consistent; it is intentionally left unchanged (applying the same flip there would introduce the inconsistency).

## Verification

Reproduced live on the bundled 0.8.6 build with a minimal IFC4 file (an `IfcExtrudedAreaSolid` in an `IfcRepresentationMap`, referenced by an `IfcMappedItem` whose `MappingTarget` mirrors X): with an identity target 12/12 triangles agree winding vs normals, with the mirrored target 0/12 agree (12/12 disagree), matching #806. The patched binary is not runtime-tested (no local kernel build); the fix targets exactly the reproduced disagreement, and CI's `build-ifcopenshell` compile-checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)