### PR TITLE
bonsai: surface IFC-aware join in the object/right-click context menu (#4349)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/ui.py
+++ b/src/bonsai/bonsai/bim/module/geometry/ui.py
@@ -63,6 +63,7 @@ def mode_menu(self, context):
 def object_menu(self, context):
     self.layout.separator()
     self.layout.operator("bim.override_object_duplicate_move", icon="PLUGIN")
+    self.layout.operator("bim.override_object_join", icon="PLUGIN")
     self.layout.operator("bim.override_object_delete", icon="PLUGIN")
     self.layout.operator("bim.override_paste_buffer", icon="PLUGIN")
     self.layout.menu("BIM_MT_object_set_origin", icon="PLUGIN")


### PR DESCRIPTION
Fixes #4349.

## Root cause

`bim.override_object_join` ("IFC Join") already exists and correctly keeps the Blender mesh join in sync with the IFC representation, and Ctrl+J is already bound to it by default. But Bonsai's appended object-menu block (drawn into both `VIEW3D_MT_object` and `VIEW3D_MT_object_context_menu`) never included it, so anyone joining via the right-click context menu instead of the Ctrl+J shortcut falls through to Blender's native, non-IFC-aware `object.join` — which is hardcoded into Blender's own menu scripts and can't be removed, only appended after. That native join leaves the IFC representation stale, producing the confusing "needs a manual Save Representation step" state the issue describes. It also requires enabling Developer Extras and searching via F3 to find the IFC-aware operator at all.

## Fix

Add `bim.override_object_join` to the existing appended object menu, right alongside the other IFC-aware override operators (duplicate, delete) that are already there. This surfaces it in both the Object menu and the right-click context menu without needing Developer Extras.

## Verification

Live-tested in headless Blender (5.2): the operator is now present in both menus, and exercising it end-to-end on two IFC objects confirms the join updates the first object's IFC `Representation` in the same call — no separate manual save-representation step needed.

`black --check --diff .` and `ruff check .` pass on the changed file.

Generated with the assistance of an AI coding tool.