### PR TITLE
ifcgeom: honour POLYHEDRON triangulation type in the CGAL kernel (#5485)

### DIFF
--- a/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
@@ -382,7 +382,14 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 	}
 
 	const bool setting_use_original_edges = settings.get<ifcopenshell::geometry::settings::CgalEmitOriginalEdges>().get();
-	
+
+	// When a polyhedral triangulation type is requested we do not emit a raw
+	// triangle mesh, but reconstruct planar faces (optionally with holes) from
+	// the coplanar triangle components, mirroring the OpenCascade kernel.
+	const auto triangulation_type = settings.get<ifcopenshell::geometry::settings::TriangulationType>().get();
+	const bool polyhedral_output = triangulation_type != ifcopenshell::geometry::settings::TRIANGLE_MESH;
+	const bool polyhedral_output_without_holes = triangulation_type == ifcopenshell::geometry::settings::POLYHEDRON_WITHOUT_HOLES;
+
 	std::set<std::set<Kernel_::Point_3>> original_edges;
 	if (setting_use_original_edges) {
 		for (auto it = shape_to_use->edges_begin(); it != shape_to_use->edges_end(); ++it) {
@@ -444,7 +451,7 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 	// edges are to be registered.
 	std::vector<std::set<Facet_const_handle>> components;
 	std::map<Facet_const_handle, typename decltype(components)::const_iterator> facet_to_component;
-	if (!setting_use_original_edges) {
+	if (!setting_use_original_edges || polyhedral_output) {
 		partition_coplanar_components(*shape_to_use, components);
 		for (auto it = components.begin(); it != components.end(); ++it) {
 			for (auto& f : *it) {
@@ -474,6 +481,10 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 	std::map<postion_normal, size_t> welds;
 
 	std::set<std::pair<int, int>> registered_edges;
+
+	// For polyhedral output the triangles are accumulated per coplanar component
+	// so that planar faces (optionally with holes) can be reconstructed after the loop.
+	std::map<typename decltype(components)::const_iterator, std::vector<std::tuple<int, int, int>>> component_triangles;
 
 	int num_faces = 0, num_vertices = 0;
 	for (auto &face : faces(*shape_to_use)) {
@@ -560,26 +571,47 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 			++current_halfedge;
 		} while (current_halfedge != face->facet_begin());
 
-		t->addFace(item_id, surface_style_id, vertexidx[0], vertexidx[1], vertexidx[2]);
-		for (size_t i = 0; i < 3; ++i) {
-			if (is_face_boundary[i]) {
-				// In CGAL, the vertex of a halfedge is the incident vertex, i.e
-				// the second vertex of the edge, so in order to get corresponding
-				// vertex and edge indices we need to find vertexids (i-1, i) for
-				// the boundary registered in i.
-				auto a = vertexidx[(i + 2) % 3];
-				auto b = vertexidx[(i + 3) % 3];
-				if (a > b) {
-					std::swap(a, b);
-				}
-				if (registered_edges.find({ a, b }) == registered_edges.end()) {
-					registered_edges.insert({ a,b });
-					t->registerEdge(item_id, a, b);
+		if (polyhedral_output) {
+			component_triangles[facet_to_component[face]].push_back({ vertexidx[0], vertexidx[1], vertexidx[2] });
+		} else {
+			t->addFace(item_id, surface_style_id, vertexidx[0], vertexidx[1], vertexidx[2]);
+			for (size_t i = 0; i < 3; ++i) {
+				if (is_face_boundary[i]) {
+					// In CGAL, the vertex of a halfedge is the incident vertex, i.e
+					// the second vertex of the edge, so in order to get corresponding
+					// vertex and edge indices we need to find vertexids (i-1, i) for
+					// the boundary registered in i.
+					auto a = vertexidx[(i + 2) % 3];
+					auto b = vertexidx[(i + 3) % 3];
+					if (a > b) {
+						std::swap(a, b);
+					}
+					if (registered_edges.find({ a, b }) == registered_edges.end()) {
+						registered_edges.insert({ a,b });
+						t->registerEdge(item_id, a, b);
+					}
 				}
 			}
 		}
 
 		++num_faces;
+	}
+
+	if (polyhedral_output) {
+		// Reconstruct a planar face per coplanar component from its triangles,
+		// honouring the requested POLYHEDRON_WITHOUT_HOLES / POLYHEDRON_WITH_HOLES type.
+		for (auto& component : component_triangles) {
+			auto loops = IfcGeom::util::find_boundary_loops(t->verts(), component.second);
+			if (polyhedral_output_without_holes) {
+				if (!loops.empty() && !loops[0].empty()) {
+					t->addFace(item_id, surface_style_id, loops[0]);
+				}
+			} else {
+				if (!loops.empty()) {
+					t->addFace(item_id, surface_style_id, loops);
+				}
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes #5485.

## Problem

Two parts to this issue. The "`geometry.edges` always empty with the CGAL kernel" half is already resolved in v0.8.0 (the edge-registration path via `partition_coplanar_components` / `t->registerEdge` is present). The remaining unaddressed half: the CGAL `Triangulate` ignored `settings::TriangulationType` and always emitted a raw triangle mesh, so `POLYHEDRON_WITH_HOLES` / `POLYHEDRON_WITHOUT_HOLES` output was unavailable, unlike the OpenCascade kernel which honours it.

## Fix

When a polyhedral triangulation type is requested, reuse the existing coplanar-component partition to bucket the triangles per planar component, then after the face loop reconstruct each face with `IfcGeom::util::find_boundary_loops(t->verts(), tris)` and emit `addFace(loops[0])` for `POLYHEDRON_WITHOUT_HOLES` or `addFace(loops)` for `POLYHEDRON_WITH_HOLES`, mirroring `OpenCascadeConversionResult.cpp`. The default `TRIANGLE_MESH` path (per-triangle `addFace` plus edge registration) is left byte-for-byte unchanged, so only the opt-in polyhedral modes (currently ignored) are affected.

## Verification

Symbols confirmed by reading headers: `IfcGeom::util::find_boundary_loops` (`ConversionResult.h`), the `addFace` overloads (`IfcGeomRepresentation.h`), and the `TRIANGLE_MESH` / `POLYHEDRON_WITH_HOLES` / `POLYHEDRON_WITHOUT_HOLES` enum (`ConversionSettings.h`); the construct mirrors what the OpenCascade kernel already compiles. Not runtime-tested (no local kernel build); CI's `build-ifcopenshell` compile-checks it. Since the change is gated on a non-default `TriangulationType`, the common triangle-mesh output cannot be affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)