### PR TITLE
Add copy attribute to selection for boundaries

### DIFF
--- a/src/bonsai/bonsai/bim/module/boundary/__init__.py
+++ b/src/bonsai/bonsai/bim/module/boundary/__init__.py
@@ -23,6 +23,7 @@ from . import operator, prop, ui
 classes = (
     operator.AddBoundary,
     operator.ColourByRelatedBuildingElement,
+    operator.CopyBoundaryAttributeToSelection,
     operator.DecorateBoundaries,
     operator.DisableEditingBoundary,
     operator.DisableEditingBoundaryGeometry,

--- a/src/bonsai/bonsai/bim/module/boundary/operator.py
+++ b/src/bonsai/bonsai/bim/module/boundary/operator.py
@@ -39,6 +39,7 @@ from ifcopenshell.util.shape_builder import ShapeBuilder
 from mathutils import Matrix, Vector
 
 import bonsai.bim.import_ifc as import_ifc
+import bonsai.core.attribute as core
 import bonsai.core.geometry
 import bonsai.tool as tool
 from bonsai.bim.ifc import IfcStore
@@ -420,6 +421,32 @@ class EditBoundaryAttributes(bpy.types.Operator, tool.Ifc.Operator):
         ifcopenshell.api.boundary.edit_attributes(tool.Ifc.get(), entity=boundary, **attributes)
         bpy.ops.bim.disable_editing_boundary()
         return {"FINISHED"}
+
+
+class CopyBoundaryAttributeToSelection(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.copy_boundary_attribute_to_selection"
+    bl_label = "Copy Boundary Attribute To Selection"
+    bl_options = {"REGISTER", "UNDO"}
+    name: bpy.props.StringProperty()
+
+    def _execute(self, context):
+        obj = tool.Blender.get_active_object()
+        assert obj
+        bprops = tool.Boundary.get_object_boundary_props(obj)
+        if self.name in EDITABLE_ATTRIBUTES:
+            blender_prop = EDITABLE_ATTRIBUTES[self.name]
+            blender_obj = getattr(bprops, blender_prop, None)
+            value = tool.Ifc.get_entity(blender_obj) if blender_obj else None
+        elif self.name == "PhysicalOrVirtualBoundary":
+            value = bprops.physical_or_virtual
+        elif self.name == "InternalOrExternalBoundary":
+            value = bprops.internal_or_external
+        else:
+            return
+        total = core.copy_attribute_to_selection(
+            tool.Ifc, tool.Blender, tool.Root, tool.Spatial, name=self.name, value=value
+        )
+        self.report({"INFO"}, f"Attribute was successfully copied to {total} elements.")
 
 
 class UpdateBoundaryGeometry(bpy.types.Operator, tool.Ifc.Operator):

--- a/src/bonsai/bonsai/bim/module/boundary/ui.py
+++ b/src/bonsai/bonsai/bim/module/boundary/ui.py
@@ -77,10 +77,14 @@ class BIM_PT_Boundary(Panel):
             self.draw_relation_editor(boundary, "RelatedBuildingElement", "related_building_element")
             self.draw_relation_editor(boundary, "ParentBoundary", "parent_boundary")
             self.draw_relation_editor(boundary, "CorrespondingBoundary", "corresponding_boundary")
-            row = self.layout.row()
+            row = self.layout.row(align=True)
             row.prop(self.bprops, "physical_or_virtual")
-            row = self.layout.row()
+            op = row.operator("bim.copy_boundary_attribute_to_selection", text="", icon="COPYDOWN")
+            op.name = "PhysicalOrVirtualBoundary"
+            row = self.layout.row(align=True)
             row.prop(self.bprops, "internal_or_external")
+            op = row.operator("bim.copy_boundary_attribute_to_selection", text="", icon="COPYDOWN")
+            op.name = "InternalOrExternalBoundary"
         else:
             row = self.layout.row()
             row.operator("bim.enable_editing_boundary", icon="GREASEPENCIL", text="Edit")
@@ -125,6 +129,8 @@ class BIM_PT_Boundary(Panel):
         if hasattr(boundary, ifc_attribute):
             row = self.layout.row(align=True)
             row.prop(self.bprops, blender_property)
+            op = row.operator("bim.copy_boundary_attribute_to_selection", text="", icon="COPYDOWN")
+            op.name = ifc_attribute
 
 
 class BIM_PT_SpaceBoundaries(Panel):

--- a/src/bonsai/bonsai/core/attribute.py
+++ b/src/bonsai/bonsai/core/attribute.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
 
@@ -31,7 +31,7 @@ def copy_attribute_to_selection(
     root: type[tool.Root],
     spatial: type[tool.Spatial],
     name: str,
-    value: Union[str, None],
+    value: Any,
 ) -> int:
     total_changed = 0
     has_edited_spatial_name = False


### PR DESCRIPTION
## Summary

This PR adds a "Copy Attribute To Selection" paste button (the same `COPYDOWN` icon button used for basic element attributes) to `IfcRelSpaceBoundary` specific attributes in the Space Boundary editing panel:

- `RelatingSpace`
- `RelatedBuildingElement`
- `ParentBoundary`
- `CorrespondingBoundary`
- `PhysicalOrVirtualBoundary`
- `InternalOrExternalBoundary`

When clicked, the attribute value of the active boundary is copied to all other selected `IfcRelSpaceBoundary` objects.

## Implementation

The existing `bonsai.core.attribute.copy_attribute_to_selection` function is **reused** as-is. A new `CopyBoundaryAttributeToSelection` operator (`bim.copy_boundary_attribute_to_selection`) reads the value from the active boundary `BIMObjectBoundaryProps` and delegates to the core function, which applies it via `ifc.run("attribute.edit_attributes", ...)` to each selected object.

- For relation attributes (`RelatingSpace`, `RelatedBuildingElement`, `ParentBoundary`, `CorrespondingBoundary`), the Blender object pointer is resolved to its IFC entity before being passed as the value.
- For enum attributes (`PhysicalOrVirtualBoundary`, `InternalOrExternalBoundary`), the string value is passed directly.

## Review request

**@Moult — please review especially the change in `src/bonsai/bonsai/core/attribute.py`.**

The only modification to the core file is broadening the `value` parameter type hint from `Union[str, None]` to `Any`. This is required because boundary relation attributes pass IFC entity instances (not strings) through the existing function. The runtime behavior is unchanged — `attribute.edit_attributes` already handles arbitrary attribute values via `setattr`.

## Files changed

- `src/bonsai/bonsai/core/attribute.py` — type hint `Union[str, None]` → `Any`
- `src/bonsai/bonsai/bim/module/boundary/operator.py` — new `CopyBoundaryAttributeToSelection` operator
- `src/bonsai/bonsai/bim/module/boundary/ui.py` — `COPYDOWN` buttons added to editing UI
- `src/bonsai/bonsai/bim/module/boundary/__init__.py` — operator registered

## Testing

- Ruff: passes
- Existing `test/core/test_attribute.py` (4 tests): all pass

Generated with the assistance of an AI coding tool.