### PR TITLE
api.project.append_asset: preserve material styles reached via a layer set usage

### DIFF
--- a/docs/dev-notes/README.md
+++ b/docs/dev-notes/README.md
@@ -1,0 +1,28 @@
+<!-- This file was generated with the assistance of an AI coding tool. -->
+
+# Developer notes (in-progress features)
+
+This directory holds **living design/working notes for unmerged feature branches**,
+one Markdown file per feature, named after its branch (e.g.
+`opening-template-on-type.md`).
+
+## Purpose
+
+A shared scratchpad so collaborators — and the AI agents they work with — can pick up
+the context behind an in-progress branch: the problem, the design decisions and the
+*why*, dead ends already ruled out, and what still needs testing. Because the note is
+committed on the branch, it travels with the PR and shows up in the diff, so it is
+discoverable without anyone being told where to look.
+
+## How to use it (humans and agents)
+
+- **Before working on a feature branch**, read its note here if one exists.
+- **As the PR is refined**, keep the note current — append decisions, correct things
+  that changed, update the test checklist.
+- **One file per feature**, named after the branch.
+
+## Lifecycle
+
+These are *not* permanent user documentation. When a PR merges, either remove its note
+or promote the durable parts (the load-bearing "why") into code comments or the regular
+docs, so stale notes do not accumulate on the default branch.

--- a/docs/dev-notes/append-asset-material-styles.md
+++ b/docs/dev-notes/append-asset-material-styles.md
@@ -1,0 +1,92 @@
+<!-- This file was generated with the assistance of an AI coding tool. -->
+
+# append_asset material styles — preserving surface styles reached via a layer set usage
+
+> **Living dev note** for this fix. Read before working on the feature; append decisions
+> and findings as the PR is refined. This is *not* user documentation — at merge it is
+> removed or its durable parts promoted to code comments. See [README.md](README.md) for
+> the convention.
+
+## Problem
+
+Appending an object with `bpy.ops.bim.append_library_element_by_query()` (or any
+`ifcopenshell.api.project.append_asset`) brought a wall's **materials** across but not the
+**`IfcSurfaceStyle` assigned to each material**. In the project the appended materials came
+out with `HasRepresentation == ()` — no `IfcMaterialDefinitionRepresentation`, so no colour.
+
+Only reproduces when the material is reached through an **`IfcMaterialLayerSetUsage`**
+(i.e. real wall *occurrences*), not a bare layer set on a type. A single directly-assigned
+material, or a type product with a bare layer set, both carried styles fine — which is why
+it evaded synthetic reproduction at first.
+
+## Key facts established
+
+- `append_asset` copies the style faithfully **when it runs**. The loss is purely that the
+  code that transplants a material's inverse attributes (`check_inverses`) is **never called**
+  on these materials — confirmed by tracing: `check_inverses` never fired for the styled
+  materials, and the subgraph walk logged
+  `subloop IfcMaterialLayerSet #… -> EXISTING (queue NOT extended)`.
+- This is **not** a Bonsai import bug. `AppendLibraryElement.import_materials` →
+  `import_material_styles` → `IfcImporter.create_style` were all correct; they just had no
+  style data to import because the IFC arrived style-less. (Ruled out and reverted a red
+  herring about `create_style`'s `active_style_type` update callback not firing.)
+- Regression from the material-set **reuse** feature (`material_sets_are_equal`). The older
+  `ifcopenshell` shipped on the reporter's machine (no `material_sets_are_equal`) carried
+  styles fine; the newer repo copy Blender loads does not.
+
+### Root cause (`append_asset.py`, `Usecase.add_element`)
+
+1. The wall's `RelatingMaterial` is an `IfcMaterialLayerSetUsage` → `IfcMaterialLayerSet`.
+2. `file_add` **forward-copies** the whole usage → set → layers → materials subgraph into the
+   project. `file_add` only copies *forward* attributes; inverses (`HasRepresentation`,
+   `HasProperties`, …) are the job of `check_inverses`, which runs from `add_element`'s
+   subgraph traversal.
+3. When that traversal reaches the layer set, `get_existing_element` matches the fresh
+   forward-copy as "existing" (via `material_sets_are_equal`), so it takes the
+   `if existing_element:` branch — which **does not extend the queue into the set**. The
+   member `IfcMaterial`s are never visited, `check_inverses` never runs on them, and
+   `IfcMaterial.HasRepresentation` (which carries the `IfcSurfaceStyle`) is never transplanted.
+4. The subsequent type append short-circuits even earlier: the set is already in
+   `added_elements`, so `add_element` returns immediately.
+
+## Fix
+
+In the `if existing_element:` branch, when the matched-existing subelement is a material set,
+descend into it so each member material gets `check_inverses`:
+
+```python
+if subelement.is_a() in MATERIAL_SETS:
+    subelement_queue.extend(self.settings["library"].traverse(subelement, max_levels=1)[1:])
+```
+
+The existing `has_whitelisted_inverses` guard keeps genuine reuse **idempotent**: when the
+project already contains the same-named styled materials, the member materials are still
+enqueued but their `check_inverses` is skipped (they already have `HasRepresentation`), so no
+duplicate materials or styles are created — verified.
+
+## Status — implemented and validated (no Blender/py3.11 binary needed)
+
+- `src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py`: the 2-line descent
+  above (+ comment) in `add_element`. Single, localised change.
+- `test/api/project/test_append_asset.py`:
+  `test_append_an_occurrence_keeps_styled_materials_reached_via_a_layer_set_usage` — appends a
+  wall occurrence (via a manually-built `IfcMaterialLayerSetUsage`) and asserts the member
+  material keeps `HasRepresentation`, exactly one `IfcSurfaceStyle` survives, no duplicate
+  materials, and the style is on the appended material.
+- Validated by swapping the repo `append_asset.py` into the conda `Python312`
+  `site-packages` `ifcopenshell` (the local one is too old to run the modern suite) and
+  running the test body standalone: **FAILs without the fix** ("material lost
+  HasRepresentation"), **PASSes with it**. Idempotency (no duplicates when materials
+  pre-exist) checked separately.
+
+## Things to test / verify
+
+- Real-file confirmation in Blender (done by reporter): appended wall's materials now show
+  their colours.
+- IFC2X3 path: the added test also runs under `TestAppendAssetIFC4` (which subclasses the
+  2X3 class); the `IfcMaterialLayerSetUsage` attributes used are common to both schemas.
+- Other material-set kinds (`IfcMaterialConstituentSet`, `IfcMaterialProfileSet`) and their
+  usages should benefit from the same descent, since the fix keys off `MATERIAL_SETS`; a
+  profile-set occurrence (e.g. a styled steel column) is worth a spot-check.
+- Performance: descending into already-existing sets adds queue work; bounded and guarded,
+  but worth a glance on very large appends.

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -458,6 +458,14 @@ class Usecase:
                 self.added_elements[subelement.id()] = existing_element
                 if not self.has_whitelisted_inverses(existing_element):
                     self.check_inverses(subelement)
+                # A material set matched as "existing" may have just been forward-copied
+                # by file_add (which only copies forward attributes, not inverses). In that
+                # case its member materials never had their inverse attributes transplanted
+                # (notably IfcMaterial.HasRepresentation, which carries the material's surface
+                # style). Descend into the set so each member material gets check_inverses.
+                # The has_whitelisted_inverses guard keeps genuinely-reused materials idempotent.
+                if subelement.is_a() in MATERIAL_SETS:
+                    subelement_queue.extend(self.settings["library"].traverse(subelement, max_levels=1)[1:])
             else:
                 self.added_elements[subelement.id()] = self.file_add(subelement)
                 self.check_inverses(subelement)

--- a/src/ifcopenshell-python/test/api/project/test_append_asset.py
+++ b/src/ifcopenshell-python/test/api/project/test_append_asset.py
@@ -229,6 +229,56 @@ class TestAppendAssetIFC2X3(test.bootstrap.IFC2X3):
         assert self.file.by_type("IfcWallType")[0].HasAssociations[0].RelatingMaterial.HasRepresentation
         assert len(self.file.by_type("IfcGeometricRepresentationContext")) == 1
 
+    def test_append_an_occurrence_keeps_styled_materials_reached_via_a_layer_set_usage(self):
+        # Regression: appending a wall occurrence whose material is a layer set
+        # reached through an IfcMaterialLayerSetUsage used to drop the member
+        # materials' styles (IfcMaterial.HasRepresentation). The layer set was
+        # forward-copied by file_add and then matched as "existing", so the
+        # traversal never descended into it to transplant the materials' inverses.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(self.file, context_type="Model")
+
+        library = ifcopenshell.api.project.create_file(version=self.file.schema)
+        ifcopenshell.api.root.create_entity(library, ifc_class="IfcProject")
+        context = ifcopenshell.api.context.add_context(library, context_type="Model")
+
+        wall_type = ifcopenshell.api.root.create_entity(library, ifc_class="IfcWallType")
+        wall = ifcopenshell.api.root.create_entity(library, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(library, related_objects=[wall], relating_type=wall_type)
+
+        material = ifcopenshell.api.material.add_material(library, name="Material")
+        style = ifcopenshell.api.style.add_style(library)
+        ifcopenshell.api.style.assign_material_style(library, material=material, style=style, context=context)
+
+        layer_set = ifcopenshell.api.material.add_material_set(library, set_type="IfcMaterialLayerSet")
+        layer = ifcopenshell.api.material.add_layer(library, layer_set=layer_set, material=material)
+        ifcopenshell.api.material.edit_layer(library, layer=layer, attributes={"LayerThickness": 0.1})
+        # The type carries the bare layer set; the occurrence wraps it in a usage.
+        ifcopenshell.api.material.assign_material(library, products=[wall_type], material=layer_set)
+        usage = library.create_entity(
+            "IfcMaterialLayerSetUsage",
+            ForLayerSet=layer_set,
+            LayerSetDirection="AXIS2",
+            DirectionSense="POSITIVE",
+            OffsetFromReferenceLine=0.0,
+        )
+        library.create_entity(
+            "IfcRelAssociatesMaterial",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedObjects=[wall],
+            RelatingMaterial=usage,
+        )
+
+        ifcopenshell.api.project.append_asset(self.file, library=library, element=wall)
+
+        new_material = self.file.by_type("IfcMaterial")[0]
+        assert new_material.HasRepresentation
+        assert len(self.file.by_type("IfcSurfaceStyle")) == 1
+        assert len(self.file.by_type("IfcMaterial")) == 1
+        # The style must belong to the appended material, not a stray copy.
+        styled_item = new_material.HasRepresentation[0].Representations[0].Items[0]
+        assert self.file.by_type("IfcSurfaceStyle")[0] in styled_item.Styles
+
     def test_append_a_material(self):
         library = ifcopenshell.api.project.create_file(version=self.file.schema)
         material = ifcopenshell.api.material.add_material(library, name="Material")


### PR DESCRIPTION
Fixes #8662.

## Problem

`ifcopenshell.api.project.append_asset` drops a material's **surface style**
(`IfcMaterial.HasRepresentation` → `IfcMaterialDefinitionRepresentation` →
`IfcSurfaceStyle`) when the material is reached through an **`IfcMaterialLayerSetUsage`**
— i.e. real wall/slab occurrences. The materials are appended but arrive with
`HasRepresentation == ()`, losing their colour.

In Bonsai this is what users hit with `append_library_element` /
`append_library_element_by_query`: the object's materials come across but the styles
assigned to those materials do not. It only reproduces via a *usage*; a directly-assigned
material or a type carrying a bare `IfcMaterialLayerSet` keep their styles.

## Root cause

In `Usecase.add_element`:

1. `file_add` forward-copies the `IfcMaterialLayerSetUsage → IfcMaterialLayerSet → layers
   → materials` subgraph into the project. `file_add` copies only *forward* attributes;
   inverses (`HasRepresentation`, …) are transplanted by `check_inverses`, which runs from
   `add_element`'s subgraph traversal.
2. When the traversal reaches the layer set, `get_existing_element` matches the fresh
   forward-copy as "existing" (via `material_sets_are_equal`), so it takes the
   `if existing_element:` branch — which **does not extend the queue into the set**. The
   member `IfcMaterial`s are never visited, `check_inverses` never runs on them, and their
   `HasRepresentation` (surface style) is never transplanted.

This is a regression from the material-set-by-name reuse feature (`b4740b6949`,
`a17b0604e1`).

## Fix

When a matched-existing subelement is a material set, descend into it so each member
material gets `check_inverses`:

```python
if subelement.is_a() in MATERIAL_SETS:
    subelement_queue.extend(self.settings["library"].traverse(subelement, max_levels=1)[1:])
```

The existing `has_whitelisted_inverses` guard keeps genuine reuse **idempotent**: when the
project already contains the same-named styled materials, members are still enqueued but
their `check_inverses` is skipped, so no duplicate materials/styles are created. Keyed off
`MATERIAL_SETS`, so constituent and profile sets benefit too.

## Test

`test_append_an_occurrence_keeps_styled_materials_reached_via_a_layer_set_usage` in
`test_append_asset.py` appends a wall occurrence (via an `IfcMaterialLayerSetUsage`) and
asserts the member material keeps `HasRepresentation`, exactly one `IfcSurfaceStyle`
survives, no duplicate materials, and the style is on the appended material. It fails
without the fix ("material lost HasRepresentation") and passes with it. Runs for both
IFC2X3 and IFC4 (the second commit is a droppable working dev-note under
`docs/dev-notes/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
