### PR TITLE
Bonsai: let standalone windows bound spaces and boundaries

### DIFF
--- a/src/bonsai/bonsai/bim/module/boundary/operator.py
+++ b/src/bonsai/bonsai/bim/module/boundary/operator.py
@@ -678,10 +678,14 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
 
         # Identify all potential building elements
         # TODO: don't select everything, use AABB culling in Blender
+        # Windows filling an opening are already bound through their host
+        # element, so only standalone windows are gathered here.
+        standalone_windows = [w for w in ifc_file.by_type("IfcWindow") if not tool.Spatial.get_host_element(w)]
         building_elements = (
             tool.Ifc.get().by_type("IfcWall")
             + tool.Ifc.get().by_type("IfcSlab")
             + tool.Ifc.get().by_type("IfcVirtualElement")
+            + standalone_windows
         )
 
         for building_element in building_elements:
@@ -827,6 +831,14 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
                                 parent_boundary.InternalOrExternalBoundary = "EXTERNAL"
                             elif is_external is False:
                                 parent_boundary.InternalOrExternalBoundary = "INTERNAL"
+                    elif building_element.is_a("IfcWindow"):
+                        is_external = ifcopenshell.util.element.get_pset(
+                            building_element, "Pset_WindowCommon", "IsExternal"
+                        )
+                        if is_external is True:
+                            parent_boundary.InternalOrExternalBoundary = "EXTERNAL"
+                        elif is_external is False:
+                            parent_boundary.InternalOrExternalBoundary = "INTERNAL"
                     parent_boundary.RelatingSpace = space
                     parent_boundary.RelatedBuildingElement = building_element
                     parent_boundary.ConnectionGeometry = self.create_connection_geometry_from_polygon(

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -758,6 +758,11 @@ class Spatial(bonsai.core.tool.Spatial):
         for ifc_class in ["IfcWall", "IfcColumn", "IfcMember", "IfcVirtualElement", "IfcPlate"]:
             if visible_element.is_a(ifc_class):
                 return True
+        # A window is only its own boundary when it isn't filling an opening
+        # in another building element, since a hosted window already bounds
+        # the space through its host wall.
+        if visible_element.is_a("IfcWindow") and not cls.get_host_element(visible_element):
+            return True
         return False
 
     @classmethod
@@ -937,6 +942,8 @@ class Spatial(bonsai.core.tool.Spatial):
         for obj in selected_objects:
             subelement = tool.Ifc.get_entity(obj)
             if subelement.is_a("IfcWall") or subelement.is_a("IfcColumn"):
+                boundary_elements.append(subelement)
+            elif subelement.is_a("IfcWindow") and not cls.get_host_element(subelement):
                 boundary_elements.append(subelement)
         return boundary_elements
 


### PR DESCRIPTION
Fixes #3995.

Companion to #8653, which fixed the same gap for standalone IfcCurtainWall but deliberately left IfcWindow untouched. This is that remaining piece.

`Spatial.is_bounding_class`, `Spatial.get_boundary_elements`, and `AddBoundary.auto_generate_boundaries`'s building-element gather never included IfcWindow at all, so a window not hosted in a wall opening (e.g. a standalone glazed panel used as a whole room side) was invisible to space and boundary generation.

A window is only treated as bounding when it has no host (via the existing `get_host_element` chain: FillsVoids to RelatingOpeningElement to VoidsElements to RelatingBuildingElement). A window that fills a wall opening already gets its boundary through the host wall, so treating both independently would create duplicate boundaries for the ordinary hosted case, which this deliberately avoids.

Tested live in headless Blender: a 4x4m room built from 3 real walls plus one standalone window (no FillsVoids) went from 0 generated spaces to 1 correctly bounded space, and from 0 to 4 boundaries (3 walls plus the window) on auto-detect. A regression check with a genuinely hosted window (real IfcOpeningElement plus IfcRelFillsElement) confirms it is still correctly excluded, no duplicate boundary.

Doors were left out of scope, the report and title are specifically about windows.

Generated with the assistance of an AI coding tool.