### PR TITLE
bonsai(drawing): join mitred wall/slab linework by actual layer materials, not LayerSetName

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1443,13 +1443,17 @@ class CreateDrawing(bpy.types.Operator):
             join_criteria = join_criteria.split(",")
         else:
             # Drawing convention states that same objects classes with the same material are merged when cut.
+            # We compare the resolved list of constituent material names ("materials.Name") rather than
+            # "material.Name", because for layered walls/slabs the latter resolves to the optional
+            # IfcMaterialLayerSet.LayerSetName, which is frequently left unset (or set inconsistently) even when
+            # two elements share the exact same layer composition. That caused mitred/butt-joined walls with
+            # identical materials to keep a spurious visible seam in the 2D linework. See #6274.
             join_criteria = [
                 "class",
-                "material.Name",
+                "materials.Name",
                 "/Pset_.*Common/.Status",
                 "EPset_Status.Status",
                 "EPset_Status.UserDefinedStatus",
-                "Material.Name",
             ]
 
         group = root.find("{http://www.w3.org/2000/svg}g")


### PR DESCRIPTION
## Problem

Mitred or butt-joined walls that share the same material composition still show a spurious seam line in 2D drawing output, instead of merging into continuous linework.

## Root cause

The default drawing join criteria compared IfcMaterialLayerSetUsage via material.Name, which for layered walls resolves to the optional IfcMaterialLayerSet.LayerSetName attribute. Two walls with an identical layer composition (same materials, same thicknesses) can still have a different or unset LayerSetName depending on how the material was assigned (direct instance override vs wall type), which made the 2D cut linework merge fail.

## Fix

Switch to materials.Name, which resolves the actual list of constituent material names via ifcopenshell.util.element.get_materials, so two elements are only treated as different when their real material composition differs. Also removed a redundant Material.Name entry that never resolved to anything (get_element_value only recognizes the lowercase material/materials keys), so it was silently matching None for every element.

## Testing

Live-verified in headless Blender 5.2 against the reporter's attached Wall joins & visualisation.ifc: before the fix, the mitred wall pair (a brick+concrete layered wall) rendered as two separate SVG groups with a visible seam; after the fix they merge into one group with no seam. As a bonus, unrelated walls that only coincidentally shared an unset LayerSetName no longer get incorrectly merged together either.

Fixes #6274.

Generated with the assistance of an AI coding tool.