### PR TITLE
Support block comments in the selector filter syntax (#5023)

### DIFF
--- a/src/ifcopenshell-python/docs/ifcopenshell-python/selector_syntax.rst
+++ b/src/ifcopenshell-python/docs/ifcopenshell-python/selector_syntax.rst
@@ -89,6 +89,11 @@ The filters are chained and apply from left to right.
 
     filter[, filter]*
 
+Any part of a query may be commented out using a ``/* ... */`` block comment.
+This lets you temporarily disable part of a query without deleting the text, for
+example ``IfcWall + /* IfcSlab, material=concrete */`` selects only walls while
+keeping the slab criteria on hand. Block comments may span multiple lines.
+
 Below is the table of filters to choose from. Most of these filters will filter
 previously added elements in your filter group based on their criteria.
 

--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -40,7 +40,7 @@ import ifcopenshell.util.system
 import ifcopenshell.util.unit
 
 filter_elements_grammar = lark.Lark("""start: filter_group
-    filter_group: facet_list ("+" facet_list)*
+    filter_group: facet_list ("+" facet_list)* "+"?
     facet_list: facet ("," facet)*
 
     facet: instance | entity | attribute | type | material | query | classification | location | property | group | parent
@@ -108,8 +108,10 @@ filter_elements_grammar = lark.Lark("""start: filter_group
     CR : /\\r/
     LF : /\\n/
     NEWLINE: (CR? LF)+
+    COMMENT: "/*" /.*?/s "*/"
 
     %ignore WS // Disregard spaces in text
+    %ignore COMMENT // Allow /* ... */ block comments to toggle parts of a query
 """)
 
 get_element_grammar = lark.Lark("""start: keys

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -351,6 +351,22 @@ class TestFilterElements(test.bootstrap.IFC4):
         assert subject.filter_elements(self.file, "IfcWall, Name=Foo + IfcSlab") == {element, element2}
         assert subject.filter_elements(self.file, "IfcWall, Name=Foo + IfcSlab, Name=Bar") == {element, element2}
 
+    def test_block_comments_are_ignored(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element.Name = "Foo"
+        element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSlab")
+        element2.Name = "Bar"
+        # A /* ... */ block comment lets a query be toggled off without deleting the text.
+        assert subject.filter_elements(self.file, "IfcWall /* + IfcSlab */") == {element}
+        assert subject.filter_elements(self.file, "IfcWall + /* IfcSlab */") == {element}
+        assert subject.filter_elements(self.file, "/* IfcWall + */ IfcSlab") == {element2}
+        assert subject.filter_elements(self.file, "IfcWall /* commented */ + IfcSlab") == {element, element2}
+        # Comments may span multiple lines.
+        assert subject.filter_elements(self.file, "IfcWall + /* multi\nline\ncomment */ IfcSlab") == {element, element2}
+        # A /* sequence inside a quoted string is not treated as a comment.
+        element.Name = "a/*b"
+        assert subject.filter_elements(self.file, 'IfcWall, Name="a/*b"') == {element}
+
     def test_using_elements_argument(self):
         wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         slab = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSlab")


### PR DESCRIPTION
Closes #5023.

### Request
theoryshaw asked for the ability to comment out part of a selector query, e.g. `IfcWall + /* IfcObject, EPset_Status.Status="NEW" */`, so a facet can be toggled off without deleting and retyping the text.

### Problem
The `filter_elements` grammar had no comment token. Any `/* ... */` (or a bare `/`) raised `UnexpectedCharacters` / `UnexpectedEOF`, so the feature was impossible.

### Fix (`ifcopenshell/util/selector.py`, filter grammar only)
- Add a `COMMENT: "/*" /.*?/s "*/"` terminal and `%ignore COMMENT`. The `/s` (DOTALL) flag lets a comment span multiple lines.
- Change `filter_group: facet_list ("+" facet_list)*` to `... "+"?` so a **trailing** `+` is tolerated. This is what makes the issue's literal `IfcWall + /* IfcSlab */` parse: the comment removes the second operand and leaves a dangling `+`, which the `FacetTransformer` (accumulating via `facet_list` side effects) safely ignores.

Only the filter grammar changes. `get_element` and `format`, which use `/` for regex and division, are untouched. A `/*` sequence inside a quoted string is **not** treated as a comment.

### Verification
Baseline (`origin/v0.8.0`) rejects every comment form; patched accepts them:

| query | baseline | patched |
|---|---|---|
| `IfcWall + /* IfcSlab */` | UnexpectedCharacters | `[IfcWall]` |
| `IfcWall /* + IfcSlab */` | UnexpectedCharacters | `[IfcWall]` |
| `/* IfcWall + */ IfcSlab` | UnexpectedCharacters | `[IfcSlab]` |
| `IfcWall + /* multi\nline */ IfcSlab` | UnexpectedCharacters | `[IfcWall, IfcSlab]` |
| `IfcWall, Name="a/*b"` | (matches) | (matches — `/*` in a string is not a comment) |

Adds regression test `TestFilterElements::test_block_comments_are_ignored` and documents the syntax in `selector_syntax.rst`.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)