### PR TITLE
ifcgeom: CGAL kernel should emit the smoothed, unit vertex normal (#6997)

### DIFF
--- a/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
@@ -541,9 +541,22 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 				);
 				welds.insert({ pn, vidx });
 
-				auto nx = CGAL::to_double(face_normals_map[face].cartesian(0));
-				auto ny = CGAL::to_double(face_normals_map[face].cartesian(1));
-				auto nz = CGAL::to_double(face_normals_map[face].cartesian(2));
+				// Emit the per-vertex normal that was used as the weld key (this is the
+				// smoothed normal when CgalSmoothAngleDegrees is set, otherwise the flat
+				// facet normal). Previously the raw facet normal was emitted here, which
+				// made the smoothing subsystem a no-op and produced only flat/faceted
+				// shading. addNormal() does not normalize, and CGAL's compute_face_normals
+				// does not guarantee unit-length vectors under the exact (Epeck) kernel, so
+				// we normalize to unit length here to match the OpenCascade kernel output.
+				auto nx = CGAL::to_double(vertex_norm.cartesian(0));
+				auto ny = CGAL::to_double(vertex_norm.cartesian(1));
+				auto nz = CGAL::to_double(vertex_norm.cartesian(2));
+				const double nlen = std::sqrt(nx * nx + ny * ny + nz * nz);
+				if (nlen > 0) {
+					nx /= nlen;
+					ny /= nlen;
+					nz /= nlen;
+				}
 
 				t->addNormal(nx, ny, nz);
 			} else {


### PR DESCRIPTION
Fixes #6997.

## Problem

Geometry from the CGAL kernel has flat/faceted or non-unit vertex normals in glTF output, unlike the OpenCascade kernel.

In `CgalShape::Triangulate`, the code computes `vertex_norm` (the smoothed per-vertex normal when `CgalSmoothAngleDegrees > 0`, otherwise the flat facet normal) and uses it as the vertex weld key, but then emits the raw `face_normals_map[face]` facet normal via `addNormal`. So:

- the existing smoothing subsystem was a dead no-op (the smoothed value was discarded), and
- `addNormal` stores the components verbatim and CGAL's `compute_face_normals` does not guarantee unit-length vectors under the exact (Epeck) kernel, so the emitted normals were not unit length (OpenCascade emits a unit `gp_Dir`).

## Fix

Emit the normalized `vertex_norm`, the same value already used as the weld key. In the default no-smoothing case this emits the flat facet normal as a unit vector; enabling `CgalSmoothAngleDegrees` now actually produces smooth shading.

## Verification

`vertex_norm` is defined and (when smoothing) accumulated just above, and is already read as the weld key, so this only aligns the emitted normal with the weld key and normalizes it. `std::sqrt` is already used in this file. The change is confined to the triangle-mesh weld loop and is orthogonal to the coplanar-component / original-edges branches. Not runtime-tested (no local kernel build); CI's `build-ifcopenshell` compile-checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)