### PR TITLE
Fix ci-bonsai-daily: avoid tripled repo path breaking BDD link_ifc tests

### DIFF
--- a/.github/workflows/ci-bonsai-daily.yml
+++ b/.github/workflows/ci-bonsai-daily.yml
@@ -128,12 +128,16 @@ jobs:
           blender --command extension install-file -r user_default -e $bonsai_zip
           blender --command extension list
 
-          git clone https://github.com/IfcOpenShell/IfcOpenShell.git IfcOpenShell
+          # NOTE: cloned into "ifcopenshell_repo" (not "IfcOpenShell") to avoid nesting under
+          # the runner's default workspace, which is already .../work/IfcOpenShell/IfcOpenShell.
+          # Naming this clone "IfcOpenShell" produced a tripled .../IfcOpenShell/IfcOpenShell/IfcOpenShell
+          # path that broke test fixture path resolution (e.g. bim.link_ifc FileNotFoundError).
+          git clone https://github.com/IfcOpenShell/IfcOpenShell.git ifcopenshell_repo
 
           # Reregister Bonsai.
           # Note that running it in background might miss some errors
           # (e.g. tools are not registered in background mode).
-          blender --background --python IfcOpenShell/src/bonsai/scripts/reregister_bonsai.py
+          blender --background --python ifcopenshell_repo/src/bonsai/scripts/reregister_bonsai.py
 
           # Install sverchok.
           wget -q -O sverchok.zip https://github.com/nortikin/sverchok/archive/refs/heads/master.zip
@@ -145,7 +149,7 @@ jobs:
           blender --command extension install-file -r user_default sverchok.zip
 
           # Install ifcsverchok.
-          cd IfcOpenShell/src/ifcsverchok
+          cd ifcopenshell_repo/src/ifcsverchok
           make dist
           sverchok_zip="$(pwd)/dist/$(ls dist)"
           blender --command extension install-file -r user_default $sverchok_zip
@@ -178,7 +182,7 @@ jobs:
           blender --online-mode --command extension sync
           blender --online-mode --command extension install --enable --sync sun_position
 
-          cd IfcOpenShell/src/bonsai
+          cd ifcopenshell_repo/src/bonsai
           pip install -r requirements-dev.txt
           blender --background --python scripts/setup_pytest.py
           blender --python-expr "import bonsai; print(bonsai.bbim_semver); import ifcopenshell; print(ifcopenshell.version)" --background


### PR DESCRIPTION
## Summary

A cluster of BDD failures in `ci-bonsai-daily` (the `test_link_ifc__*` scenarios in `src/bonsai/test/bim/feature/project.feature`) are caused by a **CI-config path collision**, not a source bug.

The `update-extensions-repo-and-run-tests` job has no top-level `actions/checkout`, so GitHub Actions' default workspace is already `work/IfcOpenShell/IfcOpenShell` (the standard `<org>/<repo>` layout — both are named `IfcOpenShell`). The job then does `git clone …/IfcOpenShell.git IfcOpenShell`, cloning into a **third** `IfcOpenShell` segment: `…/IfcOpenShell/IfcOpenShell/IfcOpenShell`. The BDD fixtures template `Path.cwd()` (`test/bim/test_feature.py:54`) into `bim.link_ifc` file paths, so those tests look for fixture files under the tripled path and hit `FileNotFoundError` in `LinkIfc.link_ifc`.

## Fix

Rename the manually-cloned directory to `ifcopenshell_repo` and update its three dependent references (`reregister_bonsai.py`, `ifcsverchok`, `bonsai` `cd`s). Pure rename; removes the collision.

## Verification

Diagnosed by exact command reconstruction — the reconstructed path matches the failing string character-for-character. Final confirmation is the next `ci-bonsai-daily` run (this job needs GitHub-hosted runners and can't be reproduced locally), so a maintainer should confirm on the scheduled run before/after merge.

This change was made with the assistance of an AI tool.