### PR TITLE
Bonsai: label the Explore Tool query results in the Links panel

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/ui.py
+++ b/src/bonsai/bonsai/bim/module/project/ui.py
@@ -522,8 +522,10 @@ class BIM_PT_links(Panel):
                 row.label(text="No Object Queried with Explore Tool", icon="QUESTION")
             return
 
+        self.layout.separator()
         row = self.layout.row(align=True)
-        row.label(text="")
+        # Distinguishes the Explore Tool query results from the link list above.
+        row.label(text="Queried Element", icon="VIEWZOOM")
         row.operator("bim.append_inspected_linked_element", icon="APPEND_BLEND", text="")
 
         for name, value in LinksData.linked_data["attributes"].items():


### PR DESCRIPTION
Addresses the UX side note on #7087.

@CyrilWaechter noted that data queried via the Explore Tool (right click, Hide Queried Element) renders inside the Links panel with no heading, so it reads as part of the linked model list rather than as query results.

The grouping itself is correct: querying only works on linked IFC elements, so the feature genuinely belongs under Links. What was missing was a label separating the attribute/property dump from the link list above it. Added a separator and a "Queried Element" row label with a magnifier icon in place of the previous blank label.

AI-generated PR, human-reviewed.