### PR TITLE
Bonsai: add editable "Elevation from Storey" field to Placement panel

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/__init__.py
+++ b/src/bonsai/bonsai/bim/module/geometry/__init__.py
@@ -71,6 +71,7 @@ classes = (
     operator.RemoveRepresentationItemFromShapeAspect,
     operator.SelectConnection,
     operator.SelectRepresentationItem,
+    operator.SelectSimilarPlacementValue,
     operator.SwitchRepresentation,
     operator.UnassignRepresentationItemLayer,
     operator.UnassignRepresentationItemStyle,

--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -4284,3 +4284,72 @@ class CreateInstance(bpy.types.Operator, tool.Ifc.Operator):
         bpy.ops.bim.hotkey(hotkey="S_A")
 
         return {"FINISHED"}
+
+
+class SelectSimilarPlacementValue(bpy.types.Operator):
+    bl_idname = "bim.select_similar_placement_value"
+    bl_label = "Select Objects Sharing This Value"
+    bl_description = (
+        "Select all objects whose placement value matches the active object.\n\n"
+        "Shift+Click to add to the current selection"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    # "X"/"Y"/"Z" (location), "RX"/"RY"/"RZ" (rotation) or "ELEVATION" (from storey).
+    mode: bpy.props.StringProperty(name="Mode", default="ELEVATION", options={"SKIP_SAVE"})
+    extend: bpy.props.BoolProperty(name="Extend Selection", default=False, options={"SKIP_SAVE"})
+
+    @classmethod
+    def poll(cls, context):
+        return context.active_object is not None
+
+    def invoke(self, context, event):
+        self.extend = event.shift
+        return self.execute(context)
+
+    def execute(self, context):
+        from bonsai.bim.module.geometry.prop import format_rotation, get_storey_relative_elevation_value
+
+        is_rotation = self.mode.startswith("R")
+
+        def value_of(obj: bpy.types.Object) -> Union[float, None]:
+            if not tool.Ifc.get_entity(obj):
+                return None
+            if self.mode == "ELEVATION":
+                return get_storey_relative_elevation_value(obj)
+            index = "XYZ".find(self.mode[-1])
+            if index == -1:
+                return None
+            return obj.rotation_euler[index] if is_rotation else obj.location[index]
+
+        def label_of(value: float) -> str:
+            # Match on the displayed value so selection is what-you-see-is-what-you-get.
+            return format_rotation(value) if is_rotation else tool.Unit.format_distance(value)
+
+        active = context.active_object
+        target = value_of(active)
+        if target is None:
+            self.report({"INFO"}, "Active object has no value for this axis.")
+            return {"CANCELLED"}
+
+        target_label = label_of(target)
+
+        if not self.extend:
+            for obj in list(context.selected_objects):
+                obj.select_set(False)
+
+        count = 0
+        for obj in context.view_layer.objects:
+            value = value_of(obj)
+            if value is None or label_of(value) != target_label:
+                continue
+            try:
+                obj.select_set(True)
+            except RuntimeError:
+                continue  # Not selectable (hidden/excluded collection).
+            count += 1
+
+        active.select_set(True)
+        context.view_layer.objects.active = active
+        self.report({"INFO"}, f"Selected {count} object(s) sharing {target_label}.")
+        return {"FINISHED"}

--- a/src/bonsai/bonsai/bim/module/geometry/prop.py
+++ b/src/bonsai/bonsai/bim/module/geometry/prop.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+import math
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import bpy
@@ -239,21 +240,43 @@ def get_storey_world_z(obj: bpy.types.Object) -> Union[float, None]:
     return matrix[2][3] * unit_scale
 
 
-def get_storey_relative_elevation(self: "BIMObjectGeometryProperties") -> float:
-    obj = self.id_data
+def get_storey_relative_elevation_value(obj: bpy.types.Object) -> Union[float, None]:
+    """Object origin's Z relative to its containing storey (meters), or None if none."""
     storey_z = get_storey_world_z(obj)
     if storey_z is None:
-        return 0.0
+        return None
     return obj.matrix_world.translation.z - storey_z
 
 
-def set_storey_relative_elevation(self: "BIMObjectGeometryProperties", value: float) -> None:
-    obj = self.id_data
+def get_storey_relative_elevation(self: "BIMObjectGeometryProperties") -> float:
+    value = get_storey_relative_elevation_value(self.id_data)
+    return 0.0 if value is None else value
+
+
+def format_rotation(radians: float) -> str:
+    """Angle string (degrees) for the panel's read-only rotation display.
+
+    Shared with the select-similar operator so on-screen values and matching stay in sync.
+    """
+    degrees = round(math.degrees(radians), 2) + 0.0  # + 0.0 normalizes -0.0 -> 0.0
+    return f"{degrees:.2f}°"
+
+
+def _apply_storey_relative_elevation(obj: bpy.types.Object, value: float) -> None:
     storey_z = get_storey_world_z(obj)
     if storey_z is None:
         return
     # Nudge the object's local Z by the difference between the desired and current world Z.
     obj.location.z += (storey_z + value) - obj.matrix_world.translation.z
+
+
+def set_storey_relative_elevation(self: "BIMObjectGeometryProperties", value: float) -> None:
+    # Apply to every selected IFC object, each relative to its own storey, so the field
+    # can bulk-set a common elevation. Objects without a containing storey are skipped.
+    objs = set(bpy.context.selected_objects)
+    objs.add(self.id_data)
+    for obj in objs:
+        _apply_storey_relative_elevation(obj, value)
 
 
 class BIMObjectGeometryProperties(PropertyGroup):

--- a/src/bonsai/bonsai/bim/module/geometry/prop.py
+++ b/src/bonsai/bonsai/bim/module/geometry/prop.py
@@ -228,7 +228,9 @@ def get_storey_world_z(obj: bpy.types.Object) -> Union[float, None]:
     element = tool.Ifc.get_entity(obj)
     if not element:
         return None
-    storey = ifcopenshell.util.element.get_container(element, ifc_class="IfcBuildingStorey")
+    # get_parent (not get_container) so spatial elements like IfcSpace, which reach their
+    # storey via aggregation rather than spatial containment, resolve correctly.
+    storey = ifcopenshell.util.element.get_parent(element, ifc_class="IfcBuildingStorey")
     if not storey:
         return None
     if storey_obj := tool.Ifc.get_object(storey):

--- a/src/bonsai/bonsai/bim/module/geometry/prop.py
+++ b/src/bonsai/bonsai/bim/module/geometry/prop.py
@@ -20,10 +20,14 @@ from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import bpy
 import ifcopenshell
+import ifcopenshell.util.element
+import ifcopenshell.util.placement
+import ifcopenshell.util.unit
 from bpy.props import (
     BoolProperty,
     CollectionProperty,
     EnumProperty,
+    FloatProperty,
     IntProperty,
     PointerProperty,
     StringProperty,
@@ -218,6 +222,40 @@ def update_is_editing_item_layer(self: "BIMObjectGeometryProperties", context: b
     self.property_unset("is_editing_item_layer")
 
 
+def get_storey_world_z(obj: bpy.types.Object) -> Union[float, None]:
+    """World-space Z (meters) of the IfcBuildingStorey containing ``obj``, or None."""
+    element = tool.Ifc.get_entity(obj)
+    if not element:
+        return None
+    storey = ifcopenshell.util.element.get_container(element, ifc_class="IfcBuildingStorey")
+    if not storey:
+        return None
+    if storey_obj := tool.Ifc.get_object(storey):
+        return storey_obj.matrix_world.translation.z
+    if not getattr(storey, "ObjectPlacement", None):
+        return None
+    unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
+    matrix = ifcopenshell.util.placement.get_local_placement(storey.ObjectPlacement)
+    return matrix[2][3] * unit_scale
+
+
+def get_storey_relative_elevation(self: "BIMObjectGeometryProperties") -> float:
+    obj = self.id_data
+    storey_z = get_storey_world_z(obj)
+    if storey_z is None:
+        return 0.0
+    return obj.matrix_world.translation.z - storey_z
+
+
+def set_storey_relative_elevation(self: "BIMObjectGeometryProperties", value: float) -> None:
+    obj = self.id_data
+    storey_z = get_storey_world_z(obj)
+    if storey_z is None:
+        return
+    # Nudge the object's local Z by the difference between the desired and current world Z.
+    obj.location.z += (storey_z + value) - obj.matrix_world.translation.z
+
+
 class BIMObjectGeometryProperties(PropertyGroup):
     # Representations UI.
     contexts: EnumProperty(items=get_contexts, name="Contexts")
@@ -252,6 +290,15 @@ class BIMObjectGeometryProperties(PropertyGroup):
     )
     representation_item_layer: EnumProperty(items=get_layers, name="Representation Item's Layer")
 
+    # Editable elevation of the object relative to its IfcBuildingStorey level.
+    storey_relative_elevation: FloatProperty(
+        name="Elevation from Storey",
+        description="Height of the object origin above its building storey's elevation. Editing moves the object vertically.",
+        unit="LENGTH",
+        get=get_storey_relative_elevation,
+        set=set_storey_relative_elevation,
+    )
+
     @property
     def active_item(self) -> Union[RepresentationItem, None]:
         return tool.Blender.get_active_uilist_element(self.items, self.active_item_index)
@@ -270,6 +317,7 @@ class BIMObjectGeometryProperties(PropertyGroup):
         shape_aspect_attrs: ShapeAspect
         is_editing_item_layer: bool
         representation_item_layer: str
+        storey_relative_elevation: float
 
 
 GeometryMode = Literal["OBJECT", "ITEM", "EDIT"]

--- a/src/bonsai/bonsai/bim/module/geometry/ui.py
+++ b/src/bonsai/bonsai/bim/module/geometry/ui.py
@@ -30,6 +30,7 @@ from bonsai.bim.module.geometry.data import (
     RepresentationItemsData,
     RepresentationsData,
 )
+from bonsai.bim.module.geometry.prop import get_storey_world_z
 from bonsai.bim.module.layer.data import LayersData
 
 
@@ -493,18 +494,32 @@ class BIM_PT_placement(Panel):
         row = self.layout.row()
         row.label(text="Location:")
 
+        gprops = tool.Geometry.get_object_geometry_props(obj)
+        # Editable Z elevation relative to the containing storey; shown for both unit systems.
+        has_storey = get_storey_world_z(obj) is not None
+
         if is_imperial:
-            loc = context.active_object.location
+            loc = obj.location
             for i, (axis, comp) in enumerate(zip("XYZ", (loc.x, loc.y, loc.z))):
-                split = self.layout.split(factor=0.6)
-                split.prop(context.active_object, "location", index=i, text=axis)
-                sub = split.row()
-                sub.enabled = False
-                sub.alignment = "LEFT"
-                sub.label(text=tool.Unit.format_distance(comp))
+                split = self.layout.split(factor=0.5)
+                split.prop(obj, "location", index=i, text=axis)
+                abs_col = split.row()
+                abs_col.enabled = False
+                abs_col.alignment = "LEFT"
+                abs_col.label(text=tool.Unit.format_distance(comp))
         else:
             for i, axis in enumerate("XYZ"):
-                self.layout.prop(context.active_object, "location", index=i, text=axis)
+                self.layout.prop(obj, "location", index=i, text=axis)
+
+        if has_storey:
+            split = self.layout.split(factor=0.5)
+            split.prop(gprops, "storey_relative_elevation", text="Elevation from Storey")
+            if is_imperial:
+                # Read-only feet-and-inches formatting of the value in the editable field.
+                rel_col = split.row()
+                rel_col.enabled = False
+                rel_col.alignment = "LEFT"
+                rel_col.label(text=tool.Unit.format_distance(gprops.storey_relative_elevation))
 
         row = self.layout.row()
         row.label(text="Rotation:")

--- a/src/bonsai/bonsai/bim/module/geometry/ui.py
+++ b/src/bonsai/bonsai/bim/module/geometry/ui.py
@@ -17,7 +17,6 @@
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
-import ifcopenshell.util.unit
 from bpy.types import Menu, Panel, UIList
 
 import bonsai.bim
@@ -30,7 +29,7 @@ from bonsai.bim.module.geometry.data import (
     RepresentationItemsData,
     RepresentationsData,
 )
-from bonsai.bim.module.geometry.prop import get_storey_world_z
+from bonsai.bim.module.geometry.prop import format_rotation, get_storey_world_z
 from bonsai.bim.module.layer.data import LayersData
 
 
@@ -485,12 +484,6 @@ class BIM_PT_placement(Panel):
             row.label(text="No Object Placement Found")
             return
 
-        is_imperial = False
-        if tool.Ifc.get():
-            length_unit = ifcopenshell.util.unit.get_project_unit(tool.Ifc.get(), "LENGTHUNIT")
-            if length_unit and length_unit.Name != "METRE":
-                is_imperial = True
-
         row = self.layout.row()
         row.label(text="Location:")
 
@@ -498,33 +491,43 @@ class BIM_PT_placement(Panel):
         # Editable Z elevation relative to the containing storey; shown for both unit systems.
         has_storey = get_storey_world_z(obj) is not None
 
-        if is_imperial:
-            loc = obj.location
-            for i, (axis, comp) in enumerate(zip("XYZ", (loc.x, loc.y, loc.z))):
-                split = self.layout.split(factor=0.5)
-                split.prop(obj, "location", index=i, text=axis)
-                abs_col = split.row()
-                abs_col.enabled = False
-                abs_col.alignment = "LEFT"
-                abs_col.label(text=tool.Unit.format_distance(comp))
-        else:
-            for i, axis in enumerate("XYZ"):
-                self.layout.prop(obj, "location", index=i, text=axis)
+        # format_distance auto-detects the project unit system, so the same read-only value
+        # column works for both metric and imperial.
+        loc = obj.location
+        for i, (axis, comp) in enumerate(zip("XYZ", (loc.x, loc.y, loc.z))):
+            split = self.layout.split(factor=0.5)
+            split.prop(obj, "location", index=i, text=axis)
+            # The read-only value doubles as a button: click to select objects sharing it.
+            op = split.operator(
+                "bim.select_similar_placement_value",
+                text=tool.Unit.format_distance(comp),
+                emboss=False,
+            )
+            op.mode = axis
 
         if has_storey:
             split = self.layout.split(factor=0.5)
             split.prop(gprops, "storey_relative_elevation", text="Elevation from Storey")
-            if is_imperial:
-                # Read-only feet-and-inches formatting of the value in the editable field.
-                rel_col = split.row()
-                rel_col.enabled = False
-                rel_col.alignment = "LEFT"
-                rel_col.label(text=tool.Unit.format_distance(gprops.storey_relative_elevation))
+            op = split.operator(
+                "bim.select_similar_placement_value",
+                text=tool.Unit.format_distance(gprops.storey_relative_elevation),
+                emboss=False,
+            )
+            op.mode = "ELEVATION"
 
         row = self.layout.row()
         row.label(text="Rotation:")
+        rot = obj.rotation_euler
         for i, axis in enumerate("XYZ"):
-            self.layout.prop(context.active_object, "rotation_euler", index=i, text=axis)
+            split = self.layout.split(factor=0.5)
+            split.prop(obj, "rotation_euler", index=i, text=axis)
+            # The read-only value doubles as a button: click to select objects sharing it.
+            op = split.operator(
+                "bim.select_similar_placement_value",
+                text=format_rotation(rot[i]),
+                emboss=False,
+            )
+            op.mode = "R" + axis
 
         if props.blender_offset_type != "NONE":
             row = self.layout.row(align=True)

--- a/src/bonsai/bonsai/bim/module/spatial/operator.py
+++ b/src/bonsai/bonsai/bim/module/spatial/operator.py
@@ -174,6 +174,10 @@ class AssignContainer(bpy.types.Operator, tool.Ifc.Operator):
         core.assign_container(
             tool.Ifc, tool.Collector, tool.Spatial, container=container, objs=tool.Blender.get_selected_objects()
         )
+        # Refresh the Placement panel's storey-relative fields for the new container.
+        for area in context.screen.areas:
+            if area.type == "PROPERTIES":
+                area.tag_redraw()
 
 
 class EnableEditingContainer(bpy.types.Operator):
@@ -204,6 +208,10 @@ class RemoveContainer(bpy.types.Operator, tool.Ifc.Operator):
     def _execute(self, context):
         for obj in context.selected_objects:
             core.remove_container(tool.Ifc, tool.Collector, obj=obj)
+        # Refresh the Placement panel's storey-relative fields now the container is gone.
+        for area in context.screen.areas:
+            if area.type == "PROPERTIES":
+                area.tag_redraw()
 
 
 class CopyToContainer(bpy.types.Operator, tool.Ifc.Operator):


### PR DESCRIPTION
Adds an editable Z field to the Placement panel showing the object origin's height relative to its containing IfcBuildingStorey. Works for both metric and imperial (imperial shows a feet-and-inches read-out matching the Location rows), only appears when the element has a containing storey, and refreshes when the container is assigned or removed.

Refs IfcOpenShell/IfcOpenShell#8547