### PR TITLE
Bonsai docs: fix version switcher scheme mismatch (http vs https) (#8023)

### DIFF
--- a/src/bonsai/docs/_templates/sidebar/brand.html
+++ b/src/bonsai/docs/_templates/sidebar/brand.html
@@ -38,8 +38,8 @@ Hope your day's going well. :)
 <script>
   // Define the mapping of versions to URLs
   const versionURLs = {
-    stable: 'http://docs.bonsaibim.org/',
-    unstable: 'http://docs-unstable.bonsaibim.org/',
+    stable: 'https://docs.bonsaibim.org/',
+    unstable: 'https://docs-unstable.bonsaibim.org/',
     // Add more versions here as needed
   };
 


### PR DESCRIPTION
## Summary

Fixes #8023. The docs version switcher never highlights/switches to "Unstable" because the URL comparison fails.

## Root cause

`src/bonsai/docs/_templates/sidebar/brand.html` — `versionURLs` maps version labels to `http://` URLs, but the actual doc sites are served over `https://`. The switcher's `currentURL.includes(url)` check compares the browser's real `https://` URL against the stored `http://` one, which never matches.

## Fix

One-line scheme correction:
```diff
-    stable: 'http://docs.bonsaibim.org/',
-    unstable: 'http://docs-unstable.bonsaibim.org/',
+    stable: 'https://docs.bonsaibim.org/',
+    unstable: 'https://docs-unstable.bonsaibim.org/',
```

`https://docs.bonsaibim.org/...` is used consistently as the canonical scheme elsewhere in the docs source, and `https://docs-unstable.bonsaibim.org/` is confirmed live in the issue's own repro steps.

This change was made with the assistance of an AI tool.
