### PR TITLE
Bonsai: allow nesting element type objects together (#2283)

### DIFF
--- a/src/bonsai/bonsai/tool/nest.py
+++ b/src/bonsai/bonsai/tool/nest.py
@@ -47,7 +47,15 @@ class Nest(bonsai.core.tool.Nest):
             return False
         if relating_object == related_object:
             return False
-        is_compatible_class = relating_object.is_a("IfcElement") and related_object.is_a("IfcElement")
+        # IfcRelNests.RelatingObject/RelatedObjects are typed as the general
+        # IfcObjectDefinition, so nesting is schema-legal both between element
+        # occurrences (the common case, e.g. a faucet nested into a sink) and
+        # between element types (e.g. an assembly type nesting its component
+        # types). Mixing an occurrence with a type isn't a real modeling
+        # pattern, so only allow same-kind pairs. See #2283.
+        is_compatible_class = (relating_object.is_a("IfcElement") and related_object.is_a("IfcElement")) or (
+            relating_object.is_a("IfcTypeProduct") and related_object.is_a("IfcTypeProduct")
+        )
         if not is_compatible_class:
             return False
         # Prevent cyclic references: walk up the full hierarchy from the


### PR DESCRIPTION
## Summary

Fixes #2283. Nesting two IfcElementType objects together silently created no relationship.

## Root cause

`tool.Nest.can_nest()` only permits `IfcElement`-to-`IfcElement` pairs. `IfcElementType` is a separate branch of the schema, not a subtype of `IfcElement`, so nesting two type objects (e.g. an `IfcElementAssemblyType` nesting a component `IfcDoorType`) was always rejected.

`IfcRelNests.RelatingObject`/`RelatedObjects` are typed as the general `IfcObjectDefinition` in the schema, so type-to-type nesting is schema legal. The core `ifcopenshell.api.nest.assign_object` usecase already handles it generically with no restriction of its own, and the Nest UI panel is driven purely by `ifcopenshell.util.element.get_nest`/`get_components` (IFC data queries, not Blender collection structure), so once the relationship exists it displays correctly with no other changes needed.

## Fix

Extended `is_compatible_class` in `can_nest()` to also accept a same-kind `IfcTypeProduct` pair, alongside the existing `IfcElement` pair. Mixing an occurrence element with a type is intentionally still rejected, that isn't a real modeling pattern.

## Verification

Live-tested in headless Blender:
- Type-to-type nesting (an `IfcElementAssemblyType` nesting an `IfcDoorType`) now creates a real `IfcRelNests`.
- `ifcopenshell.util.element.get_nest`/`get_components`, the exact functions the Nest UI panel uses, correctly reflect it.
- Mixing an occurrence element with a type is still correctly rejected.
- Existing element-to-element nesting (e.g. a faucet into a sink) is unaffected.

This change was made with the assistance of an AI tool.
