### PR TITLE
Fix ci-bonsai-daily: configure unmerged_blobs mock in git_mergetool tests

### DIFF
--- a/src/bonsai/test/tool/test_ifcgit.py
+++ b/src/bonsai/test/tool/test_ifcgit.py
@@ -497,6 +497,8 @@ class TestGitMergetool:
         with tempfile.TemporaryDirectory() as tmpdir:
             ifc_path = os.path.join(tmpdir, "model.ifc")
             mock_repo = mock.MagicMock()
+            # A clean mergetool resolution leaves no unmerged blobs in the index.
+            mock_repo.index.unmerged_blobs.return_value = {}
             IfcGitRepo.repo = mock_repo
             result = IfcGit.git_mergetool("ifcmerge", ifc_path)
             assert result is None
@@ -511,6 +513,8 @@ class TestGitMergetool:
             report_path = ifc_path + ".ifcmerge"
             open(report_path, "w").close()
             mock_repo = mock.MagicMock()
+            # A clean mergetool resolution leaves no unmerged blobs in the index.
+            mock_repo.index.unmerged_blobs.return_value = {}
             IfcGitRepo.repo = mock_repo
             result = IfcGit.git_mergetool("ifcmerge", ifc_path)
             assert result is None


### PR DESCRIPTION
## Summary

`TestGitMergetool::test_returns_none_when_report_file_absent` and `_empty` build a `MagicMock()` repo without configuring `index.unmerged_blobs()`, so it returned a truthy `MagicMock`. `git_mergetool`'s **load-bearing** fallback (`tool/ifcgit.py:646-647`) — which returns the unmerged blobs to prevent silently committing an unresolved merge — then returned that list instead of `None`, failing `assert [] is None`.

The production fallback is correct and is **left untouched**; the tests simply misrepresented the 'mergetool resolved cleanly' scenario they're named for. Set `mock_repo.index.unmerged_blobs.return_value = {}` in both.

## Verification

Headless Blender: `test/tool/test_ifcgit.py::TestGitMergetool` **2 failed / 1 passed → 3 passed**. Test-only.

This change was made with the assistance of an AI tool.