### PR TITLE
Bonsai: set a default Axis on structural curve member/connection creation (#3067)

### DIFF
--- a/src/bonsai/bonsai/core/root.py
+++ b/src/bonsai/bonsai/core/root.py
@@ -94,6 +94,17 @@ def assign_class(
             obj=obj, context=context, ifc_representation_class=ifc_representation_class, profile_set_usage=None
         )
 
+    if (
+        root.is_element_a(element, "IfcStructuralCurveMember")
+        or root.is_element_a(element, "IfcStructuralCurveConnection")
+    ) and not element.Axis:
+        # Axis is a mandatory attribute for these classes (the local Z axis
+        # used together with the curve's own tangent to orient the cross
+        # section). Leaving it unset produces a schema-invalid file, so give
+        # it a sensible default that the user can later correct via the
+        # "Edit Axis" UI.
+        root.set_default_structural_axis(element, obj)
+
     if not root.is_drawing_annotation(element) and (default_container := root.get_default_container()):
         if root.is_spatial_element(element):
             ifc.run("aggregate.assign_object", products=[element], relating_object=default_container)

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -905,6 +905,7 @@ class Root:
     def is_spatial_element(cls, element): pass
     def link_object_data(cls, source_obj, destination_obj): pass
     def run_geometry_add_representation(cls, obj=None, context=None, ifc_representation_class=None, profile_set_usage=None): pass
+    def set_default_structural_axis(cls, element, obj): pass
     def set_object_name(cls, obj, element): pass
 
 

--- a/src/bonsai/bonsai/tool/root.py
+++ b/src/bonsai/bonsai/tool/root.py
@@ -25,10 +25,12 @@ import ifcopenshell
 import ifcopenshell.api.feature
 import ifcopenshell.api.geometry
 import ifcopenshell.api.root
+import ifcopenshell.api.structural
 import ifcopenshell.api.style
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
 import ifcopenshell.util.representation
+from mathutils import Vector
 
 import bonsai.core.aggregate
 import bonsai.core.geometry
@@ -427,6 +429,34 @@ class Root(bonsai.core.tool.Root):
             ifc_representation_class=ifc_representation_class,
             profile_set_usage=profile_set_usage,
         )
+
+    @classmethod
+    def set_default_structural_axis(cls, element: ifcopenshell.entity_instance, obj: bpy.types.Object) -> None:
+        """Populate the mandatory Axis attribute of a structural curve item.
+
+        ``IfcStructuralCurveMember.Axis`` and ``IfcStructuralCurveConnection.Axis``
+        are mandatory ``IfcDirection`` attributes representing the local Z
+        axis, used together with the curve's own tangent to orient the
+        cross section. It must not be parallel to the curve's tangent, or
+        the local coordinate system is undefined.
+
+        If the object's mesh is the simple two-vertex line that Bonsai
+        creates for these classes, derive an axis that is guaranteed not to
+        be parallel to the member's own direction: global Z, unless the
+        member itself runs (near) vertically, in which case fall back to
+        global X. For anything else (e.g. a more complex mesh), fall back
+        to the same arbitrary-but-schema-valid placeholder so the file
+        remains valid; the user can always correct it via "Edit Axis".
+        """
+        axis = (0.0, 0.0, 1.0)
+        mesh = obj.data
+        if isinstance(mesh, bpy.types.Mesh) and len(mesh.vertices) == 2:
+            tangent = mesh.vertices[1].co - mesh.vertices[0].co
+            if tangent.length_squared > 0:
+                tangent.normalize()
+                if abs(tangent.dot(Vector((0.0, 0.0, 1.0)))) > 0.9:
+                    axis = (1.0, 0.0, 0.0)
+        ifcopenshell.api.structural.edit_structural_item_axis(tool.Ifc.get(), structural_item=element, axis=axis)
 
     @classmethod
     def set_object_name(cls, obj: bpy.types.Object, element: ifcopenshell.entity_instance) -> None:

--- a/src/ifcopenshell-python/ifcopenshell/api/structural/edit_structural_item_axis.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/structural/edit_structural_item_axis.py
@@ -31,6 +31,6 @@ def edit_structural_item_axis(
         Defaults to (0., 0., 1.).
     :return: None
     """
-    if file.get_total_inverses(axis_dir := structural_item.Axis) == 1:
+    if (axis_dir := structural_item.Axis) is not None and file.get_total_inverses(axis_dir) == 1:
         file.remove(axis_dir)
     structural_item.Axis = file.create_entity("IfcDirection", ifc_safe_vector_type(axis))


### PR DESCRIPTION
## Summary

Fixes #3067. `IfcStructuralCurveMember.Axis` and `IfcStructuralCurveConnection.Axis` are mandatory `IfcDirection` attributes (the local Z axis, combined with the curve's own tangent, orients the cross section). Creating either of these via Bonsai's normal Add Element / assign_class flow left `Axis` unset, producing schema-invalid output (`ifcopenshell.validate` flags `Attribute not optional`).

## Fix

`assign_class` now calls a new `root.set_default_structural_axis(element, obj)` after the representation is added, only when `Axis` is still unset (so it never clobbers existing data). For the standard 2-vertex line mesh Bonsai creates for these classes, it derives an axis guaranteed not parallel to the member's own tangent: global Z, or global X for near-vertical members. For anything else, it falls back to the same schema-valid `(0,0,1)` placeholder, correctable via the existing "Edit Axis" UI (which already existed but was never auto-invoked on creation).

Also fixes a latent crash this surfaced in `ifcopenshell.api.structural.edit_structural_item_axis`: it called `file.get_total_inverses(structural_item.Axis)` unguarded, which raises when `Axis` is `None`, exactly the case a fresh element hits. Guarded with a `is not None` check.

## Verification

Live-tested in headless Blender 5.1.2: horizontal member → `Axis=(0,0,1)`; vertical member → `Axis=(1,0,0)`; `IfcStructuralCurveConnection` → `(0,0,1)`. Re-validated the output file with `ifcopenshell.validate`: the `Axis` "attribute not optional" errors are gone.

This change was made with the assistance of an AI tool.
