### PR TITLE
ifc4d: tolerate activities without a CalendarObjectId in P6 import (#5617)

### DIFF
--- a/src/ifc4d/ifc4d/p62ifc.py
+++ b/src/ifc4d/ifc4d/p62ifc.py
@@ -28,6 +28,7 @@ class P62Ifc:
         self.file = None
         self.work_plan = None
         self.project = {}
+        self.default_calendar_id = None
         self.calendars = {}
         self.wbs = {}
         self.root_activites = []
@@ -89,6 +90,7 @@ class P62Ifc:
         self.ns = {"pr": root.tag[1:].partition("}")[0]}
         project = root.find("pr:Project", self.ns)
         self.project["Name"] = project.findtext("pr:Name") or "Unnamed"
+        self.default_calendar_id = project.findtext("pr:ActivityDefaultCalendarObjectId", namespaces=self.ns)
         self.parse_calendar_xml(root)
         self.parse_calendar_xml(project)
         self.parse_wbs_xml(project)
@@ -174,6 +176,9 @@ class P62Ifc:
                 self.wbs[wbs_id]["activities"].append(activity_id)
             else:
                 self.root_activites.append(activity_id)
+            # CalendarObjectId is optional in the P6 schema: an activity without one
+            # inherits the project's ActivityDefaultCalendarObjectId.
+            calendar_id = activity.findtext("pr:CalendarObjectId", namespaces=self.ns)
             self.activities[activity_id] = {
                 "Name": activity.find("pr:Name", self.ns).text,
                 "Identification": activity.find("pr:Id", self.ns).text,
@@ -181,7 +186,7 @@ class P62Ifc:
                 "FinishDate": datetime.datetime.fromisoformat(activity.find("pr:FinishDate", self.ns).text),
                 "PlannedDuration": activity.find("pr:PlannedDuration", self.ns).text,
                 "Status": activity.find("pr:Status", self.ns).text,
-                "CalendarObjectId": activity.find("pr:CalendarObjectId", self.ns).text,
+                "CalendarObjectId": calendar_id or self.default_calendar_id,
                 "ifc": None,
             }
 


### PR DESCRIPTION
Refs #5617 (fixes the P6 re-import crash; that issue tracks several Gantt items).

### Problem
Importing a Primavera P6 XML crashed:
```
File ".../ifc4d/p62ifc.py", line 184, in parse_activity_xml
    "CalendarObjectId": activity.find("pr:CalendarObjectId", self.ns).text,
AttributeError: 'NoneType' object has no attribute 'text'
```
`CalendarObjectId` is **optional** on a P6 `Activity`; when omitted, the activity inherits the project's `ActivityDefaultCalendarObjectId`. The code read `.find(...).text` unconditionally.

### Fix (`src/ifc4d/ifc4d/p62ifc.py`)
Capture the project's `ActivityDefaultCalendarObjectId` in `parse_xml`, and use `calendar_id or self.default_calendar_id` for each activity.

### Verification (reporter's attached `20241021 Cronograma.xml`)
- 3 of 14 activities lack a `CalendarObjectId` and reproduced the exact crash on v0.8.0.
- After the fix, `parse_xml` completes; those 3 resolve to the project default calendar `"2"` (a valid calendar in the file); an activity with an explicit id keeps its own value. The full `execute()` -> `create_ifc()` path then runs end to end.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)