### PR TITLE
ifcgeom: honour PnIndex in IfcTriangulatedFaceSet and IfcPolygonalFaceSet (#3434)

### DIFF
--- a/src/ifcgeom/mapping/IfcPolygonalFaceSet.cpp
+++ b/src/ifcgeom/mapping/IfcPolygonalFaceSet.cpp
@@ -39,8 +39,25 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcPolygonalFaceSet* inst) {
 
 	int max_index = (int)points.size();
 
+	// When the optional PnIndex is present, CoordIndex values do not index into
+	// CoordList directly but into PnIndex, which in turn remaps to CoordList.
+	// Both index levels are 1-based per the IFC specification.
+	auto pn_index = inst->PnIndex();
+	auto resolve = [&](int idx) -> const taxonomy::point3::ptr& {
+		if (pn_index) {
+			if (idx < 1 || idx > (int)pn_index->size()) {
+				throw IfcParse::IfcException("IfcPolygonalFaceSet PnIndex out of bounds for index " + boost::lexical_cast<std::string>(idx));
+			}
+			idx = (*pn_index)[idx - 1];
+		}
+		if (idx < 1 || idx > max_index) {
+			throw IfcParse::IfcException("IfcPolygonalFaceSet index out of bounds for index " + boost::lexical_cast<std::string>(idx));
+		}
+		return points[idx - 1];
+	};
+
 	auto shell = taxonomy::make<taxonomy::shell>();
-	
+
 	for (auto& f : *polygonal_faces) {
 		auto fa = taxonomy::make<taxonomy::face>();
 		shell->children.push_back(fa);
@@ -52,17 +69,14 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcPolygonalFaceSet* inst) {
 			auto indices = f->CoordIndex();
 			taxonomy::point3::ptr previous;
 			for (std::vector<int>::const_iterator jt = indices.begin(); jt != indices.end(); ++jt) {
-				if (*jt < 1 || *jt > max_index) {
-					throw IfcParse::IfcException("IfcPolygonalFaceSet index out of bounds for index " + boost::lexical_cast<std::string>(*jt));
-				}
-				auto current = points[(*jt) - 1];
+				auto current = resolve(*jt);
 				if (jt != indices.begin()) {
 					loop->children.push_back(taxonomy::make<taxonomy::edge>(previous, current));
 				}
 				previous = current;
 			}
 			if (!indices.empty()) {
-				auto current = points[indices.front() - 1];
+				auto current = resolve(indices.front());
 				loop->children.push_back(taxonomy::make<taxonomy::edge>(previous, current));
 			}
 		}
@@ -77,17 +91,14 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcPolygonalFaceSet* inst) {
 					loop->external = false;
 
 					for (std::vector<int>::const_iterator jt = li.begin(); jt != li.end(); ++jt) {
-						if (*jt < 1 || *jt > max_index) {
-							throw IfcParse::IfcException("IfcPolygonalFaceSet index out of bounds for index " + boost::lexical_cast<std::string>(*jt));
-						}
-						auto current = points[(*jt) - 1];
+						auto current = resolve(*jt);
 						if (jt != li.begin()) {
 							loop->children.push_back(taxonomy::make<taxonomy::edge>(previous, current));
 						}
 						previous = current;
 					}
 					if (!li.empty()) {
-						auto current = points[li.front() - 1];
+						auto current = resolve(li.front());
 						loop->children.push_back(taxonomy::make<taxonomy::edge>(previous, current));
 					}
 				}

--- a/src/ifcgeom/mapping/IfcTriangulatedFaceSet.cpp
+++ b/src/ifcgeom/mapping/IfcTriangulatedFaceSet.cpp
@@ -39,6 +39,23 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcTriangulatedFaceSet* inst) {
 
 	int max_index = (int)points.size();
 
+	// When the optional PnIndex is present, CoordIndex values do not index into
+	// CoordList directly but into PnIndex, which in turn remaps to CoordList.
+	// Both index levels are 1-based per the IFC specification.
+	auto pn_index = inst->PnIndex();
+	auto resolve = [&](int idx) -> const taxonomy::point3::ptr& {
+		if (pn_index) {
+			if (idx < 1 || idx > (int)pn_index->size()) {
+				throw IfcParse::IfcException("IfcTriangulatedFaceSet PnIndex out of bounds for index " + boost::lexical_cast<std::string>(idx));
+			}
+			idx = (*pn_index)[idx - 1];
+		}
+		if (idx < 1 || idx > max_index) {
+			throw IfcParse::IfcException("IfcTriangulatedFaceSet index out of bounds for index " + boost::lexical_cast<std::string>(idx));
+		}
+		return points[idx - 1];
+	};
+
 	auto shell = taxonomy::make<taxonomy::shell>();
 
 	for (auto& indices : indices_list) {
@@ -51,10 +68,7 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcTriangulatedFaceSet* inst) {
 			loop->external = true;
 			taxonomy::point3::ptr first, previous;
 			for (std::vector<int>::const_iterator jt = indices.begin(); jt != indices.end(); ++jt) {
-				if (*jt < 1 || *jt > max_index) {
-					throw IfcParse::IfcException("IfcTriangulatedFaceSet index out of bounds for index " + boost::lexical_cast<std::string>(*jt));
-				}
-				const taxonomy::point3::ptr& current = points[(*jt) - 1];
+				const taxonomy::point3::ptr& current = resolve(*jt);
 				if (jt == indices.begin()) {
 					first = current;
 				} else {


### PR DESCRIPTION
Fixes #3434.

## Problem

`IfcTriangulatedFaceSet` and `IfcPolygonalFaceSet` used `CoordIndex` values to index `Coordinates.CoordList` directly, ignoring the optional `PnIndex` attribute. Per the IFC spec, when `PnIndex` is present it remaps point references, so a `CoordIndex` value `i` must resolve as `CoordList[PnIndex[i-1]-1]` (both levels 1-based). Any model carrying a `PnIndex` therefore rendered from the wrong points.

## Fix

Add a `resolve(idx)` helper in both mappings that, when `PnIndex` is present, remaps the index through it (with its own bounds check) before indexing the point list, then applies the existing bounds check. All lookup sites (triangulated loop; polygonal outer loop and its closing edge; the void inner loops and their closing edges) route through it. When `PnIndex` is absent, `resolve` is the original bounds-checked lookup, so behavior is unchanged.

## Verification

Reproduced live on the shipped 0.8.6 build: a 4-point `IfcTriangulatedFaceSet` with `PnIndex = [4,2,3,1]` and `CoordIndex = [(1,2,3)]` produced `{(0,0,0),(1,0,0),(1,1,0)}` instead of the correct `{(5,5,5),(1,0,0),(1,1,0)}`, confirming `PnIndex` was ignored. The patched binary is not runtime-tested (no local kernel build); the no-PnIndex path is provably unchanged, and CI's `build-ifcopenshell` compile-checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)