### PR TITLE
ifcopenshell: don't merge distinct splines through a mesh round-trip when writing curves (#5268)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/add_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/add_representation.py
@@ -551,6 +551,21 @@ class Usecase:
                     return self.create_curves_from_mesh_ifc2x3(should_exclude_faces=should_exclude_faces, is_2d=is_2d)
                 return self.create_curves_from_mesh(should_exclude_faces=should_exclude_faces, is_2d=is_2d)
 
+        # Polyline-only curves (ie. no bezier splines needing flattening into line
+        # segments) can be converted directly, spline by spline, without going
+        # through a mesh round-trip. Routing them through the mesh round-trip below
+        # is not only unnecessary, it is actively destructive: remove_doubles_from_mesh
+        # merges vertices by distance regardless of which spline they belong to, so
+        # multiple splines that legitimately share a point (eg. several leader arrows
+        # fanning out from the same origin) get welded into a single branching vertex.
+        # Converting that back into a curve then arbitrarily re-chains the edges into
+        # a different, wrong set of splines (eg. two arrows get merged into one zigzag
+        # spline while losing the shared origin as each spline's start point). See #5268.
+        if isinstance(geom_data, bpy.types.Curve) and not any(spline.type == "BEZIER" for spline in geom_data.splines):
+            if self.file.schema == "IFC2X3":
+                return self.create_curves_from_curve_ifc2x3(is_2d=is_2d, curve_object_data=geom_data)
+            return self.create_curves_from_curve(is_2d=is_2d, curve_object_data=geom_data)
+
         import bonsai.tool as tool
 
         selected_objects = bpy.context.selected_objects


### PR DESCRIPTION
Fixes #5268.

## Root cause

`create_curves()` in the `geometry.add_representation` API routes every Blender curve object through a destructive "convert to mesh → `bmesh.ops.remove_doubles` (0.0001 threshold) → convert back to curve" round trip before writing the `IfcGeometricCurveSet`. `remove_doubles` welds vertices by distance with no regard for which spline they belong to, so a multi-arrow leader whose splines legitimately share one anchor point gets that anchor merged into a single branching mesh vertex. Converting that branching mesh back into a curve then arbitrarily re-chains the edges into a different, wrong set of splines — two arrows get fused into one zigzag spline, and the shared anchor lands mid-spline instead of at each spline's start point, exactly matching the reported before/after-reopen screenshots. Single-arrow leaders never trip this since there's only one spline and nothing to merge, which is why they "work fine".

## Fix

When a curve's splines are all `POLY` (no bezier flattening needed), convert each spline directly via the existing `create_curves_from_curve()`/`create_curves_from_curve_ifc2x3()` helpers instead of routing through the destructive mesh round-trip. Scoped, additive change — no other curve-authoring paths touched.

## Verification

Verified live via an actual save-then-reopen round trip (two separate Blender processes) using the real Bonsai leader-authoring operators: before the fix, 3 authored arrow splines collapsed to 2 curves (one zigzag) on save, and the reconstructed anchor landed at the wrong point on reopen. After the fix, all 3 splines survive the save intact and reopening reconstructs the exact original structure with the correct anchor. Also verified against the reporter's own attached repro file (`leader.with.multiple.arrows.ifc`).

`black --check --diff .` and `ruff check .` pass on the changed file.

Generated with the assistance of an AI coding tool.