### PR TITLE
Fix IfcSweptDiskSolid directrix round-trip when updating representations

### DIFF
--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1007,7 +1007,10 @@ class Geometry(bonsai.core.tool.Geometry):
         cls, obj: bpy.types.Object, only_assigned_to_faces: bool = False
     ) -> list[Union[ifcopenshell.entity_instance, None]]:
         styles = [tool.Ifc.get_entity(s.material) for s in obj.material_slots if s.material]
-        if not only_assigned_to_faces:
+        # Face-usage filtering only makes sense for meshes. Curve-based representations
+        # (e.g. IfcSweptDiskSolid directrices, see #3496) have no polygons to inspect,
+        # so fall back to returning every assigned style.
+        if not only_assigned_to_faces or not isinstance(obj.data, bpy.types.Mesh):
             return styles
 
         usage_count = [0] * len(obj.material_slots)

--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/add_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/add_representation.py
@@ -563,6 +563,13 @@ class Usecase:
         bpy.context.scene.collection.objects.link(dummy)
         tool.Blender.select_and_activate_single_object(bpy.context, dummy)
         if not isinstance(geom_data, bpy.types.Mesh):
+            if isinstance(dummy.data, bpy.types.Curve) and dummy.data.bevel_depth:
+                # IfcSweptDiskSolid directrices are loaded as curves with a bevel_depth
+                # (see #3496), so the object renders as a solid tube. Strip the bevel
+                # before converting to a mesh, otherwise the intermediate mesh is the
+                # tube's surface (no loose wire edges), and converting it back to a
+                # curve below silently produces another mesh instead of a curve.
+                dummy.data.bevel_depth = 0.0
             bpy.ops.object.convert(target="MESH")
         self.remove_doubles_from_mesh(dummy.data)
         bpy.ops.object.convert(target="CURVE")


### PR DESCRIPTION
## Problem

#3496 asked whether Bonsai supports interactively authoring `IfcSweptDiskSolid` representations (the profile used for cables, rebar, pipes). Dion Moult replied that Bonsai was "very close (or maybe already there)" and sketched the intended design: swept disks with a single radius are loaded as beveled Blender curves, and Tab (Edit Mode) should let you edit the directrix (polyline) directly, the same way slab/wall profile editing works. He also noted a "gotcha": he tested it and "it glitched out so maybe the code is now broken or something."

That glitch is still present. The native curve import/edit-mode machinery for swept disk solids already exists (`tool.Loader.is_native_swept_disk_solid` / `create_native_swept_disk_solid` in `src/bonsai/bonsai/tool/loader.py`, and `ifcopenshell.api.geometry.add_representation`'s `create_swept_disk_solid_representation` for the write-back), and Blender's own curve Edit Mode already lets you drag the directrix points. But saving those edits via "Update Representation" crashed with two separate `AttributeError`s:

1. **`ifcopenshell/api/geometry/add_representation.py`** - `create_curves()` always round-trips curve geometry through a temporary "dummy" mesh to recover a detailed polyline. For a swept-disk curve (which has `bevel_depth` set to the pipe/rebar radius), converting to mesh bakes in the bevel and produces a solid tube surface instead of a bare wire. Converting that tube mesh back to a curve then has no loose wire edges to reconstruct a spline from, so it silently stays a `Mesh`, and the caller crashes on `mesh.splines`.
2. **`bonsai/tool/geometry.py`** - `get_styles(obj, only_assigned_to_faces=True)` is called unconditionally from the "Update Representation" operator and unconditionally iterates `obj.data.polygons`, which doesn't exist on curve data.

## Fix

- `create_curves()`: strip the dummy object's `bevel_depth` before the mesh round-trip, so only the directrix path (not the tube surface) survives the conversion.
- `get_styles()`: only apply face-usage filtering to `Mesh` data; for curves (which have no polygons), fall back to returning every assigned style, matching the pre-existing "no filtering" behavior for other non-mesh types.

## Verification

Live-tested end to end in headless Blender against this checkout:
1. Authored an `IfcPipeSegment` with an `IfcSweptDiskSolid` representation from a Blender curve object with `bevel_depth` set (mirroring how Bonsai's own loader creates these objects on import).
2. Loaded that IFC back into Bonsai (`bpy.ops.bim.load_project`), confirming it comes back as a native Blender curve object with the directrix as editable spline points, per `tool.Loader.create_native_swept_disk_solid`.
3. Entered Edit Mode, moved a directrix point.
4. Ran `bpy.ops.bim.update_representation()` (the same operator behind the "Update Representation" button) - before the fix this crashed with `AttributeError: 'Mesh' object has no attribute 'splines'` and then, after fixing that, `AttributeError: 'Curve' object has no attribute 'polygons'`; after the fix it succeeds and the `IfcSweptDiskSolid`'s `Directrix` reflects the moved point.

## AI disclosure

This PR (investigation, fix, and description) was generated with the assistance of an AI coding tool, per this repo's `AGENTS.md`.

Fixes #3496