### PR TITLE
ifcopenshell: don't let camera Depth rescale Width/Height in perspective mode (#6322)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/add_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/add_representation.py
@@ -366,22 +366,26 @@ class Usecase:
     def create_camera_pyramid_representation(self) -> ifcopenshell.entity_instance:
         assert isinstance(self.geometry, bpy.types.Camera)
         props = tool.Drawing.get_camera_props(self.geometry)
-        raster_x = props.raster_x
-        raster_y = props.raster_y
-        fov = self.settings["geometry"].angle
 
         clip_end = self.settings["geometry"].clip_end
         clip_start = self.settings["geometry"].clip_start
 
-        if self.is_camera_landscape():
-            half_width = math.tan(fov / 2) * clip_end
-            half_height = half_width * raster_y / raster_x
-        else:
-            half_height = math.tan(fov / 2) * clip_end
-            half_width = half_height * raster_x / raster_y
+        # Width and Height are independent camera framing properties set by the
+        # user (`props.width` / `props.height`), just like Depth (`clip_end`).
+        # They must be used directly as the pyramid's base dimensions instead of
+        # being derived from the camera's field of view (`camera.angle`) and
+        # `clip_end`, otherwise editing Depth alone rescales Width/Height on the
+        # next representation regeneration (#6322). The field of view itself is
+        # only needed for Blender's perspective viewport preview, so it's the
+        # derived quantity here, computed the same way as on import (see
+        # `Loader.create_camera`).
+        x_length = props.width
+        y_length = props.height
+        half_width = x_length / 2
+        half_height = y_length / 2
 
-        x_length = 2 * half_width
-        y_length = 2 * half_height
+        fov = 2 * math.atan(max(half_width, half_height) / clip_end)
+        self.geometry.angle = fov
 
         pyramid = self.file.create_entity(
             "IfcRectangularPyramid",


### PR DESCRIPTION
Fixes #6322.

## Root cause

`create_camera_pyramid_representation()` built the IFC pyramid's base dimensions (`XLength`/`YLength`) from the camera's field of view (`camera.angle`) and Depth (`clip_end`), instead of from the user-set Width/Height camera properties. So editing Depth alone and regenerating the representation rescaled the pyramid's base, and that rescaled base was read straight back into the Width/Height UI properties on next load — making Width/Height appear tied to Depth, exactly as theoryshaw independently observed.

This is a distinct bug from #5640 (an unresolved general "properties visibly reset until the drawing finishes regenerating" UI-refresh symptom on the same repro file, investigated separately and not fixed there) — #6322 persists regardless of any UI-refresh fix, because the underlying persisted values themselves were being rescaled, not just their on-screen display.

## Fix

Width/Height are now the source of truth for the pyramid's `XLength`/`YLength`, the same way Depth already was for its own `Height` dimension. The field of view (`camera.angle`) becomes the derived quantity instead, computed the same way `Loader.create_camera` already derives it on import, so round-tripping stays self-consistent.

## Verification

Live-tested with the reporter's own attached file (`House - Copy.ifc`, its PERSPECTIVE drawing): before the fix, changing Depth from 1219.2 to 609.6 halved both Width and Height too. After the fix, the same Depth change leaves Width/Height completely unchanged, and the camera's field of view is what updates instead. Editing Width alone now correctly leaves Depth unchanged too.

`black --check --diff .` and `ruff check .` pass on the changed file.

Generated with the assistance of an AI coding tool.