### PR TITLE
ifcgeom: deterministic iterator output order under multithreading (#3904)

### DIFF
--- a/src/ifcgeom/Iterator.cpp
+++ b/src/ifcgeom/Iterator.cpp
@@ -173,9 +173,7 @@ void IfcGeom::Iterator::flush_worker_log(ifcopenshell::geometry::Converter* kern
 	}
 }
 
-void IfcGeom::Iterator::process_finished_rep(geometry_conversion_result* rep, ifcopenshell::geometry::Converter* kernel) {
-	flush_worker_log(kernel);
-
+void IfcGeom::Iterator::emit_finished_rep_(geometry_conversion_result* rep) {
 	if (rep->elements.empty()) {
 		return;
 	}
@@ -192,6 +190,11 @@ void IfcGeom::Iterator::process_finished_rep(geometry_conversion_result* rep, if
 	}
 
 	progress_ = (int)(++processed_ * 100 / tasks_.size());
+}
+
+void IfcGeom::Iterator::process_finished_rep(geometry_conversion_result* rep, ifcopenshell::geometry::Converter* kernel) {
+	flush_worker_log(kernel);
+	emit_finished_rep_(rep);
 }
 
 void IfcGeom::Iterator::process_concurrently() {
@@ -216,6 +219,26 @@ void IfcGeom::Iterator::process_concurrently() {
 
 	std::vector<std::future<geometry_conversion_result*>> threadpool;
 
+	// Results are emitted in a deterministic order (the input order of tasks_,
+	// which follows the products' file/step order) rather than in thread
+	// completion order. Completed tasks are buffered by their ordinal within
+	// tasks_ and the contiguous in-order prefix is flushed as it becomes ready,
+	// which keeps the streaming producer/consumer intact without deadlocking.
+	std::map<size_t, geometry_conversion_result*> ready_buffer;
+	size_t next_emit = 0;
+
+	auto buffer_and_flush = [this, &ready_buffer, &next_emit](geometry_conversion_result* finished) {
+		size_t ordinal = (size_t)(finished - tasks_.data());
+		ready_buffer[ordinal] = finished;
+		auto it = ready_buffer.find(next_emit);
+		while (it != ready_buffer.end()) {
+			emit_finished_rep_(it->second);
+			ready_buffer.erase(it);
+			++next_emit;
+			it = ready_buffer.find(next_emit);
+		}
+	};
+
 	for (auto& rep : tasks_) {
 		ifcopenshell::geometry::Converter* K = nullptr;
 		if (threadpool.size() < kernel_pool.size()) {
@@ -228,7 +251,11 @@ void IfcGeom::Iterator::process_concurrently() {
 				std::future_status status;
 				status = fu.wait_for(std::chrono::seconds(0));
 				if (status == std::future_status::ready) {
-					process_finished_rep(fu.get(), kernel_pool[i]);
+					// Flush the worker log at completion time, but defer element
+					// emission to buffer_and_flush so output order stays deterministic.
+					geometry_conversion_result* finished = fu.get();
+					flush_worker_log(kernel_pool[i]);
+					buffer_and_flush(finished);
 
 					std::swap(threadpool[i], threadpool.back());
 					threadpool.pop_back();
@@ -276,8 +303,19 @@ void IfcGeom::Iterator::process_concurrently() {
 	}
 
 	for (size_t i = 0; i < threadpool.size(); ++i) {
-		process_finished_rep(threadpool[i].get(), kernel_pool[i]);
+		geometry_conversion_result* finished = threadpool[i].get();
+		flush_worker_log(kernel_pool[i]);
+		buffer_and_flush(finished);
 	}
+
+	// Emit any results still buffered. In the normal case the contiguous flush
+	// above has already drained everything; this only matters on early
+	// termination, where a dispatch gap can leave completed tasks buffered.
+	// Emitting them (in ascending ordinal order) avoids leaking their elements.
+	for (auto& kv : ready_buffer) {
+		emit_finished_rep_(kv.second);
+	}
+	ready_buffer.clear();
 
 	finished_ = true;
 

--- a/src/ifcgeom/Iterator.h
+++ b/src/ifcgeom/Iterator.h
@@ -300,6 +300,11 @@ namespace IfcGeom {
 
 		void process_finished_rep(geometry_conversion_result* rep, ifcopenshell::geometry::Converter* kernel = nullptr);
 
+		// Appends the (already computed) elements of a finished task to the output
+		// lists. Must be called in a deterministic order (see process_concurrently)
+		// so that the emitted element order does not depend on thread completion order.
+		void emit_finished_rep_(geometry_conversion_result* rep);
+
 		void process_concurrently();
 
 		/// Computes model's bounding box (bounds_min and bounds_max).


### PR DESCRIPTION
Fixes #3904.

## Problem

The multithreaded geometry iterator appended converted elements to its output list in **thread completion order**, so repeated `IfcConvert` runs on the same file emitted elements in different orders (non-reproducible output).

## Fix

Add a small reordering buffer in `Iterator::process_concurrently`: completed tasks are buffered by their ordinal within `tasks_` (the deterministic input / step order from `get_representations`), and the contiguous in-order prefix is flushed to the consumer as it becomes ready. `process_finished_rep` is split so the single-threaded path is untouched.

The output order is now deterministic and independent of thread scheduling. The streaming producer/consumer and its locking are preserved (the producer never waits on the consumer, so no deadlock is introduced), and only task pointers are buffered so memory is unaffected.

## Verification

Built locally (OpenCASCADE 7.9.2) and converted a 60-element IFC4 model to OBJ **three times with `--threads 8`**: the output is now byte-for-byte identical across runs (same element ordering every time). Compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)