### PR TITLE
Bonsai: fix missing closing edge when importing a closed IfcPolyline profile for editing

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -618,7 +618,7 @@ class Model(bonsai.core.tool.Model):
 
             cls.edges.extend([(i, i + 1) for i in range(offset, len(cls.vertices) - 1)])
             if is_closed:
-                cls.edges[-1] = (len(cls.vertices) - 1, offset)  # Close the loop
+                cls.edges.append((len(cls.vertices) - 1, offset))  # Close the loop
 
         elif curve.is_a("IfcCompositeCurve"):
             # This is a first pass incomplete implementation only for simple polylines, and misses many details.


### PR DESCRIPTION
## Problem

Entering Direct Profile Edit on an IfcExtrudedAreaSolid/IfcArbitraryClosedProfileDef item leaves the resultant profile not fully closed.

## Root cause

tool.Model.convert_curve_to_mesh() builds the editable Blender mesh for an IfcArbitraryClosedProfileDef's OuterCurve. For a closed IfcPolyline (first and last point coincide), it correctly drops the duplicate closing point, then tried to reconnect the loop by overwriting the last entry of cls.edges with the closing edge (N-1, 0) instead of appending it. Since the preceding edge list already contained exactly N-1 edges for the N points added (one edge per consecutive pair, no placeholder), that assignment clobbered the real edge between the last two profile vertices rather than adding the missing closing edge.

## Fix

Append the closing edge instead of overwriting the last one, matching the sibling IfcIndexedPolyCurve closed-loop handling a few lines below, which already appends correctly.

## Testing

Live-verified in headless Blender 5.2 with a closed 4-point square IfcPolyline profile: before the fix, the imported mesh had 4 vertices but only 3 edges (open loop). After the fix, it correctly has 4 vertices and 4 edges (closed loop).

Fixes #6930.

Generated with the assistance of an AI coding tool.