### PR TITLE
bonsai: fix IFC Set Origin silently doing nothing for most objects (#6205)

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -272,8 +272,14 @@ class OverrideOriginSet(bpy.types.Operator, tool.Ifc.Operator):
             representation = tool.Geometry.get_active_representation(obj)
             if not representation:
                 continue
-            representation = ifcopenshell.util.representation.resolve_representation(representation)
-            if not tool.Geometry.is_meshlike(representation):
+            # NOTE: previously this also required tool.Geometry.is_meshlike(representation),
+            # which excludes common representation types such as SweptSolid (e.g. a plain
+            # extruded profile with no material). That meant Origin Set silently did nothing
+            # for most simple, non-material-based objects (see #6205). update_representation()
+            # already safely no-ops (with an INFO report) for representations that are
+            # parametrically driven by a material profile/layer set, so it's not necessary to
+            # pre-filter by representation type here.
+            if not tool.Geometry.is_geometric_data(obj.data):
                 continue
             bpy.ops.object.origin_set(type=self.origin_type)
             bpy.ops.bim.update_representation(obj=obj.name)


### PR DESCRIPTION
Fixes #6205.

## Root cause

`OverrideOriginSet` ("IFC Set Origin") gated all work behind `tool.Geometry.is_meshlike(representation)`, an allowlist that does not include `"SweptSolid"` — the representation type of a plain extruded-profile object with no material, the most common case for simple proxies, beams and columns. For any such object the operator silently `continue`d without ever calling `bpy.ops.object.origin_set` or `bpy.ops.bim.update_representation`: no error, no report, a pure no-op. This matches both reports in the issue — a non-material object where the origin change didn't stick, and a user who couldn't get it to work at all, since `SweptSolid` covers most real elements. The described workaround (Discard Changes, toggle Should Save, return to Object Mode) works because that path reaches `update_representation` via a mesh-checksum diff, bypassing the `is_meshlike` gate entirely.

`update_representation()` already has its own correct, pre-existing safety net for representations parametrically driven by a material profile or layer set: it reports an `INFO` message and returns without touching the representation. So the `is_meshlike` pre-filter in `OverrideOriginSet` was redundant for that case and simply over-broad for everything else.

## Fix

Replaced the `is_meshlike(representation)` gate with `tool.Geometry.is_geometric_data(obj.data)` — only require that the object actually has editable mesh/curve data, the same check `update_representation` and `is_data_supported_for_adding_representation` already rely on elsewhere — and let `update_representation`'s existing material-parametric guard handle the case where a representation shouldn't be literally rewritten.

## Verification

Live-tested in headless Blender (5.2): a non-material `SweptSolid` object previously no-op'd entirely (Blender location unchanged, IFC `ObjectPlacement` unchanged) when running Origin Set directly, with no workaround. After the fix, the same call moves the origin and writes the new `ObjectPlacement` to IFC, confirmed by independently re-evaluating the shape and diffing against Blender's evaluated mesh — bounding boxes match to float precision, `RepresentationType` stays `SweptSolid`. A material-layer-set object still correctly triggers `update_representation`'s existing guard with no crash.

`black --check --diff .` and `ruff check .` pass on the changed file.

Generated with the assistance of an AI coding tool.