### PR TITLE
Bonsai: realign plate placement when a triangular profile is edited in 3D

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -2596,6 +2596,12 @@ class OverrideModeSetObject(bpy.types.Operator, tool.Ifc.Operator):
                 tool.Geometry.import_item(obj)
         elif item.is_a("IfcSweptAreaSolid"):
             ProfileDecorator.uninstall()
+            if (
+                item.is_a("IfcExtrudedAreaSolid")
+                and tool.Cad.is_x(tool.Model.get_existing_x_angle(item), 0, tolerance=0.001)
+                and tool.Model.realign_to_triangle_profile(obj, Matrix())
+            ):
+                tool.Geometry.sync_item_positions()
             if not (profile := tool.Model.export_profile(obj)):
 
                 def msg(self, context):

--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -42,7 +42,6 @@ from bonsai.bim.module.model.decorator import (
     ProfileDecorator,
 )
 from bonsai.bim.module.model.polyline import PolylineOperator
-from bonsai.tool.cad import WELD_TOLERANCE
 
 
 class DumbSlabGenerator:
@@ -670,53 +669,6 @@ class EnableEditingExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):
         return {"FINISHED"}
 
 
-def realign_placement_to_triangle_profile(obj: bpy.types.Object, position: Matrix) -> None:
-    """Realign the element when a 3 point profile was edited out of plane.
-
-    Any 3 non collinear points define a plane, so instead of flattening the
-    edit back onto the old extrusion plane (losing the user's 3D node
-    positions), rotate the object so the extrusion plane matches the new
-    triangle, keeping all 3 nodes at their edited world positions.
-    """
-    assert isinstance(obj.data, bpy.types.Mesh)
-    mesh = obj.data
-    if len(mesh.vertices) != 3 or len(mesh.edges) != 3:
-        return
-    edge_keys = {frozenset(e.vertices) for e in mesh.edges}
-    if len(edge_keys) != 3 or any(len(k) != 2 for k in edge_keys):
-        return
-    if any(v.groups for v in mesh.vertices):  # Arcs and circles keep the flattening behaviour.
-        return
-    points = [v.co.copy() for v in mesh.vertices]
-    if any((points[i] - points[j]).length <= WELD_TOLERANCE for i, j in ((0, 1), (0, 2), (1, 2))):
-        return  # Would weld into a degenerate profile, keep the legacy failure path.
-    position_i = position.inverted()
-    # 0.1mm, matching the profile rounding tolerance in auto_detect_profiles.
-    if max(abs((position_i @ p).z) for p in points) <= 1e-4:
-        return
-    normal = (points[1] - points[0]).cross(points[2] - points[0])
-    if normal.length < 1e-8:
-        return  # Degenerate triangle, existing profile validation will report it.
-    normal.normalize()
-    if normal.dot(position.col[2].to_3d()) < 0:
-        normal.negate()  # Keep the extrusion on the same side as before.
-    x_axis = position.col[0].to_3d()
-    x_axis -= normal * x_axis.dot(normal)
-    if x_axis.length < 1e-6:
-        x_axis = points[1] - points[0]
-    x_axis.normalize()
-    y_axis = normal.cross(x_axis)
-    origin = position.translation - normal * normal.dot(position.translation - points[0])
-    plane = Matrix([x_axis, y_axis, normal, origin]).to_4x4().transposed()
-    plane_i = plane.inverted()
-    for vert in mesh.vertices:
-        local = plane_i @ vert.co
-        vert.co = position @ Vector((local.x, local.y, 0.0))
-    obj.matrix_world = obj.matrix_world @ plane @ position_i
-    bpy.context.view_layer.update()
-    bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
-
-
 class EditExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_extrusion_profile"
     bl_label = "Edit Extrusion Profile"
@@ -758,8 +710,10 @@ class EditExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):
         else:
             position = Matrix()
 
-        if tool.Cad.is_x(existing_x_angle, 0, tolerance=0.001):
-            realign_placement_to_triangle_profile(obj, position)
+        if tool.Cad.is_x(existing_x_angle, 0, tolerance=0.001) and tool.Model.realign_to_triangle_profile(
+            obj, position
+        ):
+            bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
 
         profile = tool.Model.export_profile(obj, position=position, x_angle=existing_x_angle)
 

--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -42,6 +42,7 @@ from bonsai.bim.module.model.decorator import (
     ProfileDecorator,
 )
 from bonsai.bim.module.model.polyline import PolylineOperator
+from bonsai.tool.cad import WELD_TOLERANCE
 
 
 class DumbSlabGenerator:
@@ -669,6 +670,53 @@ class EnableEditingExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):
         return {"FINISHED"}
 
 
+def realign_placement_to_triangle_profile(obj: bpy.types.Object, position: Matrix) -> None:
+    """Realign the element when a 3 point profile was edited out of plane.
+
+    Any 3 non collinear points define a plane, so instead of flattening the
+    edit back onto the old extrusion plane (losing the user's 3D node
+    positions), rotate the object so the extrusion plane matches the new
+    triangle, keeping all 3 nodes at their edited world positions.
+    """
+    assert isinstance(obj.data, bpy.types.Mesh)
+    mesh = obj.data
+    if len(mesh.vertices) != 3 or len(mesh.edges) != 3:
+        return
+    edge_keys = {frozenset(e.vertices) for e in mesh.edges}
+    if len(edge_keys) != 3 or any(len(k) != 2 for k in edge_keys):
+        return
+    if any(v.groups for v in mesh.vertices):  # Arcs and circles keep the flattening behaviour.
+        return
+    points = [v.co.copy() for v in mesh.vertices]
+    if any((points[i] - points[j]).length <= WELD_TOLERANCE for i, j in ((0, 1), (0, 2), (1, 2))):
+        return  # Would weld into a degenerate profile, keep the legacy failure path.
+    position_i = position.inverted()
+    # 0.1mm, matching the profile rounding tolerance in auto_detect_profiles.
+    if max(abs((position_i @ p).z) for p in points) <= 1e-4:
+        return
+    normal = (points[1] - points[0]).cross(points[2] - points[0])
+    if normal.length < 1e-8:
+        return  # Degenerate triangle, existing profile validation will report it.
+    normal.normalize()
+    if normal.dot(position.col[2].to_3d()) < 0:
+        normal.negate()  # Keep the extrusion on the same side as before.
+    x_axis = position.col[0].to_3d()
+    x_axis -= normal * x_axis.dot(normal)
+    if x_axis.length < 1e-6:
+        x_axis = points[1] - points[0]
+    x_axis.normalize()
+    y_axis = normal.cross(x_axis)
+    origin = position.translation - normal * normal.dot(position.translation - points[0])
+    plane = Matrix([x_axis, y_axis, normal, origin]).to_4x4().transposed()
+    plane_i = plane.inverted()
+    for vert in mesh.vertices:
+        local = plane_i @ vert.co
+        vert.co = position @ Vector((local.x, local.y, 0.0))
+    obj.matrix_world = obj.matrix_world @ plane @ position_i
+    bpy.context.view_layer.update()
+    bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
+
+
 class EditExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_extrusion_profile"
     bl_label = "Edit Extrusion Profile"
@@ -709,6 +757,9 @@ class EditExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator):
 
         else:
             position = Matrix()
+
+        if tool.Cad.is_x(existing_x_angle, 0, tolerance=0.001):
+            realign_placement_to_triangle_profile(obj, position)
 
         profile = tool.Model.export_profile(obj, position=position, x_angle=existing_x_angle)
 

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -1069,7 +1069,10 @@ class EditObjectUI:
         row.separator()
         row.label(text="Mode") if ui_context != "TOOL_HEADER" else row
 
-        if AuthoringData.data["active_material_usage"] == "LAYER3":
+        if AuthoringData.data["active_material_usage"] == "LAYER3" or (
+            AuthoringData.data["active_material_usage"] is None
+            and tool.Model.is_layer3_capable_class(AuthoringData.data["active_class"])
+        ):
             if len(context.selected_objects) == 1 and AuthoringData.data["has_extrusion"]:
                 row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
                 add_layout_hotkey_operator(row, "Edit Profile", "S_E", "", ui_context)
@@ -1242,7 +1245,9 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
             if bpy.context.selected_objects[0] != active_object:
                 return
 
-            if self.active_material_usage == "LAYER3":
+            if self.active_material_usage == "LAYER3" or (
+                self.active_material_usage is None and tool.Model.is_layer3_capable_class(self.active_class)
+            ):
                 # Edit LAYER3 profile
                 if (
                     active_object.mode == "OBJECT"

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -1137,6 +1137,11 @@ class Model(bonsai.core.tool.Model):
                 return "PROFILE"
 
     @classmethod
+    def is_layer3_capable_class(cls, ifc_class: str) -> bool:
+        """Classes whose single-extrusion body is edited as a LAYER3 profile."""
+        return ifc_class in ("IfcSlab", "IfcRoof", "IfcRamp", "IfcPlate")
+
+    @classmethod
     def get_wall_axis(
         cls, obj: bpy.types.Object, layers: Optional[MaterialLayerParameters] = None
     ) -> dict[str, list[Vector]]:

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -288,6 +288,60 @@ class Model(bonsai.core.tool.Model):
             return tool.Ifc.get().add(result["profile_def"])
 
     @classmethod
+    def realign_to_triangle_profile(cls, obj: bpy.types.Object, position: Matrix) -> bool:
+        """Realign `obj` when a 3 point profile was edited out of plane.
+
+        Any 3 non collinear points define a plane, so instead of flattening the
+        edit back onto the old extrusion plane (losing the user's 3D node
+        positions), rotate the object so the extrusion plane matches the new
+        triangle, keeping all 3 nodes at their edited world positions.
+
+        `position` is the profile position matrix the mesh was imported with
+        (identity for representation item objects). Returns True if the object
+        was realigned; the caller is responsible for persisting the new
+        placement to IFC.
+        """
+        from bonsai.tool.cad import WELD_TOLERANCE
+
+        assert isinstance(obj.data, bpy.types.Mesh)
+        mesh = obj.data
+        if len(mesh.vertices) != 3 or len(mesh.edges) != 3:
+            return False
+        edge_keys = {frozenset(e.vertices) for e in mesh.edges}
+        if len(edge_keys) != 3 or any(len(k) != 2 for k in edge_keys):
+            return False
+        if any(v.groups for v in mesh.vertices):  # Arcs and circles keep the flattening behaviour.
+            return False
+        points = [v.co.copy() for v in mesh.vertices]
+        if any((points[i] - points[j]).length <= WELD_TOLERANCE for i, j in ((0, 1), (0, 2), (1, 2))):
+            return False  # Would weld into a degenerate profile, keep the legacy failure path.
+        position_i = position.inverted()
+        # 0.1mm, matching the profile rounding tolerance in auto_detect_profiles.
+        if max(abs((position_i @ p).z) for p in points) <= 1e-4:
+            return False
+        normal = (points[1] - points[0]).cross(points[2] - points[0])
+        if normal.length < 1e-8:
+            return False  # Degenerate triangle, existing profile validation will report it.
+        normal.normalize()
+        if normal.dot(position.col[2].to_3d()) < 0:
+            normal.negate()  # Keep the extrusion on the same side as before.
+        x_axis = position.col[0].to_3d()
+        x_axis -= normal * x_axis.dot(normal)
+        if x_axis.length < 1e-6:
+            x_axis = points[1] - points[0]
+        x_axis.normalize()
+        y_axis = normal.cross(x_axis)
+        origin = position.translation - normal * normal.dot(position.translation - points[0])
+        plane = Matrix([x_axis, y_axis, normal, origin]).to_4x4().transposed()
+        plane_i = plane.inverted()
+        for vert in mesh.vertices:
+            local = plane_i @ vert.co
+            vert.co = position @ Vector((local.x, local.y, 0.0))
+        obj.matrix_world = obj.matrix_world @ plane @ position_i
+        bpy.context.view_layer.update()
+        return True
+
+    @classmethod
     def export_curves(
         cls, obj: bpy.types.Object, position: Optional[Matrix] = None
     ) -> list[ifcopenshell.entity_instance] | None:

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -618,7 +618,7 @@ class Model(bonsai.core.tool.Model):
 
             cls.edges.extend([(i, i + 1) for i in range(offset, len(cls.vertices) - 1)])
             if is_closed:
-                cls.edges[-1] = (len(cls.vertices) - 1, offset)  # Close the loop
+                cls.edges.append((len(cls.vertices) - 1, offset))  # Close the loop
 
         elif curve.is_a("IfcCompositeCurve"):
             # This is a first pass incomplete implementation only for simple polylines, and misses many details.


### PR DESCRIPTION
Fixes #6377.

@brunopostle this is your own scoped-down compromise: for a plate/slab profile of exactly 3 nodes, moving a node in full 3D now realigns the whole element's orientation to the new triangle, instead of silently flattening the edit back onto the old extrusion plane (which is what happens today, verified live).

Any 3 non collinear points define a plane, so this is well defined: the new plane keeps the extrusion normal on the same side as before (no flips), keeps the X axis as close as possible to the old one (minimal rotation), and keeps the origin as close as possible to the old profile origin (minimal drift). All 3 edited world positions round trip back exactly through the new placement, verified numerically (within 1e-4) rather than just visually.

Out of scope, exactly as you described: 4+ node profiles (a single realignment can't generally force them planar) and the multi-plate aggregate coincident-node case, both keep today's existing behavior untouched.

Marked draft since I'd like your read on whether this actually gets you what you were after before treating it as final.

AI-generated PR (design and implementation), human-reviewed.