### PR TITLE
Bonsai: lock IfcRelSpaceBoundary object transform to prevent geometry desync (#2621)

### DIFF
--- a/src/bonsai/bonsai/tool/collector.py
+++ b/src/bonsai/bonsai/tool/collector.py
@@ -80,6 +80,13 @@ class Collector(bonsai.core.tool.Collector):
             collection = cls._create_project_child_collection("IfcStructuralItem")
             cls.link_collection_object_safe(collection, obj)
         elif element.is_a("IfcRelSpaceBoundary"):
+            # A boundary's geometry is only valid when its object origin
+            # matches its RelatingSpace's origin (see #2621). There is no
+            # legitimate reason to translate/rotate a boundary object in
+            # Object Mode, so always lock it to prevent silently desyncing
+            # the boundary geometry from its space. This doesn't affect
+            # entering Edit Mode to edit the boundary's mesh/geometry.
+            tool.Geometry.lock_object(obj)
             collection = cls._create_project_child_collection("IfcRelSpaceBoundary")
             cls.link_collection_object_safe(collection, obj)
         elif element.is_a("IfcLinearPositioningElement"):


### PR DESCRIPTION
## Summary

Fixes #2621. Moving an IfcRelSpaceBoundary object in Object Mode silently desyncs its geometry from the parent space, producing wrong boundary geometry with no warning.

## Root cause

A boundary's geometry is only valid when its Blender object origin matches its `RelatingSpace`'s origin (the codebase already has `Boundary.move_origin_to_space_origin`, used by the "Update Boundary Geometry" operator, confirming this constraint). `Collector.assign` already applies `tool.Geometry.lock_object()` to other origin-sensitive types (`IfcGrid`/`IfcGridAxis`, `IfcSpace`, `IfcProject`), but had no lock treatment at all for `IfcRelSpaceBoundary`, so nothing stopped a user from moving or rotating one in Object Mode.

## Fix

Added `tool.Geometry.lock_object(obj)` to the `IfcRelSpaceBoundary` branch of `Collector.assign`, unconditional (matching `IfcProject`'s treatment, since there's no legitimate reason to translate/rotate a boundary object in Object Mode). This only sets native Blender transform locks (blocks G/R in the viewport), it doesn't touch the separate `is_locked()` gate used for delete/duplicate, so deletion, duplication, and Edit Mode geometry editing are unaffected.

## Verification

Live-tested in headless Blender 5.1.2:
- Unpatched: boundary object had `lock_location=(False,False,False)`, an interactive translate moved it freely.
- Patched: `lock_location`/`lock_rotation` both `(True,True,True)`, the same translate call no longer moves the object.
- Confirmed unaffected: Edit Mode mesh editing and normal geometry regeneration (`bim.update_boundary_geometry`) both still work.

This change was made with the assistance of an AI tool.
