### PR TITLE
bonsai: preserve original tessellation edges from the CGAL kernel

### DIFF
--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -727,6 +727,15 @@ class Loader(bonsai.core.tool.Loader):
             settings.set("layerset-first", True)
             # Wire intersection checks is prohibitively slow on advanced breps. See bug #5999.
             settings.set("no-wire-intersection-check", True)
+            # By default the CGAL kernel groups adjacent coplanar triangles into a
+            # single face boundary, discarding edges between distinct but coplanar
+            # source faces (e.g. a tessellation deliberately split into two
+            # coplanar quads). This makes those edges vanish when entering edit
+            # mode (see #5711, #5862). Preserve the original face boundaries
+            # instead. This is a no-op for the OpenCASCADE kernel and, in the
+            # default hybrid-cgal-simple-opencascade library, booleans/voids are
+            # resolved via the OpenCASCADE fallback so this does not affect them.
+            settings.set("cgal-original-edges", True)
             # settings.set("triangulation-type", ifcopenshell.ifcopenshell_wrapper.POLYHEDRON_WITHOUT_HOLES)
             if is_gross:
                 settings.set("disable-opening-subtractions", True)


### PR DESCRIPTION
## Problem

A tessellated IFC representation deliberately split into two coplanar faces (e.g. two coplanar quads sharing an edge) silently collapses into one merged n-gon the moment the object is edited in Bonsai, even though nothing in the source IFC file asked for that simplification.

## Root cause

tool.Loader.create_settings() builds the geometry settings used for every import without enabling the CGAL kernel's cgal-original-edges option. Bonsai's default geometry library is hybrid-cgal-simple-opencascade, so most elements are triangulated by CGAL, which groups all mutually adjacent coplanar triangles into a single face boundary and only reports edges between non-coplanar components. Any edge between two distinct but coplanar source faces is therefore never recorded, so Geometry.dissolve_triangulated_edges silently merges those faces.

This root cause was already independently diagnosed by the maintainers across #5862 (Gorgious56) and #6173 (aothms, who built the cgal-original-edges setting specifically for this), but nobody had wired it into Bonsai's loader.

## Fix

Enable cgal-original-edges in Loader.create_settings(), so the kernel reports genuine face boundaries instead of grouping by coplanarity.

## Testing

Live-verified in headless Blender 5.2 with a synthetic tessellated wall split into two coplanar quads: before the fix the imported mesh collapsed to a 6-vertex ngon plus a quad (10 edges), after the fix it kept 3 separate quads (11 edges), matching the OpenCASCADE kernel's output.

Also verified against a synthetic wall with an opening (the case aothms flagged as risky, since booleans/voids have no meaningful original topology to preserve), using Bonsai's actual default hybrid-cgal-simple-opencascade library end to end: face and edge counts were identical with and without the setting, because that library already falls back to OpenCASCADE for boolean/void geometry, so this change does not affect that path.

One caveat: if a user explicitly switches Geometry Library to plain CGAL on a model with lots of openings, a synthetic-only check of that combination showed more exposed triangulation edges. That combination was not the reported bug and is not the default path, so it was not chased further here.

Fixes #5711. Also relevant to #5862 and #6747.

Generated with the assistance of an AI coding tool.