### PR TITLE
Fix ci-bonsai-daily: classification operators honor their obj argument

### DIFF
--- a/src/bonsai/bonsai/bim/module/classification/operator.py
+++ b/src/bonsai/bonsai/bim/module/classification/operator.py
@@ -77,10 +77,14 @@ class AddManualClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
 
     def _execute(self, context):
         if self.obj_type == "Object":
-            if context.selected_objects:
+            if self.obj:
+                objects = [self.obj]
+            elif context.selected_objects:
                 objects = [o.name for o in context.selected_objects]
-            else:
+            elif context.active_object:
                 objects = [context.active_object.name]
+            else:
+                objects = []
         else:
             objects = [self.obj]
         props = tool.Classification.get_classification_reference_props()
@@ -284,12 +288,15 @@ class RemoveClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
     obj_type: bpy.props.StringProperty()
 
     def _execute(self, context):
-        obj = bpy.data.objects.get(self.obj) if self.obj else context.active_object
         if self.obj_type == "Object":
-            if context.selected_objects:
+            if self.obj:
+                objects = [self.obj]
+            elif context.selected_objects:
                 objects = [o.name for o in context.selected_objects]
-            else:
+            elif context.active_object:
                 objects = [context.active_object.name]
+            else:
+                objects = []
         else:
             objects = [self.obj]
 
@@ -348,10 +355,14 @@ class AddClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
 
     def _execute(self, context):
         if self.obj_type == "Object":
-            if context.selected_objects:
+            if self.obj:
+                objects = [self.obj]
+            elif context.selected_objects:
                 objects = [o.name for o in context.selected_objects]
-            else:
+            elif context.active_object:
                 objects = [context.active_object.name]
+            else:
+                objects = []
         else:
             objects = [self.obj]
         props = tool.Classification.get_classification_props()
@@ -389,10 +400,14 @@ class AddClassificationReferenceFromBSDD(bpy.types.Operator, tool.Ifc.Operator):
 
     def _execute(self, context):
         if self.obj_type == "Object":
-            if context.selected_objects:
+            if self.obj:
+                objects = [self.obj]
+            elif context.selected_objects:
                 objects = [o.name for o in context.selected_objects]
-            else:
+            elif context.active_object:
                 objects = [context.active_object.name]
+            else:
+                objects = []
         else:
             objects = [self.obj]
         bprops = tool.Bsdd.get_bsdd_props()


### PR DESCRIPTION
## Summary

Four classification operators (`AddManualClassificationReference`, `RemoveClassificationReference`, `AddClassificationReference`, `AddClassificationReferenceFromBSDD`) ignored their own `obj` `StringProperty` in the `obj_type == "Object"` branch, using `context.selected_objects` / `context.active_object` instead.

But `bim.assign_class` runs first and clears/replaces the selection (it recreates the object for `IfcElementType` targets), so `context.active_object` is `None` by the time these operators run — which is exactly why the BDD scenarios pass `obj='IfcWallType/Cube'` explicitly. The operators never read it, so they crashed on `context.active_object.name`.

## Fix

Apply the same precedence `AssignClass` itself uses: explicit `self.obj` first, then selected objects, then a guarded `active_object`, else empty (already a no-op via the `if products:` guard). Fixes the crash and honors the passed argument.

## Verification

Headless Blender: the 5 classification BDD scenarios (add / enable-editing / disable-editing / remove / edit classification reference) go from **5 failed → passing** (6 passed incl. a sibling). Confirmed against the current `origin/v0.8.0` operator code.

This change was made with the assistance of an AI tool.
