### PR TITLE
IfcConvert: add --fail-on-error to exit non-zero on conversion errors (#1118)

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -252,6 +252,10 @@ int main(int argc, char** argv) {
 		("stderr-progress", "output progress to stderr stream")
 		("yes,y", "answer 'yes' automatically to possible confirmation queries (e.g. overwriting an existing output file)")
 		("no-progress", "suppress possible progress bar type of prints that use carriage return")
+		("fail-on-error", "return a non-zero exit code when one or more errors were logged during "
+			"geometry conversion (e.g. an element failed to convert). By default IfcConvert exits "
+			"successfully as long as an output file could be written, even if some elements were "
+			"silently dropped. Enable this flag so scripts and CI can detect partial conversions.")
 		("log-format", po::value<std::string>(&log_format), "log format: plain or json")
 		("log-file", new po::typed_value<path_t, char_t>(&log_file), "redirect log output to file");
 
@@ -449,6 +453,7 @@ int main(int argc, char** argv) {
 
 	const bool mmap = vmap.count("mmap") != 0;
 	const bool no_progress = vmap.count("no-progress") != 0;
+	const bool fail_on_error = vmap.count("fail-on-error") != 0;
 	const bool quiet = vmap.count("quiet") != 0;
 	const bool stderr_progress = vmap.count("stderr-progress") != 0;
 
@@ -1217,6 +1222,11 @@ int main(int argc, char** argv) {
 
 	if (geometry_settings.get<ifcopenshell::geometry::settings::ValidateQuantities>().get() && logger.MaxSeverity() >= Logger::LOG_ERROR) {
 		logger.Error("SYS", 24, "Errors encountered during processing.");
+		successful = false;
+	}
+
+	if (fail_on_error && logger.MaxSeverity() >= Logger::LOG_ERROR) {
+		logger.Error("SYS", 26, "Errors encountered during processing, failing due to --fail-on-error.");
 		successful = false;
 	}
 


### PR DESCRIPTION
Fixes #1118.

## Problem

IfcConvert returns a success exit code even when geometry conversion logs errors and silently drops elements. In #1118 a wall fails a `TopoDS::Shell` build under `--enable-layerset-slicing`; IfcConvert logs the error, drops most elements, yet writes a valid-looking partial output and exits `0`, so scripts and CI cannot detect the data loss. The existing `successful` flag only reflects output-file rename failure or `--validate` quantity errors, not per-element conversion errors.

## Fix

Add an opt-in `--fail-on-error` flag: after processing, if any error was logged (`logger.MaxSeverity() >= LOG_ERROR`), exit non-zero. This reuses the exact `MaxSeverity`-based pattern already used for `--validate` just above it.

It is a flag rather than a default change on purpose: many real-world files legitimately have a few elements that fail to convert, and flipping the default would break existing pipelines. The default exit behaviour is untouched.

## Verification

Built locally (OpenCASCADE 7.9.2). On a file with one valid box and one degenerate (zero-depth) extrusion that logs a GEO error:
- default run exits `0` (error tolerated, unchanged),
- `--fail-on-error` run exits `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)