### PR TITLE
Fix ValueError in get_axis2placement for 2D RefDirection

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/placement.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/placement.py
@@ -77,8 +77,7 @@ def get_axis2placement(placement: ifcopenshell.entity_instance) -> MatrixType:
     elif ifc_class == "IfcAxis2Placement2D":
         z = np.array((0, 0, 1))
         if placement.RefDirection:
-            x = np.array(placement.RefDirection.DirectionRatios)
-            x.resize(3)
+            x = np.array((*placement.RefDirection.DirectionRatios, 0.0))
         else:
             x = np.array((1, 0, 0))
         o = (*placement.Location.Coordinates, 0.0)

--- a/src/ifcopenshell-python/test/util/test_placement.py
+++ b/src/ifcopenshell-python/test/util/test_placement.py
@@ -40,3 +40,31 @@ class TestGetStoreyElevationIFC4(test.bootstrap.IFC4):
         assert subject.get_storey_elevation(storey) == 0.0
         building = self.file.createIfcBuilding()
         assert subject.get_storey_elevation(building) == 0.0
+
+
+class TestGetAxis2PlacementIFC4(test.bootstrap.IFC4):
+    def test_2d_placement_with_ref_direction(self):
+        """Regression test: IfcCircleProfileDef.Position is always a real
+        IfcAxis2Placement2D with an explicit RefDirection (never None), so
+        this path is exercised on every parameterized-profile slab/column.
+        Previously raised ValueError from an in-place ndarray.resize() call
+        on a 2-element DirectionRatios array."""
+        placement = self.file.createIfcAxis2Placement2D(
+            Location=self.file.createIfcCartesianPoint((1.0, 2.0)),
+            RefDirection=self.file.createIfcDirection((0.0, 1.0)),
+        )
+        matrix = subject.get_axis2placement(placement)
+        assert list(matrix[:, 3]) == [1.0, 2.0, 0.0, 1.0]
+
+    def test_2d_placement_without_ref_direction_defaults_to_identity_axes(self):
+        placement = self.file.createIfcAxis2Placement2D(
+            Location=self.file.createIfcCartesianPoint((0.0, 0.0)),
+            RefDirection=None,
+        )
+        matrix = subject.get_axis2placement(placement)
+        assert matrix.tolist() == [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]


### PR DESCRIPTION
## Summary
This issue is a separate fix arising from testing while Claude was improving the Copilot produced #8239
- `ifcopenshell.util.placement.get_axis2placement()` builds the local X-axis for an `IfcAxis2Placement2D` via `x = np.array(RefDirection.DirectionRatios); x.resize(3)`. The in-place `ndarray.resize()` raises `ValueError: cannot resize an array that references or is referenced by another array in this way` whenever numpy considers the array unsafe to resize in place.
- This path is always hit for `IfcCircleProfileDef`, since its `Position` is never null (unlike `IfcRectangleProfileDef`, whose `Position` stays `None` and never reaches this code), so any code calling `get_axis2placement` on a circle profile's placement hits this reliably.
- Fix: build the 3-element array directly (`np.array((*DirectionRatios, 0.0))`) instead of resizing in place.

## AI disclosure
This fix and its regression tests were generated with the assistance of an AI coding tool.

## Test plan
- [x] Added `TestGetAxis2PlacementIFC4` in `test/util/test_placement.py` covering both the `RefDirection` and no-`RefDirection` cases; ran via `pytest -p no:pytest-blender util/test_placement.py` (5 passed).
- [x] Ran the full `util/` test suite to check for regressions (355 passed; the only failures were pre-existing/unrelated to this change — `mathutils` unavailable outside Blender, and an unrelated `IsUserdefinedType` test).