### PR TITLE
Bonsai: don't crash save when an object's IFC entity no longer exists (#2778)

### DIFF
--- a/src/bonsai/bonsai/bim/export_ifc.py
+++ b/src/bonsai/bonsai/bim/export_ifc.py
@@ -98,7 +98,18 @@ class IfcExporter:
         return results
 
     def sync_object_placement(self, obj: bpy.types.Object) -> Union[ifcopenshell.entity_instance, None]:
-        element = self.file.by_id(tool.Blender.get_object_bim_props(obj).ifc_definition_id)
+        ifc_definition_id = tool.Blender.get_object_bim_props(obj).ifc_definition_id
+        try:
+            element = self.file.by_id(ifc_definition_id)
+        except RuntimeError:
+            # The IFC entity linked to this Blender object no longer exists in the
+            # IFC file (for example, it was removed by a script without also
+            # removing the Blender object). Skip it instead of crashing the save.
+            print(
+                f"WARNING. Object '{obj.name}' is linked to IFC entity #{ifc_definition_id} "
+                "which no longer exists in the IFC file. Skipping it during save."
+            )
+            return
         # Handle camera scales specially
         if obj.type == "CAMERA":
             # Check if this is a reflected ceiling plan camera


### PR DESCRIPTION
## Summary

Partial fix for #2778, scoped to one of its two concrete repro scenarios (the general "graceful save framework" goal in that issue is out of scope for this PR).

Reproduced scenario: if an IFC entity gets removed from the model without the corresponding Blender object also being cleaned up (e.g. via a script calling `file.remove()` directly), saving the project crashes the entire process instead of skipping the stale object.

## Root cause

`IfcExporter.sync_object_placement` does `self.file.by_id(ifc_definition_id)` unguarded. If that id no longer exists in the IFC file, this raises an unhandled `RuntimeError`, which propagates out of `sync_all_objects` (whose own `try/except` only catches `ReferenceError`, a different exception) and aborts the save.

## Fix

Wrap the lookup in `try/except RuntimeError`, print a clear warning naming the object and the stale entity id, and skip it (`return None`). `sync_object_placement` already has an established `None`-returning contract at its only meaningful caller (`sync_all_objects` does `if result: results.append(result)`), so this fits the existing pattern without changing behavior for any other case.

## Verification

Reproduced with the issue's own attached sample (`DeletedSomehowInIfc.zip`): live in headless Blender 5.1.2, before the fix `bpy.ops.bim.save_project()` raised `RuntimeError: Instance #63 not found`; after the fix it returns `{'FINISHED'}`, prints the warning, and produces a valid output IFC with the deleted entity correctly absent.

The other repro in the issue (loop-cut + reversed normal on a space boundary mesh) no longer reproduces at all, the boundary-geometry edit workflow was redesigned since 2023 to reconstruct purely from edge topology, so face count/normal direction have no effect anymore. Live-verified that scenario too: no error on save.

This change was made with the assistance of an AI tool.
