### PR TITLE
serializers: don't abort the whole SVG drawing when one element's HLR fails (#4130, #3849)

### DIFF
--- a/src/serializers/SvgSerializer.h
+++ b/src/serializers/SvgSerializer.h
@@ -539,9 +539,18 @@ namespace {
 			size_t n_included = 0;
 			for (auto it = items_.begin(); it != items_.end(); ++it) {
 				if (!use_prefiltering_ || !is_obscured_(&it->second)) {
-					hlr_writer vis(it->second);
-					boost::apply_visitor(vis, engine_);
-					n_included++;
+					// Meshing (poly) and Load/Add can throw on degenerate or
+					// topologically invalid shapes. Skip the offending element
+					// with a warning rather than aborting the whole drawing.
+					try {
+						hlr_writer vis(it->second);
+						boost::apply_visitor(vis, engine_);
+						n_included++;
+					} catch (const std::exception& e) {
+						logger_.Error("SER", 36, std::string("Skipped element in hidden line removal: ") + e.what(), it->first);
+					} catch (...) {
+						logger_.Error("SER", 36, "Skipped element in hidden line removal", it->first);
+					}
 				}
 			}
 			if (use_prefiltering_) {
@@ -553,7 +562,17 @@ namespace {
 				vis.set_product_shape(&items_);
 			}
 			vis.set_classified_shapes(&classified_items_);
-			return boost::apply_visitor(vis, engine_);
+			// The combined hidden line removal projection can still throw on
+			// invalid topology that survived per-element loading. Degrade to an
+			// empty projection layer for this drawing instead of aborting.
+			try {
+				return boost::apply_visitor(vis, engine_);
+			} catch (const std::exception& e) {
+				logger_.Error("SER", 37, std::string("Hidden line removal failed for drawing: ") + e.what());
+			} catch (...) {
+				logger_.Error("SER", 37, "Hidden line removal failed for drawing");
+			}
+			return {};
 		}
 	};
 }


### PR DESCRIPTION
Fixes #4130. Fixes #3849.

## Problem

Creating a drawing (SVG) can fail the entire output with "RuntimeError: An unknown error occurred" when a single element has invalid topology (for example a face with self-intersecting inner wires).

The poly hidden-line-removal step throws an OCCT `Standard_Failure`, which unwinds through `draw_hlr` to `SvgSerializer::finalize()` and surfaces at the SWIG boundary, aborting the whole drawing. `prefiltered_hlr::build()` is the single chokepoint for both storey-plan and section/elevation HLR, so both #4130 and #3849 land here.

## Fix

Wrap the two HLR entry points in `build()` in try/catch:
- a per-element failure is logged (`SER 36`, with the offending IFC product attached) and that one element is skipped;
- a whole-drawing projection failure is logged (`SER 37`) and degrades to an empty projection layer instead of aborting.

Section-cut linework is written on a separate path and is unaffected. `Standard_Failure` derives from `std::exception` in OCCT 7+, so the `catch (const std::exception&)` covers it (only `.what()` is used, so no new include). The scope is limited to the HLR calls, with no broad swallowing.

## Verification

Reproduced on the current 0.8 wrapper (bundled ifcopenshell 0.8.6a) with the #3849 minimal sample and the flagged elements: `finalize()` raised the exact `RuntimeError: An unknown error occurred`. Isolated the origin by toggling `setUseHlrPoly`: off -> a 114 KB SVG is produced, on -> crash, confirming the throw is in the guarded poly-HLR path and is a catchable exception. Patched behavior is not runtime-tested (no local kernel build); CI's `build-ifcopenshell` compile-checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)