### PR TITLE
bonsai: report a clean error instead of crashing on invalid CAD hotkey selections (#7228)

### DIFF
--- a/src/bonsai/bonsai/bim/module/cad/workspace.py
+++ b/src/bonsai/bonsai/bim/module/cad/workspace.py
@@ -234,7 +234,15 @@ class CadHotkey(bpy.types.Operator):
 
     def execute(self, context):
         self.props = tool.Cad.get_cad_props()
-        getattr(self, f"hotkey_{self.hotkey}")()
+        try:
+            getattr(self, f"hotkey_{self.hotkey}")()
+        except RuntimeError as e:
+            # Nested operators (e.g. bpy.ops.bim.cad_arc_from_2_points) that report
+            # an ERROR and return CANCELLED surface here as a RuntimeError instead
+            # of a clean report. Convert it back into a report so the user sees a
+            # readable message instead of a Python traceback.
+            self.report({"ERROR"}, str(e).replace("Error: ", "", 1))
+            return {"CANCELLED"}
         return {"FINISHED"}
 
     def draw(self, context):


### PR DESCRIPTION
Fixes #7228.

## Root cause

`CadHotkey.execute()` dispatches to `hotkey_*` methods that call nested `bpy.ops.bim.*` operators (e.g. `bim.cad_arc_from_2_points` for the 2-Point Arc tool). Those nested operators already validate their selection correctly and call `self.report({"ERROR"}, "...")` before returning `CANCELLED`, but Blender's Python operator-call convention converts an ERROR-report + CANCELLED result into a raised `RuntimeError` at the calling site. `CadHotkey.execute()` never caught that exception, so it escaped uncaught all the way to Blender's top-level dispatcher, producing a raw Python traceback instead of the clean report the nested operator already tried to give — exactly matching Moult's diagnosis ("just need better error reporting here").

## Fix

`CadHotkey.execute()` now wraps the `hotkey_*` dispatch in `try/except RuntimeError`, converting a caught error back into a clean `self.report({"ERROR"}, ...)` + `CANCELLED`. This is a narrow fix at the dispatch layer only — no change to the arc/fillet construction logic itself, and it applies uniformly to any CAD hotkey whose nested operator reports a validation failure, not just the 2-point arc case.

## Verification

Live-tested in headless Blender: invoking the 2-Point Arc hotkey with the wrong number of vertices selected (0 or 3) previously produced a raw Python traceback; after the fix it shows only the clean message "Error: Exactly 2 vertices should be selected." with no traceback. The correct-selection case (exactly 2 vertices) is unaffected before and after, confirming zero behavioral change to the working path.

`black --check --diff .` and `ruff check .` pass on the changed file.

Generated with the assistance of an AI coding tool.