### PR TITLE
ifc5d: wire up GrossFootprintArea/NetFootprintArea for IfcWall QTO

### DIFF
--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
@@ -606,13 +606,13 @@
             },
             "IfcWall": {
                 "Qto_WallBaseQuantities": {
-                    "GrossFootprintArea": null,
+                    "GrossFootprintArea": "gross_get_footprint_area",
                     "GrossSideArea": "gross_get_side_area",
                     "GrossVolume": "gross_get_volume",
                     "GrossWeight": "gross_get_weight",
                     "Height": "net_get_z",
                     "Length": "net_get_x",
-                    "NetFootprintArea": null,
+                    "NetFootprintArea": "net_get_footprint_area",
                     "NetSideArea": "net_get_side_area",
                     "NetVolume": "net_get_volume",
                     "NetWeight": "net_get_weight",

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
@@ -769,13 +769,13 @@
             },
             "IfcWall + IfcWallType": {
                 "Qto_WallBaseQuantities": {
-                    "GrossFootPrintArea": null,
+                    "GrossFootPrintArea": "gross_get_footprint_area",
                     "GrossSideArea": "gross_get_side_area",
                     "GrossVolume": "gross_get_volume",
                     "GrossWeight": "gross_get_weight",
                     "Height": "net_get_z",
                     "Length": "net_get_x",
-                    "NetFootPrintArea": null,
+                    "NetFootPrintArea": "net_get_footprint_area",
                     "NetSideArea": "net_get_side_area",
                     "NetVolume": "net_get_volume",
                     "NetWeight": "net_get_weight",


### PR DESCRIPTION
## Problem

Qto_WallBaseQuantities is missing GrossFootprintArea/NetFootprintArea when computed via the IfcOpenShell geometry-engine calculator ruleset.

## Root cause

IFC4QtoBaseQuantities.json and IFC4X3QtoBaseQuantities.json left IfcWall's GrossFootprintArea/NetFootprintArea mapped to null, so these two quantities were silently omitted whenever that ruleset was used. The generic gross_get_footprint_area/net_get_footprint_area formulas already exist and are already wired up for IfcSlab in the same files, so this was a missing mapping, not a missing implementation.

## Fix

Wire up the same formulas already used for IfcSlab, for IfcWall.

## Testing

Built a synthetic IFC4 wall via ifcopenshell.api, ran ifc5d.qto.quantify with the ruleset before and after the fix. Before: GrossFootprintArea/NetFootprintArea keys absent entirely. After: both present and numerically correct (matched length x width in project units).

Fixes #7029.

Generated with the assistance of an AI coding tool.