### PR TITLE
Size entity attribute storage to schema arity, not token count

### DIFF
--- a/src/ifcparse/IfcFile.cpp
+++ b/src/ifcparse/IfcFile.cpp
@@ -273,9 +273,18 @@ IfcEntityInstanceData IfcParse::parse_context::construct(boost::optional<size_t>
         return IfcEntityInstanceData(in_memory_attribute_storage(0));
     }
 
+    // When the schema declaration is known, size the storage to the schema's
+    // attribute count rather than the (possibly smaller) number of tokens
+    // actually found. Attributes are only assigned for indices covered by
+    // tokens_ below; any remaining trailing indices stay at their
+    // default-constructed blank value. This keeps every instance's storage
+    // consistent with its schema arity, so that a malformed/truncated
+    // instance (e.g. corrupted STEP syntax dropping a trailing attribute)
+    // degrades to a blank value for the missing attribute instead of an
+    // out-of-range access when that attribute is later read by index.
     in_memory_attribute_storage storage(coerce_attribute_count
         ? (decl != nullptr
-        ? (std::min)(parameter_types.size(), tokens_.size())
+        ? parameter_types.size()
         : tokens_.size())
 		: tokens_.size()
     );


### PR DESCRIPTION
## Problem

A single byte corruption of a valid IFC file's STEP syntax (e.g. dropping a trailing attribute token) reliably crashes IfcConvert with an uncaught exception and SIGABRT, instead of being handled as a parse warning. Found via the fuzzing script attached to #5679.

## Root cause

When a STEP instance has fewer attribute tokens than its schema declares, parse_context::construct() sized the in memory attribute storage to the smaller token count instead of the schema's attribute count. This left the storage's trailing attribute slots nonexistent rather than blank, so any later read of one of those attributes by index threw IfcParse::IfcException ("Index N is out of range for storage of size N") that escaped every catch block and terminated the process.

## Fix

When the schema declaration is known, size the storage to the schema's attribute count. The storage constructor already blank initializes every slot, and this matches an established pattern already used elsewhere in the same file (in_memory_attribute_storage(T::Class().attribute_count())). The attribute population loop is bounded by the actual token count regardless of storage size, so trailing indices beyond the tokens found simply stay blank instead of being read out of bounds.

## Testing

Reproduced with the fuzzing script attached to #5679: the exact crash files (single byte corruption of #1=IFCPROJECT(...)) aborted with the out of range exception before the fix; after the fix, both parse with a logged SYN012 error and exit code 0. Re ran a 1500 iteration fuzz sweep against the patched binary with no regressions, and confirmed a real world 24,305 entity IFC4 file converts identically (614 objects) before and after.

Fixes #5679.

Generated with the assistance of an AI coding tool.