### PR TITLE
Fix ci-bonsai-daily: guard on_depsgraph_update_caps during file load

### DIFF
--- a/src/bonsai/bonsai/tool/clip_box.py
+++ b/src/bonsai/bonsai/tool/clip_box.py
@@ -1270,6 +1270,17 @@ class ClipBox:
     def on_depsgraph_update_caps(cls, scene, depsgraph) -> None:
         """Depsgraph entry-point — guard, then delegate to the
         modal-aware debounce in :meth:`_handle_cap_tick`."""
+        # Same file-load danger window as on_depsgraph_update: a real
+        # depsgraph tick during load (between load_pre and the new file's
+        # first paint) must not re-arm a cap-rebuild timer. _on_load_pre
+        # already cancels any in-flight timer via _cancel_pending_cap_rebuild;
+        # without this gate, a depsgraph_update_post event firing later in
+        # the same load (Blender fires these while building the new file's
+        # scene) would immediately reschedule one via _handle_cap_tick,
+        # undoing that cancellation and re-arming against regions whose GPU
+        # state is not yet wired.
+        if cls._file_loading:
+            return
         if getattr(bpy.context, "screen", None) is None:
             return
         if cls._active_scene_props(scene) is None:


### PR DESCRIPTION
## Summary

`on_depsgraph_update` and `on_depsgraph_update_caps` are registered together as persistent depsgraph handlers (`bim/module/clip_box/__init__.py:50-52`). `on_depsgraph_update` correctly guards with `if cls._file_loading: return`, but the sibling `on_depsgraph_update_caps` did **not** — so a real depsgraph tick during the file-load window still ran it (the failing test forces one via `evaluated_depsgraph_get()`).

Beyond the test, this matters for real users: it could re-arm a cap-rebuild `bpy.app.timers` callback during the exact load window `_on_load_pre` explicitly cancels timers for, against regions whose GPU state isn't yet wired.

## Fix

Add the same `_file_loading` guard as the first check in `on_depsgraph_update_caps`, mirroring the sibling.

## Verification

Headless Blender: `test_clip_box.py::TestRefreshTimerLifecycle::test_depsgraph_update_no_op_while_loading` **1 failed → passed**.

This change was made with the assistance of an AI tool.