### PR TITLE
ifcgeom: cut openings when the wall void boundary has sub-precision edges (#4118)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -22,6 +22,7 @@
 #include <BOPAlgo_PaveFiller.hxx>
 #include <BOPAlgo_Alerts.hxx>
 #include <ShapeFix_Shape.hxx>
+#include <ShapeFix_Wireframe.hxx>
 #include <BRepCheck_Analyzer.hxx>
 #include <BRepCheck.hxx>
 #include <ShapeAnalysis_Edge.hxx>
@@ -832,7 +833,37 @@ bool IfcGeom::util::points_on_planar_face_generator::operator()(gp_Pnt& p) {
 }
 
 
-bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const TopoDS_Shape& a_input, const NCollection_List<TopoDS_Shape>& b_input, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness) {
+namespace {
+	// Merge or drop edges shorter than 'tol' from a shape. Used as a last resort
+	// when a cut fails at every fuzziness because the first operand carries
+	// sub-precision length edges, for example a wall profile whose curved inner
+	// void boundary is tessellated into a polyline containing segments only a
+	// fraction of a millimetre long (see #4118). Such tiny edges make
+	// BRepAlgoAPI_Cut return a result that trips the intersecting-wires and
+	// edge-length interference checks, so the opening is silently dropped and the
+	// wall is left uncut. ShapeFix_Wireframe removes the offending edges while
+	// keeping the shape within 'tol' of the original. The original shape is
+	// returned unchanged on any failure.
+	TopoDS_Shape heal_small_edges(const TopoDS_Shape& s, double tol) {
+		try {
+			ShapeFix_Wireframe sfw(s);
+			sfw.SetPrecision(tol);
+			sfw.SetMaxTolerance(tol);
+			sfw.ModeDropSmallEdges() = Standard_True;
+			sfw.FixSmallEdges();
+			sfw.FixWireGaps();
+			TopoDS_Shape fixed = sfw.Shape();
+			if (fixed.IsNull()) {
+				return s;
+			}
+			return fixed;
+		} catch (...) {
+			return s;
+		}
+	}
+}
+
+bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const TopoDS_Shape& a_input, const NCollection_List<TopoDS_Shape>& b_input, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness, bool heal_operand_on_failure) {
 	using namespace std::string_literals;
 
 	const bool do_unify = true;
@@ -1417,7 +1448,27 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 	}
 	if (!success) {
 		if (allow_retry) {
-			return boolean_operation(settings, a, b, op, result, new_fuzziness);
+			return boolean_operation(settings, a, b, op, result, new_fuzziness, heal_operand_on_failure);
+		} else if (op == BOPAlgo_CUT && heal_operand_on_failure) {
+			// Last resort robustness for #4118: the cut can fail at every fuzziness
+			// when the first operand carries sub-precision length edges, for example a
+			// wall profile whose curved inner void boundary is tessellated into a
+			// polyline containing segments only a fraction of a millimetre long. The
+			// standard unify() step deliberately caps its tolerance below the smallest
+			// edge, so these tiny edges survive and keep tripping the result validity
+			// checks. Remove them from the first operand and attempt the cut once more.
+			// This only runs after every normal fuzziness attempt has already failed,
+			// so cuts that succeed normally are never affected, and if the healed
+			// operand still fails the outcome is identical to today (opening dropped).
+			const double heal_tolerance = settings.precision * 1000.;
+			TopoDS_Shape a_healed = heal_small_edges(a_input, heal_tolerance);
+			if (!a_healed.IsNull() && !a_healed.IsSame(a_input)) {
+				Logger::Root().Notice("GEO", 154, "Retrying cut with small edges removed from first operand");
+				if (boolean_operation(settings, a_healed, b_input, op, result, -1., false)) {
+					return true;
+				}
+			}
+			Logger::Root().Notice("GEO", 154, "No longer attempting boolean operation with higher fuzziness");
 		} else {
 			Logger::Root().Notice("GEO", 154, "No longer attempting boolean operation with higher fuzziness");
 		}

--- a/src/ifcgeom/kernels/opencascade/boolean_utils.h
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.h
@@ -97,7 +97,7 @@ namespace IfcGeom {
 			double precision;
 		};
 
-		bool boolean_operation(const boolean_settings& settings, const TopoDS_Shape&, const NCollection_List<TopoDS_Shape>&, BOPAlgo_Operation, TopoDS_Shape&, double fuzziness = -1.);
+		bool boolean_operation(const boolean_settings& settings, const TopoDS_Shape&, const NCollection_List<TopoDS_Shape>&, BOPAlgo_Operation, TopoDS_Shape&, double fuzziness = -1., bool heal_operand_on_failure = true);
 
 		bool boolean_operation(const boolean_settings& settings, const TopoDS_Shape&, const TopoDS_Shape&, BOPAlgo_Operation, TopoDS_Shape&, double fuzziness = -1.);
 


### PR DESCRIPTION
Fixes #4118.

## Problem

An opening cut on a wall fails at every fuzziness and is silently dropped, leaving the wall uncut. The wall body is an `IfcArbitraryProfileDefWithVoids` whose curved inner void boundary is tessellated into a polyline containing sub-precision-length segments (down to ~0.0013 in model units). These tiny edges survive the standard `unify()` step (which caps its tolerance below the smallest edge) and make `BRepAlgoAPI_Cut` return a result that fails the intersecting-wires and edge-length checks (`GEO147/148/150`).

## Fix

As a gated last resort in `boolean_operation`: when a `CUT` has exhausted every normal fuzziness attempt, heal the first operand with `ShapeFix_Wireframe` (drop small edges) and retry the cut once, behind a recursion guard. It only runs after all standard attempts fail, so cuts that already succeed are untouched; if the healed operand still fails, behaviour is identical to today.

## Verification (built and measured locally, OCC 7.9.2)

Converted the issue's IFC4 sample and measured the wall solid volume:

| | wall volume |
|---|---|
| baseline (v0.8.0) | 21.700 (both openings dropped, wall uncut) |
| with this fix | 21.487 |

The fix removes ~0.213 m3, the correct wall-band overlap of the two openings (which mostly protrude into the hollow interior). Builds cleanly.

## Note

This is independent of #8489 (coincident tool faces): the degeneracy here is in the wall operand, not the tool, and I confirmed #8489's enlarge-tool mechanism does not recover this case. Both add a gated last resort in the same `!success` branch; if both are merged the two arms can be chained (heal operand, then enlarge tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)