### PR TITLE
Fix #6896 wall generation from composite/arc/circle/rectangle slab profiles

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1244,7 +1244,9 @@ class DumbWallAligner:
 
 
 class DumbWallGenerator:
-    SLAB_ARC_RESOLUTION = 24
+    SLAB_ARC_RESOLUTION = 24  # max samples for a full-size arc/circle
+    SLAB_MIN_ARC_SEGMENTS = 4  # min samples so small fillets stay visibly curved
+    SLAB_ARC_SEGMENT_LENGTH = 0.1  # metres; target physical length per sampled segment
     SLAB_POINT_MERGE_TOLERANCE = 1e-6
 
     def __init__(self, relating_type):
@@ -1305,30 +1307,48 @@ class DumbWallGenerator:
         """Detect whether an IfcIndexedPolyCurve perimeter includes arc segments."""
         if not curve.is_a("IfcIndexedPolyCurve"):
             return False
-        segments = getattr(curve, "Segments", None) or ()
-        for segment in segments:
-            # Different schema wrappers expose segment typing either as entities
-            # (IfcArcIndex / IfcLineIndex) or as index tuples.
-            if hasattr(segment, "is_a"):
-                if segment.is_a("IfcArcIndex"):
-                    return True
-                continue
-            if len(segment[0]) == 3:
-                return True
-        return False
+        segments = curve.Segments or ()
+        return any(segment.is_a("IfcArcIndex") for segment in segments)
 
-    def _world_xy_point(self, slab_obj: bpy.types.Object, elevation: float, ifc_coord: Any) -> Vector:
-        return slab_obj.matrix_world @ Vector(
-            (ifc_coord[0] * self.unit_scale, ifc_coord[1] * self.unit_scale, elevation)
-        )
+    def _world_xy_point(self, world_matrix: Matrix, elevation: float, ifc_coord: Any) -> Vector:
+        return world_matrix @ Vector((ifc_coord[0] * self.unit_scale, ifc_coord[1] * self.unit_scale, elevation))
+
+    def _resolution_for_radius(self, radius: float) -> int:
+        """Sample count for a circle/arc of the given (world-unit) radius.
+
+        Scales with physical size so a small fillet doesn't get the same vertex
+        count as a large arc, which would otherwise explode a small rounded
+        corner into many near-duplicate tiny wall segments.
+        """
+        if radius <= 0:
+            return self.SLAB_MIN_ARC_SEGMENTS
+        segment_count = math.ceil((2 * math.pi * radius) / self.SLAB_ARC_SEGMENT_LENGTH)
+        return max(self.SLAB_MIN_ARC_SEGMENTS, min(segment_count, self.SLAB_ARC_RESOLUTION))
+
+    def _estimate_arc_segment_count(self, p1: Vector, p2: Vector, p3: Vector) -> int:
+        """Estimate a sample count for the 3-point arc [start, through, end]."""
+        a = (p2 - p3).length
+        b = (p1 - p3).length
+        c = (p1 - p2).length
+        area = 0.5 * (p2 - p1).cross(p3 - p1).length
+        if area < self.SLAB_POINT_MERGE_TOLERANCE:
+            return self.SLAB_MIN_ARC_SEGMENTS
+        radius = (a * b * c) / (4 * area)
+        return self._resolution_for_radius(radius)
+
+    def _profile_position_matrix(self, position: Union[ifcopenshell.entity_instance, None]) -> Matrix:
+        if not position:
+            return Matrix.Identity(4)
+        matrix = Matrix(ifcopenshell.util.placement.get_axis2placement(position).tolist())
+        matrix.translation *= self.unit_scale
+        return matrix
 
     def _derive_points_from_arc_segments(
-        self, slab_obj: bpy.types.Object, elevation: float, curve: ifcopenshell.entity_instance
+        self, world_matrix: Matrix, elevation: float, curve: ifcopenshell.entity_instance
     ) -> list[Vector]:
         """Return world-space perimeter points for an indexed curve with arc segments."""
         points: list[Vector] = []
         coord_list = curve.Points.CoordList
-        arc_resolution = self.SLAB_ARC_RESOLUTION
         precision = self.SLAB_POINT_MERGE_TOLERANCE
 
         def append_point(point: Vector) -> None:
@@ -1339,12 +1359,13 @@ class DumbWallGenerator:
         for segment in curve.Segments:
             segment_indices = [i - 1 for i in segment[0]]
             if len(segment_indices) == 3:
-                p1 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[0]])
-                p2 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[1]])
-                p3 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[2]])
+                p1 = self._world_xy_point(world_matrix, elevation, coord_list[segment_indices[0]])
+                p2 = self._world_xy_point(world_matrix, elevation, coord_list[segment_indices[1]])
+                p3 = self._world_xy_point(world_matrix, elevation, coord_list[segment_indices[2]])
+                segment_count = self._estimate_arc_segment_count(p1, p2, p3)
                 # create_arc_segments returns (sampled_points, sampled_edges);
                 # only sampled_points are needed for wall generation.
-                sampled_arc_points, _ = tool.Cad.create_arc_segments([p1, p2, p3], num_verts=arc_resolution + 1)
+                sampled_arc_points, _ = tool.Cad.create_arc_segments([p1, p2, p3], num_verts=segment_count + 1)
                 sampled_arc_points = [Vector(arc_point) for arc_point in sampled_arc_points]
                 # Cad.create_arc_segments may return samples from end->start for a
                 # [start, through, end] input, so normalize to start->end to keep
@@ -1355,35 +1376,42 @@ class DumbWallGenerator:
                     append_point(arc_point)
             elif len(segment_indices) >= 2:
                 for segment_index in segment_indices:
-                    append_point(self._world_xy_point(slab_obj, elevation, coord_list[segment_index]))
+                    append_point(self._world_xy_point(world_matrix, elevation, coord_list[segment_index]))
 
         if points and (points[0] - points[-1]).length >= precision:
             points.append(points[0].copy())
         return points
 
     def _derive_points_from_circle(
-        self, slab_obj: bpy.types.Object, elevation: float, circle: ifcopenshell.entity_instance
+        self,
+        world_matrix: Matrix,
+        elevation: float,
+        circle: ifcopenshell.entity_instance,
+        radius_override: Union[float, None] = None,
     ) -> list[Vector]:
-        """Return world-space perimeter points for an IfcCircle perimeter."""
-        points: list[Vector] = []
-        arc_resolution = self.SLAB_ARC_RESOLUTION
-        precision = self.SLAB_POINT_MERGE_TOLERANCE
-        radius = circle.Radius * self.unit_scale
+        """Return world-space perimeter points for a circular perimeter.
 
-        circle_position = Matrix.Identity(4)
-        if getattr(circle, "Position", None):
-            circle_position = Matrix(ifcopenshell.util.placement.get_axis2placement(circle.Position).tolist())
-            circle_position.translation *= self.unit_scale
+        Handles both an ``IfcCircle`` curve and a parameterized
+        ``IfcCircleProfileDef`` (both expose compatible ``Radius``/``Position``
+        attributes). ``radius_override`` lets callers sample a circle of a
+        different radius (e.g. the inner void of an ``IfcCircleHollowProfileDef``)
+        using the same center/orientation.
+        """
+        points: list[Vector] = []
+        precision = self.SLAB_POINT_MERGE_TOLERANCE
+        radius = (radius_override if radius_override is not None else circle.Radius) * self.unit_scale
+        circle_position = self._profile_position_matrix(getattr(circle, "Position", None))
+        resolution = self._resolution_for_radius(radius)
 
         def append_point(point: Vector) -> None:
             if points and (points[-1] - point).length < precision:
                 return
             points.append(point)
 
-        for i in range(arc_resolution):
-            theta = (2 * math.pi * i) / arc_resolution
+        for i in range(resolution):
+            theta = (2 * math.pi * i) / resolution
             local_point = Vector((radius * math.cos(theta), radius * math.sin(theta), 0.0))
-            world_point = slab_obj.matrix_world @ circle_position @ local_point
+            world_point = world_matrix @ circle_position @ local_point
             world_point.z = elevation
             append_point(world_point)
 
@@ -1391,7 +1419,87 @@ class DumbWallGenerator:
             points.append(points[0].copy())
         return points
 
-    def derive_from_slab(self):
+    def _derive_points_from_rectangle(
+        self,
+        world_matrix: Matrix,
+        elevation: float,
+        position: Union[ifcopenshell.entity_instance, None],
+        x_dim: float,
+        y_dim: float,
+    ) -> list[Vector]:
+        """Return world-space perimeter points for a parameterized rectangle profile."""
+        half_x = (x_dim * self.unit_scale) / 2
+        half_y = (y_dim * self.unit_scale) / 2
+        corners = (
+            Vector((-half_x, -half_y, 0.0)),
+            Vector((half_x, -half_y, 0.0)),
+            Vector((half_x, half_y, 0.0)),
+            Vector((-half_x, half_y, 0.0)),
+            Vector((-half_x, -half_y, 0.0)),
+        )
+        rectangle_position = self._profile_position_matrix(position)
+        points = []
+        for corner in corners:
+            world_point = world_matrix @ rectangle_position @ corner
+            world_point.z = elevation
+            points.append(world_point)
+        return points
+
+    def _derive_points_from_curve(
+        self, world_matrix: Matrix, elevation: float, curve: ifcopenshell.entity_instance
+    ) -> list[Vector]:
+        """Return world-space perimeter points for an outer/inner profile curve."""
+        if self._curve_has_arc_segments(curve):
+            return self._derive_points_from_arc_segments(world_matrix, elevation, curve)
+        if curve.is_a("IfcCircle"):
+            return self._derive_points_from_circle(world_matrix, elevation, curve)
+        builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
+        polyline_points = builder.get_polyline_coords(curve)
+        polyline_points = [[(v * self.unit_scale) for v in p] for p in polyline_points]
+        return [world_matrix @ Vector((p[0], p[1], elevation)) for p in polyline_points]
+
+    def _get_profile_loops(
+        self, world_matrix: Matrix, elevation: float, profile: ifcopenshell.entity_instance
+    ) -> list[list[Vector]]:
+        """Return point loops for a single (non-composite) profile.
+
+        The first loop is the outer boundary; any further loops are inner
+        voids (holes) that should also get their own ring of walls.
+        """
+        if profile.is_a("IfcCircleProfileDef"):
+            loops = [self._derive_points_from_circle(world_matrix, elevation, profile)]
+            if profile.is_a("IfcCircleHollowProfileDef") and profile.WallThickness:
+                inner_radius = profile.Radius - profile.WallThickness
+                if inner_radius > 0:
+                    loops.append(
+                        self._derive_points_from_circle(world_matrix, elevation, profile, radius_override=inner_radius)
+                    )
+            return loops
+
+        if profile.is_a("IfcRectangleProfileDef"):
+            loops = [
+                self._derive_points_from_rectangle(
+                    world_matrix, elevation, profile.Position, profile.XDim, profile.YDim
+                )
+            ]
+            if profile.is_a("IfcRectangleHollowProfileDef") and profile.WallThickness:
+                inner_x = profile.XDim - 2 * profile.WallThickness
+                inner_y = profile.YDim - 2 * profile.WallThickness
+                if inner_x > 0 and inner_y > 0:
+                    loops.append(
+                        self._derive_points_from_rectangle(world_matrix, elevation, profile.Position, inner_x, inner_y)
+                    )
+            return loops
+
+        loops = [self._derive_points_from_curve(world_matrix, elevation, profile.OuterCurve)]
+        if profile.is_a("IfcArbitraryProfileDefWithVoids"):
+            loops.extend(
+                self._derive_points_from_curve(world_matrix, elevation, inner_curve)
+                for inner_curve in profile.InnerCurves
+            )
+        return loops
+
+    def derive_from_slab(self) -> list[list[Union[dict[str, Any], None]]]:
         slab_obj = bpy.context.active_object
         slab = tool.Ifc.get_entity(slab_obj)
         container = ifcopenshell.util.element.get_container(slab)
@@ -1399,36 +1507,35 @@ class DumbWallGenerator:
         elevation = self.container_obj.location.z
         representation = ifcopenshell.util.representation.get_representation(slab, "Model", "Body", "MODEL_VIEW")
         extrusion = tool.Model.get_extrusion(representation)
+        # IfcExtrudedAreaSolid.Position places the profile's 2D coordinate
+        # system within the object's local space; without it, profiles whose
+        # extrusion isn't centered/aligned on the object origin (e.g. after
+        # "Convert To Rectangle/Circle Extrusion") come out translated/rotated.
+        world_matrix = slab_obj.matrix_world @ self._profile_position_matrix(extrusion.Position)
         swept_area = extrusion.SweptArea
         if swept_area.is_a("IfcCompositeProfileDef"):
             profiles = swept_area.Profiles
         else:
             profiles = [swept_area]
+
         wall_groups = []
         for profile in profiles:
-            outer_curve = profile.OuterCurve
-            if self._curve_has_arc_segments(outer_curve):
-                polyline_points = self._derive_points_from_arc_segments(slab_obj, elevation, outer_curve)
-            elif outer_curve.is_a("IfcCircle"):
-                polyline_points = self._derive_points_from_circle(slab_obj, elevation, outer_curve)
-            else:
-                builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
-                polyline_points = builder.get_polyline_coords(outer_curve)
-                polyline_points = [[(v * self.unit_scale) for v in p] for p in polyline_points]
-                polyline_points = [slab_obj.matrix_world @ Vector((p[0], p[1], elevation)) for p in polyline_points]
-
-            if len(polyline_points) < 3:
-                continue
-            if not tool.Cad.is_counter_clockwise_order(polyline_points[0], polyline_points[1], polyline_points[2]):
-                polyline_points = polyline_points[::-1]
-            loop_walls = []
-            for i in range(len(polyline_points) - 1):
-                vec1 = polyline_points[i]
-                vec2 = polyline_points[i + 1]
-                coords = (vec1, vec2)
-                loop_walls.append(self.create_wall_from_2_points(coords))
-            if loop_walls:
-                wall_groups.append(loop_walls)
+            loops = self._get_profile_loops(world_matrix, elevation, profile)
+            for loop_index, polyline_points in enumerate(loops):
+                if len(polyline_points) < 3:
+                    continue
+                is_outer_loop = loop_index == 0
+                is_ccw = tool.Cad.is_counter_clockwise_order(polyline_points[0], polyline_points[1], polyline_points[2])
+                # Outer boundaries are wound CCW, inner void boundaries CW, so wall
+                # thickness consistently offsets away from the slab's solid area.
+                if is_ccw != is_outer_loop:
+                    polyline_points = polyline_points[::-1]
+                loop_walls = []
+                for i in range(len(polyline_points) - 1):
+                    coords = (polyline_points[i], polyline_points[i + 1])
+                    loop_walls.append(self.create_wall_from_2_points(coords))
+                if loop_walls:
+                    wall_groups.append(loop_walls)
         return wall_groups
 
     def create_wall_from_2_points(self, coords, should_round=False) -> Union[dict[str, Any], None]:

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1243,6 +1243,9 @@ class DumbWallAligner:
 
 
 class DumbWallGenerator:
+    SLAB_ARC_RESOLUTION = 24
+    SLAB_POINT_MERGE_TOLERANCE = 1e-6
+
     def __init__(self, relating_type):
         self.relating_type = relating_type
         self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
@@ -1302,7 +1305,11 @@ class DumbWallGenerator:
             return False
         segments = getattr(curve, "Segments", None) or ()
         for segment in segments:
-            if (hasattr(segment, "is_a") and segment.is_a("IfcArcIndex")) or len(segment[0]) == 3:
+            if hasattr(segment, "is_a"):
+                if segment.is_a("IfcArcIndex"):
+                    return True
+                continue
+            if len(segment[0]) == 3:
                 return True
         return False
 
@@ -1314,8 +1321,8 @@ class DumbWallGenerator:
     ) -> list[Vector]:
         points: list[Vector] = []
         coord_list = curve.Points.CoordList
-        arc_resolution = 24
-        precision = 1e-6
+        arc_resolution = self.SLAB_ARC_RESOLUTION
+        precision = self.SLAB_POINT_MERGE_TOLERANCE
 
         def append_point(point: Vector) -> None:
             if points and (points[-1] - point).length < precision:
@@ -1330,6 +1337,9 @@ class DumbWallGenerator:
                 p3 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[2]])
                 arc_points, _ = tool.Cad.create_arc_segments([p1, p2, p3], num_verts=arc_resolution + 1)
                 arc_points = [Vector(arc_point) for arc_point in arc_points]
+                # Cad.create_arc_segments may return samples from end->start for a
+                # [start, through, end] input, so normalize to start->end to keep
+                # perimeter traversal contiguous with neighboring line segments.
                 if arc_points and (arc_points[0] - p1).length > (arc_points[-1] - p1).length:
                     arc_points.reverse()
                 for arc_point in arc_points:

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1316,8 +1316,10 @@ class DumbWallGenerator:
                 return True
         return False
 
-    def _world_xy_point(self, slab_obj: bpy.types.Object, elevation: float, coord: Any) -> Vector:
-        return slab_obj.matrix_world @ Vector((coord[0] * self.unit_scale, coord[1] * self.unit_scale, elevation))
+    def _world_xy_point(self, slab_obj: bpy.types.Object, elevation: float, ifc_coord: Any) -> Vector:
+        return slab_obj.matrix_world @ Vector(
+            (ifc_coord[0] * self.unit_scale, ifc_coord[1] * self.unit_scale, elevation)
+        )
 
     def _derive_points_from_arc_segments(
         self, slab_obj: bpy.types.Object, elevation: float, curve: ifcopenshell.entity_instance
@@ -1341,14 +1343,14 @@ class DumbWallGenerator:
                 p3 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[2]])
                 # create_arc_segments returns (sampled_points, sampled_edges);
                 # only sampled_points are needed for wall generation.
-                arc_points, _ = tool.Cad.create_arc_segments([p1, p2, p3], num_verts=arc_resolution + 1)
-                arc_points = [Vector(arc_point) for arc_point in arc_points]
+                sampled_arc_points, _ = tool.Cad.create_arc_segments([p1, p2, p3], num_verts=arc_resolution + 1)
+                sampled_arc_points = [Vector(arc_point) for arc_point in sampled_arc_points]
                 # Cad.create_arc_segments may return samples from end->start for a
                 # [start, through, end] input, so normalize to start->end to keep
                 # perimeter traversal contiguous with neighboring line segments.
-                if arc_points and (arc_points[0] - p1).length > (arc_points[-1] - p1).length:
-                    arc_points.reverse()
-                for arc_point in arc_points:
+                if sampled_arc_points and (sampled_arc_points[0] - p1).length > (sampled_arc_points[-1] - p1).length:
+                    sampled_arc_points.reverse()
+                for arc_point in sampled_arc_points:
                     append_point(arc_point)
             elif len(segment_indices) >= 2:
                 for segment_index in segment_indices:

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1297,6 +1297,51 @@ class DumbWallGenerator:
             walls.append(self.create_wall_from_2_points(coords))
         return walls, is_polyline_closed
 
+    def _curve_has_arc_segments(self, curve: ifcopenshell.entity_instance) -> bool:
+        if not curve.is_a("IfcIndexedPolyCurve"):
+            return False
+        segments = getattr(curve, "Segments", None) or ()
+        for segment in segments:
+            if (hasattr(segment, "is_a") and segment.is_a("IfcArcIndex")) or len(segment[0]) == 3:
+                return True
+        return False
+
+    def _world_xy_point(self, slab_obj: bpy.types.Object, elevation: float, coord: Any) -> Vector:
+        return slab_obj.matrix_world @ Vector((coord[0] * self.unit_scale, coord[1] * self.unit_scale, elevation))
+
+    def _derive_points_from_arc_segments(
+        self, slab_obj: bpy.types.Object, elevation: float, curve: ifcopenshell.entity_instance
+    ) -> list[Vector]:
+        points: list[Vector] = []
+        coord_list = curve.Points.CoordList
+        arc_resolution = 24
+        precision = 1e-6
+
+        def append_point(point: Vector) -> None:
+            if points and (points[-1] - point).length < precision:
+                return
+            points.append(point)
+
+        for segment in curve.Segments:
+            segment_indices = [i - 1 for i in segment[0]]
+            if len(segment_indices) == 3:
+                p1 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[0]])
+                p2 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[1]])
+                p3 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[2]])
+                arc_points, _ = tool.Cad.create_arc_segments([p1, p2, p3], num_verts=arc_resolution + 1)
+                arc_points = [Vector(arc_point) for arc_point in arc_points]
+                if arc_points and (arc_points[0] - p1).length > (arc_points[-1] - p1).length:
+                    arc_points.reverse()
+                for arc_point in arc_points:
+                    append_point(arc_point)
+            elif len(segment_indices) >= 2:
+                append_point(self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[0]]))
+                append_point(self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[1]]))
+
+        if points and (points[0] - points[-1]).length >= precision:
+            points.append(points[0].copy())
+        return points
+
     def derive_from_slab(self):
         slab_obj = bpy.context.active_object
         slab = tool.Ifc.get_entity(slab_obj)
@@ -1305,10 +1350,17 @@ class DumbWallGenerator:
         elevation = self.container_obj.location.z
         representation = ifcopenshell.util.representation.get_representation(slab, "Model", "Body", "MODEL_VIEW")
         extrusion = tool.Model.get_extrusion(representation)
-        builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
-        polyline_points = builder.get_polyline_coords(extrusion.SweptArea.OuterCurve)
-        polyline_points = [[(v * self.unit_scale) for v in p] for p in polyline_points]
-        polyline_points = [slab_obj.matrix_world @ Vector((p[0], p[1], elevation)) for p in polyline_points]
+        outer_curve = extrusion.SweptArea.OuterCurve
+        if self._curve_has_arc_segments(outer_curve):
+            polyline_points = self._derive_points_from_arc_segments(slab_obj, elevation, outer_curve)
+        else:
+            builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
+            polyline_points = builder.get_polyline_coords(outer_curve)
+            polyline_points = [[(v * self.unit_scale) for v in p] for p in polyline_points]
+            polyline_points = [slab_obj.matrix_world @ Vector((p[0], p[1], elevation)) for p in polyline_points]
+
+        if len(polyline_points) < 3:
+            return []
         if not tool.Cad.is_counter_clockwise_order(polyline_points[0], polyline_points[1], polyline_points[2]):
             polyline_points = polyline_points[::-1]
         walls = []

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1398,27 +1398,33 @@ class DumbWallGenerator:
         elevation = self.container_obj.location.z
         representation = ifcopenshell.util.representation.get_representation(slab, "Model", "Body", "MODEL_VIEW")
         extrusion = tool.Model.get_extrusion(representation)
-        outer_curve = extrusion.SweptArea.OuterCurve
-        if self._curve_has_arc_segments(outer_curve):
-            polyline_points = self._derive_points_from_arc_segments(slab_obj, elevation, outer_curve)
-        elif outer_curve.is_a("IfcCircle"):
-            polyline_points = self._derive_points_from_circle(slab_obj, elevation, outer_curve)
+        swept_area = extrusion.SweptArea
+        if swept_area.is_a("IfcCompositeProfileDef"):
+            profiles = swept_area.Profiles
         else:
-            builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
-            polyline_points = builder.get_polyline_coords(outer_curve)
-            polyline_points = [[(v * self.unit_scale) for v in p] for p in polyline_points]
-            polyline_points = [slab_obj.matrix_world @ Vector((p[0], p[1], elevation)) for p in polyline_points]
-
-        if len(polyline_points) < 3:
-            return []
-        if not tool.Cad.is_counter_clockwise_order(polyline_points[0], polyline_points[1], polyline_points[2]):
-            polyline_points = polyline_points[::-1]
+            profiles = [swept_area]
         walls = []
-        for i in range(len(polyline_points) - 1):
-            vec1 = polyline_points[i]
-            vec2 = polyline_points[i + 1]
-            coords = (vec1, vec2)
-            walls.append(self.create_wall_from_2_points(coords))
+        for profile in profiles:
+            outer_curve = profile.OuterCurve
+            if self._curve_has_arc_segments(outer_curve):
+                polyline_points = self._derive_points_from_arc_segments(slab_obj, elevation, outer_curve)
+            elif outer_curve.is_a("IfcCircle"):
+                polyline_points = self._derive_points_from_circle(slab_obj, elevation, outer_curve)
+            else:
+                builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
+                polyline_points = builder.get_polyline_coords(outer_curve)
+                polyline_points = [[(v * self.unit_scale) for v in p] for p in polyline_points]
+                polyline_points = [slab_obj.matrix_world @ Vector((p[0], p[1], elevation)) for p in polyline_points]
+
+            if len(polyline_points) < 3:
+                continue
+            if not tool.Cad.is_counter_clockwise_order(polyline_points[0], polyline_points[1], polyline_points[2]):
+                polyline_points = polyline_points[::-1]
+            for i in range(len(polyline_points) - 1):
+                vec1 = polyline_points[i]
+                vec2 = polyline_points[i + 1]
+                coords = (vec1, vec2)
+                walls.append(self.create_wall_from_2_points(coords))
         return walls
 
     def create_wall_from_2_points(self, coords, should_round=False) -> Union[dict[str, Any], None]:

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1301,10 +1301,13 @@ class DumbWallGenerator:
         return walls, is_polyline_closed
 
     def _curve_has_arc_segments(self, curve: ifcopenshell.entity_instance) -> bool:
+        """Detect whether an IfcIndexedPolyCurve perimeter includes arc segments."""
         if not curve.is_a("IfcIndexedPolyCurve"):
             return False
         segments = getattr(curve, "Segments", None) or ()
         for segment in segments:
+            # Different schema wrappers expose segment typing either as entities
+            # (IfcArcIndex / IfcLineIndex) or as index tuples.
             if hasattr(segment, "is_a"):
                 if segment.is_a("IfcArcIndex"):
                     return True
@@ -1319,6 +1322,7 @@ class DumbWallGenerator:
     def _derive_points_from_arc_segments(
         self, slab_obj: bpy.types.Object, elevation: float, curve: ifcopenshell.entity_instance
     ) -> list[Vector]:
+        """Return world-space perimeter points for an indexed curve with arc segments."""
         points: list[Vector] = []
         coord_list = curve.Points.CoordList
         arc_resolution = self.SLAB_ARC_RESOLUTION
@@ -1335,6 +1339,8 @@ class DumbWallGenerator:
                 p1 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[0]])
                 p2 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[1]])
                 p3 = self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[2]])
+                # create_arc_segments returns (sampled_points, sampled_edges);
+                # only sampled_points are needed for wall generation.
                 arc_points, _ = tool.Cad.create_arc_segments([p1, p2, p3], num_verts=arc_resolution + 1)
                 arc_points = [Vector(arc_point) for arc_point in arc_points]
                 # Cad.create_arc_segments may return samples from end->start for a
@@ -1345,8 +1351,8 @@ class DumbWallGenerator:
                 for arc_point in arc_points:
                     append_point(arc_point)
             elif len(segment_indices) >= 2:
-                append_point(self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[0]]))
-                append_point(self._world_xy_point(slab_obj, elevation, coord_list[segment_indices[1]]))
+                for segment_index in segment_indices:
+                    append_point(self._world_xy_point(slab_obj, elevation, coord_list[segment_index]))
 
         if points and (points[0] - points[-1]).length >= precision:
             points.append(points[0].copy())

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1012,11 +1012,12 @@ class AddWallsFromSlab(bpy.types.Operator, tool.Ifc.Operator):
                 "Please select a slab.",
             )
             return {"FINISHED"}
-        walls = DumbWallGenerator(self.relating_type).generate("SLAB")
+        wall_groups = DumbWallGenerator(self.relating_type).generate("SLAB")
 
-        if walls:
-            for wall1, wall2 in zip(walls, walls[1:] + [walls[0]]):
-                DumbWallJoiner().connect(wall2["obj"], wall1["obj"])
+        if wall_groups:
+            for walls in wall_groups:
+                for wall1, wall2 in zip(walls, walls[1:] + [walls[0]]):
+                    DumbWallJoiner().connect(wall2["obj"], wall1["obj"])
 
 
 class DrawPolylineWall(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
@@ -1403,7 +1404,7 @@ class DumbWallGenerator:
             profiles = swept_area.Profiles
         else:
             profiles = [swept_area]
-        walls = []
+        wall_groups = []
         for profile in profiles:
             outer_curve = profile.OuterCurve
             if self._curve_has_arc_segments(outer_curve):
@@ -1420,12 +1421,15 @@ class DumbWallGenerator:
                 continue
             if not tool.Cad.is_counter_clockwise_order(polyline_points[0], polyline_points[1], polyline_points[2]):
                 polyline_points = polyline_points[::-1]
+            loop_walls = []
             for i in range(len(polyline_points) - 1):
                 vec1 = polyline_points[i]
                 vec2 = polyline_points[i + 1]
                 coords = (vec1, vec2)
-                walls.append(self.create_wall_from_2_points(coords))
-        return walls
+                loop_walls.append(self.create_wall_from_2_points(coords))
+            if loop_walls:
+                wall_groups.append(loop_walls)
+        return wall_groups
 
     def create_wall_from_2_points(self, coords, should_round=False) -> Union[dict[str, Any], None]:
         direction = coords[1] - coords[0]

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1360,6 +1360,36 @@ class DumbWallGenerator:
             points.append(points[0].copy())
         return points
 
+    def _derive_points_from_circle(
+        self, slab_obj: bpy.types.Object, elevation: float, circle: ifcopenshell.entity_instance
+    ) -> list[Vector]:
+        """Return world-space perimeter points for an IfcCircle perimeter."""
+        points: list[Vector] = []
+        arc_resolution = self.SLAB_ARC_RESOLUTION
+        precision = self.SLAB_POINT_MERGE_TOLERANCE
+        radius = circle.Radius * self.unit_scale
+
+        circle_position = Matrix.Identity(4)
+        if getattr(circle, "Position", None):
+            circle_position = Matrix(ifcopenshell.util.placement.get_axis2placement(circle.Position).tolist())
+            circle_position.translation *= self.unit_scale
+
+        def append_point(point: Vector) -> None:
+            if points and (points[-1] - point).length < precision:
+                return
+            points.append(point)
+
+        for i in range(arc_resolution):
+            theta = (2 * math.pi * i) / arc_resolution
+            local_point = Vector((radius * math.cos(theta), radius * math.sin(theta), 0.0))
+            world_point = slab_obj.matrix_world @ circle_position @ local_point
+            world_point.z = elevation
+            append_point(world_point)
+
+        if points:
+            points.append(points[0].copy())
+        return points
+
     def derive_from_slab(self):
         slab_obj = bpy.context.active_object
         slab = tool.Ifc.get_entity(slab_obj)
@@ -1371,6 +1401,8 @@ class DumbWallGenerator:
         outer_curve = extrusion.SweptArea.OuterCurve
         if self._curve_has_arc_segments(outer_curve):
             polyline_points = self._derive_points_from_arc_segments(slab_obj, elevation, outer_curve)
+        elif outer_curve.is_a("IfcCircle"):
+            polyline_points = self._derive_points_from_circle(slab_obj, elevation, outer_curve)
         else:
             builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
             polyline_points = builder.get_polyline_coords(outer_curve)

--- a/src/bonsai/test/bim/module/model/test_slab_wall_generation.py
+++ b/src/bonsai/test/bim/module/model/test_slab_wall_generation.py
@@ -1,0 +1,536 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Coverage for ``DumbWallGenerator``'s slab-to-wall perimeter extraction
+(``Shift+A -> Add From Perimeter``), in particular the profile shapes that
+used to raise or produce wrong geometry:
+
+- ``IfcCircleProfileDef`` / ``IfcRectangleProfileDef`` (and their hollow
+  variants): these have no ``OuterCurve`` attribute at all, so the
+  ``profile.OuterCurve`` access previously crashed with ``AttributeError``
+  the same way ``IfcCompositeProfileDef`` did before that was fixed.
+- ``IfcIndexedPolyCurve`` arc segments: previously treated as straight
+  chords through raw ``CoordList`` order.
+- ``IfcArbitraryProfileDefWithVoids``: inner curves (holes) are now turned
+  into their own ring of walls, wound opposite the outer boundary.
+
+Tests exercise the helper methods directly with real ``ifcopenshell``
+entities (built via a throwaway ``ifcopenshell.file()``) and plain
+``mathutils.Matrix``/``Mock`` objects -- these helpers never touch
+Blender's RNA/registered-class layer."""
+
+import math
+from unittest.mock import Mock, patch
+
+import ifcopenshell
+import ifcopenshell.util.element
+import ifcopenshell.util.representation
+import pytest
+from mathutils import Matrix, Vector
+
+import bonsai.tool as tool
+from bonsai.bim.module.model.wall import DumbWallGenerator
+
+pytestmark = pytest.mark.model
+
+
+def make_generator(unit_scale: float = 1.0) -> DumbWallGenerator:
+    """A ``DumbWallGenerator`` with just ``unit_scale`` set, bypassing
+    ``__init__``'s dependency on a live IFC file / relating type -- the
+    methods under test only read ``self.unit_scale``."""
+    generator = object.__new__(DumbWallGenerator)
+    generator.unit_scale = unit_scale
+    return generator
+
+
+def make_slab_obj(matrix_world: Matrix = None) -> Mock:
+    slab_obj = Mock()
+    slab_obj.matrix_world = matrix_world if matrix_world is not None else Matrix.Identity(4)
+    return slab_obj
+
+
+def polyline_points_from_walls(loop_walls) -> list[Vector]:
+    """Reconstruct the ordered point loop from the ``coords`` recorded on
+    each wall dict: point0->point1, point1->point2, ..."""
+    points = [loop_walls[0]["coords"][0]]
+    for wall in loop_walls:
+        points.append(wall["coords"][1])
+    return points
+
+
+# ---------------------------------------------------------------------------
+# _curve_has_arc_segments
+# ---------------------------------------------------------------------------
+
+
+def test_curve_has_arc_segments_true_for_arc_index():
+    ifc_file = ifcopenshell.file()
+    points = ifc_file.createIfcCartesianPointList2D(CoordList=[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)])
+    segments = [ifc_file.createIfcArcIndex((1, 2, 3))]
+    curve = ifc_file.createIfcIndexedPolyCurve(Points=points, Segments=segments)
+
+    assert make_generator()._curve_has_arc_segments(curve) is True
+
+
+def test_curve_has_arc_segments_false_for_line_index_only():
+    ifc_file = ifcopenshell.file()
+    points = ifc_file.createIfcCartesianPointList2D(CoordList=[(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)])
+    segments = [ifc_file.createIfcLineIndex((1, 2)), ifc_file.createIfcLineIndex((2, 3))]
+    curve = ifc_file.createIfcIndexedPolyCurve(Points=points, Segments=segments)
+
+    assert make_generator()._curve_has_arc_segments(curve) is False
+
+
+def test_curve_has_arc_segments_false_for_non_indexed_poly_curve():
+    ifc_file = ifcopenshell.file()
+    curve = ifc_file.createIfcCircle(Radius=1.0)
+
+    assert make_generator()._curve_has_arc_segments(curve) is False
+
+
+# ---------------------------------------------------------------------------
+# _resolution_for_radius / _estimate_arc_segment_count -- arc/circle sample
+# count scales with physical size so small fillets don't explode into many
+# tiny wall segments, while large arcs stay capped at SLAB_ARC_RESOLUTION.
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_for_radius_clamps_small_fillet_to_minimum():
+    generator = make_generator()
+    # A 5cm fillet is well under one SLAB_ARC_SEGMENT_LENGTH (10cm) of arc length.
+    assert generator._resolution_for_radius(0.05) == generator.SLAB_MIN_ARC_SEGMENTS
+
+
+def test_resolution_for_radius_caps_large_radius_at_max():
+    generator = make_generator()
+    assert generator._resolution_for_radius(1.0) == generator.SLAB_ARC_RESOLUTION
+
+
+def test_resolution_for_radius_scales_between_bounds():
+    generator = make_generator()
+    resolution = generator._resolution_for_radius(0.2)
+    assert generator.SLAB_MIN_ARC_SEGMENTS < resolution < generator.SLAB_ARC_RESOLUTION
+
+
+def test_resolution_for_radius_handles_zero_or_negative():
+    generator = make_generator()
+    assert generator._resolution_for_radius(0.0) == generator.SLAB_MIN_ARC_SEGMENTS
+    assert generator._resolution_for_radius(-1.0) == generator.SLAB_MIN_ARC_SEGMENTS
+
+
+def test_estimate_arc_segment_count_matches_known_radius():
+    generator = make_generator()
+    # Quarter circle of radius 1 centred on the origin: (1,0) -> (cos45,sin45) -> (0,1).
+    p1 = Vector((1.0, 0.0, 0.0))
+    p2 = Vector((math.cos(math.radians(45)), math.sin(math.radians(45)), 0.0))
+    p3 = Vector((0.0, 1.0, 0.0))
+
+    assert generator._estimate_arc_segment_count(p1, p2, p3) == generator._resolution_for_radius(1.0)
+
+
+def test_estimate_arc_segment_count_handles_collinear_points():
+    """Three collinear points are a degenerate 'arc' (zero-area triangle);
+    the circumradius formula would divide by zero, so this must fall back
+    to a safe minimum rather than raising or returning nonsense."""
+    generator = make_generator()
+    p1 = Vector((0.0, 0.0, 0.0))
+    p2 = Vector((1.0, 0.0, 0.0))
+    p3 = Vector((2.0, 0.0, 0.0))
+
+    assert generator._estimate_arc_segment_count(p1, p2, p3) == generator.SLAB_MIN_ARC_SEGMENTS
+
+
+# ---------------------------------------------------------------------------
+# _derive_points_from_circle -- also used directly for IfcCircleProfileDef
+# ---------------------------------------------------------------------------
+
+
+def test_derive_points_from_circle_samples_expected_radius():
+    ifc_file = ifcopenshell.file()
+    circle = ifc_file.createIfcCircle(Radius=2.0)
+    generator = make_generator()
+
+    points = generator._derive_points_from_circle(Matrix.Identity(4), elevation=3.0, circle=circle)
+
+    assert points[0] == points[-1]  # explicitly closed loop
+    assert len(points) - 1 == generator._resolution_for_radius(2.0)
+    assert all(p.z == 3.0 for p in points)
+    # theta=0 sample sits exactly on +X at the given radius.
+    assert points[0].x == pytest.approx(2.0)
+    assert points[0].y == pytest.approx(0.0)
+
+
+def test_derive_points_from_circle_radius_override_for_hollow_inner_loop():
+    ifc_file = ifcopenshell.file()
+    circle = ifc_file.createIfcCircle(Radius=2.0)
+    generator = make_generator()
+
+    points = generator._derive_points_from_circle(Matrix.Identity(4), elevation=0.0, circle=circle, radius_override=1.5)
+
+    assert points[0].x == pytest.approx(1.5)
+
+
+def test_derive_points_from_circle_applies_unit_scale():
+    ifc_file = ifcopenshell.file()
+    circle = ifc_file.createIfcCircle(Radius=1000.0)  # e.g. millimetres
+    generator = make_generator(unit_scale=0.001)  # project length unit is mm
+
+    points = generator._derive_points_from_circle(Matrix.Identity(4), elevation=0.0, circle=circle)
+
+    assert points[0].x == pytest.approx(1.0)  # scaled down to metres
+
+
+def test_derive_points_from_circle_applies_world_matrix():
+    """world_matrix carries both the object's own transform and the
+    IfcExtrudedAreaSolid's Position -- a plain translation here stands in
+    for either (or their combination)."""
+    ifc_file = ifcopenshell.file()
+    circle = ifc_file.createIfcCircle(Radius=2.0)
+    generator = make_generator()
+    world_matrix = Matrix.Translation(Vector((10.0, 5.0, 0.0)))
+
+    points = generator._derive_points_from_circle(world_matrix, elevation=0.0, circle=circle)
+
+    assert points[0].x == pytest.approx(12.0)
+    assert points[0].y == pytest.approx(5.0)
+
+
+def test_derive_points_from_circle_handles_profile_with_real_ref_direction():
+    """Regression test: unlike IfcRectangleProfileDef (whose Position is
+    always None from the profile-fitting operator), IfcCircleProfileDef.Position
+    is always a real IfcAxis2Placement2D with an explicit RefDirection -- this
+    used to raise ValueError from ifcopenshell.util.placement.get_axis2placement's
+    in-place ndarray.resize() call on the 2-element DirectionRatios."""
+    ifc_file = ifcopenshell.file()
+    position = ifc_file.createIfcAxis2Placement2D(
+        Location=ifc_file.createIfcCartesianPoint((0.0, 0.0)),
+        RefDirection=ifc_file.createIfcDirection((1.0, 0.0)),
+    )
+    profile = ifc_file.createIfcCircleProfileDef(ProfileType="AREA", ProfileName=None, Position=position, Radius=2.0)
+    generator = make_generator()
+
+    loops = generator._get_profile_loops(Matrix.Identity(4), elevation=0.0, profile=profile)  # must not raise
+
+    assert len(loops) == 1
+    assert loops[0][0].x == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# _derive_points_from_rectangle -- powers IfcRectangleProfileDef
+# ---------------------------------------------------------------------------
+
+
+def test_derive_points_from_rectangle_returns_centered_closed_loop():
+    generator = make_generator()
+
+    points = generator._derive_points_from_rectangle(
+        Matrix.Identity(4), elevation=1.0, position=None, x_dim=4.0, y_dim=2.0
+    )
+
+    assert len(points) == 5
+    assert points[0] == points[-1]
+    xs = sorted({round(p.x, 6) for p in points})
+    ys = sorted({round(p.y, 6) for p in points})
+    assert xs == [-2.0, 2.0]
+    assert ys == [-1.0, 1.0]
+    assert all(p.z == 1.0 for p in points)
+
+
+def test_derive_points_from_rectangle_is_wound_counter_clockwise():
+    generator = make_generator()
+
+    points = generator._derive_points_from_rectangle(
+        Matrix.Identity(4), elevation=0.0, position=None, x_dim=2.0, y_dim=2.0
+    )
+
+    assert tool.Cad.is_counter_clockwise_order(points[0], points[1], points[2])
+
+
+def test_derive_points_from_rectangle_applies_world_matrix_rotation_and_translation():
+    """Regression test: a rectangle profile fitted by 'Convert To Rectangle
+    Extrusion' bakes its real offset/rotation into IfcExtrudedAreaSolid.Position
+    (not profile.Position, which stays None) -- derive_from_slab must fold
+    that into world_matrix, or generated walls end up translated/rotated
+    away from the actual slab footprint."""
+    generator = make_generator()
+    # 90-degree rotation about Z plus a translation, standing in for
+    # slab_obj.matrix_world combined with a non-identity extrusion Position.
+    world_matrix = Matrix.Translation(Vector((10.0, 0.0, 0.0))) @ Matrix.Rotation(math.radians(90), 4, "Z")
+
+    points = generator._derive_points_from_rectangle(world_matrix, elevation=0.0, position=None, x_dim=4.0, y_dim=2.0)
+
+    # Each local corner (+-2, +-1) rotates 90 deg CCW about Z then translates by (10, 0).
+    # Note two corners end up sharing a world Y (both local corners with x=2 map to
+    # world y=2), so the check must compare the full point set, not a single axis.
+    transformed = {(round(p.x, 6), round(p.y, 6)) for p in points[:-1]}
+    assert transformed == {(11.0, -2.0), (11.0, 2.0), (9.0, 2.0), (9.0, -2.0)}
+
+
+# ---------------------------------------------------------------------------
+# _get_profile_loops -- the actual bug fix: IfcCircleProfileDef /
+# IfcRectangleProfileDef (and hollow variants) no longer crash on the
+# missing OuterCurve attribute, and InnerCurves now produce extra loops.
+# ---------------------------------------------------------------------------
+
+
+def test_get_profile_loops_handles_circle_profile_def_without_crashing():
+    """Regression test: IfcCircleProfileDef has no OuterCurve attribute, so
+    the pre-fix code (`profile.OuterCurve`) raised AttributeError here --
+    the same bug class the PR fixed for IfcCompositeProfileDef."""
+    ifc_file = ifcopenshell.file()
+    profile = ifc_file.createIfcCircleProfileDef(ProfileType="AREA", ProfileName=None, Position=None, Radius=2.0)
+    generator = make_generator()
+
+    loops = generator._get_profile_loops(Matrix.Identity(4), elevation=0.0, profile=profile)
+
+    assert len(loops) == 1
+    assert len(loops[0]) > 3
+
+
+def test_get_profile_loops_handles_rectangle_profile_def_without_crashing():
+    ifc_file = ifcopenshell.file()
+    profile = ifc_file.createIfcRectangleProfileDef(
+        ProfileType="AREA", ProfileName=None, Position=None, XDim=4.0, YDim=2.0
+    )
+    generator = make_generator()
+
+    loops = generator._get_profile_loops(Matrix.Identity(4), elevation=0.0, profile=profile)
+
+    assert len(loops) == 1
+    assert len(loops[0]) == 5
+
+
+def test_get_profile_loops_circle_hollow_adds_inner_void_loop():
+    ifc_file = ifcopenshell.file()
+    profile = ifc_file.createIfcCircleHollowProfileDef(
+        ProfileType="AREA", ProfileName=None, Position=None, Radius=2.0, WallThickness=0.5
+    )
+    generator = make_generator()
+
+    loops = generator._get_profile_loops(Matrix.Identity(4), elevation=0.0, profile=profile)
+
+    assert len(loops) == 2
+    assert loops[0][0].x == pytest.approx(2.0)
+    assert loops[1][0].x == pytest.approx(1.5)
+
+
+def test_get_profile_loops_rectangle_hollow_adds_inner_void_loop():
+    ifc_file = ifcopenshell.file()
+    profile = ifc_file.createIfcRectangleHollowProfileDef(
+        ProfileType="AREA", ProfileName=None, Position=None, XDim=4.0, YDim=2.0, WallThickness=0.5
+    )
+    generator = make_generator()
+
+    loops = generator._get_profile_loops(Matrix.Identity(4), elevation=0.0, profile=profile)
+
+    assert len(loops) == 2
+    outer_xs = sorted({round(p.x, 6) for p in loops[0]})
+    inner_xs = sorted({round(p.x, 6) for p in loops[1]})
+    assert outer_xs == [-2.0, 2.0]
+    assert inner_xs == [-1.5, 1.5]  # 4.0/2 - 0.5 wall thickness
+
+
+def test_get_profile_loops_hollow_profile_skips_inner_loop_when_thickness_closes_it():
+    """A wall thickness >= half the outer dimension collapses the inner void
+    to zero/negative -- must not emit a degenerate/inverted inner loop."""
+    ifc_file = ifcopenshell.file()
+    profile = ifc_file.createIfcCircleHollowProfileDef(
+        ProfileType="AREA", ProfileName=None, Position=None, Radius=1.0, WallThickness=1.0
+    )
+    generator = make_generator()
+
+    loops = generator._get_profile_loops(Matrix.Identity(4), elevation=0.0, profile=profile)
+
+    assert len(loops) == 1
+
+
+def test_get_profile_loops_arbitrary_profile_with_voids_adds_inner_loops():
+    ifc_file = ifcopenshell.file()
+
+    def polyline(coords):
+        return ifc_file.createIfcPolyline(Points=[ifc_file.createIfcCartesianPoint(c) for c in coords])
+
+    outer = polyline([(-2.0, -2.0), (2.0, -2.0), (2.0, 2.0), (-2.0, 2.0), (-2.0, -2.0)])
+    inner = polyline([(-0.5, -0.5), (0.5, -0.5), (0.5, 0.5), (-0.5, 0.5), (-0.5, -0.5)])
+    profile = ifc_file.createIfcArbitraryProfileDefWithVoids(
+        ProfileType="AREA", ProfileName=None, OuterCurve=outer, InnerCurves=[inner]
+    )
+    generator = make_generator()
+
+    loops = generator._get_profile_loops(Matrix.Identity(4), elevation=0.0, profile=profile)
+
+    assert len(loops) == 2
+    assert len(loops[0]) == 5
+    assert len(loops[1]) == 5
+
+
+def test_get_profile_loops_arbitrary_closed_profile_has_no_extra_loops():
+    ifc_file = ifcopenshell.file()
+    outer = ifc_file.createIfcPolyline(
+        Points=[
+            ifc_file.createIfcCartesianPoint(c)
+            for c in [(-2.0, -2.0), (2.0, -2.0), (2.0, 2.0), (-2.0, 2.0), (-2.0, -2.0)]
+        ]
+    )
+    profile = ifc_file.createIfcArbitraryClosedProfileDef(ProfileType="AREA", ProfileName=None, OuterCurve=outer)
+    generator = make_generator()
+
+    loops = generator._get_profile_loops(Matrix.Identity(4), elevation=0.0, profile=profile)
+
+    assert len(loops) == 1
+
+
+# ---------------------------------------------------------------------------
+# derive_from_slab -- end to end: composite profiles, parameterized
+# profiles, and inner voids all become their own wall ring, with the
+# expected winding (outer CCW, void CW) so wall thickness offsets away
+# from the slab's solid area either way.
+# ---------------------------------------------------------------------------
+
+
+def test_derive_from_slab_generates_ring_per_loop_and_winds_voids_opposite_outer():
+    ifc_file = ifcopenshell.file()
+
+    def polyline(coords):
+        return ifc_file.createIfcPolyline(Points=[ifc_file.createIfcCartesianPoint(c) for c in coords])
+
+    # Outer boundary, authored counter-clockwise.
+    outer = polyline([(-2.0, -2.0), (2.0, -2.0), (2.0, 2.0), (-2.0, 2.0), (-2.0, -2.0)])
+    # Inner void, deliberately authored with the *same* winding as the outer
+    # loop so the reversal logic in derive_from_slab has to do real work.
+    inner = polyline([(-0.5, -0.5), (0.5, -0.5), (0.5, 0.5), (-0.5, 0.5), (-0.5, -0.5)])
+    profile = ifc_file.createIfcArbitraryProfileDefWithVoids(
+        ProfileType="AREA", ProfileName=None, OuterCurve=outer, InnerCurves=[inner]
+    )
+    extrusion = Mock(SweptArea=profile, Position=None)
+
+    generator = make_generator()
+    generator.container_obj = Mock(location=Vector((0.0, 0.0, 5.0)))
+    slab_obj = make_slab_obj()
+
+    recorded_walls = []
+
+    def fake_create_wall_from_2_points(coords, should_round=False):
+        wall = {"coords": coords, "obj": Mock()}
+        recorded_walls.append(wall)
+        return wall
+
+    generator.create_wall_from_2_points = fake_create_wall_from_2_points
+
+    with (
+        patch.object(tool.Ifc, "get_entity", return_value=Mock()),
+        patch.object(ifcopenshell.util.element, "get_container", return_value=Mock()),
+        patch.object(tool.Ifc, "get_object", return_value=generator.container_obj),
+        patch.object(ifcopenshell.util.representation, "get_representation", return_value=Mock()),
+        patch.object(tool.Model, "get_extrusion", return_value=extrusion),
+        patch("bonsai.bim.module.model.wall.bpy") as mock_bpy,
+    ):
+        mock_bpy.context.active_object = slab_obj
+        wall_groups = generator.derive_from_slab()
+
+    assert len(wall_groups) == 2
+    outer_loop, inner_loop = wall_groups
+    assert len(outer_loop) == 4  # 5-point closed square -> 4 wall segments
+    assert len(inner_loop) == 4
+
+    outer_points = polyline_points_from_walls(outer_loop)
+    inner_points = polyline_points_from_walls(inner_loop)
+
+    assert tool.Cad.is_counter_clockwise_order(outer_points[0], outer_points[1], outer_points[2])
+    # Authored with the same winding as the outer loop, but derive_from_slab
+    # must flip void loops so they end up wound the opposite way.
+    assert not tool.Cad.is_counter_clockwise_order(inner_points[0], inner_points[1], inner_points[2])
+
+
+def test_derive_from_slab_handles_composite_of_parameterized_profiles():
+    """End-to-end regression: a slab whose SweptArea is an
+    IfcCompositeProfileDef made of parameterized (circle/rectangle)
+    profiles previously crashed on `profile.OuterCurve` for each member."""
+    ifc_file = ifcopenshell.file()
+    circle = ifc_file.createIfcCircleProfileDef(ProfileType="AREA", ProfileName=None, Position=None, Radius=1.0)
+    rectangle = ifc_file.createIfcRectangleProfileDef(
+        ProfileType="AREA", ProfileName=None, Position=None, XDim=2.0, YDim=2.0
+    )
+    composite = ifc_file.createIfcCompositeProfileDef(ProfileType="AREA", Profiles=[circle, rectangle])
+    extrusion = Mock(SweptArea=composite, Position=None)
+
+    generator = make_generator()
+    generator.container_obj = Mock(location=Vector((0.0, 0.0, 0.0)))
+    slab_obj = make_slab_obj()
+    generator.create_wall_from_2_points = lambda coords, should_round=False: {"coords": coords, "obj": Mock()}
+
+    with (
+        patch.object(tool.Ifc, "get_entity", return_value=Mock()),
+        patch.object(ifcopenshell.util.element, "get_container", return_value=Mock()),
+        patch.object(tool.Ifc, "get_object", return_value=generator.container_obj),
+        patch.object(ifcopenshell.util.representation, "get_representation", return_value=Mock()),
+        patch.object(tool.Model, "get_extrusion", return_value=extrusion),
+        patch("bonsai.bim.module.model.wall.bpy") as mock_bpy,
+    ):
+        mock_bpy.context.active_object = slab_obj
+        wall_groups = generator.derive_from_slab()  # must not raise AttributeError
+
+    assert len(wall_groups) == 2  # one ring per profile in the composite
+
+
+def test_derive_from_slab_applies_extrusion_position_for_rectangle_profile():
+    """Regression test for a real bug: "Convert To Rectangle Extrusion" (and
+    Circle) bakes the profile's real offset/rotation into
+    IfcExtrudedAreaSolid.Position, not profile.Position (which stays None).
+    Before this fix, derive_from_slab only read profile.Position, so
+    generated walls came out with correct dimensions but translated/rotated
+    away from the slab's actual footprint."""
+    ifc_file = ifcopenshell.file()
+    profile = ifc_file.createIfcRectangleProfileDef(
+        ProfileType="AREA", ProfileName=None, Position=None, XDim=4.0, YDim=2.0
+    )
+    # 90-degree rotation about Z (RefDirection (0,1,0) instead of default (1,0,0))
+    # plus a translation of (10, 0, 0) -- verified against
+    # ifcopenshell.util.placement.get_axis2placement directly.
+    extrusion_position = ifc_file.createIfcAxis2Placement3D(
+        Location=ifc_file.createIfcCartesianPoint((10.0, 0.0, 0.0)),
+        Axis=None,
+        RefDirection=ifc_file.createIfcDirection((0.0, 1.0, 0.0)),
+    )
+    extrusion = Mock(SweptArea=profile, Position=extrusion_position)
+
+    generator = make_generator()
+    generator.container_obj = Mock(location=Vector((0.0, 0.0, 0.0)))
+    slab_obj = make_slab_obj()  # identity matrix_world -- isolates the extrusion Position effect
+    generator.create_wall_from_2_points = lambda coords, should_round=False: {"coords": coords, "obj": Mock()}
+
+    with (
+        patch.object(tool.Ifc, "get_entity", return_value=Mock()),
+        patch.object(ifcopenshell.util.element, "get_container", return_value=Mock()),
+        patch.object(tool.Ifc, "get_object", return_value=generator.container_obj),
+        patch.object(ifcopenshell.util.representation, "get_representation", return_value=Mock()),
+        patch.object(tool.Model, "get_extrusion", return_value=extrusion),
+        patch("bonsai.bim.module.model.wall.bpy") as mock_bpy,
+    ):
+        mock_bpy.context.active_object = slab_obj
+        wall_groups = generator.derive_from_slab()
+
+    assert len(wall_groups) == 1
+    points = polyline_points_from_walls(wall_groups[0])
+    # Each local rectangle corner (+-2, +-1) rotates 90deg CCW about Z then
+    # translates by (10, 0). If extrusion.Position were ignored (the bug),
+    # these would instead sit at the untransformed (+-2, +-1).
+    transformed = {(round(p.x, 6), round(p.y, 6)) for p in points[:-1]}
+    assert transformed == {(11.0, -2.0), (11.0, 2.0), (9.0, 2.0), (9.0, -2.0)}


### PR DESCRIPTION
## Summary

Supersedes #8239 that was created to address issue #6896. Builds on that PR's fixes for `Shift+A -> Add From Perimeter` (arc segments, `IfcCircle`, `IfcCompositeProfileDef`) and adds the following, found and fixed while reviewing and manually testing #8239:

- **Fixes a crash** on `IfcCircleProfileDef` / `IfcRectangleProfileDef` (and their hollow variants) — same root cause #8239 fixed for `IfcCompositeProfileDef` (no `OuterCurve` attribute), just not caught for parameterized profiles. Reachable natively in Bonsai via Object Data Properties -> Representation Utilities -> "Convert To Rectangle/Circle Extrusion", not just external IFC files.
- **Adds inner-void support**: `IfcArbitraryProfileDefWithVoids.InnerCurves` (and hollow circle/rectangle profiles) now also produce their own ring of walls, wound opposite the outer boundary, instead of being silently ignored.
- **Fixes a real misalignment bug** found via manual testing: `IfcExtrudedAreaSolid.Position` (the extrusion's own 3D placement) was never applied, only the profile's own `Position` — generated walls had correct dimensions but were translated/rotated away from the slab's actual footprint whenever the extrusion wasn't centered on the object origin (e.g. after "Convert To Rectangle/Circle Extrusion").
- **Fixes arc/circle oversampling**: sample resolution now scales with physical radius instead of a flat segment count, so a small fillet doesn't explode into as many wall segments as a near-full-circle arc.
- Minor cleanup: removed an unreachable fallback branch in the arc-segment detector, added a missing return type annotation.
- Added test coverage (`test/bim/module/model/test_slab_wall_generation.py`).

## Depends on

**#8586** — `ifcopenshell.util.placement.get_axis2placement()` raises `ValueError` for any `IfcAxis2Placement2D` with a `RefDirection` set, via an in-place `ndarray.resize()` call. `IfcCircleProfileDef.Position` always has a `RefDirection` set (never null), so the circle-profile path here needs that fix merged first (or included) to work.

## AI disclosure

This PR's commits on top of #8239 (`Fix wall generation for parameterized profiles`, `Add tests for slab-to-wall perimeter extraction`) were generated with the assistance of an AI coding tool, including manual verification in Blender by the PR author.

## Test plan

- [x] New test suite (27 tests) covering arc/circle resolution scaling, parameterized + hollow profile handling, inner voids, and the extrusion-Position fix — run via `pytest test/bim -m model -k test_slab_wall_generation`, all passing.
- [x] Full `model`-marked regression suite (484 tests) run clean, no regressions from these changes.
- [x] Manually tested in Blender: composite multi-loop slabs, arc/fillet perimeters, and both rectangle and circle profiles produced via "Convert To Rectangle/Circle Extrusion" — walls now align correctly with the slab footprint.