### PR TITLE
Bonsai: skip out-of-view-layer spaces in toggle_hide_spaces (#5309)

### DIFF
--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -1258,19 +1258,20 @@ class Spatial(bonsai.core.tool.Spatial):
 
     @classmethod
     def toggle_hide_spaces(cls, spaces: list[ifcopenshell.entity_instance]) -> None:
-        first_obj = tool.Ifc.get_object(spaces[0])
-        assert isinstance(first_obj, bpy.types.Object)
-        obj: bpy.types.Object
-        if first_obj.hide_get() == False:
-            for space in spaces:
-                obj = tool.Ifc.get_object(space)
-                obj.hide_set(True)
+        # `hide_get`/`hide_set` raise for objects that are not in the active view
+        # layer (e.g. spaces living in an excluded collection), so skip those.
+        view_layer = bpy.context.view_layer
+        objs = [
+            obj
+            for space in spaces
+            if isinstance(obj := tool.Ifc.get_object(space), bpy.types.Object) and view_layer.objects.get(obj.name)
+        ]
+        if not objs:
             return
 
-        elif first_obj.hide_get() == True:
-            for space in spaces:
-                obj = tool.Ifc.get_object(space)
-                obj.hide_set(False)
+        should_hide = objs[0].hide_get() == False
+        for obj in objs:
+            obj.hide_set(should_hide)
 
     @classmethod
     def set_default_container(cls, container: ifcopenshell.entity_instance) -> None:


### PR DESCRIPTION
Closes #5309.

### Problem
Toggling space visibility crashed with:

```
RuntimeError: Object 'IfcSpace/0-2' cannot be hidden because it is not in View Layer 'ViewLayer'!
```

`tool.Spatial.toggle_hide_spaces` called `hide_get`/`hide_set` unconditionally. Blender raises for any object not in the active view layer, e.g. an IfcSpace whose object lives in a collection excluded from the view layer. The rest of `spatial.py` already guards these calls with `view_layer.objects.get(obj.name)`; this method was the outlier.

### Fix (`src/bonsai/bonsai/tool/spatial.py`)
Filter the spaces to objects present in the active view layer, derive the toggle direction from the first surviving object, and apply `hide_set` only to those. Objects not in the view layer are skipped (they cannot be hidden anyway), and the method returns cleanly when nothing is toggleable. Matches the existing convention in the same file.

### Verification (live, headless Blender)
Repro: two IfcSpaces, one object placed in a collection **excluded** from the view layer, then `toggle_hide_spaces([space0, space1])`.
- **Before:** `RuntimeError: ... not in View Layer 'ViewLayer'!` (matches the report).
- **After:** completes cleanly; the in-view-layer space is hidden (`hide_get() == True`), the excluded space is skipped.
- Core `test_spatial.py`: 12 passed.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)