### PR TITLE
build: decouple the OpenCascade examples from BUILD_CONVERT (#7835)

### DIFF
--- a/src/ifcgeom/CMakeLists.txt
+++ b/src/ifcgeom/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(kernels)
 set(kernel_libraries ${kernel_libraries} PARENT_SCOPE)
 
-if((BUILD_CONVERT OR BUILD_IFCPYTHON) AND WITH_OPENCASCADE)
+if((BUILD_CONVERT OR BUILD_IFCPYTHON OR BUILD_EXAMPLES) AND WITH_OPENCASCADE)
     add_subdirectory(Serialization)
     set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} PARENT_SCOPE)
 endif()


### PR DESCRIPTION
Fixes #7835.

## Problem

The OpenCascade examples (`IfcOpenHouse`, `IfcAdvancedHouse`) link the `geometry_serializer` target, but that target (the `ifcgeom/Serialization` subdirectory) is only added under `BUILD_CONVERT` or `BUILD_IFCPYTHON`:

```cmake
if((BUILD_CONVERT OR BUILD_IFCPYTHON) AND WITH_OPENCASCADE)
    add_subdirectory(Serialization)
```

So configuring with `-DBUILD_EXAMPLES=ON -DWITH_OPENCASCADE=ON` but without building IfcConvert fails to configure, because the examples reference a target that was never defined.

## Fix

Add `BUILD_EXAMPLES` to that guard, so `geometry_serializer` is available whenever Open CASCADE is enabled, independent of `BUILD_CONVERT`. The `Serialization` subdirectory is processed before the examples subdirectory, so the target exists when the examples reference it. Normal `BUILD_CONVERT` / `BUILD_IFCPYTHON` builds are unchanged, and `WITH_OPENCASCADE=OFF` still skips both the Serialization add and the OCC examples.

## Verification

Reasoned from the CMake dependency graph and subdirectory ordering; not built locally (this configuration needs the OCCT toolchain and CI does not exercise the examples target). The change is additive to the guard, so it cannot affect the existing convert/python builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)