### PR TITLE
Guard append_asset against an empty aggregate attribute (#7261)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -775,7 +775,10 @@ class Usecase:
 
         # Utils method for the loop.
         def get_tuple_type(tuple_: tuple) -> type:
-            while isinstance(tuple_, tuple):
+            # Guard against empty (possibly nested) tuples, e.g. an aggregate
+            # attribute set to `()` or `((),)`, which would otherwise index
+            # into an empty tuple and raise IndexError (see #7261).
+            while isinstance(tuple_, tuple) and tuple_:
                 tuple_ = tuple_[0]
             return type(tuple_)
 


### PR DESCRIPTION
Fixes #7261.

## Problem
`project.append_asset` raises `IndexError: tuple index out of range` when an appended asset has an empty aggregate attribute (e.g. an `IfcCartesianPointList2D` with `CoordList == ((),)`).

## Root cause
`get_tuple_type` descends nested tuples with `while isinstance(tuple_, tuple): tuple_ = tuple_[0]`, indexing `[0]` into an empty tuple.

## Fix
Stop descending at an empty tuple:
```python
while isinstance(tuple_, tuple) and tuple_:
    tuple_ = tuple_[0]
return type(tuple_)
```
It then returns `tuple`, which matches neither `entity_instance` nor `float` in the copy loop, so the empty aggregate is carried through unchanged and the append proceeds.

## Verification (headless)
- Empty aggregate (`CoordList=((),)`): before → IndexError; after → append succeeds, empty list preserved.
- Normal populated profile: appends unchanged.

This contribution was generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Also fixes #6972 (same get_tuple_type empty-tuple crash, triggered by an invalid/empty IfcSurfaceStyles list when appending a type).