### PR TITLE
Bonsai: fix/report IFC Set Origin no-op on SweptSolid representations (#6727)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -273,10 +273,43 @@ class OverrideOriginSet(bpy.types.Operator, tool.Ifc.Operator):
             if not representation:
                 continue
             representation = ifcopenshell.util.representation.resolve_representation(representation)
-            if not tool.Geometry.is_meshlike(representation):
+            if not tool.Geometry.is_meshlike(representation) and not self.can_regenerate_swept_solid(
+                element, representation
+            ):
+                # Parametric representations (e.g. SweptSolid) aren't stored as raw mesh
+                # vertices, so Blender's origin_set can't simply be applied to them. A
+                # single simple extrusion can safely be re-derived from the tessellated
+                # mesh after the origin shift (the same logic bim.update_representation
+                # already uses), but anything more complex - multiple extrusions,
+                # booleans, or a parametric material profile/layer set as used by walls,
+                # columns and beams - can't be safely re-centered without risking
+                # silently replacing the parametric representation with a plain mesh.
+                # Rather than doing nothing silently, tell the user explicitly.
+                self.report(
+                    {"WARNING"},
+                    f"IFC Set Origin is not supported for '{obj.name}': its representation "
+                    f"('{representation.RepresentationType}') is parametric and cannot be safely re-centered.",
+                )
                 continue
             bpy.ops.object.origin_set(type=self.origin_type)
             bpy.ops.bim.update_representation(obj=obj.name)
+
+    @staticmethod
+    def can_regenerate_swept_solid(
+        element: ifcopenshell.entity_instance, representation: ifcopenshell.entity_instance
+    ) -> bool:
+        """Whether a non-meshlike representation is a simple enough SweptSolid to be safely
+        re-derived from its (tessellated) Blender mesh, the same way bim.update_representation
+        does for meshlike representations.
+        """
+        if not tool.Geometry.is_swept_profile(representation):
+            return False
+        material = ifcopenshell.util.element.get_material(element, should_skip_usage=True)
+        if material and material.is_a() in ("IfcMaterialProfileSet", "IfcMaterialLayerSet"):
+            # Parametrically defined by axis + material profile/layer set. Re-deriving
+            # the extrusion from the mesh would discard that parametric definition.
+            return False
+        return bool(tool.Geometry.get_ifc_representation_class(element, representation))
 
 
 class AddRepresentation(bpy.types.Operator, tool.Ifc.Operator):


### PR DESCRIPTION
## Summary

Fixes #6727. "IFC Set Origin" silently did nothing on `IfcExtrudedAreaSolid`/SweptSolid representations — `OverrideOriginSet._execute` skipped anything non-meshlike with a bare `continue`, giving the user no feedback.

## Approach

A hybrid, not a blanket enable: real fix where it's safe to re-derive the extrusion, an explicit warning where it isn't.

Bonsai already has a mature "regenerate SweptSolid from mesh" path (`bim.update_representation` via `ifcopenshell.api.geometry.add_representation`) that re-derives a single simple `IfcExtrudedAreaSolid` from a tessellated mesh outline — the same mechanism used whenever a wall/column mesh is edited directly and "Update Representation" is run. For that well-scoped case (`can_regenerate_swept_solid`), Set Origin now runs through the exact same path as the meshlike case.

For anything riskier — a parametric material profile/layer set (`IfcMaterialProfileSet`/`IfcMaterialLayerSet`, used by walls/columns/beams) or a representation too complex to re-derive — `add_representation` would silently downgrade the parametric SweptSolid to a plain Tessellation, which is worse than the original no-op. Those now get an explicit `self.report({"WARNING"}, ...)` instead, matching the existing warning convention already used elsewhere in this file.

## Verification

Live-tested in headless Blender (swap-protocol against the installed extension, restored after):
- Simple column, single rectangle extrusion, no material set: origin moved as expected, world-space bbox unchanged, representation stayed `SweptSolid`/`IfcExtrudedAreaSolid`.
- Wall with `IfcMaterialLayerSet`: operator now reports `"IFC Set Origin is not supported for '...': its representation ('SweptSolid') is parametric and cannot be safely re-centered."`, object left completely untouched (previously silent no-op).

This change was made with the assistance of an AI tool.
