### PR TITLE
bonsai/ifcopenshell: fix mep bend crash when the segment gap is purely axial

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/mep.py
+++ b/src/bonsai/bonsai/bim/module/model/mep.py
@@ -1291,8 +1291,20 @@ class MEPAddBend(bpy.types.Operator, tool.Ifc.Operator):
         ref_point = end_point.copy()
         end_segment_dir = (second_segment_end - end_point).normalized()
         # we prioritize direction between end_point and start_point for bend_vector
-        # if those point match we use general end segment direction
-        if tool.Cad.is_x((end_point - start_point).length, 0):
+        # if those points match we use general end segment direction.
+        #
+        # We also fall back to the general end segment direction if start_point
+        # and end_point do differ but their offset is purely along the start
+        # segment's own local Z axis (e.g. a segment is extended straight ahead
+        # before turning into the bend, so the "gap" sits entirely on the
+        # start segment's own axis instead of laterally). In that case the raw
+        # point offset carries no lateral (local X/Y) component at all, even
+        # though the bend itself is perfectly well defined, and mep_bend_shape
+        # requires bend_vector to carry a detectable lateral component to
+        # determine the bend's second axis.
+        offset_local = (to_start_object_space @ end_point) - (to_start_object_space @ start_point)
+        no_lateral_offset = tool.Cad.is_x(offset_local.x, 0) and tool.Cad.is_x(offset_local.y, 0)
+        if tool.Cad.is_x((end_point - start_point).length, 0) or no_lateral_offset:
             ref_point = end_point + end_segment_dir
         bend_vector = (to_start_object_space @ ref_point) - (to_start_object_space @ start_point)
 

--- a/src/ifcopenshell-python/ifcopenshell/util/shape_builder.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/shape_builder.py
@@ -2199,7 +2199,15 @@ class ShapeBuilder:
         assert profile_dim is not None
 
         rounded_bend_vector = np_round_to_precision(bend_vector, si_conversion)
-        lateral_axis = next(i for i in range(2) if not is_x(rounded_bend_vector[i], 0))
+        try:
+            lateral_axis = next(i for i in range(2) if not is_x(rounded_bend_vector[i], 0))
+        except StopIteration:
+            raise ValueError(
+                "Cannot determine mep bend lateral axis: `bend_vector` has no offset along either "
+                f"local X or Y axis (bend_vector = {tuple(bend_vector)}). The bend direction between "
+                "the two segments must have a lateral (X or Y) component in the start segment's local "
+                "space; an offset purely along the start segment's local Z axis does not define a bend."
+            )
         non_lateral_axis = 1 if lateral_axis == 0 else 0
         lateral_sign = np.sign(bend_vector[lateral_axis])
         z_sign = -1 if flip_z_axis else 1


### PR DESCRIPTION
Found while investigating another MEP report — not tied to a filed issue.

## Root cause

Adding a bend/fitting (`bim.mep_add_bend`) between two duct or pipe segments whose gap sits entirely along the start segment's own local axis (no lateral X/Y offset at all — e.g. one segment extended straight ahead before turning into the bend) crashes with a raw `StopIteration` deep in `mep_bend_shape`.

`MEPAddBend` computed `bend_vector` directly from the raw start-to-end point offset. When that offset has no lateral (local X/Y) component, `bend_vector` itself has none either, and `mep_bend_shape`'s `next(i for i in range(2) if not is_x(...))` has nothing to find, since it assumes `bend_vector` always carries a lateral component to identify the bend's second axis.

## Fix, two layers

1. In `MEPAddBend`, when the start-to-end offset has no lateral component (checked in the start segment's own local space), fall back to using the general end-segment direction to compute `bend_vector` instead — the same fallback already used for the coincident-points case, extended to this related degenerate offset case, which correctly restores a lateral component for any bend that has a genuine corner to turn.
2. In `mep_bend_shape`, the previously-unguarded `next(...)` now raises a clear, informative `ValueError` instead of a raw `StopIteration` for any remaining case that still has no lateral component even after the above fallback — a genuinely undefined/degenerate bend, not something to paper over.

## Verification

Live-tested in headless Blender: reproduced the original crash on unpatched code with a genuine axial-only gap between two segments. After the fix, the same configuration succeeds and produces a correctly-oriented `IfcDuctFitting`. Regression-checked a reversed selection order (same physical geometry, different active/start object) and a standard lateral-offset bend: both identical before and after the fix, confirming no behavioral change to the working cases.

`black --check --diff .` and `ruff check .` pass on the changed files.

Generated with the assistance of an AI coding tool.