### PR TITLE
IfcParse: don't abort when a string literal runs off the end of the file

### DIFF
--- a/src/ifcparse/IfcCharacterDecoder.cpp
+++ b/src/ifcparse/IfcCharacterDecoder.cpp
@@ -98,8 +98,9 @@ namespace {
         int codepage = 1;
         unsigned int hex = 0;
         unsigned int hex_count = 0;
+        bool closed = false;
 
-        while ((current_char = stream_.peek()) != 0) {
+        while (!stream_.eof() && (current_char = stream_.peek()) != 0) {
             if (EXPECTS_CHARACTER(parse_state)) {
                 builder_.push_back(IfcUtil::convert_codepage(codepage, current_char + 0x80));
                 parse_state = 0;
@@ -162,6 +163,7 @@ namespace {
                                                   (current_char == '\\' && parse_state == FIRST_SOLIDUS) ||
                                                   (current_char == '\'' && parse_state == APOSTROPHE))) {
                 if (parse_state == APOSTROPHE && current_char != '\'') {
+                    closed = true;
                     break;
                 }
                 throw IfcInvalidTokenException(stream_.tell(), current_char);
@@ -170,6 +172,9 @@ namespace {
                 builder_.push_back(current_char);
             }
             stream_.increment();
+        }
+        if (!closed && stream_.eof()) {
+            logger.Warning("SYN", 41, "Unterminated string literal at offset " + std::to_string(stream_.tell()));
         }
         builder_.push_back('\'');
 


### PR DESCRIPTION
The fuzzer from #5679 found that corrupting a string delimiter (removing/relocating a `'`) crashes `IfcConvert` instead of producing a syntax warning.

**Root cause:** `read_string()` in `src/ifcparse/IfcCharacterDecoder.cpp` scans a STEP string/binary literal with:

```cpp
while ((current_char = stream_.peek()) != 0) {
```

This assumes `FileReader::peek()` returns `0` at EOF. It actually throws `std::out_of_range("peek at EOF")` (`src/ifcparse/FileReader.cpp:287`). If a fuzzed file has no valid closing quote for a string literal (e.g. the opening quote is corrupted/relocated so the decoder never registers a proper start, or an extra quote mid-list opens a literal that's never closed), the loop keeps advancing the cursor past the physical end of the file. The exception then propagates uncaught and aborts the process.

**Fix:** check `stream_.eof()` in the loop condition, so an unterminated literal ends the scan at EOF instead of throwing. Added a `closed` flag that's only set on the loop's existing, legitimate "found the closing quote" break path, so a `SYN 41` warning ("Unterminated string literal") fires specifically for the genuinely-unterminated case — not for the pre-existing (unrelated) null-byte early exit.

Test file: 
[segfault_1421521_2103.ifc.txt](https://github.com/user-attachments/files/30103375/segfault_1421521_2103.ifc.txt)

This fix works for me, but @aothms should have a look before merging.

Generated with the assistance of an AI coding tool.