### PR TITLE
Bonsai: preserve Z when editing FALL/slope annotation curves

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -2671,7 +2671,18 @@ class OverrideModeSetObject(bpy.types.Operator, tool.Ifc.Operator):
             tool.Geometry.import_item_attributes(obj)
         elif tool.Geometry.is_curvelike_item(item):
             ProfileDecorator.uninstall()
-            new = tool.Model.export_curves(obj)
+            # Fall / slope annotations encode their slope as a real Z difference
+            # between the curve's own points, so unlike ordinary 2D profile
+            # curves their Z must be preserved instead of being flattened.
+            preserve_z = False
+            if rep_obj and (rep_element := tool.Ifc.get_entity(rep_obj)) and rep_element.is_a("IfcAnnotation"):
+                preserve_z = ifcopenshell.util.element.get_predefined_type(rep_element) in (
+                    "FALL",
+                    "SLOPE_ANGLE",
+                    "SLOPE_FRACTION",
+                    "SLOPE_PERCENT",
+                )
+            new = tool.Model.export_curves(obj, preserve_z=preserve_z)
 
             if not new:
 

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -289,13 +289,13 @@ class Model(bonsai.core.tool.Model):
 
     @classmethod
     def export_curves(
-        cls, obj: bpy.types.Object, position: Optional[Matrix] = None
+        cls, obj: bpy.types.Object, position: Optional[Matrix] = None, preserve_z: bool = False
     ) -> list[ifcopenshell.entity_instance] | None:
         if position is None:
             position = Matrix()
 
         results = []
-        result = cls.auto_detect_curves(obj, obj.data, position)
+        result = cls.auto_detect_curves(obj, obj.data, position, preserve_z=preserve_z)
         if isinstance(result, dict) and result["curves"]:
             for curve in result["curves"]:
                 results.append(tool.Ifc.get().add(curve))
@@ -2494,8 +2494,17 @@ class Model(bonsai.core.tool.Model):
 
     @classmethod
     def auto_detect_curves(
-        cls, obj: bpy.types.Object, mesh: bpy.types.Mesh, position: Matrix | None = None
+        cls,
+        obj: bpy.types.Object,
+        mesh: bpy.types.Mesh,
+        position: Matrix | None = None,
+        preserve_z: bool = False,
     ) -> Union[tuple, dict]:
+        """
+        :param preserve_z: Keep each point's Z coordinate instead of flattening
+            to a 2D curve. Used for annotations whose geometry has a meaningful
+            Z difference between points, such as a FALL/slope indicator.
+        """
         unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
 
         if position is None:
@@ -2651,18 +2660,20 @@ class Model(bonsai.core.tool.Model):
                         segments[-1][0] = last_segment_indices
                     curves.append(tmp.createIfcIndexedPolyCurve(points, segments))
                 elif tmp.schema == "IFC2X3":
-                    points = [
-                        tmp.createIfcCartesianPoint(list(((position_i @ v.co) / unit_scale).to_2d()))
-                        for v in loop_verts
-                    ]
+                    coords = [(position_i @ v.co) / unit_scale for v in loop_verts]
+                    points = [tmp.createIfcCartesianPoint(list(co if preserve_z else co.to_2d())) for co in coords]
                     if is_closed:
                         points.append(points[0])
                     curves.append(tmp.createIfcPolyline(points))
                 else:  # Pure straight polyline, no segments required
-                    coord_list = [list(((position_i @ v.co) / unit_scale).to_2d()) for v in loop_verts]
+                    coords = [(position_i @ v.co) / unit_scale for v in loop_verts]
+                    coord_list = [list(co if preserve_z else co.to_2d()) for co in coords]
                     if is_closed:
                         coord_list.append(coord_list[0])
-                    points = tmp.createIfcCartesianPointList2D(coord_list)
+                    if preserve_z:
+                        points = tmp.createIfcCartesianPointList3D(coord_list)
+                    else:
+                        points = tmp.createIfcCartesianPointList2D(coord_list)
                     curves.append(tmp.createIfcIndexedPolyCurve(points))
 
         return {"ifc_file": tmp, "curves": curves}


### PR DESCRIPTION
## Problem

Editing a FALL (or slope) annotation's endpoint in item edit mode and tabbing out reverts the Z move. The slope you just edited silently disappears.

## Root cause

export_curves() always flattened curve points to 2D via auto_detect_curves(), correct for ordinary 2D profile/annotation curves. But a FALL/slope annotation's whole meaning is the Z difference between its two points, confirmed by the decorator and SVG writer code, both of which compute the slope directly from A.z minus B.z.

## Fix

Added a preserve_z flag threaded through export_curves/auto_detect_curves, set only when the edited item belongs to an IfcAnnotation with predefined type FALL, SLOPE_ANGLE, SLOPE_FRACTION, or SLOPE_PERCENT. In that case the straight polyline branches keep full 3D coordinates and build an IfcCartesianPointList3D instead of 2D. All other curve types (profiles, dimensions, leaders, etc.) default to preserve_z False, unchanged behaviour.

## Testing

Directly exercised the new IFC entity construction logic in headless Blender 5.2 against the real ifcopenshell library. preserve_z True now yields a 3D curve keeping the real Z value, preserve_z False still yields the old 2D curve unchanged. Could not drive a full interactive tab out of edit mode UI test, since Blender 5.x's wheel based extension packaging isn't practical to fully register headlessly, and background mode object.mode_set toggling is independently unreliable outside a real viewport (confirmed on an unrelated operator, an environment limitation not caused by this fix).

Fixes #6557.

Generated with the assistance of an AI coding tool.