### PR TITLE
Bonsai: import georeferencing from BlenderGIS scene properties

### DIFF
--- a/src/bonsai/bonsai/bim/module/georeference/__init__.py
+++ b/src/bonsai/bonsai/bim/module/georeference/__init__.py
@@ -32,6 +32,7 @@ classes = (
     operator.EnableEditingTrueNorth,
     operator.EnableEditingWCS,
     operator.GetCursorLocation,
+    operator.ImportGeoreferencingFromBlenderGIS,
     operator.ImportPlot,
     operator.RemoveGeoreferencing,
     operator.RemoveTrueNorth,

--- a/src/bonsai/bonsai/bim/module/georeference/blendergis.py
+++ b/src/bonsai/bonsai/bim/module/georeference/blendergis.py
@@ -1,0 +1,129 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""Bridge to read georeferencing data written by the BlenderGIS addon.
+
+BlenderGIS (https://github.com/domlysz/BlenderGIS) is a separate, optional
+Blender addon. It is never imported here: its scene properties are simply
+documented custom ID properties, read directly off bpy.context.scene, so
+this bridge degrades to a no-op when BlenderGIS is absent or has not
+georeferenced the scene.
+
+The property keys and their semantics below are taken from BlenderGIS's own
+geoscene.py (class GeoScene, alias SK) and core/proj/srs.py (class SRS), as
+published on the BlenderGIS repository. A scene is only considered
+georeferenced by BlenderGIS itself once both a CRS and the CRS coordinates
+of the scene origin are set.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+CRS_KEY = "SRID"
+EASTING_KEY = "crs x"
+NORTHING_KEY = "crs y"
+SCALE_KEY = "scale"
+LONGITUDE_KEY = "longitude"
+LATITUDE_KEY = "latitude"
+
+
+class SceneProperties(Protocol):
+    def get(self, key: str, default: object = None) -> object: ...
+
+
+@dataclass
+class BlenderGISGeoreference:
+    crs_name: str
+    eastings: float
+    northings: float
+    scale: float
+    longitude: Optional[float] = None
+    latitude: Optional[float] = None
+
+
+def normalise_crs_name(raw_srid: str) -> str:
+    """Turn a BlenderGIS SRID string into an IfcProjectedCRS Name.
+
+    BlenderGIS's SRS class accepts a bare EPSG code, an "AUTH:CODE" string,
+    or a proj4 string. The first two both identify a CRS by authority and
+    code, which is also the format Bonsai/IFC use for a projected CRS name
+    (e.g. "EPSG:7856"). A proj4-only definition has no such identifier and
+    is passed through unchanged.
+    """
+    raw_srid = raw_srid.strip()
+    if raw_srid.isdigit():
+        return f"EPSG:{raw_srid}"
+    if ":" in raw_srid and not raw_srid.startswith("+"):
+        auth, _, code = raw_srid.partition(":")
+        return f"{auth.upper()}:{code}"
+    return raw_srid
+
+
+def read_blendergis_scene(scene: SceneProperties) -> Optional[BlenderGISGeoreference]:
+    """Read BlenderGIS's georeferencing properties off a Blender scene.
+
+    Returns None if BlenderGIS never wrote its georeferencing keys onto
+    this scene, or wrote them only partially, matching BlenderGIS's own
+    notion of GeoScene.isGeoref.
+    """
+    crs = scene.get(CRS_KEY)
+    eastings = scene.get(EASTING_KEY)
+    northings = scene.get(NORTHING_KEY)
+    if not crs or eastings is None or northings is None:
+        return None
+    scale = scene.get(SCALE_KEY, 1) or 1
+    return BlenderGISGeoreference(
+        crs_name=normalise_crs_name(str(crs)),
+        eastings=float(eastings),
+        northings=float(northings),
+        scale=float(scale),
+        longitude=scene.get(LONGITUDE_KEY),
+        latitude=scene.get(LATITUDE_KEY),
+    )
+
+
+def compute_map_conversion(
+    data: BlenderGISGeoreference, blender_offset: tuple[float, float, float] = (0.0, 0.0, 0.0)
+) -> dict[str, float]:
+    """Compute IfcMapConversion attributes that reproduce BlenderGIS's georeferencing.
+
+    BlenderGIS keeps its scene X/Y axes aligned with the CRS easting/northing
+    axes, it never stores a grid north rotation, so the imported map
+    conversion is always unrotated (XAxisAbscissa=1, XAxisOrdinate=0). Any
+    existing grid north rotation in the IFC file is overwritten. True north
+    is a separate, independent Bonsai setting and is left untouched.
+
+    blender_offset is Bonsai's own "Blender session offset", the local
+    engineering coordinates of Blender's (0, 0, 0) (see tool.Georeference).
+    It is (0, 0, 0) when there is no such offset, in which case Eastings and
+    Northings become BlenderGIS's crs x/crs y unchanged.
+    """
+    offset_x, offset_y, offset_z = blender_offset
+    scale = data.scale
+    return {
+        "Eastings": data.eastings - scale * offset_x,
+        "Northings": data.northings - scale * offset_y,
+        "OrthogonalHeight": -scale * offset_z,
+        "XAxisAbscissa": 1.0,
+        "XAxisOrdinate": 0.0,
+        "Scale": scale,
+    }

--- a/src/bonsai/bonsai/bim/module/georeference/operator.py
+++ b/src/bonsai/bonsai/bim/module/georeference/operator.py
@@ -33,6 +33,22 @@ class AddGeoreferencing(bpy.types.Operator, tool.Ifc.Operator):
         core.add_georeferencing(tool.Georeference)
 
 
+class ImportGeoreferencingFromBlenderGIS(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.import_georeferencing_from_blendergis"
+    bl_label = "Import Georeferencing From BlenderGIS"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = (
+        "Read the CRS and scene origin set by the BlenderGIS addon and use them as the "
+        "Projected CRS and Map Conversion. Does nothing if BlenderGIS has not georeferenced "
+        "the active scene"
+    )
+
+    def _execute(self, context):
+        message = core.import_georeferencing_from_blendergis(tool.Ifc, tool.Georeference)
+        if isinstance(message, str):
+            self.report({"WARNING"}, message)
+
+
 class EnableEditingGeoreferencing(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.enable_editing_georeferencing"
     bl_label = "Enable Editing Georeferencing"

--- a/src/bonsai/bonsai/bim/module/georeference/ui.py
+++ b/src/bonsai/bonsai/bim/module/georeference/ui.py
@@ -102,6 +102,10 @@ class BIM_PT_gis(Panel):
                 row.prop(props, "coordinate_operation_class", text="")
                 row.operator("bim.add_georeferencing", icon="ADD", text="")
 
+        if tool.Ifc.get_schema() != "IFC2X3":
+            row = self.layout.row(align=True)
+            row.operator("bim.import_georeferencing_from_blendergis", icon="IMPORT", text="Import From BlenderGIS")
+
         if GeoreferenceData.data["projected_crs"]:
             row = self.layout.row(align=True)
             row.label(text="Projected CRS", icon="WORLD")

--- a/src/bonsai/bonsai/core/georeference.py
+++ b/src/bonsai/bonsai/core/georeference.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
 
@@ -27,6 +27,22 @@ if TYPE_CHECKING:
 
 def add_georeferencing(georeference: type[tool.Georeference]) -> None:
     georeference.add_georeferencing()
+    georeference.set_model_origin()
+
+
+def import_georeferencing_from_blendergis(
+    ifc: type[tool.Ifc], georeference: type[tool.Georeference]
+) -> Union[str, None]:
+    result = georeference.get_blendergis_map_conversion()
+    if result is None:
+        return "No BlenderGIS georeferencing data was found on the active scene."
+    projected_crs, coordinate_operation = result
+    ifc.run("georeference.add_georeferencing")
+    ifc.run(
+        "georeference.edit_georeferencing",
+        projected_crs=projected_crs,
+        coordinate_operation=coordinate_operation,
+    )
     georeference.set_model_origin()
 
 

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -509,6 +509,7 @@ class Georeference:
     def export_coordinate_operation(cls): pass
     def export_projected_crs(cls): pass
     def export_wcs(cls): pass
+    def get_blendergis_map_conversion(cls): pass
     def get_coordinates(cls, io): pass
     def get_cursor_location(cls): pass
     def get_true_north_attributes(cls): pass

--- a/src/bonsai/bonsai/tool/georeference.py
+++ b/src/bonsai/bonsai/tool/georeference.py
@@ -417,3 +417,19 @@ class Georeference(bonsai.core.tool.Georeference):
     @classmethod
     def has_blender_offset(cls) -> bool:
         return tool.Georeference.get_georeference_props().has_blender_offset
+
+    @classmethod
+    def get_blendergis_map_conversion(cls) -> Union[tuple[dict[str, Any], dict[str, Any]], None]:
+        from bonsai.bim.module.georeference import blendergis
+
+        data = blendergis.read_blendergis_scene(bpy.context.scene)
+        if data is None:
+            return None
+        props = cls.get_georeference_props()
+        offset = (
+            (float(props.blender_offset_x), float(props.blender_offset_y), float(props.blender_offset_z))
+            if props.has_blender_offset
+            else (0.0, 0.0, 0.0)
+        )
+        coordinate_operation = blendergis.compute_map_conversion(data, offset)
+        return {"Name": data.crs_name}, coordinate_operation

--- a/src/bonsai/test/bim/module/georeference/__init__.py
+++ b/src/bonsai/test/bim/module/georeference/__init__.py
@@ -1,0 +1,17 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.

--- a/src/bonsai/test/bim/module/georeference/test_blendergis.py
+++ b/src/bonsai/test/bim/module/georeference/test_blendergis.py
@@ -1,0 +1,112 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Tests for the BlenderGIS bridge against synthetic, BlenderGIS-shaped scene data.
+
+These tests do not exercise the real BlenderGIS addon (which is not
+installed here). The scene property keys and value formats used below (a
+plain dict standing in for bpy.context.scene, using the exact "SRID",
+"crs x", "crs y", "scale" keys) were confirmed by reading BlenderGIS's own
+geoscene.py and core/proj/srs.py source on GitHub. See the module docstring
+of blendergis.py for details.
+"""
+
+import pytest
+
+from bonsai.bim.module.georeference import blendergis
+
+pytestmark = pytest.mark.georeference
+
+
+class TestNormaliseCrsName:
+    def test_a_bare_epsg_code(self):
+        assert blendergis.normalise_crs_name("2154") == "EPSG:2154"
+
+    def test_an_already_formatted_srid(self):
+        assert blendergis.normalise_crs_name("EPSG:2154") == "EPSG:2154"
+
+    def test_a_lowercase_authority(self):
+        assert blendergis.normalise_crs_name("epsg:2154") == "EPSG:2154"
+
+    def test_a_proj4_string_is_passed_through(self):
+        proj4 = "+proj=lcc +lat_1=44 +lat_2=49 +lat_0=46.5"
+        assert blendergis.normalise_crs_name(proj4) == proj4
+
+
+class TestReadBlenderGISScene:
+    def test_returning_none_when_no_data_is_present(self):
+        assert blendergis.read_blendergis_scene({}) is None
+
+    def test_returning_none_when_only_the_crs_is_set(self):
+        assert blendergis.read_blendergis_scene({"SRID": "2154"}) is None
+
+    def test_returning_none_when_only_the_origin_is_set(self):
+        assert blendergis.read_blendergis_scene({"crs x": 1.0, "crs y": 2.0}) is None
+
+    def test_reading_a_fully_georeferenced_scene(self):
+        scene = {"SRID": "2154", "crs x": 500000.0, "crs y": 6500000.0}
+        data = blendergis.read_blendergis_scene(scene)
+        assert data.crs_name == "EPSG:2154"
+        assert data.eastings == 500000.0
+        assert data.northings == 6500000.0
+        assert data.scale == 1.0
+
+    def test_reading_a_scene_with_a_non_default_scale(self):
+        scene = {"SRID": "2154", "crs x": 0.0, "crs y": 0.0, "scale": 2.0}
+        data = blendergis.read_blendergis_scene(scene)
+        assert data.scale == 2.0
+
+    def test_reading_longitude_and_latitude_when_present(self):
+        scene = {"SRID": "2154", "crs x": 0.0, "crs y": 0.0, "longitude": 2.5, "latitude": 47.5}
+        data = blendergis.read_blendergis_scene(scene)
+        assert data.longitude == 2.5
+        assert data.latitude == 47.5
+
+
+class TestComputeMapConversion:
+    def test_with_no_blender_offset(self):
+        data = blendergis.BlenderGISGeoreference(
+            crs_name="EPSG:2154", eastings=500000.0, northings=6500000.0, scale=1.0
+        )
+        conversion = blendergis.compute_map_conversion(data)
+        assert conversion == {
+            "Eastings": 500000.0,
+            "Northings": 6500000.0,
+            "OrthogonalHeight": 0.0,
+            "XAxisAbscissa": 1.0,
+            "XAxisOrdinate": 0.0,
+            "Scale": 1.0,
+        }
+
+    def test_with_a_blender_offset(self):
+        data = blendergis.BlenderGISGeoreference(
+            crs_name="EPSG:2154", eastings=500000.0, northings=6500000.0, scale=1.0
+        )
+        conversion = blendergis.compute_map_conversion(data, blender_offset=(100.0, 200.0, 3.0))
+        assert conversion["Eastings"] == 499900.0
+        assert conversion["Northings"] == 6499800.0
+        assert conversion["OrthogonalHeight"] == -3.0
+
+    def test_with_a_non_default_scale_and_a_blender_offset(self):
+        data = blendergis.BlenderGISGeoreference(crs_name="EPSG:2154", eastings=1000.0, northings=2000.0, scale=2.0)
+        conversion = blendergis.compute_map_conversion(data, blender_offset=(10.0, 10.0, 0.0))
+        assert conversion["Eastings"] == 1000.0 - 2.0 * 10.0
+        assert conversion["Northings"] == 2000.0 - 2.0 * 10.0
+        assert conversion["Scale"] == 2.0

--- a/src/bonsai/test/core/test_georeference.py
+++ b/src/bonsai/test/core/test_georeference.py
@@ -27,6 +27,26 @@ class TestAddGeoreferencing:
         subject.add_georeferencing(georeference)
 
 
+class TestImportGeoreferencingFromBlenderGIS:
+    def test_run(self, ifc, georeference):
+        georeference.get_blendergis_map_conversion().should_be_called().will_return(
+            ("projected_crs_attributes", "coordinate_operation_attributes")
+        )
+        ifc.run("georeference.add_georeferencing").should_be_called()
+        ifc.run(
+            "georeference.edit_georeferencing",
+            projected_crs="projected_crs_attributes",
+            coordinate_operation="coordinate_operation_attributes",
+        ).should_be_called()
+        georeference.set_model_origin().should_be_called()
+        subject.import_georeferencing_from_blendergis(ifc, georeference)
+
+    def test_doing_nothing_if_blendergis_has_no_georeference_data(self, ifc, georeference):
+        georeference.get_blendergis_map_conversion().should_be_called().will_return(None)
+        result = subject.import_georeferencing_from_blendergis(ifc, georeference)
+        assert isinstance(result, str)
+
+
 class TestEnableEditingGeoreferencing:
     def test_run(self, georeference):
         georeference.import_projected_crs().should_be_called()

--- a/src/bonsai/test/tool/test_georeference.py
+++ b/src/bonsai/test/tool/test_georeference.py
@@ -271,6 +271,74 @@ class TestXyz2Enh(NewFile):
         assert subject.xyz2enh((0.0, 0.0, 0.0)) == (1.0, 1.0, 0.0)
 
 
+class TestGetBlenderGISMapConversion(NewFile):
+    def test_returning_none_without_blendergis_data(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        assert subject.get_blendergis_map_conversion() is None
+
+    def test_reading_a_blendergis_scene(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        scene = bpy.context.scene
+        scene["SRID"] = "2154"
+        scene["crs x"] = 500000.0
+        scene["crs y"] = 6500000.0
+        projected_crs, coordinate_operation = subject.get_blendergis_map_conversion()
+        assert projected_crs == {"Name": "EPSG:2154"}
+        assert coordinate_operation == {
+            "Eastings": 500000.0,
+            "Northings": 6500000.0,
+            "OrthogonalHeight": 0.0,
+            "XAxisAbscissa": 1.0,
+            "XAxisOrdinate": 0.0,
+            "Scale": 1.0,
+        }
+
+    def test_reading_a_blendergis_scene_with_an_existing_blender_offset(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        scene = bpy.context.scene
+        scene["SRID"] = "EPSG:2154"
+        scene["crs x"] = 500000.0
+        scene["crs y"] = 6500000.0
+        props = tool.Georeference.get_georeference_props()
+        props.has_blender_offset = True
+        props.blender_offset_x = "100.0"
+        props.blender_offset_y = "200.0"
+        projected_crs, coordinate_operation = subject.get_blendergis_map_conversion()
+        assert projected_crs == {"Name": "EPSG:2154"}
+        assert coordinate_operation["Eastings"] == 499900.0
+        assert coordinate_operation["Northings"] == 6499800.0
+
+    def test_importing_the_result_via_ifcopenshell_api(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        scene = bpy.context.scene
+        scene["SRID"] = "2154"
+        scene["crs x"] = 500000.0
+        scene["crs y"] = 6500000.0
+        projected_crs, coordinate_operation = subject.get_blendergis_map_conversion()
+        ifcopenshell.api.georeference.add_georeferencing(ifc)
+        ifcopenshell.api.georeference.edit_georeferencing(
+            ifc, projected_crs=projected_crs, coordinate_operation=coordinate_operation
+        )
+        crs = ifc.by_type("IfcProjectedCRS")[0]
+        assert crs.Name == "EPSG:2154"
+        map_conversion = ifc.by_type("IfcMapConversion")[0]
+        assert map_conversion.Eastings == 500000.0
+        assert map_conversion.Northings == 6500000.0
+        assert subject.xyz2enh((0.0, 0.0, 0.0)) == (500000.0, 6500000.0, 0.0)
+
+
 class TestEnh2Xyz(NewFile):
     def test_run(self):
         ifc = ifcopenshell.file()


### PR DESCRIPTION
Addresses #1428.

The 2021 ask was integration between Bonsai's and BlenderGIS's georeferencing. Moult's original reply raised several gaps, most of which are already resolved natively in Bonsai's own georeference module today (full Map Conversion, Projected CRS, true north versus grid north tracked separately, model origin offset handling). The one part still missing is what this adds: reading BlenderGIS's own scene data so it does not have to be re-entered by hand.

BlenderGIS is never imported or depended on. Its georeferencing lives in plain custom scene ID properties (`SRID`, `crs x`, `crs y`, `scale`), read directly, confirmed against BlenderGIS's own source (`geoscene.py`, `core/proj/srs.py`, not guessed). New operator `bim.import_georeferencing_from_blendergis` (Georeferencing panel, "Import From BlenderGIS") reads those, when present, into `IfcProjectedCRS`/`IfcMapConversion` via the existing `ifcopenshell.api.georeference` calls the rest of the module already uses. Degrades to a clean no-op when BlenderGIS is absent or the scene was never georeferenced by it.

Design notes, stated plainly:
- BlenderGIS never stores a grid north rotation (it keeps its axes aligned to the CRS), so the imported Map Conversion is always unrotated. True North is a separate Bonsai setting and is left untouched.
- BlenderGIS's `scale` property is labelled "map scale denominator" in its UI, but its actual code (`view3dToProj`) uses it as a literal multiplier between local and CRS coordinates, the same mathematical role as `IfcMapConversion.Scale`, so it is carried through directly.

Verification is split honestly: the BlenderGIS property schema is verified by reading BlenderGIS's real source, not by installing and running it (not practical here). The Bonsai-side conversion logic is verified live in headless Blender 5.2 against synthetic scene data shaped exactly like BlenderGIS's real properties, plus a full pytest suite (tool and core layers).

Generated with the assistance of an AI coding tool.