### PR TITLE
Fix #8570: populate ifc5d IfcOpenShell QTO for 11 more classes

### DIFF
--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
@@ -68,8 +68,8 @@
             },
             "IfcBuildingElementProxy": {
                 "Qto_BuildingElementProxyQuantities": {
-                    "NetSurfaceArea": null,
-                    "NetVolume": null
+                    "NetSurfaceArea": "net_get_area",
+                    "NetVolume": "net_get_volume"
                 }
             },
             "IfcBuildingStorey": {
@@ -209,27 +209,27 @@
             },
             "IfcDistributionChamberElement": {
                 "Qto_DistributionChamberElementBaseQuantities": {
-                    "GrossSurfaceArea": null,
-                    "GrossVolume": null,
-                    "NetSurfaceArea": null,
-                    "NetVolume": null
+                    "GrossSurfaceArea": "gross_get_area",
+                    "GrossVolume": "gross_get_volume",
+                    "NetSurfaceArea": "net_get_area",
+                    "NetVolume": "net_get_volume"
                 }
             },
             "IfcDoor": {
                 "Qto_DoorBaseQuantities": {
-                    "Area": null,
-                    "Height": null,
+                    "Area": "net_get_max_side_area",
+                    "Height": "net_get_z",
                     "Perimeter": null,
-                    "Width": null
+                    "Width": "net_get_x"
                 }
             },
             "IfcDuctFitting": {
                 "Qto_DuctFittingBaseQuantities": {
                     "GrossCrossSectionArea": null,
                     "GrossWeight": null,
-                    "Length": null,
+                    "Length": "net_get_max_xyz",
                     "NetCrossSectionArea": null,
-                    "OuterSurfaceArea": null
+                    "OuterSurfaceArea": "net_get_outer_surface_area"
                 }
             },
             "IfcDuctSegment": {
@@ -441,8 +441,8 @@
             },
             "IfcProjectionElement": {
                 "Qto_ProjectionElementBaseQuantities": {
-                    "Area": null,
-                    "Volume": null
+                    "Area": "net_get_max_side_area",
+                    "Volume": "net_get_volume"
                 }
             },
             "IfcProtectiveDevice": {
@@ -462,23 +462,23 @@
             },
             "IfcRailing": {
                 "Qto_RailingBaseQuantities": {
-                    "Length": null
+                    "Length": "net_get_max_xyz"
                 }
             },
             "IfcRampFlight": {
                 "Qto_RampFlightBaseQuantities": {
-                    "GrossArea": null,
-                    "GrossVolume": null,
-                    "Length": null,
-                    "NetArea": null,
-                    "NetVolume": null,
+                    "GrossArea": "gross_get_footprint_area",
+                    "GrossVolume": "gross_get_volume",
+                    "Length": "net_get_max_xy",
+                    "NetArea": "net_get_footprint_area",
+                    "NetVolume": "net_get_volume",
                     "Width": null
                 }
             },
             "IfcReinforcingElement": {
                 "Qto_ReinforcingElementBaseQuantities": {
                     "Count": null,
-                    "Length": null,
+                    "Length": "net_get_max_xyz",
                     "Weight": null
                 }
             },
@@ -501,8 +501,8 @@
             },
             "IfcSite": {
                 "Qto_SiteBaseQuantities": {
-                    "GrossArea": null,
-                    "GrossPerimeter": null
+                    "GrossArea": "gross_get_footprint_area",
+                    "GrossPerimeter": "gross_get_footprint_perimeter"
                 }
             },
             "IfcSlab": {
@@ -545,7 +545,7 @@
             "IfcSpaceHeater": {
                 "Qto_SpaceHeaterBaseQuantities": {
                     "GrossWeight": null,
-                    "Length": null,
+                    "Length": "net_get_max_xyz",
                     "NetWeight": null
                 }
             },
@@ -570,7 +570,7 @@
                 "Qto_TankBaseQuantities": {
                     "GrossWeight": null,
                     "NetWeight": null,
-                    "TotalSurfaceArea": null
+                    "TotalSurfaceArea": "net_get_outer_surface_area"
                 }
             },
             "IfcTransformer": {

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
@@ -68,8 +68,8 @@
             },
             "IfcBuildingElementProxy + IfcBuildingElementProxyType": {
                 "Qto_BuildingElementProxyQuantities": {
-                    "NetSurfaceArea": null,
-                    "NetVolume": null
+                    "NetSurfaceArea": "net_get_area",
+                    "NetVolume": "net_get_volume"
                 }
             },
             "IfcBuildingStorey": {
@@ -226,27 +226,27 @@
             "IfcDistributionChamberElement + IfcDistributionChamberElementType": {
                 "Qto_DistributionChamberElementBaseQuantities": {
                     "Depth": null,
-                    "GrossSurfaceArea": null,
-                    "GrossVolume": null,
-                    "NetSurfaceArea": null,
-                    "NetVolume": null
+                    "GrossSurfaceArea": "gross_get_area",
+                    "GrossVolume": "gross_get_volume",
+                    "NetSurfaceArea": "net_get_area",
+                    "NetVolume": "net_get_volume"
                 }
             },
             "IfcDoor + IfcDoorType": {
                 "Qto_DoorBaseQuantities": {
-                    "Area": null,
-                    "Height": null,
+                    "Area": "net_get_max_side_area",
+                    "Height": "net_get_z",
                     "Perimeter": null,
-                    "Width": null
+                    "Width": "net_get_x"
                 }
             },
             "IfcDuctFitting + IfcDuctFittingType": {
                 "Qto_DuctFittingBaseQuantities": {
                     "GrossCrossSectionArea": null,
                     "GrossWeight": null,
-                    "Length": null,
+                    "Length": "net_get_max_xyz",
                     "NetCrossSectionArea": null,
-                    "OuterSurfaceArea": null
+                    "OuterSurfaceArea": "net_get_outer_surface_area"
                 }
             },
             "IfcDuctSegment + IfcDuctSegmentType": {
@@ -542,8 +542,8 @@
             },
             "IfcProjectionElement": {
                 "Qto_ProjectionElementBaseQuantities": {
-                    "Area": null,
-                    "Volume": null
+                    "Area": "net_get_max_side_area",
+                    "Volume": "net_get_volume"
                 }
             },
             "IfcProtectiveDevice + IfcProtectiveDeviceType": {
@@ -570,16 +570,16 @@
             },
             "IfcRailing + IfcRailingType": {
                 "Qto_RailingBaseQuantities": {
-                    "Length": null
+                    "Length": "net_get_max_xyz"
                 }
             },
             "IfcRampFlight + IfcRampFlightType": {
                 "Qto_RampFlightBaseQuantities": {
-                    "GrossArea": null,
-                    "GrossVolume": null,
-                    "Length": null,
-                    "NetArea": null,
-                    "NetVolume": null,
+                    "GrossArea": "gross_get_footprint_area",
+                    "GrossVolume": "gross_get_volume",
+                    "Length": "net_get_max_xy",
+                    "NetArea": "net_get_footprint_area",
+                    "NetVolume": "net_get_volume",
                     "Width": null
                 }
             },
@@ -595,7 +595,7 @@
             "IfcReinforcingElement + IfcReinforcingElementType": {
                 "Qto_ReinforcingElementBaseQuantities": {
                     "Count": null,
-                    "Length": null,
+                    "Length": "net_get_max_xyz",
                     "Weight": null
                 }
             },
@@ -637,8 +637,8 @@
             },
             "IfcSite": {
                 "Qto_SiteBaseQuantities": {
-                    "GrossArea": null,
-                    "GrossPerimeter": null
+                    "GrossArea": "gross_get_footprint_area",
+                    "GrossPerimeter": "gross_get_footprint_perimeter"
                 }
             },
             "IfcSlab + IfcSlabType": {
@@ -681,7 +681,7 @@
             "IfcSpaceHeater + IfcSpaceHeaterType": {
                 "Qto_SpaceHeaterBaseQuantities": {
                     "GrossWeight": null,
-                    "Length": null,
+                    "Length": "net_get_max_xyz",
                     "NetWeight": null
                 }
             },
@@ -719,7 +719,7 @@
                 "Qto_TankBaseQuantities": {
                     "GrossWeight": null,
                     "NetWeight": null,
-                    "TotalSurfaceArea": null
+                    "TotalSurfaceArea": "net_get_outer_surface_area"
                 }
             },
             "IfcTrackElement, PredefinedType=\"SLEEPER\" + IfcTrackElementType, PredefinedType=\"SLEEPER\"": {


### PR DESCRIPTION
## Summary

Follow-up to #8572 (which fixed `IfcSpace`), completing #8570 for the remaining all-null `IfcOpenShell`-calculator classes the issue listed. Ported `Qto_*BaseQuantities` formulas for **11 classes** in both `IFC4QtoBaseQuantities.json` and `IFC4X3QtoBaseQuantities.json`:

`IfcBuildingElementProxy`, `IfcDistributionChamberElement`, `IfcDoor`, `IfcDuctFitting`, `IfcProjectionElement`, `IfcRailing`, `IfcRampFlight`, `IfcReinforcingElement`, `IfcSite`, `IfcSpaceHeater`, `IfcTank`.

Each quantity maps to the `ifcopenshell.util.shape` function the Blender calculator uses, matching existing precedent in the file (`IfcColumn`/`IfcSlab`/`IfcWindow`/`IfcStairFlight`/`IfcFooting`).

**`IfcConstructionMaterialResource`** (the 12th) is left fully null: it's not an `IfcProduct` (no `Representation`/`ObjectPlacement`), so QTO doesn't apply — `quantify()` returns `{}` without crashing.

Quantities left `null` match the Blender ruleset (weights, cross-section areas, and dimensions with no `util.shape` equivalent such as `IfcDoor` Perimeter and `IfcRampFlight` Width) — **not guessed**.

## Verification

Live on IFC4 (box geometry via `ifcopenshell.api`, quantified with `ifc5d.qto`), every populated quantity returns the exact expected value, e.g.:
- `IfcDoor` 0.9×0.2×2.1 → Area 1.89, Height 2.1, Width 0.9
- `IfcSite` 10×8 footprint → GrossArea 80, GrossPerimeter 36
- `IfcTank` 2×2×3 → TotalSurfaceArea 24.0
- `IfcBuildingElementProxy` 2×1×0.5 → NetSurfaceArea 7.0, NetVolume 1.0

This change was made with the assistance of an AI tool.
