### PR TITLE
Bonsai: switch to external styles on RENDERED shading for viewports created mid-session (#3296)

### DIFF
--- a/src/bonsai/bonsai/bim/__init__.py
+++ b/src/bonsai/bonsai/bim/__init__.py
@@ -272,6 +272,9 @@ def register():
     parametric_lifecycle.install_parametric_lifecycle_handlers()
     bpy.app.handlers.load_post.append(handler.load_post)
     bpy.app.handlers.load_post.append(handler.loadIfcStore)
+    # Global (not per-area) draw handler: covers viewports created or converted
+    # to VIEW_3D during the session too, see #3296.
+    handler.install_external_styles_draw_handler()
     bpy.types.Scene.BIMProperties = bpy.props.PointerProperty(type=prop.BIMProperties)
     bpy.types.Scene.BIMSnapProperties = bpy.props.PointerProperty(type=prop.BIMSnapProperties)
     bpy.types.Scene.BIMSnapGroups = bpy.props.PointerProperty(type=prop.BIMSnapGroups)
@@ -328,6 +331,7 @@ def unregister():
     unregister_classes(classes)
 
     parametric_lifecycle.uninstall_parametric_lifecycle_handlers()
+    handler.uninstall_external_styles_draw_handler()
     bpy.app.handlers.load_post.remove(handler.load_post)
     bpy.app.handlers.load_post.remove(handler.loadIfcStore)
     del bpy.types.Scene.BIMProperties

--- a/src/bonsai/bonsai/bim/handler.py
+++ b/src/bonsai/bonsai/bim/handler.py
@@ -417,26 +417,50 @@ def get_user(ifc: ifcopenshell.file) -> Union[ifcopenshell.entity_instance, None
         return pao
 
 
-def viewport_shading_changed_callback(area: bpy.types.Area) -> None:
-    shading = area.spaces.active.shading.type
-    if shading == "RENDERED":
-        tool.Style.get_style_props().active_style_type = "External"
+external_styles_draw_handler = None
 
 
-def subscribe_to_viewport_shading_changes():
-    """Subscribe to changes in viewport shading mode"""
-    # NOTE: couldn't find a way to make it work for new areas too
-    # it starts working for them after blender restart though
-    for screen in bpy.data.screens:
-        for area in screen.areas:
-            if area.type != "VIEW_3D":
-                continue
-            shading = area.spaces.active.shading
-            key = shading.path_resolve("type", False)
+def sync_external_styles_on_viewport_draw() -> None:
+    """Switch to external styles whenever a 3D viewport's shading is RENDERED.
 
-            bpy.msgbus.subscribe_rna(
-                key=key, owner=global_subscription_owner, args=(area,), notify=viewport_shading_changed_callback
-            )
+    This is a ``SpaceView3D.draw_handler_add`` callback, so it fires on every
+    redraw of every VIEW_3D area regardless of when that area was created.
+    Unlike a msgbus subscription installed once per known area (see #3296),
+    it needs no "new area" detection: any viewport that is ever drawn -
+    including ones split, duplicated, or converted to VIEW_3D during the
+    current session - is covered automatically.
+
+    Kept cheap (a couple of attribute reads and an early return) since it
+    runs on every viewport draw call.
+    """
+    space = bpy.context.space_data
+    if not isinstance(space, bpy.types.SpaceView3D):
+        return
+    if space.shading.type != "RENDERED":
+        return
+    scene = bpy.context.scene
+    if scene is None:
+        return
+    style_props = scene.BIMStylesProperties
+    if style_props.active_style_type != "External":
+        style_props.active_style_type = "External"
+
+
+def install_external_styles_draw_handler() -> None:
+    global external_styles_draw_handler
+    if external_styles_draw_handler is not None:
+        return
+    external_styles_draw_handler = bpy.types.SpaceView3D.draw_handler_add(
+        sync_external_styles_on_viewport_draw, (), "WINDOW", "PRE_VIEW"
+    )
+
+
+def uninstall_external_styles_draw_handler() -> None:
+    global external_styles_draw_handler
+    if external_styles_draw_handler is None:
+        return
+    bpy.types.SpaceView3D.draw_handler_remove(external_styles_draw_handler, "WINDOW")
+    external_styles_draw_handler = None
 
 
 def _apply_save_file_invariants(scene: bpy.types.Scene) -> None:
@@ -468,8 +492,8 @@ def _apply_save_file_invariants(scene: bpy.types.Scene) -> None:
 
 
 def _apply_user_preferences() -> None:
-    """User-preference-driven UI setup: toolbar, BIM workspace, viewport shading
-    subscription, scene-panel hijack, tab layout, snap defaults."""
+    """User-preference-driven UI setup: toolbar, BIM workspace, scene-panel
+    hijack, tab layout, snap defaults."""
     preferences = tool.Blender.get_addon_preferences()
     if not preferences.should_setup_toolbar:
         tool.Blender.unregister_toolbar()
@@ -480,9 +504,6 @@ def _apply_user_preferences() -> None:
                 bpy.context.window.workspace = bpy.data.workspaces["BIM"]
         else:
             bpy.ops.workspace.append_activate(idname="BIM", filepath=os.path.join(cwd, "data", "workspace.blend"))
-
-    # After appending the workspace to ensure BIM viewport is affected.
-    subscribe_to_viewport_shading_changes()
 
     # To improve usability for new users, we hijack the scene properties
     # tab. We override default scene properties panels with our own poll


### PR DESCRIPTION
## Summary

Fixes #3296. Automatically switching a viewport to external IFC styles when its shading mode is set to RENDERED only worked for viewport areas that existed when Blender/the session first loaded, not ones split, duplicated, or converted to VIEW_3D afterward. A full restart was needed to pick up new areas.

## Root cause

`subscribe_to_viewport_shading_changes` (added in `c7b333149`) iterated `bpy.data.screens`/areas once at `_apply_user_preferences()` time and installed a per-area `bpy.msgbus.subscribe_rna` on each area's `shading.type`. Any area created after that point was never subscribed (the function's own comment already noted this: "couldn't find a way to make it work for new areas too").

## Fix

Replaced the per-area msgbus subscriptions with a single global `SpaceView3D.draw_handler_add` callback, registered once in `register()`/unregistered in `unregister()`. This exact pattern (a global draw handler bound to the space *type*, not a specific area instance) is already used pervasively elsewhere in this codebase for viewport overlays (`ProfileDecorator`, gizmos, boundary decorator), so it needs no "new area" detection at all: it fires on every VIEW_3D redraw regardless of when that area was created. The callback is a cheap early-return check (isinstance, shading type read, equality check) that only writes `active_style_type` when it would actually change.

## Verification

Live-tested in headless Blender 5.1.2 (patched the installed extension, restored after): confirmed the handler registers a real `SpaceView3D` handle even in background mode, is idempotent across register/unregister cycles, and the callback safely no-ops with no `space_data` (background mode has no windows/areas). The full interactive "split a viewport, set RENDERED" loop couldn't be exercised end to end headlessly, but the logic mirrors the exact same proven mechanism already used for other Bonsai viewport overlays in this codebase.

This change was made with the assistance of an AI tool.
