### PR TITLE
Fixes double unit conversion when convert-back-units are used

### DIFF
--- a/src/ifcwrap/IfcGeomWrapper.i
+++ b/src/ifcwrap/IfcGeomWrapper.i
@@ -977,12 +977,14 @@ struct ShapeRTTI : public boost::static_visitor<PyObject*>
 			if (item == nullptr) {
 				throw IfcParse::IfcException("Failed to convert placement");
 			}
+			/*
             if (st.get<ifcopenshell::geometry::settings::ConvertBackUnits>().get()) {
                 // we pass the settings to the Transformation object, but access the data just offloads to the
                 // generic cartesian_base<Matrix4> so there's no time to apply the settings to the translation part.
                 item = ifcopenshell::geometry::taxonomy::matrix4::ptr(item->clone_());
                 item->components().col(3).head<3>() /= kernel.settings().get<ifcopenshell::geometry::settings::LengthUnit>().get();
             }
+			*/
 			return new IfcGeom::Transformation(kernel.settings(), item);
 		} else {
 			if (!representation) {


### PR DESCRIPTION
The combination of `create_shape` using `convert-back-units=True` and its subsequent call to `IfcGeom::Transformation`'s constructor causes unit conversion to be incorrectly applied twice.

The attached model and script illustrate the issue. The output from the script is

~~~
Project length unit: 'foot' (1 foot = 0.3048 m)

10+00.00   DistanceAlong=   0.0 foot   BasisCurve=#22
25+00.00   DistanceAlong=   0.0 foot   BasisCurve=#131
10+10.00   DistanceAlong=  10.0 foot   BasisCurve=#22
10+40.00   DistanceAlong=  40.0 foot   BasisCurve=#22

Referent   Expected (ft)   create_shape (ft)   Ratio
10+00.00   0.0000          0.0000              nan
25+00.00   50.0000         164.0420            3.28084
10+10.00   10.0000         32.8084             3.28084
10+40.00   40.0000         131.2336            3.28084
~~~

You can also see a manifestation of the bug in Blender/Bonsai by opening the IFC file and inspecting the coordinates of the referents.
[referent_placement_bug.zip](https://github.com/user-attachments/files/29894547/referent_placement_bug.zip)

This PR removes the redundant unit converse.

@aothms this is a little out of my area of expertise, so please review.

Full disclosure, my good friend Claude helped me diagnose the root cause of the problem.