### PR TITLE
ifcopenshell: fix geom.iterator memory growth on the OCC path (#6904)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
@@ -295,8 +295,16 @@ def create_shape_from_serialization(
             ss.ReadFromString(brep_data)
             occ_shape = ss.Shape(ss.NbShapes())
         else:
+            # The single-argument breptools.ReadFromString allocates and returns
+            # a new TopoDS_Shape on every call, which pythonOCC documents as
+            # increasing memory; pass the shape by reference to reuse it instead
+            # and fall back for older bindings lacking that overload. See #6904.
             ss = BRepTools.breptools()
-            occ_shape = ss.ReadFromString(brep_data)
+            occ_shape = TopoDS.TopoDS_Shape()
+            try:
+                ss.ReadFromString(brep_data, occ_shape)
+            except TypeError:
+                occ_shape = ss.ReadFromString(brep_data)
     except BaseException as e:
         print("Error occurred parsing a shape from a string:", e)
 


### PR DESCRIPTION
Fixes #6904.

### Problem
`ifcopenshell.geom.iterator` grows in memory when `use_python_opencascade=True`. The reporter's `memory_profiler` traces show the OCC path climbing monotonically (roughly +184 MB over the run) while the default occt path stays flat.

### Cause
On the pythonOCC path the iterator emits `SERIALIZED` elements, and each element's brep is deserialized by `create_shape_from_serialization` in `geom/occ_utils.py`. For OCC >= 7.8 this called the single-argument overload `breptools.ReadFromString(brep_data)`. pythonOCC's own binding documents that overload as allocating and returning a new `TopoDS_Shape` on every call, and provides the by-reference overload `ReadFromString(brep_data, shape)` specifically "to prevent memory increase." The allocating overload was being used, so a fresh shape was created per element for the life of the iteration.

### Fix
Use the by-reference overload against a pre-allocated `TopoDS_Shape`, falling back to the single-argument form (via `TypeError`) for older bindings that only expose it. One file, `geom/occ_utils.py`.

### Verification
- Reporter's traces: OCC path +184 MB monotonic vs occt path flat (+4.7 MB) — leak confirmed on their build.
- The C++ SERIALIZED brep production, isolated, is flat, so the growth is on the pythonOCC deserialization side, not the kernel.
- In isolation the by-reference overload is measurably flatter than the single-argument one on repeated real-brep deserialization, matching pythonOCC's documented intent.

Note on scope: I could not reproduce the full in-process 184 MB locally, because loading a standalone conda pythonOCC alongside IfcOpenShell's bundled static OCCT causes a symbol clash that aborts the iterator's `initialize()` on my machine. The change targets exactly the documented growing-allocation overload the report points at and is verified flatter in isolation; the biggest improvement is expected on the older pythonOCC versions where the reporter saw it (they noted it as most noticeable on 0.8.2 / 0.8.3). @duming, if you can run your original profile against this branch it would be good to confirm the full drop on your model.

This contribution was produced with the assistance of an AI coding tool.
