### PR TITLE
bonsai: extend each cost value by its own unit basis before summing (#8625)

### DIFF
--- a/src/bonsai/bonsai/bim/module/cost/data.py
+++ b/src/bonsai/bonsai/bim/module/cost/data.py
@@ -149,7 +149,6 @@ class CostSchedulesData:
         data["UnitBasisUnitSymbol"] = None
         data["TotalAppliedValue"] = 0.0
         data["TotalCost"] = 0.0
-        has_unit_basis = False
         is_sum = False
         values: list[ifcopenshell.entity_instance]
         if root_element.is_a("IfcCostItem"):
@@ -158,25 +157,26 @@ class CostSchedulesData:
             values = root_element.BaseCosts
         else:
             assert False, root_element
+        cost_quantity = 1 if data["TotalCostQuantity"] is None else data["TotalCostQuantity"]
         for cost_value in values or []:
             cls._load_cost_value(root_element, data, cost_value)
             # data["CostValues"].append(cost_value.id())
-            data["TotalAppliedValue"] += cls._cost_values[cost_value.id()]["AppliedValue"]
+            applied_value = cls._cost_values[cost_value.id()]["AppliedValue"]
+            data["TotalAppliedValue"] += applied_value
             if cost_value.UnitBasis:
                 cost_value_data = cls._cost_values[cost_value.id()]
-                data["UnitBasisValueComponent"] = cost_value_data["UnitBasis"]["ValueComponent"]
+                unit_basis_value_component = cost_value_data["UnitBasis"]["ValueComponent"]
+                data["UnitBasisValueComponent"] = unit_basis_value_component
                 data["UnitBasisUnitSymbol"] = cost_value_data["UnitBasis"]["UnitSymbol"]
-                has_unit_basis = True
             else:
+                unit_basis_value_component = 1
                 data["UnitBasisValueComponent"] = 1
                 data["UnitBasisUnitSymbol"] = "U"
+            # Each cost value must be extended by the cost quantity and its OWN unit basis
+            # before being summed, since different cost values may use different unit bases.
+            data["TotalCost"] += applied_value * cost_quantity / unit_basis_value_component
             if cost_value.Category == "*":
                 is_sum = True
-        cost_quantity = 1 if data["TotalCostQuantity"] is None else data["TotalCostQuantity"]
-        if has_unit_basis:
-            data["TotalCost"] = data["TotalAppliedValue"] * cost_quantity / data["UnitBasisValueComponent"]
-        else:
-            data["TotalCost"] = data["TotalAppliedValue"] * cost_quantity
         if is_sum:
             pass  # If it is None it doesn't allow me to assign a cost rate composed by sum
             # data["TotalAppliedValue"] = None


### PR DESCRIPTION
Fixes #8625.

## Root cause

`_load_cost_values()` summed every `IfcCostValue`'s raw `AppliedValue` into one `TotalAppliedValue` first, then applied only the LAST-encountered cost value's `UnitBasis` to that combined sum after the loop ended. For a cost item with multiple cost values using different unit bases, this silently produces a wrong total: e.g. `AppliedValue 5`/`UnitBasis 2m²` plus `AppliedValue 3`/`UnitBasis 1m²` against a 10m² quantity computed `(5+3) × 10/1 = 80` instead of the correct `(10/2×5) + (10/1×3) = 55`.

`ifcopenshell.util.cost.calculate_applied_value()` itself is not the problem — it correctly resolves a single cost value's raw `AppliedValue` (handling `ArithmeticOperator`/`Components`/`Category="*"` nesting) and already gives the correct per-value result when called directly. The extend-by-quantity-and-unit-basis step that's actually needed already existed for nested cost-item roll-ups (`sum_child_root_elements` in `ifcopenshell/util/cost.py`), but was never applied to a cost item's own direct `CostValues` in Bonsai's `data.py`.

## Fix

Moved the extend-then-sum math into the per-`cost_value` loop, so each value is extended by the cost quantity and its OWN unit basis (or treated as a flat `AppliedValue` if it has no unit basis) before being added to `TotalCost`, instead of summing raw `AppliedValue`s first and applying one basis afterward. `Category` (e.g. "Labor") needed no special handling — it's only used as a grouping key for the separate `CategoryValues` display, not in the cost arithmetic.

## Verification

Live-tested with the reporter's own attached minimal IFC file (`5D_Sandbox_Mixed_UnitBasis.ifc`): before the fix, `TotalCost` showed `80.0`, reproducing the bug exactly. After the fix, `TotalCost` is `55.0`, matching the expected calculation. Regression-checked two common cases: multiple cost values sharing the same unit basis, and cost values with no unit basis at all — both unchanged before and after, confirming the existing correct behavior for those cases is preserved.

`black --check --diff .` and `ruff check .` pass on the changed file.

Generated with the assistance of an AI coding tool.