### PR TITLE
Fix ci-bonsai-daily: renumber stale STEP ids in BDD feature fixtures

### DIFF
--- a/src/bonsai/test/bim/feature/boolean.feature
+++ b/src/bonsai/test/bim/feature/boolean.feature
@@ -12,7 +12,7 @@ Scenario: Ensure added booleans are marked as manual
     And I click "OK"
     And the object "IfcFurniture/Unnamed" exists
     And I toggle edit mode
-    And the object "Item/IfcExtrudedAreaSolid/77" exists
+    And the object "Item/IfcExtrudedAreaSolid/73" exists
     And I open the "Add Item" menu
     When I click "Half Space Solid"
     And the object "Item/IfcHalfSpaceSolid/90" exists
@@ -33,7 +33,7 @@ Scenario: Ensure removed booleans are unmarked as manual
     And I click "OK"
     And the object "IfcFurniture/Unnamed" exists
     And I toggle edit mode
-    And the object "Item/IfcExtrudedAreaSolid/77" exists
+    And the object "Item/IfcExtrudedAreaSolid/73" exists
     And I open the "Add Item" menu
     And I click "Half Space Solid"
     And I deselect all objects

--- a/src/bonsai/test/bim/feature/root.feature
+++ b/src/bonsai/test/bim/feature/root.feature
@@ -24,7 +24,7 @@ Scenario: Add element - an element with no geometry
     When I click "OK"
     And I select the object "IfcFurniture/Unnamed"
     And I toggle edit mode
-    Then the object "Item/IfcExtrudedAreaSolid/77" exists
+    Then the object "Item/IfcExtrudedAreaSolid/73" exists
 
 Scenario: Add element - an element with extrusion geometry
     Given an empty IFC project
@@ -36,7 +36,7 @@ Scenario: Add element - an element with extrusion geometry
     When I click "OK"
     And I select the object "IfcFurniture/Unnamed"
     And I toggle edit mode
-    Then the object "Item/IfcExtrudedAreaSolid/77" exists
+    Then the object "Item/IfcExtrudedAreaSolid/73" exists
 
 Scenario: Add element - an element with custom tessellation geometry
     Given an empty IFC project
@@ -48,7 +48,7 @@ Scenario: Add element - an element with custom tessellation geometry
     When I click "OK"
     And I select the object "IfcFurniture/Unnamed"
     And I toggle edit mode
-    Then the object "Item/IfcPolygonalFaceSet/76" exists
+    Then the object "Item/IfcPolygonalFaceSet/72" exists
 
 Scenario: Add element - an element with tessellation geometry from an object
     Given an empty IFC project
@@ -62,8 +62,8 @@ Scenario: Add element - an element with tessellation geometry from an object
     When I click "OK"
     And I select the object "IfcFurniture/Unnamed"
     And I toggle edit mode
-    Then the object "Item/IfcPolygonalFaceSet/76" exists
-    And the object "Item/IfcPolygonalFaceSet/76" dimensions are "2,2,2"
+    Then the object "Item/IfcPolygonalFaceSet/72" exists
+    And the object "Item/IfcPolygonalFaceSet/72" dimensions are "2,2,2"
 
 Scenario: Reassign class
     Given an empty IFC project

--- a/src/bonsai/test/bim/feature/structural.feature
+++ b/src/bonsai/test/bim/feature/structural.feature
@@ -12,7 +12,7 @@ Scenario: Add element - a structural point connection
     And I make the collection "IfcStructuralItem" visible
     And I select the object "IfcStructuralPointConnection/Foo"
     And I toggle edit mode
-    Then the object "Item/IfcVertexPoint/69" exists
+    Then the object "Item/IfcVertexPoint/65" exists
 
 Scenario: Add element - a structural curve member
     Given an empty IFC project
@@ -25,7 +25,7 @@ Scenario: Add element - a structural curve member
     And I make the collection "IfcStructuralItem" visible
     And I select the object "IfcStructuralCurveMember/Foo"
     And I toggle edit mode
-    Then the object "Item/IfcEdge/72" exists
+    Then the object "Item/IfcEdge/68" exists
 
 Scenario: Add element - a structural surface member
     Given an empty IFC project
@@ -38,7 +38,7 @@ Scenario: Add element - a structural surface member
     And I make the collection "IfcStructuralItem" visible
     And I select the object "IfcStructuralSurfaceMember/Foo"
     And I toggle edit mode
-    Then the object "Item/IfcFace/74" exists
+    Then the object "Item/IfcFace/70" exists
 
 Scenario: Load structural analysis models
     Given an empty IFC project


### PR DESCRIPTION
## Summary

Several `ci-bonsai-daily` BDD scenarios hardcode absolute representation-item object names whose trailing number is the IFC STEP line id (`f"Item/{item.is_a()}/{item.id()}"`). These ids drift when file-creation order changes; a recent shift moved all of them by a uniform **−4**, so the scenarios fail with `Item/.../NN does not exist`.

## How the correct ids were recovered (no local build needed)

The failing step `the_object_name_exists` in `test_feature.py` dumps the **full `bpy.data.objects` listing** on failure. So the correct current ids are readable directly from the CI log (run `29208793599`, tested commit `36e21e882f` — an ancestor of current HEAD with only a `.gitignore` commit between). Renumbered:

| old | new | file |
|---|---|---|
| `IfcExtrudedAreaSolid/77` | `73` | boolean.feature ×2, root.feature ×2 |
| `IfcPolygonalFaceSet/76` | `72` | root.feature ×2 |
| `IfcVertexPoint/69` | `65` | structural.feature |
| `IfcEdge/72` | `68` | structural.feature |
| `IfcFace/74` | `70` | structural.feature |

## Verification

Validated against CI's own object-listing dump (a local build produces different ids, so this is verified by the CI failure output rather than a local run).

**Left as-is on purpose:** `boolean.feature` also hardcodes `IfcHalfSpaceSolid/90` and panel text `[91]`, which are *downstream* of the failing assertion — CI never reached them and never dumped them. Rather than guess `90→86`/`91→87` from the −4 pattern, they're left for a same-day follow-up (the boolean scenarios will progress further next run and print a fresh dump if still stale).

This change was made with the assistance of an AI tool.
