### PR TITLE
Fix serialize_shape() dropping the outermost shape's placement

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/occ_utils.py
@@ -34,6 +34,7 @@ import ifcopenshell.ifcopenshell_wrapper as ifcopenshell_wrapper
 try:
     from OCC.Core import (  # pyright: ignore[reportMissingImports]  # ty:ignore[unresolved-import]
         AIS,
+        BRep,
         BRepTools,
         Graphic3d,
         Quantity,
@@ -46,6 +47,7 @@ try:
 except ImportError:
     from OCC import (  # pyright: ignore[reportMissingImports]  # ty:ignore[unresolved-import]
         AIS,
+        BRep,
         BRepTools,
         Graphic3d,
         Quantity,
@@ -242,7 +244,16 @@ def serialize_shape(shape):
     # see whether this is necessary
     shapes.SetFormatNb(2)
 
-    shapes.Add(shape)
+    # BRepTools_ShapeSet does not persist the location of the outermost shape
+    # (it is only written for shapes referenced by a parent). Wrap in an
+    # identity-located compound so the original shape becomes a referenced
+    # child and its location round-trips. See issue #2992.
+    compound = TopoDS.TopoDS_Compound()
+    builder = BRep.BRep_Builder()
+    builder.MakeCompound(compound)
+    builder.Add(compound, shape)
+
+    shapes.Add(compound)
 
     # Check if WriteToString method exists and has the correct signature
     # In PythonOCC >= 7.8.0, WriteToString signature changed and requires additional arguments


### PR DESCRIPTION
Fixes #2992.

`BRepTools_ShapeSet.Add()` only persists a shape's `TopLoc_Location` when that shape is referenced as a child of another shape in the set. The outermost shape has no parent, so its own location was silently dropped on write. This made two OCC shapes that FreeCAD (and OCCT itself) consider identically placed serialize to different results, depending on whether the placement was baked into the underlying geometry or carried as a location on the shape itself, exactly as reported.

Wraps the shape in an identity-located `TopoDS_Compound` before adding it to the shape set, so the original shape becomes a referenced child and its location round-trips correctly. This is the workaround @aothms suggested in the thread, and it mirrors what IfcOpenShell's own C++ side already does (`as_compound()` + `Serialize()`) for the `SerializedElement.geometry.brep_data` path, which was never affected by this bug, so the codebase is now internally consistent between the two paths.

Verified live with pythonocc-core 7.9.0 against a locally built `ifcopenshell_wrapper`: a box built at the origin and relocated via a top-level `TopLoc_Location` round-tripped through `ifcopenshell.geom.serialise()` and a full write/reopen/tessellate cycle to `(0,0,0)` instead of its actual placement before this fix, matching the reported symptom precisely. After the fix it matches an equivalent box built directly at the target location. An already-compound input shape and the ordinary non-relocated case are unaffected.

AI-generated PR, human-reviewed.