### PR TITLE
bonsai: don't rebind Save target during Advanced-mode import preview (#8611)

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1141,8 +1141,18 @@ class LoadProject(bpy.types.Operator, IFCFileSelector, ImportHelper):
             if not self.is_advanced and not self.should_start_fresh_session:
                 bpy.ops.bim.convert_to_blender()
 
+            # #8611: In Advanced mode the picked file is parsed here only to populate the
+            # preview/filter UI (element counts, decomposition tree, class/type lists).
+            # tool.Ifc.set_path() also rebinds the Save target (bim_props.ifc_file) to it,
+            # which must NOT happen until the user actually commits by clicking
+            # "Load Project Elements". Remember the current Save target so it can be
+            # restored below for the (uncommitted) Advanced preview.
+            bim_props = tool.Blender.get_bim_props()
+            previous_ifc_file = bim_props.ifc_file
             tool.Ifc.set_path(filepath)
             if not tool.Ifc.get():
+                # Preview parse failed: leave the Save target as it was.
+                bim_props.ifc_file = previous_ifc_file
                 self.report(
                     {"ERROR"},
                     f"Error loading IFC file from filepath '{filepath}'. See logs above in the system console for the details.",
@@ -1155,9 +1165,13 @@ class LoadProject(bpy.types.Operator, IFCFileSelector, ImportHelper):
                     "load it via Project Setup → Project Library → Select Library File instead.",
                 )
                 IfcStore.purge()
+                # Load aborted: don't leave the Save target rebound to this file.
+                bim_props.ifc_file = previous_ifc_file
                 return {"CANCELLED"}
             props = tool.Project.get_project_props()
             props.is_loading = True
+            # Clear any stale pending-preview path from an earlier, abandoned Advanced load.
+            props.advanced_load_filepath = ""
             props.total_elements = len(tool.Ifc.get().by_type("IfcElement"))
             props.use_relative_project_path = self.use_relative_path
 
@@ -1169,7 +1183,12 @@ class LoadProject(bpy.types.Operator, IFCFileSelector, ImportHelper):
                 tool.Project.add_recent_ifc_project(self.get_filepath_abs())
 
             if self.is_advanced:
-                pass
+                # #8611: This is only a preview so the filter UI can be reviewed. Roll back
+                # the Save-target rebind done by set_path() above and stash the file path;
+                # LoadProjectElements commits the Save target for real once the user clicks
+                # "Load Project Elements".
+                bim_props.ifc_file = previous_ifc_file
+                props.advanced_load_filepath = str(filepath)
             elif len(tool.Ifc.get().by_type("IfcElement")) > 30000:
                 self.report({"WARNING"}, "Warning: large model. Please review advanced settings to continue.")
             else:
@@ -1249,7 +1268,16 @@ class LoadProjectElements(bpy.types.Operator):
             level=logging.DEBUG,
         )
         props = tool.Blender.get_bim_props()
-        settings = import_ifc.IfcImportSettings.factory(context, props.ifc_file, logger)
+        # #8611: Advanced import defers binding the Save target until this real commit
+        # point. If a preview is pending, bind the Save target to the previewed file now
+        # (clicking "Load Project Elements" is the user's explicit commitment) and use it
+        # as the import source. For every other caller advanced_load_filepath is empty and
+        # the already-bound props.ifc_file is used, exactly as before.
+        pending_filepath = self.props.advanced_load_filepath
+        if pending_filepath:
+            self.props.advanced_load_filepath = ""
+            tool.Ifc.set_path(pending_filepath)
+        settings = import_ifc.IfcImportSettings.factory(context, pending_filepath or props.ifc_file, logger)
         settings.has_filter = self.props.filter_mode != "NONE"
         settings.should_filter_spatial_elements = self.props.should_filter_spatial_elements
         if self.props.filter_mode == "DECOMPOSITION":

--- a/src/bonsai/bonsai/bim/module/project/prop.py
+++ b/src/bonsai/bonsai/bim/module/project/prop.py
@@ -327,6 +327,15 @@ class PendingArrayRepair(PropertyGroup):
 class BIMProjectProperties(PropertyGroup):
     is_editing: BoolProperty(name="Is Editing", default=False)
     is_loading: BoolProperty(name="Is Loading", default=False)
+    advanced_load_filepath: StringProperty(
+        name="Advanced Load Pending Filepath",
+        description=(
+            "Transient path of the file being previewed in Advanced import mode. The Save target is deliberately "
+            "left unchanged while this is set, and is only committed to this path once the user clicks "
+            '"Load Project Elements" (see #8611)'
+        ),
+        options={"SKIP_SAVE"},
+    )
     mvd: StringProperty(name="MVD")
     author_name: StringProperty(name="Author")
     author_email: StringProperty(name="Author Email")
@@ -532,6 +541,7 @@ class BIMProjectProperties(PropertyGroup):
     if TYPE_CHECKING:
         is_editing: bool
         is_loading: bool
+        advanced_load_filepath: str
         mvd: str
         author_name: str
         author_email: str


### PR DESCRIPTION
Fixes #8611.

## Root cause

`LoadProject.finish_loading_project()` calls `tool.Ifc.set_path(filepath)` unconditionally to parse the picked file for the Advanced-mode preview UI (element counts, decomposition tree, filters). `set_path()` also rebinds `bim_props.ifc_file`, which is the path `File > Save` writes to — so the Save target silently switched to the newly-picked file the instant it was parsed for preview, before the user had committed to loading anything by clicking "Load Project Elements". Nothing visibly changes in the viewport at that point, so a Save then silently overwrites the picked file with unrelated data. This is the exact scenario in the report.

## Fix

Scoped strictly to the `is_advanced=True` branch:

- The current Save target is captured before the preview parse, and restored right after it (and on error/abort paths), so the preview no longer changes what Save writes to.
- The picked path is stashed in a new transient prop, `BIMProjectProperties.advanced_load_filepath`.
- `LoadProjectElements` (the actual "Load Project Elements" click, i.e. real commitment) only then binds the Save target for real, using the stashed path if present.
- Every other caller of `bim.load_project` (Open IFC Project, recent-projects list, drag-and-drop, autosave recovery, BCF/document/GIS-triggered loads, plain non-advanced import) never sets `is_advanced=True`, so the stash is always empty for them and their behavior is unchanged.

## Verification

Live-tested in headless Blender (5.2):
- Reported scenario (fresh session, Advanced mode, pick file, don't click "Load Project Elements"): Save target no longer changes.
- Legitimate Advanced-mode load (pick file, click "Load Project Elements"): elements import correctly and the Save target now binds at that commit point.
- Non-advanced import: unaffected, Save target binds immediately as before.
- "Open IFC Project" (non-advanced): unaffected.
- `use_relative_path` flow: unaffected.
- Negative control against the unpatched code reproduces the bug, confirming the test actually catches it.

`black --check --diff .` and `ruff check .` both pass on the changed files.

## Scope note

This fixes the reported scenario, which is always a fresh session (the default). I'm leaving a comment with a related edge case in a non-default combination that's worth a maintainer's eyes but is out of scope for this PR.

Generated with the assistance of an AI coding tool.