### PR TITLE
ifcpatch: use stdlib graphlib for Optimise, fixing missing toposort in Bonsai (#4399)

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/Optimise.py
+++ b/src/ifcpatch/ifcpatch/recipes/Optimise.py
@@ -25,18 +25,18 @@ def _toposort(graph: dict[int, set[int]], logger: logging.Logger) -> list[int]:
     """Flatten a dependency graph of entity ids into dependency order.
 
     Uses igraph's C-backed topological sort when available, otherwise falls
-    back to the pure python toposort package with a warning.
+    back to the stdlib graphlib topological sort with a warning.
     """
     try:
         import igraph
     except ImportError:
         logger.warning(
-            "igraph is not installed, falling back to the slower pure python toposort. "
+            "igraph is not installed, falling back to the slower stdlib graphlib. "
             "Install python-igraph for better performance."
         )
-        from toposort import toposort_flatten
+        from graphlib import TopologicalSorter
 
-        return toposort_flatten(graph)
+        return list(TopologicalSorter(graph).static_order())
 
     ids = list(graph)
     index = {id_: i for i, id_ in enumerate(ids)}

--- a/src/ifcpatch/pyproject.toml
+++ b/src/ifcpatch/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
 ]
-dependencies = ["ifcopenshell", "toposort", "numpy"]
+dependencies = ["ifcopenshell", "numpy"]
 
 [project.optional-dependencies]
 advanced = [


### PR DESCRIPTION
Closes #4399.

### Problem
`ifcpatch/recipes/Optimise.py` did `from toposort import toposort_flatten`. `toposort` is a third-party PyPI package listed in ifcpatch's own `pyproject.toml`, but it is **not bundled with Bonsai**, so running the Optimise recipe inside Blender/Bonsai raised:

```
ModuleNotFoundError: No module named 'toposort'
```

### Fix
Replace `toposort` with the standard-library `graphlib.TopologicalSorter` (available since Python 3.9), which gives the identical **dependencies-first** ordering the recipe relies on — every forward-referenced instance is mapped before the instances that reference it. The dependency-graph dict format (`{node: {predecessors}}`) is the same for both libraries, so graph construction is unchanged; only the sort call differs (`toposort_flatten(graph)` → `TopologicalSorter(graph).static_order()`). `toposort` is dropped from ifcpatch's dependencies since nothing else uses it.

### Verification (with `toposort` NOT installed)
- `import toposort` → `ModuleNotFoundError` (reproduces the reported failure).
- Patched recipe on `src/examples/IfcParseExamples_test.ifc` (IFC2X3): **88 → 63** instances, all **6** `IfcProduct`s preserved, output serializes and reopens cleanly (wall intact).
- Minimal synthetic model with duplicate points/placements: 6 → 4, project preserved.
- `test/test_RegenerateGlobalIds.py`: 4 passed (nearest ifcpatch regression check; there is no dedicated Optimise test).

This narrowly fixes the reported `ModuleNotFoundError`; aothms's separate `get_info(recursive=False)` performance suggestion on the issue is left out to keep the change contained and low-risk.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)