### PR TITLE
Fix CI: IFC4X3 schema resolution and process-type assignment false positives

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/type/assign_type.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/type/assign_type.py
@@ -208,13 +208,26 @@ class Usecase:
                 allowed_occurrences.add(occurrence_class)
             except RuntimeError:
                 pass
-        mismatched_classes = sorted({o.is_a() for o in related_objects if o.is_a() not in allowed_occurrences})
-        if mismatched_classes:
-            raise TypeError(
-                f"{relating_type.is_a()} cannot type {', '.join(mismatched_classes)} "
-                f"in schema {self.file.schema} (allowed occurrence classes: "
-                f"{', '.join(sorted(allowed_occurrences)) or '<none>'})"
-            )
+        # The buildingSMART implementer agreement map is generated only from
+        # (and only guaranteed complete for) the CorrectTypeAssigned /
+        # CorrectStyleAssigned WHERE rules, which the EXPRESS schema only
+        # declares on IfcElement occurrence/type pairs. Every class the map
+        # does cover has at least one applicable occurrence class by
+        # construction (see bonsai/scripts/generate_util_type_json.py), so an
+        # empty result here always means "outside the map's scope" (e.g.
+        # IfcTask/IfcTaskType, IfcCrewResource/IfcCrewResourceType,
+        # IfcController/IfcControllerType), never "no valid pairing exists".
+        # Only enforce the check when we have positive data to enforce it
+        # with, otherwise every process/resource/control type assignment
+        # would be wrongly rejected.
+        if allowed_occurrences:
+            mismatched_classes = sorted({o.is_a() for o in related_objects if o.is_a() not in allowed_occurrences})
+            if mismatched_classes:
+                raise TypeError(
+                    f"{relating_type.is_a()} cannot type {', '.join(mismatched_classes)} "
+                    f"in schema {self.file.schema} (allowed occurrence classes: "
+                    f"{', '.join(sorted(allowed_occurrences)) or '<none>'})"
+                )
 
         ifc2x3 = self.file.schema == "IFC2X3"
         related_objects_set = set(related_objects)

--- a/src/ifcopenshell-python/ifcopenshell/util/schema.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/schema.py
@@ -174,9 +174,16 @@ def geometry_classes_introduced_after(target_schema: IFC_SCHEMA, source_schema: 
     (``IfcPolygonalFaceSet``, ``IfcTriangulatedFaceSet``, ``IfcAdvancedBrep``,
     B-splines, advanced surfaces, alignment curves on IFC4X3 → 2X3, …) or
     purge. Defaults match the IFC4 → IFC2X3 case for backwards compatibility
-    with the original caller."""
-    source = ifcopenshell_wrapper.schema_by_name(source_schema)
-    target = ifcopenshell_wrapper.schema_by_name(target_schema)
+    with the original caller.
+
+    Uses :func:`ifcopenshell.schema_by_name` (not the raw
+    ``ifcopenshell_wrapper.schema_by_name``) because the latter has no
+    "IFC4X3" schema registered under that exact identifier in builds that
+    only compile the latest IFC4X3 addendum (e.g. ``IFC4X3_ADD2``, as CI
+    does). Only ``ifcopenshell.schema_by_name`` knows to resolve the bare
+    ISO name to the concrete compiled schema."""
+    source = ifcopenshell.schema_by_name(source_schema)
+    target = ifcopenshell.schema_by_name(target_schema)
     target_names = {decl.name() for decl in target.entities()}
     result: set[str] = set()
     for decl in source.entities():


### PR DESCRIPTION
## Problem

The main ci workflow is red: 5 test failures across test_schema.py, test_Migrate.py, and test_element.py.

## Root cause 1: RuntimeError: No schema named IFC4X3

geometry_classes_introduced_after() called the raw ifcopenshell_wrapper.schema_by_name() directly with the bare "IFC4X3" identifier. CI's cmake invocation builds with -DSCHEMA_VERSIONS=2x3;4;4x3_add2, which only compiles in the IFC4X3_ADD2 schema, not the bare IFC4X3 one. Every other call site in the codebase resolves this through the public ifcopenshell.schema_by_name(), which already aliases "IFC4X3" to "IFC4X3_ADD2".

## Fix 1

Route the call through the public ifcopenshell.schema_by_name() instead of the raw wrapper. Fixes 3 failures (2 in test_schema.py, 1 in test_Migrate.py).

## Root cause 2: TypeError: IfcTaskType cannot type IfcTask

A class-mismatch guard added to ifcopenshell.api.type.assign_type derives its allow-list from ifcopenshell.util.type.get_applicable_entities(), generated only from EXPRESS WHERE rules that exist on IfcElement occurrence/type pairs. It has no data at all for IfcProcess/IfcResource/IfcControl pairs (e.g. IfcTask/IfcTaskType), so every such assignment was hard-rejected.

## Fix 2

Only enforce the check when the map actually has data for the relating type's class (every class the map does cover is guaranteed non-empty by construction). Fixes 2 failures in test_element.py.

## Testing

Built locally against CI's exact -DSCHEMA_VERSIONS=2x3;4;4x3_add2 flag: all 5 previously-failing tests now pass, plus the full test/api/type/test_assign_type.py suite (50/50, including the existing mismatch-rejection tests, which still correctly raise) and test/test_Migrate.py (7/7).

Note: a separate, pre-existing test_validate_stub failure (SWIG stub/wrapper signature drift, unrelated to schemas) is left untouched, out of scope for this fix.

Generated with the assistance of an AI coding tool.