### PR TITLE
Fix #1367: map IfcAsymmetricIShapeProfileDef in IFC4+

### DIFF
--- a/src/ifcgeom/mapping/IfcIShapeProfileDef.cpp
+++ b/src/ifcgeom/mapping/IfcIShapeProfileDef.cpp
@@ -109,3 +109,56 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcIShapeProfileDef* inst) {
 		{{-x1,-y + ft1}, {fe1}}
 	});
 }
+
+#ifdef SCHEMA_IfcAsymmetricIShapeProfileDef_HAS_BottomFlangeWidth
+// In IFC4 IfcAsymmetricIShapeProfileDef is no longer a subtype of
+// IfcIShapeProfileDef, so it has its own dedicated mapping. Bottom and top
+// flanges may differ in width, thickness, fillet radius, edge radius and slope.
+taxonomy::ptr mapping::map_impl(const IfcSchema::IfcAsymmetricIShapeProfileDef* inst) {
+	const double x1 = inst->BottomFlangeWidth() / 2.0 * length_unit_;
+	const double x2 = inst->TopFlangeWidth() / 2.0 * length_unit_;
+	const double y = inst->OverallDepth() / 2.0 * length_unit_;
+	const double d1 = inst->WebThickness() / 2.0 * length_unit_;
+	const double ft1 = inst->BottomFlangeThickness() * length_unit_;
+	const double ft2 = inst->TopFlangeThickness().get_value_or(inst->BottomFlangeThickness()) * length_unit_;
+
+	const double f1 = inst->BottomFlangeFilletRadius().get_value_or(0.) * length_unit_;
+	const double f2 = inst->TopFlangeFilletRadius().get_value_or(0.) * length_unit_;
+	const double fe1 = inst->BottomFlangeEdgeRadius().get_value_or(0.) * length_unit_;
+	const double fe2 = inst->TopFlangeEdgeRadius().get_value_or(0.) * length_unit_;
+
+	const double dy1 = (x1 > d1) ? (x1 - d1) * tan(inst->BottomFlangeSlope().get_value_or(0.) * angle_unit_) : 0.;
+	const double dy2 = (x2 > d1) ? (x2 - d1) * tan(inst->TopFlangeSlope().get_value_or(0.) * angle_unit_) : 0.;
+
+	const double tol = settings_.get<settings::Precision>().get();
+
+	if (x1 < tol || x2 < tol || y < tol || d1 < tol || ft1 < tol || ft2 < tol) {
+		logger_.Message(Logger::LOG_NOTICE, "GEO", 264, "Skipping zero sized profile:", inst);
+		return nullptr;
+	}
+
+	taxonomy::matrix4::ptr m4;
+	bool has_position = true;
+#ifdef SCHEMA_IfcParameterizedProfileDef_Position_IS_OPTIONAL
+	has_position = !!inst->Position();
+#endif
+	if (has_position) {
+		m4 = taxonomy::cast<taxonomy::matrix4>(map(inst->Position()));
+	}
+
+	return profile_helper(m4, {
+		{{-x1,-y}},
+		{{x1,-y}},
+		{{x1,-y + ft1}, {fe1}},
+		{{d1,-y + ft1 + dy1},{f1}},
+		{{d1,y - ft2 - dy2},{f2}},
+		{{x2,y - ft2}, {fe2}},
+		{{x2,y}},
+		{{-x2,y}},
+		{{-x2,y - ft2}, {fe2}},
+		{{-d1,y - ft2 - dy2},{f2}},
+		{{-d1,-y + ft1 + dy1},{f1}},
+		{{-x1,-y + ft1}, {fe1}}
+	});
+}
+#endif

--- a/src/ifcgeom/mapping/mapping.i
+++ b/src/ifcgeom/mapping/mapping.i
@@ -89,7 +89,11 @@ BIND(IfcRectangleHollowProfileDef);
 BIND(IfcRectangleProfileDef);
 BIND(IfcTrapeziumProfileDef);
 BIND(IfcCShapeProfileDef);
-// IfcAsymmetricIShapeProfileDef included
+#ifdef SCHEMA_IfcAsymmetricIShapeProfileDef_HAS_BottomFlangeWidth
+// In IFC4+ IfcAsymmetricIShapeProfileDef is not a subtype of IfcIShapeProfileDef
+BIND(IfcAsymmetricIShapeProfileDef);
+#endif
+// IfcAsymmetricIShapeProfileDef included (as IfcIShapeProfileDef subtype in IFC2X3)
 BIND(IfcIShapeProfileDef);
 BIND(IfcLShapeProfileDef);
 BIND(IfcTShapeProfileDef);


### PR DESCRIPTION
Fixes #1367.

## Problem
In IFC2x3 `IfcAsymmetricIShapeProfileDef` is a subtype of `IfcIShapeProfileDef` and was covered by that mapping (the dispatch uses `inst->as<T>()`, which respects inheritance). In **IFC4 it was re-parented directly to `IfcParameterizedProfileDef`**, so nothing binds it and `mapping::map()` falls through to:

```
[Error] GEO307 No operation defined for: IfcAsymmetricIShapeProfileDef(...)
```

producing empty geometry. The inline `is(IfcAsymmetricIShapeProfileDef)` branch inside the I-shape mapper is unreachable for standalone IFC4 instances, and it reads `OverallWidth()` which IFC4 asymmetric profiles do not have (they carry `BottomFlangeWidth`/`TopFlangeWidth`).

## Fix
Add a dedicated `map_impl(const IfcAsymmetricIShapeProfileDef*)`, guarded by `SCHEMA_IfcAsymmetricIShapeProfileDef_HAS_BottomFlangeWidth` (defined only where the type is standalone, i.e. IFC4+), that builds the section from independent bottom/top flange width, thickness, fillet radius, edge radius and slope. Bind it under the same guard. IFC2x3 keeps using the existing I-shape path unchanged.

## Verification (local build 0.8.6, OCC 7.9.2)
Extruded an IFC4 `IfcAsymmetricIShapeProfileDef` (BottomFlangeWidth 0.2, TopFlangeWidth 0.1, depth 0.4):

| | before | after |
|---|---|---|
| verts | 0 (GEO307) | 24 |
| bottom flange width | - | 0.200 (as specified) |
| top flange width | - | 0.100 (as specified) |

IFC2x3 asymmetric profile: still 24 verts, correct 0.2/0.1 widths, no error (no regression).