### PR TITLE
Keep valid non-manifold subtraction instead of dropping the cut (#1015)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -832,8 +832,17 @@ bool IfcGeom::util::points_on_planar_face_generator::operator()(gp_Pnt& p) {
 }
 
 
-bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const TopoDS_Shape& a_input, const NCollection_List<TopoDS_Shape>& b_input, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness) {
+bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const TopoDS_Shape& a_input, const NCollection_List<TopoDS_Shape>& b_input, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness, bool allow_nonmanifold_fallback) {
 	using namespace std::string_literals;
+
+	// A geometrically valid (BRepCheck_Analyzer) subtraction result that is
+	// rejected only for being non-manifold is remembered here. Some real models
+	// (e.g. a mitered/half-space beam end cut that grazes fine end detailing,
+	// see #1015) can only be resolved into such a result. Silently discarding
+	// the whole cut and returning the un-subtracted first operand is worse than
+	// keeping this result, so it is used as a last resort once the fuzziness
+	// retries are exhausted.
+	TopoDS_Shape nonmanifold_fallback;
 
 	const bool do_unify = true;
 	const bool do_subtraction_eliminate_disjoint_bbox = true;
@@ -1390,6 +1399,12 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 
 				} else {
 					settings.log().Notice("GEO", 151, "Boolean operation yields non-manifold result");
+					// r passed BRepCheck_Analyzer above and was rejected solely for
+					// being non-manifold. Remember it as a last-resort fallback so a
+					// difficult but valid subtraction is not dropped entirely (#1015).
+					if (op == BOPAlgo_CUT && nonmanifold_fallback.IsNull() && !r.IsNull()) {
+						nonmanifold_fallback = r;
+					}
 				}
 			}
 		}
@@ -1417,9 +1432,24 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 	}
 	if (!success) {
 		if (allow_retry) {
-			return boolean_operation(settings, a, b, op, result, new_fuzziness);
+			// Retry at a higher fuzziness in the hope of a clean manifold result.
+			// The retry is not allowed to apply the non-manifold fallback itself:
+			// that decision is deferred to this (finer-fuzziness) frame so that,
+			// if every retry also fails, the most accurate fallback is used.
+			if (boolean_operation(settings, a, b, op, result, new_fuzziness, false)) {
+				return true;
+			}
 		} else {
 			settings.log().Notice("GEO", 154, "No longer attempting boolean operation with higher fuzziness");
+		}
+
+		if (allow_nonmanifold_fallback && !nonmanifold_fallback.IsNull()) {
+			// Every attempt failed the manifold check but produced a geometrically
+			// valid subtraction. Keeping it preserves the boolean cut instead of
+			// silently returning the un-subtracted first operand (#1015).
+			settings.log().Message(Logger::LOG_WARNING, "GEO", 155, "Boolean subtraction result is non-manifold, using it regardless to preserve the cut");
+			result = nonmanifold_fallback;
+			return true;
 		}
 	}
 	return success && !result.IsNull();

--- a/src/ifcgeom/kernels/opencascade/boolean_utils.h
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.h
@@ -104,7 +104,7 @@ namespace IfcGeom {
 			Logger& log() const { return logger ? *logger : Logger::Root(); }
 		};
 
-		bool boolean_operation(const boolean_settings& settings, const TopoDS_Shape&, const NCollection_List<TopoDS_Shape>&, BOPAlgo_Operation, TopoDS_Shape&, double fuzziness = -1.);
+		bool boolean_operation(const boolean_settings& settings, const TopoDS_Shape&, const NCollection_List<TopoDS_Shape>&, BOPAlgo_Operation, TopoDS_Shape&, double fuzziness = -1., bool allow_nonmanifold_fallback = true);
 
 		bool boolean_operation(const boolean_settings& settings, const TopoDS_Shape&, const TopoDS_Shape&, BOPAlgo_Operation, TopoDS_Shape&, double fuzziness = -1.);
 


### PR DESCRIPTION
Fixes #1015.

## Problem
The beams in the sample lose their subtraction entirely: booleans-on output is byte-identical to booleans-off (a clean un-subtracted prism, no miter, no notches).

## Root cause
`util::boolean_operation` accepts a result only if it is manifold (`success = !is_manifold(a) || is_manifold(result)`). The beam end is a mitered `IfcHalfSpaceSolid` cut that grazes the fine end-notch detailing; the CUT succeeds and is `BRepCheck_Analyzer`-valid, but the result is non-manifold at a knife-edge. Every fuzziness retry (1e-7 → 1e-3) is likewise non-manifold, so `boolean_operation` returns `false` and the caller keeps the un-subtracted first operand, silently dropping the whole subtraction chain.

## Fix
Remember a `BRepCheck`-valid CUT result that was rejected *solely* for being non-manifold, and use it as a last resort once all fuzziness retries are exhausted. A new defaulted parameter `allow_nonmanifold_fallback` is passed `false` into the retry recursion, so the fallback decision is deferred to the finest (most accurate) top-level frame. New diagnostic `GEO 155`.

This is the same gated last-resort family as the existing enlarge-tool / edge-heal / 2D-path fallbacks in this file; the difference is only that this one preserves a valid non-manifold solid rather than discarding a real cut.

## Verification (OCC 7.9.2, clean origin/v0.8.0 baseline vs fix, welded OBJ)
| model | baseline | fix | result |
|---|---|---|---|
| #1015 beam | 40 verts (un-subtracted) | 514 verts (mitered, 0.87 m end wedge removed) | fixed |
| #4118 (IFC4) | md5 3561079b | md5 3561079b | identical |
| #5473 (IFC4) | md5 3b391923 | md5 3b391923 | identical |
| #5186 (IFC2X3) | md5 ed46108c | md5 ed46108c | identical |
| #511 (IFC2X3) | md5 869b1495 | md5 869b1495 | identical |

The success path returns early exactly as before, so the change is provably inert for currently-passing cuts (four representative models byte-identical) and only affects cuts that were previously being dropped. Note: where a cleaner manifold fallback already resolves a case (for example the enlarge-tool path), that path succeeds first and this fallback never triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)