### PR TITLE
bonsai: strip CSS comments before embedding into generated SVG (#5567)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/scheduler.py
+++ b/src/bonsai/bonsai/bim/module/drawing/scheduler.py
@@ -32,7 +32,7 @@ from odf.table import Table, TableCell, TableColumn, TableRow
 from odf.text import P
 
 import bonsai.tool as tool
-from bonsai.bim.module.drawing.svgwriter import SvgWriter
+from bonsai.bim.module.drawing.svgwriter import SvgWriter, strip_css_comments
 
 DEBUG = False
 
@@ -83,7 +83,7 @@ class Scheduler:
             if not os.path.exists(stylesheet_path):
                 stylesheet_path = tool.Blender.get_data_dir_path(Path("assets") / "schedule.css")
         with open(stylesheet_path, "r") as stylesheet:
-            css = stylesheet.read()
+            css = strip_css_comments(stylesheet.read())
 
         matches = re.search(r"--font-size-pt:\s*([0-9.]+);", css)
         self.font_size_pt = float(matches.groups()[0]) if matches else 12  # Default to 12pt

--- a/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
@@ -18,6 +18,7 @@
 
 import math
 import os
+import re
 import shutil
 import xml.etree.ElementTree as ET
 from collections.abc import Callable, Sequence
@@ -41,6 +42,17 @@ from mathutils import Vector, geometry
 import bonsai.bim.module.drawing.helper as helper
 import bonsai.tool as tool
 from bonsai.bim.module.drawing.data import DecoratorData, DrawingsData
+
+
+def strip_css_comments(css: str) -> str:
+    """Strip `/* ... */` comments from CSS text before it's embedded into an SVG.
+
+    Some SVG consumers (e.g. Inkscape, see
+    https://gitlab.com/inkscape/inbox/-/issues/11113) crash when parsing CSS
+    comments inside an embedded `<style>` block, so comments are removed
+    before the CSS is written out.
+    """
+    return re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
 
 
 class External(svgwrite.container.Group):
@@ -286,7 +298,7 @@ class SvgWriter:
                 print(f"WARNING. Couldn't find stylesheet for the drawing by the path: {path}")
                 continue
             with open(path, "r") as stylesheet:
-                self.svg.defs.add(self.svg.style(stylesheet.read()))
+                self.svg.defs.add(self.svg.style(strip_css_comments(stylesheet.read())))
 
     def add_markers(self):
         path = self.resource_paths["Markers"]


### PR DESCRIPTION
Fixes #5567.

## Root cause

Bonsai embeds raw, unprocessed CSS file contents into a generated drawing's SVG `<style>` block (both the main drawing stylesheet in `svgwriter.py`'s `add_stylesheet()`, and the schedule stylesheet in `scheduler.py`'s `parse_css()`). Bonsai's own shipped default stylesheets (`default.css`, `schedule.css`, `sample.css`) start with a GPL license-header comment and contain further inline comments, so this isn't only a problem for hand-customized CSS — every drawing exported with default settings embeds comment-laden CSS. Per the linked upstream Inkscape bug (https://gitlab.com/inkscape/inbox/-/issues/11113), some SVG consumers crash outright when parsing CSS comments inside an embedded `<style>` block.

## Fix

Added `strip_css_comments()` — a simple regex strip of `/* ... */` blocks, no new dependency, matching the existing regex-based CSS handling already used in `scheduler.py` — and call it at both embedding sites before the CSS text is written into the SVG.

## Verification

Live-tested: generated SVG output for both the main drawing stylesheet and the schedule stylesheet no longer contains any comment markers after the fix, while all actual CSS rules and the schedule's `--font-size-pt`/`--font-size-px`/`--font-width` custom properties are preserved and still parsed correctly. Output SVG parses as valid XML.

`black --check --diff .` and `ruff check .` pass on the changed files.

Generated with the assistance of an AI coding tool.