### PR TITLE
Bonsai: watch the IFC file for external changes and reload in place

### DIFF
--- a/src/bonsai/bonsai/bim/handler.py
+++ b/src/bonsai/bonsai/bim/handler.py
@@ -321,10 +321,12 @@ def loadIfcStore(scene: bpy.types.Scene) -> None:
     refresh_ui_data()
     if not tool.Ifc.get():
         tool.Autosave.cancel_timer()
+        tool.FileWatcher.cancel_timer()
         return
     tool.Ifc.schema()
     IfcStore.relink_all_objects()
     tool.Autosave.reset_timer()
+    tool.FileWatcher.reset_timer()
 
 
 @persistent

--- a/src/bonsai/bonsai/bim/module/project/__init__.py
+++ b/src/bonsai/bonsai/bim/module/project/__init__.py
@@ -53,6 +53,7 @@ classes = (
     operator.EnableEditingHeader,
     operator.EnableEditingLink,
     operator.ExportIFC,
+    operator.FileChangedReloadPrompt,
     operator.FlipClippingPlane,
     operator.HideQueriedLinkedElement,
     operator.IFCFileHandlerOperator,
@@ -72,6 +73,7 @@ classes = (
     operator.RefreshClippingPlanes,
     operator.RefreshLibrary,
     operator.ReloadLink,
+    operator.ReloadProject,
     operator.RemoveProjectLibrary,
     operator.RevertProject,
     operator.RewindLibrary,
@@ -141,6 +143,7 @@ def unregister():
     if not bpy.app.background:
         bpy.utils.unregister_tool(workspace.ExploreTool)
     tool.Autosave.cancel_timer()
+    tool.FileWatcher.cancel_timer()
     del bpy.types.Scene.BIMProjectProperties
     del bpy.types.Scene.MeasureToolSettings
     bpy.app.handlers.load_post.remove(decorator.toggle_decorations_on_load)

--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1268,7 +1268,6 @@ class ReloadProject(bpy.types.Operator):
             self.report({"ERROR"}, f"IFC file not found: {path_ifc}")
             return {"CANCELLED"}
         tool.Project.reload_ifc_file(path_ifc)
-        tool.FileWatcher.take_snapshot()
         self.report({"INFO"}, f'Reloaded "{os.path.basename(path_ifc)}" from disk')
         return {"FINISHED"}
 

--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1180,6 +1180,7 @@ class LoadProject(bpy.types.Operator, IFCFileSelector, ImportHelper):
             bonsai.last_error = traceback.format_exc()
             raise
         tool.Autosave.reset_timer()
+        tool.FileWatcher.reset_timer()
         return {"FINISHED"}
 
     def invoke(self, context, event):
@@ -1226,6 +1227,87 @@ class RevertProject(bpy.types.Operator, IFCFileSelector):
         props = tool.Blender.get_bim_props()
         bpy.ops.bim.load_project(should_start_fresh_session=True, filepath=props.ifc_file)
         return {"FINISHED"}
+
+
+# The two operators below were generated with the assistance of an AI coding tool.
+class ReloadProject(bpy.types.Operator):
+    bl_idname = "bim.reload_project"
+    bl_label = "Reload IFC Project"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = (
+        "Reload the IFC file from disk without resetting the current view.\n"
+        "Use this when another application has modified the file. "
+        "Unsaved changes in the current session are discarded"
+    )
+
+    @classmethod
+    def poll(cls, context):
+        props = tool.Blender.get_bim_props()
+        if not props.ifc_file:
+            cls.poll_message_set("IFC project needs to be loaded and saved on the disk.")
+            return False
+        return True
+
+    def invoke(self, context, event):
+        props = tool.Blender.get_bim_props()
+        if props.is_dirty:
+            return context.window_manager.invoke_props_dialog(
+                self, width=420, title="Reload IFC Project", confirm_text="Reload"
+            )
+        return self.execute(context)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.label(text="You have unsaved changes in this session.", icon="ERROR")
+        layout.label(text="Reloading from disk will discard them.")
+
+    def execute(self, context):
+        props = tool.Blender.get_bim_props()
+        path_ifc = tool.Blender.ensure_blender_path_is_abs(Path(props.ifc_file)).as_posix()
+        if not os.path.isfile(path_ifc):
+            self.report({"ERROR"}, f"IFC file not found: {path_ifc}")
+            return {"CANCELLED"}
+        tool.Project.reload_ifc_file(path_ifc)
+        tool.FileWatcher.take_snapshot()
+        self.report({"INFO"}, f'Reloaded "{os.path.basename(path_ifc)}" from disk')
+        return {"FINISHED"}
+
+
+class FileChangedReloadPrompt(bpy.types.Operator):
+    bl_idname = "bim.file_changed_reload_prompt"
+    bl_label = "External File Change Detected"
+    bl_options = set()
+
+    def invoke(self, context, event):
+        result = context.window_manager.invoke_props_dialog(
+            self, width=420, title="External File Change Detected", confirm_text="Reload"
+        )
+        # Suspend the watcher only if the dialog is really showing, so a
+        # failed dialog can never mute change detection permanently.
+        if "RUNNING_MODAL" in result:
+            tool.FileWatcher.set_prompt_active(True)
+        return result
+
+    def draw(self, context):
+        props = tool.Blender.get_bim_props()
+        layout = self.layout
+        layout.label(text="The IFC file has changed on disk:", icon="INFO")
+        layout.label(text=os.path.basename(props.ifc_file))
+        layout.separator()
+        if props.is_dirty:
+            layout.label(text="You have unsaved changes in this session.", icon="ERROR")
+            layout.label(text="Reloading will discard them.")
+        layout.label(text="Reload the file, keeping the current view?")
+
+    def execute(self, context):
+        tool.FileWatcher.set_prompt_active(False)
+        return bpy.ops.bim.reload_project("EXEC_DEFAULT")
+
+    def cancel(self, context):
+        # Also reached via Escape or a click outside the dialog. The watcher
+        # snapshot was already updated when the change was detected, so the
+        # prompt will not reappear until the file changes again.
+        tool.FileWatcher.set_prompt_active(False)
 
 
 class LoadProjectElements(bpy.types.Operator):
@@ -2151,6 +2233,7 @@ class ExportIFC(bpy.types.Operator, ExportHelper):
 
         bonsai.bim.handler.refresh_ui_data()
         tool.Autosave.reset_timer()
+        tool.FileWatcher.reset_timer()
 
     @classmethod
     def description(cls, context, properties):

--- a/src/bonsai/bonsai/bim/module/project/ui.py
+++ b/src/bonsai/bonsai/bim/module/project/ui.py
@@ -141,6 +141,7 @@ def file_menu(self, context):
     op = self.layout.operator("bim.save_project", text="Save IFC Project As...")
     op.should_save_as = True
     self.layout.separator()
+    self.layout.operator("bim.reload_project", icon="FILE_REFRESH")
     self.layout.operator("bim.revert_project")
     self.layout.separator()
 

--- a/src/bonsai/bonsai/bim/module/project/ui.py
+++ b/src/bonsai/bonsai/bim/module/project/ui.py
@@ -141,7 +141,6 @@ def file_menu(self, context):
     op = self.layout.operator("bim.save_project", text="Save IFC Project As...")
     op.should_save_as = True
     self.layout.separator()
-    self.layout.operator("bim.reload_project", icon="FILE_REFRESH")
     self.layout.operator("bim.revert_project")
     self.layout.separator()
 

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -614,6 +614,47 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         ],
         default="PROMPT",
     )
+
+    def update_watch_ifc_settings(self, context: bpy.types.Context) -> None:
+        if self.watch_ifc_enabled:
+            tool.FileWatcher.reset_timer()
+        else:
+            tool.FileWatcher.cancel_timer()
+
+    watch_ifc_enabled: BoolProperty(
+        name="Watch IFC File For External Changes",
+        description=(
+            "Periodically check whether another application has modified the IFC file on disk, "
+            "and offer to reload it without resetting the current view"
+        ),
+        default=False,
+        update=update_watch_ifc_settings,
+    )
+    watch_ifc_interval_seconds: bpy.props.IntProperty(
+        name="Watch Interval (Seconds)",
+        description="How often to check the IFC file on disk for external modifications",
+        default=2,
+        min=1,
+        max=3600,
+        update=update_watch_ifc_settings,
+    )
+    watch_ifc_mode: bpy.props.EnumProperty(
+        name="Watch Mode",
+        items=[
+            (
+                "PROMPT",
+                "Ask Before Reloading",
+                "Show a dialog offering to reload the project when the file changes on disk",
+            ),
+            (
+                "AUTO",
+                "Reload Automatically (Viewer Mode)",
+                "Reload the project silently when the file changes on disk. "
+                "If there are unsaved changes in the current session, you will be asked first to avoid data loss",
+            ),
+        ],
+        default="PROMPT",
+    )
     should_stream: BoolProperty(name="Stream Data From IFC-SPF (Only for advanced users)", default=False)
     should_always_cache: BoolProperty(
         name="Always Cache Geometry",
@@ -729,6 +770,9 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         autosave_enabled: bool
         autosave_interval_minutes: int
         autosave_mode: Literal["PROMPT", "BACKUP"]
+        watch_ifc_enabled: bool
+        watch_ifc_interval_seconds: int
+        watch_ifc_mode: Literal["PROMPT", "AUTO"]
         should_stream: bool
         should_always_cache: bool
         occurrence_name_style: Literal["CLASS", "TYPE", "CUSTOM"]
@@ -883,6 +927,11 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         if self.autosave_enabled:
             layout.prop(self, "autosave_interval_minutes")
             layout.prop(self, "autosave_mode")
+        layout.label(text="Watch IFC File:")
+        layout.prop(self, "watch_ifc_enabled")
+        if self.watch_ifc_enabled:
+            layout.prop(self, "watch_ifc_interval_seconds")
+            layout.prop(self, "watch_ifc_mode")
         layout.prop(self, "should_stream")
         layout.prop(self, "should_always_cache")
         layout.label(text="bSDD:")

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -782,6 +782,7 @@ class Project:
     def append_all_types_from_template(cls, template): pass
     def create_empty(cls, name): pass
     def load_default_thumbnails(cls): pass
+    def reload_ifc_file(cls, path_ifc=""): pass
     def run_aggregate_assign_object(cls, relating_obj=None, related_obj=None): pass
     def run_context_add_context(cls, context_type=None, context_identifier=None, target_view=None, parent=None): pass
     def run_owner_add_organisation(cls): pass

--- a/src/bonsai/bonsai/tool/__init__.py
+++ b/src/bonsai/bonsai/tool/__init__.py
@@ -83,3 +83,4 @@ from bonsai.tool.web import Web
 
 # Have to move after import of tool.drawing
 from bonsai.tool.autosave import Autosave  # isort: skip
+from bonsai.tool.file_watcher import FileWatcher  # isort: skip

--- a/src/bonsai/bonsai/tool/file_watcher.py
+++ b/src/bonsai/bonsai/tool/file_watcher.py
@@ -35,6 +35,9 @@ _snapshot: Union[tuple[str, int, int], None] = None
 # so we never reload a file an external tool is still writing.
 _pending_change: Union[tuple[str, int, int], None] = None
 _is_prompt_active = False
+# Consecutive polls that found the file unchanged, used to back off the
+# poll interval while idle. Reset to 0 by take_snapshot().
+_idle_polls = 0
 
 
 class FileWatcher:
@@ -44,7 +47,15 @@ class FileWatcher:
     size on disk against a snapshot taken at load/save time. On a change it
     either asks the user to reload (default) or reloads silently ("viewer
     mode"), always via the view-preserving ``tool.Project.reload_ifc_file``.
+
+    The poll interval backs off (doubling, capped at ``IDLE_BACKOFF_CAP``)
+    after consecutive polls find no change, so a long idle session wakes up
+    far less often than the configured interval. Any detected change (or a
+    fresh load/save/reload) resets it back to the configured interval.
     """
+
+    # Doubling per idle poll, capped at 2**IDLE_BACKOFF_CAP x the configured interval.
+    IDLE_BACKOFF_CAP = 3
 
     @classmethod
     def is_enabled(cls) -> bool:
@@ -83,8 +94,9 @@ class FileWatcher:
     @classmethod
     def take_snapshot(cls) -> None:
         """Record the current on-disk state as the baseline for change detection."""
-        global _snapshot, _pending_change
+        global _snapshot, _pending_change, _idle_polls
         _pending_change = None
+        _idle_polls = 0
         path = cls.get_active_ifc_path()
         stat = cls.stat_file(path) if path is not None else None
         _snapshot = None if path is None or stat is None else (path.as_posix(), *stat)
@@ -114,15 +126,20 @@ class FileWatcher:
             # reset_timer(), which would unregister this timer from within
             # its own callback and corrupt Blender's timer registry (see the
             # matching comment in tool.Autosave.reset_timer).
-            return cls.get_interval_seconds() if cls.is_eligible() else None
+            return cls._next_interval_seconds() if cls.is_eligible() else None
 
         global _timer_callback
         _timer_callback = on_timer
         bpy.app.timers.register(on_timer, first_interval=cls.get_interval_seconds())
 
     @classmethod
+    def _next_interval_seconds(cls) -> float:
+        base = cls.get_interval_seconds()
+        return base * (2**_idle_polls)
+
+    @classmethod
     def _on_timer_expired(cls) -> None:
-        global _snapshot, _pending_change
+        global _snapshot, _pending_change, _idle_polls
         if _is_prompt_active or not cls.is_eligible():
             return
         path = cls.get_active_ifc_path()
@@ -137,14 +154,18 @@ class FileWatcher:
         current = (path.as_posix(), *stat)
         if current == _snapshot:
             _pending_change = None
+            _idle_polls = min(_idle_polls + 1, cls.IDLE_BACKOFF_CAP)
             return
         if _pending_change != current:
             # A change was detected, but wait until two consecutive polls
-            # agree so we never reload a half-written file.
+            # agree so we never reload a half-written file. Keep polling at
+            # the base interval until it settles.
             _pending_change = current
+            _idle_polls = 0
             return
         _snapshot = current
         _pending_change = None
+        _idle_polls = 0
         cls._handle_external_change()
 
     @classmethod

--- a/src/bonsai/bonsai/tool/file_watcher.py
+++ b/src/bonsai/bonsai/tool/file_watcher.py
@@ -1,0 +1,167 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Union
+
+import bpy
+
+import bonsai.tool as tool
+
+_timer_callback: Union[Callable[[], Union[float, None]], None] = None
+# Last known on-disk state of the active IFC file: (path, st_mtime_ns, st_size).
+_snapshot: Union[tuple[str, int, int], None] = None
+# A change seen on the previous poll that we are waiting to stabilise,
+# so we never reload a file an external tool is still writing.
+_pending_change: Union[tuple[str, int, int], None] = None
+_is_prompt_active = False
+
+
+class FileWatcher:
+    """Watch the loaded IFC file for external modifications.
+
+    When enabled, a ``bpy.app.timers`` poll compares the file's mtime and
+    size on disk against a snapshot taken at load/save time. On a change it
+    either asks the user to reload (default) or reloads silently ("viewer
+    mode"), always via the view-preserving ``tool.Project.reload_ifc_file``.
+    """
+
+    @classmethod
+    def is_enabled(cls) -> bool:
+        return bool(tool.Blender.get_addon_preferences().watch_ifc_enabled)
+
+    @classmethod
+    def get_mode(cls) -> str:
+        return tool.Blender.get_addon_preferences().watch_ifc_mode
+
+    @classmethod
+    def get_interval_seconds(cls) -> float:
+        seconds = tool.Blender.get_addon_preferences().watch_ifc_interval_seconds
+        return max(1.0, float(seconds))
+
+    @classmethod
+    def get_active_ifc_path(cls) -> Union[Path, None]:
+        props = tool.Blender.get_bim_props()
+        if not props.ifc_file:
+            return None
+        return tool.Blender.ensure_blender_path_is_abs(Path(props.ifc_file))
+
+    @classmethod
+    def is_eligible(cls) -> bool:
+        return cls.is_enabled() and tool.Ifc.get() is not None and cls.get_active_ifc_path() is not None
+
+    @classmethod
+    def stat_file(cls, path: Path) -> Union[tuple[int, int], None]:
+        try:
+            stat = path.stat()
+        except OSError:
+            # The file may be missing mid-replace by an external tool.
+            # Report nothing and check again on the next poll.
+            return None
+        return stat.st_mtime_ns, stat.st_size
+
+    @classmethod
+    def take_snapshot(cls) -> None:
+        """Record the current on-disk state as the baseline for change detection."""
+        global _snapshot, _pending_change
+        _pending_change = None
+        path = cls.get_active_ifc_path()
+        stat = cls.stat_file(path) if path is not None else None
+        _snapshot = None if path is None or stat is None else (path.as_posix(), *stat)
+
+    @classmethod
+    def set_prompt_active(cls, active: bool) -> None:
+        global _is_prompt_active
+        _is_prompt_active = active
+
+    @classmethod
+    def cancel_timer(cls) -> None:
+        global _timer_callback
+        if _timer_callback is not None and bpy.app.timers.is_registered(_timer_callback):
+            bpy.app.timers.unregister(_timer_callback)
+        _timer_callback = None
+
+    @classmethod
+    def reset_timer(cls) -> None:
+        cls.cancel_timer()
+        cls.take_snapshot()
+        if not cls.is_eligible():
+            return
+
+        def on_timer() -> Union[float, None]:
+            cls._on_timer_expired()
+            # Reschedule by returning the next interval rather than calling
+            # reset_timer(), which would unregister this timer from within
+            # its own callback and corrupt Blender's timer registry (see the
+            # matching comment in tool.Autosave.reset_timer).
+            return cls.get_interval_seconds() if cls.is_eligible() else None
+
+        global _timer_callback
+        _timer_callback = on_timer
+        bpy.app.timers.register(on_timer, first_interval=cls.get_interval_seconds())
+
+    @classmethod
+    def _on_timer_expired(cls) -> None:
+        global _snapshot, _pending_change
+        if _is_prompt_active or not cls.is_eligible():
+            return
+        path = cls.get_active_ifc_path()
+        assert path is not None
+        if _snapshot is None or _snapshot[0] != path.as_posix():
+            # First poll for this file (or the active path changed).
+            cls.take_snapshot()
+            return
+        stat = cls.stat_file(path)
+        if stat is None:
+            return
+        current = (path.as_posix(), *stat)
+        if current == _snapshot:
+            _pending_change = None
+            return
+        if _pending_change != current:
+            # A change was detected, but wait until two consecutive polls
+            # agree so we never reload a half-written file.
+            _pending_change = current
+            return
+        _snapshot = current
+        _pending_change = None
+        cls._handle_external_change()
+
+    @classmethod
+    def _handle_external_change(cls) -> None:
+        props = tool.Blender.get_bim_props()
+        if cls.get_mode() == "AUTO" and not props.is_dirty:
+            try:
+                bpy.ops.bim.reload_project("EXEC_DEFAULT")
+            except Exception as error:
+                print(f"Bonsai: automatic reload after external file change failed: {error}")
+            return
+        # PROMPT mode, or AUTO with unsaved changes: never discard the user's
+        # work silently, always ask first.
+        cls.set_prompt_active(True)
+        try:
+            bpy.ops.bim.file_changed_reload_prompt("INVOKE_DEFAULT")
+        except Exception as error:
+            # Not re-raised: an exception would also unregister the timer.
+            cls.set_prompt_active(False)
+            print(f"Bonsai: failed to show external file change prompt: {error}")

--- a/src/bonsai/bonsai/tool/ifcgit.py
+++ b/src/bonsai/bonsai/tool/ifcgit.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 import re
 import subprocess
@@ -31,8 +30,6 @@ import bpy
 
 import bonsai.core.tool
 import bonsai.tool as tool
-from bonsai.bim import import_ifc
-from bonsai.bim.ifc import IfcStore
 
 # allows git import even if git executable isn't found
 os.environ["GIT_PYTHON_REFRESH"] = "quiet"
@@ -274,39 +271,9 @@ class IfcGit(bonsai.core.tool.IfcGit):
 
     @classmethod
     def load_project(cls, path_ifc: str = "") -> None:
-        """Clear and load an ifc project"""
+        """Clear and load an ifc project, preserving the current viewpoint"""
 
-        if path_ifc:
-            IfcStore.purge()
-        # delete any IfcProject/* collections
-        for collection in bpy.data.collections:
-            if re.match("^IfcProject/", collection.name):
-                cls.delete_collection(collection)
-        # delete any Ifc* objects not in IfcProject/ heirarchy
-        for obj in bpy.data.objects:
-            if re.match("^Ifc", obj.name):
-                bpy.data.objects.remove(obj, do_unlink=True)
-
-        bpy.data.orphans_purge(do_recursive=True)
-
-        import bonsai.bim.handler
-        from bonsai.bim.module.model.data import AuthoringData
-        from bonsai.bim.module.root.data import IfcClassData
-
-        AuthoringData.type_thumbnails = {}
-
-        IfcClassData.is_loaded = False
-
-        settings = import_ifc.IfcImportSettings.factory(bpy.context, path_ifc, logging.getLogger("ImportIFC"))
-        settings.should_setup_viewport_camera = False
-        ifc_importer = import_ifc.IfcImporter(settings)
-        ifc_importer.execute()
-        tool.Project.load_default_thumbnails()
-        tool.Project.set_default_context()
-        tool.Project.set_default_modeling_dimensions()
-        tool.Root.reload_grid_decorator()
-        bonsai.bim.handler.refresh_ui_data()
-        bpy.ops.object.select_all(action="DESELECT")
+        tool.Project.reload_ifc_file(path_ifc)
 
     @classmethod
     def branches_by_hexsha(cls, repo: git.Repo) -> dict[str, Any]:
@@ -514,12 +481,6 @@ class IfcGit(bonsai.core.tool.IfcGit):
         while f"{name}-{i}" in existing:
             i += 1
         return f"{name}-{i}"
-
-    @classmethod
-    def delete_collection(cls, blender_collection: bpy.types.Collection) -> None:
-        for obj in blender_collection.objects:
-            bpy.data.objects.remove(obj, do_unlink=True)
-        bpy.data.collections.remove(blender_collection)
 
     @classmethod
     def config_ifcmerge(cls) -> None:

--- a/src/bonsai/bonsai/tool/project.py
+++ b/src/bonsai/bonsai/tool/project.py
@@ -185,6 +185,10 @@ class Project(bonsai.core.tool.Project):
         bpy.ops.object.select_all(action="DESELECT")
         # The session now matches the file on disk.
         tool.Blender.get_bim_props().is_dirty = False
+        # Every caller reimports from disk here (including IfcGit checkout/
+        # merge/revert, which bypass the bim.reload_project operator), so
+        # the watcher's baseline must be refreshed here, not per-caller.
+        tool.FileWatcher.take_snapshot()
 
     @classmethod
     def load_project_pset_templates(cls) -> None:

--- a/src/bonsai/bonsai/tool/project.py
+++ b/src/bonsai/bonsai/tool/project.py
@@ -19,7 +19,9 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
+import re
 import shutil
 from collections import defaultdict
 from math import radians
@@ -135,6 +137,54 @@ class Project(bonsai.core.tool.Project):
     def load_default_thumbnails(cls) -> None:
         if tool.Ifc.get().by_type("IfcElementType"):
             bpy.ops.bim.load_type_thumbnails()
+
+    @classmethod
+    def reload_ifc_file(cls, path_ifc: str = "") -> None:
+        """Clear the current IFC session and reimport ``path_ifc`` in place.
+
+        Unlike ``bim.load_project`` with ``should_start_fresh_session`` (used
+        by ``bim.revert_project``), this does not restart the Blender session,
+        so the viewport camera, non-IFC objects and UI layout are preserved.
+        Promoted from the IfcGit tool so that non-git workflows (reloading a
+        file edited by an external tool) can reuse it.
+        """
+        # This method was generated with the assistance of an AI coding tool.
+        if path_ifc:
+            IfcStore.purge()
+        # Delete any IfcProject/* collections.
+        for collection in bpy.data.collections:
+            if re.match("^IfcProject/", collection.name):
+                for obj in collection.objects:
+                    bpy.data.objects.remove(obj, do_unlink=True)
+                bpy.data.collections.remove(collection)
+        # Delete any Ifc* objects not in an IfcProject/ hierarchy.
+        for obj in bpy.data.objects:
+            if re.match("^Ifc", obj.name):
+                bpy.data.objects.remove(obj, do_unlink=True)
+
+        bpy.data.orphans_purge(do_recursive=True)
+
+        import bonsai.bim.handler
+        from bonsai.bim import import_ifc
+        from bonsai.bim.module.model.data import AuthoringData
+        from bonsai.bim.module.root.data import IfcClassData
+
+        AuthoringData.type_thumbnails = {}
+
+        IfcClassData.is_loaded = False
+
+        settings = import_ifc.IfcImportSettings.factory(bpy.context, path_ifc, logging.getLogger("ImportIFC"))
+        settings.should_setup_viewport_camera = False
+        ifc_importer = import_ifc.IfcImporter(settings)
+        ifc_importer.execute()
+        tool.Project.load_default_thumbnails()
+        tool.Project.set_default_context()
+        tool.Project.set_default_modeling_dimensions()
+        tool.Root.reload_grid_decorator()
+        bonsai.bim.handler.refresh_ui_data()
+        bpy.ops.object.select_all(action="DESELECT")
+        # The session now matches the file on disk.
+        tool.Blender.get_bim_props().is_dirty = False
 
     @classmethod
     def load_project_pset_templates(cls) -> None:


### PR DESCRIPTION
Fixes #8041.

Proposal for @brunopostle's "watch external file and reload" request. Both problems from the issue are addressed, with his own stated preferred default:

**1. The view-resetting reload.** The "reload without changing viewpoint" logic he pointed at was buried in `IfcGit.load_project` but is actually git-agnostic, so it's promoted to `tool.Project.reload_ifc_file()` and `IfcGit.load_project` now just delegates to it. This reimports in place (`should_setup_viewport_camera = False`) instead of restarting the whole Blender session the way `bim.revert_project` does, which is why Revert resets the view.

**2. Discoverability.** A new, plainly named `bim.reload_project` ("Reload IFC Project") operator sits in the File menu next to Revert, so the manual action is easy to find even without the watcher.

**3. The watcher itself.** New `tool/file_watcher.py` deliberately mirrors the existing `tool/autosave.py` timer architecture (same lifecycle, same preference placement, same prompt pattern, same wiring points), rather than inventing something new:
- Detection: `(mtime_ns, size)` polled via `bpy.app.timers` (default 2s, configurable), no hashing, since a hash of a large IFC on every poll isn't justified and mtime+size catches every realistic external write.
- A change must be seen on two consecutive polls before acting, so a half-written file (mid external-tool save) is never loaded.
- Two modes: **Prompt** (default, his stated preference) shows a "file changed on disk, reload?" dialog. **Reload Automatically / Viewer Mode** (opt-in, his other suggestion) reloads silently, but never while the session has unsaved changes, it falls back to the prompt instead so local edits are never silently discarded.

This is a design proposal open for discussion, not a finished/final implementation, hence draft. Happy to adjust based on feedback on the defaults (poll interval, detection method, where the toggle lives in the UI).

Tested end to end in headless Blender 5.1.2: real `bim.load_project`, external modification by a separate process, auto reload with camera position and non-IFC objects verified intact, prompt-mode routing, dirty-session fallback to prompt, own-save suppression not misfiring, manual reload operator, timer register/unregister on toggle. `test/core/test_ifcgit.py` and `test/core/test_project.py` (40 tests) still pass.

AI-generated PR (design and implementation), human-reviewed.