### PR TITLE
project.append_asset: don't abort batch on GlobalId collision (#8667)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -429,13 +429,26 @@ class Usecase:
                 element=element_type,
                 reuse_identities=self.reuse_identities,
             )
-            ifcopenshell.api.type.assign_type(
-                self.file,
-                should_run_listeners=False,  # ty:ignore[unknown-argument]
-                related_objects=[element],
-                relating_type=new_type,
-                should_map_representations=False,
-            )
+            # `new_type` may resolve to a pre-existing element reused by
+            # GlobalId (see `get_existing_element`, which reuses any IfcRoot by
+            # GUID regardless of class). If the library type's GlobalId collides
+            # with an unrelated element already in the project, `new_type` can be
+            # an occurrence rather than a type and `assign_type` would raise,
+            # aborting the whole append. Guard it so one bad/colliding asset
+            # doesn't abort the batch; the occurrence is appended untyped. (#8667)
+            try:
+                ifcopenshell.api.type.assign_type(
+                    self.file,
+                    should_run_listeners=False,  # ty:ignore[unknown-argument]
+                    related_objects=[element],
+                    relating_type=new_type,
+                    should_map_representations=False,
+                )
+            except TypeError as e:
+                print(
+                    "Warning: append_asset could not type %s #%s with %s "
+                    "(GlobalId collision?): %s" % (element.is_a(), element.id(), new_type.is_a(), e)
+                )
             ifcopenshell.api.owner.settings.restore()
 
         return element


### PR DESCRIPTION
Fixes #8667.

## Problem

When `project.append_asset` appends a product whose **type**'s `GlobalId` collides with an element of a *different class* already present in the destination file, the whole append aborts with:

```
TypeError: IfcFlowTerminal cannot type IfcSanitaryTerminal in schema IFC4 (allowed occurrence classes: <none>)
```

This only happens when appending into an existing (populated) file, never into a blank one.

## Root cause

`get_existing_element` reuses any `IfcRoot` purely by `GlobalId`, regardless of class:

```python
if element.is_a("IfcRoot"):
    return self.by_guid(element.GlobalId)
```

In `append_product` the occurrence's type is appended recursively and passed to `assign_type`. If the library type's `GlobalId` already exists in the destination on an unrelated element (e.g. an `IfcFlowTerminal` occurrence), `get_existing_element` returns that occurrence as the "type", and `assign_type` correctly rejects it — aborting the entire batch append and leaving the model partially modified.

## Fix

Guard the `assign_type` call in `append_product` so a single colliding/malformed asset does not abort the whole batch: the occurrence is appended untyped and a concise warning is emitted.

A minimal reproduction is in the linked issue. A deeper follow-up (making `get_existing_element` reject cross-class GlobalId matches) is noted in the issue as an alternative/complementary fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)