### PR TITLE
Bonsai: stop deleting manually-created Level (Section) annotations

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1603,7 +1603,20 @@ class Drawing(bonsai.core.tool.Drawing):
 
     @classmethod
     def is_auto_annotation(cls, element: ifcopenshell.entity_instance):
-        return element.is_a("IfcAnnotation") and element.ObjectType in ("GRID", "SECTION", "ELEVATION", "SECTION_LEVEL")
+        if not element.is_a("IfcAnnotation"):
+            return False
+        if element.ObjectType in ("GRID", "SECTION", "ELEVATION"):
+            # These types only ever exist as system-generated drawing references.
+            return True
+        if element.ObjectType == "SECTION_LEVEL":
+            # SECTION_LEVEL is also a regular, manually creatable annotation type
+            # ("Level (Section)" in the Annotation tool), unlike GRID/SECTION/ELEVATION.
+            # Only treat it as a system-managed reference annotation if it is actually
+            # tied to a referenced product, otherwise a manually authored Level (Section)
+            # annotation would be wrongly swept up as an "orphaned" auto reference and
+            # deleted by sync_references(), or blocked from being deleted directly.
+            return cls.get_assigned_product(element) is not None
+        return False
 
     @classmethod
     def get_drawing_reference_annotation(


### PR DESCRIPTION
## Problem

A manually-created "Level (Section)" annotation disappears the moment you activate a drawing. The same annotation also can't be deleted directly, with the message "References cannot be deleted. Exclude the referenced element instead."

## Root cause

is_auto_annotation() classifies every IfcAnnotation with ObjectType in (GRID, SECTION, ELEVATION, SECTION_LEVEL) as a system-managed drawing reference, and sync_references() (called on every bim.activate_drawing) deletes any such annotation lacking a product assignment as an "orphan." Unlike GRID/SECTION/ELEVATION, which are exclusively created by the auto-generation code path, SECTION_LEVEL is also a regular, manually-creatable annotation type exposed in the Annotation tool as "Level (Section)." A manually created one never receives that product link, so it was being silently deleted every time a drawing was activated.

## Fix

is_auto_annotation() now only treats a SECTION_LEVEL annotation as system-managed if it's actually tied to a referenced product; GRID/SECTION/ELEVATION keep the unconditional check since they can never be manually created. This also fixes the related issue where Bonsai refused to let users delete their own manually-created Level (Section) annotations, since the same check gates deletion.

## Testing

Live-verified in headless Blender 5.2: a manually-created SECTION_LEVEL annotation (via bim.add_annotation) survives bim.activate_drawing after the fix, while a genuinely auto-generated storey-reference SECTION_LEVEL annotation continues to be correctly tracked/regenerated, no regression.

Fixes #7450.

Generated with the assistance of an AI coding tool.