### PR TITLE
Fix #4322. Support importing IfcMaterial and profile attributes and psets via Spreadsheet Import/Export

### DIFF
--- a/src/ifccsv/ifccsv.py
+++ b/src/ifccsv/ifccsv.py
@@ -109,7 +109,13 @@ class IfcCsv:
             result = []
 
             for attribute in attributes:
-                value = ifcopenshell.util.selector.get_element_value(element, attribute)
+                if attribute == "GlobalId" and not hasattr(element, "GlobalId"):
+                    # Entities such as IfcMaterial or IfcProfileDef have no
+                    # GlobalId. Fall back to the STEP id so they can still be
+                    # uniquely identified when the spreadsheet is imported back.
+                    value = element.id()
+                else:
+                    value = ifcopenshell.util.selector.get_element_value(element, attribute)
                 if value is None:
                     value = null
                 elif value == "":
@@ -486,14 +492,29 @@ class IfcCsv:
         bool_false: str,
         concat: str,
     ) -> None:
-        # Patterns to skip during import (substrings)
-        SKIP_PATTERNS = {"count", "material"}
+        # Keys that resolve to read-only or computed values and therefore
+        # cannot be written back to the IFC file. This is an exact match
+        # against the whole key, not a substring match, since a substring
+        # match would also skip legitimate keys that merely contain these
+        # words, such as a property set named "Pset_MaterialCommon" or a
+        # quantity named "RoomCount".
+        SKIP_KEYS = {"count", "material", "mat", "materials", "mats"}
 
         try:
             element = ifc_file.by_guid(row[0])
-        except:
-            print("The element with GUID {} was not found".format(row[0]))
-            return
+        except Exception:
+            element = None
+
+        if element is None:
+            # Entities such as IfcMaterial or IfcProfileDef have no GlobalId,
+            # so on export a fallback STEP id is written instead. Recognise
+            # that here so those entities can also be imported.
+            try:
+                element = ifc_file.by_id(int(row[0]))
+            except Exception:
+                print("The element with GUID {} was not found".format(row[0]))
+                return
+
         for i, value in enumerate(row):
             if i == 0:
                 continue  # Skip GlobalId
@@ -507,8 +528,8 @@ class IfcCsv:
                 value = False
             key = attributes[i] or headers[i]
 
-            # Skip keys containing certain patterns
-            if any(pattern in key.lower() for pattern in SKIP_PATTERNS):
+            # Skip read-only/computed keys
+            if key.lower() in SKIP_KEYS:
                 continue
 
             ifcopenshell.util.selector.set_element_value(ifc_file, element, key, value, concat=concat)

--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -606,6 +606,23 @@ def filter_elements(
 class SetElementValueException(Exception): ...
 
 
+def _is_editable_pset(pset: ifcopenshell.entity_instance) -> bool:
+    """True if `pset` holds simple properties that can be written using
+    ifcopenshell.api.pset.edit_pset.
+
+    This includes IfcPropertySet, as well as IfcMaterialProperties and
+    IfcProfileProperties (IFC4+), and IfcExtendedMaterialProperties
+    (IFC2X3), which are edited the same way. IfcElementQuantity is handled
+    separately via ifcopenshell.api.pset.edit_qto.
+    """
+    return (
+        pset.is_a("IfcPropertySet")
+        or pset.is_a("IfcMaterialProperties")
+        or pset.is_a("IfcProfileProperties")
+        or pset.is_a("IfcExtendedMaterialProperties")
+    )
+
+
 def set_element_value(
     ifc_file: ifcopenshell.file,
     element: Union[
@@ -807,11 +824,11 @@ def set_element_value(
             if isinstance(key, re.Pattern):
                 for prop, prop_value in element.items():
                     if key.match(prop):
-                        if pset.is_a("IfcPropertySet") and prop_value != value:
+                        if _is_editable_pset(pset) and prop_value != value:
                             ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties={prop: value})
                         elif pset.is_a("IfcElementQuantity") and prop_value != float(value):
                             ifcopenshell.api.pset.edit_qto(ifc_file, qto=pset, properties={prop: float(value)})
-            elif pset.is_a("IfcPropertySet") and element.get(key, None) != value:
+            elif _is_editable_pset(pset) and element.get(key, None) != value:
 
                 def process_pset_prop_value(
                     pset: ifcopenshell.entity_instance, prop: str, value: Any


### PR DESCRIPTION
Fixes #4322.

Three compounding bugs prevented round-tripping `IfcMaterial`/`IfcProfileDef` attributes and psets through Spreadsheet Import/Export:

1. `IfcCsv.export` wrote a null placeholder in the GlobalId column for entities without a GlobalId (materials, profiles), and import looked entities up exclusively by GlobalId, so those rows could never be matched back on reimport. Now falls back to the STEP id on both export and import, per the fallback identifier suggested in the issue thread.
2. `ifcopenshell.util.selector.set_element_value` only knew how to write property values into `IfcPropertySet` and `IfcElementQuantity`. `IfcMaterialProperties`, `IfcProfileProperties` and `IfcExtendedMaterialProperties` are already read and created the same generic way elsewhere (`get_pset`, `edit_pset`), but `set_element_value` silently no-op'd on them. Added an `_is_editable_pset` helper so all four go through `edit_pset` consistently.
3. An unrelated regression from an earlier #7298 fix matched its skip-pattern as a substring of the whole key, which incidentally skipped importing any pset whose name merely contains "material", including the standard `Pset_MaterialCommon`/`Pset_MaterialConcrete` on ordinary products and types. Changed to an exact key match.

Live-tested round trip for material and profile psets. Full existing `test/util/test_selector.py` suite (39 tests) still passes.

AI-generated PR, human-reviewed.