### PR TITLE
Bonsai: add Round and Arch shapes to the parametric window

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/data.py
+++ b/src/bonsai/bonsai/bim/module/model/data.py
@@ -484,7 +484,9 @@ class WindowData:
         data = cls.data["pset_data"]["data_dict"]
         lining_data = data["lining_properties"]
         lining_params = {}
-        lining_props = props.get_lining_kwargs(window_type=data["window_type"])
+        lining_props = props.get_lining_kwargs(
+            window_type=data["window_type"], window_shape=data.get("window_shape", "RECTANGLE")
+        )
         for prop_name in lining_props:
             prop_readable_name, prop_value = get_prop_from_data(props, lining_data, prop_name)
             lining_params[prop_readable_name] = prop_value

--- a/src/bonsai/bonsai/bim/module/model/prop.py
+++ b/src/bonsai/bonsai/bim/module/model/prop.py
@@ -831,11 +831,21 @@ def window_type_prop_update(self, context):
     update_window(self, context)
 
 
+def window_shape_prop_update(self, context):
+    # non-rectangular shapes are single-partition by design
+    if self.window_shape != "RECTANGLE" and self.window_type != "SINGLE_PANEL":
+        self.window_type = "SINGLE_PANEL"  # triggers its own update
+        return
+    update_window(self, context)
+
+
 # default prop values are in mm and converted later
 class BIMWindowProperties(PropertyGroup):
     non_si_units_props = (
         "is_editing",
         "window_type",
+        "window_shape",
+        "arch_muntin_count",
         "lining_material",
         "framing_material",
         "glazing_material",
@@ -857,6 +867,16 @@ class BIMWindowProperties(PropertyGroup):
     # fmt: on
 
     is_editing: bpy.props.BoolProperty(default=False)
+    window_shape: bpy.props.EnumProperty(
+        name="Window Shape",
+        items=[
+            ("RECTANGLE", "Rectangle", "Rectangular window"),
+            ("ROUND", "Round", "Circular window, overall width is used as the diameter"),
+            ("ARCH", "Arch", "Rectangular window topped by a semicircular fanlight with radiating muntin bars"),
+        ],
+        default="RECTANGLE",
+        update=window_shape_prop_update,
+    )
     window_type: bpy.props.EnumProperty(
         name="Window Type",
         items=[(i, i, "") for i in get_args(tool.Model.WindowType)],
@@ -867,6 +887,14 @@ class BIMWindowProperties(PropertyGroup):
         name="Overall Height", default=0.9, subtype="DISTANCE", update=update_window
     )
     overall_width: bpy.props.FloatProperty(name="Overall Width", default=0.6, subtype="DISTANCE", update=update_window)
+    arch_muntin_count: bpy.props.IntProperty(
+        name="Arch Muntin Bars",
+        description="Number of radiating muntin bars in the arch fanlight",
+        default=4,
+        min=0,
+        max=24,
+        update=update_window,
+    )
 
     # lining properties
     lining_depth: bpy.props.FloatProperty(
@@ -935,9 +963,11 @@ class BIMWindowProperties(PropertyGroup):
 
     if TYPE_CHECKING:
         is_editing: bool
+        window_shape: tool.Model.WindowShape
         window_type: tool.Model.WindowType
         overall_height: float
         overall_width: float
+        arch_muntin_count: int
         lining_depth: float
         lining_thickness: float
         lining_offset: float
@@ -960,19 +990,27 @@ class BIMWindowProperties(PropertyGroup):
 
     def get_general_kwargs(self, convert_to_project_units: bool = False) -> dict[str, Any]:
         kwargs = {
+            "window_shape": self.window_shape,
             "window_type": self.window_type,
             "overall_height": self.overall_height,
             "overall_width": self.overall_width,
         }
+        if self.window_shape == "ARCH":
+            kwargs["arch_muntin_count"] = self.arch_muntin_count
         if not convert_to_project_units:
             return kwargs
-        return tool.Model.convert_data_to_project_units(kwargs, ["window_type"])
+        return tool.Model.convert_data_to_project_units(kwargs, ["window_shape", "window_type", "arch_muntin_count"])
 
     def get_lining_kwargs(
-        self, window_type: Optional[tool.Model.WindowType] = None, convert_to_project_units: bool = False
+        self,
+        window_type: Optional[tool.Model.WindowType] = None,
+        window_shape: Optional[tool.Model.WindowShape] = None,
+        convert_to_project_units: bool = False,
     ) -> dict[str, Any]:
         if not window_type:
             window_type = self.window_type
+        if not window_shape:
+            window_shape = self.window_shape
         kwargs = {
             "lining_depth": self.lining_depth,
             "lining_thickness": self.lining_thickness,
@@ -981,33 +1019,39 @@ class BIMWindowProperties(PropertyGroup):
             "lining_to_panel_offset_y": self.lining_to_panel_offset_y,
         }
 
-        if window_type in (
-            "DOUBLE_PANEL_VERTICAL",
-            "TRIPLE_PANEL_BOTTOM",
-            "TRIPLE_PANEL_TOP",
-            "TRIPLE_PANEL_LEFT",
-            "TRIPLE_PANEL_RIGHT",
-            "TRIPLE_PANEL_VERTICAL",
-        ):
+        if window_shape == "ARCH":
+            # spring line transom and radiating muntin bars of the fanlight
             kwargs["mullion_thickness"] = self.mullion_thickness
-            kwargs["first_mullion_offset"] = self.first_mullion_offset
-
-        if window_type in (
-            "DOUBLE_PANEL_HORIZONTAL",
-            "TRIPLE_PANEL_BOTTOM",
-            "TRIPLE_PANEL_TOP",
-            "TRIPLE_PANEL_LEFT",
-            "TRIPLE_PANEL_RIGHT",
-            "TRIPLE_PANEL_HORIZONTAL",
-        ):
             kwargs["transom_thickness"] = self.transom_thickness
-            kwargs["first_transom_offset"] = self.first_transom_offset
 
-        if window_type in ("TRIPLE_PANEL_VERTICAL",):
-            kwargs["second_mullion_offset"] = self.second_mullion_offset
+        if window_shape == "RECTANGLE":
+            if window_type in (
+                "DOUBLE_PANEL_VERTICAL",
+                "TRIPLE_PANEL_BOTTOM",
+                "TRIPLE_PANEL_TOP",
+                "TRIPLE_PANEL_LEFT",
+                "TRIPLE_PANEL_RIGHT",
+                "TRIPLE_PANEL_VERTICAL",
+            ):
+                kwargs["mullion_thickness"] = self.mullion_thickness
+                kwargs["first_mullion_offset"] = self.first_mullion_offset
 
-        if window_type in ("TRIPLE_PANEL_HORIZONTAL",):
-            kwargs["second_transom_offset"] = self.second_transom_offset
+            if window_type in (
+                "DOUBLE_PANEL_HORIZONTAL",
+                "TRIPLE_PANEL_BOTTOM",
+                "TRIPLE_PANEL_TOP",
+                "TRIPLE_PANEL_LEFT",
+                "TRIPLE_PANEL_RIGHT",
+                "TRIPLE_PANEL_HORIZONTAL",
+            ):
+                kwargs["transom_thickness"] = self.transom_thickness
+                kwargs["first_transom_offset"] = self.first_transom_offset
+
+            if window_type in ("TRIPLE_PANEL_VERTICAL",):
+                kwargs["second_mullion_offset"] = self.second_mullion_offset
+
+            if window_type in ("TRIPLE_PANEL_HORIZONTAL",):
+                kwargs["second_transom_offset"] = self.second_transom_offset
 
         if not convert_to_project_units:
             return kwargs

--- a/src/bonsai/bonsai/bim/module/model/ui.py
+++ b/src/bonsai/bonsai/bim/module/model/ui.py
@@ -774,6 +774,12 @@ def draw_window_properties(layout: bpy.types.UILayout, props: module_prop.BIMWin
     # General and lining properties
     general_props = props.get_general_kwargs()
     for prop in general_props:
+        # partitioning is forced to SINGLE_PANEL for non-rectangular shapes
+        if prop == "window_type" and props.window_shape != "RECTANGLE":
+            continue
+        # a round window is defined by its diameter (overall width)
+        if prop == "overall_height" and props.window_shape == "ROUND":
+            continue
         layout.prop(props, prop)
 
     layout.label(text="Lining Properties")

--- a/src/bonsai/bonsai/bim/module/model/window.py
+++ b/src/bonsai/bonsai/bim/module/model/window.py
@@ -19,6 +19,7 @@
 
 import collections.abc
 import json
+import math
 from typing import TYPE_CHECKING
 
 import bmesh
@@ -59,9 +60,14 @@ def update_window_modifier_representation(context: bpy.types.Context) -> None:
     ifc_file = tool.Ifc.get()
     si_conversion = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
 
+    # a round window is geometrically defined by its diameter (overall width)
+    overall_height = props.overall_width if props.window_shape == "ROUND" else props.overall_height
+
     representation_data = {
         "partition_type": props.window_type,
-        "overall_height": props.overall_height / si_conversion,
+        "window_shape": props.window_shape,
+        "arch_muntin_count": props.arch_muntin_count,
+        "overall_height": overall_height / si_conversion,
         "overall_width": props.overall_width / si_conversion,
         "lining_properties": {
             "LiningDepth": props.lining_depth / si_conversion,
@@ -141,7 +147,7 @@ def update_window_modifier_representation(context: bpy.types.Context) -> None:
     occurrences = tool.Ifc.get_all_element_occurrences(element)
     for occurrence in occurrences:
         occurrence.OverallWidth = props.overall_width / si_conversion
-        occurrence.OverallHeight = props.overall_height / si_conversion
+        occurrence.OverallHeight = overall_height / si_conversion
 
     tool.Model.update_simple_openings(element)
 
@@ -262,13 +268,168 @@ def create_bm_window(
     return (window_lining_verts, frame_verts, glass_verts)
 
 
-def update_window_modifier_bmesh(context: bpy.types.Context) -> None:
-    obj = context.active_object
-    assert obj
-    props = tool.Model.get_window_props(obj)
-    if not props.is_editing:
-        return
+def create_bm_circle_points(
+    center_x: float, center_z: float, radius: float, segments: int = 32
+) -> list[tuple[float, float]]:
+    return [
+        (
+            center_x + radius * math.cos(2 * math.pi * i / segments),
+            center_z + radius * math.sin(2 * math.pi * i / segments),
+        )
+        for i in range(segments)
+    ]
 
+
+def create_bm_fan_points(
+    center_x: float, radius: float, chord_z: float, segments: int = 24
+) -> list[tuple[float, float]]:
+    """Fanlight outline: chord at `chord_z` topped by an arc of `radius` centered at (center_x, 0)"""
+    chord_half = max(radius**2 - chord_z**2, 0) ** 0.5
+    start_angle = math.atan2(chord_z, chord_half)
+    points = [(center_x - chord_half, chord_z), (center_x + chord_half, chord_z)]
+    for i in range(1, segments):
+        angle = start_angle + (math.pi - 2 * start_angle) * i / segments
+        points.append((center_x + radius * math.cos(angle), radius * math.sin(angle)))
+    return points
+
+
+def create_bm_extruded_ring(
+    bm: bmesh.types.BMesh,
+    outer_points: list[tuple[float, float]],
+    inner_points: list[tuple[float, float]],
+    depth: float,
+    position: Vector = V_(0, 0, 0).freeze(),
+) -> list[bmesh.types.BMVert]:
+    """`outer_points` and `inner_points` are matched length 2D (X, Z) loops"""
+    outer_verts = [bm.verts.new((x, 0, z)) for x, z in outer_points]
+    inner_verts = [bm.verts.new((x, 0, z)) for x, z in inner_points]
+    n_verts = len(outer_verts)
+    faces = [
+        bm.faces.new((outer_verts[i], outer_verts[(i + 1) % n_verts], inner_verts[(i + 1) % n_verts], inner_verts[i]))
+        for i in range(n_verts)
+    ]
+    extruded = bmesh.ops.extrude_face_region(bm, geom=faces)
+    translate_verts = [v for v in extruded["geom"] if isinstance(v, BMVert)]
+    bmesh.ops.translate(bm, vec=Vector((0, depth, 0)), verts=translate_verts)
+    all_verts = outer_verts + inner_verts + translate_verts
+    bmesh.ops.translate(bm, vec=position, verts=all_verts)
+    return all_verts
+
+
+def create_bm_prism(
+    bm: bmesh.types.BMesh,
+    points: list[tuple[float, float]],
+    depth: float,
+    position: Vector = V_(0, 0, 0).freeze(),
+) -> list[bmesh.types.BMVert]:
+    """extrude a 2D (X, Z) polygon along +Y by `depth`"""
+    verts = [bm.verts.new((x, 0, z)) for x, z in points]
+    face = bm.faces.new(verts)
+    extruded = bmesh.ops.extrude_face_region(bm, geom=[face])
+    translate_verts = [v for v in extruded["geom"] if isinstance(v, BMVert)]
+    bmesh.ops.translate(bm, vec=Vector((0, depth, 0)), verts=translate_verts)
+    all_verts = verts + translate_verts
+    bmesh.ops.translate(bm, vec=position, verts=all_verts)
+    return all_verts
+
+
+def create_bm_round_window(bm: bmesh.types.BMesh, props: "BIMWindowProperties") -> None:
+    glass_thickness = 0.01
+    radius = props.overall_width / 2
+    frame_depth = props.frame_depth[0]
+    frame_thickness = props.frame_thickness[0]
+    lining_to_panel_offset_y_full = (props.lining_depth - frame_depth) + props.lining_to_panel_offset_y
+
+    outer_points = create_bm_circle_points(radius, radius, radius)
+    inner_points = create_bm_circle_points(radius, radius, radius - props.lining_thickness)
+    create_bm_extruded_ring(bm, outer_points, inner_points, props.lining_depth)
+
+    frame_radius = radius - props.lining_to_panel_offset_x
+    frame_outer_points = create_bm_circle_points(radius, radius, frame_radius)
+    frame_inner_points = create_bm_circle_points(radius, radius, frame_radius - frame_thickness)
+    create_bm_extruded_ring(
+        bm, frame_outer_points, frame_inner_points, frame_depth, V_(0, lining_to_panel_offset_y_full, 0)
+    )
+
+    glass_y = lining_to_panel_offset_y_full + frame_depth / 2 - glass_thickness / 2
+    create_bm_prism(bm, frame_inner_points, glass_thickness, V_(0, glass_y, 0))
+
+
+def create_bm_arch_window(bm: bmesh.types.BMesh, props: "BIMWindowProperties") -> None:
+    glass_thickness = 0.01
+    width = props.overall_width
+    radius = width / 2
+    lining_thickness = props.lining_thickness
+    transom_thickness = props.transom_thickness / 2
+    frame_depth = props.frame_depth[0]
+    frame_thickness = props.frame_thickness[0]
+    lining_to_panel_offset_x = props.lining_to_panel_offset_x
+    lining_to_panel_offset_y_full = (props.lining_depth - frame_depth) + props.lining_to_panel_offset_y
+
+    spring_height = props.overall_height - radius
+    base_frame_clear = lining_to_panel_offset_x + frame_thickness - lining_thickness
+    offset_z_top = base_frame_clear - frame_thickness + transom_thickness
+
+    if spring_height > 0:
+        x_offsets = [lining_to_panel_offset_x, offset_z_top] + [lining_to_panel_offset_x] * 2
+        frame_size = V_(
+            width - x_offsets[0] - x_offsets[2],
+            frame_depth,
+            spring_height - x_offsets[1] - x_offsets[3],
+        )
+        create_bm_window(
+            bm,
+            V_(width, props.lining_depth, spring_height),
+            [lining_thickness, transom_thickness] + [lining_thickness] * 2,
+            lining_to_panel_offset_x,
+            lining_to_panel_offset_y_full,
+            frame_size,
+            frame_thickness,
+            glass_thickness,
+            V_(0, 0, 0),
+            x_offsets,
+        )
+        fan_bottom_lining = transom_thickness
+        fan_bottom_frame_offset = offset_z_top
+    else:
+        # degenerate arch (lunette): no lower panel, fan sits on the sill
+        spring_height = 0
+        fan_bottom_lining = lining_thickness
+        fan_bottom_frame_offset = lining_to_panel_offset_x
+
+    outer_points = create_bm_fan_points(radius, radius, 0)
+    inner_points = create_bm_fan_points(radius, radius - lining_thickness, fan_bottom_lining)
+    create_bm_extruded_ring(bm, outer_points, inner_points, props.lining_depth, V_(0, 0, spring_height))
+
+    frame_radius = radius - lining_to_panel_offset_x
+    frame_outer_points = create_bm_fan_points(radius, frame_radius, fan_bottom_frame_offset)
+    frame_inner_points = create_bm_fan_points(
+        radius, frame_radius - frame_thickness, fan_bottom_frame_offset + frame_thickness
+    )
+    frame_position = V_(0, lining_to_panel_offset_y_full, spring_height)
+    create_bm_extruded_ring(bm, frame_outer_points, frame_inner_points, frame_depth, frame_position)
+
+    glass_y = lining_to_panel_offset_y_full + frame_depth / 2 - glass_thickness / 2
+    create_bm_prism(bm, frame_inner_points, glass_thickness, V_(0, glass_y, spring_height))
+
+    # radiating muntin bars, from the arch center to the middle of the frame ring
+    bar_length = frame_radius - frame_thickness / 2
+    half = props.mullion_thickness / 2
+    for bar_i in range(1, props.arch_muntin_count + 1):
+        angle = math.pi * bar_i / (props.arch_muntin_count + 1)
+        direction = Vector((math.cos(angle), math.sin(angle)))
+        normal = Vector((-math.sin(angle), math.cos(angle)))
+        start = Vector((radius, 0))
+        bar_points = [
+            tuple(start - normal * half),
+            tuple(start - normal * half + direction * bar_length),
+            tuple(start + normal * half + direction * bar_length),
+            tuple(start + normal * half),
+        ]
+        create_bm_prism(bm, bar_points, frame_depth, frame_position)
+
+
+def create_bm_rect_window(bm: bmesh.types.BMesh, props: "BIMWindowProperties") -> None:
     panel_schema = DEFAULT_PANEL_SCHEMAS[props.window_type]
     accumulated_height = [0] * len(panel_schema[0])
     built_panels = []
@@ -279,7 +440,6 @@ def update_window_modifier_bmesh(context: bpy.types.Context) -> None:
     lining_to_panel_offset_x = props.lining_to_panel_offset_x
     lining_to_panel_offset_y = props.lining_to_panel_offset_y
     lining_thickness = props.lining_thickness
-    lining_offset = props.lining_offset
 
     mullion_thickness = props.mullion_thickness / 2
     first_mullion_offset = props.first_mullion_offset
@@ -290,7 +450,6 @@ def update_window_modifier_bmesh(context: bpy.types.Context) -> None:
 
     glass_thickness = 0.01
 
-    bm = bmesh.new()
     panel_schema = list(reversed(panel_schema))
 
     # TODO: need more readable way to define panel width and height
@@ -397,7 +556,23 @@ def update_window_modifier_bmesh(context: bpy.types.Context) -> None:
             accumulated_height[column_i] += panel_height
             accumulated_width += panel_width
 
-    bmesh.ops.translate(bm, vec=V_(0, lining_offset, 0), verts=bm.verts)
+
+def update_window_modifier_bmesh(context: bpy.types.Context) -> None:
+    obj = context.active_object
+    assert obj
+    props = tool.Model.get_window_props(obj)
+    if not props.is_editing:
+        return
+
+    bm = bmesh.new()
+    if props.window_shape == "ROUND":
+        create_bm_round_window(bm, props)
+    elif props.window_shape == "ARCH":
+        create_bm_arch_window(bm, props)
+    else:
+        create_bm_rect_window(bm, props)
+
+    bmesh.ops.translate(bm, vec=V_(0, props.lining_offset, 0), verts=bm.verts)
     bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.0001)
     bmesh.ops.recalc_face_normals(bm, faces=bm.faces)
 
@@ -619,6 +794,7 @@ class GizmoWindowEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
             axis=(0, 0, 1),
             min_value=0.01,
             text_alignment="start",
+            visibility_condition=lambda p: p.window_shape != "ROUND",
             matrix_position=lambda p: V_(p.overall_width + _G.GIZMO_OFFSET, p.lining_offset - _G.GIZMO_OFFSET, 0),
         ),
         DimensionGizmoConfig(

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -1846,6 +1846,8 @@ class Model(bonsai.core.tool.Model):
         "TRIPLE_PANEL_VERTICAL",
     ]
 
+    WindowShape = Literal["RECTANGLE", "ROUND", "ARCH"]
+
     RoofGenerationMethod = Literal["HEIGHT", "ANGLE"]
 
     RailingType = Literal["FRAMELESS_PANEL", "WALL_MOUNTED_HANDRAIL"]

--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/add_window_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/add_window_representation.py
@@ -47,6 +47,8 @@ WINDOW_TYPE = Literal[
     "TRIPLE_PANEL_VERTICAL",
 ]
 
+WINDOW_SHAPE = Literal["RECTANGLE", "ROUND", "ARCH"]
+
 DEFAULT_PANEL_SCHEMAS = {
     "SINGLE_PANEL": [[0]],
     "DOUBLE_PANEL_HORIZONTAL": [[0], [1]],
@@ -234,6 +236,123 @@ def create_ifc_window(
     return {"Lining": lining_items, "Framing": frame_extruded_items, "Glazing": [glass]}
 
 
+def create_fan_curve(
+    builder: ShapeBuilder, center_x: float, radius: float, chord_z: float
+) -> ifcopenshell.entity_instance:
+    """Closed fanlight boundary: chord at `chord_z` topped by an arc of `radius`.
+
+    Coordinates are local, arc center at (center_x, 0)."""
+    chord_half = max(radius**2 - chord_z**2, 0) ** 0.5
+    p_left = (center_x - chord_half, chord_z)
+    p_right = (center_x + chord_half, chord_z)
+    if builder.file.schema == "IFC2X3":
+        # arcs in polylines are not supported in IFC2X3, use polygonal approximation
+        segments = 16
+        start_angle = np.arctan2(chord_z, chord_half)
+        angles = np.linspace(start_angle, np.pi - start_angle, segments + 1)[1:-1]
+        arc_points = [(center_x + radius * np.cos(a), radius * np.sin(a)) for a in angles]
+        return builder.polyline([p_left, p_right, *arc_points], closed=True)
+    return builder.polyline([p_left, p_right, (center_x, radius)], arc_points=(2,), closed=True)
+
+
+def create_ifc_round_window(
+    builder: ShapeBuilder,
+    overall_diameter: float,
+    lining_thickness: float,
+    lining_depth: float,
+    lining_to_panel_offset_x: float,
+    lining_to_panel_offset_y_full: float,
+    frame_depth: float,
+    frame_thickness: float,
+    glass_thickness: float,
+) -> dict[str, list[ifcopenshell.entity_instance]]:
+    """Create a circular (porthole) window: annular lining, annular frame and a glass disk."""
+    radius = overall_diameter / 2
+    center = (radius, radius)
+
+    lining_profile = builder.profile(
+        builder.circle(center, radius), inner_curves=[builder.circle(center, radius - lining_thickness)]
+    )
+    lining = builder.extrude(lining_profile, lining_depth, **builder.extrude_kwargs("Y"))
+
+    frame_radius = radius - lining_to_panel_offset_x
+    frame_inner = builder.circle(center, frame_radius - frame_thickness)
+    frame_profile = builder.profile(builder.circle(center, frame_radius), inner_curves=[frame_inner])
+    frame_position = V(0, lining_to_panel_offset_y_full, 0)
+    frame = builder.extrude(frame_profile, frame_depth, position=frame_position, **builder.extrude_kwargs("Y"))
+
+    glass_position = V(0, lining_to_panel_offset_y_full + frame_depth / 2 - glass_thickness / 2, 0)
+    glass = builder.extrude(
+        builder.deep_copy(frame_inner), glass_thickness, position=glass_position, **builder.extrude_kwargs("Y")
+    )
+
+    return {"Lining": [lining], "Framing": [frame], "Glazing": [glass]}
+
+
+def create_ifc_arch_fan(
+    builder: ShapeBuilder,
+    width: float,
+    bottom_lining_thickness: float,
+    lining_thickness: float,
+    lining_depth: float,
+    lining_to_panel_offset_x: float,
+    bottom_frame_offset: float,
+    lining_to_panel_offset_y_full: float,
+    frame_depth: float,
+    frame_thickness: float,
+    glass_thickness: float,
+    muntin_count: int,
+    muntin_thickness: float,
+    position: np.ndarray,
+) -> dict[str, list[ifcopenshell.entity_instance]]:
+    """Create a semicircular fanlight panel with radiating muntin bars.
+
+    Local origin is at the arch center (left edge of the panel on the spring line)."""
+    radius = width / 2
+    center_x = radius
+
+    lining_outer = create_fan_curve(builder, center_x, radius, 0)
+    lining_inner = create_fan_curve(builder, center_x, radius - lining_thickness, bottom_lining_thickness)
+    lining_profile = builder.profile(lining_outer, inner_curves=[lining_inner])
+    lining = builder.extrude(lining_profile, lining_depth, position=position, **builder.extrude_kwargs("Y"))
+
+    frame_radius = radius - lining_to_panel_offset_x
+    frame_outer = create_fan_curve(builder, center_x, frame_radius, bottom_frame_offset)
+    frame_inner = create_fan_curve(
+        builder, center_x, frame_radius - frame_thickness, bottom_frame_offset + frame_thickness
+    )
+    frame_profile = builder.profile(frame_outer, inner_curves=[frame_inner])
+    frame_position = position + V(0, lining_to_panel_offset_y_full, 0)
+    frame = builder.extrude(frame_profile, frame_depth, position=frame_position, **builder.extrude_kwargs("Y"))
+    framing_items = [frame]
+
+    glass_position = position + V(0, lining_to_panel_offset_y_full + frame_depth / 2 - glass_thickness / 2, 0)
+    glass = builder.extrude(
+        builder.deep_copy(frame_inner), glass_thickness, position=glass_position, **builder.extrude_kwargs("Y")
+    )
+
+    # radiating muntin bars, from the arch center to the middle of the frame ring
+    bar_length = frame_radius - frame_thickness / 2
+    half = muntin_thickness / 2
+    for bar_i in range(1, muntin_count + 1):
+        angle = np.pi * bar_i / (muntin_count + 1)
+        direction = np.array((np.cos(angle), np.sin(angle)))
+        normal = np.array((-np.sin(angle), np.cos(angle)))
+        start = np.array((center_x, 0.0))
+        bar_points = [
+            start - normal * half,
+            start - normal * half + direction * bar_length,
+            start + normal * half + direction * bar_length,
+            start + normal * half,
+        ]
+        bar_profile = builder.profile(builder.polyline(bar_points, closed=True))
+        framing_items.append(
+            builder.extrude(bar_profile, frame_depth, position=frame_position, **builder.extrude_kwargs("Y"))
+        )
+
+    return {"Lining": [lining], "Framing": framing_items, "Glazing": [glass]}
+
+
 # we use dataclass as we need default values for arguments
 # it's okay to use slots since we don't need dynamic attributes
 @dataclasses.dataclass(slots=True)
@@ -364,6 +483,8 @@ def add_window_representation(
     panel_properties: Optional[list[Union[WindowPanelProperties, dict[str, Any]]]] = None,
     part_of_product: Optional[ifcopenshell.entity_instance] = None,
     unit_scale: Optional[float] = None,
+    window_shape: WINDOW_SHAPE = "RECTANGLE",
+    arch_muntin_count: int = 4,
 ) -> ifcopenshell.entity_instance:
     """units in usecase_settings expected to be in ifc project units
 
@@ -371,6 +492,12 @@ def add_window_representation(
     :param overall_height: Overall window height. Defaults to 0.9m.
     :param overall_width: Overall window width. Defaults to 0.6m.
     :param partition_type: Type of the window. Defaults to SINGLE_PANEL.
+    :param window_shape: Overall window shape. Defaults to RECTANGLE.
+        ROUND is a circular window, overall_width is the diameter and overall_height is ignored.
+        ARCH is a rectangular window topped by a semicircular fanlight, the arch radius
+        is half the overall width and the arch apex is at overall_height.
+        Non-rectangular shapes are always single-partition, partition_type is forced to SINGLE_PANEL.
+    :param arch_muntin_count: Number of radiating muntin bars in the ARCH fanlight.
     :param lining_properties: WindowLiningProperties or a dictionary to create one.
         See WindowLiningProperties description for details.
     :param panel_properties: A list of WindowPanelProperties or dictionaries to create one.
@@ -389,6 +516,8 @@ def add_window_representation(
     # define unit_scale first as it's going to be used setting default arguments
     unit_scale = ifcopenshell.util.unit.calculate_unit_scale(file) if unit_scale is None else unit_scale
     settings: dict[str, Any] = {"unit_scale": unit_scale}
+    # assign before convert_si_to_unit is used for the default arguments below
+    usecase.settings = settings
 
     if lining_properties is None:
         lining_properties = WindowLiningProperties()
@@ -407,6 +536,9 @@ def add_window_representation(
         properties.initialize_properties(unit_scale)
         panel_properties[i] = dataclasses.asdict(properties)
 
+    if window_shape != "RECTANGLE":
+        partition_type = "SINGLE_PANEL"
+
     settings.update(
         {
             "context": context,
@@ -416,10 +548,11 @@ def add_window_representation(
             "lining_properties": lining_properties,
             "panel_properties": panel_properties,
             "part_of_product": part_of_product,
+            "window_shape": window_shape,
+            "arch_muntin_count": arch_muntin_count,
         }
     )
 
-    usecase.settings = settings
     usecase.settings["panel_schema"] = DEFAULT_PANEL_SCHEMAS[usecase.settings["partition_type"]]
     return usecase.execute()
 
@@ -636,112 +769,184 @@ class Usecase:
         if self.settings["context"].TargetView == "PLAN_VIEW":
             return create_ifc_window_2d_representation()
 
-        # TODO: need more readable way to define panel width and height
-        unique_rows_in_col = [
-            len(set(row[column_i] for row in panel_schema)) for column_i in range(len(panel_schema[0]))
-        ]
-
-        for row_i, panel_row in enumerate(panel_schema):
-            accumulated_width = 0
-            unique_cols = len(set(panel_row))
-
-            for column_i, panel_i in enumerate(panel_row):
-                # detect mullion
-                has_mullion = unique_cols > 1
-                first_column = column_i == 0
-                last_column = column_i == unique_cols - 1
-                left_to_mullion = has_mullion and not last_column
-                right_to_mullion = has_mullion and not first_column
-
-                # detect transom
-                has_transom = unique_rows_in_col[column_i] > 1
-                first_row = row_i == 0
-                last_row = row_i == unique_rows_in_col[column_i] - 1
-                top_to_transom = has_transom and not first_row
-                bottom_to_transom = has_transom and not last_row
-
-                # calculate current panel dimensions
-                if has_mullion:
-                    # panel_width
-                    if first_column:
-                        panel_width = first_mullion_offset
-                    elif last_column:
-                        panel_width = overall_width - accumulated_width
-                    else:
-                        panel_width = second_mullion_offset - accumulated_width
-                else:
-                    panel_width = overall_width
-
-                if has_transom:
-                    if first_row:
-                        panel_height = first_transom_offset
-                    elif last_row:
-                        panel_height = overall_height - accumulated_height[column_i]
-                    else:
-                        panel_height = second_transom_offset - accumulated_height[column_i]
-                else:
-                    panel_height = overall_height
-
-                if panel_i in built_panels:
-                    accumulated_height[column_i] += panel_height
-                    accumulated_width += panel_width
-                    continue
-
-                cur_panel = panels[panel_i]
-                frame_depth = cur_panel["FrameDepth"]
-                frame_thickness = cur_panel["FrameThickness"]
-                lining_to_panel_offset_y_full = (lining_depth - frame_depth) + lining_to_panel_offset_y
-
-                # fmt: off
-                # calculate lining thickness and frame size / offset
-                # taking into account mullions and transoms
-                window_lining_thickness = [
-                    mullion_thickness if right_to_mullion  else lining_thickness,
-                    transom_thickness if bottom_to_transom else lining_thickness,
-                    mullion_thickness if left_to_mullion   else lining_thickness,
-                    transom_thickness if top_to_transom    else lining_thickness,
-                ]
-
-                # x offsets can differ if there are mullions or transoms because we're trying to maintain symmetry
-                base_frame_clear = lining_to_panel_offset_x + frame_thickness - lining_thickness
-                current_offset_x = base_frame_clear - frame_thickness + mullion_thickness
-                current_offset_z = base_frame_clear - frame_thickness + transom_thickness
-                x_offsets = [
-                    current_offset_x if right_to_mullion  else lining_to_panel_offset_x,  # LEFT
-                    current_offset_z if bottom_to_transom else lining_to_panel_offset_x,  # TOP
-                    current_offset_x if left_to_mullion   else lining_to_panel_offset_x,  # RIGHT
-                    current_offset_z if top_to_transom    else lining_to_panel_offset_x,  # BOTTOM
-                ]
-                # fmt: on
-
-                window_lining_size = V(panel_width, lining_depth, panel_height)
-                frame_size = window_lining_size.copy()
-                frame_size[np_Y] = frame_depth
-                frame_size[np_X] -= x_offsets[0] + x_offsets[2]
-                frame_size[np_Z] -= x_offsets[1] + x_offsets[3]
-
-                window_panel_position = V(accumulated_width, 0, accumulated_height[column_i])
-                # create window panel
-                current_window_items = create_ifc_window(
+        window_shape: WINDOW_SHAPE = self.settings["window_shape"]
+        if window_shape in ("ROUND", "ARCH"):
+            frame_depth = panels[0]["FrameDepth"]
+            frame_thickness = panels[0]["FrameThickness"]
+            lining_to_panel_offset_y_full = (lining_depth - frame_depth) + lining_to_panel_offset_y
+            if window_shape == "ROUND":
+                shaped_items = create_ifc_round_window(
                     builder,
-                    window_lining_size,
-                    window_lining_thickness,
+                    overall_width,
+                    lining_thickness,
+                    lining_depth,
                     lining_to_panel_offset_x,
                     lining_to_panel_offset_y_full,
-                    frame_size,
+                    frame_depth,
                     frame_thickness,
                     glass_thickness,
-                    window_panel_position,
-                    x_offsets,
                 )
-                built_panels.append(panel_i)
-                window_items.extend(chain(*current_window_items.values()))
-                lining_items.extend(current_window_items["Lining"])
-                framing_items.extend(current_window_items["Framing"])
-                glazing_items.extend(current_window_items["Glazing"])
+            else:
+                radius = overall_width / 2
+                spring_height = overall_height - radius
+                base_frame_clear = lining_to_panel_offset_x + frame_thickness - lining_thickness
+                offset_z_top = base_frame_clear - frame_thickness + transom_thickness
+                if spring_height > 0:
+                    x_offsets = [lining_to_panel_offset_x, offset_z_top] + [lining_to_panel_offset_x] * 2
+                    lower_lining_thickness = [lining_thickness, transom_thickness] + [lining_thickness] * 2
+                    frame_size = V(
+                        overall_width - x_offsets[0] - x_offsets[2],
+                        frame_depth,
+                        spring_height - x_offsets[1] - x_offsets[3],
+                    )
+                    lower_items = create_ifc_window(
+                        builder,
+                        V(overall_width, lining_depth, spring_height),
+                        lower_lining_thickness,
+                        lining_to_panel_offset_x,
+                        lining_to_panel_offset_y_full,
+                        frame_size,
+                        frame_thickness,
+                        glass_thickness,
+                        V(0, 0, 0),
+                        x_offsets,
+                    )
+                    fan_bottom_lining = transom_thickness
+                    fan_bottom_frame_offset = offset_z_top
+                else:
+                    # degenerate arch (lunette): no lower panel, fan sits on the sill
+                    spring_height = 0
+                    lower_items = {"Lining": [], "Framing": [], "Glazing": []}
+                    fan_bottom_lining = lining_thickness
+                    fan_bottom_frame_offset = lining_to_panel_offset_x
+                fan_items = create_ifc_arch_fan(
+                    builder,
+                    overall_width,
+                    fan_bottom_lining,
+                    lining_thickness,
+                    lining_depth,
+                    lining_to_panel_offset_x,
+                    fan_bottom_frame_offset,
+                    lining_to_panel_offset_y_full,
+                    frame_depth,
+                    frame_thickness,
+                    glass_thickness,
+                    self.settings["arch_muntin_count"],
+                    lining_props["MullionThickness"],
+                    V(0, 0, spring_height),
+                )
+                shaped_items = {key: lower_items[key] + fan_items[key] for key in fan_items}
+            lining_items.extend(shaped_items["Lining"])
+            framing_items.extend(shaped_items["Framing"])
+            glazing_items.extend(shaped_items["Glazing"])
+            window_items.extend(chain(*shaped_items.values()))
+        else:
+            # TODO: need more readable way to define panel width and height
+            unique_rows_in_col = [
+                len(set(row[column_i] for row in panel_schema)) for column_i in range(len(panel_schema[0]))
+            ]
 
-                accumulated_height[column_i] += panel_height
-                accumulated_width += panel_width
+            for row_i, panel_row in enumerate(panel_schema):
+                accumulated_width = 0
+                unique_cols = len(set(panel_row))
+
+                for column_i, panel_i in enumerate(panel_row):
+                    # detect mullion
+                    has_mullion = unique_cols > 1
+                    first_column = column_i == 0
+                    last_column = column_i == unique_cols - 1
+                    left_to_mullion = has_mullion and not last_column
+                    right_to_mullion = has_mullion and not first_column
+
+                    # detect transom
+                    has_transom = unique_rows_in_col[column_i] > 1
+                    first_row = row_i == 0
+                    last_row = row_i == unique_rows_in_col[column_i] - 1
+                    top_to_transom = has_transom and not first_row
+                    bottom_to_transom = has_transom and not last_row
+
+                    # calculate current panel dimensions
+                    if has_mullion:
+                        # panel_width
+                        if first_column:
+                            panel_width = first_mullion_offset
+                        elif last_column:
+                            panel_width = overall_width - accumulated_width
+                        else:
+                            panel_width = second_mullion_offset - accumulated_width
+                    else:
+                        panel_width = overall_width
+
+                    if has_transom:
+                        if first_row:
+                            panel_height = first_transom_offset
+                        elif last_row:
+                            panel_height = overall_height - accumulated_height[column_i]
+                        else:
+                            panel_height = second_transom_offset - accumulated_height[column_i]
+                    else:
+                        panel_height = overall_height
+
+                    if panel_i in built_panels:
+                        accumulated_height[column_i] += panel_height
+                        accumulated_width += panel_width
+                        continue
+
+                    cur_panel = panels[panel_i]
+                    frame_depth = cur_panel["FrameDepth"]
+                    frame_thickness = cur_panel["FrameThickness"]
+                    lining_to_panel_offset_y_full = (lining_depth - frame_depth) + lining_to_panel_offset_y
+
+                    # fmt: off
+                    # calculate lining thickness and frame size / offset
+                    # taking into account mullions and transoms
+                    window_lining_thickness = [
+                        mullion_thickness if right_to_mullion  else lining_thickness,
+                        transom_thickness if bottom_to_transom else lining_thickness,
+                        mullion_thickness if left_to_mullion   else lining_thickness,
+                        transom_thickness if top_to_transom    else lining_thickness,
+                    ]
+
+                    # x offsets can differ if there are mullions or transoms because we're trying to maintain symmetry
+                    base_frame_clear = lining_to_panel_offset_x + frame_thickness - lining_thickness
+                    current_offset_x = base_frame_clear - frame_thickness + mullion_thickness
+                    current_offset_z = base_frame_clear - frame_thickness + transom_thickness
+                    x_offsets = [
+                        current_offset_x if right_to_mullion  else lining_to_panel_offset_x,  # LEFT
+                        current_offset_z if bottom_to_transom else lining_to_panel_offset_x,  # TOP
+                        current_offset_x if left_to_mullion   else lining_to_panel_offset_x,  # RIGHT
+                        current_offset_z if top_to_transom    else lining_to_panel_offset_x,  # BOTTOM
+                    ]
+                    # fmt: on
+
+                    window_lining_size = V(panel_width, lining_depth, panel_height)
+                    frame_size = window_lining_size.copy()
+                    frame_size[np_Y] = frame_depth
+                    frame_size[np_X] -= x_offsets[0] + x_offsets[2]
+                    frame_size[np_Z] -= x_offsets[1] + x_offsets[3]
+
+                    window_panel_position = V(accumulated_width, 0, accumulated_height[column_i])
+                    # create window panel
+                    current_window_items = create_ifc_window(
+                        builder,
+                        window_lining_size,
+                        window_lining_thickness,
+                        lining_to_panel_offset_x,
+                        lining_to_panel_offset_y_full,
+                        frame_size,
+                        frame_thickness,
+                        glass_thickness,
+                        window_panel_position,
+                        x_offsets,
+                    )
+                    built_panels.append(panel_i)
+                    window_items.extend(chain(*current_window_items.values()))
+                    lining_items.extend(current_window_items["Lining"])
+                    framing_items.extend(current_window_items["Framing"])
+                    glazing_items.extend(current_window_items["Glazing"])
+
+                    accumulated_height[column_i] += panel_height
+                    accumulated_width += panel_width
 
         builder.translate(window_items, (0, lining_offset, 0))  # wall offset
         representation = builder.get_representation(self.settings["context"], window_items)

--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/add_window_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/add_window_representation.py
@@ -255,6 +255,30 @@ def create_fan_curve(
     return builder.polyline([p_left, p_right, (center_x, radius)], arc_points=(2,), closed=True)
 
 
+def create_circle_profile(
+    builder: ShapeBuilder, center: tuple[float, float], radius: float
+) -> ifcopenshell.entity_instance:
+    """A solid circular profile, for the glass disk."""
+    position = builder.create_axis2_placement_2d(center)
+    return builder.file.create_entity("IfcCircleProfileDef", ProfileType="AREA", Position=position, Radius=radius)
+
+
+def create_circle_hollow_profile(
+    builder: ShapeBuilder, center: tuple[float, float], radius: float, wall_thickness: float
+) -> ifcopenshell.entity_instance:
+    """A concentric annular ring, for the lining/frame. One profile entity instead of an
+    outer circle plus an inner void, per https://github.com/IfcOpenShell/IfcOpenShell/pull/8695#issuecomment-5002906597.
+    """
+    position = builder.create_axis2_placement_2d(center)
+    return builder.file.create_entity(
+        "IfcCircleHollowProfileDef",
+        ProfileType="AREA",
+        Position=position,
+        Radius=radius,
+        WallThickness=wall_thickness,
+    )
+
+
 def create_ifc_round_window(
     builder: ShapeBuilder,
     overall_diameter: float,
@@ -270,20 +294,21 @@ def create_ifc_round_window(
     radius = overall_diameter / 2
     center = (radius, radius)
 
-    lining_profile = builder.profile(
-        builder.circle(center, radius), inner_curves=[builder.circle(center, radius - lining_thickness)]
-    )
+    lining_profile = create_circle_hollow_profile(builder, center, radius, lining_thickness)
     lining = builder.extrude(lining_profile, lining_depth, **builder.extrude_kwargs("Y"))
 
     frame_radius = radius - lining_to_panel_offset_x
-    frame_inner = builder.circle(center, frame_radius - frame_thickness)
-    frame_profile = builder.profile(builder.circle(center, frame_radius), inner_curves=[frame_inner])
+    frame_profile = create_circle_hollow_profile(builder, center, frame_radius, frame_thickness)
     frame_position = V(0, lining_to_panel_offset_y_full, 0)
     frame = builder.extrude(frame_profile, frame_depth, position=frame_position, **builder.extrude_kwargs("Y"))
 
+    glass_radius = frame_radius - frame_thickness
     glass_position = V(0, lining_to_panel_offset_y_full + frame_depth / 2 - glass_thickness / 2, 0)
     glass = builder.extrude(
-        builder.deep_copy(frame_inner), glass_thickness, position=glass_position, **builder.extrude_kwargs("Y")
+        create_circle_profile(builder, center, glass_radius),
+        glass_thickness,
+        position=glass_position,
+        **builder.extrude_kwargs("Y"),
     )
 
     return {"Lining": [lining], "Framing": [frame], "Glazing": [glass]}


### PR DESCRIPTION
Fixes #3621.

Adds a Window Shape option (Rectangle, Round, Arch) to the parametric window modifier.

**Round** is a circular porthole-style window: overall width is used as the diameter, overall height is ignored for geometry and synced to the diameter on the IFC occurrence attributes. Lining and frame are concentric annular rings (`IfcCircle` profiles with voids), glass is a disk.

**Arch** is a Palladian-style window: the arch radius is half the overall width, the apex sits at the overall height, so the spring line is derived (height minus radius) with no extra parameter needed. Below the spring line the existing rectangular single-panel construction is reused unchanged, treating the shared edge exactly like a transom. Above it, a semicircular fanlight is built from chord+arc profiles (`IfcIndexedPolyCurve` arc segments, with a polygonal fallback for IFC2X3, which forbids arcs in polylines), with radiating muntin bars fanning out from the arch center at even angular spacing (new "Arch Muntin Bars" property, default 4). Degrades gracefully to a lunette when height is at or below the radius.

Non-rectangular shapes are single-partition by design, selecting Round or Arch forces `SINGLE_PANEL` and hides the panel grid options. The default Rectangle shape goes through the exact original code path (the rectangular panel loop moved verbatim into an `else` branch, same variable names and structure, byte-for-byte tessellation-identical output verified for all 9 partition types).

Both geometry layers are covered: the authoritative IFC representation in `ifcopenshell.api.geometry.add_window_representation` and the live bmesh preview used while editing, so the full edit-mode flow works for the new shapes, including re-entering edit mode on saved shaped windows. Plan/elevation representations and simple wall openings keep their existing simplified rectangular output for now, stated clearly as a follow-up.

Also fixes a latent crash in `add_window_representation` when `overall_height`/`overall_width` were omitted: a default-value helper ran before `usecase.settings` was assigned, raising `AttributeError`.

Tested headless in Blender 5.1.2: 32 API-level geometry assertions (circularity, arch radius bounds, apex position, muntin count/placement, IFC2X3 fallback, all 9 partition types regression-checked) and 27 live Bonsai assertions (preview and final meshes, pset round-trip, occurrence attribute sync, save/reload persistence, stock-identical rectangular regression).

AI-generated PR, human-reviewed.