### PR TITLE
serializers: SVG cut plane from storey global placement, not Elevation attribute (#1231)

### DIFF
--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -389,6 +389,24 @@ namespace {
 	boost::optional<std::pair<const IfcUtil::IfcBaseEntity*, double>> storey_elevation_from_element(const IfcGeom::BRepElement* o) {
 		for (const auto& p : o->parents()) {
 			if (p->type() == "IfcBuildingStorey") {
+				// Prefer the storey's globally-resolved placement Z over the
+				// Elevation attribute. The Elevation attribute is measured from
+				// the storey's own local placement origin and therefore ignores
+				// any Z-offset contributed by ancestor placements (e.g. a site
+				// or building elevation). The section cut plane has to live in
+				// the same global frame as the transformed element geometry, so
+				// using the Elevation attribute alone places the cut plane at the
+				// wrong height and the element gets culled ("Element not written
+				// to SVG due to section heights", see #1231/#4828). The parent
+				// storey's transformation matrix is produced by the same mapping
+				// that positions the geometry, so its translation is unit- and
+				// frame-consistent with the element compound.
+				const auto& m = p->transformation().data();
+				if (m) {
+					double storey_elevation = m->ccomponents()(2, 3);
+					return std::make_pair(p->product(), storey_elevation);
+				}
+				// Fallback: legacy behaviour based on the Elevation attribute.
 				try {
 					double e = p->product()->get("Elevation");
 					double storey_elevation = e * o->geometry().settings().get<ifcopenshell::geometry::settings::LengthUnit>().get();


### PR DESCRIPTION
Fixes #1231.

## Problem

Elements are dropped from SVG plan output with "Element not written to SVG due to section heights", and whole top-storey `<g>` groups go missing (#4828).

`storey_elevation_from_element()` derives the per-element floor-plan cut plane from the `IfcBuildingStorey` `Elevation` attribute. That attribute is relative to the storey's own local placement origin and ignores any Z contributed by **ancestor** placements (for example a site or building elevation). The element geometry, however, is transformed by the fully resolved global placement. When an ancestor adds a Z offset, the cut plane (`storey_elevation + 1.0`) lands nowhere near the geometry, the straddle test `zmin > cut_z || zmax < cut_z` skips every subshape, and the element is culled.

Traced on `wall.ifc`: storey `Elevation = 10.64`, but its placement resolves through a site at `Z = 165`, so the storey origin and the wall sit near `175.64`; the old cut at `11.64` misses entirely.

## Fix

Take the storey elevation from the storey's globally resolved placement matrix translation Z, produced by the same mapping that positions the element geometry, so the cut plane and the geometry share a frame. For models with no ancestor Z offset the placement Z equals `Elevation * lengthunit`, so behavior is unchanged; the Elevation attribute is kept as a fallback when the placement matrix is unavailable.

## Verification

`#1231` traced at file level to the ancestor-Z mismatch and the fix restores the correct cut height. The common (site at Z=0) case is unchanged, so only currently mis-culled elements are affected. Not runtime-tested (no local kernel build); CI's `build-ifcopenshell` compile-checks it.

This very likely also resolves **#4828** (same per-element code path, no section-height flag in play), but I could not re-fetch that model to confirm, so I am not auto-closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)