### PR TITLE
Use NEGATIVE-side IfcSurfaceStyle as a fallback instead of dropping it (#5618)

### DIFF
--- a/src/ifcgeom/mapping/mapping.cpp
+++ b/src/ifcgeom/mapping/mapping.cpp
@@ -488,20 +488,41 @@ namespace {
 #endif
 
         IfcSchema::IfcSurfaceStyle *surface_style_ = nullptr;
+        // A surface style with Side == NEGATIVE targets the back (negative) face.
+        // When a POSITIVE or BOTH style is also present it is preferred for the
+        // visible front face, but a NEGATIVE style must still be used as a
+        // fallback so a styled item is not left completely unstyled (see #5618).
+        IfcSchema::IfcSurfaceStyle *negative_surface_style_ = nullptr;
+        std::pair<IfcSchema::IfcSurfaceStyle*, T*> negative_fallback{nullptr, nullptr};
         for (auto& style : prs_styles) {
             if (auto surface_style = style->as<IfcSchema::IfcSurfaceStyle>()) {
-                if (surface_style->Side() != IfcSchema::IfcSurfaceSide::IfcSurfaceSide_NEGATIVE) {
+                const bool is_negative = surface_style->Side() == IfcSchema::IfcSurfaceSide::IfcSurfaceSide_NEGATIVE;
+                if (is_negative) {
+                    if (negative_surface_style_ == nullptr) {
+                        negative_surface_style_ = surface_style;
+                    }
+                } else {
                     surface_style_ = surface_style;
-                    auto styles_elements = surface_style->Styles();
-                    for (auto mt = styles_elements->begin(); mt != styles_elements->end(); ++mt) {
-                        if ((*mt)->template as<T>()) {
+                }
+                auto styles_elements = surface_style->Styles();
+                for (auto mt = styles_elements->begin(); mt != styles_elements->end(); ++mt) {
+                    if ((*mt)->template as<T>()) {
+                        if (!is_negative) {
                             return std::make_pair(surface_style, (*mt)->as<T>());
+                        } else if (negative_fallback.first == nullptr) {
+                            negative_fallback = std::make_pair(surface_style, (*mt)->as<T>());
                         }
                     }
                 }
             }
         }
-        return std::make_pair(surface_style_, nullptr);
+        if (negative_fallback.first != nullptr) {
+            return negative_fallback;
+        }
+        if (surface_style_ != nullptr) {
+            return std::make_pair(surface_style_, nullptr);
+        }
+        return std::make_pair(negative_surface_style_, nullptr);
     }
 
     bool process_colour(IfcSchema::IfcColourRgb* colour, double* rgb) {


### PR DESCRIPTION
Fixes #5618.

## Problem
An item styled only with an `IfcSurfaceStyle` whose `Side` is `.NEGATIVE.` is rendered unstyled (gray `DefaultMaterial`); the style is silently ignored.

## Root cause
The surface-style picker in `mapping.cpp` skipped every style with `Side == NEGATIVE` outright, so if no `POSITIVE` / `BOTH` style was present the item ended up with no style at all.

## Fix
Keep preferring a `POSITIVE` or `BOTH` style for the visible front face (returned immediately, behavior unchanged), but remember a `NEGATIVE`-side style and its shading and use it as a fallback when no `POSITIVE`/`BOTH` style supplies the requested presentation type. The item is then no longer left unstyled.

## Verification (OCC 7.9.2, two-box IFC4 fixture)
One box styled red on the NEGATIVE side, one green on the POSITIVE side. Emitted OBJ/MTL:

| | NEG box | POS box |
|---|---|---|
| before | `DefaultMaterial` (Kd 0.7 0.7 0.7) | green (Kd 0 1 0) |
| after | its red (Kd 1 0 0) | green (Kd 0 1 0), unchanged |

The `POSITIVE`/`BOTH` early-return path is untouched, so styled items that already resolve a front-face style are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)