### PR TITLE
Bonsai: fix Timeline text date format to match sequence module convention (#2477)

### DIFF
--- a/src/bonsai/bonsai/tool/sequence.py
+++ b/src/bonsai/bonsai/tool/sequence.py
@@ -1525,7 +1525,10 @@ class Sequence(bonsai.core.tool.Sequence):
             finish = parser.parse(props.finish, dayfirst=True, fuzzy=True)
             duration = finish - start
             frame_date = (((scene.frame_current - props.start_frame) / props.total_frames) * duration) + start
-            return frame_date.date().isoformat()
+            # Match the DD/MM/YY convention used everywhere else in the sequence
+            # module for displaying dates (see ifcopenshell.util.date.canonicalise_time),
+            # instead of a lone ISO 8601 outlier. See #2477.
+            return ifcopenshell.util.date.canonicalise_time(frame_date.date())
 
         data = bpy.data.curves.get("Timeline")
         if not data:


### PR DESCRIPTION
## Summary

Fixes #2477. Date formatting was inconsistent between panels: the Work Plan/task list shows dates as `DD/MM/YY`, while the 4D-animation Timeline text object showed `YYYY-MM-DD`.

## Root cause

`ifcopenshell.util.date.canonicalise_time()` (`DD/MM/YY`) is already the established display convention across the sequence module, used consistently for task list start/finish, derived start/finish, and the visualisation date-picker labels. The Timeline text object's `get_frame_date()` was the one outlier, using `frame_date.date().isoformat()` directly instead.

## Fix

One line: route the Timeline text through `canonicalise_time()` like everywhere else. This isn't picking a new canonical format, it's aligning the single outlier to the format already used everywhere else in this module.

A separate, deliberate convention exists for editable IFC date/datetime attribute fields (paired with a date-picker operator, matching IFC's native serialization for round-trip editing) — that's untouched, it's not part of this display inconsistency.

## Verification

Live-tested in headless Blender 5.1.2 (factory startup): created a work schedule/task (start 2026-03-05, finish 2026-06-15), drove the frame-change handler. Before: Timeline body `'2026-04-14'`. After: `'14/04/26'`, matching the task-row/visualisation-date format for the same schedule.

This change was made with the assistance of an AI tool.
