### PR TITLE
Fix ci-bonsai-daily: get_dictionaries no longer clobbers injected bSDD client

### DIFF
--- a/src/bonsai/bonsai/tool/bsdd.py
+++ b/src/bonsai/bonsai/tool/bsdd.py
@@ -138,7 +138,6 @@ class Bsdd(bonsai.core.tool.Bsdd):
     def get_dictionaries(cls) -> list[bsdd.DictionaryContractV1]:
         prefs = tool.Blender.get_addon_preferences()
         baseurl = getattr(prefs, "bsdd_baseurl", "https://api.bsdd.buildingsmart.org/api/")
-        cls.client = bsdd.Client()
         if hasattr(cls.client, "baseurl"):
             cls.client.baseurl = baseurl
         response = cls.client.get_dictionary(include_test_dictionaries=prefs.bsdd_load_test_dictionaries)


### PR DESCRIPTION
## Summary

`Bsdd.get_dictionaries()` unconditionally ran `cls.client = bsdd.Client()`, replacing whatever client was already assigned — including the `bSDDClientStub` the BDD suite injects at module load (`test_feature.py`: `tool.Bsdd.client = bSDDClientStub()`) so scenarios never hit the network. Since "Load bSDD Dictionaries" is the first step of every `bsdd.feature` scenario, the stub was discarded on the very next line, and the whole feature file silently ran against the real network (and failed to see the stub's fixture data).

## Fix

Drop the clobbering `cls.client = bsdd.Client()` assignment; reuse whichever client is already set. The re-init loses nothing — `bsdd.Client.__init__` only sets `baseurl` + blank tokens, and the following line already updates `baseurl` defensively (`if hasattr(cls.client, "baseurl")`).

## Verification

Headless Blender: `test_load_bsdd_dictionaries`, `test_search_bsdd_classifications__search_all_dictionaries`, `test_search_bsdd_classifications__search_single_dictionary` go from **3 failed** (`Could not see 'LCA' / 'BonsaiTestDict'`) to **3 passed**. Confirmed against the current `origin/v0.8.0` `tool/bsdd.py`.

This change was made with the assistance of an AI tool.
