### PR TITLE
bonsai: add opt-in exact-geometry hidden line removal for smoother SVG curves (#4067)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1316,7 +1316,7 @@ class CreateDrawing(bpy.types.Operator):
         )
         self.serialiser.setWithoutStoreys(True)
         self.serialiser.setPolygonal(True)
-        self.serialiser.setUseHlrPoly(True)
+        self.serialiser.setUseHlrPoly(self.props.should_use_hlr_poly)
         # Objects with more than these edges are rendered as wireframe instead of HLR for optimisation
         self.serialiser.setProfileThreshold(10000)
         self.serialiser.setUseNamespace(True)

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -432,12 +432,26 @@ class DocProperties(PropertyGroup):
     active_sheet_index: IntProperty(name="Active Sheet Index")
     drawing_styles: CollectionProperty(name="Drawing Styles", type=DrawingStyle)
     should_draw_decorations: BoolProperty(name="Should Draw Decorations", update=update_should_draw_decorations)
+    should_use_hlr_poly: BoolProperty(
+        name="Use Polygonal Hidden Line Removal",
+        description=(
+            "Compute hidden line removal on a coarsely faceted mesh, which is fast and reliable but renders "
+            "circles, arcs, and other curves as choppy straight-edged polygons.\n\n"
+            "Disable this to run hidden line removal on the exact curved geometry instead, producing smoother "
+            "round elements in the SVG. This is slower and more experimental (e.g. on very large or complex "
+            "models), so it is recommended to only disable this if you notice choppy curves in your drawings.\n\n"
+            "Global option for all drawings."
+        ),
+        default=True,
+        options=set(),
+    )
 
     if TYPE_CHECKING:
         should_use_underlay_cache: bool
         should_use_linework_cache: bool
         should_use_annotation_cache: bool
         should_draw_linked_projects: bool
+        should_use_hlr_poly: bool
         is_editing_drawings: bool
         is_editing_schedules: bool
         is_editing_references: bool

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -93,6 +93,9 @@ class BIM_PT_camera(Panel):
                 else:
                     panel.label(text="No IFC projects linked and loaded.")
 
+        row = col.row(align=True)
+        row.prop(dprops, "should_use_hlr_poly")
+
         row = self.layout.row(align=True)
         row.prop(props, "target_view")
 


### PR DESCRIPTION
Refs #4067.

## Root cause

Bonsai hardcodes `CreateDrawing.setUseHlrPoly(True)`, always routing curved silhouettes through OpenCascade's `HLRBRep_PolyAlgo`. That Poly-HLR path facets the shape via `BRepMesh_IncrementalMesh` with a **hardcoded, non-configurable 0.10 deflection tolerance** before removing hidden lines, completely independent of any Python-exposed setting. That's why the deflection-tolerance workaround suggested earlier in this thread (`settings.set("mesher-linear-deflection", ...)`) had zero effect under the default: the value is silently ignored by the Poly HLR path.

The exact-BRep path (`HLRBRep_Algo`, enabled via `setUseHlrPoly(False)`) preserves the true curved surface through hidden line removal, and its resulting curve tessellation for SVG output *is* governed by the configurable deflection setting.

## Verification

Tested on a synthetic circular column, both via the raw serializer engine and end-to-end through the real `bim.create_drawing` operator in headless Blender (5.2):

| Setting | Silhouette | Effect of finer deflection tolerance |
|---|---|---|
| `hlr_poly=True` (current default) | 26-segment coarse polygon | None — ignored (52→52 points at 500x finer tolerance) |
| `hlr_poly=False` | Smooth 39-40 point curve | Fully effective (40→123 points at 10x finer tolerance) |

Both modes produced valid drawings, and the shapely/svgfill fill pipeline (the stated reason for defaulting to Poly HLR) succeeded identically in both for this shape.

## Change

Shipped as a new **opt-in toggle** (`DocProperties.should_use_hlr_poly`, default `True`, no behavior change for existing users) rather than flipping the global default — only a single simple shape (a circular column) was validated here. Door arcs, boolean-subtracted curved openings, and large-model HLR performance with the exact-BRep path are untested, so a default-behavior change isn't warranted yet. A maintainer can graduate this to a default change later if broader testing confirms no regressions.

`black --check --diff .` and `ruff check .` pass on the changed files.

Generated with the assistance of an AI coding tool.