### PR TITLE
Fix ci: test_get_class_relations calls the wrong bSDD client method

### DIFF
--- a/src/bsdd/tests/test_bsdd.py
+++ b/src/bsdd/tests/test_bsdd.py
@@ -39,7 +39,7 @@ def test_get_class():
 
 def test_get_class_relations():
     uri_light_fixture = next(l for l in get_ifc_classes()["classes"] if "IfcLightFixture" == l["code"])["uri"]
-    ifc4x3_light_fixture_relations = client.get_class_properties(uri_light_fixture, True)
+    ifc4x3_light_fixture_relations = client.get_class_relations(uri_light_fixture, True)
     assert "Electrical unit for light-line system" and "Tubelight system" in [
         r["className"] for r in ifc4x3_light_fixture_relations["classRelations"]
     ]


### PR DESCRIPTION
## Summary

One of the two `test_bsdd.py` failures in the `ci` workflow's `Test ifcopenshell-python` step is a deterministic test bug (the other, `test_get_class`, is transient live-API flakiness).

`test_get_class_relations` asserts on a `classRelations` key:

```python
ifc4x3_light_fixture_relations = client.get_class_properties(uri_light_fixture, True)
assert ... in [r["className"] for r in ifc4x3_light_fixture_relations["classRelations"]]
```

but `get_class_properties()` hits `Class/Properties/v1`, whose response contains `classProperties`, never `classRelations` — so the test fails on every run regardless of API state. The `Class/Relations/v1` endpoint is exposed by `get_class_relations()`, which takes the same `get_reverse_relations` positional the test already passes (`True`) and returns the `classRelations` payload the assertion expects.

## Fix

Call `client.get_class_relations(...)` instead of `client.get_class_properties(...)` in `test_get_class_relations`.

Verified live against the bSDD API: the corrected call passes (`1 passed`).

This change was made with the assistance of an AI tool.