### PR TITLE
Refuse cyclic aggregation in aggregate.assign_object (#7154)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/aggregate/assign_object.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/aggregate/assign_object.py
@@ -161,7 +161,7 @@ def assign_object(
                 "OwnerHistory": ifcopenshell.api.owner.create_owner_history(file),
                 "RelatedObjects": list(products_set),
                 "RelatingObject": relating_object,
-            }
+            },
         )
 
     # localize placement relative to a new aggregate for affected products

--- a/src/ifcopenshell-python/ifcopenshell/api/aggregate/assign_object.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/aggregate/assign_object.py
@@ -88,6 +88,24 @@ def assign_object(
         return
 
     products_set = set(products)
+
+    # Guard against creating a cyclic aggregation. Aggregating a product under
+    # relating_object makes the product an ancestor of relating_object, so if a
+    # product is relating_object itself or already an ancestor of it, the
+    # relationship would form a loop. Such a cycle later causes infinite
+    # recursion (e.g. RecursionError) when placements or the decomposition tree
+    # are traversed, so refuse it up front. See issue #7154.
+    ancestor = relating_object
+    ancestors: set[ifcopenshell.entity_instance] = set()
+    while ancestor is not None and ancestor not in ancestors:
+        ancestors.add(ancestor)
+        ancestor = ifcopenshell.util.element.get_aggregate(ancestor)
+    cycling = products_set & ancestors
+    if cycling:
+        raise ValueError(
+            "Cannot aggregate an object under itself or one of its descendants "
+            f"(would create a cyclic aggregation): {cycling}"
+        )
     is_decomposed_by = next((i for i in relating_object.IsDecomposedBy if i.is_a("IfcRelAggregates")), None)
 
     previous_aggregates_rels: set[ifcopenshell.entity_instance] = set()


### PR DESCRIPTION
Fixes #7154.

## Problem
Creating an aggregate from an object plus an aggregate can raise `RecursionError: maximum recursion depth exceeded` when the operation nests an aggregate into itself (a cycle).

## Root cause
`aggregate.assign_object` writes the `IfcRelAggregates` without checking for a cycle. When a product is `relating_object` itself or already an ancestor of it, the relationship closes a loop; traversing it later (e.g. `util.placement.get_local_placement` following `PlacementRelTo`) recurses without end. Without placements it silently writes an invalid cyclic model.

## Fix
Before writing, walk the aggregate ancestor chain of `relating_object` (including itself, with a visited set to stay safe against pre-existing cycles) and raise a clear `ValueError` if any product is in it. Fixing this in the api protects every caller, including the Bonsai operator.

## Verification (headless)
- self-aggregation, 2-node cycle, deep cycle: `RecursionError` → clean `ValueError`.
- normal aggregate of a distinct element under a distinct aggregate: unchanged.
- existing `test/api/aggregate` suite (20 tests) passes.

This contribution was generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)