### PR TITLE
Bonsai: move temporary section cutaway panels to Drawings and Documents tab

### DIFF
--- a/src/bonsai/bonsai/bim/__init__.py
+++ b/src/bonsai/bonsai/bim/__init__.py
@@ -187,6 +187,8 @@ classes = [
     # Drawings and documents
     ui.BIM_PT_tab_sheets,
     ui.BIM_PT_tab_drawings,
+    ui.BIM_PT_section_plane,
+    ui.BIM_PT_section_with_cappings,
     ui.BIM_PT_tab_schedules,
     ui.BIM_PT_tab_references,
     # Services and systems
@@ -210,9 +212,6 @@ classes = [
     ui.BIM_PT_tab_clash_detection,
     ui.BIM_PT_tab_collaboration,
     ui.BIM_PT_tab_sandbox,
-    # TODO: move this somewhere else and clean it up
-    ui.BIM_PT_section_plane,
-    ui.BIM_PT_section_with_cappings,
     ui.BIM_PT_decorators_overlay,
     ui.BIM_PT_snappping,
 ]

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -132,9 +132,9 @@ class BIM_PT_section_plane(Panel):
     bl_label = "Temporary Section Cutaways"
     bl_space_type = "PROPERTIES"
     bl_region_type = "WINDOW"
-    bl_context = "output"
+    bl_context = "scene"
     bl_options = {"DEFAULT_CLOSED"}
-    bl_parent_id = "BIM_PT_tab_sandbox"
+    bl_parent_id = "BIM_PT_tab_drawings"
 
     def draw(self, context):
         assert self.layout
@@ -156,9 +156,9 @@ class BIM_PT_section_with_cappings(Panel):
     bl_label = "Section Cutaways With Cappings"
     bl_space_type = "PROPERTIES"
     bl_region_type = "WINDOW"
-    bl_context = "output"
+    bl_context = "scene"
     bl_options = {"DEFAULT_CLOSED"}
-    bl_parent_id = "BIM_PT_tab_sandbox"
+    bl_parent_id = "BIM_PT_tab_drawings"
 
     def draw(self, context):
         assert self.layout


### PR DESCRIPTION
Fixes #4309.

The "Temporary Section Cutaways" and "Section Cutaways With Cappings" panels lived under Quality and Coordination > Sandbox, unrelated to their actual purpose (viewport cross-section culling for documentation work). A maintainer TODO (`# TODO: move this somewhere else and clean it up`, 2023) sat directly above their registration.

Reparented both panels to the Drawings and Documents tab, matching the same `bl_context`/`bl_parent_id` pattern already used by the sibling drawing panels in that tab. No behavior change, pure UI relocation.

AI-generated PR, human-reviewed.