### PR TITLE
Bonsai: let Shift+E extend non-typed profile extrusions

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -267,6 +267,10 @@ class DumbProfileRegenerator:
         return results
 
 
+class MissingExtrudedProfileError(Exception):
+    pass
+
+
 class ExtendProfile(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.extend_profile"
     bl_label = "Extend Profile"
@@ -284,7 +288,10 @@ class ExtendProfile(bpy.types.Operator, tool.Ifc.Operator):
         joiner = DumbProfileJoiner()
         if self.join_type == "-":
             for obj in selected_objs:
-                joiner.unjoin(obj)
+                try:
+                    joiner.unjoin(obj)
+                except MissingExtrudedProfileError as e:
+                    self.report({"ERROR"}, str(e))
             return {"FINISHED"}
         if not context.active_object:
             return {"FINISHED"}
@@ -292,21 +299,32 @@ class ExtendProfile(bpy.types.Operator, tool.Ifc.Operator):
             tool.Geometry.clear_scale(obj)
 
         if len(selected_objs) == 1:
-            joiner.join_E(context.active_object, context.scene.cursor.location)
+            try:
+                joiner.join_E(context.active_object, context.scene.cursor.location)
+            except MissingExtrudedProfileError as e:
+                self.report({"ERROR"}, str(e))
+                return {"CANCELLED"}
             return {"FINISHED"}
 
         if len(selected_objs) == 2:
-            if self.join_type == "L":
-                joiner.join_L(next(o for o in selected_objs if o != context.active_object), context.active_object)
-            elif self.join_type == "V":
-                joiner.join_V(next(o for o in selected_objs if o != context.active_object), context.active_object)
+            try:
+                if self.join_type == "L":
+                    joiner.join_L(next(o for o in selected_objs if o != context.active_object), context.active_object)
+                elif self.join_type == "V":
+                    joiner.join_V(next(o for o in selected_objs if o != context.active_object), context.active_object)
+            except MissingExtrudedProfileError as e:
+                self.report({"ERROR"}, str(e))
+                return {"CANCELLED"}
         if len(selected_objs) < 2:
             return {"FINISHED"}
         if self.join_type == "T":
             for obj in selected_objs:
                 if obj == context.active_object:
                     continue
-                joiner.join_T(obj, context.active_object)
+                try:
+                    joiner.join_T(obj, context.active_object)
+                except MissingExtrudedProfileError as e:
+                    self.report({"ERROR"}, str(e))
 
         return {"FINISHED"}
 
@@ -449,14 +467,23 @@ class DumbProfileJoiner:
         self.body = copy.deepcopy(body)
         material = ifcopenshell.util.element.get_material(element, should_skip_usage=False)
         usage = None
-        if not material:
-            return
-        if "ProfileSet" not in material.is_a():
-            return
-        if material.is_a("IfcMaterialProfileSetUsage"):
-            usage = material
-            material = material.ForProfileSet
-        self.profile = material.CompositeProfile or material.MaterialProfiles[0].Profile
+        if material and "ProfileSet" in material.is_a():
+            if material.is_a("IfcMaterialProfileSetUsage"):
+                usage = material
+                material = material.ForProfileSet
+            self.profile = material.CompositeProfile or material.MaterialProfiles[0].Profile
+        else:
+            # No profile set material (e.g. an ad-hoc extrusion): fall back to the
+            # element's own body extrusion so joins still work without a typed profile.
+            body_representation = ifcopenshell.util.representation.get_representation(
+                element, "Model", "Body", "MODEL_VIEW"
+            )
+            extrusion = tool.Model.get_extrusion(body_representation) if body_representation else None
+            if not extrusion:
+                raise MissingExtrudedProfileError(
+                    f"{element} has no profile set material and no extruded body representation to extend."
+                )
+            self.profile = extrusion.SweptArea
         self.clippings = []
 
         for rel in element.ConnectedTo:

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -1081,6 +1081,11 @@ class Model(bonsai.core.tool.Model):
                 return "PROFILE"
             elif material.is_a("IfcMaterialProfileSet"):
                 return "PROFILE"
+        # No layer/profile set material (e.g. an ad-hoc extrusion): treat a plain
+        # extruded body as a profile too, so join/extend tools still apply to it.
+        body = tool.Geometry.get_body_representation(element)
+        if body and cls.get_extrusion(body):
+            return "PROFILE"
 
     @classmethod
     def get_wall_axis(


### PR DESCRIPTION
Fixes #3565.

Shift+E (`bim.extend_profile`) silently did nothing on elements with a plain, ad-hoc `IfcExtrudedAreaSolid` body and no `IfcMaterialProfileSet` material, e.g. the reporter's IfcActuator placed with a manually authored box extrusion instead of a typed column/beam generator.

Two places gated this on a profile-set material. `DumbProfileJoiner.recreate_profile` in `profile.py` returned early when the element had no profile-set material, instead of deriving a profile. `tool.Model.get_usage_type` classified such elements as having no usage at all, so the Shift+E hotkey dispatcher never even called `bim.extend_profile` in the first place, a deeper root cause than initially expected.

`recreate_profile` now falls back to reading the `SweptArea` straight off the element's existing Body extrusion (via the already-used `tool.Model.get_extrusion`) when there's no profile-set material, and raises a clear `MissingExtrudedProfileError` when the element has neither a profile-set material nor an extruded body, caught and reported as a normal operator error rather than a silent no-op or crash. `get_usage_type` now falls back to the same extruded-body check when the material isn't a layer or profile set, so the hotkey dispatcher routes these elements into the profile tools to begin with.

Live-verified in headless Blender 5.1: before the fix, Shift+E left an ad-hoc box element's geometry unchanged (silent no-op); after the fix, it extends to the 3D cursor exactly like a typed profile element does. T-joins between two ad-hoc elements now also create the expected `IfcRelConnectsPathElements` relationships. An element with no body representation at all now reports a clear error instead of a crash or silent no-op. Re-verified the existing typed profile (material profile set usage) case is completely unaffected.

AI-generated PR, human-reviewed.