### PR TITLE
express: include referencing SELECT types in typeof() (#3187)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/express/rule_compiler.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rule_compiler.py
@@ -939,10 +939,27 @@ def typeof(inst):
         # If V evaluates to indeterminate (?), an empty set is returned.
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    # Per ISO 10303-11 12.4.3, TYPEOF() also includes every select data type
+    # that references (transitively) any of the value's types as a member of
+    # its select list. Cache, per schema, the reverse map type name -> select
+    # types directly referencing it.
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -951,7 +968,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
     def __bool__(self):

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC2X3.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC2X3.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X1.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X1.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X2.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X2.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_ADD1.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_ADD1.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_ADD2.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_ADD2.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC1.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC1.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC2.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC2.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC3.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC3.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC4.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC4.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_TC1.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_TC1.py
@@ -96,11 +96,24 @@ def typeof(inst):
     if not inst:
         return express_set([])
     schema_name = inst.is_a(True).split('.')[0].lower()
+    schema = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name)
+    select_parents = getattr(typeof, '_select_parents', None)
+    if select_parents is None:
+        select_parents = typeof._select_parents = {}
+    schema_selects = select_parents.get(schema_name)
+    if schema_selects is None:
+        schema_selects = {}
+        for decl in schema.declarations():
+            if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.select_type):
+                sel_name = decl.name().lower()
+                for member in decl.select_list():
+                    schema_selects.setdefault(member.name().lower(), []).append(sel_name)
+        select_parents[schema_name] = schema_selects
 
     def inner():
-        decl = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_name).declaration_by_name(inst.is_a())
+        decl = schema.declaration_by_name(inst.is_a())
         while decl:
-            yield '.'.join((schema_name, decl.name().lower()))
+            yield decl.name().lower()
             if isinstance(decl, ifcopenshell.ifcopenshell_wrapper.entity):
                 decl = decl.supertype()
             else:
@@ -109,7 +122,15 @@ def typeof(inst):
                     decl = decl.declared_type()
                 if not isinstance(decl, ifcopenshell.ifcopenshell_wrapper.type_declaration):
                     break
-    return express_set(inner())
+    names = set(inner())
+    queue = list(names)
+    while queue:
+        name = queue.pop()
+        for sel_name in schema_selects.get(name, ()):
+            if sel_name not in names:
+                names.add(sel_name)
+                queue.append(sel_name)
+    return express_set('.'.join((schema_name, name)) for name in names)
 
 class indeterminate_type:
 


### PR DESCRIPTION
Closes #3187.

### Problem
Per ISO 10303-11 §12.4.3, `TYPEOF()` must return every type a value conforms to, **including any SELECT data type that references it (transitively) as a member**. The express `typeof()` only walked entity supertypes and defined-type chains, so it never reported SELECT types. This silently broke every WHERE rule that tests SELECT membership through `typeof`.

Concrete case from the issue: `IfcFillAreaStyle.MaxOneColour` and `ConsistentHatchStyleDef` test `'ifc4.ifccolour' in typeof(style)`. Because `IfcColourRgb` never reported `ifccolour`, an `IfcFillAreaStyle` with two `IfcColourRgb` entries passed validation when it should have failed.

### Fix
`typeof()` now builds a per-schema (cached) reverse map from a type name to the SELECT types that reference it as a direct member, then closes the base type set over that map so selects-of-selects are included too. The canonical implementation lives in the `rule_compiler.py` preamble (the codegen source of truth) and is copied verbatim into every generated `rules/*.py`, so source and generated files are updated in lockstep (a regeneration from the `.exp` schemas would produce the same result).

### Verification
Before:
```
typeof(IfcColourRgb): ['ifc4.ifccolourrgb', 'ifc4.ifccolourspecification', 'ifc4.ifcpresentationitem']
'ifc4.ifccolour' in typeof: False   -> IfcFillAreaStyle with two colours passes (wrong)
```
After:
```
typeof(IfcColourRgb): ['ifc4.ifccolour', 'ifc4.ifccolourorfactor', 'ifc4.ifccolourrgb',
                       'ifc4.ifccolourspecification', 'ifc4.ifcfillstyleselect', 'ifc4.ifcpresentationitem']
'ifc4.ifccolour' in typeof: True    -> MaxOneColour + ConsistentHatchStyleDef now fire
```
All **138** express rule fixtures pass (75 `pass-*` at 0 errors, 63 `fail-*` still flagged), no regressions.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)