### PR TITLE
Fix ci-bonsai-daily: assign_class drops active_object; assign_material usage type

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -380,6 +380,14 @@ class AssignClass(bpy.types.Operator, tool.Ifc.Operator):
         # TODO: reload representation might lead to the object being replaced by object of the other type.
         # We probably should track it somehow and keep the original selection.
 
+        # Objects may have just been relinked into new collections (e.g. types
+        # into the "IfcTypeProduct" collection) above. Make sure the view
+        # layer's object bases are up to date before validating the selection
+        # below, otherwise a just-relinked (but perfectly valid) active object
+        # can be seen as "not in the current view layer" and be dropped,
+        # leaving `context.active_object` as None for the rest of the caller.
+        context.view_layer.update()
+
         # Validate selection and reapply it.
         current_selection = tool.Blender.validate_object_selection(*current_selection)
         tool.Blender.set_objects_selection(*current_selection)

--- a/src/bonsai/bonsai/core/material.py
+++ b/src/bonsai/bonsai/core/material.py
@@ -150,12 +150,20 @@ def assign_material(
         assigned_material = material_tool.get_material(element)
         assert assigned_material  # Type checker.
 
+        # Usages wrap the actual material set, unwrap it so an empty derived
+        # set (occurrence without a type) still gets its first layer/profile.
+        assigned_material_set = assigned_material
+        if assigned_material.is_a("IfcMaterialLayerSetUsage"):
+            assigned_material_set = assigned_material.ForLayerSet
+        elif assigned_material.is_a("IfcMaterialProfileSetUsage"):
+            assigned_material_set = assigned_material.ForProfileSet
+
         if material_tool.is_a_material_set(material):
             # Ensure set is a valid IFC.
             default_material = material_tool.get_default_material()
             material_tool.add_material_to_set(material_set=material, material=default_material)
-        elif material_tool.is_a_material_set(assigned_material):
-            material_tool.add_material_to_set(material_set=assigned_material, material=material)
+        elif material_tool.is_a_material_set(assigned_material_set):
+            material_tool.add_material_to_set(material_set=assigned_material_set, material=material)
         material_tool.ensure_material_assigned(
             elements=[element], material_type=element_material_type, material=material
         )

--- a/src/bonsai/bonsai/core/material.py
+++ b/src/bonsai/bonsai/core/material.py
@@ -130,10 +130,23 @@ def assign_material(
 
         if can_be_usage and not material_tool.is_type_product(element):
             element_material_type = material_type + "Usage"
+            # A "...Usage" type always wraps an existing material *set*
+            # (IfcMaterialLayerSet/IfcMaterialProfileSet), never a plain
+            # IfcMaterial. `material` here is whatever single IfcMaterial is
+            # selected in the Object Materials UI, so it can't be passed
+            # through as-is or ifcopenshell.api.material.assign_material will
+            # assert (e.g. "IfcMaterial cannot be assiged as a
+            # IfcMaterialLayerSetUsage."). Passing None lets the API derive
+            # (or create) the proper set from the element's type; the
+            # selected material is added into that set below instead.
+            material_for_assignment = None
         else:
             element_material_type = material_type
+            material_for_assignment = material
 
-        ifc.run("material.assign_material", products=[element], type=element_material_type, material=material)
+        ifc.run(
+            "material.assign_material", products=[element], type=element_material_type, material=material_for_assignment
+        )
         assigned_material = material_tool.get_material(element)
         assert assigned_material  # Type checker.
 

--- a/src/bonsai/test/bim/test_feature.py
+++ b/src/bonsai/test/bim/test_feature.py
@@ -979,6 +979,7 @@ def i_click_button_and_expect_error_error_msg(button, error_msg):
 
 @given(parsers.parse('I evaluate expression "{expression}"'))
 @when(parsers.parse('I evaluate expression "{expression}"'))
+@then(parsers.parse('I evaluate expression "{expression}"'))
 def i_evaluate_expression(expression):
     expression = replace_variables(expression)
     exec(expression)


### PR DESCRIPTION
## Summary

~16 failing BDD scenarios in the material / assign-type area trace to two root causes:

### 1. `AssignClass` drops the active object
`AssignClass._execute` (`bim/module/root/operator.py`) relinks objects into new collections (e.g. types into the hidden `IfcTypeProduct` collection) and then restores the selection via `tool.Blender.validate_object_selection`. Without a `context.view_layer.update()` in between, a just-relinked (but valid) active object is seen as "not in the current view layer" and dropped — so `context.active_object` becomes `None` for the rest of the caller, and every scenario that reads `active_object` after assigning a type fails. Add `view_layer.update()` before the selection-restore (an idiom already used ~15× elsewhere).

### 2. `assign_material` passes a plain material into a `...Usage` type
`core.assign_material` forwarded the selected plain `IfcMaterial` into `ifcopenshell.api.material.assign_material` even when auto-upgrading to a `...Usage` type, which only accepts a material *set* or `None` — tripping an intentional API assertion. Pass `material=None` for the usage branch and let the existing `add_material_to_set` follow-up populate the derived set.

## Verification

Headless Blender, material / assign_type / assigned-material BDD cluster: **23 failed / 14 passed → 7 failed / 30 passed**. The 7 remaining are an unrelated stale-STEP-id fixture cluster (`Item/IfcFace/NN`), handled separately.

This change was made with the assistance of an AI tool.
