### PR TITLE
docker: make the build env work on macOS / Apple Silicon hosts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,15 @@ ENV PATH="/usr/lib/ccache:$PATH"
 # if your host user has a different UID/GID.
 ARG USER_UID=1000
 ARG USER_GID=1000
-RUN groupadd -g "${USER_GID}" builder \
+# groupadd fails outright if USER_GID is already taken by an existing
+# system group - which happens whenever a host's primary GID collides with
+# one baked into the rockylinux9 base image. The main real-world case is
+# macOS, where the default user's primary group is "staff" at GID 20, and
+# GID 20 is "games" on RHEL-family images. Only create the "builder" group
+# when that GID is actually free; otherwise useradd just attaches to
+# whichever group already owns it. Either way the builder user ends up
+# with the right GID for bind-mount ownership, which is all that matters.
+RUN (getent group "${USER_GID}" >/dev/null || groupadd -g "${USER_GID}" builder) \
     && useradd -m -u "${USER_UID}" -g "${USER_GID}" -s /bin/bash builder \
     && echo "builder ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/builder
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -4,6 +4,14 @@ services:
     container_name: ifcopenshell-${UNIQUE_ID}
     image: ifcopenshell-build-env:updated
     platform: linux/amd64
+    # There's no `build:` section - the image is always produced ahead of
+    # time by `./ifcos_env create` (`docker build`, not `docker compose
+    # build`). Without this, a platform mismatch between the pin above and
+    # whatever's in the local image store makes compose treat the image as
+    # absent and fall back to pulling ifcopenshell-build-env:updated from
+    # Docker Hub, where it doesn't exist. Fail fast with a clear "not
+    # found" instead of an obscure registry access-denied error.
+    pull_policy: never
     volumes:
       - type: bind
         source: ../

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -4,14 +4,6 @@ services:
     container_name: ifcopenshell-${UNIQUE_ID}
     image: ifcopenshell-build-env:updated
     platform: linux/amd64
-    # There's no `build:` section - the image is always produced ahead of
-    # time by `./ifcos_env create` (`docker build`, not `docker compose
-    # build`). Without this, a platform mismatch between the pin above and
-    # whatever's in the local image store makes compose treat the image as
-    # absent and fall back to pulling ifcopenshell-build-env:updated from
-    # Docker Hub, where it doesn't exist. Fail fast with a clear "not
-    # found" instead of an obscure registry access-denied error.
-    pull_policy: never
     volumes:
       - type: bind
         source: ../

--- a/docker/ifcos_env
+++ b/docker/ifcos_env
@@ -24,18 +24,7 @@ set_env
 
 function create() {
     echo "⭐ Creating image: ifcopenshell-build-env"
-    # compose.yaml pins the service to platform: linux/amd64 (this stack
-    # always targets the rockylinux9-x64 build-outputs branch and produces
-    # linux64 artifacts, regardless of host arch). Building without
-    # --platform would tag the image for the host's native arch instead -
-    # harmless on an amd64 host, but on an arm64 host (e.g. Apple Silicon)
-    # it leaves a local image that doesn't match what compose asked for, so
-    # `docker compose up` decides the requested platform is "missing" and
-    # tries to pull ifcopenshell-build-env:updated from Docker Hub instead
-    # of using the image just built. Pinning the build platform here keeps
-    # the local image's arch in sync with compose's pin on every host.
     docker build -f Dockerfile \
-        --platform linux/amd64 \
         --build-arg USER_UID="$(id -u)" --build-arg USER_GID="$(id -g)" \
         -t ifcopenshell-build-env:updated .
 }

--- a/docker/ifcos_env
+++ b/docker/ifcos_env
@@ -24,7 +24,18 @@ set_env
 
 function create() {
     echo "⭐ Creating image: ifcopenshell-build-env"
+    # compose.yaml pins the service to platform: linux/amd64 (this stack
+    # always targets the rockylinux9-x64 build-outputs branch and produces
+    # linux64 artifacts, regardless of host arch). Building without
+    # --platform would tag the image for the host's native arch instead -
+    # harmless on an amd64 host, but on an arm64 host (e.g. Apple Silicon)
+    # it leaves a local image that doesn't match what compose asked for, so
+    # `docker compose up` decides the requested platform is "missing" and
+    # tries to pull ifcopenshell-build-env:updated from Docker Hub instead
+    # of using the image just built. Pinning the build platform here keeps
+    # the local image's arch in sync with compose's pin on every host.
     docker build -f Dockerfile \
+        --platform linux/amd64 \
         --build-arg USER_UID="$(id -u)" --build-arg USER_GID="$(id -g)" \
         -t ifcopenshell-build-env:updated .
 }
@@ -112,7 +123,16 @@ function unique() {
         echo -e "\nUNIQUE_ID=dummy\n" >> "$ENV_FILE"
     fi
 
-    export UNIQUE_ID="$(pwd | sha256sum | cut -c -8)" && sed -si "s/^UNIQUE_ID=.*$/UNIQUE_ID=${UNIQUE_ID}/" "$ENV_FILE"
+    export UNIQUE_ID="$(pwd | sha256sum | cut -c -8)"
+
+    # `sed -i` takes incompatible syntax between GNU sed (Linux) and BSD sed
+    # (macOS) - `-si` is GNU-only and errors as "illegal option -- s" under
+    # BSD/macOS sed. Avoid -i altogether and do the in-place edit via a temp
+    # file + mv instead, which behaves identically with either sed.
+    local tmp_file
+    tmp_file="$(mktemp "${ENV_FILE}.XXXXXX")"
+    sed "s/^UNIQUE_ID=.*$/UNIQUE_ID=${UNIQUE_ID}/" "$ENV_FILE" > "$tmp_file"
+    mv "$tmp_file" "$ENV_FILE"
 
     set_env
 }


### PR DESCRIPTION
## Summary

Follow-up to #8564 (thanks @sboddy — the docker env is genuinely useful). Three small host-portability fixes so `docker/` runs on **macOS / Apple Silicon** as well as Linux. All three are **no-ops on native amd64 Linux**.

1. **Dockerfile GID collision** — macOS's default primary group `staff` is GID 20, which already exists as `games` in `rockylinux:9`, so `groupadd -g 20 builder` aborted the image build. Only `groupadd` when the GID is free (`getent group "${USER_GID}" >/dev/null || groupadd ...`); `useradd -g` accepts the existing GID.
2. **`ifcos_env` `sed -si`** — GNU-only; BSD/macOS sed errors `illegal option -- s`, breaking the `UNIQUE_ID` rewrite. Replaced with a portable `sed > tmp && mv` (verified against macOS BSD sed).
3. **Image arch / pull-instead-of-local** — `create()` built without `--platform`, so on arm64 the local image is tagged `linux/arm64` while `compose.yaml` pins `platform: linux/amd64`; compose then treats the local image as absent and tries to pull the local-only tag from Docker Hub (access denied). Build with explicit `--platform linux/amd64` so the local image matches the pin, plus `pull_policy: never` as a clear-error safety net.

## Caveat (honest)

On Apple Silicon the amd64 build runs under emulation and a cold full build is slow; `ccache` makes incremental rebuilds tolerable. A native Linux/Intel host or CI remains the better choice for routine use — but these fixes turn "hard broken" into "works, with a caveat" on macOS. Happy to adjust or drop any of these if you'd prefer a different approach.

This change was made with the assistance of an AI tool.
