### PR TITLE
Fix ci-lint: black-format selector.py rotation-keys tuple

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -707,7 +707,17 @@ def set_element_value(
             return
         elif key == "classification":
             element = ifcopenshell.util.classification.get_references(element)
-        elif key in ("x", "y", "z", "easting", "northing", "elevation", "rotation_x", "rotation_y", "rotation_z") and hasattr(element, "ObjectPlacement"):
+        elif key in (
+            "x",
+            "y",
+            "z",
+            "easting",
+            "northing",
+            "elevation",
+            "rotation_x",
+            "rotation_y",
+            "rotation_z",
+        ) and hasattr(element, "ObjectPlacement"):
             # TODO: add support
             if key in ("easting", "northing", "elevation", "rotation_x", "rotation_y", "rotation_z"):
                 return


### PR DESCRIPTION
## Summary

`ci-lint` is currently red on `v0.8.0`. The `black` check fails on a single file, `src/ifcopenshell-python/ifcopenshell/util/selector.py`:

```
would reformat .../ifcopenshell/util/selector.py
Oh no! 💥 💔 💥
1 file would be reformatted, 1796 files would be left unchanged.
```

Root cause: PR #6262 ("Selector: add rotation_x/y/z value keys") extended the placement-key tuple in `set_element_value` with `rotation_x/y/z` without running black, pushing the `elif key in (...)` line past the length limit. Every subsequent commit inherits the red because they don't touch this file.

## Fix

Reformat the tuple one key per line, exactly as `black` 26.5.1 produces (the version CI's `psf/black@stable` currently resolves to). Formatting only, **no behavioural change**.

Verified locally with the CI-exact toolchain: `black==26.5.1 --check` now passes on the file, and `ruff==0.15.21` was already clean. The other `ci-lint` sub-checks (syntax compile, ruff, ty) were already green; black was the sole blocker.

This change was made with the assistance of an AI tool.