### PR TITLE
ifcopenshell: attach owning file to geom.tree select results (#3189)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/main.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/main.py
@@ -370,6 +370,17 @@ CLASH_TYPE_ITEMS = ("protrusion", "pierce", "collision", "clearance")
 
 
 class tree(ifcopenshell_wrapper.tree):
+    @staticmethod
+    def _wrap(e: ifcopenshell_wrapper.entity_instance) -> entity_instance:
+        inst = entity_instance(e)
+        # #3189 attach the owning file so that equality and hashing of
+        # selected instances use the fast step-id based path instead of
+        # falling back to a slow recursive attribute comparison.
+        ptr = e.file_pointer()
+        if ptr:
+            inst.wrapped_data.file = file.from_pointer(ptr)
+        return inst
+
     def __init__(self, file: Optional[file] = None, settings: Optional[settings] = None):
         args = [self]
         if file is not None:
@@ -412,7 +423,7 @@ class tree(ifcopenshell_wrapper.tree):
                 args.append(kwargs.get("completely_within", False))
                 if "extend" in kwargs:
                     args.append(kwargs["extend"])
-        return [entity_instance(e) for e in ifcopenshell_wrapper.tree.select(*args)]
+        return [self._wrap(e) for e in ifcopenshell_wrapper.tree.select(*args)]
 
     def select_box(self, value, **kwargs) -> list[entity_instance]:
         def unwrap(value):
@@ -427,7 +438,7 @@ class tree(ifcopenshell_wrapper.tree):
             args.append(kwargs.get("completely_within", False))
         if "extend" in kwargs:
             args.append(kwargs.get("extend", -1.0e-5))
-        return [entity_instance(e) for e in ifcopenshell_wrapper.tree.select_box(*args)]
+        return [self._wrap(e) for e in ifcopenshell_wrapper.tree.select_box(*args)]
 
     def clash_intersection_many(
         self,


### PR DESCRIPTION
Fixes #3189.

### Problem
Elements returned by `geom.tree.select` / `select_box` come back with `wrapped_data.file == None`. That forces `entity_instance.__eq__` down the slow recursive `get_info_2` attribute comparison instead of the fast step-id path, and drops the file reference that keeps the instance alive, which showed up as slowdowns and transaction issues.

### Cause
Both methods wrapped their C++ results as `entity_instance(e)` with no file argument, so `__init__` set `wrapped_data.file = None`. The underlying instances carry a valid `file_pointer()`, so the owning file was recoverable but never attached. (The 2023 PR #3190 added the lazy `entity_instance.file` getter but never assigned `wrapped_data.file` on tree results, so the reported problem persisted.)

### Fix
Add a small `tree._wrap` helper that resolves the owning file from each result's `file_pointer()` via `file.from_pointer()` and attaches it, and route both `select` and `select_box` through it.

### Verification
Repro on `basic.ifc` with the compiled wrapper:
- Before: `wrapped_data.file` is `None`; equality takes the slow path (2 `get_info_2` calls).
- After: file attached; equality/hash use the fast path (0 slow calls); `eq` and `hash` match an identically-owned instance, for both `select` and `select_box`.

black and ruff (line-length 120) pass.

This contribution was produced with the assistance of an AI coding tool.
