### PR TITLE
Bonsai: link external SVG/DXF files as snappable reference geometry

### DIFF
--- a/src/bonsai/bonsai/bim/__init__.py
+++ b/src/bonsai/bonsai/bim/__init__.py
@@ -91,6 +91,7 @@ modules = {
     "light": None,
     "alignment": None,
     "clip_box": None,
+    "linked_reference": None,
     # Uncomment this line to enable loading of the demo module. Happy hacking!
     # The name "demo" must correlate to a folder name in `bim/module/`.
     # "demo": None,

--- a/src/bonsai/bonsai/bim/export_ifc.py
+++ b/src/bonsai/bonsai/bim/export_ifc.py
@@ -45,6 +45,7 @@ class IfcExporter:
         self.set_header()
         IfcStore.update_cache()
         self.sync_all_objects()
+        tool.LinkedReference.sync_placements_to_ifc()
         extension = self.ifc_export_settings.output_file.split(".")[-1].lower()
         if extension == "ifczip":
             with tempfile.TemporaryDirectory() as unzipped_path:

--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -293,6 +293,7 @@ class IfcImporter:
         self.update_linked_aggregates()
         self.profile_code("Setup arrays")
         tool.Project.load_linked_models_from_ifc()
+        tool.LinkedReference.load_from_ifc()
         self.profile_code("Load linked models")
         self.add_project_to_scene()
         self.profile_code("Add project to scene")

--- a/src/bonsai/bonsai/bim/module/linked_reference/__init__.py
+++ b/src/bonsai/bonsai/bim/module/linked_reference/__init__.py
@@ -1,0 +1,58 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import bpy
+from bpy.app.handlers import persistent
+
+import bonsai.tool as tool
+
+from . import operator, prop, ui
+
+classes = (
+    operator.LinkReference,
+    operator.UnlinkReference,
+    operator.LoadLinkedReference,
+    operator.UnloadLinkedReference,
+    operator.RefreshLinkedReference,
+    operator.SelectLinkedReferenceHandle,
+    operator.ToggleLinkedReferenceVisibility,
+    prop.LinkedReferenceLink,
+    prop.BIMLinkedReferenceProperties,
+    ui.BIM_UL_linked_references,
+    ui.BIM_PT_linked_references,
+)
+
+
+@persistent
+def _on_load_post(filepath):
+    tool.LinkedReference.reset_timer()
+
+
+def register():
+    bpy.types.Scene.BIMLinkedReferenceProperties = bpy.props.PointerProperty(type=prop.BIMLinkedReferenceProperties)
+    if _on_load_post not in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.append(_on_load_post)
+
+
+def unregister():
+    tool.LinkedReference.cancel_timer()
+    if _on_load_post in bpy.app.handlers.load_post:
+        bpy.app.handlers.load_post.remove(_on_load_post)
+    del bpy.types.Scene.BIMLinkedReferenceProperties

--- a/src/bonsai/bonsai/bim/module/linked_reference/operator.py
+++ b/src/bonsai/bonsai/bim/module/linked_reference/operator.py
@@ -1,0 +1,214 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import bpy
+from bpy_extras.io_utils import ImportHelper
+
+import bonsai.tool as tool
+from bonsai.tool.linked_reference import SUPPORTED_SUFFIXES, LinkedReferenceError
+
+
+class LinkReference(bpy.types.Operator, ImportHelper, tool.Ifc.Operator):
+    bl_idname = "bim.link_reference"
+    bl_label = "Link Reference"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = (
+        "Link an external .svg or .dxf file as snappable background reference geometry.\n\n"
+        "The file is not stored in the IFC model, only a document reference to it"
+    )
+
+    filter_glob: bpy.props.StringProperty(default="*.svg;*.dxf", options={"HIDDEN"})
+    use_relative_path: bpy.props.BoolProperty(
+        name="Use Relative Path",
+        description="Whether to store the linked file path relative to the currently opened IFC file",
+        default=False,
+    )
+
+    if TYPE_CHECKING:
+        filepath: str
+        filter_glob: str
+        use_relative_path: bool
+
+    def draw(self, context):
+        assert self.layout
+        if tool.Ifc.get() and Path(tool.Ifc.get_path()).is_file():
+            self.layout.prop(self, "use_relative_path")
+        else:
+            self.use_relative_path = False
+
+    def _execute(self, context):
+        filepath = Path(self.filepath)
+        if filepath.suffix.lower() not in SUPPORTED_SUFFIXES:
+            self.report({"ERROR"}, f"Unsupported file format '{filepath.suffix}', expected .svg or .dxf.")
+            return {"CANCELLED"}
+        if not filepath.is_file():
+            self.report({"ERROR"}, f"File does not exist: '{filepath}'.")
+            return {"CANCELLED"}
+
+        props = tool.LinkedReference.get_props()
+        uri = tool.Ifc.get_uri(filepath, use_relative_path=self.use_relative_path)
+        if any(link.filepath == uri for link in props.references):
+            self.report({"ERROR"}, f"'{uri}' is already linked.")
+            return {"CANCELLED"}
+
+        link = props.references.add()
+        link.name = filepath.name
+        link.filepath = uri
+        if tool.Ifc.get():
+            link.ifc_definition_id = tool.LinkedReference.add_document_reference(uri).id()
+        index = len(props.references) - 1
+        props.active_reference_index = index
+        try:
+            bpy.ops.bim.load_linked_reference(reference_index=index)
+        finally:
+            # A file that cannot be imported should not leave a dead entry.
+            if not props.references[index].is_loaded:
+                tool.LinkedReference.remove_document_reference(props.references[index])
+                props.references.remove(index)
+                props.active_reference_index = min(props.active_reference_index, len(props.references) - 1)
+
+
+class UnlinkReference(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.unlink_reference"
+    bl_label = "Unlink Reference"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Remove the linked reference, its imported geometry and its document reference"
+
+    reference_index: bpy.props.IntProperty(name="Reference Index")
+
+    if TYPE_CHECKING:
+        reference_index: int
+
+    def _execute(self, context):
+        props = tool.LinkedReference.get_props()
+        link = props.references[self.reference_index]
+        if link.is_loaded:
+            tool.LinkedReference.unload_link(link)
+        tool.LinkedReference.remove_document_reference(link)
+        props.references.remove(self.reference_index)
+        props.active_reference_index = min(props.active_reference_index, len(props.references) - 1)
+
+
+class LoadLinkedReference(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.load_linked_reference"
+    bl_label = "Load Linked Reference"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Import the linked file as geometry at its stored placement"
+
+    reference_index: bpy.props.IntProperty(name="Reference Index")
+
+    if TYPE_CHECKING:
+        reference_index: int
+
+    def _execute(self, context):
+        link = tool.LinkedReference.get_props().references[self.reference_index]
+        if link.is_loaded:
+            return
+        try:
+            anchor = tool.LinkedReference.load_link(link)
+        except LinkedReferenceError as error:
+            self.report({"ERROR"}, str(error))
+            return {"CANCELLED"}
+        tool.Blender.select_and_activate_single_object(context, anchor)
+
+
+class UnloadLinkedReference(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.unload_linked_reference"
+    bl_label = "Unload Linked Reference"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Remove the imported geometry, keeping the link and its placement"
+
+    reference_index: bpy.props.IntProperty(name="Reference Index")
+
+    if TYPE_CHECKING:
+        reference_index: int
+
+    def _execute(self, context):
+        link = tool.LinkedReference.get_props().references[self.reference_index]
+        tool.LinkedReference.unload_link(link)
+
+
+class RefreshLinkedReference(bpy.types.Operator):
+    bl_idname = "bim.refresh_linked_reference"
+    bl_label = "Refresh Linked Reference"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Re-import the linked file from disk, keeping the current placement"
+
+    reference_index: bpy.props.IntProperty(name="Reference Index")
+
+    if TYPE_CHECKING:
+        reference_index: int
+
+    def execute(self, context):
+        link = tool.LinkedReference.get_props().references[self.reference_index]
+        try:
+            tool.LinkedReference.refresh_link(link)
+        except LinkedReferenceError as error:
+            self.report({"ERROR"}, str(error))
+            return {"CANCELLED"}
+        return {"FINISHED"}
+
+
+class SelectLinkedReferenceHandle(bpy.types.Operator):
+    bl_idname = "bim.select_linked_reference_handle"
+    bl_label = "Select Linked Reference Handle"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Select the anchor empty to move, rotate or scale the linked reference"
+
+    reference_index: bpy.props.IntProperty(name="Reference Index")
+
+    if TYPE_CHECKING:
+        reference_index: int
+
+    def execute(self, context):
+        link = tool.LinkedReference.get_props().references[self.reference_index]
+        anchor = tool.LinkedReference.get_anchor(link)
+        if anchor is None:
+            self.report({"ERROR"}, "Linked reference is not loaded.")
+            return {"CANCELLED"}
+        tool.Blender.select_and_activate_single_object(context, anchor)
+        return {"FINISHED"}
+
+
+class ToggleLinkedReferenceVisibility(bpy.types.Operator):
+    bl_idname = "bim.toggle_linked_reference_visibility"
+    bl_label = "Toggle Linked Reference Visibility"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Hide or show the linked reference geometry in the viewport"
+
+    reference_index: bpy.props.IntProperty(name="Reference Index")
+
+    if TYPE_CHECKING:
+        reference_index: int
+
+    def execute(self, context):
+        link = tool.LinkedReference.get_props().references[self.reference_index]
+        anchor = tool.LinkedReference.get_anchor(link)
+        if anchor is None:
+            self.report({"ERROR"}, "Linked reference is not loaded.")
+            return {"CANCELLED"}
+        hide = not anchor.hide_viewport
+        anchor.hide_viewport = hide
+        for obj in anchor.children:
+            obj.hide_viewport = hide
+        return {"FINISHED"}

--- a/src/bonsai/bonsai/bim/module/linked_reference/prop.py
+++ b/src/bonsai/bonsai/bim/module/linked_reference/prop.py
@@ -1,0 +1,93 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+from typing import TYPE_CHECKING
+
+import bpy
+from bpy.props import BoolProperty, CollectionProperty, IntProperty, PointerProperty, StringProperty
+from bpy.types import PropertyGroup
+
+import bonsai.tool as tool
+
+
+def update_auto_refresh(self: "BIMLinkedReferenceProperties", context: bpy.types.Context) -> None:
+    tool.LinkedReference.reset_timer()
+
+
+class LinkedReferenceLink(PropertyGroup):
+    name: StringProperty(name="Name")
+    filepath: StringProperty(
+        name="Filepath",
+        description="Path to the linked .svg or .dxf file, possibly relative to the active IFC file",
+    )
+    transformation: StringProperty(
+        name="Transformation",
+        description="4x4 placement matrix as a flattened comma separated list",
+        default="",
+    )
+    ifc_definition_id: IntProperty(
+        name="IFC Definition ID",
+        description="STEP ID of the IfcDocumentReference persisting this link. Zero when no IFC project exists",
+        default=0,
+    )
+    anchor: PointerProperty(
+        name="Anchor Object",
+        description="Empty holding the user placement. Imported geometry is parented to it",
+        type=bpy.types.Object,
+    )
+    is_loaded: BoolProperty(name="Is Loaded", default=False)
+    file_mtime: StringProperty(
+        name="File Modification Time",
+        description="Modification time of the source file at last import, used to detect updates",
+        default="",
+    )
+
+    if TYPE_CHECKING:
+        name: str
+        filepath: str
+        transformation: str
+        ifc_definition_id: int
+        anchor: bpy.types.Object | None
+        is_loaded: bool
+        file_mtime: str
+
+
+class BIMLinkedReferenceProperties(PropertyGroup):
+    references: CollectionProperty(name="Linked References", type=LinkedReferenceLink)
+    active_reference_index: IntProperty(name="Active Reference Index")
+    auto_refresh: BoolProperty(
+        name="Auto Refresh",
+        description="Periodically check linked reference files on disk and re-import them when they change",
+        default=False,
+        update=update_auto_refresh,
+    )
+    auto_refresh_interval: IntProperty(
+        name="Interval (s)",
+        description="How often to check linked reference files for changes, in seconds",
+        default=5,
+        min=1,
+        soft_max=3600,
+    )
+
+    if TYPE_CHECKING:
+        references: bpy.types.bpy_prop_collection_idprop[LinkedReferenceLink]
+        active_reference_index: int
+        auto_refresh: bool
+        auto_refresh_interval: int

--- a/src/bonsai/bonsai/bim/module/linked_reference/ui.py
+++ b/src/bonsai/bonsai/bim/module/linked_reference/ui.py
@@ -1,0 +1,95 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+from typing import TYPE_CHECKING
+
+import bpy
+from bpy.types import Panel, UIList
+
+import bonsai.tool as tool
+
+if TYPE_CHECKING:
+    from bonsai.bim.module.linked_reference.prop import BIMLinkedReferenceProperties, LinkedReferenceLink
+
+
+class BIM_PT_linked_references(Panel):
+    bl_label = "Linked References"
+    bl_idname = "BIM_PT_linked_references"
+    bl_options = {"DEFAULT_CLOSED"}
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "scene"
+    bl_parent_id = "BIM_PT_tab_project_setup"
+
+    def draw(self, context):
+        assert self.layout
+        props = tool.LinkedReference.get_props()
+
+        row = self.layout.row(align=True)
+        row.operator("bim.link_reference", icon="LINKED")
+
+        if not props.references:
+            return
+
+        index = props.active_reference_index
+        if 0 <= index < len(props.references):
+            link = props.references[index]
+            row = self.layout.row(align=True)
+            row.alignment = "RIGHT"
+            if link.is_loaded:
+                row.operator("bim.select_linked_reference_handle", text="", icon="OBJECT_DATA").reference_index = index
+                row.operator("bim.refresh_linked_reference", text="", icon="FILE_REFRESH").reference_index = index
+                row.operator("bim.unload_linked_reference", text="", icon="UNLINKED").reference_index = index
+            else:
+                row.operator("bim.load_linked_reference", text="", icon="LINKED").reference_index = index
+            row.operator("bim.unlink_reference", text="", icon="X").reference_index = index
+
+        self.layout.template_list("BIM_UL_linked_references", "", props, "references", props, "active_reference_index")
+
+        row = self.layout.row(align=True)
+        row.prop(props, "auto_refresh")
+        if props.auto_refresh:
+            row.prop(props, "auto_refresh_interval")
+
+
+class BIM_UL_linked_references(UIList):
+    def draw_item(
+        self,
+        context,
+        layout: bpy.types.UILayout,
+        data: "BIMLinkedReferenceProperties",
+        item: "LinkedReferenceLink",
+        icon,
+        active_data,
+        active_propname,
+        index,
+    ):
+        row = layout.row(align=True)
+        row.label(text=item.filepath)
+        if item.is_loaded:
+            anchor = tool.LinkedReference.get_anchor(item)
+            hidden = bool(anchor and anchor.hide_viewport)
+            op = row.operator(
+                "bim.toggle_linked_reference_visibility",
+                text="",
+                icon="HIDE_ON" if hidden else "HIDE_OFF",
+                emboss=False,
+            )
+            op.reference_index = index

--- a/src/bonsai/bonsai/tool/__init__.py
+++ b/src/bonsai/bonsai/tool/__init__.py
@@ -49,6 +49,7 @@ from bonsai.tool.ifc import Ifc
 from bonsai.tool.ifcgit import IfcGit, IfcGitRepo
 from bonsai.tool.layer import Layer
 from bonsai.tool.library import Library
+from bonsai.tool.linked_reference import LinkedReference
 from bonsai.tool.loader import Loader
 from bonsai.tool.material import Material
 from bonsai.tool.misc import Misc

--- a/src/bonsai/bonsai/tool/linked_reference.py
+++ b/src/bonsai/bonsai/tool/linked_reference.py
@@ -274,6 +274,7 @@ class LinkedReference:
     def import_dxf(cls, filepath: Path, collection: bpy.types.Collection) -> list[bpy.types.Object]:
         try:
             import ezdxf
+            import ezdxf.entities
             import ezdxf.path
             import ezdxf.units
         except ImportError as e:

--- a/src/bonsai/bonsai/tool/linked_reference.py
+++ b/src/bonsai/bonsai/tool/linked_reference.py
@@ -1,0 +1,379 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Union
+
+import bpy
+import ifcopenshell
+import ifcopenshell.api.document
+from mathutils import Matrix
+
+import bonsai.tool as tool
+
+if TYPE_CHECKING:
+    from bonsai.bim.module.linked_reference.prop import BIMLinkedReferenceProperties, LinkedReferenceLink
+
+REFERENCES_COLLECTION_NAME = "LinkedReferences"
+DOCUMENT_SCOPE = "LINKED_REFERENCE"
+SUPPORTED_SUFFIXES = (".svg", ".dxf")
+
+_timer_callback: Union[Callable[[], Union[float, None]], None] = None
+
+
+class LinkedReferenceError(Exception):
+    """User facing failure while loading or refreshing a linked reference."""
+
+
+class LinkedReference:
+    @classmethod
+    def get_props(cls) -> BIMLinkedReferenceProperties:
+        assert (scene := bpy.context.scene)
+        return scene.BIMLinkedReferenceProperties  # pyright: ignore[reportAttributeAccessIssue]
+
+    @classmethod
+    def get_collection(cls, create: bool = False) -> Union[bpy.types.Collection, None]:
+        assert (scene := bpy.context.scene)
+        for child in scene.collection.children:
+            if child.name == REFERENCES_COLLECTION_NAME:
+                return child
+        if not create:
+            return None
+        collection = bpy.data.collections.new(REFERENCES_COLLECTION_NAME)
+        scene.collection.children.link(collection)
+        return collection
+
+    @classmethod
+    def matrix_to_string(cls, matrix: Matrix) -> str:
+        return ",".join(str(value) for row in matrix for value in row)
+
+    @classmethod
+    def string_to_matrix(cls, string: str) -> Matrix:
+        values = [float(value) for value in string.split(",")]
+        return Matrix((values[0:4], values[4:8], values[8:12], values[12:16]))
+
+    @classmethod
+    def resolve_path(cls, filepath: str) -> Path:
+        return Path(tool.Ifc.resolve_uri(filepath))
+
+    @classmethod
+    def get_file_mtime(cls, filepath: Path) -> str:
+        return str(filepath.stat().st_mtime_ns)
+
+    @classmethod
+    def get_anchor(cls, link: LinkedReferenceLink) -> Union[bpy.types.Object, None]:
+        try:
+            anchor = link.anchor
+        except ReferenceError:
+            return None
+        if anchor is None or anchor.name not in bpy.data.objects:
+            return None
+        return anchor
+
+    @classmethod
+    def load_link(cls, link: LinkedReferenceLink) -> bpy.types.Object:
+        filepath = cls.resolve_path(link.filepath)
+        if not filepath.is_file():
+            raise LinkedReferenceError(f"File not found: '{filepath}'.")
+        collection = cls.get_collection(create=True)
+        assert collection
+        anchor = bpy.data.objects.new(f"LinkedReference/{Path(link.filepath).name}", None)
+        anchor.empty_display_type = "ARROWS"
+        collection.objects.link(anchor)
+        if link.transformation:
+            anchor.matrix_world = cls.string_to_matrix(link.transformation)
+        try:
+            objects = cls.import_file(filepath, collection)
+        except LinkedReferenceError:
+            bpy.data.objects.remove(anchor)
+            raise
+        for obj in objects:
+            obj.parent = anchor
+        link.anchor = anchor
+        link.is_loaded = True
+        link.file_mtime = cls.get_file_mtime(filepath)
+        return anchor
+
+    @classmethod
+    def refresh_link(cls, link: LinkedReferenceLink) -> None:
+        anchor = cls.get_anchor(link)
+        if anchor is None:
+            raise LinkedReferenceError("Linked reference is not loaded.")
+        filepath = cls.resolve_path(link.filepath)
+        if not filepath.is_file():
+            raise LinkedReferenceError(f"File not found: '{filepath}'.")
+        collection = cls.get_collection(create=True)
+        assert collection
+        old_children = list(anchor.children)
+        # Import before removing so a failed import keeps the previous geometry.
+        objects = cls.import_file(filepath, collection)
+        for obj in objects:
+            obj.parent = anchor
+        cls.remove_objects(old_children)
+        link.file_mtime = cls.get_file_mtime(filepath)
+
+    @classmethod
+    def unload_link(cls, link: LinkedReferenceLink) -> None:
+        cls.store_placement(link)
+        if anchor := cls.get_anchor(link):
+            cls.remove_objects(list(anchor.children))
+            bpy.data.objects.remove(anchor)
+        link.anchor = None
+        link.is_loaded = False
+
+    @classmethod
+    def remove_objects(cls, objects: Iterable[bpy.types.Object]) -> None:
+        data = set()
+        for obj in objects:
+            if obj.data:
+                data.add(obj.data)
+            bpy.data.objects.remove(obj)
+        for datablock in data:
+            if datablock.users == 0:
+                if isinstance(datablock, bpy.types.Mesh):
+                    bpy.data.meshes.remove(datablock)
+                elif isinstance(datablock, bpy.types.Curve):
+                    bpy.data.curves.remove(datablock)
+
+    @classmethod
+    def store_placement(cls, link: LinkedReferenceLink) -> None:
+        anchor = cls.get_anchor(link)
+        if anchor is None:
+            return
+        link.transformation = cls.matrix_to_string(anchor.matrix_world)
+        if link.ifc_definition_id and tool.Ifc.get():
+            try:
+                reference = tool.Ifc.get().by_id(link.ifc_definition_id)
+            except RuntimeError:
+                return
+            reference[1] = link.transformation
+
+    @classmethod
+    def sync_placements_to_ifc(cls) -> None:
+        try:
+            props = cls.get_props()
+        except (AssertionError, AttributeError):
+            return
+        for link in props.references:
+            if link.is_loaded:
+                cls.store_placement(link)
+
+    @classmethod
+    def get_linked_reference_documents(cls) -> dict[str, ifcopenshell.entity_instance]:
+        documents = {}
+        for document in tool.Ifc.get().by_type("IfcDocumentInformation"):
+            if document.Scope == DOCUMENT_SCOPE:
+                for reference in tool.Document.get_document_references(document):
+                    documents[Path(reference.Location).as_posix()] = document
+                    break
+        return documents
+
+    @classmethod
+    def add_document_reference(cls, filepath: str) -> ifcopenshell.entity_instance:
+        ifc_file = tool.Ifc.get()
+        if not (document := cls.get_linked_reference_documents().get(filepath)):
+            document = ifcopenshell.api.document.add_information(ifc_file)
+            document.Name = Path(filepath).name
+            document.Scope = DOCUMENT_SCOPE
+        reference = ifcopenshell.api.document.add_reference(ifc_file, information=document)
+        reference[1] = cls.matrix_to_string(Matrix.Identity(4))
+        reference.Location = filepath.replace("\\", "/")
+        return reference
+
+    @classmethod
+    def remove_document_reference(cls, link: LinkedReferenceLink) -> None:
+        if not link.ifc_definition_id or not tool.Ifc.get():
+            return
+        try:
+            reference = tool.Ifc.get().by_id(link.ifc_definition_id)
+        except RuntimeError:
+            return
+        document = tool.Document.get_reference_document(reference)
+        ifcopenshell.api.document.remove_reference(tool.Ifc.get(), reference)
+        if document and not tool.Document.get_document_references(document):
+            ifcopenshell.api.document.remove_information(tool.Ifc.get(), document)
+
+    @classmethod
+    def load_from_ifc(cls) -> None:
+        references = cls.get_props().references
+        references.clear()
+        for document in tool.Ifc.get().by_type("IfcDocumentInformation"):
+            if document.Scope != DOCUMENT_SCOPE:
+                continue
+            for reference in tool.Document.get_document_references(document):
+                link = references.add()
+                link.name = Path(reference.Location).name
+                link.filepath = reference.Location
+                link.ifc_definition_id = reference.id()
+                link.transformation = reference[1] or ""
+
+    @classmethod
+    def import_file(cls, filepath: Path, collection: bpy.types.Collection) -> list[bpy.types.Object]:
+        suffix = filepath.suffix.lower()
+        if suffix == ".svg":
+            return cls.import_svg(filepath, collection)
+        elif suffix == ".dxf":
+            return cls.import_dxf(filepath, collection)
+        raise LinkedReferenceError(f"Unsupported file format '{suffix}', expected .svg or .dxf.")
+
+    @classmethod
+    def import_svg(cls, filepath: Path, collection: bpy.types.Collection) -> list[bpy.types.Object]:
+        previous_objects = set(bpy.data.objects)
+        previous_collections = set(bpy.data.collections)
+        try:
+            result = bpy.ops.import_curve.svg(filepath=str(filepath))
+        except (AttributeError, RuntimeError):
+            result = cls._retry_svg_with_addon(filepath)
+        if "FINISHED" not in result:
+            raise LinkedReferenceError(f"SVG import failed for '{filepath}'.")
+        objects = [obj for obj in bpy.data.objects if obj not in previous_objects]
+        if not objects:
+            raise LinkedReferenceError(f"No importable geometry found in '{filepath.name}'.")
+        for obj in objects:
+            for users_collection in obj.users_collection:
+                users_collection.objects.unlink(obj)
+            collection.objects.link(obj)
+        for orphan in [c for c in bpy.data.collections if c not in previous_collections and not c.objects]:
+            bpy.data.collections.remove(orphan)
+        return objects
+
+    @classmethod
+    def _retry_svg_with_addon(cls, filepath: Path) -> set[str]:
+        import addon_utils
+
+        try:
+            addon_utils.enable("io_curve_svg", default_set=True)
+            return bpy.ops.import_curve.svg(filepath=str(filepath))
+        except Exception as e:
+            raise LinkedReferenceError(
+                "Blender's bundled SVG importer (io_curve_svg) is not available. "
+                f"Enable the 'Import-Export: Scalable Vector Graphics' add-on and retry. Error: {e}"
+            )
+
+    @classmethod
+    def import_dxf(cls, filepath: Path, collection: bpy.types.Collection) -> list[bpy.types.Object]:
+        try:
+            import ezdxf
+            import ezdxf.path
+            import ezdxf.units
+        except ImportError as e:
+            raise LinkedReferenceError(f"The bundled ezdxf library is required for DXF references: {e}")
+
+        try:
+            doc = ezdxf.readfile(str(filepath))
+        except Exception as e:
+            raise LinkedReferenceError(f"Failed to read DXF file '{filepath}': {e}")
+
+        insunits = doc.header.get("$INSUNITS", 0)
+        try:
+            scale = ezdxf.units.conversion_factor(insunits, ezdxf.units.M) if insunits else 1.0
+        except ValueError:
+            scale = 1.0
+
+        verts: list[tuple[float, float, float]] = []
+        edges: list[tuple[int, int]] = []
+        # Curve flattening tolerance of 5mm, expressed in drawing units.
+        distance = 0.005 / scale
+
+        def walk(entities: Iterable[ezdxf.entities.DXFEntity], depth: int = 0) -> Iterator[ezdxf.entities.DXFEntity]:
+            for entity in entities:
+                if entity.dxftype() == "INSERT":
+                    if depth < 8:
+                        try:
+                            yield from walk(entity.virtual_entities(), depth + 1)
+                        except Exception:
+                            pass
+                else:
+                    yield entity
+
+        skipped = 0
+        for entity in walk(doc.modelspace()):
+            if entity.dxftype() == "POINT":
+                point = entity.dxf.location
+                verts.append((point.x * scale, point.y * scale, point.z * scale))
+                continue
+            try:
+                points = list(ezdxf.path.make_path(entity).flattening(distance))
+            except (TypeError, ValueError, AttributeError):
+                skipped += 1
+                continue
+            if len(points) < 2:
+                continue
+            start = len(verts)
+            verts.extend((point.x * scale, point.y * scale, point.z * scale) for point in points)
+            edges.extend((start + i, start + i + 1) for i in range(len(points) - 1))
+
+        if not verts:
+            raise LinkedReferenceError(
+                f"No importable geometry found in '{filepath.name}' ({skipped} unsupported entities skipped)."
+            )
+
+        mesh = bpy.data.meshes.new(filepath.name)
+        mesh.from_pydata(verts, edges, [])
+        obj = bpy.data.objects.new(filepath.name, mesh)
+        collection.objects.link(obj)
+        return [obj]
+
+    @classmethod
+    def cancel_timer(cls) -> None:
+        global _timer_callback
+        if _timer_callback is not None and bpy.app.timers.is_registered(_timer_callback):
+            bpy.app.timers.unregister(_timer_callback)
+        _timer_callback = None
+
+    @classmethod
+    def reset_timer(cls) -> None:
+        cls.cancel_timer()
+        try:
+            props = cls.get_props()
+        except (AssertionError, AttributeError):
+            return
+        if not props.auto_refresh:
+            return
+
+        def on_timer() -> Union[float, None]:
+            try:
+                cls.refresh_outdated_links()
+            except Exception as error:
+                print(f"Bonsai: linked reference auto refresh failed: {error}")
+            # Reschedule by returning the next interval, see Autosave.reset_timer.
+            try:
+                props = cls.get_props()
+                return float(props.auto_refresh_interval) if props.auto_refresh else None
+            except (AssertionError, AttributeError):
+                return None
+
+        global _timer_callback
+        _timer_callback = on_timer
+        bpy.app.timers.register(on_timer, first_interval=float(props.auto_refresh_interval))
+
+    @classmethod
+    def refresh_outdated_links(cls) -> None:
+        for link in cls.get_props().references:
+            if not link.is_loaded or cls.get_anchor(link) is None:
+                continue
+            filepath = cls.resolve_path(link.filepath)
+            if not filepath.is_file():
+                continue
+            if cls.get_file_mtime(filepath) != link.file_mtime:
+                cls.refresh_link(link)

--- a/src/bonsai/test/tool/test_linked_reference.py
+++ b/src/bonsai/test/tool/test_linked_reference.py
@@ -1,0 +1,159 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import math
+
+import bpy
+import ifcopenshell
+import ifcopenshell.api.document
+import pytest
+from mathutils import Matrix
+
+import bonsai.tool as tool
+import test.bim.bootstrap
+from bonsai.tool.linked_reference import LinkedReference as subject
+from bonsai.tool.linked_reference import LinkedReferenceError
+
+SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">'
+    '<rect x="10" y="10" width="50" height="30" fill="none" stroke="black"/>'
+    "</svg>"
+)
+SVG_TWO_SHAPES = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">'
+    '<rect x="10" y="10" width="50" height="30" fill="none" stroke="black"/>'
+    '<circle cx="80" cy="80" r="15" fill="none" stroke="red"/>'
+    "</svg>"
+)
+
+
+def add_link(filepath: str):
+    link = subject.get_props().references.add()
+    link.name = filepath
+    link.filepath = filepath
+    return link
+
+
+class TestMatrixString(test.bim.bootstrap.NewFile):
+    def test_round_trip(self):
+        matrix = Matrix.Translation((1.0, 2.0, 3.0)) @ Matrix.Rotation(math.radians(45), 4, "Z")
+        assert subject.string_to_matrix(subject.matrix_to_string(matrix)) == matrix
+
+
+class TestLoadLink(test.bim.bootstrap.NewFile):
+    def test_svg_loads_as_curves_parented_to_anchor(self, tmp_path):
+        svg = tmp_path / "background.svg"
+        svg.write_text(SVG)
+        link = add_link(str(svg))
+        anchor = subject.load_link(link)
+        assert link.is_loaded
+        assert anchor.type == "EMPTY"
+        children = list(anchor.children)
+        assert children
+        assert all(obj.type == "CURVE" for obj in children)
+        assert all(obj.parent == anchor for obj in children)
+        collection = subject.get_collection()
+        assert collection and anchor.name in collection.objects
+
+    def test_missing_file_raises(self):
+        link = add_link("/tmp/does-not-exist-7334.svg")
+        with pytest.raises(LinkedReferenceError):
+            subject.load_link(link)
+        assert not link.is_loaded
+
+    def test_dxf_loads_as_mesh_with_unit_scaling(self, tmp_path):
+        ezdxf = pytest.importorskip("ezdxf")
+        dxf = tmp_path / "background.dxf"
+        doc = ezdxf.new("R2010", setup=False)
+        doc.units = ezdxf.units.MM
+        msp = doc.modelspace()
+        msp.add_line((0, 0), (1000, 0))
+        doc.saveas(str(dxf))
+        link = add_link(str(dxf))
+        anchor = subject.load_link(link)
+        (obj,) = anchor.children
+        assert obj.type == "MESH"
+        assert len(obj.data.vertices) == 2
+        assert max(v.co.x for v in obj.data.vertices) == pytest.approx(1.0)
+
+
+class TestRefreshLink(test.bim.bootstrap.NewFile):
+    def test_refresh_replaces_geometry_and_keeps_placement(self, tmp_path):
+        svg = tmp_path / "background.svg"
+        svg.write_text(SVG)
+        link = add_link(str(svg))
+        anchor = subject.load_link(link)
+        old_children = set(anchor.children)
+        matrix = Matrix.Translation((5.0, 3.0, 0.0)) @ Matrix.Rotation(math.radians(30), 4, "Z")
+        anchor.matrix_world = matrix
+        bpy.context.view_layer.update()
+
+        svg.write_text(SVG_TWO_SHAPES)
+        subject.refresh_link(link)
+        bpy.context.view_layer.update()
+
+        new_children = list(anchor.children)
+        assert new_children and not old_children.intersection(new_children)
+        assert len(new_children) > len(old_children)
+        for i in range(4):
+            for j in range(4):
+                assert anchor.matrix_world[i][j] == pytest.approx(matrix[i][j])
+        child = new_children[0]
+        expected = matrix @ child.matrix_basis
+        for i in range(4):
+            for j in range(4):
+                assert child.matrix_world[i][j] == pytest.approx(expected[i][j], abs=1e-5)
+
+
+class TestIfcPersistence(test.bim.bootstrap.NewFile):
+    def test_document_reference_round_trip(self, tmp_path):
+        ifc = ifcopenshell.file()
+        ifc.createIfcProject()
+        tool.Ifc.set(ifc)
+        reference = subject.add_document_reference("/tmp/background.svg")
+        document = tool.Document.get_reference_document(reference)
+        assert document.Scope == "LINKED_REFERENCE"
+        assert reference.Location == "/tmp/background.svg"
+
+        subject.load_from_ifc()
+        references = subject.get_props().references
+        assert len(references) == 1
+        assert references[0].filepath == "/tmp/background.svg"
+        assert references[0].ifc_definition_id == reference.id()
+        assert not references[0].is_loaded
+
+        subject.remove_document_reference(references[0])
+        assert not ifc.by_type("IfcDocumentReference")
+        assert not ifc.by_type("IfcDocumentInformation")
+
+    def test_store_placement_writes_matrix_to_reference(self, tmp_path):
+        ifc = ifcopenshell.file()
+        ifc.createIfcProject()
+        tool.Ifc.set(ifc)
+        svg = tmp_path / "background.svg"
+        svg.write_text(SVG)
+        link = add_link(str(svg))
+        link.ifc_definition_id = subject.add_document_reference(str(svg)).id()
+        anchor = subject.load_link(link)
+        anchor.matrix_world = Matrix.Translation((7.0, 0.0, 0.0))
+        bpy.context.view_layer.update()
+        subject.sync_placements_to_ifc()
+        reference = ifc.by_id(link.ifc_definition_id)
+        assert subject.string_to_matrix(reference[1]) == Matrix.Translation((7.0, 0.0, 0.0))


### PR DESCRIPTION
Proposal for #7334.

@theoryshaw @sboddy @Gorgious56 this mirrors the existing "Link IFC" mechanism rather than the `IfcAnnotation`-based "IFC Reference Image", since the reporter explicitly didn't want this stored as `IfcAnnotation`, and @sboddy himself flagged the texture-conversion idea as "probably a bad idea because it is not Ifc conformant."

- A new Linked References panel links an on-disk `.svg`/`.dxf`. The file is never imported into the IFC model itself. Persistence reuses the exact pattern `Link IFC` already uses: an `IfcDocumentInformation` (Scope `LINKED_REFERENCE`) plus an `IfcDocumentReference` carrying the file location and placement matrix, the same as how `Scope LINKED_MODEL` links already persist. No `IfcAnnotation`, no texture entities.
- Geometry imports as real, snappable objects (@theoryshaw's requirement, @Gorgious56's suggestion): SVG via Blender's own bundled `io_curve_svg` importer, DXF via the `ezdxf` library Bonsai already bundles as a wheel. No raster textures, no new dependency, no Inkscape.
- Each link gets an anchor empty; imported geometry parents to it. You place/scale the anchor once, refresh re-imports and re-parents under the same anchor, so the recorded placement reapplies automatically instead of needing to be redone every time an updated file arrives.
- Manual Refresh button, plus an opt-in auto-refresh timer that polls file mtimes (same pattern as the existing autosave timer).

Scoped out for now: printing linked geometry through Bonsai's drawing pipeline (a real follow-up, since sheets already composite SVG underlays), and the web-server/URI-serving idea, which wasn't actually what was requested.

Live-tested across Blender 4.5.8, 5.1.2 and 5.2.0: real import, transform preservation across refresh, IFC save/reload round trip, auto-refresh detection. New pytest coverage in `test/tool/test_linked_reference.py`, existing `test_document.py` unaffected.

Marked draft, this is a proposal, would like feedback on the design before treating it as final.

AI-generated PR (design and implementation), human-reviewed.