### PR TITLE
Bonsai: add tooltips to 67 operators in classification, document, group, layer, library and unit modules

### DIFF
--- a/src/bonsai/bonsai/bim/module/classification/operator.py
+++ b/src/bonsai/bonsai/bim/module/classification/operator.py
@@ -43,6 +43,7 @@ class LoadClassificationLibrary(bpy.types.Operator, tool.Ifc.Operator, ImportHel
 class AddClassification(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_classification"
     bl_label = "Add Classification"
+    bl_description = "Add the classification selected from the loaded classification library to the project"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -56,6 +57,7 @@ class AddClassification(bpy.types.Operator, tool.Ifc.Operator):
 class AddManualClassification(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_manual_classification"
     bl_label = "Add Manual Classification"
+    bl_description = "Add a new classification to the project with attributes entered manually"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -71,6 +73,7 @@ class AddManualClassification(bpy.types.Operator, tool.Ifc.Operator):
 class AddManualClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_manual_classification_reference"
     bl_label = "Add Manual Classification Reference"
+    bl_description = "Add a manually defined classification reference and assign it to the selected objects"
     bl_options = {"REGISTER", "UNDO"}
     obj: bpy.props.StringProperty()
     obj_type: bpy.props.StringProperty()
@@ -106,6 +109,7 @@ class AddManualClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
 class AddClassificationFromBSDD(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_classification_from_bsdd"
     bl_label = "Add Classification From bSDD"
+    bl_description = "Add the classification system(s) selected from bSDD to the project"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -138,6 +142,7 @@ class AddClassificationFromBSDD(bpy.types.Operator, tool.Ifc.Operator):
 class EnableAddingManualClassification(bpy.types.Operator):
     bl_idname = "bim.enable_adding_manual_classification"
     bl_label = "Enable Adding Manual Classification"
+    bl_description = "Show the form to manually add a new classification"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -152,6 +157,7 @@ class EnableAddingManualClassification(bpy.types.Operator):
 class DisableAddingManualClassification(bpy.types.Operator):
     bl_idname = "bim.disable_adding_manual_classification"
     bl_label = "Disable Adding Manual Classification"
+    bl_description = "Hide the form for manually adding a new classification"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -163,6 +169,7 @@ class DisableAddingManualClassification(bpy.types.Operator):
 class EnableAddingManualClassificationReference(bpy.types.Operator):
     bl_idname = "bim.enable_adding_manual_classification_reference"
     bl_label = "Enable Adding Manual Classification Reference"
+    bl_description = "Show the form to manually add a new classification reference"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -176,6 +183,7 @@ class EnableAddingManualClassificationReference(bpy.types.Operator):
 class DisableAddingManualClassificationReference(bpy.types.Operator):
     bl_idname = "bim.disable_adding_manual_classification_reference"
     bl_label = "Disable Adding Manual Classification Reference"
+    bl_description = "Hide the form for manually adding a new classification reference"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -187,6 +195,7 @@ class DisableAddingManualClassificationReference(bpy.types.Operator):
 class EnableEditingClassification(bpy.types.Operator):
     bl_idname = "bim.enable_editing_classification"
     bl_label = "Enable Editing Classification"
+    bl_description = "Load the attributes of the selected classification for editing"
     bl_options = {"REGISTER", "UNDO"}
     classification: bpy.props.IntProperty()
 
@@ -204,6 +213,7 @@ class EnableEditingClassification(bpy.types.Operator):
 class DisableEditingClassification(bpy.types.Operator):
     bl_idname = "bim.disable_editing_classification"
     bl_label = "Disable Editing Classification"
+    bl_description = "Close the classification editing form without saving changes"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -233,6 +243,7 @@ class RemoveClassification(bpy.types.Operator, tool.Ifc.Operator):
 class EditClassification(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_classification"
     bl_label = "Edit Classification"
+    bl_description = "Save the edited attributes to the classification"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -250,6 +261,7 @@ class EditClassification(bpy.types.Operator, tool.Ifc.Operator):
 class EnableEditingClassificationReference(bpy.types.Operator):
     bl_idname = "bim.enable_editing_classification_reference"
     bl_label = "Enable Editing Classification Reference"
+    bl_description = "Load the attributes of the selected classification reference for editing"
     bl_options = {"REGISTER", "UNDO"}
     reference: bpy.props.IntProperty()
     obj: bpy.props.StringProperty()
@@ -267,6 +279,7 @@ class EnableEditingClassificationReference(bpy.types.Operator):
 class DisableEditingClassificationReference(bpy.types.Operator):
     bl_idname = "bim.disable_editing_classification_reference"
     bl_label = "Disable Editing Classification Reference"
+    bl_description = "Close the classification reference editing form without saving changes"
     bl_options = {"REGISTER", "UNDO"}
     obj: bpy.props.StringProperty()
 
@@ -278,6 +291,7 @@ class DisableEditingClassificationReference(bpy.types.Operator):
 class RemoveClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.remove_classification_reference"
     bl_label = "Remove Classification Reference"
+    bl_description = "Remove the classification reference from the selected objects"
     bl_options = {"REGISTER", "UNDO"}
     reference: bpy.props.IntProperty()
     obj: bpy.props.StringProperty()
@@ -319,6 +333,7 @@ class RemoveClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
 class EditClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_classification_reference"
     bl_label = "Edit Classification Reference"
+    bl_description = "Save the edited attributes to the classification reference"
     bl_options = {"REGISTER", "UNDO"}
     obj: bpy.props.StringProperty()
 
@@ -341,6 +356,7 @@ class EditClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
 class AddClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_classification_reference"
     bl_label = "Add Classification Reference"
+    bl_description = "Assign the selected reference from the loaded classification library to the selected objects"
     bl_options = {"REGISTER", "UNDO"}
     reference: bpy.props.IntProperty()
     obj: bpy.props.StringProperty()
@@ -472,6 +488,7 @@ class AddClassificationReferenceFromBSDD(bpy.types.Operator, tool.Ifc.Operator):
 class ChangeClassificationLevel(bpy.types.Operator):
     bl_idname = "bim.change_classification_level"
     bl_label = "Change Classification Level"
+    bl_description = "Browse into the child references of the selected classification library reference"
     bl_options = {"REGISTER", "UNDO"}
     parent_id: bpy.props.IntProperty()
 
@@ -495,6 +512,7 @@ class ChangeClassificationLevel(bpy.types.Operator):
 class DisableEditingClassificationReferences(bpy.types.Operator):
     bl_idname = "bim.disable_editing_classification_references"
     bl_label = "Disable Editing Classification References"
+    bl_description = "Clear the list of classification library references currently being browsed"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):

--- a/src/bonsai/bonsai/bim/module/document/operator.py
+++ b/src/bonsai/bonsai/bim/module/document/operator.py
@@ -29,6 +29,7 @@ from bonsai.bim.module.document.data import ObjectDocumentData
 class LoadProjectDocuments(bpy.types.Operator):
     bl_idname = "bim.load_project_documents"
     bl_label = "Load Project Documents"
+    bl_description = "Load the tree of documents and document references attached to the project"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -39,6 +40,7 @@ class LoadProjectDocuments(bpy.types.Operator):
 class DisableDocumentEditingUI(bpy.types.Operator):
     bl_idname = "bim.disable_document_editing_ui"
     bl_label = "Disable Document Editing UI"
+    bl_description = "Close the project documents tree"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -49,6 +51,7 @@ class DisableDocumentEditingUI(bpy.types.Operator):
 class DisableObjectDocumentEditingUI(bpy.types.Operator):
     bl_idname = "bim.disable_object_document_editing_ui"
     bl_label = "Disable Object Document Editing UI"
+    bl_description = "Close the list of documents assignable to the active object"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -59,6 +62,7 @@ class DisableObjectDocumentEditingUI(bpy.types.Operator):
 class EnableEditingDocument(bpy.types.Operator):
     bl_idname = "bim.enable_editing_document"
     bl_label = "Enable Editing Document"
+    bl_description = "Load the attributes of the selected document or reference for editing"
     bl_options = {"REGISTER", "UNDO"}
     document: bpy.props.IntProperty()
 
@@ -70,6 +74,7 @@ class EnableEditingDocument(bpy.types.Operator):
 class DisableEditingDocument(bpy.types.Operator):
     bl_idname = "bim.disable_editing_document"
     bl_label = "Disable Editing Document"
+    bl_description = "Close the document editing form without saving changes"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -80,6 +85,7 @@ class DisableEditingDocument(bpy.types.Operator):
 class AddInformation(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_information"
     bl_label = "Add Information"
+    bl_description = "Add a new document information to the project, or as a child of the selected document"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -117,6 +123,7 @@ class AddInformation(bpy.types.Operator, tool.Ifc.Operator):
 class AddDocumentReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_document_reference"
     bl_label = "Add Document Reference"
+    bl_description = "Add a new reference (e.g. file or URI) as a child of the selected document information"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -152,6 +159,7 @@ class AddDocumentReference(bpy.types.Operator, tool.Ifc.Operator):
 class EditDocument(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_document"
     bl_label = "Edit Information"
+    bl_description = "Save the edited attributes to the document or reference"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -164,6 +172,7 @@ class EditDocument(bpy.types.Operator, tool.Ifc.Operator):
 class RemoveDocument(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.remove_document"
     bl_label = "Remove Document"
+    bl_description = "Remove the document information or reference, and any children references, from the project"
     bl_options = {"REGISTER", "UNDO"}
     document: bpy.props.IntProperty()
 
@@ -194,6 +203,7 @@ class AssignDocument(bpy.types.Operator, tool.Ifc.Operator):
 class UnassignDocument(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.unassign_document"
     bl_label = "Unassign Document"
+    bl_description = "Unassign the document from the selected objects, or the active object if none are selected"
     bl_options = {"REGISTER", "UNDO"}
     obj: bpy.props.StringProperty()
     document: bpy.props.IntProperty()
@@ -223,6 +233,7 @@ class UnassignDocument(bpy.types.Operator, tool.Ifc.Operator):
 class SelectDocumentObjects(bpy.types.Operator):
     bl_idname = "bim.select_document_objects"
     bl_label = "Select Document Objects"
+    bl_description = "Select all objects that reference the provided document"
     bl_options = {"REGISTER", "UNDO"}
     document: bpy.props.IntProperty(name="Document ID", default=0)
 
@@ -294,6 +305,7 @@ class OpenIFCDocument(bpy.types.Operator):
 class ToggleDocument(bpy.types.Operator):
     bl_idname = "bim.toggle_document"
     bl_label = "Toggle Document"
+    bl_description = "Expand or collapse the document in the project documents tree"
     bl_options = {"REGISTER", "UNDO"}
     document: bpy.props.IntProperty()
     option: bpy.props.StringProperty()

--- a/src/bonsai/bonsai/bim/module/group/operator.py
+++ b/src/bonsai/bonsai/bim/module/group/operator.py
@@ -29,6 +29,7 @@ import bonsai.tool as tool
 class LoadGroups(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.load_groups"
     bl_label = "Load Groups"
+    bl_description = "Load the list of groups in the project for editing"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -41,6 +42,7 @@ class LoadGroups(bpy.types.Operator, tool.Ifc.Operator):
 class ToggleGroup(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.toggle_group"
     bl_label = "Toggle Group"
+    bl_description = "Expand or collapse the group in the groups tree"
     bl_options = {"REGISTER", "UNDO"}
 
     ifc_definition_id: bpy.props.IntProperty()
@@ -65,6 +67,7 @@ class ToggleGroup(bpy.types.Operator, tool.Ifc.Operator):
 class DisableGroupEditingUI(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.disable_group_editing_ui"
     bl_label = "Disable Group Editing UI"
+    bl_description = "Close the groups tree"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -98,6 +101,7 @@ class AddGroup(bpy.types.Operator, tool.Ifc.Operator):
 class EditGroup(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_group"
     bl_label = "Edit Group"
+    bl_description = "Save the edited attributes to the group"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -112,6 +116,7 @@ class EditGroup(bpy.types.Operator, tool.Ifc.Operator):
 class RemoveGroup(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.remove_group"
     bl_label = "Remove Group"
+    bl_description = "Remove the group from the project"
     bl_options = {"REGISTER", "UNDO"}
     group: bpy.props.IntProperty()
 
@@ -126,6 +131,7 @@ class RemoveGroup(bpy.types.Operator, tool.Ifc.Operator):
 class EnableEditingGroup(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.enable_editing_group"
     bl_label = "Enable Editing Group"
+    bl_description = "Load the attributes of the selected group for editing"
     bl_options = {"REGISTER", "UNDO"}
     group: bpy.props.IntProperty()
 
@@ -141,6 +147,7 @@ class EnableEditingGroup(bpy.types.Operator, tool.Ifc.Operator):
 class DisableEditingGroup(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.disable_editing_group"
     bl_label = "Disable Editing Group"
+    bl_description = "Close the group editing form without saving changes"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):

--- a/src/bonsai/bonsai/bim/module/layer/operator.py
+++ b/src/bonsai/bonsai/bim/module/layer/operator.py
@@ -38,6 +38,7 @@ def get_active_mesh(context: bpy.types.Context, mesh_name: str) -> bpy.types.Mes
 class LoadLayers(bpy.types.Operator):
     bl_idname = "bim.load_layers"
     bl_label = "Load Layers"
+    bl_description = "Load the list of presentation layers in the project for editing"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -63,6 +64,7 @@ class LoadLayers(bpy.types.Operator):
 class DisableLayerEditingUI(bpy.types.Operator):
     bl_idname = "bim.disable_layer_editing_ui"
     bl_label = "Disable Layer Editing UI"
+    bl_description = "Close the presentation layers list"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -74,6 +76,7 @@ class DisableLayerEditingUI(bpy.types.Operator):
 class EnableEditingLayer(bpy.types.Operator):
     bl_idname = "bim.enable_editing_layer"
     bl_label = "Enable Editing Layer"
+    bl_description = "Load the attributes of the selected presentation layer for editing"
     bl_options = {"REGISTER", "UNDO"}
     layer: bpy.props.IntProperty()
 
@@ -91,6 +94,7 @@ class EnableEditingLayer(bpy.types.Operator):
 class DisableEditingLayer(bpy.types.Operator):
     bl_idname = "bim.disable_editing_layer"
     bl_label = "Disable Editing Layer"
+    bl_description = "Close the presentation layer editing form without saving changes"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
@@ -120,6 +124,7 @@ class AddPresentationLayer(bpy.types.Operator, tool.Ifc.Operator):
 class EditPresentationLayer(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_presentation_layer"
     bl_label = "Edit Layer"
+    bl_description = "Save the edited attributes to the presentation layer"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -134,6 +139,7 @@ class EditPresentationLayer(bpy.types.Operator, tool.Ifc.Operator):
 class RemovePresentationLayer(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.remove_presentation_layer"
     bl_label = "Remove Presentation Layer"
+    bl_description = "Remove the presentation layer from the project"
     bl_options = {"REGISTER", "UNDO"}
     layer: bpy.props.IntProperty()
 
@@ -194,6 +200,7 @@ class UnassignPresentationLayer(bpy.types.Operator, tool.Ifc.Operator):
 class SelectLayerProducts(bpy.types.Operator):
     bl_idname = "bim.select_layer_products"
     bl_label = "Select Layer Products"
+    bl_description = "Select all visible objects assigned to the presentation layer"
     bl_options = {"REGISTER", "UNDO"}
     layer: bpy.props.IntProperty()
 
@@ -213,6 +220,7 @@ class SelectLayerProducts(bpy.types.Operator):
 class SelectLayerInLayerUI(bpy.types.Operator):
     bl_idname = "bim.layer_ui_select"
     bl_label = "Select Layer In Layers UI"
+    bl_description = "Highlight the layer in the Layers UI list"
     bl_options = {"REGISTER", "UNDO"}
     layer_id: bpy.props.IntProperty()
 

--- a/src/bonsai/bonsai/bim/module/library/operator.py
+++ b/src/bonsai/bonsai/bim/module/library/operator.py
@@ -25,6 +25,7 @@ import bonsai.tool as tool
 class AddLibrary(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_library"
     bl_label = "Add Library"
+    bl_description = "Add a new library to the project"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -34,6 +35,7 @@ class AddLibrary(bpy.types.Operator, tool.Ifc.Operator):
 class RemoveLibrary(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.remove_library"
     bl_label = "Remove Library"
+    bl_description = "Remove the library and all of its references from the project"
     bl_options = {"REGISTER", "UNDO"}
     library: bpy.props.IntProperty()
 
@@ -44,6 +46,7 @@ class RemoveLibrary(bpy.types.Operator, tool.Ifc.Operator):
 class EnableEditingLibraryReferences(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.enable_editing_library_references"
     bl_label = "Enable Editing Library References"
+    bl_description = "List the references belonging to the selected library"
     bl_options = {"REGISTER", "UNDO"}
     library: bpy.props.IntProperty()
 
@@ -54,6 +57,7 @@ class EnableEditingLibraryReferences(bpy.types.Operator, tool.Ifc.Operator):
 class DisableEditingLibraryReferences(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.disable_editing_library_references"
     bl_label = "Disable Editing Library References"
+    bl_description = "Close the list of references belonging to the selected library"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -63,6 +67,7 @@ class DisableEditingLibraryReferences(bpy.types.Operator, tool.Ifc.Operator):
 class EnableEditingLibrary(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.enable_editing_library"
     bl_label = "Enable Editing Library"
+    bl_description = "Load the attributes of the active library for editing"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -72,6 +77,7 @@ class EnableEditingLibrary(bpy.types.Operator, tool.Ifc.Operator):
 class DisableEditingLibrary(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.disable_editing_library"
     bl_label = "Disable Editing Library"
+    bl_description = "Close the library editing form without saving changes"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -81,6 +87,7 @@ class DisableEditingLibrary(bpy.types.Operator, tool.Ifc.Operator):
 class EditLibrary(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_library"
     bl_label = "Edit Library"
+    bl_description = "Save the edited attributes to the library"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -90,6 +97,7 @@ class EditLibrary(bpy.types.Operator, tool.Ifc.Operator):
 class AddLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_library_reference"
     bl_label = "Add Library Reference"
+    bl_description = "Add a new reference to the active library"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -99,6 +107,7 @@ class AddLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
 class RemoveLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.remove_library_reference"
     bl_label = "Remove Library Reference"
+    bl_description = "Remove the reference from the library"
     bl_options = {"REGISTER", "UNDO"}
     reference: bpy.props.IntProperty()
 
@@ -109,6 +118,7 @@ class RemoveLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
 class EnableEditingLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.enable_editing_library_reference"
     bl_label = "Enable Editing Library Reference"
+    bl_description = "Load the attributes of the selected library reference for editing"
     bl_options = {"REGISTER", "UNDO"}
     reference: bpy.props.IntProperty()
 
@@ -119,6 +129,7 @@ class EnableEditingLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
 class DisableEditingLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.disable_editing_library_reference"
     bl_label = "Disable Editing Library Reference"
+    bl_description = "Close the library reference editing form without saving changes"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -128,6 +139,7 @@ class DisableEditingLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
 class EditLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_library_reference"
     bl_label = "Edit Library Reference"
+    bl_description = "Save the edited attributes to the library reference"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -137,6 +149,7 @@ class EditLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
 class AssignLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.assign_library_reference"
     bl_label = "Assign Library Reference"
+    bl_description = "Assign the library reference to the active object"
     bl_options = {"REGISTER", "UNDO"}
     reference: bpy.props.IntProperty()
 
@@ -149,6 +162,7 @@ class AssignLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
 class UnassignLibraryReference(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.unassign_library_reference"
     bl_label = "Unassign Library Reference"
+    bl_description = "Unassign the library reference from the active object"
     bl_options = {"REGISTER", "UNDO"}
     reference: bpy.props.IntProperty()
 

--- a/src/bonsai/bonsai/bim/module/unit/operator.py
+++ b/src/bonsai/bonsai/bim/module/unit/operator.py
@@ -85,6 +85,7 @@ class DisableUnitEditingUI(bpy.types.Operator):
 class RemoveUnit(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.remove_unit"
     bl_label = "Remove Unit"
+    bl_description = "Remove the unit from the project"
     bl_options = {"REGISTER", "UNDO"}
     unit: bpy.props.IntProperty()
 
@@ -95,6 +96,7 @@ class RemoveUnit(bpy.types.Operator, tool.Ifc.Operator):
 class AddConversionBasedUnit(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_conversion_based_unit"
     bl_label = "Add Conversion Based Unit"
+    bl_description = "Add a new unit converted from an SI unit, such as an imperial unit"
     bl_options = {"REGISTER", "UNDO"}
     name: bpy.props.StringProperty()
 
@@ -105,6 +107,7 @@ class AddConversionBasedUnit(bpy.types.Operator, tool.Ifc.Operator):
 class AddMonetaryUnit(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_monetary_unit"
     bl_label = "Add Monetary Unit"
+    bl_description = "Add a new currency unit to the project"
     bl_options = {"REGISTER", "UNDO"}
 
     def _execute(self, context):
@@ -114,6 +117,7 @@ class AddMonetaryUnit(bpy.types.Operator, tool.Ifc.Operator):
 class AddSIUnit(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_si_unit"
     bl_label = "Add SI Unit"
+    bl_description = "Add a new SI unit of the provided type to the project"
     bl_options = {"REGISTER", "UNDO"}
     unit_type: bpy.props.StringProperty()
 
@@ -124,6 +128,7 @@ class AddSIUnit(bpy.types.Operator, tool.Ifc.Operator):
 class AddContextDependentUnit(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_context_dependent_unit"
     bl_label = "Add Context Dependent Unit"
+    bl_description = "Add a new custom unit that does not map to a standard SI unit"
     bl_options = {"REGISTER", "UNDO"}
     name: bpy.props.StringProperty()
     unit_type: bpy.props.StringProperty()
@@ -135,6 +140,7 @@ class AddContextDependentUnit(bpy.types.Operator, tool.Ifc.Operator):
 class EnableEditingUnit(bpy.types.Operator):
     bl_idname = "bim.enable_editing_unit"
     bl_label = "Enable Editing Unit"
+    bl_description = "Load the attributes of the selected unit for editing"
     bl_options = {"REGISTER", "UNDO"}
     unit: bpy.props.IntProperty()
 
@@ -146,6 +152,7 @@ class EnableEditingUnit(bpy.types.Operator):
 class DisableEditingUnit(bpy.types.Operator):
     bl_idname = "bim.disable_editing_unit"
     bl_label = "Disable Editing Unit"
+    bl_description = "Close the unit editing form without saving changes"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context) -> set["rna_enums.OperatorReturnItems"]:
@@ -156,6 +163,7 @@ class DisableEditingUnit(bpy.types.Operator):
 class EditUnit(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.edit_unit"
     bl_label = "Edit Unit"
+    bl_description = "Save the edited attributes to the unit"
     bl_options = {"REGISTER", "UNDO"}
     unit: bpy.props.IntProperty()
 


### PR DESCRIPTION
Partial contribution to #1646 (Moult's ongoing "New contributor? Try this one!" tooltip tracker), following the same pattern as previously merged batches (e.g. #5348).

Adds `bl_description` to 67 previously undocumented operators across six related project-metadata modules (classification, document, group, layer, library, unit), each based on actually reading the operator's implementation, not guessed from the class/idname. Operators with a dynamic `description()` classmethod override are correctly skipped, a static description there would be dead code.

Live-verified in real Blender (10 operators spanning all six modules, spot-checked via `get_rna_type().description`, all correct).

Hundreds of operators across other modules remain undocumented and are deliberately left for future contributors, that's the intent of this issue staying open as an onboarding tracker, not something to close in one PR.

AI-generated PR, human-reviewed.