### PR TITLE
ifcwrap: keep geometry's owning element alive to fix silent data corruption

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/main.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/main.py
@@ -475,8 +475,8 @@ def create_shape(
     """
     Returns a geometric interpretation of the IFC entity instance
 
-    Note that in Python, you must store a reference to the element returned by this function to prevent garbage
-    collection when you access its children. See #1124.
+    The returned element's ``geometry`` keeps a reference to its owning element, so accessing children
+    (e.g. ``create_shape(...).geometry.verts``) no longer requires holding onto the element. See #1124.
 
     :raises RuntimeError: If failed to process shape. You can turn detailed logging to get more details.
 

--- a/src/ifcwrap/IfcGeomWrapper.i
+++ b/src/ifcwrap/IfcGeomWrapper.i
@@ -793,14 +793,24 @@ struct ShapeRTTI : public boost::static_visitor<PyObject*>
 %extend IfcGeom::TriangulationElement {
 	%pythoncode %{
         # Hide the getters with read-only property implementations
-        geometry = property(geometry)
+        # Keep the owning element alive while its geometry is referenced (#1124).
+        def _geometry_with_backref(self, _f=geometry):
+            result = _f(self)
+            result._parent = self
+            return result
+        geometry = property(_geometry_with_backref)
 	%}
 };
 
 %extend IfcGeom::SerializedElement {
 	%pythoncode %{
         # Hide the getters with read-only property implementations
-        geometry = property(geometry)
+        # Keep the owning element alive while its geometry is referenced (#1124).
+        def _geometry_with_backref(self, _f=geometry):
+            result = _f(self)
+            result._parent = self
+            return result
+        geometry = property(_geometry_with_backref)
 	%}
 };
 
@@ -825,10 +835,15 @@ struct ShapeRTTI : public boost::static_visitor<PyObject*>
 
     %pythoncode %{
         # Hide the getters with read-only property implementations
-        geometry = property(geometry)
+        # Keep the owning element alive while its geometry is referenced (#1124).
+        def _geometry_with_backref(self, _f=geometry):
+            result = _f(self)
+            result._parent = self
+            return result
+        geometry = property(_geometry_with_backref)
         volume = property(calc_volume_)
         surface_area = property(calc_surface_area_)
-    %}    
+    %}
 };
 
 /*


### PR DESCRIPTION
Fixes #1124 (create_shape path). tree.select_ray()'s separate 2024 corruption report is scoped as follow-up, see below.

`create_shape()` returns a Python-owned `Element` (`SWIG_POINTER_OWN` in the `boost::variant` out typemap). Its `.geometry` property calls `Element::geometry()`, which returns a reference into the element's `boost::shared_ptr<Representation>` `_geometry` member. SWIG wraps that reference as a non-owning pointer, so the returned Triangulation/BRep/Serialization proxy does not keep the element alive.

When a caller keeps only `.geometry` (e.g. `create_shape(s, e).geometry`) and drops the parent element, Python garbage collects the element, destroying its `shared_ptr` and freeing the underlying representation. Subsequent reads of `verts`/`faces` then return freed memory: empty or implausible float/int garbage, non-deterministically depending on GC and allocator timing. Silent data corruption, not a crash, and it's bitten users since 2020 (this exact issue, and independently again via `tree.select_ray()` in 2024).

Fix: in the `TriangulationElement`/`SerializedElement`/`BRepElement` pythoncode, wrap the geometry getter so the returned geometry stores a backreference to its owning element (`result._parent = self`). This is @aothms's own suggested backreference pattern from the thread, applied generically and automatically in the binding rather than left as something every caller has to remember to do themselves, which is exactly what failed to actually protect anyone for 4+ years.

Reproduced deterministically (washBasin fixture) against a real compiled build: before the fix, `verts` length flips between 0 and the real 133500 across repeated GC-pressure runs. After the fix, 133500 every run, for all three element types. `test_create_shape.py` passes, no regressions.

Also updates `create_shape`'s own docstring, which previously warned users they "must store a reference to the element... See #1124", since that workaround is no longer required.

**Follow-up scope, not attempted here:** `tree.select_ray()`'s `ray_intersection_result` (the 2024 corruption report in this same issue) is a distinct ownership mechanism (a `std::vector` element reference plus a pointer into a `std::array` struct member, not the shared_ptr representation path this PR fixes). A safe fix needs targeted handling of that separate SWIG plumbing; attempting it in this same pass risked an unsafe broad change to shared `std_vector` machinery for comparatively little benefit given this PR already covers the primary, most-hit entry point.

AI-generated PR, human-reviewed.