### PR TITLE
bonsai: reveal hidden collections when selecting objects by material (#4050)

### DIFF
--- a/src/bonsai/bonsai/core/material.py
+++ b/src/bonsai/bonsai/core/material.py
@@ -84,7 +84,10 @@ def disable_editing_materials(material: type[tool.Material]) -> None:
 def select_by_material(
     material_tool: type[tool.Material], spatial: type[tool.Spatial], material: ifcopenshell.entity_instance
 ) -> None:
-    spatial.select_products(material_tool.get_elements_by_material(material))
+    # `unhide=True` so that objects whose only remaining reference is on a type
+    # (or another collection hidden from the viewport by default) are actually
+    # revealed and selected, instead of silently doing nothing. See #4050.
+    spatial.select_products(material_tool.get_elements_by_material(material), unhide=True)
 
 
 def enable_editing_material(material_tool: type[tool.Material], material: ifcopenshell.entity_instance) -> None:

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -224,6 +224,15 @@ class Spatial(bonsai.core.tool.Spatial):
             if obj and view_layer.objects.get(obj.name):
                 if unhide:
                     obj.hide_set(False)
+                    # `obj.hide_set` only clears the object's own hide flag. If the
+                    # object lives in a collection that's hidden from the viewport
+                    # by default (e.g. "IfcTypeProduct", "IfcStructuralItem",
+                    # "Unsorted", "IfcAnnotation*" - see
+                    # Collector.set_layer_collection_visibility), it still won't
+                    # show up as selected, so also reveal its collection(s).
+                    for collection in obj.users_collection:
+                        if layer_collection := tool.Blender.get_layer_collection(collection):
+                            layer_collection.hide_viewport = False
                 obj.select_set(True)
 
     @classmethod


### PR DESCRIPTION
Fixes #4050.

## Root cause

`select_by_material()` already resolves objects still referencing a material correctly, including through `IfcTypeObject`, layers, profiles and constituents (`ifcopenshell.util.element.get_elements_by_material`). But `select_products()`'s `unhide=True` handling only cleared the target object's own `hide` flag, never the visibility of its containing collection. Bonsai hides the `IfcTypeProduct`, `IfcStructuralItem`, `Unsorted` and `IfcAnnotation*` collections from the viewport by default. So when a material's last remaining reference was on a type object (the common case: as instances get deleted one by one, the type's own material association is what's left), the operator selected the object internally, reported `FINISHED`, but nothing became visible and nothing appeared in `context.selected_objects` — exactly matching the report of not being able to find the last object a material is tied to.

## Fix

- `tool.Spatial.select_products(..., unhide=True)` now also unhides the object's containing `LayerCollection`(s), via the existing `tool.Blender.get_layer_collection()` helper.
- `select_by_material()` now opts into `unhide=True`, matching how other callers of `select_products` (e.g. clash/system operators) already use this parameter for the same purpose.

## Verification

Live-tested in headless Blender (5.2): a material whose only remaining reference is on an `IfcTypeObject` is now correctly selected and revealed (0 visible objects selected before the fix, correctly selected and revealed after). A material referenced by a normal, already-visible instance is unaffected.

`black --check --diff .` and `ruff check .` both pass on the changed files.

## Scope note

The issue's second half — a "hard remove" that force-deletes a material and reassigns its references to a default/chosen replacement — is a separate, self-labeled feature request with no maintainer commitment (design questions around what happens to psets/styles on the replaced material are unresolved). Not addressed here; this PR only fixes the discoverability bug that was actually blocking the reporter.

Generated with the assistance of an AI coding tool.