### PR TITLE
ifcgeom: fall back to unsliced representation when layerset slicing fails (#6607)

### DIFF
--- a/src/ifcgeom/Converter.cpp
+++ b/src/ifcgeom/Converter.cpp
@@ -55,17 +55,29 @@ IfcGeom::BRepElement* ifcopenshell::geometry::Converter::create_brep_for_represe
 		std::map<IfcUtil::IfcBaseEntity*, ifcopenshell::geometry::layerset_information> neigbour_layers;
 		int layerset_id, lid;
 
-		if (mapping_->get_layerset_information(product, layerinfo, layerset_id)) {
-			representation_id_builder << "-layerset-" << layerset_id;
-			if (mapping_->get_wall_neighbours(product, neighbours)) {
-				for (auto& n : neighbours) {
-					auto p = std::get<2>(n);
-					mapping_->get_layerset_information(p, neigbour_layers[p], lid);
+		// Layerset slicing is best-effort: gathering the layerset information or
+		// applying it may throw (e.g. when the axis representation cannot be cast
+		// to a curve, or when the active kernel does not implement slicing). In
+		// that case the element still has a perfectly valid unsliced body
+		// representation in `shapes`, so we fall back to that rather than letting
+		// the exception propagate and silently drop the element entirely (#6607).
+		try {
+			if (mapping_->get_layerset_information(product, layerinfo, layerset_id)) {
+				representation_id_builder << "-layerset-" << layerset_id;
+				if (mapping_->get_wall_neighbours(product, neighbours)) {
+					for (auto& n : neighbours) {
+						auto p = std::get<2>(n);
+						mapping_->get_layerset_information(p, neigbour_layers[p], lid);
+					}
+					kernel_->apply_folded_layerset(shapes, layerinfo, neigbour_layers);
+				} else {
+					kernel_->apply_layerset(shapes, layerinfo);
 				}
-				kernel_->apply_folded_layerset(shapes, layerinfo, neigbour_layers);
-			} else {
-				kernel_->apply_layerset(shapes, layerinfo);
 			}
+		} catch (const std::exception& e) {
+			logger_.Message(Logger::LOG_WARNING, "GEO", 260, std::string("Layerset slicing failed, falling back to unsliced representation: ") + e.what(), product);
+		} catch (...) {
+			logger_.Message(Logger::LOG_WARNING, "GEO", 260, "Layerset slicing failed, falling back to unsliced representation", product);
 		}
 
 		/*


### PR DESCRIPTION
Fixes #6607.

### Problem
Running IfcConvert with `--enable-layerset-slicing` produces almost nothing — most elements are silently dropped.

### Cause
The layerset block at `Converter.cpp:58` had no exception handling, and the OCC-side layerset path on v0.8.0 can throw for common inputs:
- `get_layerset_information` does `taxonomy::cast<collection>(...)` on a wall's mapped Axis representation and throws `"Unexpected topology"` when that axis isn't castable;
- even when it succeeds, `apply_layerset` / `apply_folded_layerset` resolve to the `AbstractKernel` stubs that `throw not_implemented_error()` (no kernel overrides them).

Because nothing caught these, the first failing element aborted the **entire** conversion, so the whole run emitted zero geometry.

### Fix
Wrap the layerset block in a try/catch: on any failure, log `GEO 260` and keep the element's already-built unsliced body representation instead of letting the exception propagate. Elements that slice successfully are unaffected.

### Verification (local OpenCascade build, OCC 7.9.2, reporter's Cassiopae sample)
- `--enable-layerset-slicing` **before**: exit 1, **0 objects**, `GEO060 Unexpected topology`.
- `--enable-layerset-slicing` **after**: exit 0, **all 215 objects** emitted, with 90 `GEO260` fallback warnings.
- Default (no slicing): **byte-identical** before and after.

### Honest caveat
Geometric layerset slicing itself is not implemented on the OpenCascade kernel on the v0.8.0 line (the real slicing code in `Converter.cpp` is commented out and the kernel methods are `not_implemented` stubs), so the recovered elements are emitted **unsliced**. This change is scoped to the reported defect — it stops `--enable-layerset-slicing` from dropping elements — and is not an implementation of slicing. Happy to adjust if you'd prefer the flag to hard-error that slicing is unsupported on this kernel instead of degrading gracefully.

This contribution was produced with the assistance of an AI coding tool.
