### PR TITLE
Bonsai: fix mismatched Fillet tooltip in CAD tool for plain mesh edit mode

### DIFF
--- a/src/bonsai/bonsai/bim/module/cad/workspace.py
+++ b/src/bonsai/bonsai/bim/module/cad/workspace.py
@@ -197,7 +197,7 @@ class CadTool(WorkSpaceTool):
             )
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
             add_layout_hotkey_operator(
-                row, "Fillet", "S_F", bpy.ops.bim.add_ifcarcindex_fillet.__doc__.split("\n", 1)[1].strip(), ui_context
+                row, "Fillet", "S_F", bpy.ops.bim.cad_fillet.__doc__.split("\n", 1)[1].strip(), ui_context
             )
             row = row if ui_context == "TOOL_HEADER" else layout.row(align=True)
             add_layout_hotkey_operator(


### PR DESCRIPTION
## Problem

The CAD tool's "Fillet" hotkey tooltip tells you to select vertices, but the operator it actually runs requires two selected edges, so following the tooltip crashes with RuntimeError: Exactly 2 edges should be selected.

## Root cause

In the general edit-mesh branch of CadTool.draw_settings (not a profile object, not an AXIS subshape), the tooltip showed bim.add_ifcarcindex_fillet's docstring ("Add a fillet for the selected vertices"), but hotkey_S_F in that same branch actually calls bim.cad_fillet, which requires two selected edges. The adjacent AXIS-subshape branch already points at the correct docstring, confirming the mismatch was isolated to this one branch.

## Fix

Point the tooltip at bim.cad_fillet's docstring instead, matching what Shift+F actually executes there.

## Testing

Verified live: for a plain mesh object, the tooltip now reads "Add fillet to the 2 selected edges," matching the actual operator's requirement.

Fixes #7231.

Generated with the assistance of an AI coding tool.