### PR TITLE
Bonsai: copy-property-to-selection must not edit the inherited type pset (#7412)

### DIFF
--- a/src/bonsai/bonsai/core/pset.py
+++ b/src/bonsai/bonsai/core/pset.py
@@ -40,7 +40,11 @@ def copy_property_to_selection(
     element = ifc.get_entity(obj)
     if not element:
         return
-    ifc_pset = pset.get_element_pset(element, pset_name)
+    # Only consider the element's own property set, never one inherited from its
+    # type. Otherwise copying an occurrence override would edit the type's pset
+    # (and thus every occurrence) instead of creating/updating the override on
+    # this element. See https://github.com/IfcOpenShell/IfcOpenShell/issues/7412.
+    ifc_pset = pset.get_element_pset(element, pset_name, should_inherit=False)
     if not ifc_pset:
         ifc_pset = ifc.run("pset.add_pset" if is_pset else "pset.add_qto", product=element, name=pset_name)
     if is_pset:

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -814,7 +814,7 @@ class Pset:
     def cast_string_to_primitive(cls, value: str): pass
     def clear_blender_pset_properties(cls, props): pass
     def enable_proposed_pset(cls, props, pset_name, pset_type, has_template): pass
-    def get_element_pset(cls, element, pset_name): pass
+    def get_element_pset(cls, element, pset_name, should_inherit=True): pass
     def get_prop_template_primitive_type(cls, prop_template): pass
     def get_pset_name(cls, obj, obj_type, pset_type): pass
     def get_pset_template(cls, name): pass

--- a/src/bonsai/bonsai/tool/pset.py
+++ b/src/bonsai/bonsai/tool/pset.py
@@ -70,9 +70,9 @@ class Pset(bonsai.core.tool.Pset):
 
     @classmethod
     def get_element_pset(
-        cls, element: ifcopenshell.entity_instance, pset_name: str
+        cls, element: ifcopenshell.entity_instance, pset_name: str, should_inherit: bool = True
     ) -> Union[ifcopenshell.entity_instance, None]:
-        pset = ifcopenshell.util.element.get_pset(element, pset_name)
+        pset = ifcopenshell.util.element.get_pset(element, pset_name, should_inherit=should_inherit)
         if pset:
             return tool.Ifc.get().by_id(pset["id"])
 

--- a/src/bonsai/test/core/test_pset.py
+++ b/src/bonsai/test/core/test_pset.py
@@ -29,7 +29,7 @@ class TestCopyPropertyToSelection:
 
     def test_copying_the_property_to_an_existing_pset(self, ifc, pset):
         ifc.get_entity("obj").should_be_called().will_return("element")
-        pset.get_element_pset("element", "pset_name").should_be_called().will_return("pset")
+        pset.get_element_pset("element", "pset_name", should_inherit=False).should_be_called().will_return("pset")
         ifc.run("pset.edit_pset", pset="pset", properties={"prop_name": "prop_value"}).should_be_called()
         subject.copy_property_to_selection(
             ifc, pset, is_pset=True, obj="obj", pset_name="pset_name", prop_name="prop_name", prop_value="prop_value"
@@ -37,7 +37,7 @@ class TestCopyPropertyToSelection:
 
     def test_creating_a_new_pset_if_it_doesnt_exist(self, ifc, pset):
         ifc.get_entity("obj").should_be_called().will_return("element")
-        pset.get_element_pset("element", "pset_name").should_be_called().will_return(None)
+        pset.get_element_pset("element", "pset_name", should_inherit=False).should_be_called().will_return(None)
         ifc.run("pset.add_pset", product="element", name="pset_name").should_be_called().will_return("pset")
         ifc.run("pset.edit_pset", pset="pset", properties={"prop_name": "prop_value"}).should_be_called()
         subject.copy_property_to_selection(
@@ -46,7 +46,7 @@ class TestCopyPropertyToSelection:
 
     def test_copying_the_quantity_to_an_existing_qto(self, ifc, pset):
         ifc.get_entity("obj").should_be_called().will_return("element")
-        pset.get_element_pset("element", "qto_name").should_be_called().will_return("qto")
+        pset.get_element_pset("element", "qto_name", should_inherit=False).should_be_called().will_return("qto")
         ifc.run("pset.edit_qto", qto="qto", properties={"prop_name": "prop_value"}).should_be_called()
         subject.copy_property_to_selection(
             ifc, pset, is_pset=False, obj="obj", pset_name="qto_name", prop_name="prop_name", prop_value="prop_value"
@@ -54,7 +54,7 @@ class TestCopyPropertyToSelection:
 
     def test_creating_a_new_qto_if_it_doesnt_exist(self, ifc, pset):
         ifc.get_entity("obj").should_be_called().will_return("element")
-        pset.get_element_pset("element", "qto_name").should_be_called().will_return(None)
+        pset.get_element_pset("element", "qto_name", should_inherit=False).should_be_called().will_return(None)
         ifc.run("pset.add_qto", product="element", name="qto_name").should_be_called().will_return("qto")
         ifc.run("pset.edit_qto", qto="qto", properties={"prop_name": "prop_value"}).should_be_called()
         subject.copy_property_to_selection(


### PR DESCRIPTION
Closes #7412.

### Problem
Editing an occurrence value through **Copy property to selection** modified the value on the element's **type** instead of creating an override on the occurrence, so every occurrence of that type changed.

`core.copy_property_to_selection` resolves the target pset via `tool.Pset.get_element_pset`, which calls `ifcopenshell.util.element.get_pset` with `should_inherit=True` (the default). When the selected occurrence has no pset of its own but its type does, `get_pset` returns the **type's** pset, and `pset.edit_pset` then edits the type.

### Fix
Add a `should_inherit` parameter to `get_element_pset` (default `True`, so the ~30 other callers are unaffected) and pass `should_inherit=False` from `copy_property_to_selection`. Only the element's own pset is considered; if none exists, the existing fallback creates an override pset on the occurrence. The core interface stub and the four Prophecy mock expectations are updated to match.

### Verification
Live, headless Blender. Type `Pset_Custom.MyProp="TYPE_VALUE"`, two occurrences typed to it, then copy `MyProp="OCC_VALUE"` to each occurrence:

| | before | after |
|---|---|---|
| type `MyProp` | **OCC_VALUE** (clobbered) | **TYPE_VALUE** (untouched) |
| occurrence own pset | none created | **OCC_VALUE** override on each |

Core tests: `test/core/test_pset.py` — 6 passed.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)