### PR TITLE
Fix ci-bonsai-daily: get_linked_element_geom_slice hidden-face index space

### DIFF
--- a/src/bonsai/bonsai/tool/project.py
+++ b/src/bonsai/bonsai/tool/project.py
@@ -745,7 +745,7 @@ class Project(bonsai.core.tool.Project):
             index = obj_guids.index(guid)
             if index in obj_hidden_indices:
                 assert False, "Unexpected. Why would you need the geometry for the hidden element?"
-            obj_guid_ids = cls.get_linked_element_guid_ids(obj, skip_hidden=False)
+            obj_guid_ids = cls.get_linked_element_guid_ids(obj, skip_hidden=True)
             guid_end_index = obj_guid_ids[index]
             guid_start_index = index and obj_guid_ids[index - 1]
             return slice(guid_start_index, guid_end_index)


### PR DESCRIPTION
## Summary

`Project.Link.get_linked_element_geom_slice` returns a `slice` into `obj.data.polygons`, which is the index space that **excludes hidden faces**. But it built its cumulative `guid_ids` via `get_linked_element_guid_ids(obj, skip_hidden=False)` — the raw, un-shifted index space — so the slice was wrong whenever any face was hidden. The sibling call two lines above (`get_guid_by_face_index`) already correctly uses `skip_hidden=True`.

## Fix

One word: `skip_hidden=False` → `True` at the `get_linked_element_geom_slice` call site.

## Verification

Headless Blender, `test/tool/test_project.py::TestGettingLinkedElementGeomSlice`: **2 failed / 3 passed → 5 passed**. The two `skip_hidden` cases (`test_skip_hidden_first_element`, `test_skip_hidden_middle_element`) now return the correct slice; the non-hidden cases are unaffected.

This change was made with the assistance of an AI tool.