### PR TITLE
Fix #5685 squared curves on open

### DIFF
--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1148,6 +1148,9 @@ class Geometry(bonsai.core.tool.Geometry):
         settings.set("layerset-first", True)
         settings.set("keep-bounding-boxes", True)
         settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
+        settings.set("mesher-linear-deflection", ifc_import_settings.deflection_tolerance)
+        settings.set("mesher-angular-deflection", ifc_import_settings.angular_tolerance)
+        geometry_library = ifc_import_settings.geometry_library
 
         ifc_importer = bonsai.bim.import_ifc.IfcImporter(ifc_import_settings)
         ifc_importer.file = tool.Ifc.get()
@@ -1159,7 +1162,11 @@ class Geometry(bonsai.core.tool.Geometry):
         shape = None
         if elements:
             iterator = ifcopenshell.geom.iterator(
-                settings, tool.Ifc.get(), multiprocessing.cpu_count(), include=elements
+                settings,
+                tool.Ifc.get(),
+                multiprocessing.cpu_count(),
+                include=elements,
+                geometry_library=geometry_library,
             )
         else:
             iterator = None  # For example, when switching representation of a type with no occurrences
@@ -1214,7 +1221,9 @@ class Geometry(bonsai.core.tool.Geometry):
         for element in element_types:
             if obj := tool.Ifc.get_object(element):
                 if representation := ifcopenshell.util.representation.get_representation(element, context):
-                    geometry = ifcopenshell.geom.create_shape(settings, representation)
+                    geometry = ifcopenshell.geom.create_shape(
+                        settings, representation, geometry_library=geometry_library
+                    )
                     mesh_name = tool.Loader.get_mesh_name_from_shape(geometry)
                     mesh = meshes.get(mesh_name)
                     if mesh is None:


### PR DESCRIPTION
## Summary

Fixes the case reported in #5685 (and previously #5482) where a curved
`IfcArbitraryClosedProfileDef` boundary (an `IfcIndexedPolyCurve` using
`IfcArcIndex`) renders as a faceted, angular polygon on file open, and only
becomes smooth after the user tabs into edit mode on the object and back out.

Reproduced with the `curved slab.ifc` file attached to #5685: a slab with a
gently curved, large-radius sidewalk boundary defined by two 3-point arc
segments.

## Root cause

Two independent bugs compounded to produce the reported symptom:

1. **CGAL kernel arc tessellation ignored deflection settings.**
   `evaluate_conic()` in `src/ifcgeom/kernels/cgal/CgalKernel.cpp` sized the
   polyline approximation of an arc purely from the fixed `circle-segments`
   setting (default 16) scaled by the arc's fraction of a full turn. For a
   long, shallow arc this rounds down to as few as 2 segments regardless of
   the arc's actual size, since `circle-segments` only accounts for the
   angular span, not the radius. OpenCASCADE does not have this problem
   because it keeps arcs as exact BRep edges and only discretizes them at
   final mesh time using `mesher-linear-deflection` /
   `mesher-angular-deflection`. Since Bonsai's default Geometry Library is
   `hybrid-cgal-simple-opencascade` (CGAL first, OpenCASCADE only as a
   fallback on a hard failure, not on merely low-quality output), the coarse
   CGAL result is what silently ships on initial import.

2. **The geometry-reload path used a different, unintentional configuration
   than the initial import.** `reimport_element_representations()` in
   `src/bonsai/bonsai/tool/geometry.py` (reached via
   `switch_representation()`, which runs whenever an object's representation
   is reloaded — including when exiting Bonsai's Item/edit mode) builds its
   own `ifcopenshell.geom.settings()` object from scratch. It never copies
   over `deflection_tolerance` / `angular_tolerance` from the
   `IfcImportSettings` it had just constructed one line above, and never
   passes `geometry_library` to either the `iterator()` or `create_shape()`
   calls it makes. It therefore silently fell back to IfcOpenShell's
   hard-coded mesher default (0.001 linear deflection, ~50x finer than the
   project default of 0.05) and to a different default geometry kernel. This
   is why tabbing into and back out of edit mode — with no actual edits made
   — visibly "fixed" the arc: the reload path was, by accident, far more
   precise than the initial import.

## Changes

- `src/ifcgeom/kernels/cgal/CgalKernel.cpp`: `evaluate_conic()` now also
  derives a segment count from `mesher-angular-deflection` (angle-per-segment
  cap) and `mesher-linear-deflection` (chord-sagitta cap based on the conic's
  radius), and takes the max against the existing `circle-segments`-derived
  count.
- `src/bonsai/bonsai/tool/geometry.py`: `reimport_element_representations()`
  now copies `deflection_tolerance` / `angular_tolerance` /
  `geometry_library` from its `IfcImportSettings` instance into the geometry
  settings used for both the `iterator()` and `create_shape()` calls.

## Behavioural note

With both fixes applied, initial import and post-Tab reload converge on the
*same* (now noticeably improved) tessellation quality, at whatever
`deflection_tolerance` / `angular_tolerance` / Geometry Library the project
is configured with. Tabbing into and out of edit mode no longer changes the
mesh. If a project wants tessellation as fine as the (accidental) previous
post-Tab result, that is available today by lowering Deflection Tolerance
and/or switching Geometry Library to OpenCASCADE in Project Properties — a
deliberate, user-controlled trade-off against import performance on large
files, rather than a side effect of a settings bug.

## Testing

- Manually verified against the `curved slab.ifc` file from #5685, loaded
  through Bonsai in Blender (not just via the raw `ifcopenshell.geom` API),
  comparing vertex/face counts and viewport appearance before and after each
  fix, and before/after tabbing into edit mode.
- No automated test was added. A regression test against the attached IFC
  file (checking boundary vertex count for the CGAL kernel, and/or that
  `reimport_element_representations` preserves the configured deflection
  settings) would be a reasonable addition — flagging this as a gap rather
  than including one, since it wasn't written as part of this change.
- Did not benchmark import performance impact of the CGAL kernel change on
  large files; the added work is bounded (a handful of trig calls per arc)
  but this hasn't been measured against a large real-world model.

## AI-generated content

This entire PR — investigation, root-cause analysis, and both commits — was
produced with the assistance of an AI coding tool (Claude Code). A human
contributor built and ran the changes in Blender/Bonsai, provided the
before/after vertex counts and screenshots used to confirm the diagnosis at
each step, and reviewed the resulting diffs.
