### PR TITLE
ifcgeom: fix inverted normals for indirect curved surfaces in IfcGeom::serialise (#5067)

### DIFF
--- a/src/ifcgeom/Serialization/schema/Serialization.cpp
+++ b/src/ifcgeom/Serialization/schema/Serialization.cpp
@@ -6,6 +6,7 @@
 #include <Geom_Plane.hxx>
 #include <Geom_BSplineSurface.hxx>
 #include <Geom_CylindricalSurface.hxx>
+#include <Geom_ElementarySurface.hxx>
 
 #include <BRepTools_WireExplorer.hxx>
 
@@ -559,7 +560,20 @@ int convert_to_ifc(const TopoDS_Face& f, IfcSchema::IfcFace*& face, bool advance
 		if (!convert_to_ifc(surf, surface, advanced)) {
 			return 0;
 		}
-		face = new IfcSchema::IfcAdvancedFace(bounds, surface, f.Orientation() == TopAbs_FORWARD);
+		// The emitted IFC surface placement is an IfcAxis2Placement3D, which is
+		// inherently right-handed (like gp_Ax2). For an elementary surface whose
+		// underlying gp_Ax3 is indirect (left-handed) the Ax3 -> Ax2 conversion
+		// performed in the surface converter silently flips the surface normal
+		// sense (radial for cylinder/cone/sphere, axial for plane). The face
+		// SameSense flag is derived from the original TopoDS orientation, so it
+		// must be inverted to keep agreeing with the emitted surface normal,
+		// otherwise round-tripped curved faces (e.g. cylinders) come out inverted. See #5067.
+		bool same_sense = f.Orientation() == TopAbs_FORWARD;
+		opencascade::handle<Geom_ElementarySurface> elem = opencascade::handle<Geom_ElementarySurface>::DownCast(surf);
+		if (!elem.IsNull() && !elem->Position().Direct()) {
+			same_sense = !same_sense;
+		}
+		face = new IfcSchema::IfcAdvancedFace(bounds, surface, same_sense);
 		return 1;
 #else
 		// No IfcAdvancedFace in Ifc2x3


### PR DESCRIPTION
Fixes #5067.

## Problem

Round-tripping a shape through `IfcGeom::serialise` produces back-faces only for curved (cylindrical / conical / spherical) faces: their normals come out inverted.

The `IfcAdvancedFace` `SameSense` flag is already derived from the TopoDS face orientation, so that is not the defect. The real cause is in the surface converter: it maps the OCCT surface `gp_Ax3` to an IFC `IfcAxis2Placement3D` via `gp_Ax2`, which is inherently right-handed and silently discards the direct/indirect handedness. For a surface whose normal is handedness-dependent (radial for cylinder/cone/sphere, axial for plane), an indirect (left-handed) placement is emitted with an inverted normal, so `SameSense` no longer agrees with the emitted surface.

## Fix

After building the surface, when the underlying `Geom_ElementarySurface` placement is indirect (`Position().Direct() == false`), invert `SameSense` to compensate. The common direct case and non-elementary surfaces (BSpline) are untouched, so only the currently inverted indirect case changes.

## Verification

This is analytically derived, not runtime-verified: `serialise` lives in the compiled kernel and the available prebuilt binary cannot exercise the patched behavior, and constructing an indirect-axis cylinder face to demonstrate even the pre-patch inversion needs low-level OCCT `gp_Ax3` construction not reachable from the Python bindings. The change is strictly gated on an indirect elementary-surface placement, so it cannot affect the common right-handed output. `Geom_ElementarySurface::Position()` and `gp_Ax3::Direct()` are present in the OCCT headers, and CI's `build-ifcopenshell` compile-checks it. Flagged for a maintainer with a build to confirm the round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)