### PR TITLE
Bonsai docs: fix quickstart isolate/hide/show default claim

### DIFF
--- a/src/bonsai/docs/quickstart/explore_model.rst
+++ b/src/bonsai/docs/quickstart/explore_model.rst
@@ -142,12 +142,13 @@ find objects, and use the **Select Icon** to select them.
 
 .. note::
 
-   The **Isolate** button and **Hide / Show Icons** shown above next to the
-   **Spatial Container** list are not enabled by default, since they can
-   conflict with active status filters (see
-   :menuselection:`Properties --> Scheduling --> Status`). To bring them
-   back, enable **Container hide/show/isolate** under
-   :menuselection:`Edit --> Preferences --> Add-ons --> Bonsai --> Extras`.
+   The **Element** list **Isolate** button and **Hide / Show Icons** shown
+   above do not currently respect an active status filter (see
+   :menuselection:`Properties --> Scheduling --> Status`), and vice versa.
+   The older **Spatial Container** list versions of these buttons do not
+   have this problem, which is why they are still available as an opt in
+   under :menuselection:`Edit --> Preferences --> Add-ons --> Bonsai -->
+   Extras`, enable **Container hide/show/isolate** to bring them back.
 
 **Elements** are grouped into IFC **Classes**, such as Wall, Slab, or Door.
 Within that, **Elements** are grouped into **Construction Types**. You'll see a

--- a/src/bonsai/docs/quickstart/explore_model.rst
+++ b/src/bonsai/docs/quickstart/explore_model.rst
@@ -133,12 +133,21 @@ contained inside the actively selected **Spatial Container**.
 
 .. image:: images/spatial-tree.png
 
-With a **Spatial Container** selected, use the **Isolate** button or **Hide /
-Show Icons** to quickly focus or control visibility. Use the search filters at
-the bottom of the **Container** or **Element** lists to quickly find objects,
-and use the **Select Icon** to select them.
+With an **Element** selected in the list, use the **Isolate** button or
+**Hide / Show Icons** to quickly focus or control visibility. Use the search
+filters at the bottom of the **Container** or **Element** lists to quickly
+find objects, and use the **Select Icon** to select them.
 
 .. image:: images/spatial-tree-features.png
+
+.. note::
+
+   The **Isolate** button and **Hide / Show Icons** shown above next to the
+   **Spatial Container** list are not enabled by default, since they can
+   conflict with active status filters (see
+   :menuselection:`Properties --> Scheduling --> Status`). To bring them
+   back, enable **Container hide/show/isolate** under
+   :menuselection:`Edit --> Preferences --> Add-ons --> Bonsai --> Extras`.
 
 **Elements** are grouped into IFC **Classes**, such as Wall, Slab, or Door.
 Within that, **Elements** are grouped into **Construction Types**. You'll see a


### PR DESCRIPTION
Fixes #6410.

The quickstart tutorial showed the container level Isolate and Hide/Show icons in the Spatial Decomposition panel as default UI. They aren't. @sboddy explained this was a deliberate redesign (element level isolate/hide/show now live in the Elements list), and pointed at #6664 for why: genuine, still open interaction bugs between the newer element level buttons and active status filters (not the older container level buttons, thanks @sboddy for the correction). @CyrilWaechter pushed back that the redesign felt less intuitive.

#6664 is still open with no fix landed, so I did not flip the `container_hide_show_isolate` default to true, that would silently reintroduce the redesign UX change for every user by default before the underlying element/status filter interaction bug is actually fixed.

The actual remaining gap is the tutorial doc itself. Updated `src/bonsai/docs/quickstart/explore_model.rst` to point readers at the Elements list icons (today's actual default), and added a note explaining that the Elements list icons don't currently respect an active status filter and vice versa, and that the container level buttons remain available as an opt in precisely because they don't have that problem.

Docs only, no code change.

AI-generated PR, human-reviewed.