### PR TITLE
Bonsai: fix duplicate xmlns:xlink in drawings that use SVG patterns with <use> elements

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
@@ -44,15 +44,27 @@ from bonsai.bim.module.drawing.data import DecoratorData, DrawingsData
 
 
 class External(svgwrite.container.Group):
+    # Parsed elements must use svgwrite's literal xmlns:prefix convention, or
+    # ET.tostring() re-declares the namespace on top of svgwrite's own declaration.
+    _NS_PREFIXES = {
+        "http://www.w3.org/2000/svg": "",
+        "http://www.w3.org/1999/xlink": "xlink",
+    }
+
     def __init__(self, xml, **extra):
         self.xml = xml
 
-        # Remove namespace
-        ns = "{http://www.w3.org/2000/svg}"
-        nsl = len(ns)
         for elem in self.xml.iter():
-            if elem.tag.startswith(ns):
-                elem.tag = elem.tag[nsl:]
+            if elem.tag.startswith("{"):
+                uri, _, local = elem.tag[1:].partition("}")
+                prefix = self._NS_PREFIXES.get(uri, "")
+                elem.tag = f"{prefix}:{local}" if prefix else local
+            for key in list(elem.attrib):
+                if key.startswith("{"):
+                    uri, _, local = key[1:].partition("}")
+                    prefix = self._NS_PREFIXES.get(uri)
+                    new_key = f"{prefix}:{local}" if prefix else local
+                    elem.attrib[new_key] = elem.attrib.pop(key)
 
         super().__init__(**extra)
 


### PR DESCRIPTION
Fixes #8232.

The duplicate does not come from `sheeter.py`'s own tree writes, as two prior in-thread diagnoses (both mine) suspected. It comes from `svgwriter.py`'s `add_patterns`/`add_markers`/`add_symbols`, which parse external SVG resources (e.g. a hatch pattern containing `<use xlink:href="...">`) with `xml.etree.ElementTree` and wrap them in the `External` class so svgwrite can embed them in the drawing's `<defs>`.

svgwrite always declares `xmlns:xlink` as a literal string attribute on its own root and knows nothing about ET's namespace machinery. `External` kept the parsed element's real, namespace-qualified attribute names (Clark notation). When svgwrite serializes the merged tree via `ET.tostring()`, ET re-declares that namespace on the root using whatever prefix is currently registered in ET's **global, process-wide** namespace registry. On a fresh session nothing has registered "xlink" yet, so no collision occurs, but once any sheet action runs (`sheeter.py` calls `ET.register_namespace("xlink", ...)` in several places), that registration persists globally for the rest of the session, and every subsequent drawing regeneration collides svgwrite's literal declaration with ET's auto-declared one. This matches the reporter's exact observation that a restart clears it and creating a sheet is what triggers it.

The fix normalizes `External`'s namespace-qualified tag and attribute names back into svgwrite's own literal `xmlns:prefix` convention before merging, so no Clark-notation attribute ever reaches ET's auto-declaration logic, independent of global session state.

Live-verified in real Blender 5.1.2 (a patched copy of the actual installed wheel, restored after): reproduced the exact duplicate byte-for-byte through the reporter's scenario (custom pattern with the reported `<use>` snippet, generate drawing, add sheet, add drawing to sheet, regenerate 3x in the same session), confirmed it's gone after the fix across all 3 regenerations, the `<use>` reference still resolves correctly, a drawing that never touches a sheet is unaffected, and all output parses as well-formed XML.

AI-generated PR, human-reviewed.