### PR TITLE
Share docker ccache volume across checkouts, cap at 2G

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /_deps-vs*-x*-installed/
 /_installed-vs*-x*/
 /build/
+/build.log
+/output/
 /src/examples/build/
 # ifctester docs output
 /src/ifctester/test/build/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,8 +28,11 @@ RUN git config --system --add safe.directory '*'
 # volume mount point at runtime - anything `ccache -M` writes to a config
 # file under it during this build gets shadowed once the real volume is
 # mounted, so the size cap only actually takes effect via the env var.
+# 2G is generous: a full build (IfcParse+IfcGeom+IfcConvert+wrapper, one
+# Python version) measures ~300MB, and the volume is now shared across all
+# checkouts (see compose.yaml), so this covers several diverging branches.
 ENV CCACHE_DIR=/ccache
-ENV CCACHE_MAXSIZE=5G
+ENV CCACHE_MAXSIZE=2G
 ENV PATH="/usr/lib/ccache:$PATH"
 
 # Non-root user matching the host UID/GID that bind-mounts the repo (default

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -12,3 +12,4 @@ services:
 
 volumes:
   ccache:
+    name: ifcopenshell-ccache-shared


### PR DESCRIPTION
## Summary
- The `docker/` local build environment's `ccache` volume had no explicit name, so Compose namespaced it per-checkout (via the `UNIQUE_ID`-derived project name) instead of actually sharing it, even though `docker/README.md` already documented the cache as shared between checkouts. Give the volume a fixed name so all checkouts attach the same one.
- Measured cache size after a full build (IfcParse+IfcGeom+IfcConvert+wrapper, one Python version) is ~300MB, only ~5% of the previous 5G cap. Shrink `CCACHE_MAXSIZE` to 2G, which comfortably covers the shared baseline plus per-branch deltas across several diverging checkouts.

This PR is entirely AI-generated (Claude), reviewed and tested by me.

## Test plan
- [x] Rebuilt the image and recreated containers for two separate checkouts sharing this `docker/` setup; confirmed both mount the same `ifcopenshell-ccache-shared` volume and report `CCACHE_MAXSIZE=2G` via `ccache -s`.