### PR TITLE
Warn when a face inner boundary intersects another boundary (#527)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/face.cpp
+++ b/src/ifcgeom/kernels/opencascade/face.cpp
@@ -31,6 +31,7 @@
 #include <ShapeFix_Shape.hxx>
 #include <ShapeFix_ShapeTolerance.hxx>
 #include <BRep_Tool.hxx>
+#include <BRepExtrema_DistShapeShape.hxx>
 
 #include <Standard_Macro.hxx>
 #include <TopoDS_Shape.hxx>
@@ -354,6 +355,27 @@ bool OpenCascadeKernel::convert(const taxonomy::face::ptr face, TopoDS_Shape& re
 	if (fd.wires().empty()) {
 		Logger::Root().Warning("GEO", 162, "Face with no boundaries", face->instance);
 		return false;
+	}
+
+	// #527: A face whose inner boundary intersects the outer boundary (or
+	// another inner boundary) is invalid per the schema. Open Cascade heals or
+	// drops such a face silently, so the intended hole is lost with no
+	// diagnostic. The distance between two non-intersecting loops is strictly
+	// positive; a distance at (or below) the modelling precision means the
+	// boundaries touch or cross. Emit a clear warning so the invalid input is
+	// not silently lost. wires() is ordered outer-first, inner-bounds after.
+	if (fd.wires().size() > 1) {
+		const auto& fwires = fd.wires();
+		bool reported = false;
+		for (size_t i = 1; i < fwires.size() && !reported; ++i) {
+			for (size_t j = 0; j < i && !reported; ++j) {
+				BRepExtrema_DistShapeShape dss(fwires[i], fwires[j]);
+				if (dss.IsDone() && dss.Value() < precision_) {
+					logger().Warning("GEO", 402, "Face inner boundary intersects another face boundary", face->instance);
+					reported = true;
+				}
+			}
+		}
 	}
 
 	if (fd.surface().IsNull()) {


### PR DESCRIPTION
Fixes #527.

## Problem
A face whose inner boundary crosses the outer boundary (or another inner boundary) is invalid, but IfcOpenShell handles it silently: the 2018 report saw the face dropped (0 triangles) with no error; on the current line Open Cascade instead heals it into wrong geometry, still with no diagnostic. Either way the user gets no signal that their input face is malformed.

## Fix
After the wires are collected, if a face has inner boundaries, measure the `BRepExtrema_DistShapeShape` distance between each inner wire and every earlier wire (outer plus prior inners). Two non intersecting loops have strictly positive distance, so a distance at or below the modelling precision means the boundaries touch or cross; emit `GEO 402` naming the offending face. Diagnostic only, no geometry change. The check is gated on faces that actually have inner wires.

The warning is emitted via the kernel `logger()` rather than `Logger::Root()`. IfcConvert configures a local `Logger` and worker logs merge into it, whereas `Logger::Root()` is a separate unconfigured singleton whose messages are discarded (a latent issue that also affects some existing GEO messages, worth a separate look).

## Verification (OCC 7.9.2, synthesized IFC4 faces, run with -v)
| case | GEO 402 | note |
|---|---|---|
| valid 4x4 hole | 0 | triangulates identically, area 84.0 |
| inner triangle crossing outer right edge | 1 | flagged |
| inner straddling bottom edge | 1 | flagged |
| inner self-intersecting (bowtie), no crossing | 0 | separate class, left untouched |
| inner containing outer | 0 | separate class, left untouched |

No regression on the valid holed face (identical output, no new warning) in both sequential and multithreaded runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)