### PR TITLE
build: do not request the header-only Boost.System component (fixes configure on Boost 1.70+)

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -314,8 +314,12 @@ if(WASM_BUILD)
 else()
     # @todo review this, shouldn't this be all possible header-only now?
     # ... or rewritten using C++17 features?
+    # Boost.System has been header-only since 1.69 and its compiled stub library
+    # was dropped in newer Boost, so requesting it as a component makes
+    # find_package fail on Boost 1.70 and up (for example Boost 1.90). It is
+    # still pulled in transitively by thread / iostreams where needed, so do not
+    # request it explicitly.
     set(BOOST_COMPONENTS
-        system
         program_options
         regex
         thread


### PR DESCRIPTION
## Problem

Configuring IfcOpenShell against a modern Boost fails at `find_package`:

```
Could not find a package configuration file provided by "boost_system"
...
Could NOT find Boost (missing: system)
```

`cmake/CMakeLists.txt` lists `system` in `BOOST_COMPONENTS`. Boost.System has been header-only since Boost 1.69, and its compiled stub library was dropped in newer Boost, so requesting it as a component makes configuration fail on Boost 1.70 and up (seen here with Homebrew Boost 1.90).

## Fix

Drop `system` from the requested component list (there is already a `@todo` in that block noting these should be header-only now). Boost.System is still pulled in transitively by `thread` / `iostreams` where it is actually needed, so nothing links less.

## Verification

With this change, IfcOpenShell configures and builds `IfcConvert` cleanly against Homebrew Boost 1.90 and OpenCASCADE 7.9.2 on macOS (arm64). It does not change which libraries are linked on older Boost, since `system` continues to arrive transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)