### PR TITLE
Bonsai: keep 'disable selection' objects visible when activating a drawing (#7681)

### DIFF
--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -2315,10 +2315,23 @@ class Blender(bonsai.core.tool.Blender):
             bpy.ops.object.hide_view_clear(select=False)
 
         bpy.ops.object.select_all(action="DESELECT")
-        for obj in objs:
-            obj.select_set(True)
-        with bpy.context.temp_override(**override):
-            bpy.ops.object.hide_view_set(unselected=True)
+        # Objects with "disable selection" (hide_select) enabled cannot be
+        # selected, so they would be treated as unselected and hidden by
+        # hide_view_set(unselected=True) below - see #7681. Temporarily clear
+        # hide_select so they can be selected (and thus kept visible), then
+        # restore it afterwards.
+        unselectable = []
+        try:
+            for obj in objs:
+                if obj.hide_select:
+                    obj.hide_select = False
+                    unselectable.append(obj)
+                obj.select_set(True)
+            with bpy.context.temp_override(**override):
+                bpy.ops.object.hide_view_set(unselected=True)
+        finally:
+            for obj in unselectable:
+                obj.hide_select = True
 
         bpy.ops.object.select_all(action="DESELECT")
         for name in previously_selected:


### PR DESCRIPTION
Closes #7681.

### Problem
With **disable selection** (`hide_select`) enabled on an object, activating a drawing turns that object off (hides it).

`tool.Blender.isolate_objects` keeps the intended objects visible by selecting them and then hiding everything unselected via `hide_view_set(unselected=True)`. But Blender refuses to select an object whose `hide_select` is set (`select_set(True)` silently leaves it unselected), so that object is treated as unselected and gets hidden.

### Fix (`src/bonsai/bonsai/tool/blender.py`)
Temporarily clear `hide_select` on the target objects so they can actually be selected (and thus kept visible), then restore it. The clear/restore is wrapped in `try/finally` so `hide_select` is always restored even if the hide operator raises.

### Verification (headless Blender, real objects)
The full operator needs a 3D viewport, but the hide-step logic is exercised faithfully with real Blender objects and true `hide_select`/`select_get`/`hide_set` semantics:

| | KeepLocked (disable-selection ON) hidden? | hide_select preserved? | unrelated object hidden? |
|---|---|---|---|
| before | **True** (bug) | - | True |
| after | **False** | True | True |

Mechanism confirmed directly: `obj.hide_select=True; obj.select_set(True)` leaves `select_get()==False`, which is why the object was being hidden.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)