### PR TITLE
ifcgeom: recover BRepCheck-valid non-manifold subtractions instead of dropping them (#620, #616)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -832,7 +832,14 @@ bool IfcGeom::util::points_on_planar_face_generator::operator()(gp_Pnt& p) {
 }
 
 
-bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const TopoDS_Shape& a_input, const NCollection_List<TopoDS_Shape>& b_input, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness) {
+namespace IfcGeom { namespace util {
+	// Internal worker for boolean_operation(). When allow_nonmanifold is true a
+	// BRepCheck-valid but non-manifold CUT result is accepted as a last resort
+	// (see #620 / #616) instead of discarding the subtraction.
+	bool boolean_operation_impl(const boolean_settings& settings, const TopoDS_Shape& a_input, const NCollection_List<TopoDS_Shape>& b_input, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness, bool allow_nonmanifold);
+} }
+
+bool IfcGeom::util::boolean_operation_impl(const boolean_settings& settings, const TopoDS_Shape& a_input, const NCollection_List<TopoDS_Shape>& b_input, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness, bool allow_nonmanifold) {
 	using namespace std::string_literals;
 
 	const bool do_unify = true;
@@ -1284,6 +1291,21 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 						}
 					}
 					success = operands_nonmanifold;
+
+					if (!success && allow_nonmanifold && op == BOPAlgo_CUT) {
+						// #620 / #616: OCCT performed the subtraction and produced a
+						// BRepCheck-valid solid, but it is non-manifold (e.g. an opening
+						// edge coincides with a clip/face seam). Rather than discarding
+						// the whole subtraction, accept the valid result as a gated last
+						// resort, provided it actually removed meaningful volume (guard
+						// against no-op cuts that should instead escalate fuzziness, cf. #5630).
+						const double va = shape_volume(a);
+						const double vr = shape_volume(r);
+						if (va > 1.e-9 && (va - vr) > va * 1.e-4) {
+							success = true;
+							Logger::Root().Notice("GEO", 157, "Accepting valid but non-manifold boolean CUT result as last resort");
+						}
+					}
 				}
 
 				if (success) {
@@ -1417,12 +1439,54 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 	}
 	if (!success) {
 		if (allow_retry) {
-			return boolean_operation(settings, a, b, op, result, new_fuzziness);
+			return boolean_operation_impl(settings, a, b, op, result, new_fuzziness, allow_nonmanifold);
 		} else {
 			Logger::Root().Notice("GEO", 154, "No longer attempting boolean operation with higher fuzziness");
 		}
 	}
 	return success && !result.IsNull();
+}
+
+bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const TopoDS_Shape& a, const NCollection_List<TopoDS_Shape>& b, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness) {
+	// First attempt with the strict (manifold-required) behaviour so that
+	// currently-working cuts are completely unaffected.
+	if (boolean_operation_impl(settings, a, b, op, result, fuzziness, /*allow_nonmanifold=*/false)) {
+		return true;
+	}
+
+	// Last-resort recovery for subtractions only (#620 / #616). Two failure modes
+	// are handled, both gated behind the strict attempt having already failed:
+	//  1) OCCT performs the cut but the valid result is non-manifold -> accept it.
+	//  2) A simultaneous multi-tool cut fails outright, yet applying the tools
+	//     one-by-one succeeds -> fall back to sequential application.
+	if (op != BOPAlgo_CUT) {
+		return false;
+	}
+
+	if (b.Extent() > 1) {
+		TopoDS_Shape current = a;
+		bool any_applied = false;
+		for (NCollection_List<TopoDS_Shape>::Iterator it(b); it.More(); it.Next()) {
+			NCollection_List<TopoDS_Shape> single;
+			single.Append(it.Value());
+			TopoDS_Shape part;
+			if (boolean_operation_impl(settings, current, single, op, part, fuzziness, /*allow_nonmanifold=*/true) && !part.IsNull()) {
+				current = part;
+				any_applied = true;
+			}
+			// If a single tool cannot be applied it is skipped; keeping the
+			// partially-subtracted solid is preferable to dropping every opening.
+		}
+		if (any_applied) {
+			Logger::Root().Notice("GEO", 158, "Applied subtraction operands sequentially as last resort");
+			result = current;
+			return true;
+		}
+		return false;
+	}
+
+	// Single tool: retry allowing a valid non-manifold result.
+	return boolean_operation_impl(settings, a, b, op, result, fuzziness, /*allow_nonmanifold=*/true);
 }
 
 bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const TopoDS_Shape& a, const TopoDS_Shape& b, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness) {


### PR DESCRIPTION
Fixes #620 and #616 (same subtraction-robustness family, one change).

### Problem
On certain walls the opening / half-space clip subtractions are silently dropped, so the wall renders solid (no openings), while other tools (e.g. Solibri) show the cuts.

### Cause
Both samples end at the same place: OCCT performs the subtraction and returns a **BRepCheck-valid** solid, but that solid is **non-manifold** (an opening edge coincides with a wall or clip face seam). The manifold gate (`success = !is_manifold(a) || is_manifold(r)`) rejects it, and after fuzziness escalation the whole subtraction is discarded. #616 additionally fails the *simultaneous* four-tool cut outright (`IsDone() == false` at all fuzziness), even though applying the four half-spaces one by one succeeds.

### Fix (`boolean_utils.cpp`)
Split `boolean_operation` into a strict internal worker `boolean_operation_impl(..., allow_nonmanifold)` (byte-for-byte the previous behaviour) and a thin orchestrator that:
1. runs the **strict** attempt first, so currently-working cuts are completely unaffected;
2. only if that fails, and only for `CUT`, attempts recovery:
   - multiple tools → apply them **sequentially** (GEO 158);
   - accept a **BRepCheck-valid non-manifold** result as a gated last resort (GEO 157), guarded by "removed meaningful volume" (`(va − vr) > va·1e-4`) so no-op cuts still escalate fuzziness instead of being falsely accepted.

The recovery path is unreachable unless the strict attempt already returned false, so no cut that currently succeeds can change.

### Verification (local OpenCascade build, OCC 7.9.2, vs a freshly built unpatched baseline)
Oracle = signed-tetra volume + edge parity from the welded OBJ.

| sample | baseline (unpatched) | fixed |
|---|---|---|
| #620 | vol 5.8881, 20 v (subtraction dropped) | **vol 4.5381, 34 v** (openings applied, −1.35 m³) |
| #616 | vol 16.4684, 8 v (4 clips dropped) | **vol 15.0497, 22 v** (4 clips applied, −1.42 m³) |

Both fixed results are watertight (0 boundary edges). The single non-manifold seam edge is inherent to these models (an opening/clip corner coincident with a wall face) and matches the expected geometry in the issue screenshots. Regression: the new path is structurally unreachable for currently-succeeding cuts, and a sweep of the repo's IFC2X3 geometry files plus a crafted clean through-opening wall are byte-identical between baseline and fixed.

This contribution was produced with the assistance of an AI coding tool.
