### PR TITLE
Fix property set fixture schema

### DIFF
--- a/src/ifcopenshell-python/test/fixtures/ColumnPSetsOfSets.ifc
+++ b/src/ifcopenshell-python/test/fixtures/ColumnPSetsOfSets.ifc
@@ -2,7 +2,7 @@ ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION(('ViewDefinition [CoordinationView]','RevitIdentifiers [ContentGUID: a0df3484-2dab-42c5-b806-8c10d313bee0, VersionGUID: 658c1394-f3a4-43d1-9b3c-eee44a0cd67a, NumberOfSaves: 2]','CoordinateReference [CoordinateBase: Shared Coordinates]'),'2;1');
 FILE_NAME('Column_4x3.ifc','2025-03-12T13:53:30+00:00',(''),(''),'ODA SDAI 24.12','Autodesk Revit 25.4.0.32 (ENG) - IFC 25.4.0.32','');
-FILE_SCHEMA(('IFC2X3'));
+FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
 #1=IFCORGANIZATION($,'Autodesk Revit 2025 (ENG)',$,$,$);


### PR DESCRIPTION
## Summary

Correct the `ColumnPSetsOfSets.ifc` fixture header from IFC2X3 to IFC4.

## Root cause

The fixture contains IFC4 entities and `IfcPropertySetDefinitionSet`, but declared IFC2X3. The parser therefore selected IFC2X3, could not construct the defined type, and exposed a raw aggregate instead.

## Verification

- Relevant streaming and normal-open checks: 5 passed locally.
- Local mmap and RocksDB cases could not run because the local wrapper was built without those features.
- `black --check --diff .` and `ruff check .` passed.

## AI disclosure

The one-line fixture header update and this PR description were generated with the assistance of an AI coding tool.