### PR TITLE
ifcgeom: skip text literals with a warning instead of a conversion error

### DIFF
--- a/src/ifcgeom/mapping/IfcTextLiteral.cpp
+++ b/src/ifcgeom/mapping/IfcTextLiteral.cpp
@@ -1,0 +1,32 @@
+/********************************************************************************
+ *                                                                              *
+ * This file is part of IfcOpenShell.                                           *
+ *                                                                              *
+ * IfcOpenShell is free software: you can redistribute it and/or modify         *
+ * it under the terms of the Lesser GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3.0 of the License, or          *
+ * (at your option) any later version.                                          *
+ *                                                                              *
+ * IfcOpenShell is distributed in the hope that it will be useful,              *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 *
+ * Lesser GNU General Public License for more details.                          *
+ *                                                                              *
+ * You should have received a copy of the Lesser GNU General Public License     *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.         *
+ *                                                                              *
+ ********************************************************************************/
+
+// This file was generated with the assistance of an AI coding tool.
+
+#include "mapping.h"
+#define mapping POSTFIX_SCHEMA(mapping)
+
+using namespace ifcopenshell::geometry;
+
+taxonomy::ptr mapping::map_impl(const IfcSchema::IfcTextLiteral* inst) {
+	// Rendering glyphs as geometry is not supported, see #431
+	logger_.Message(Logger::LOG_WARNING, "GEO", 328, "Text literals are not converted to geometry, skipping:", inst);
+	failed_on_purpose_.insert(inst);
+	return nullptr;
+}

--- a/src/ifcgeom/mapping/mapping.i
+++ b/src/ifcgeom/mapping/mapping.i
@@ -82,6 +82,8 @@ BIND(IfcSurfaceCurveSweptAreaSolid);
 BIND(IfcSweptDiskSolid);
 
 BIND(IfcAnnotationFillArea);
+// IfcTextLiteralWithExtent included
+BIND(IfcTextLiteral);
 // IfcArbitraryProfileDefWithVoids included
 BIND(IfcArbitraryClosedProfileDef);
 BIND(IfcRoundedRectangleProfileDef);

--- a/src/ifcopenshell-python/test/test_create_shape.py
+++ b/src/ifcopenshell-python/test/test_create_shape.py
@@ -9,6 +9,7 @@ import pytest
 
 import ifcopenshell
 import ifcopenshell.api.context
+import ifcopenshell.api.geometry
 import ifcopenshell.api.owner.settings
 import ifcopenshell.api.project
 import ifcopenshell.api.root
@@ -235,6 +236,53 @@ def test_logging():
     assert ("GEO089", "Non-positive extrusion height encountered for:") in [
         (msg.code, msg.message) for msg in new_items
     ]
+
+
+def test_text_literal_skipped_gracefully():
+    # https://github.com/IfcOpenShell/IfcOpenShell/issues/431
+    ifc_file = ifcopenshell.file()
+    ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject", name="Test")
+    context = ifcopenshell.api.context.add_context(ifc_file, context_type="Model")
+
+    builder = ShapeBuilder(ifc_file)
+
+    def make_text_literal():
+        placement = ifc_file.create_entity(
+            "IfcAxis2Placement2D", ifc_file.create_entity("IfcCartesianPoint", (0.0, 0.0))
+        )
+        extent = ifc_file.create_entity("IfcPlanarExtent", 1.0, 0.3)
+        return ifc_file.create_entity("IfcTextLiteralWithExtent", "Hello", placement, "LEFT", extent, "top-left")
+
+    settings = ifcopenshell.geom.settings()
+    settings.set("dimensionality", W.CURVES_SURFACES_AND_SOLIDS)
+
+    logger = ifcopenshell.logger()
+    logger.OutputFormat(logger.FMT_INMEMORY)
+
+    # A representation mixing text with curves converts the curves and skips the text.
+    curve = builder.rectangle()
+    representation = builder.get_representation(context, (curve, make_text_literal()))
+    shape = ifcopenshell.geom.create_shape(settings, representation, logger=logger)
+    edges_item_ids = ifcopenshell.util.shape.get_edges_representation_item_ids(shape)
+    assert set(edges_item_ids) == {curve.id()}
+
+    codes = [msg.code for msg in logger]
+    assert "GEO328" in codes
+    assert "GEO307" not in codes  # no "No operation defined for:" error
+
+    # A text-only annotation has no convertible geometry and raises,
+    # but with the explicit warning instead of conversion errors.
+    annotation = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcAnnotation")
+    ifcopenshell.api.geometry.edit_object_placement(ifc_file, product=annotation)
+    representation = builder.get_representation(context, make_text_literal())
+    ifcopenshell.api.geometry.assign_representation(ifc_file, product=annotation, representation=representation)
+    num_log_items = len(list(logger))
+    with pytest.raises(RuntimeError):
+        ifcopenshell.geom.create_shape(settings, annotation, logger=logger)
+    new_items = list(logger)[num_log_items:]
+    assert "GEO328" in [msg.code for msg in new_items]
+    assert "GEO307" not in [msg.code for msg in new_items]
+    assert "GEO326" not in [msg.code for msg in new_items]  # no "Failed to convert:" error
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See #431.

CyrilWaechter narrowed the original 2018 report down to one real bug in 2023: `IfcTextLiteralWithExtent` has no geometry mapping, so converting an `IfcAnnotation` containing one produced a generic "No operation defined for" error, escalating to a misleading "Failed to convert" error before `create_shape` raised.

Binds `IfcTextLiteral` (covers `IfcTextLiteralWithExtent`) to mark it as failed on purpose, the same pattern already used for `IfcBoundingBox` when deliberately skipped. Mixed representations now convert their remaining items cleanly, and the skip is a single clear warning instead of an error cascade. A text-only representation still raises in `create_shape` since there's genuinely no geometry to return, consistent with a bounding-box-only representation, and the iterator path continues over failures as before.

Rendering actual glyph geometry (the freetype idea floated in the thread) stays out of scope: the official dependency build compiles OCCT with `USE_FREETYPE=OFF` and doesn't link `TKService`, so there's no already-integrated font tessellation to build on in any current release toolchain. A real implementation would need FreeType enabled across every platform build, kernel-agnostic glyph tessellation (both OCCT and CGAL), and a font-resolution policy for the usually-absent `IfcTextStyleFontModel`. That's a genuine multi-week feature and a build-system decision, not something this PR attempts.

Verified against the original `AC20-Institute-Var-2.ifc` sample from the issue: with curves enabled, 112/113 annotations convert with warnings only (previously 8 hard errors), and `IfcConvert` output is byte-identical otherwise. New regression test in `test_create_shape.py`.

AI-generated PR, human-reviewed.