### PR TITLE
bonsai: catch kernel RuntimeError when finishing an arbitrary profile edit

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2450,7 +2450,15 @@ class Model(bonsai.core.tool.Model):
         # First convert to Shapely
         polygons = {}
         for curve in curves:
-            geometry = ifcopenshell.geom.create_shape(settings, curve)
+            try:
+                geometry = ifcopenshell.geom.create_shape(settings, curve)
+            except RuntimeError:
+                # The reconstructed curve can be geometrically degenerate (e.g. a
+                # sliver loop collapsed below the kernel's tolerance after an edit),
+                # which the geometry kernel rejects outright instead of returning an
+                # empty shape. Treat that the same as any other invalid profile
+                # instead of letting the exception crash the calling operator.
+                return (False, "INVALID_SHAPE")
             assert isinstance(geometry, W.Triangulation)
             v = ifcopenshell.util.shape.get_vertices(geometry, is_2d=True)
             v = np.round(v, 4)  # Round to nearest 0.1mm, otherwise things like circles don't polygonise reliably


### PR DESCRIPTION
## Problem

Finishing an edit on an arbitrary profile sometimes crashes with a raw traceback instead of the intended "INVALID PROFILE" popup.

## Root cause

auto_detect_profiles() reconstructs an IfcIndexedPolyCurve from the edited Blender mesh and calls ifcopenshell.geom.create_shape() on it to sort outer boundaries from voids. Every other invalid-profile case in that function (unclosed loops, malformed arcs or circles) returns a graceful (False, reason) tuple, but this create_shape call had no exception handling at all. When the reconstructed curve is geometrically valid topology but numerically degenerate at the kernel's internal tolerance, create_shape raises RuntimeError, which propagated straight through export_profile and crashed bim.edit_arbitrary_profile with a raw traceback.

## Fix

Catch RuntimeError around the create_shape call and treat it the same as the other invalid-profile branches, so a bad edit surfaces the existing friendly error message instead of an unhandled crash.

## Testing

Live-verified in headless Blender 5.2 with a weld-safe mesh whose coordinates land near the kernel's internal degeneracy tolerance once converted to project length units: before the fix, create_shape raised RuntimeError and crashed the operator; after the fix, the same case returns gracefully and surfaces the friendly INVALID PROFILE message instead.

Fixes #6259.

Generated with the assistance of an AI coding tool.