### PR TITLE
Expand wildcard attributes in IfcCsv export (#3424)

### DIFF
--- a/src/ifccsv/ifccsv.py
+++ b/src/ifccsv/ifccsv.py
@@ -105,6 +105,9 @@ class IfcCsv:
             attributes.insert(0, "GlobalId")
             headers.insert(0, "GlobalId")
 
+        elements = list(elements)
+        attributes, headers = self.expand_wildcard_attributes(attributes, headers, elements)
+
         for element in elements:
             result = []
 
@@ -383,6 +386,44 @@ class IfcCsv:
     def export_pd(self):
         self.dataframe = pd.DataFrame(self.results, columns=self.headers)
         return self.dataframe
+
+    def expand_wildcard_attributes(self, attributes, headers, elements):
+        """Expand any attribute containing ``*`` into concrete attribute names.
+
+        A bare ``*`` expands to every direct attribute of the exported elements.
+        A ``Pset_Name.*`` (or ``Qto_Name.*``) query expands to every property of
+        that named property set / quantity set, using ``get_wildcard_attributes``.
+        Attributes without a ``*`` are passed through unchanged so explicit
+        named queries keep their position and any custom header.
+        """
+        expanded_attributes = []
+        expanded_headers = []
+        for attribute, header in zip(attributes, headers):
+            if "*" not in attribute:
+                expanded_attributes.append(attribute)
+                expanded_headers.append(header)
+                continue
+            if attribute == "*":
+                expansions = self.get_element_attributes(elements)
+            else:
+                expansions = self.get_wildcard_attributes(attribute)
+            for expanded in expansions:
+                if expanded in expanded_attributes:
+                    continue  # Avoid duplicate columns (e.g. GlobalId).
+                expanded_attributes.append(expanded)
+                # Expanded columns fall back to the attribute name as header.
+                expanded_headers.append(None)
+        return expanded_attributes, expanded_headers
+
+    def get_element_attributes(self, elements):
+        results = []
+        for element in elements:
+            for name in element.get_info(recursive=False):
+                if name in ("id", "type"):
+                    continue
+                if name not in results:
+                    results.append(name)
+        return results
 
     def get_wildcard_attributes(self, attribute):
         results = set()


### PR DESCRIPTION
Fixes #3424.

## Problem
Exporting with a `*` attribute (or `Pset_Name.*`) emits a literal `*` column filled with the null placeholder instead of expanding to real columns. The `get_wildcard_attributes` helper had no callers after a refactor dropped the expansion step.

## Fix
`export()` now calls a new `expand_wildcard_attributes` before the per-element loop:
- non-wildcard queries pass through unchanged (position and custom header preserved);
- a bare `*` expands to every direct attribute of the exported elements (new `get_element_attributes` helper);
- `Pset_Name.*` / `Qto_Name.*` expand via the existing `get_wildcard_attributes` helper;
- expanded columns that duplicate an existing one (e.g. `GlobalId`, an explicit `Name`) are skipped.

Bare `*` = all direct attributes and `Pset_Name.*` = that pset's properties. A wildcard for "every pset on the element" is out of scope (would need a separate token).

## Verification (headless)
| query | before | after |
|---|---|---|
| `["Name","*"]` | `[GlobalId, *]` → literal `*`, value `-` | `[GlobalId, Name, ..., Tag, PredefinedType]` with real values |
| `["Pset_WallCommon.*"]` | `[GlobalId, Pset_WallCommon.*]` → `-` | `[..., Pset_WallCommon.IsExternal, Pset_WallCommon.LoadBearing]` with YES/NO |
| `["Name","Description","Tag"]` | unchanged | unchanged |

This contribution was generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)