### PR TITLE
Bonsai: guard import_item against a None geometry shape

### DIFF
--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2230,16 +2230,33 @@ class Geometry(bonsai.core.tool.Geometry):
             obj.data.from_pydata([co], [], [])
         else:
             geometry = tool.Loader.create_generic_shape(item)
-            verts = ifcopenshell.util.shape.get_vertices(geometry)
-            if (cartesian_point_offset := cls.get_cartesian_point_offset(rep_obj)) is not None:
-                verts = verts - cartesian_point_offset
-            tool.Loader.convert_geometry_to_mesh(geometry, obj.data, verts=verts)
+            if geometry is None:
+                # The geometry kernel can legitimately fail to produce a shape for an
+                # item (e.g. an invalid or degenerate boolean/clipping result). Every
+                # other caller of create_generic_shape already guards against this
+                # (see import_ifc.py and tool/loader.py). Without the same guard here,
+                # get_vertices(None) raises an unhandled AttributeError which aborts
+                # mid-edit after obj.data.clear_geometry() already ran, leaving the
+                # item's mesh empty/corrupted instead of failing gracefully.
+                logging.getLogger("ImportIFC").error(
+                    "Failed to regenerate geometry for representation item #%d (%s). "
+                    "Its mesh has been cleared - check for invalid geometry, such as "
+                    "a boolean or clipping result with no remaining volume.",
+                    item.id(),
+                    item.is_a(),
+                )
+                obj.matrix_world = rep_obj.matrix_world.copy()
+            else:
+                verts = ifcopenshell.util.shape.get_vertices(geometry)
+                if (cartesian_point_offset := cls.get_cartesian_point_offset(rep_obj)) is not None:
+                    verts = verts - cartesian_point_offset
+                tool.Loader.convert_geometry_to_mesh(geometry, obj.data, verts=verts)
 
-            if ios_materials := list(obj.data["ios_materials"]):
-                material = tool.Ifc.get_object(tool.Ifc.get().by_id(ios_materials[0]))
-                obj.data.materials.append(material)
+                if ios_materials := list(obj.data["ios_materials"]):
+                    material = tool.Ifc.get_object(tool.Ifc.get().by_id(ios_materials[0]))
+                    obj.data.materials.append(material)
 
-            obj.matrix_world = rep_obj.matrix_world.copy()
+                obj.matrix_world = rep_obj.matrix_world.copy()
 
         if is_swept_area := item.is_a("IfcSweptAreaSolid"):
             position = item.Position

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2229,6 +2229,7 @@ class Geometry(bonsai.core.tool.Geometry):
             co = np.array(item.VertexGeometry.Coordinates) * ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
             obj.data.from_pydata([co], [], [])
         else:
+            cartesian_point_offset = cls.get_cartesian_point_offset(rep_obj)
             geometry = tool.Loader.create_generic_shape(item)
             if geometry is None:
                 # The geometry kernel can legitimately fail to produce a shape for an
@@ -2248,7 +2249,7 @@ class Geometry(bonsai.core.tool.Geometry):
                 obj.matrix_world = rep_obj.matrix_world.copy()
             else:
                 verts = ifcopenshell.util.shape.get_vertices(geometry)
-                if (cartesian_point_offset := cls.get_cartesian_point_offset(rep_obj)) is not None:
+                if cartesian_point_offset is not None:
                     verts = verts - cartesian_point_offset
                 tool.Loader.convert_geometry_to_mesh(geometry, obj.data, verts=verts)
 


### PR DESCRIPTION
## Problem

Editing an IfcRepresentationItem's geometry and exiting item edit mode can crash with an unhandled AttributeError instead of failing gracefully, leaving the item's mesh cleared.

## Root cause

Exiting item edit mode re-imports geometry through tool.Geometry.import_item, which calls tool.Loader.create_generic_shape(item) and immediately passes the result to ifcopenshell.util.shape.get_vertices without checking it. The geometry kernel can legitimately return None for an item (e.g. an invalid or degenerate boolean/clipping result), which is exactly what every other caller of create_generic_shape already guards against (import_ifc.py and tool/loader.py both check the result before using it). Without the same guard here, get_vertices(None) raises an unhandled AttributeError partway through import_item, after obj.data.clear_geometry() has already run.

A follow-up fix in the same branch addresses a second bug introduced by the first guard: cartesian_point_offset was only assigned inside the non-None branch's walrus operator, but is referenced unconditionally later for IfcSweptAreaSolid items, which raised UnboundLocalError in that combination. Fixed by hoisting the lookup so it's always computed.

## Fix

Guard the create_generic_shape result: on None, log a clear error naming the offending representation item and skip only the geometry-dependent steps, instead of crashing.

## Testing

The reporter's real .ifc file was shared privately with maintainers and wasn't available to us, so verification is synthetic: built a real IFC element and monkeypatched create_generic_shape to return None, matching the reported crash mechanism exactly (AttributeError: 'NoneType' object has no attribute 'verts_buffer', matching the reported traceback). Confirmed the fixed path completes without crashing and logs the error instead. Also confirmed the follow-up UnboundLocalError reproduces and is fixed for the IfcSweptAreaSolid case.

Fixes #6693.

Generated with the assistance of an AI coding tool.