### PR TITLE
Bonsai: don't crash decoration labels on a zero-length text direction

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -403,7 +403,13 @@ class BaseDecorator:
 
         color = tool.Blender.get_addon_preferences().decorations_colour
 
-        ang = -Vector((1, 0)).angle_signed(text_dir)
+        # text_dir can collapse to a zero-length vector (e.g. a section-level callout edge that
+        # points along the view axis loses its direction once projected to 2D via to_2d()).
+        # angle_signed() raises on zero-length input, so fall back to horizontal in that case.
+        if text_dir.length < 1e-6:
+            ang = 0.0
+        else:
+            ang = -Vector((1, 0)).angle_signed(text_dir)
         cos = math.cos(ang)
         sin = math.sin(ang)
         rotation_matrix = Matrix.Rotation(-ang, 2)


### PR DESCRIPTION
### Problem
`draw_label()` computes its text rotation with:
```python
ang = -Vector((1, 0)).angle_signed(text_dir)
```
`angle_signed()` raises `ValueError: zero length vectors have no valid angle` when `text_dir` is zero-length. This happens for a `SectionLevelDecorator` callout edge oriented along the view axis: the direction is `-edge_dir`, which collapses to `(0, 0)` once projected to 2D via `to_2d()`. Because it fires from a draw handler, it spams a traceback on every viewport redraw.

```
File ".../drawing/decoration.py", line 409, in draw_label
    ang = -Vector((1, 0)).angle_signed(text_dir)
ValueError: Vector.angle_signed(other): zero length vectors have no valid angle
```

### Fix
A zero-length direction carries no orientation, so fall back to a horizontal angle (`0`) instead of calling `angle_signed()`. The guard sits in the shared `draw_label()` sink, so it protects every decorator that draws labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)