### PR TITLE
Bonsai: clean error instead of a traceback for Extend To Underside on a non-wall selection (#7454)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -1280,11 +1280,6 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
             bpy.ops.bim.extend_profile(join_type="T")
 
         else:
-            # Extend LAYER2 walls to the underside of another selected element.
-            # Guard the selection here so an invalid combination (e.g. a column
-            # and a slab, with no wall involved) reports a clean end-user error
-            # instead of surfacing the nested operator's ERROR as a developer
-            # traceback (see #7454).
             walls = [
                 obj
                 for obj in bpy.context.selected_objects
@@ -1294,7 +1289,10 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
                 bpy.ops.bim.extend_walls_to_underside()
             else:
                 self.report(
-                    {"ERROR"}, "Please select at least one LAYER2 element and at least one other IFC element"
+                    {"ERROR"},
+                    "Extend to underside works with layered walls (LAYER2): "
+                    "select at least one wall plus the target element. "
+                    "Extending columns or similar elements is not supported yet.",
                 )
 
     def hotkey_S_F(self):

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -1280,7 +1280,22 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
             bpy.ops.bim.extend_profile(join_type="T")
 
         else:
-            bpy.ops.bim.extend_walls_to_underside()
+            # Extend LAYER2 walls to the underside of another selected element.
+            # Guard the selection here so an invalid combination (e.g. a column
+            # and a slab, with no wall involved) reports a clean end-user error
+            # instead of surfacing the nested operator's ERROR as a developer
+            # traceback (see #7454).
+            walls = [
+                obj
+                for obj in bpy.context.selected_objects
+                if (element := tool.Ifc.get_entity(obj)) and tool.Parametric.is_path_connectable_wall(element)
+            ]
+            if walls and len(bpy.context.selected_objects) > len(walls):
+                bpy.ops.bim.extend_walls_to_underside()
+            else:
+                self.report(
+                    {"ERROR"}, "Please select at least one LAYER2 element and at least one other IFC element"
+                )
 
     def hotkey_S_F(self):
         if not bpy.context.selected_objects:


### PR DESCRIPTION
Refs #7454 (fixes the reported traceback; see scope note below).

### Problem
Selecting a non-wall pair (e.g. a column and a slab) and pressing **Shift+E** surfaced a developer Python traceback ending at:

```
File ".../bonsai/bim/module/model/workspace.py", line 1283, in hotkey_S_E
    bpy.ops.bim.extend_walls_to_underside()
RuntimeError: ...
```

`Hotkey.hotkey_S_E`'s catch-all `else` unconditionally called `bpy.ops.bim.extend_walls_to_underside()`. When the selection has no path-connectable wall, that nested operator reports an ERROR and returns CANCELLED, which - invoked via `bpy.ops` from inside the outer operator - re-raises as an unhandled `RuntimeError`, so the user sees a full traceback.

### Fix (`src/bonsai/bonsai/bim/module/model/workspace.py`)
Guard the selection with the operator's own predicate (`tool.Parametric.is_path_connectable_wall`): dispatch to `extend_walls_to_underside` only when at least one wall and at least one other element are selected, otherwise `self.report({"ERROR"}, ...)` with a clear message. Mirrors the accepted pattern already used by `hotkey_S_X` (align) for the analogous #6246. The valid wall + target path is unchanged.

### Scope
This hardens the reported **crash**. It does **not** implement extending a column to a slab underside, which is the separate feature the issue title also asks for; that is left for a follow-up. Hence this references rather than closes #7454.

### Verification (live, headless Blender)
Column + slab selected, `bim.hotkey(hotkey="S_E")`:
- **Before:** `Python: Traceback ...` with `workspace.py` / `extend_walls_to_underside` frames (the reported crash).
- **After:** a single clean `Error: Please select at least one LAYER2 element and at least one other IFC element` — no traceback.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)