### PR TITLE
Bonsai: let curtain wall members/plates close space boundaries

### DIFF
--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -936,7 +936,12 @@ class Spatial(bonsai.core.tool.Spatial):
         boundary_elements = []
         for obj in selected_objects:
             subelement = tool.Ifc.get_entity(obj)
-            if subelement.is_a("IfcWall") or subelement.is_a("IfcColumn"):
+            if not subelement:
+                continue
+            # Use the same bounding classes as get_space_polygon_from_context_visible_objects
+            # (is_bounding_class) so curtain wall members/plates can close a room boundary
+            # just like walls and columns do.
+            if cls.is_bounding_class(subelement):
                 boundary_elements.append(subelement)
         return boundary_elements
 


### PR DESCRIPTION
## Summary

`Generate Spaces From Walls` (`bim.generate_spaces_from_walls`) only recognized `IfcWall`/`IfcColumn` as boundary elements via `tool.Spatial.get_boundary_elements`. Its sibling operator, `Generate Space` (`bim.generate_space`), already treats `IfcMember`, `IfcVirtualElement` and `IfcPlate` as bounding classes too, via `tool.Spatial.is_bounding_class`:

```python
@classmethod
def is_bounding_class(cls, visible_element: ifcopenshell.entity_instance) -> bool:
    for ifc_class in ["IfcWall", "IfcColumn", "IfcMember", "IfcVirtualElement", "IfcPlate"]:
        if visible_element.is_a(ifc_class):
            return True
    return False
```

Because `get_boundary_elements` had its own, narrower, hardcoded list, any room with a curtain-wall side (an `IfcCurtainWall` aggregating `IfcMember` mullions + `IfcPlate` panes via `IfcRelAggregates`) silently failed to close and no `IfcSpace` was generated for it when using "Generate Spaces From Walls".

This fixes #3747, where the reporter's real Revit-exported IFC (heavy curtain wall usage) produced no spaces on a level.

## Fix

`get_boundary_elements` now delegates to `is_bounding_class` so both operators agree on which classes can close a room boundary, plus a defensive null-check for selected objects with no linked IFC element.

## Test plan

Verified live in headless Blender 5.1 (before/after, same synthetic model):

- Built a synthetic IFC4 model: a 4m x 3m room bounded by 3 real `IfcWall`s and a 4th side made of an `IfcCurtainWall` aggregating 4 `IfcMember` mullions + 3 `IfcPlate` panes.
- Imported via `bim.load_project`, selected the 3 walls + all members/plates, active object a wall, ran `bpy.ops.bim.generate_spaces_from_walls()`.
- **Before fix**: 0 `IfcSpace` created (members/plates silently dropped, no closed interior).
- **After fix**: 1 `IfcSpace` created with the correct footprint (3.80m x 2.89m, matching the interior faces including the recessed curtain wall pane).
- Also confirmed the existing `bim.generate_space` (cursor-based) operator already worked correctly against the same synthetic model and against maxtillberg's real repro file linked in the issue, confirming `IfcPlate`/`IfcMember` support in that operator was already correct (Moult's original claim in the thread holds) - the previously-unfixed gap was specifically in `generate_spaces_from_walls`.

Also downloaded and inspected the reporter's linked sample file (`RAC_basic_sample_project no spaces.ifc`, a real Revit export with 9 curtain walls / 44 plates on Level 1) to confirm curtain wall members/plates do appear as valid boundary candidates in the existing cursor-based operator's algorithm.

- [x] Verified bug reproduced before fix (0 spaces)
- [x] Verified bug fixed after fix (1 correctly-bounded space)
- [x] `black`/`ruff` clean

---
AI-generated: this change (diagnosis, fix, and live verification in headless Blender) was produced by an AI coding agent, per this repo's `AGENTS.md` disclosure policy.