### PR TITLE
ifcgeom: fix CgalEmitOriginalEdges for placed elements (#6173)

### DIFF
--- a/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
@@ -382,13 +382,6 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 	}
 
 	const bool setting_use_original_edges = settings.get<ifcopenshell::geometry::settings::CgalEmitOriginalEdges>().get();
-	
-	std::set<std::set<Kernel_::Point_3>> original_edges;
-	if (setting_use_original_edges) {
-		for (auto it = shape_to_use->edges_begin(); it != shape_to_use->edges_end(); ++it) {
-			original_edges.insert({ it->vertex()->point(), it->prev()->vertex()->point() });
-		}
-	}
 
 	if (!has_iden_transform) {
 		const auto& m = place.ccomponents();
@@ -402,6 +395,19 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 		// Apply transformation
 		for (auto &vertex : shape_to_use->vertex_handles()) {
 			vertex->point() = vertex->point().transform(trsf);
+		}
+	}
+
+	// Collect the original (pre-triangulation) edges after the placement
+	// transform has been applied. The stored endpoint coordinates must match
+	// the post-transform vertex positions that are queried during face
+	// emission below; collecting them before the transform left the keys in
+	// object space, so for any non-identity placement no original edge was
+	// ever matched and the setting emitted no boundary edges at all.
+	std::set<std::set<Kernel_::Point_3>> original_edges;
+	if (setting_use_original_edges) {
+		for (auto it = shape_to_use->edges_begin(); it != shape_to_use->edges_end(); ++it) {
+			original_edges.insert({ it->vertex()->point(), it->prev()->vertex()->point() });
 		}
 	}
 


### PR DESCRIPTION
Fixes #6173.

## Problem

With the CGAL kernel, `geometry.edges` returns only the planar-boundary (coplanar-dissolved) edges rather than the original topology edges that OpenCascade preserves. The intended mechanism to keep original edges is the `cgal-original-edges` setting (`CgalEmitOriginalEdges`), but enabling it did not help for real models.

## Root cause

In `CgalShape::Triangulate`, `original_edges` was collected from the shape *before* the placement transform mutates the vertex coordinates, while the per-face boundary test (`is_face_boundary`) queries that set with the *post-transform* points. The keys are exact `std::set<Point_3>` coordinates, so for any non-identity placement they never matched the queries, the original-edge set was effectively empty, and the setting emitted no boundary edges. Only identity-placement elements ever worked, and real elements carry placements.

## Fix

Move the `original_edges` collection to after the transform block (still before `triangulate_faces`, so the topology is pre-triangulation as intended). The stored endpoint keys now live in the same coordinate space as the emission-time queries, so the setting actually preserves original edges for placed elements.

The default remains opt-in (`false`); this only makes the existing opt-in path correct, so no global edge-output behavior changes. Flipping the default is left as a separate maintainer decision.

## Verification

Pure reordering with a clear coordinate-space argument; logic-verified by reading. Not runtime-tested (no local kernel build); CI's `build-ifcopenshell` compile-checks it. No conflict with the recent CGAL changes for `TriangulationType` (#8476) or vertex normals (#8479).

🤖 Generated with [Claude Code](https://claude.com/claude-code)