### PR TITLE
Bonsai: pick the true sweep edge in detect_extrusion_edge (#5898)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/helper.py
+++ b/src/bonsai/bonsai/bim/module/geometry/helper.py
@@ -316,10 +316,18 @@ class Helper:
         return {"outer_curve": outer_loop, "inner_curves": inner_loops}
 
     # An extrusion edge is an edge that shares a single vertex with a profile
-    # face and is not on the plane of the face.
+    # face and is not on the plane of the face. Multiple such edges may exist
+    # (e.g. a slanted/stepped mesh has boundary edges that leave the profile
+    # plane only marginally); the genuine sweep edge is the one whose direction
+    # is most aligned with the profile normal. Picking the first candidate in
+    # arbitrary bmesh order could select a nearly in-plane edge, yielding a
+    # degenerate (zero-thickness) extrusion. So we pick the best-aligned edge.
     def detect_extrusion_edge(self, bm: bmesh.types.BMesh, profile_face: bmesh.types.BMFace) -> Union[list[int], None]:
         bm.edges.ensure_lookup_table()
         face_verts_set = set(profile_face.verts)
+        normal = profile_face.normal
+        best_edge = None
+        best_alignment = 0.0
         for edge in bm.edges:
             unshared_verts = set(edge.verts) - face_verts_set
             if len(unshared_verts) == 1:
@@ -327,14 +335,24 @@ class Helper:
                 if (
                     abs(
                         mathutils.geometry.distance_point_to_plane(
-                            unshared_vert.co, profile_face.verts[0].co, profile_face.normal
+                            unshared_vert.co, profile_face.verts[0].co, normal
                         )
                     )
                     > 1e-6
                 ):
-                    if unshared_vert == edge.verts[1]:
-                        return [edge.verts[0].index, edge.verts[1].index]
-                    return [edge.verts[1].index, edge.verts[0].index]
+                    direction = edge.verts[1].co - edge.verts[0].co
+                    length = direction.length
+                    if length < 1e-9:
+                        continue
+                    # 1.0 == parallel to the profile normal (a true sweep edge).
+                    alignment = abs(direction.dot(normal)) / length
+                    if alignment > best_alignment:
+                        best_alignment = alignment
+                        if unshared_vert == edge.verts[1]:
+                            best_edge = [edge.verts[0].index, edge.verts[1].index]
+                        else:
+                            best_edge = [edge.verts[1].index, edge.verts[0].index]
+        return best_edge
 
     def create_extruded_area_solid(
         self, mesh: bpy.types.Mesh, extrusion_indices: list[int], profile_def: dict[str, Any]


### PR DESCRIPTION
Fixes #5898.

## Problem
Converting slabs to `IfcArbitraryProfileDefWithVoids` renders incorrect geometry: 12 of the 69 slabs in the reported sample collapse from ~2500 volume to ~0.

## Root cause
Not the C++ WithVoids path. That path is correct: a hand-built square-with-square-hole extrusion renders volume 168.0 = (100-16)x2 exactly, closed and manifold. The defect is in Bonsai's `Helper.detect_extrusion_edge` (`geometry/helper.py`): it returned the first mesh edge that leaves the profile plane by more than 1e-6. For the bad slabs the first such edge (in arbitrary bmesh order) is a nearly lateral diagonal that only marginally clears the threshold, so the resulting `IfcExtrudedAreaSolid.ExtrudedDirection` lies in the profile plane (local Z = 0) with a bogus large depth. Extruding a planar profile along an in-plane direction is a legitimately degenerate, zero-volume sliver, which the C++ renders faithfully.

## Fix
Scan all candidate edges and return the one whose direction is most aligned with the profile-face normal, i.e. the genuine through-thickness sweep edge, keeping the same `[in_profile_vertex, off_plane_vertex]` return orientation. This benefits all four auto-detect callers.

## Verification (headless Blender 5.1 / Bonsai 0.8.6, local IfcConvert OCC 7.9.2)
Re-derived all 69 slabs, saved, rendered, and compared per-slab signed-tetra volume against the original Brep ground truth:
- before: 12 slabs degenerate (e.g. 2570.70 -> 0.0055)
- after: all 69 match Brep to 5 to 6 significant figures (worst 0.01%); the degenerate 12 are restored (0.0055 -> 2570.70) and the 57 already-correct slabs are volume-identical.

Verified with the actual staged file installed into Bonsai, not a monkeypatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)