### PR TITLE
Bonsai: fix DirectProfileEdit crash when exiting edit mode (#7624)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -2814,7 +2814,7 @@ class DirectProfileEdit(bpy.types.Operator, tool.Ifc.Operator):
             return self.exit_element_edit_mode(context, obj, element)
 
         # For other edit modes, use standard operator
-        return bpy.ops.bim.override_mode_set_object()
+        return bpy.ops.bim.override_mode_set_object("INVOKE_DEFAULT")
 
     def exit_item_edit_mode(self, context, obj):
         """Exit from representation item editing."""
@@ -2825,7 +2825,7 @@ class DirectProfileEdit(bpy.types.Operator, tool.Ifc.Operator):
 
             item = tool.Geometry.get_active_representation(obj)
             if not item:
-                return bpy.ops.bim.override_mode_set_object()
+                return bpy.ops.bim.override_mode_set_object("INVOKE_DEFAULT")
 
             # Fix vertex order for annotation items
             props = tool.Geometry.get_geometry_props()
@@ -2939,7 +2939,7 @@ class DirectProfileEdit(bpy.types.Operator, tool.Ifc.Operator):
 
             # Fallback
             else:
-                return bpy.ops.bim.override_mode_set_object()
+                return bpy.ops.bim.override_mode_set_object("INVOKE_DEFAULT")
 
         except Exception as e:
             self.report({"ERROR"}, f"Failed to save item changes: {str(e)}")
@@ -2966,7 +2966,7 @@ class DirectProfileEdit(bpy.types.Operator, tool.Ifc.Operator):
             return {"CANCELLED"}
 
         # Fallback to standard operator
-        return bpy.ops.bim.override_mode_set_object()
+        return bpy.ops.bim.override_mode_set_object("INVOKE_DEFAULT")
 
     def handle_enter_edit_mode(self, context):
         """Handle entering edit mode from object mode."""


### PR DESCRIPTION
Closes #7624.

### Problem
Exiting a slab DirectProfileEdit crashed with:
```
AttributeError: 'OverrideModeSetObject' object has no attribute 'edited_objs'
```
`DirectProfileEdit`'s fallback paths called `bpy.ops.bim.override_mode_set_object()` **bare**, which runs in `EXEC` context and dispatches straight to the operator's `_execute()`. But `edited_objs` / `unchanged_objs_with_openings` are only initialised in `_invoke()`, so `_execute()` iterated a never-set attribute and raised. Every other call site of this operator already passes `"INVOKE_DEFAULT"`; only `DirectProfileEdit`'s four fallbacks missed it.

### Fix (`src/bonsai/bonsai/bim/module/geometry/operator.py`)
Pass `"INVOKE_DEFAULT"` at all four fallback sites so `_invoke()` runs first, consistent with the rest of the codebase (0 bare calls remain).

### Verification
- The bare-call path reproduces the exact `AttributeError`; the invoke path initialises `edited_objs` before `execute()` runs and completes cleanly.
- Operators still register; core `test_geometry.py`: 14 passed.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)