### PR TITLE
Bonsai: guard drawing with no document reference in get_sheet_references (#8036, #7266)

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2830,6 +2830,10 @@ class Drawing(bonsai.core.tool.Drawing):
     def get_sheet_references(cls, drawing: ifcopenshell.entity_instance) -> list[ifcopenshell.entity_instance]:
         sheet_references: list[ifcopenshell.entity_instance] = []
         drawing_reference = cls.get_drawing_document(drawing)
+        # A drawing with no associated document reference cannot be referenced
+        # by any sheet, so there is nothing to compare against (see #8036, #7266).
+        if drawing_reference is None:
+            return sheet_references
         for sheet in tool.Ifc.get().by_type("IfcDocumentInformation"):
             if not sheet.Scope == "SHEET":
                 continue


### PR DESCRIPTION
Fixes #8036. Fixes #7266. (same root cause)

## Problem
Activating a drawing raises `AttributeError: 'NoneType' object has no attribute 'Location'`.

## Root cause
`Drawing.get_sheet_references` calls `get_drawing_document(drawing)`, which returns `None` when the drawing has no associated `IfcRelAssociatesDocument`. The loop then evaluates `reference.Location == drawing_reference.Location`, dereferencing `.Location` on `None`.

## Fix
A drawing with no document reference cannot be referenced by any sheet, so return the empty list before the comparison loop:

```python
drawing_reference = cls.get_drawing_document(drawing)
if drawing_reference is None:
    return sheet_references
```

## Verification (real ifcopenshell)
- No document reference: before → AttributeError; after → returns `[]` cleanly.
- Valid reference: output identical before and after (the guard is unreachable when the reference exists).

This contribution was generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)