### PR TITLE
Fix geom.app viewer selection crash on current pythonocc-core (#2415)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/app.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/app.py
@@ -569,7 +569,11 @@ class application(QtWidgets.QApplication):
 
         def HandleSelection(self, X, Y):
             v = self._display.Context
-            v.Select()
+            # AIS_InteractiveContext.Select() has no true zero-argument overload in the
+            # SWIG bindings (the C++ default for `theToUpdateViewer` isn't carried over),
+            # so the argument must be passed explicitly. This mirrors pythonocc-core's own
+            # OCCViewer.Select() implementation, which calls self.Context.Select(True).
+            v.Select(True)
             v.InitSelected()
             if v.MoreSelected():
                 ais = v.SelectedInteractive()


### PR DESCRIPTION
## Summary

Fixes #2415. `ifcopenshell.geom.app`'s viewer crashes on selecting an object with `TypeError: Wrong number or type of arguments for overloaded function 'AIS_InteractiveContext_Select'`.

## Root cause

`HandleSelection` calls `v.Select()` (zero arguments) on an `AIS_InteractiveContext`. That overload does not exist in the SWIG bindings, the C++ default for `theToUpdateViewer` isn't carried through to Python, so the argument must be passed explicitly.

## Fix

```diff
-            v.Select()
+            v.Select(True)
```

This mirrors pythonocc-core's own `OCCViewer.Select()` reference implementation (the method `app.py` overrides via `self._display.Select = self.HandleSelection`), which itself calls `self.Context.Select(True)`.

## Verification

Live-verified against pythonocc-core 7.9.0: reproduced the exact TypeError and overload list from the issue by constructing an `AIS_InteractiveContext` directly and calling `.Select()`, confirmed `.Select(True)` succeeds and returns a valid `AIS_StatusOfPick`. Cross-checked the OCCT header signature across 7.8.1 through 7.9.3, the single-bool overload is stable across all of them, so no version branching is needed here (unlike the related #2500 fix in the neighboring `occ_utils.py`, which does need one).

This change was made with the assistance of an AI tool.
