### PR TITLE
ifcopenshell: use a resource's work calendar for day-rate cost conversion (#4122)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/cost/calculate_cost_item_resource_value.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cost/calculate_cost_item_resource_value.py
@@ -18,6 +18,7 @@
 
 import ifcopenshell.api.cost
 import ifcopenshell.util.resource
+import ifcopenshell.util.sequence
 
 
 def calculate_cost_item_resource_value(file: ifcopenshell.file, cost_item: ifcopenshell.entity_instance) -> None:
@@ -105,7 +106,11 @@ def calculate_cost_item_resource_value(file: ifcopenshell.file, cost_item: ifcop
         if cost is None:
             continue
         if unit and "day" in unit:
-            quantity = quantity / 8  # Assume 8 hour working day - TODO implement resource calendar
+            calendar = ifcopenshell.util.resource.get_calendar(resource)
+            hours_in_day = ifcopenshell.util.sequence.get_hours_in_day(calendar)
+            # Fall back to an 8 hour working day if the resource (or its
+            # parent resource / task) has no calendar with defined working hours.
+            quantity = quantity / (hours_in_day or 8)
         formula = "{}*{}".format(cost, quantity)
         cost_value = ifcopenshell.api.cost.add_cost_value(file, parent=cost_item)
         cost_value.Name = resource.Name

--- a/src/ifcopenshell-python/ifcopenshell/util/resource.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/resource.py
@@ -21,6 +21,7 @@ from typing import Any, Union
 import ifcopenshell.util.cost
 import ifcopenshell.util.date
 import ifcopenshell.util.element
+import ifcopenshell.util.sequence
 
 PRODUCTIVITY_PSET_DATA = Union[dict[str, Any], None]
 # https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcConstructionResource.htm#Table-7.3.3.7.1.3.H
@@ -169,3 +170,26 @@ def get_parent_cost(resource: ifcopenshell.entity_instance) -> Union[tuple[Union
     else:
         cost = get_cost(nests[0].RelatingObject)
         return cost
+
+
+def get_calendar(resource: ifcopenshell.entity_instance) -> Union[ifcopenshell.entity_instance, None]:
+    """Get the IfcWorkCalendar that applies to a resource, if any.
+
+    A resource may have a calendar assigned to it directly. If not, the
+    calendar is inherited from its parent (nested) resource, or from a task
+    the resource is assigned to do work on.
+
+    :param resource: The IfcConstructionResource to inspect.
+    :return: The applicable IfcWorkCalendar, or None if none is assigned.
+    """
+    calendar = ifcopenshell.util.sequence.get_calendar(resource)
+    if calendar:
+        return calendar
+    if resource.Nests:
+        calendar = get_calendar(resource.Nests[0].RelatingObject)
+        if calendar:
+            return calendar
+    task = get_task_assignments(resource)
+    if task:
+        return ifcopenshell.util.sequence.derive_calendar(task)
+    return None

--- a/src/ifcopenshell-python/ifcopenshell/util/sequence.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/sequence.py
@@ -93,6 +93,45 @@ def get_calendar(task: ifcopenshell.entity_instance) -> Union[ifcopenshell.entit
         return calendar[0]
 
 
+def get_hours_in_day(calendar: Union[ifcopenshell.entity_instance, None]) -> Union[float, None]:
+    """Calculates the number of working hours in a typical working day of a calendar.
+
+    This is derived from the IfcTimePeriod's assigned to the recurrence
+    patterns of the calendar's working times (e.g. 9am-12pm and 1pm-5pm would
+    be 7 hours, accounting for a 1 hour lunch break). If a calendar defines
+    multiple different working time patterns (e.g. a full weekday and a
+    shorter Saturday), the longest is returned as the "typical" day.
+
+    :param calendar: The IfcWorkCalendar to inspect. May be None.
+    :return: The total hours in a typical working day, or None if it cannot
+        be derived (e.g. no calendar, or the calendar only defines which days
+        are working days without specifying the hours within them).
+    """
+    if not calendar or not calendar.WorkingTimes:
+        return None
+    hours_in_day = None
+    for work_time in calendar.WorkingTimes:
+        recurrence_pattern = work_time.RecurrencePattern
+        if not recurrence_pattern or not recurrence_pattern.TimePeriods:
+            continue
+        day_hours = 0.0
+        for time_period in recurrence_pattern.TimePeriods:
+            if not time_period.StartTime or not time_period.EndTime:
+                continue
+            start = ifcopenshell.util.date.ifc2datetime(time_period.StartTime)
+            end = ifcopenshell.util.date.ifc2datetime(time_period.EndTime)
+            seconds = (
+                datetime.datetime.combine(datetime.date.min, end) - datetime.datetime.combine(datetime.date.min, start)
+            ).total_seconds()
+            if seconds < 0:
+                # An overnight time period (e.g. a night shift crossing midnight)
+                seconds += 24 * 60 * 60
+            day_hours += seconds / 3600
+        if day_hours:
+            hours_in_day = max(hours_in_day or 0.0, day_hours)
+    return hours_in_day
+
+
 def count_working_days(start, finish, calendar: ifcopenshell.entity_instance) -> int:
     result = 0
     if start == finish:


### PR DESCRIPTION
Fixes #4122.

## Root cause

`calculate_cost_item_resource_value()` converted a day-rate quantity to hours with a hardcoded `quantity / 8`, commented `# Assume 8 hour working day - TODO implement resource calendar`. This produces silently wrong costs whenever a resource's actual calendar has a different working-day length. In the reported case, 24 man-hours against the 8-hour assumption collapsed to "1 day" instead of 3, so the cost calculation was off by 3x.

## Fix

- `ifcopenshell.util.resource.get_calendar(resource)`: resolves a resource's applicable `IfcWorkCalendar` — its own direct assignment, else its parent (nested) resource, else the task it's assigned to work on — reusing the existing `IfcWorkCalendar`/`derive_calendar` infrastructure already used by the sequence module (this data model and UI already existed, it just wasn't consulted from the cost module).
- `ifcopenshell.util.sequence.get_hours_in_day(calendar)`: sums a calendar's actual `IfcWorkTime`/`IfcTimePeriod` working hours, handling multi-period days (e.g. a lunch break) and overnight periods, returning the longest defined pattern as the "typical" day.
- The day-rate conversion now divides by the resource's real hours-in-a-day when calendar data is available, falling back to the documented 8-hour default only when it isn't — resources without a calendar behave exactly as before.

## Verification

Live-tested in headless Blender (5.2):
- No calendar assigned, 24 hours, €35/day → €105 (unchanged fallback behavior).
- Same resource with a directly-assigned 6-hour-day calendar → €140 (correct, using the real calendar).
- A calendar with a 9-12 + 13-17 lunch-break pattern correctly computes 7.0 hours/day.
- A resource with no direct calendar but assigned to a task that has one correctly inherits the task's calendar.

`black --check --diff .` and `ruff check .` pass on the changed files.

## Known remaining gap (not addressed here)

There's still no dedicated Bonsai UI to assign a calendar directly to a *resource* (only tasks have that UI today). `get_calendar()` reads the underlying IFC relationship generically, so it already works transparently for resources assigned to a task with a calendar, and is ready for a future UI addition — a resource with neither a direct calendar nor a calendared task still falls back to 8 hours by design, not a bug.

Generated with the assistance of an AI coding tool.