### PR TITLE
Bonsai: fix Activate Drawing crash for punctuated drawing names

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -483,20 +483,10 @@ class BIM_PT_sheets(Panel):
             op = row3.operator("bim.activate_drawing_from_sheet", icon="OUTLINER_OB_CAMERA", text="")
 
             if active_sheet.reference_type == "DRAWING":
-                drawingnamesvg = active_sheet.name
-                drawingname = drawingnamesvg.split(".svg")[0]
-                ifc_file = tool.Ifc.get()
-                ifc_annotations = ifc_file.by_type("IfcAnnotation")
-                drawingid = None
-                for annotation in ifc_annotations:
-                    if annotation.ObjectType != "DRAWING":
-                        continue
-                    Annotation_Name = annotation.Name.replace(",", "")  # Remove commas
-                    if Annotation_Name == drawingname:
-                        drawingid = annotation.id()
-                        break
-                if drawingid is not None:
-                    op.drawing = drawingid
+                active_reference = tool.Ifc.get().by_id(active_sheet.ifc_definition_id)
+                drawing = tool.Drawing.get_drawing_for_sheet_reference(active_reference)
+                if drawing is not None:
+                    op.drawing = drawing.id()
 
             row3.separator(factor=0.5, type="SPACE")
 

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -381,6 +381,7 @@ class Drawing:
     def get_document_uri(cls, document, description=None): pass
     def get_drawing_collection(cls, drawing): pass
     def get_drawing_document(cls, drawing): pass
+    def get_drawing_for_sheet_reference(cls, reference): pass
     def get_drawing_group(cls, drawing): pass
     def get_drawing_references(cls, drawing): pass
     def get_drawing_target_view(cls, drawing): pass

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -763,6 +763,32 @@ class Drawing(bonsai.core.tool.Drawing):
                 return rel.RelatingDocument
 
     @classmethod
+    def get_drawing_for_sheet_reference(
+        cls, reference: ifcopenshell.entity_instance
+    ) -> Union[ifcopenshell.entity_instance, None]:
+        """Find the IfcAnnotation drawing that a sheet's "DRAWING" reference item represents.
+
+        A sheet's document reference is a standalone copy created by
+        `bim.add_drawing_to_sheet` (see `AddDrawingToSheet`): it only shares
+        the drawing's `Location` (the on-disk SVG path) and has no direct IFC
+        relationship back to the originating `IfcAnnotation`. Match on that
+        `Location` instead of re-deriving the drawing's name from the
+        (filesystem-sanitised) filename, which silently fails to match
+        whenever the drawing's `Name` contains characters stripped by
+        `sanitise_filename()` (e.g. parentheses, colons, quotes).
+        """
+        location = getattr(reference, "Location", None)
+        if not location:
+            return None
+        for drawing in tool.Ifc.get().by_type("IfcAnnotation"):
+            if drawing.ObjectType != "DRAWING":
+                continue
+            drawing_reference = cls.get_drawing_document(drawing)
+            if drawing_reference and drawing_reference.Location == location:
+                return drawing
+        return None
+
+    @classmethod
     def get_drawing_references(cls, drawing: ifcopenshell.entity_instance) -> set[ifcopenshell.entity_instance]:
         results: set[ifcopenshell.entity_instance] = set()
         for inverse in tool.Ifc.get().get_inverse(drawing):


### PR DESCRIPTION
## Problem

Clicking "Activate Drawing" for a drawing added to a sheet crashes when the drawing's `Name` contains characters stripped by `sanitise_filename()` (parentheses, colons, quotes, etc.), such as the "DETAIL - SECTION - DIEWALL HEAD" style titles in the reporter's file.

## Root cause

`BIM_PT_sheets.draw()` matched a sheet's DRAWING reference back to its `IfcAnnotation` by stripping `.svg` from the reference's displayed filename and comparing it to each annotation's `Name` after removing commas only. The on-disk filename comes from `sanitise_filename()`, which strips every character outside `[A-Za-z0-9._- ]`, not just commas, so any `Name` with other punctuation never matches. The lookup then silently leaves `op.drawing` at Blender's default of `0`, and clicking the button crashes inside `ActivateDrawingBase._execute` at `by_id(0)`, since IFC entity ids never include `0`.

## Fix

Added `Drawing.get_drawing_for_sheet_reference()`, matching on the reference's `Location` (on-disk SVG path) instead of reconstructing the drawing name. This mirrors the same `Location` comparison `AddDrawingToSheet` already uses to detect a duplicate sheet reference, so it reuses an existing, verbatim link rather than reversing a filesystem-sanitised name.

## Testing

Live-verified in headless Blender 5.2 with real Bonsai operators: created a project with two drawings added to one sheet, one with a plain name and one with a punctuated name (`"DETAIL - SECTION - DIE WALL HEAD (TYP.)"`). Before the fix, the punctuated drawing's Activate Drawing button crashed with `by_id(0)`; after the fix, both activate correctly.

Fixes #7167.

Generated with the assistance of an AI coding tool.