### PR TITLE
IfcParse: don't let a malformed binary token abort the parser

### DIFF
--- a/src/ifcparse/IfcFile.cpp
+++ b/src/ifcparse/IfcFile.cpp
@@ -61,7 +61,11 @@ namespace {
     template <typename Fn>
     void dispatch_token(boost::optional<size_t> instance_id, int attribute_id, IfcParse::Token t, IfcParse::declaration* decl, Logger& logger, Fn fn) {
         if (t.type == IfcParse::Token_BINARY) {
-            fn(IfcParse::TokenFunc::asBinary(t));
+            try {
+                fn(IfcParse::TokenFunc::asBinary(t));
+            } catch (IfcParse::IfcException& e) {
+                logger.Error("VAL", 20, "Invalid binary token at offset " + std::to_string(t.startPos));
+            }
         } else if (IfcParse::TokenFunc::isBool(t)) {
             fn(IfcParse::TokenFunc::asBool(t));
         } else if (IfcParse::TokenFunc::isLogical(t)) {


### PR DESCRIPTION
The fuzzer from #5679 found that flipping a single byte to a stray double-quote inside a numeric attribute list (e.g. `(0.,0.,3.)` → `(0.,0.,".)`) crashes `IfcConvert` instead of producing a validation error.

**Root cause:** the tokenizer classifies any token starting with `"` as `Token_BINARY`. A malformed input like this produces a short, invalid binary token (e.g. a lone `"`). `dispatch_token`'s `Token_BINARY` branch in `src/ifcparse/IfcFile.cpp` calls `TokenFunc::asBinary()` unguarded:

```cpp
if (t.type == IfcParse::Token_BINARY) {
    fn(IfcParse::TokenFunc::asBinary(t));
}
```

`asBinary()` throws `IfcException("Token is not a valid binary sequence")` on invalid content. Nothing catches it, so it propagates out of `parse_context::construct` and terminates the process — unlike the `Token_ENUMERATION` branch a few lines below, which already wraps its equivalent risky call in `try`/`catch` and logs a `VAL` error instead.

**Fix:** wrap the `asBinary()` call in the same try/catch pattern, logging `VAL 20` instead of crashing.

Test file: 
[segfault_1421521_682.ifc.txt](https://github.com/user-attachments/files/30103159/segfault_1421521_682.ifc.txt)

This fix works for me, but @aothms should have a look before merging.

Generated with the assistance of an AI coding tool.
