### PR TITLE
bonsai: don't silently corrupt geometry on a reverse-direction profile join (#4360)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -579,6 +579,19 @@ class DumbProfileJoiner:
 
         intersect, _ = tool.Cad.intersect_edges(axis1, axis2)
 
+        # `intersect` is where profile1's centerline crosses profile2's centerline,
+        # extended infinitely in both directions. If that crossing point doesn't
+        # actually fall within profile2's own bounded length, profile2 doesn't
+        # physically reach profile1 (e.g. the two elements were joined in the
+        # opposite of their physically intended direction, such as pressing
+        # Shift+E with the "through" member active instead of the "crossing"
+        # member). Trimming profile1's body against profile2's face plane in that
+        # case would silently displace profile1's mesh to a location inconsistent
+        # with its own axis representation. Bail out instead of producing that
+        # broken geometry.
+        if not (0 - 0.001 <= tool.Cad.edge_percent(intersect, axis2) <= 1 + 0.001):
+            return False
+
         proposed_axis = [self.axis[0], intersect] if connection1 == "ATEND" else [intersect, self.axis[1]]
 
         if tool.Cad.is_x(tool.Cad.angle_edges(self.axis, proposed_axis, degrees=True), 180):


### PR DESCRIPTION
Fixes #4360.

## Root cause

`DumbProfileJoiner.join()` (used by Shift+E's Extend tool when two profile-based elements — e.g. slabs, beams, columns — are selected together) computes the axis-line trim point from the true centerline intersection of the two profiles, but trims the visible body/mesh against an *infinite* face-plane of the other profile, with no check that the other profile's centerline actually reaches that intersection within its own bounded length. Selecting two elements in the "wrong" active/non-active order (e.g. via ordinary multi-select, independent of how they're physically joined) triggers this: the join silently succeeds but displaces the trimmed element's mesh to a location inconsistent with its own axis, corrupting the geometry with no warning.

## Fix

After computing the centerline intersection, bail out (`return False`, matching the existing precedent for an invalid axis flip one line below) if that intersection point doesn't fall within the other profile's own bounded segment. This turns the previously-corrupting reverse-direction join into a safe no-op, leaving valid joins untouched.

## Verification

Live-tested with the reporter's own attached repro file:
- A single-object extend to cursor still works correctly.
- The file's existing correct-direction T-join remains idempotent (no regression).
- The reverse-direction join that previously shifted the slab's mesh by -2.415m off its own axis now leaves the geometry byte-for-byte unchanged instead of corrupting it — confirmed both by calling the joiner directly and by driving the real Shift+E hotkey operator with both elements selected.

`black --check --diff .` and `ruff check .` pass on the changed file.

Generated with the assistance of an AI coding tool.