### PR TITLE
serializers: SVG bounding box should follow the drawn arc, not the full circle (#2629)

### DIFF
--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -290,9 +290,29 @@ void SvgSerializer::write(path_object& p, const TopoDS_Shape& comp_or_wire, boos
 					center = ellipse->Location();
 				}
 
-				// Make sure the arc segment is entirely inside bounding box:
-				growBoundingBox(center.X() - r1, center.Y() - r1);
-				growBoundingBox(center.X() + r1, center.Y() + r1);
+				// Make sure the arc segment is entirely inside bounding box.
+				if (closed) {
+					// A full circle/ellipse: the whole conic is drawn, so grow the
+					// bounding box by its full extent.
+					growBoundingBox(center.X() - r1, center.Y() - r1);
+					growBoundingBox(center.X() + r1, center.Y() + r1);
+				} else {
+					// Only an arc segment is drawn. Growing the bounding box by the
+					// full circle (center +/- radius) massively over-counts for
+					// large-radius arcs (e.g. a curved wall with a big radius),
+					// blowing up the drawing extents and collapsing the global
+					// scale so the whole drawing shrinks (issue #2629). Instead grow
+					// by the actually drawn arc: the endpoints are already accounted
+					// for above, so here we sample the interior to catch any axis
+					// extrema that fall between the endpoints.
+					const int arc_bbox_samples = 32;
+					for (int si = 1; si < arc_bbox_samples; ++si) {
+						const double u = u1 + (u2 - u1) * (static_cast<double>(si) / arc_bbox_samples);
+						gp_Pnt pu;
+						curve->D0(u, pu);
+						growBoundingBox(pu.X(), pu.Y());
+					}
+				}
 
 				// Calculate the angle between 2d vecs to have signed result
 				const gp_Dir& d = conic->Position().XDirection();


### PR DESCRIPTION
Fixes #2629.

## Problem

An SVG plan containing a large-radius curved wall comes out shrunk and distorted: the whole drawing collapses to a tiny area.

In `SvgSerializer::write`, the arc-segment branch grew the drawing bounding box by the full circle/ellipse extent (`center +/- radius`) for every conic edge, regardless of how small the actually drawn arc is. A curved wall with a large radius draws only a small arc but expanded the extents to the entire circle, so `growBoundingBox` blew up the global bounds and the auto-computed scale shrank everything.

## Fix

Use the full-extent growth only for genuinely closed conics (a real full circle/ellipse). For an arc segment, grow the bounding box by the drawn arc alone: the endpoints are already added, so sample 32 interior points via `curve->D0` to catch any axis extrema between the endpoints. Straight lines and small arcs are unaffected in practice; only the unused portion of a large arc stops being counted.

## Verification

Logic verified by reading: `curve`, `u1`, `u2`, `closed`, `center` are all in scope, and `curve->D0` is the same API already used for the endpoints. Worst-case interior under-sampling is `r*(1 - cos(sweep/64))`, negligible and always far better than the current over-count. Not runtime-tested (no local kernel build); CI's `build-ifcopenshell` compile-checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)