### PR TITLE
Fix ci-bonsai-daily: expect bonsai_git_branch key in TestGetDebugInfo

### DIFF
--- a/src/bonsai/test/tool/test_blender.py
+++ b/src/bonsai/test/tool/test_blender.py
@@ -203,6 +203,7 @@ class TestGetDebugInfo(NewFile):
         "bonsai_version",
         "bonsai_commit_hash",
         "bonsai_commit_date",
+        "bonsai_git_branch",
         "last_actions",
         "last_error",
     }


### PR DESCRIPTION
## Summary

`get_debug_info()` gained a `bonsai_git_branch` key (`bonsai/__init__.py:138`, same bpy-free pattern as the already-expected `bonsai_commit_hash`/`bonsai_commit_date`), but `test_blender.py::TestGetDebugInfo.EXPECTED_KEYS` was never updated, so the key-set assertion failed on every run.

## Fix

Add `"bonsai_git_branch"` to `EXPECTED_KEYS`. Verified the key is emitted (present in both repo and the installed extension `__init__.py`).

This change was made with the assistance of an AI tool.