### PR TITLE
Bonsai: restore sheet SVG on undo/redo of drawing removal (#7275)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2045,7 +2045,7 @@ class RemoveDrawingFromSheet(bpy.types.Operator, tool.Ifc.Operator):
 
     def _execute(self, context):
         ifc_file = tool.Ifc.get()
-        tool.Drawing.remove_drawing_from_sheet(ifc_file.by_id(self.reference))
+        tool.Drawing.remove_drawing_from_sheet(ifc_file.by_id(self.reference), operator=self)
 
 
 class CreateSheets(bpy.types.Operator, tool.Ifc.Operator):
@@ -2579,7 +2579,7 @@ class RemoveDrawing(bpy.types.Operator, tool.Ifc.Operator):
         for drawing in drawings:
             sheet_references = tool.Drawing.get_sheet_references(drawing)
             for reference in sheet_references:
-                tool.Drawing.remove_drawing_from_sheet(reference)
+                tool.Drawing.remove_drawing_from_sheet(reference, operator=self)
             core.remove_drawing(tool.Ifc, tool.Drawing, drawing=drawing)
 
         # In case we removed the active drawing.

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -26,6 +26,7 @@ import platform
 import re
 import shutil
 import subprocess
+import tempfile
 from collections.abc import Iterable, Sequence
 from fractions import Fraction
 from pathlib import Path
@@ -2924,11 +2925,13 @@ class Drawing(bonsai.core.tool.Drawing):
         # The sheet layout SVG is edited directly on disk and isn't tracked by
         # Blender's undo system. Snapshot it so an undo/redo of `operator` can
         # restore the file to match the reverted/reapplied IFC state (#7275).
+        # Snapshots are written to disk rather than kept as bytes in the
+        # rollback/commit closures, so they don't sit on the Python heap for
+        # as long as the undo history entry is alive.
         layout_path = tool.Drawing.get_document_uri(sheet, "LAYOUT") if sheet else None
-        previous_layout: Optional[bytes] = None
+        previous_layout_path: Optional[str] = None
         if layout_path and os.path.exists(layout_path):
-            with open(layout_path, "rb") as f:
-                previous_layout = f.read()
+            previous_layout_path = cls.snapshot_layout_svg(layout_path)
 
         sheet_builder = sheeter.SheetBuilder()
         sheet_builder.remove_drawing(reference, sheet)
@@ -2937,21 +2940,34 @@ class Drawing(bonsai.core.tool.Drawing):
 
         tool.Drawing.import_sheets()
 
-        if operator is not None and previous_layout is not None and layout_path and os.path.exists(layout_path):
-            with open(layout_path, "rb") as f:
-                new_layout = f.read()
+        if operator is not None and previous_layout_path is not None and layout_path and os.path.exists(layout_path):
+            new_layout_path = cls.snapshot_layout_svg(layout_path)
 
-            def rollback(data: Any, path: str = layout_path, content: bytes = previous_layout) -> None:
-                with open(path, "wb") as f:
-                    f.write(content)
+            def rollback(data: Any, path: str = layout_path, snapshot: str = previous_layout_path) -> None:
+                shutil.copyfile(snapshot, path)
 
-            def commit(data: Any, path: str = layout_path, content: bytes = new_layout) -> None:
-                with open(path, "wb") as f:
-                    f.write(content)
+            def commit(data: Any, path: str = layout_path, snapshot: str = new_layout_path) -> None:
+                shutil.copyfile(snapshot, path)
 
             from bonsai.bim.ifc import IfcStore
 
             IfcStore.add_transaction_operation(operator, rollback=rollback, commit=commit)
+
+    @classmethod
+    def snapshot_layout_svg(cls, layout_path: str) -> str:
+        """Copy a sheet layout SVG into a temp file and return its path.
+
+        Used to snapshot undo/redo state for #7275 without holding the SVG
+        contents as bytes for the lifetime of the undo history entry. These
+        are ordinary OS temp files (same convention as
+        tool.Blender.temp_file_with_traceback) and aren't explicitly
+        tracked/cleaned up; they're small and rely on the OS's normal temp
+        directory lifecycle.
+        """
+        fd, snapshot_path = tempfile.mkstemp(prefix="bonsai_sheet_layout_", suffix=".svg")
+        os.close(fd)
+        shutil.copyfile(layout_path, snapshot_path)
+        return snapshot_path
 
     @classmethod
     def hide_all_drawing_collections(cls) -> None:

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2914,10 +2914,21 @@ class Drawing(bonsai.core.tool.Drawing):
         finalize_dxf()
 
     @classmethod
-    def remove_drawing_from_sheet(cls, reference: ifcopenshell.entity_instance) -> None:
+    def remove_drawing_from_sheet(
+        cls, reference: ifcopenshell.entity_instance, operator: Optional[bpy.types.Operator] = None
+    ) -> None:
         import bonsai.bim.module.drawing.sheeter as sheeter
 
         sheet = tool.Drawing.get_reference_document(reference)
+
+        # The sheet layout SVG is edited directly on disk and isn't tracked by
+        # Blender's undo system. Snapshot it so an undo/redo of `operator` can
+        # restore the file to match the reverted/reapplied IFC state (#7275).
+        layout_path = tool.Drawing.get_document_uri(sheet, "LAYOUT") if sheet else None
+        previous_layout: Optional[bytes] = None
+        if layout_path and os.path.exists(layout_path):
+            with open(layout_path, "rb") as f:
+                previous_layout = f.read()
 
         sheet_builder = sheeter.SheetBuilder()
         sheet_builder.remove_drawing(reference, sheet)
@@ -2925,6 +2936,22 @@ class Drawing(bonsai.core.tool.Drawing):
         ifcopenshell.api.document.remove_reference(tool.Ifc.get(), reference=reference)
 
         tool.Drawing.import_sheets()
+
+        if operator is not None and previous_layout is not None and layout_path and os.path.exists(layout_path):
+            with open(layout_path, "rb") as f:
+                new_layout = f.read()
+
+            def rollback(data: Any, path: str = layout_path, content: bytes = previous_layout) -> None:
+                with open(path, "wb") as f:
+                    f.write(content)
+
+            def commit(data: Any, path: str = layout_path, content: bytes = new_layout) -> None:
+                with open(path, "wb") as f:
+                    f.write(content)
+
+            from bonsai.bim.ifc import IfcStore
+
+            IfcStore.add_transaction_operation(operator, rollback=rollback, commit=commit)
 
     @classmethod
     def hide_all_drawing_collections(cls) -> None:


### PR DESCRIPTION
## Summary

Fixes #7275. Undo after removing a drawing from a sheet (or removing a drawing entirely) doesn't restore the sheet's SVG output.

## Root cause

`tool.Drawing.remove_drawing_from_sheet` parses the sheet's `layout.svg`, removes the `<g data-id=...>` element for that drawing, and writes the file back to disk — a direct filesystem mutation entirely outside Blender's/IFC's undo tracking (which only covers the `ifcopenshell.api.document.remove_reference` IFC-entity change, not the SVG file on disk).

## Fix

Bonsai already has a mechanism for exactly this class of problem: `IfcStore.add_transaction_operation(operator, rollback=..., commit=...)`, used elsewhere (`project/operator.py`, `brick/operator.py`, etc.) to hook non-IFC side effects into the undo/redo transaction chain. `remove_drawing_from_sheet` now snapshots the layout SVG bytes before and after the on-disk edit, and — when passed the calling operator — registers a rollback (restores pre-removal bytes) and commit (reapplies post-removal bytes). Both call sites (`RemoveDrawingFromSheet` and `RemoveDrawing`, which also strips sheet references) now pass `operator=self`.

## Verification

Live-tested in headless Blender 5.1.2 against the real, unmocked `IfcStore.add_transaction_operation` → `IfcStore.history` → `IfcStore.undo()`/`redo()` path (the same one the `undo_post`/`redo_post` handlers use) — confirmed the layout SVG is restored byte-for-byte on undo and the removal is correctly reapplied on redo. Patched the actual deployed `.whl` for testing since site-packages patches alone get wiped by Blender's wheel re-extraction.

This change was made with the assistance of an AI tool.
