### PR TITLE
Fix ci-bonsai-daily BDD: OperatorSpy.bl_rna + stale MEP port name

### DIFF
--- a/src/bonsai/test/bim/test_feature.py
+++ b/src/bonsai/test/bim/test_feature.py
@@ -187,7 +187,14 @@ class PanelSpy:
             after = ""
             if self.spied_labels:
                 after = self.spied_labels[-1]
-            spied_operator = {"operator": operator, "icon": icon, "text": text, "kwargs": {}, "after": after}
+            spied_operator = {
+                "operator": operator,
+                "icon": icon,
+                "text": text,
+                "kwargs": {},
+                "after": after,
+                "bl_idname": bl_idname,
+            }
             self.spied_operators.append(spied_operator)
             return OperatorSpy(spied_operator)
         elif self.spied_attr == "panel":
@@ -209,6 +216,14 @@ class OperatorSpy:
             super().__setattr__(name, value)
         else:
             self.spied_data["kwargs"][name] = value
+
+    @property
+    def bl_rna(self) -> Any:
+        # Mirror the real `UILayout.operator()` return value (an OperatorProperties
+        # instance), which exposes `.bl_rna` so panel code such as
+        # `"module" in op.bl_rna.properties` (bonsai/bim/helper.py) also works when
+        # drawing is spied on during BDD tests.
+        return getattr(bpy.types, self.spied_data["bl_idname"]).bl_rna
 
 
 class TemplateListSpy(PanelSpy):
@@ -773,7 +788,11 @@ def i_create_default_mep_types():
     with bpy.context.temp_override(active_object=bpy.data.objects["IfcActuatorType/ACTUATOR"]):
         bpy.ops.bim.add_port()
         # port at cube's left side
-        bpy.data.objects["IfcDistributionPort/Port"].location = (-0.5, 0, 0)
+        # Newly created ports are never given an explicit IFC `.Name` (see
+        # `core/system.py:create_port_at_cursor` / `tool/system.py`), so
+        # `tool.Loader.get_name()` falls back to the standard "Unnamed" convention
+        # used throughout Bonsai for freshly-created, not-yet-named elements.
+        bpy.data.objects["IfcDistributionPort/Unnamed"].location = (-0.5, 0, 0)
         bpy.ops.bim.hide_ports()
 
 


### PR DESCRIPTION
## Summary

Two independent test-harness/fixture defects in `test/bim/test_feature.py`, both live-verified in headless Blender.

### 1. `OperatorSpy` has no `bl_rna`
Any BDD step that redraws a panel calling `helper.draw_filter()` hits `if "module" in op.bl_rna.properties`, but the harness's `OperatorSpy` never defined `bl_rna` → `AttributeError`. Give `OperatorSpy` a `bl_rna` property forwarding to the real registered operator class (`bpy.types[bl_idname].bl_rna`), matching live `UILayout.operator()` semantics.
Fixes `test_select_all_walls`, `test_edit_filter_query`.

### 2. Stale MEP port object name
The shared `@given I create default MEP types` step looks up `bpy.data.objects["IfcDistributionPort/Port"]`, but no port-creation path ever sets `port.Name`, so `tool.Loader.get_name` deterministically produces `"IfcDistributionPort/Unnamed"`. Update the literal.
Fixes the MEP connect/transition/bend scenarios sharing this setup.

## Verification

Headless Blender, before → after:
- OperatorSpy: `AttributeError` → **2 passed**
- MEP: `KeyError: 'IfcDistributionPort/Port'` → **passing** (confirmed load-bearing by reverting just this hunk)

Test-only; no production code touched.

This change was made with the assistance of an AI tool.
