### PR TITLE
ifcparse: store integer attribute values as int64_t to allow out-of-range timestamps

### DIFF
--- a/src/ifcparse/IfcEntityInstanceData.cpp
+++ b/src/ifcparse/IfcEntityInstanceData.cpp
@@ -9,7 +9,7 @@ public:
 
     int operator()(const Blank& /*i*/) const { return -1; }
     int operator()(const Derived& /*i*/) const { return -1; }
-    int operator()(const int& /*i*/) const { return -1; }
+    int operator()(const int64_t& /*i*/) const { return -1; }
     int operator()(const bool& /*i*/) const { return -1; }
     int operator()(const boost::logic::tribool& /*i*/) const { return -1; }
     int operator()(const double& /*i*/) const { return -1; }
@@ -125,7 +125,12 @@ namespace {
 
 AttributeValue::operator int() const
 {
-    return dispatch_get_<int>(array_, storage_model_, instance_name_, entity_or_type_, index_);
+    return (int)dispatch_get_<int64_t>(array_, storage_model_, instance_name_, entity_or_type_, index_);
+}
+
+AttributeValue::operator int64_t() const
+{
+    return dispatch_get_<int64_t>(array_, storage_model_, instance_name_, entity_or_type_, index_);
 }
 
 AttributeValue::operator bool() const
@@ -526,7 +531,7 @@ void rocks_db_attribute_storage::set(void* storage, const IfcParse::declaration*
 }
 
 template IFC_PARSE_API void rocks_db_attribute_storage::set<Blank>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index, const Blank& value);
-template IFC_PARSE_API void rocks_db_attribute_storage::set<int>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index, const int& value);
+template IFC_PARSE_API void rocks_db_attribute_storage::set<int64_t>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index, const int64_t& value);
 template IFC_PARSE_API void rocks_db_attribute_storage::set<bool>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index, const bool& value);
 template IFC_PARSE_API void rocks_db_attribute_storage::set<boost::logic::tribool>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index, const boost::logic::tribool& value);
 template IFC_PARSE_API void rocks_db_attribute_storage::set<double>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index, const double& value);
@@ -551,7 +556,7 @@ template IFC_PARSE_API void rocks_db_attribute_storage::set<empty_aggregate_of_a
 
 
 template IFC_PARSE_API bool rocks_db_attribute_storage::has<Blank>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index) const;
-template IFC_PARSE_API bool rocks_db_attribute_storage::has<int>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index) const;
+template IFC_PARSE_API bool rocks_db_attribute_storage::has<int64_t>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index) const;
 template IFC_PARSE_API bool rocks_db_attribute_storage::has<bool>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index) const;
 template IFC_PARSE_API bool rocks_db_attribute_storage::has<boost::logic::tribool>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index) const;
 template IFC_PARSE_API bool rocks_db_attribute_storage::has<double>(void* storage, const IfcParse::declaration* decl, std::size_t identity, size_t index) const;

--- a/src/ifcparse/IfcEntityInstanceData.h
+++ b/src/ifcparse/IfcEntityInstanceData.h
@@ -89,6 +89,11 @@ namespace impl {
     };
 
     template <>
+    struct VariantTypeName<int64_t> {
+        static std::string get() { return "int"; }
+    };
+
+    template <>
     struct VariantTypeName<bool> {
         static std::string get() { return "bool"; }
     };
@@ -163,7 +168,9 @@ typedef parameter_pack <
     // An integer argument, e.g. 123
 
     // SCALARS:
-    int,
+    // Stored as int64_t so integer attributes (IfcInteger, IfcTimeStamp)
+    // can hold values outside the signed 32-bit range.
+    int64_t,
     // A boolean argument, it will serialize to either .T. or .F.
     bool,
     // A logical argument, it will serialize to either .T. or .F. or .U.
@@ -396,6 +403,7 @@ struct IFC_PARSE_API AttributeValue {
     {}
 
     operator int() const;
+    operator int64_t() const;
     operator bool() const;
     operator boost::logic::tribool() const;
     operator double() const;
@@ -426,7 +434,7 @@ struct IFC_PARSE_API AttributeValue {
             case IfcUtil::Argument_DERIVED:
                 return visitor(Derived{});
             case IfcUtil::Argument_INT:
-                return visitor((int)*this);
+                return visitor((int64_t)*this);
             case IfcUtil::Argument_BOOL:
                 return visitor((bool)*this);
             case IfcUtil::Argument_LOGICAL: {

--- a/src/ifcparse/IfcFile.cpp
+++ b/src/ifcparse/IfcFile.cpp
@@ -135,7 +135,7 @@ namespace {
 
         possible_aggregation_types_t aggregate_storage;
 
-        auto append_to_aggregate_storage = [&aggregate_storage, &logger](const auto& v) {
+        auto append_impl = [&aggregate_storage, &logger](const auto& v) {
             if constexpr (is_type_in_variant_v<possible_aggregation_types_t, std::vector<std::decay_t<decltype(v)>>>) {
                 if (aggregate_storage.index() == 0) {
                     aggregate_storage = std::vector<std::decay_t<decltype(v)>>{ v };
@@ -214,6 +214,15 @@ namespace {
             } else {
                 // @todo would be cool if we can trace this back to file offset
                 logger.Error("UNS", 31, std::string("Aggregates of ") + typeid(decltype(v)).name() + " are not supported in the IfcOpenShell parser");
+            }
+        };
+
+        // Scalar integers are parsed as int64_t, but integer aggregates remain 32-bit; narrow here.
+        auto append_to_aggregate_storage = [&append_impl](const auto& v) {
+            if constexpr (std::is_same_v<std::decay_t<decltype(v)>, int64_t>) {
+                append_impl((int)v);
+            } else {
+                append_impl(v);
             }
         };
 

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -266,13 +266,13 @@ inline void RemoveTokenSeparators(FileReader* stream, size_t start, size_t end, 
 }
 */
 
-bool ParseInt(const char* pStart, int& val) {
+bool ParseInt(const char* pStart, int64_t& val) {
     char* pEnd;
-    long result = strtol(pStart, &pEnd, 10);
+    long long result = strtoll(pStart, &pEnd, 10);
     if (*pEnd != 0) {
         return false;
     }
-    val = (int)result;
+    val = (int64_t)result;
     return true;
 }
 
@@ -290,7 +290,7 @@ bool ParseFloat(const char* pStart, double& val) {
     return true;
 }
 
-bool ParseBool(const char* pStart, int& val) {
+bool ParseBool(const char* pStart, int64_t& val) {
     if (strlen(pStart) != 3 || pStart[0] != '.' || pStart[2] != '.') {
         return false;
     }
@@ -397,7 +397,7 @@ bool TokenFunc::isFloat(const Token& token) {
 #endif
 }
 
-int TokenFunc::asInt(const Token& token) {
+int64_t TokenFunc::asInt(const Token& token) {
     if (token.type != Token_INT) {
         throw IfcInvalidTokenException(token.startPos, toString(token), "integer");
     }
@@ -408,7 +408,7 @@ int TokenFunc::asIdentifier(const Token& token) {
     if (token.type != Token_IDENTIFIER) {
         throw IfcInvalidTokenException(token.startPos, toString(token), "instance name");
     }
-    return token.value_int;
+    return (int)token.value_int;
 }
 
 bool TokenFunc::asBool(const Token& token) {
@@ -808,7 +808,7 @@ namespace {
             upper_(upper) {}
         void operator()(const Blank& /*i*/) { data_ << "$"; }
         void operator()(const Derived& /*i*/) { data_ << "*"; }
-        void operator()(const int& i) { data_ << i; }
+        void operator()(const int64_t& i) { data_ << i; }
         void operator()(const bool& i) { data_ << (i ? ".T." : ".F."); }
         void operator()(const boost::logic::tribool& i) { data_ << (i ? ".T." : (boost::logic::indeterminate(i) ? ".U." : ".F.")); }
         void operator()(const double& i) { data_ << format_double(i); }
@@ -1154,6 +1154,9 @@ IfcUtil::IfcBaseClass::set_attribute_value(size_t i, const T& t) {
             } else {
                 data_.set_attribute_value(storage, &declaration(), id() ? id() : identity(), i, Blank{});
             }
+        } else if constexpr (std::is_same_v<std::decay_t<T>, int>) {
+            // Integer attributes are stored as int64_t; widen the schema-generated int here.
+            data_.set_attribute_value(storage, &declaration(), id() ? id() : identity(), i, (int64_t)t);
         } else {
             data_.set_attribute_value(storage, &declaration(), id() ? id() : identity(),i, t);
         }
@@ -2951,6 +2954,7 @@ void IfcUtil::IfcBaseClass::set_attribute_value(const std::string& name, IfcUtil
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<Blank>(size_t index, const Blank& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<Derived>(size_t index, const Derived& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<int>(size_t index, const int& value);
+template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<int64_t>(size_t index, const int64_t& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<bool>(size_t index, const bool& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<boost::logic::tribool>(size_t index, const boost::logic::tribool& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<double>(size_t index, const double& value);
@@ -2970,6 +2974,7 @@ template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<aggregate
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<Blank>(const std::string& name, const Blank& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<Derived>(const std::string& name, const Derived& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<int>(const std::string& name, const int& value);
+template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<int64_t>(const std::string& name, const int64_t& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<bool>(const std::string& name, const bool& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<boost::logic::tribool>(const std::string& name, const boost::logic::tribool& value);
 template void IFC_PARSE_API IfcUtil::IfcBaseClass::set_attribute_value<double>(const std::string& name, const double& value);

--- a/src/ifcparse/IfcParse.h
+++ b/src/ifcparse/IfcParse.h
@@ -80,7 +80,7 @@ class IFC_PARSE_API TokenFunc {
     /// Returns whether the token can be interpreted as a binary type
     static bool isBinary(const Token& token);
     /// Returns the token interpreted as an integer
-    static int asInt(const Token& token);
+    static int64_t asInt(const Token& token);
     /// Returns the token interpreted as an identifier
     static int asIdentifier(const Token& token);
     /// Returns the token interpreted as an boolean (.T. or .F.)

--- a/src/ifcparse/storage.h
+++ b/src/ifcparse/storage.h
@@ -151,7 +151,7 @@ namespace IfcParse {
         TokenType type;
         union {
             char value_char;     //types: OPERATOR
-            int value_int;       //types: INT, IDENTIFIER
+            int64_t value_int;   //types: INT, IDENTIFIER
             double value_double; //types: FLOAT
         };
 

--- a/src/ifcwrap/IfcParseWrapper.i
+++ b/src/ifcwrap/IfcParseWrapper.i
@@ -531,12 +531,12 @@ private:
 		}
 	}
 
-	void setArgumentAsInt(unsigned int i, int v) {
+	void setArgumentAsInt(unsigned int i, int64_t v) {
 		IfcUtil::ArgumentType arg_type = helper_fn_attribute_type($self, i);
 		if (arg_type == IfcUtil::Argument_INT) {
-			self->set_attribute_value(i, v);	
+			self->set_attribute_value(i, v);
 		} else if ( (arg_type == IfcUtil::Argument_BOOL) && ( (v == 0) || (v == 1) ) ) {
-			self->set_attribute_value(i, v);	
+			self->set_attribute_value(i, (bool)v);
 		} else {
 			throw IfcParse::IfcException("Attribute not set");
 		}

--- a/src/ifcwrap/utils/type_conversion.i
+++ b/src/ifcwrap/utils/type_conversion.i
@@ -169,6 +169,7 @@
 	}
 
 	PyObject* pythonize(const int& t)                   { return PyInt_FromLong(t);                                                                  }
+	PyObject* pythonize(const int64_t& t)               { return PyLong_FromLongLong(t);                                                             }
 	PyObject* pythonize(const unsigned int& t)          { return PyInt_FromLong(t);                                                                  }
 	PyObject* pythonize(const bool& t)                  { return PyBool_FromLong(t);                                                                 }
 	PyObject* pythonize(const boost::logic::tribool& t) { return boost::logic::indeterminate(t) ? PyUnicode_FromString("UNKNOWN") : PyBool_FromLong((bool)t) ;}


### PR DESCRIPTION
Fixes #3058.

Setting an `IfcInteger`/`IfcTimeStamp`-typed attribute (e.g. `IfcOwnerHistory.CreationDate`) outside the signed 32-bit range raised `OverflowError: entity_instance_setArgumentAsInt, argument 3 of type 'int'`. Any Unix timestamp before 1901-12-13 or after 2038-01-19 fell outside that range, so those dates couldn't be authored at all. @aothms gave the direction back in 2023 ("make integers int64_t"); this narrows that to just the scalar integer attribute path rather than a full repo-wide migration.

- The scalar slot of the attribute variant (`Argument_INT`) becomes `int64_t`. Integer aggregates (`Argument_AGGREGATE_OF_INT`, e.g. `CoordIndex`) and instance/reference identifiers stay 32-bit, since neither is the value that overflows here.
- `IfcBaseClass::set_attribute_value` promotes the schema-generated `int` to `int64_t` at a single choke point, so the thousands of generated setters keep compiling unchanged.
- The STEP lexer, writer, and SWIG wrapper all widened together, since widening only the Python-facing setter would have silently wrapped the value on file write instead of raising (this is exactly what a naive attempt in the original thread ran into).

Verified in a build (IFC2X3 and IFC4): pre-1901, post-2038, both 32-bit boundaries, and a 9e12 value all round trip exactly both in memory and through STEP text serialization (write then reopen). Ordinary in-range integers and integer aggregates are unaffected. Existing entity/attribute test suite passes.

Built and tested against IFC2X3 + IFC4 only in this pass, not the full schema set (e.g. IFC4X3 variants), flagging that for anyone building the wider schema set to double check.

AI-generated PR, human-reviewed.