### PR TITLE
Bonsai/ifcopenshell-python: support editing IfcPropertyBoundedValue properties

### DIFF
--- a/src/bonsai/bonsai/bim/module/pset/__init__.py
+++ b/src/bonsai/bonsai/bim/module/pset/__init__.py
@@ -39,6 +39,7 @@ classes = (
     operator.BIM_OT_add_edit_custom_property,
     operator.BIM_OT_bulk_remove_psets,
     prop.IfcPropertyEnumeratedValue,
+    prop.IfcPropertyBoundedValue,
     prop.IfcProperty,
     prop.PsetProperties,
     prop.RenamePropertyEntry,

--- a/src/bonsai/bonsai/bim/module/pset/operator.py
+++ b/src/bonsai/bonsai/bim/module/pset/operator.py
@@ -125,6 +125,8 @@ class EditPset(bpy.types.Operator, tool.Ifc.Operator):
                     properties[prop.metadata.name] = [
                         e[value_name] for e in prop.enumerated_value.enumerated_values if e.is_selected
                     ]
+                elif prop.value_type == "IfcPropertyBoundedValue":
+                    properties[prop.metadata.name] = tool.Pset.get_bounded_value_dict(prop) or None
 
         if pset.is_a() in ("IfcPropertySet", "IfcMaterialProperties", "IfcProfileProperties"):
             ifcopenshell.api.pset.edit_pset(
@@ -260,6 +262,8 @@ class CopyPropertyToSelection(bpy.types.Operator, tool.Ifc.Operator):
         elif prop.value_type == "IfcPropertyEnumeratedValue":
             value_name = prop.metadata.get_value_name()
             prop_value = [e[value_name] for e in prop.enumerated_value.enumerated_values if e.is_selected]
+        elif prop.value_type == "IfcPropertyBoundedValue":
+            prop_value = tool.Pset.get_bounded_value_dict(prop) or None
         else:
             self.report({"ERROR"}, f"Unsupport value type: '{prop.value_type}'.")
             return {"CANCELLED"}

--- a/src/bonsai/bonsai/bim/module/pset/prop.py
+++ b/src/bonsai/bonsai/bim/module/pset/prop.py
@@ -266,18 +266,39 @@ class IfcPropertyEnumeratedValue(PropertyGroup):
         enumerated_values: bpy.types.bpy_prop_collection_idprop[Attribute]
 
 
-IfcPropertyValueType = Literal["IfcPropertySingleValue", "IfcPropertyEnumeratedValue"]
+class IfcPropertyBoundedValue(PropertyGroup):
+    lower_bound_value: PointerProperty(type=Attribute)
+    upper_bound_value: PointerProperty(type=Attribute)
+    set_point_value: PointerProperty(type=Attribute)
+
+    if TYPE_CHECKING:
+        lower_bound_value: Attribute
+        upper_bound_value: Attribute
+        set_point_value: Attribute
+
+
+#: Maps IfcPropertyBoundedValue Blender attribute names to the IFC attribute they represent.
+BOUNDED_VALUE_ATTRS: tuple[tuple[str, str], ...] = (
+    ("lower_bound_value", "LowerBoundValue"),
+    ("upper_bound_value", "UpperBoundValue"),
+    ("set_point_value", "SetPointValue"),
+)
+
+
+IfcPropertyValueType = Literal["IfcPropertySingleValue", "IfcPropertyEnumeratedValue", "IfcPropertyBoundedValue"]
 
 
 class IfcProperty(PropertyGroup):
     metadata: PointerProperty(type=Attribute)
     value_type: EnumProperty(items=[(v, v, v) for v in get_args(IfcPropertyValueType)], name="Value Type")
     enumerated_value: PointerProperty(type=IfcPropertyEnumeratedValue)
+    bounded_value: PointerProperty(type=IfcPropertyBoundedValue)
 
     if TYPE_CHECKING:
         metadata: Attribute
         value_type: IfcPropertyValueType
         enumerated_value: IfcPropertyEnumeratedValue
+        bounded_value: IfcPropertyBoundedValue
 
 
 class PsetProperties(PropertyGroup):

--- a/src/bonsai/bonsai/bim/module/pset/ui.py
+++ b/src/bonsai/bonsai/bim/module/pset/ui.py
@@ -50,6 +50,8 @@ def draw_property(prop: IfcProperty, layout: bpy.types.UILayout, copy_operator: 
         draw_single_property(prop, layout, copy_operator)
     elif prop.value_type == "IfcPropertyEnumeratedValue":
         draw_enumerated_property(prop, layout, copy_operator)
+    elif prop.value_type == "IfcPropertyBoundedValue":
+        draw_bounded_property(prop, layout, copy_operator)
     else:
         assert_never(prop.value_type)
 
@@ -86,6 +88,25 @@ def draw_enumerated_property(
         grid = layout.column_flow(columns=3)
         for e in prop.enumerated_value.enumerated_values:
             grid.prop(e, "is_selected", text=str(e[value_name]))
+    if copy_operator:
+        op = layout.operator(f"{copy_operator}", text="", icon="COPYDOWN")
+        op.name = prop.metadata.name
+
+
+def draw_bounded_property(prop: IfcProperty, layout: bpy.types.UILayout, copy_operator: Optional[str] = None) -> None:
+    layout.label(text=prop.metadata.name)
+    grid = layout.column_flow(columns=3)
+    for attr, label in (
+        (prop.bounded_value.lower_bound_value, "Lower"),
+        (prop.bounded_value.upper_bound_value, "Upper"),
+        (prop.bounded_value.set_point_value, "Set Point"),
+    ):
+        value_name = attr.get_value_name(display_only=True)
+        if not value_name:
+            continue
+        row = grid.row(align=True)
+        row.prop(attr, value_name, text=label)
+        row.prop(attr, "is_null", icon="RADIOBUT_OFF" if attr.is_null else "RADIOBUT_ON", text="")
     if copy_operator:
         op = layout.operator(f"{copy_operator}", text="", icon="COPYDOWN")
         op.name = prop.metadata.name

--- a/src/bonsai/bonsai/tool/pset.py
+++ b/src/bonsai/bonsai/tool/pset.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
         AddEditPropertyEntry,
         DeletePsetEntry,
         GlobalPsetProperties,
+        IfcProperty,
         PsetProperties,
         RenamePropertyEntry,
     )
@@ -47,6 +48,15 @@ class Pset(bonsai.core.tool.Pset):
     PSET_TYPE = Literal["PSET", "QTO"]
     BulkOperationType = Literal["ADD_EDIT", "RENAME", "DELETE"]
     BULK_OPERATION_TYPES = ("ADD_EDIT", "RENAME", "DELETE")
+
+    #: Maps IfcPropertyBoundedValue Blender attribute names to the IFC attribute they represent.
+    #: Kept in sync with `bonsai.bim.module.pset.prop.BOUNDED_VALUE_ATTRS` (duplicated here to
+    #: avoid a runtime circular import between this module and `bonsai.bim.module.pset.prop`).
+    BOUNDED_VALUE_ATTRS: tuple[tuple[str, str], ...] = (
+        ("lower_bound_value", "LowerBoundValue"),
+        ("upper_bound_value", "UpperBoundValue"),
+        ("set_point_value", "SetPointValue"),
+    )
 
     @classmethod
     def get_global_pset_props(cls) -> GlobalPsetProperties:
@@ -265,6 +275,16 @@ class Pset(bonsai.core.tool.Pset):
                     new = simple_prop.enumerated_value.enumerated_values.add()
                     setattr(new, data_type, enum)
                     new.is_selected = enum in selected_enum_items
+            elif prop.is_a("IfcPropertyBoundedValue"):
+                bounded_prop = props.properties.add()
+                bounded_prop.name = prop.Name
+                bounded_prop.value_type = "IfcPropertyBoundedValue"
+                metadata = bounded_prop.metadata
+                metadata.name = prop.Name
+                metadata.is_null = True
+                metadata.is_optional = True
+                process_prop_description(metadata)
+                cls.set_bounded_value_attributes(bounded_prop, prop)
             else:
                 if prop.is_a("IfcPropertySingleValue"):
                     value = prop.NominalValue.wrappedValue if prop.NominalValue else None
@@ -282,6 +302,69 @@ class Pset(bonsai.core.tool.Pset):
                 metadata.special_type = cls.get_special_type_for_prop(prop)
                 metadata.set_value(metadata.get_value_default() if metadata.is_null else value)
                 process_prop_description(metadata)
+
+    @classmethod
+    def get_bounded_value_dict(cls, prop: IfcProperty) -> dict[str, Any]:
+        """Builds the dict expected by ``ifcopenshell.api.pset.edit_pset`` for a bounded value
+        property row, containing only the sub-fields the user hasn't marked as null."""
+        return {
+            ifc_attribute: attr.get_value()
+            for attr_name, ifc_attribute in cls.BOUNDED_VALUE_ATTRS
+            if not (attr := getattr(prop.bounded_value, attr_name)).is_null
+        }
+
+    @classmethod
+    def set_bounded_value_attributes(
+        cls,
+        bounded_prop: IfcProperty,
+        prop: Union[ifcopenshell.entity_instance, None] = None,
+        data_type: Union[str, None] = None,
+    ) -> None:
+        """Populates the Lower/Upper/SetPoint Attribute sub-fields of a bounded value property row.
+
+        :param prop: An existing ``IfcPropertyBoundedValue`` to read values from, if any.
+        :param data_type: Fallback Blender data type (e.g. ``"float"``) used for sub-fields that
+            have no existing value yet, e.g. when proposing a still-empty property from a template.
+        """
+        resolved_data_type = data_type
+        if prop is not None and resolved_data_type is None:
+            for _, ifc_attribute in cls.BOUNDED_VALUE_ATTRS:
+                if (value := getattr(prop, ifc_attribute, None)) is not None:
+                    resolved_data_type = ifcopenshell.util.attribute.get_primitive_type(
+                        tool.Ifc.schema().declaration_by_name(value.is_a())
+                    )
+                    break
+        resolved_data_type = resolved_data_type or "float"
+
+        for attr_name, ifc_attribute in cls.BOUNDED_VALUE_ATTRS:
+            attr = getattr(bounded_prop.bounded_value, attr_name)
+            attr.name = ifc_attribute
+            attr.is_optional = True
+            value = getattr(prop, ifc_attribute, None) if prop is not None else None
+            if value is not None:
+                attr.set_value(value.wrappedValue)
+                attr.is_null = False
+            else:
+                attr.data_type = resolved_data_type
+                attr.is_null = True
+
+    @classmethod
+    def import_bounded_value_from_template(
+        cls,
+        pset_template: ifcopenshell.entity_instance,
+        prop_template: ifcopenshell.entity_instance,
+        props: PsetProperties,
+    ) -> None:
+        prop = props.properties.add()
+        prop.name = prop_template.Name
+        prop.value_type = "IfcPropertyBoundedValue"
+        metadata = prop.metadata
+        metadata.name = prop_template.Name
+        metadata.is_null = True
+        metadata.is_optional = True
+        metadata.ifc_class = pset_template.Name
+        bonsai.bim.helper.add_attribute_description(metadata, prop_template)
+        cls.set_bounded_value_attributes(prop, data_type=cls.get_prop_template_primitive_type(prop_template))
 
     @classmethod
     def get_prop_template_primitive_type(cls, prop_template: ifcopenshell.entity_instance) -> str:
@@ -413,9 +496,15 @@ class Pset(bonsai.core.tool.Pset):
                     continue
                 cls.import_enumerated_value_from_template(prop_template, simplified_data, props)
 
+            elif prop_template.TemplateType == "P_BOUNDEDVALUE":
+                if prop_data:
+                    # Existing property (of any class) will be added by import_pset_from_existing,
+                    # which can read all of LowerBoundValue/UpperBoundValue/SetPointValue directly.
+                    continue
+                cls.import_bounded_value_from_template(pset_template, prop_template, props)
+
             else:
                 # NOTE: currently unsupported types:
-                # - P_BOUNDEDVALUE
                 # - P_LISTVALUE
                 # - P_REFERENCEVALUE
                 # - P_TABLEVALUE

--- a/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
@@ -23,6 +23,11 @@ import ifcopenshell
 import ifcopenshell.util.element
 import ifcopenshell.util.pset
 
+#: Keys recognized in a dict value to describe an ``IfcPropertyBoundedValue``.
+#: A property value is treated as a bounded value specification if it's a dict
+#: containing at least one of these keys.
+BOUNDED_VALUE_KEYS = ("LowerBoundValue", "UpperBoundValue", "SetPointValue")
+
 
 def edit_pset(
     file: ifcopenshell.file,
@@ -73,6 +78,11 @@ def edit_pset(
         become IfcBoolean, and integers will become IfcInteger. If more
         control is desired, you may explicitly specify IFC data objects
         directly. Note that provided `properties` might be mutated in the process.
+        An ``IfcPropertyBoundedValue`` may be added or edited by providing a
+        dictionary containing any of the keys ``LowerBoundValue``,
+        ``UpperBoundValue``, or ``SetPointValue`` (at least one is required).
+        Values may be plain Python types (cast using the property set
+        template, if available) or explicit IFC data objects.
     :param pset_template: If a property set template is provided, this will
         be used to determine data types. If no user-defined template is
         provided, the built-in buildingSMART templates will be loaded.
@@ -150,6 +160,14 @@ def edit_pset(
         # Editing existing properties will retain their current data types
         # if possible. So this will still be a length measure.
         ifcopenshell.api.pset.edit_pset(model, pset=pset, properties={"ExplicitLength": 12.3})
+
+        # Bounded values (IfcPropertyBoundedValue) are described using a
+        # dictionary with LowerBoundValue / UpperBoundValue / SetPointValue keys.
+        # Any subset of these keys may be provided, and existing values are
+        # retained unless a new dictionary is passed.
+        pset = ifcopenshell.api.pset.add_pset(model, product=wall_type, name="Pset_ElectricalDeviceCommon")
+        ifcopenshell.api.pset.edit_pset(model, pset=pset,
+            properties={"RatedCurrent": {"LowerBoundValue": 1.0, "UpperBoundValue": 2.0}})
     """
     usecase = Usecase()
     usecase.file = file
@@ -224,6 +242,10 @@ class Usecase:
                     existing_props.append(prop)
             elif prop.is_a("IfcPropertySingleValue"):
                 prop = self.update_existing_prop_single_value(prop)
+                if prop:
+                    existing_props.append(prop)
+            elif prop.is_a("IfcPropertyBoundedValue"):
+                prop = self.update_existing_prop_bounded_value(prop)
                 if prop:
                     existing_props.append(prop)
             else:
@@ -315,10 +337,63 @@ class Usecase:
         del self.settings["properties"][prop.Name]
         return prop
 
+    def update_existing_prop_bounded_value(
+        self, prop: ifcopenshell.entity_instance
+    ) -> Union[ifcopenshell.entity_instance, None]:
+        """
+        NOTE: Assumes the prop exists
+        """
+        value = self.settings["properties"][prop.Name]
+
+        if value is None:
+            if self._try_purge(prop):
+                return
+            for ifc_attribute in BOUNDED_VALUE_KEYS:
+                setattr(prop, ifc_attribute, None)
+        elif isinstance(value, dict) and any(k in value for k in BOUNDED_VALUE_KEYS):
+            primary_measure_type = None
+            for ifc_attribute in BOUNDED_VALUE_KEYS:
+                if existing_value := getattr(prop, ifc_attribute):
+                    primary_measure_type = existing_value.is_a()
+                    break
+
+            for ifc_attribute in BOUNDED_VALUE_KEYS:
+                if ifc_attribute not in value:
+                    continue
+                new_value = value[ifc_attribute]
+                if new_value is None:
+                    setattr(prop, ifc_attribute, None)
+                    continue
+                if not isinstance(new_value, ifcopenshell.entity_instance):
+                    measure_type = primary_measure_type or self.get_primary_measure_type(prop.Name)
+                    assert measure_type, f"Couldn't find primary measure type for the prop value: '{prop.Name}'."
+                    new_value = self.file.create_entity(
+                        measure_type, self.cast_value_to_primary_measure_type(new_value, measure_type)
+                    )
+                setattr(prop, ifc_attribute, new_value)
+
+            if all(getattr(prop, k) is None for k in BOUNDED_VALUE_KEYS):
+                if self._try_purge(prop):
+                    return
+
+            if unit := value.get("Unit"):
+                prop.Unit = unit
+        else:
+            raise ValueError(
+                f'Value "{value}" is not a valid value for bounded property {prop.Name}. '
+                f"Expected None or a dict with any of {BOUNDED_VALUE_KEYS} keys."
+            )
+
+        del self.settings["properties"][prop.Name]
+        return prop
+
     def add_new_properties(self) -> list[ifcopenshell.entity_instance]:
         properties: list[ifcopenshell.entity_instance] = []
         for name, value in self.settings["properties"].items():
             if value is None and self.settings["should_purge"]:
+                continue
+            if isinstance(value, dict) and any(k in value for k in BOUNDED_VALUE_KEYS):
+                properties.append(self.create_bounded_value_prop(name, value))
                 continue
             unit, value = self.unpack_unit_value(value)
 
@@ -394,6 +469,34 @@ class Usecase:
 
                 properties.append(self.file.create_entity("IfcPropertySingleValue", **args))
         return properties
+
+    def create_bounded_value_prop(self, name: str, value: dict[str, Any]) -> ifcopenshell.entity_instance:
+        """Creates a new IfcPropertyBoundedValue from a dict of LowerBoundValue /
+        UpperBoundValue / SetPointValue (and optionally Unit).
+        """
+        primary_measure_type = None
+        for ifc_attribute in BOUNDED_VALUE_KEYS:
+            existing_value = value.get(ifc_attribute)
+            if isinstance(existing_value, ifcopenshell.entity_instance):
+                primary_measure_type = existing_value.is_a()
+                break
+
+        kwargs: dict[str, Any] = {"Name": name}
+        for ifc_attribute in BOUNDED_VALUE_KEYS:
+            if (bound_value := value.get(ifc_attribute)) is None:
+                continue
+            if not isinstance(bound_value, ifcopenshell.entity_instance):
+                measure_type = primary_measure_type or self.get_primary_measure_type(name)
+                assert measure_type, f"Couldn't find primary measure type for the prop value: '{name}'."
+                bound_value = self.file.create_entity(
+                    measure_type, self.cast_value_to_primary_measure_type(bound_value, measure_type)
+                )
+            kwargs[ifc_attribute] = bound_value
+
+        if unit := value.get("Unit"):
+            kwargs["Unit"] = unit
+
+        return self.file.create_entity("IfcPropertyBoundedValue", **kwargs)
 
     def assign_new_properties(self, props: list[ifcopenshell.entity_instance]) -> None:
         if hasattr(self.settings["pset"], "HasProperties"):

--- a/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
+++ b/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
@@ -330,3 +330,43 @@ class TestEditPsetIFC4(test.bootstrap.IFC4, TestEditPsetIFC2X3):
         assert len(pset.HasProperties[0].ListValues) == 3
         assert set(map(ifcopenshell.entity_instance.is_a, pset.HasProperties[0].ListValues)) == {"IfcIdentifier"}
         assert list(map(operator.itemgetter(0), pset.HasProperties[0].ListValues)) == ["One", "Two", "Three"]
+
+    def test_adding_a_bounded_valued_property(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcElectricDistributionBoard")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_ElectricalDeviceCommon")
+        ifcopenshell.api.pset.edit_pset(
+            self.file,
+            pset=pset,
+            properties={"RatedCurrent": {"LowerBoundValue": 1.0, "UpperBoundValue": 2.5}},
+        )
+        prop = pset.HasProperties[0]
+        assert prop.is_a("IfcPropertyBoundedValue")
+        assert prop.Name == "RatedCurrent"
+        assert prop.LowerBoundValue.is_a("IfcElectricCurrentMeasure")
+        assert prop.LowerBoundValue.wrappedValue == 1.0
+        assert prop.UpperBoundValue.wrappedValue == 2.5
+        assert prop.SetPointValue is None
+
+    def test_editing_an_existing_bounded_valued_property(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcElectricDistributionBoard")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_ElectricalDeviceCommon")
+        ifcopenshell.api.pset.edit_pset(
+            self.file,
+            pset=pset,
+            properties={"RatedCurrent": {"LowerBoundValue": 1.0, "UpperBoundValue": 2.5}},
+        )
+        # Editing only one bound retains the others.
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"RatedCurrent": {"SetPointValue": 3.3}})
+        prop = pset.HasProperties[0]
+        assert prop.LowerBoundValue.wrappedValue == 1.0
+        assert prop.UpperBoundValue.wrappedValue == 2.5
+        assert prop.SetPointValue.wrappedValue == 3.3
+
+    def test_removing_a_bounded_valued_property_if_specified(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcElectricDistributionBoard")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_ElectricalDeviceCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"RatedCurrent": {"LowerBoundValue": 1.0}})
+        assert len(pset.HasProperties) == 1
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"RatedCurrent": None})
+        pset = element.IsDefinedBy[0].RelatingPropertyDefinition
+        assert len(pset.HasProperties) == 0


### PR DESCRIPTION
## Summary

`Pset_ElectricalDeviceCommon.RatedCurrent` / `RatedVoltage` / `NominalFrequencyRange`, `Pset_BoilerTypeCommon.NominalPartLoadRatio`, and any other standard IFC pset template property typed as `IfcPropertyBoundedValue` (`P_BOUNDEDVALUE`) never appeared in Bonsai's pset editing UI at all. The template-to-UI dispatch only handled `P_SINGLEVALUE` and `P_ENUMERATEDVALUE`, silently skipping `P_BOUNDEDVALUE` (`src/bonsai/bonsai/tool/pset.py`, `import_pset_from_template`).

The underlying `ifcopenshell.api.pset.edit_pset` also had no support for `IfcPropertyBoundedValue`: creating one via a template raised `NotImplementedError` (`Template type 'P_BOUNDEDVALUE' is not supported yet`), and editing an existing one raised `NotImplementedError` (`Updating 'IfcPropertyBoundedValue' properties is not supported yet`). This is the second half of the gap tracked in #5195 (`IfcPropertyListValue` editing was fixed there in #8298; `IfcPropertyBoundedValue` was explicitly left out of scope at the time).

- **`ifcopenshell.api.pset.edit_pset`**: adds create/update support for `IfcPropertyBoundedValue`, driven by a dict of `LowerBoundValue`/`UpperBoundValue`/`SetPointValue` (any subset), matching the existing conventions for primitive-type casting via the pset template. Setting the property to `None`, or nulling all three sub-values, purges it, matching existing single-value semantics.
- **Bonsai pset editor** (`prop.py`, `tool/pset.py`, `ui.py`, `operator.py`): adds an `IfcPropertyBoundedValue` row type with independent Lower/Upper/SetPoint sub-fields (each individually nullable), mirroring how `IfcPropertySingleValue`/`IfcPropertyEnumeratedValue` rows are already built, drawn, saved, and copied-to-selection.

## Test plan

- [x] Added `test_adding_a_bounded_valued_property`, `test_editing_an_existing_bounded_valued_property`, `test_removing_a_bounded_valued_property_if_specified` to `test/api/pset/test_edit_pset.py`. All 30 tests in the file pass.
- [x] Live-tested in headless Blender 5.1 against a real IFC4 project: before the fix, `Pset_ElectricalDeviceCommon` on an `IfcElectricDistributionBoard` proposes only `['ConductorFunction', 'HasProtectiveEarth', 'IK_Code', 'IP_Code', 'InsulationStandardClass', 'NumberOfPoles', 'PowerFactor']` — `RatedCurrent`/`RatedVoltage`/`NominalFrequencyRange` are missing, matching the report. After the fix, all three appear, can be edited via the real `bim.edit_pset` operator, are written to the IFC file as `IfcPropertyBoundedValue` with the correct measure type (`IfcElectricCurrentMeasure`), round-trip correctly when the pset editor is reopened, and are purged when all sub-fields are cleared.
- [x] Verified the second reporter's case: `Pset_BoilerTypeCommon.NominalPartLoadRatio` now appears too.
- [x] Regression-checked that ordinary `IfcPropertySingleValue`/`IfcPropertyEnumeratedValue` pset editing (`Pset_WallCommon.Reference`/`Status`) is unaffected.
- [x] Formatted with black (line-length 120) and ruff, matching CI.

Fixes #4047

## AI disclosure

This PR was generated with the assistance of an AI coding tool (implementation, tests, and live verification in headless Blender).