### PR TITLE
Bonsai: tolerate an already-removed mesh/curve/camera data-block in delete_data

### DIFF
--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -373,6 +373,12 @@ class Geometry(bonsai.core.tool.Geometry):
                 bpy.data.curves.remove(data)
             except TypeError:
                 bpy.data.cameras.remove(data)
+        except ReferenceError:
+            # The data-block was already removed elsewhere (e.g. purged as an
+            # orphan in between an earlier "has data users" check and this
+            # deferred cleanup call). It's already gone, so there's nothing
+            # left to do.
+            pass
 
     @classmethod
     def is_locked(cls, element: ifcopenshell.entity_instance) -> bool:


### PR DESCRIPTION
## Problem

Editing representation items in a certain sequence (switch_representation calls followed by remove_representation) can abort the whole IFC operator transaction with a ReferenceError traceback.

## Root cause

tool.Geometry.delete_data() only guarded against TypeError (passing the wrong bpy.data collection). If the data-block had already been freed elsewhere between an earlier has_data_users() check and this deferred cleanup call, bpy.data.meshes.remove() raises an uncaught ReferenceError instead.

## Fix

Catch ReferenceError too and treat an already-removed data-block as a no-op, since the desired end state (the data being gone) is already met.

## Testing

Live-verified in headless Blender 5.2: created a mesh, removed it once, then called tool.Geometry.delete_data() on the stale reference. Before the fix: raised ReferenceError: StructRNA of type Mesh has been removed. After the fix: silent no-op as intended.

Fixes #5793.

Generated with the assistance of an AI coding tool.