### PR TITLE
Bonsai: skip drawing decorations when the scene has no active camera

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -2082,6 +2082,12 @@ class DecorationsHandler:
         if context.region_data.view_perspective != "CAMERA":
             return
 
+        # The view can report a CAMERA perspective while the scene has no active camera assigned
+        # (e.g. the drawing camera was deleted). Decorators need it for paper-space scaling
+        # (get_camera_width_mm), so bail out instead of crashing on camera.data.
+        if context.scene.camera is None:
+            return
+
         if not DrawingsData.is_loaded:
             DrawingsData.load()
 


### PR DESCRIPTION
### Problem
The decoration handler already returns early when the viewport isn't in camera view, but the view can report a `CAMERA` perspective while `scene.camera` is `None` (e.g. the drawing camera was deleted). Every decorator then reaches `get_camera_width_mm()`, which does `camera.data.ortho_scale` and raises on each redraw:

```
File ".../drawing/decoration.py", line 181, in get_camera_width_mm
    camera_width_model = camera.data.ortho_scale
AttributeError: 'NoneType' object has no attribute 'data'
```

### Fix
Bail out of the decoration pass when `scene.camera is None`, right alongside the existing "not in camera view" guard. Every decorator depends on the active camera for paper-space scaling, so there's nothing meaningful to draw without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)