### PR TITLE
Fix ci-bonsai-daily: reconnect Cost/IfcGit tool interfaces (TestImplementsTool)

### DIFF
--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -254,7 +254,6 @@ class Cost:
     def get_cost_schedule(cls, cost_schedule): pass
     def get_cost_value_attributes(cls): pass
     def get_cost_value_unit_component(cls): pass
-    def get_direct_cost_item_products(cls): pass
     def get_highlighted_cost_item(cls): pass
     def get_products(cls, related_object_type): pass
     def get_schedule_cost_items(cls, cost_schedule): pass

--- a/src/bonsai/bonsai/tool/ifcgit.py
+++ b/src/bonsai/bonsai/tool/ifcgit.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, Union
 
 import bpy
 
+import bonsai.core.tool
 import bonsai.tool as tool
 from bonsai.bim import import_ifc
 from bonsai.bim.ifc import IfcStore
@@ -50,7 +51,7 @@ if TYPE_CHECKING:
     from bonsai.bim.module.ifcgit.prop import IfcGitProperties
 
 
-class IfcGit:
+class IfcGit(bonsai.core.tool.IfcGit):
     STEP_IDS = dict[str, set[int]]
 
     @classmethod


### PR DESCRIPTION
## Summary

Two `TestImplementsTool` failures in `ci-bonsai-daily`:

- **`test_cost.py::TestImplementsTool`** — `tool.cost.Cost` can't instantiate because `core.tool.Cost` declares abstract `get_direct_cost_item_products`, which the concrete class never implements. The method is **dead** (zero call sites; `get_cost_item_products(is_deep=False)` already covers the direct case). Remove the abstract declaration.
- **`test_ifcgit.py::TestImplementsTool`** — `tool.ifcgit.IfcGit` was not declared as a subclass of its `core.tool.IfcGit` interface (every sibling tool class is), so `isinstance` failed. Add the base class and the `bonsai.core.tool` import it needs. All 50 interface methods are already implemented.

No behaviour change; interface-wiring only.

## Verification

Headless Blender: `isinstance(Cost(), core.tool.Cost)` and `isinstance(IfcGit(), core.tool.IfcGit)` both return `True` (were `TypeError` / `False`). A repo abstract-vs-impl AST diff confirms all 50 `IfcGit` abstracts are implemented and `get_direct_cost_item_products` has no call site.

This change was made with the assistance of an AI tool.