### PR TITLE
Bonsai: default new Git repos to a main branch

### DIFF
--- a/src/bonsai/bonsai/tool/ifcgit.py
+++ b/src/bonsai/bonsai/tool/ifcgit.py
@@ -61,7 +61,14 @@ class IfcGit(bonsai.core.tool.IfcGit):
 
     @classmethod
     def init_repo(cls, path_dir: str) -> None:
-        IfcGitRepo.repo = git.Repo.init(path_dir)
+        kwargs = {}
+        try:
+            git.Git().config("--global", "--get", "init.defaultBranch")
+        except git.exc.GitCommandError:
+            # global init.defaultBranch isn't configured, so git would otherwise
+            # fall back to its legacy "master" default; use "main" instead
+            kwargs["initial_branch"] = "main"
+        IfcGitRepo.repo = git.Repo.init(path_dir, **kwargs)
         cls.config_info_attributes(IfcGitRepo.repo)
 
     @classmethod


### PR DESCRIPTION
## Problem

New IFC Git repositories initialized via Bonsai fall back to git's legacy master default branch name whenever the user's global init.defaultBranch config isn't set.

## Root cause

IfcGit.init_repo() called git.Repo.init() with no branch argument, so it silently inherited whatever the machine's global git config said (or git's own legacy default when unset).

## Fix

Check the global init.defaultBranch setting first; only pass initial_branch="main" when it's unset, so existing user configuration is still respected.

## Testing

Verified against real git init calls in isolated HOME directories: with init.defaultBranch unset, old code produced master, patched code produces main. With it explicitly set to develop, both old and new code respect that setting (no regression).

Addresses the "default branch should be main" item from #3096.

Generated with the assistance of an AI coding tool.