### PR TITLE
Bonsai: guard MEP Add Bend against parallel segments (#6393)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/mep.py
+++ b/src/bonsai/bonsai/bim/module/model/mep.py
@@ -1260,10 +1260,21 @@ class MEPAddBend(bpy.types.Operator, tool.Ifc.Operator):
         }
 
         get_z_basis = lambda o: tool.Cad.get_basis_vector(o, 2)
-        segments_intersection_ws = tool.Cad.intersect_edges(
+        segments_intersection = tool.Cad.intersect_edges(
             (start_object.location, start_object.location + get_z_basis(start_object)),
             (end_object.location, end_object.location + get_z_basis(end_object)),
-        )[0]
+        )
+        # intersect_edges returns None when the two segment axes are parallel or
+        # collinear (no unique intersection). Report a clean error instead of
+        # crashing with "'NoneType' object is not subscriptable".
+        if segments_intersection is None:
+            self.report(
+                {"ERROR"},
+                "The two segments are parallel, so a bend cannot be computed. "
+                "Select two non-parallel segments.",
+            )
+            return {"CANCELLED"}
+        segments_intersection_ws = segments_intersection[0]
 
         start_point, first_segment_start = tool.Cad.closest_and_furthest_vectors(
             segments_intersection_ws, (start_segment_data["start_point"], start_segment_data["end_point"])


### PR DESCRIPTION
Closes #6393.

### Problem
Adding a bend to two MEP segments crashes when the segments are parallel:

```
TypeError: 'NoneType' object is not subscriptable
  .../bonsai/bim/module/model/mep.py  MEPAddBend._execute
```

`tool.Cad.intersect_edges` returns `None` when the two segment axes have no unique intersection (parallel, collinear, or zero-length), and `MEPAddBend._execute` immediately did `intersect_edges(...)[0]`. The auto-dispatch "Add Fitting" path already guards `is_parallel` before calling, but the direct `bim.mep_add_bend` operator (the "Add Bend" toolbar button and the edit-preview flow) had no such guard.

### Fix (`src/bonsai/bonsai/bim/module/model/mep.py`)
Capture the `intersect_edges` result; when it is `None`, `self.report({"ERROR"}, ...)` with a clear message and return `{"CANCELLED"}` instead of subscripting `None`. Mirrors the existing parallel guard on the dispatch path.

### Verification (live, headless Blender)
- **Before:** two parallel duct segments + `bim.mep_add_bend` → `TypeError: 'NoneType' object is not subscriptable` (exact issue traceback); `intersect_edges` returned `None`.
- **After:** same input → clean "The two segments are parallel, so a bend cannot be computed. Select two non-parallel segments." and CANCELLED, no internal traceback.
- **No regression:** a perpendicular pair still creates the bend (`{'FINISHED'}`, `IfcDuctFitting` + `IfcDuctFittingType/BEND`).

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)