### PR TITLE
serializers: section-height-from-storeys should use global placement Z (#2638)

### DIFF
--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -2379,6 +2379,7 @@ void SvgSerializer::setSectionHeightsFromStoreys(double offset) {
 	auto storeys = file->instances_by_type("IfcBuildingStorey");
 	const double lu = file->getUnit("LENGTHUNIT").second;
 	if (storeys && storeys->size() > 0) {
+		auto mapping = ifcopenshell::geometry::impl::mapping_implementations().construct(file, geometry_settings_, logger_);
 		for (auto& s : *storeys) {
 			auto attr_value = ((IfcUtil::IfcBaseEntity*)s)->get("Elevation");
 			if (!attr_value.isNull()) {
@@ -2389,12 +2390,34 @@ void SvgSerializer::setSectionHeightsFromStoreys(double offset) {
 					logger_.Error("SER", 33, e);
 					continue;
 				}
-				if (!section_data_->empty()) {
-					boost::get<horizontal_plan>(section_data_->back()).next_elevation = elev * lu;
+				// The Elevation attribute is measured from the storey's own local
+				// placement origin and ignores any Z contributed by ancestor
+				// placements (e.g. a site or building elevation). The section cut
+				// planes must live in the same global frame as the transformed
+				// element geometry, otherwise every element of the storey fails the
+				// straddle test and is culled ("Element not written to SVG due to
+				// section heights", see #2638/#1231). Prefer the storey's globally
+				// resolved placement Z, produced by the same mapping that positions
+				// the geometry; fall back to Elevation * lengthunit if unavailable.
+				double elev_global = elev * lu;
+				auto placement = ((IfcUtil::IfcBaseEntity*)s)->get("ObjectPlacement");
+				if (mapping && !placement.isNull()) {
+					auto item = mapping->map(placement);
+					auto matrix = ifcopenshell::geometry::taxonomy::cast<ifcopenshell::geometry::taxonomy::matrix4>(item);
+					if (matrix) {
+						elev_global = matrix->translation_part()(2);
+#ifdef TAXONOMY_USE_NAKED_PTR
+						delete matrix;
+#endif
+					}
 				}
-				section_data_->push_back(horizontal_plan{ (IfcUtil::IfcBaseEntity*)s, elev * lu, offset, std::numeric_limits<double>::infinity() });
-			}			
+				if (!section_data_->empty()) {
+					boost::get<horizontal_plan>(section_data_->back()).next_elevation = elev_global;
+				}
+				section_data_->push_back(horizontal_plan{ (IfcUtil::IfcBaseEntity*)s, elev_global, offset, std::numeric_limits<double>::infinity() });
+			}
 		}
+		delete mapping;
 	} else {
 		section_data_->push_back(horizontal_plan_at_element{});
 	}


### PR DESCRIPTION
Fixes #2638.

## Problem

With `--section-height-from-storeys`, whole floors go missing from the SVG floorplan (every element emits "Element not written to SVG due to section heights").

`setSectionHeightsFromStoreys` builds the per-storey cut planes from the `IfcBuildingStorey.Elevation` attribute (`elev * lengthunit`). That attribute is relative to the storey's own local placement origin and ignores any Z contributed by ancestor placements (a site or building elevation, typical of Revit exports). The element geometry, however, is fully globally placed, so when an ancestor adds a Z offset the cut planes land far from the geometry, the straddle test `zmin > cut_z || zmax < cut_z` skips every subshape, and the whole storey is culled.

## Fix

Take each storey elevation from its globally resolved placement matrix translation Z, produced by the same mapping that positions the geometry, applied to both the pushed elevation and the previous storey's range bound. This mirrors the pattern already used elsewhere in this file (`setSectionHeight` around line 2349). Models with no ancestor Z offset are unchanged, and the Elevation attribute is kept as a fallback.

## Relationship to #1231

This is the same class of bug as #1231 (PR #8471), but a distinct code path: #8471 fixed `storey_elevation_from_element` (the per-element fallback used with no section flag), and did not touch `setSectionHeightsFromStoreys`, which is the path the `--section-height-from-storeys` flag drives. So this is a separate, non-overlapping fix.

## Verification

Reasoned at file level and confirmed the code path and that it reuses the existing `construct` + `translation_part()(2)` pattern in this file. Not runtime-tested (no local kernel build, no sample attached); CI's `build-ifcopenshell` compile-checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)