### PR TITLE
Retry boolean CUT that OCCT reports done but subtracts no volume (#5630)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -1218,6 +1218,24 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 				}
 			}
 
+			// #5630 A solid-solid CUT whose tool operands survived the disjoint/
+			// touching/narrow elimination above is expected to remove material. On
+			// dense tessellated first operands (e.g. IfcPolygonalFaceSet terrain)
+			// OCCT's BOP can silently return an essentially unchanged result at a
+			// tight fuzzy value, reporting IsDone yet subtracting ~nothing. Detect
+			// this near zero volume removal and, while a higher fuzziness retry is
+			// still permitted, treat it as a failure so the existing escalation can
+			// find a fuzzy value at which the section is actually computed. When no
+			// retry is left the result is accepted as is, preserving prior behaviour.
+			if (success && op == BOPAlgo_CUT && allow_retry) {
+				const double va = shape_volume(a);
+				const double vr = shape_volume(r);
+				if (va > 1.e-9 && (va - vr) < va * 1.e-4) {
+					success = false;
+					Logger::Root().Notice("GEO", 156, "Boolean subtraction removed no volume, retrying with higher fuzziness");
+				}
+			}
+
 			if (success) {
 
 				{


### PR DESCRIPTION
Fixes #5630.

## Problem
An `IfcOpeningElement` that voids an `IfcGeographicElement` terrain (a dense `IfcPolygonalFaceSet`) does not cut: the opening solid overlaps the terrain, yet the converted terrain keeps its full volume.

## Root cause
The terrain converts to a valid closed solid and the opening is a proper solid box whose XY sits inside the terrain and whose Z spans its full thickness, so a large removal is expected. But OCCT `BRepAlgoAPI_Cut` returns `IsDone` at the tight default fuzzy value while subtracting essentially nothing, and because it reports success the existing escalating-fuzziness retry never runs. Sweeping fuzziness confirms it: at fuzz >= 5e-4 the cut removes ~17%, at fuzz <= 1e-4 it is a no-op.

## Fix
After a CUT is deemed valid, and only while a higher-fuzziness retry is still permitted, compare the result volume to the first operand. If the removed fraction is negligible (`< 1e-4` of operand A), treat the CUT as a failure so the existing escalation runs and finds a fuzzy value at which the section is actually computed. When no retry is left the result is accepted as before, so a genuinely tiny legitimate cut can never lose its outcome. New diagnostic `GEO 156`.

## Verification (OCC 7.9.2)
| | volume | verts | manifold |
|---|---|---|---|
| terrain before | 7330.878 (no hole) | 459 | closed |
| terrain after | 6058.593 (real hole, -1272) | 377 | closed |

Regression: five currently-passing cut models (#619, #4118, #5473, #5186, #511) are byte-identical before and after, and across the full 1447-object source file exactly one product (the terrain) changes. The guard only fires when OCCT reports a successful CUT that removed ~nothing, so passing cuts are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)