### PR TITLE
Bonsai: let standalone IfcCurtainWall bound spaces and boundaries

### DIFF
--- a/src/bonsai/bonsai/bim/module/boundary/operator.py
+++ b/src/bonsai/bonsai/bim/module/boundary/operator.py
@@ -682,6 +682,7 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
             tool.Ifc.get().by_type("IfcWall")
             + tool.Ifc.get().by_type("IfcSlab")
             + tool.Ifc.get().by_type("IfcVirtualElement")
+            + tool.Ifc.get().by_type("IfcCurtainWall")
         )
 
         for building_element in building_elements:

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -755,7 +755,7 @@ class Spatial(bonsai.core.tool.Spatial):
 
     @classmethod
     def is_bounding_class(cls, visible_element: ifcopenshell.entity_instance) -> bool:
-        for ifc_class in ["IfcWall", "IfcColumn", "IfcMember", "IfcVirtualElement", "IfcPlate"]:
+        for ifc_class in ["IfcWall", "IfcColumn", "IfcMember", "IfcVirtualElement", "IfcPlate", "IfcCurtainWall"]:
             if visible_element.is_a(ifc_class):
                 return True
         return False
@@ -936,7 +936,7 @@ class Spatial(bonsai.core.tool.Spatial):
         boundary_elements = []
         for obj in selected_objects:
             subelement = tool.Ifc.get_entity(obj)
-            if subelement.is_a("IfcWall") or subelement.is_a("IfcColumn"):
+            if subelement.is_a("IfcWall") or subelement.is_a("IfcColumn") or subelement.is_a("IfcCurtainWall"):
                 boundary_elements.append(subelement)
         return boundary_elements
 


### PR DESCRIPTION
## Problem

A curtain wall used as a standalone room side (not decomposed into IfcMember/IfcPlate children) is invisible to space/boundary generation.

## Root cause

IfcCurtainWall is not a schema subtype of IfcWall, so it was silently skipped by every class list checking "is this a wall/column/etc." Three separate lists needed it: tool.Spatial.is_bounding_class (cursor-based "Generate Space"), tool.Spatial.get_boundary_elements ("Generate Spaces From Walls" bulk detection), and AddBoundary.auto_generate_boundaries's element gather ("Add Boundary" auto-detect mode). CyrilWaechter specifically proposed adding curtain wall to this detection, while explicitly leaving standalone windows and structural elements as a separate, still-open design question.

## Fix

Add IfcCurtainWall to all three lists (one line each). The manual AddBoundary path (selecting a space + element directly) was already class-agnostic and needed no change, confirmed live.

## Testing

Live-verified in headless Blender: a synthetic 4m x 4m room with 3 IfcWall sides and one standalone IfcCurtainWall side produced 0 spaces via "Generate Spaces From Walls" before the fix, 1 correctly-bounded space after.

IfcWindow and structural elements remain untouched, that's the genuinely open part of the design question.

Fixes #3995.

Generated with the assistance of an AI coding tool.