### PR TITLE
bonsai: give resources their own fixed cost value field instead of borrowing Cost Schedules' (#5088)

### DIFF
--- a/src/bonsai/bonsai/bim/module/resource/__init__.py
+++ b/src/bonsai/bonsai/bim/module/resource/__init__.py
@@ -22,6 +22,7 @@ from . import operator, prop, ui
 
 classes = (
     operator.AddResource,
+    operator.AddResourceCostValue,
     operator.AddResourceQuantity,
     operator.AddProductivityData,
     operator.AssignResource,

--- a/src/bonsai/bonsai/bim/module/resource/operator.py
+++ b/src/bonsai/bonsai/bim/module/resource/operator.py
@@ -216,6 +216,24 @@ class EnableEditingResourceCosts(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class AddResourceCostValue(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.add_resource_cost_value"
+    bl_label = "Add Resource Cost Value"
+    bl_options = {"REGISTER", "UNDO"}
+    parent: bpy.props.IntProperty()
+    cost_type: bpy.props.StringProperty()
+    cost_category: bpy.props.StringProperty()
+
+    def _execute(self, context):
+        core.add_resource_cost_value(
+            tool.Ifc,
+            tool.Resource,
+            parent=tool.Ifc.get().by_id(self.parent),
+            cost_type=self.cost_type,
+            cost_category=self.cost_category,
+        )
+
+
 class DisableEditingResourceCostValue(bpy.types.Operator):
     bl_idname = "bim.disable_editing_resource_cost_value"
     bl_label = "Disable Editing Resource Cost Value"

--- a/src/bonsai/bonsai/bim/module/resource/prop.py
+++ b/src/bonsai/bonsai/bim/module/resource/prop.py
@@ -146,6 +146,7 @@ class BIMResourceProperties(PropertyGroup):
         name="Cost Types",
     )
     cost_category: StringProperty(name="Cost Category")
+    fixed_cost_value: FloatProperty(name="Fixed Cost Value")
     active_cost_value_id: IntProperty(name="Active Resource Cost Value Id")
     cost_value_editing_type: StringProperty(name="Cost Value Editing Type")
     cost_value_attributes: CollectionProperty(name="Cost Value Attributes", type=Attribute)
@@ -169,6 +170,7 @@ class BIMResourceProperties(PropertyGroup):
         editing_resource_type: EditingResourceType
         cost_types: CostType
         cost_category: str
+        fixed_cost_value: float
         active_cost_value_id: int
         cost_value_editing_type: str
         cost_value_attributes: bpy.types.bpy_prop_collection_idprop[Attribute]

--- a/src/bonsai/bonsai/bim/module/resource/ui.py
+++ b/src/bonsai/bonsai/bim/module/resource/ui.py
@@ -290,9 +290,11 @@ class BIM_PT_resources(Panel):
     def draw_editable_resource_costs_ui(self) -> None:
         row = self.layout.row(align=True)
         row.prop(self.props, "cost_types", text="")
+        if self.props.cost_types == "FIXED":
+            row.prop(self.props, "fixed_cost_value", text="")
         if self.props.cost_types == "CATEGORY":
             row.prop(self.props, "cost_category", text="")
-        op = row.operator("bim.add_cost_value", text="", icon="ADD")
+        op = row.operator("bim.add_resource_cost_value", text="", icon="ADD")
         op.parent = self.props.active_resource_id
         op.cost_type = self.props.cost_types
         if self.props.cost_types == "CATEGORY":

--- a/src/bonsai/bonsai/core/resource.py
+++ b/src/bonsai/bonsai/core/resource.py
@@ -21,7 +21,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 if TYPE_CHECKING:
     import ifcopenshell
@@ -109,6 +109,21 @@ def calculate_resource_work(
 def enable_editing_resource_costs(resource_tool: type[tool.Resource], resource: ifcopenshell.entity_instance) -> None:
     resource_tool.enable_editing_resource_costs(resource)
     resource_tool.disable_editing_resource_cost_value()
+
+
+def add_resource_cost_value(
+    ifc: type[tool.Ifc],
+    resource_tool: type[tool.Resource],
+    parent: ifcopenshell.entity_instance,
+    cost_type: Literal["FIXED", "SUM", "CATEGORY"],
+    cost_category: Optional[str] = None,
+) -> None:
+    value = ifc.run("cost.add_cost_value", parent=parent)
+    ifc.run(
+        "cost.edit_cost_value",
+        cost_value=value,
+        attributes=resource_tool.get_attributes_for_cost_value(cost_type, cost_category),
+    )
 
 
 def disable_editing_resource_cost_value(resource_tool: type[tool.Resource]) -> None:

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -863,6 +863,7 @@ class Resource:
     def enable_editing_resource_time(cls, resource): pass
     def enable_editing_resource(cls, resource): pass
     def expand_resource(cls, resource): pass
+    def get_attributes_for_cost_value(cls, cost_type, cost_category): pass
     def get_constraints(cls, resource): pass
     def get_highlighted_resource(cls): pass
     def get_metric_reference(cls, metric, is_deep): pass

--- a/src/bonsai/bonsai/tool/resource.py
+++ b/src/bonsai/bonsai/tool/resource.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import json
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import bpy
 import ifcopenshell.api.pset
@@ -198,6 +198,22 @@ class Resource(bonsai.core.tool.Resource):
         props.active_cost_value_id = cost_value.id()
         props.cost_value_editing_type = "FORMULA"
         props.cost_value_formula = ifcopenshell.util.cost.serialise_cost_value(cost_value) if cost_value else ""
+
+    @classmethod
+    def get_attributes_for_cost_value(
+        cls, cost_type: Literal["FIXED", "SUM", "CATEGORY"], cost_category: Optional[str] = None
+    ) -> dict[str, Any]:
+        if cost_type == "FIXED":
+            category = None
+            props = cls.get_resource_props()
+            attributes = {"AppliedValue": props.fixed_cost_value}
+        elif cost_type == "SUM":
+            category = "*"
+            attributes = {"Category": category}
+        elif cost_type == "CATEGORY":
+            category = cost_category
+            attributes = {"Category": category}
+        return attributes
 
     @classmethod
     def load_cost_value_attributes(cls, cost_value: ifcopenshell.entity_instance):


### PR DESCRIPTION
Fixes #5088.

## Root cause

The Resources panel's "+" (add cost value) button reused the Cost Schedules module's shared operator (`bim.add_cost_value`), which reads its `FIXED` value from `tool.Cost.get_cost_props().fixed_cost_value` — a Scene property that belongs entirely to the Cost Schedules module. The Resources module never had its own `fixed_cost_value` field or an input widget to set it, so every "new" fixed cost value on a resource silently inherited whatever number was last left in the *unrelated* Cost Schedules panel (or a stale leftover from adding a previous resource's cost value) — not what the user just tried to set. The individual cost-value edit box itself was reading live data correctly; the bug was specifically in *creating* a value with the wrong hidden source, which made every subsequent view of that value look stale, prompting the delete-and-recreate workaround described in the issue.

Cost Schedules avoids this because its own UI shows a `fixed_cost_value` input field right next to the type selector before "Add Value," round-tripping through its own props consistently — Resources just never got the same treatment.

## Fix

Gave the Resource module its own copy of that pattern instead of borrowing Cost's: a resource-scoped `fixed_cost_value` property, a matching UI field shown when `cost_types == "FIXED"`, and a new `bim.add_resource_cost_value` operator/core function/tool method mirroring the existing Cost module implementation, reading the resource's own props instead of Cost's.

## Verification

Live-tested via real `bpy.ops` operator calls: with a stale value left in the Cost module's props (simulating prior use of Cost Schedules), adding a FIXED cost value to a fresh resource previously picked up that leaked value; after the fix it correctly uses the resource's own field, isolated from the Cost module. Also re-verified the existing edit/reopen flow still shows the correct current value with no regression.

`black --check --diff .` and `ruff check .` pass on all changed files.

## Scope note

The secondary ask (showing the cost value + unit directly in the resource summary list) wasn't included — it would need new per-row lookups across all resources' cost values plus formatting/unit-guessing UI work, not a small natural extension of this fix.

Generated with the assistance of an AI coding tool.