### PR TITLE
Bonsai: stop a stale ifc_definition_id from aborting the whole project save

### DIFF
--- a/src/bonsai/bonsai/bim/export_ifc.py
+++ b/src/bonsai/bonsai/bim/export_ifc.py
@@ -91,14 +91,15 @@ class IfcExporter:
                 result = self.sync_object_placement(obj)
                 if result:
                     results.append(result)
-                if result:
-                    results.append(result)
             except ReferenceError:
                 pass  # The object is likely deleted
         return results
 
     def sync_object_placement(self, obj: bpy.types.Object) -> Union[ifcopenshell.entity_instance, None]:
-        element = self.file.by_id(tool.Blender.get_object_bim_props(obj).ifc_definition_id)
+        element = tool.Ifc.get_entity(obj)
+        if element is None:
+            print(f"WARNING. '{obj.name}' is linked to a non-existent IFC entity and was skipped during save.")
+            return
         # Handle camera scales specially
         if obj.type == "CAMERA":
             # Check if this is a reflected ceiling plan camera

--- a/src/bonsai/bonsai/bim/operator.py
+++ b/src/bonsai/bonsai/bim/operator.py
@@ -45,6 +45,7 @@ import bonsai.bim.handler
 import bonsai.tool as tool
 from bonsai.bim import import_ifc
 from bonsai.bim.helper import get_enum_items
+from bonsai.bim.ifc import IfcStore
 from bonsai.bim.prop import StrProperty
 from bonsai.bim.ui import IFCFileSelector
 
@@ -1046,6 +1047,7 @@ class ReloadIfcFile(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
         delta_elements = [new.by_guid(global_id) for global_id in ifc_diff.added_elements | changed_elements]
         tool.Ifc.set(new)
 
+        stale_objs = []
         for obj in bpy.data.objects:
             if obj.library:
                 continue
@@ -1053,9 +1055,20 @@ class ReloadIfcFile(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
             if global_id:
                 try:
                     tool.Ifc.link(new.by_guid(global_id), obj)
-                except:
+                except RuntimeError:
                     # Still prototyping, so things like types definitely won't work
                     print("Could not relink", obj)
+                    IfcStore.unlink_element(obj=obj)
+                    stale_objs.append(obj.name)
+
+        tool.Ifc.rebuild_element_maps()
+
+        if stale_objs:
+            self.report(
+                {"WARNING"},
+                f"Could not relink {len(stale_objs)} object(s) to the reloaded file, "
+                f"they were detached from IFC: {', '.join(stale_objs)}",
+            )
 
         start = time.time()
         logger = logging.getLogger("ImportIFC")


### PR DESCRIPTION
Fixes #7032.

The reporter's traceback (RuntimeError: Instance #2246 not found) comes from sync_object_placement doing a raw self.file.by_id(ifc_definition_id) on every scene object during save. One object with a stale id crashes the whole export, taking down every other object's save with it.

Root cause: bim.reload_ifc_file relinks every Blender object to a freshly loaded IFC file by GlobalId. Its pre-relink diff (ifcdiff.IfcDiff) only covers IfcElement (and optionally spatial elements), never IfcTypeProduct, so an object linked to a type (or anything else outside that scope) whose GlobalId no longer exists in the reloaded file falls into the relink failure path. That path only printed to the console and left the object's ifc_definition_id pointing at the old file's now-foreign numeric id. The next save then hit that stale id directly.

Two-layer fix:
- reload_ifc_file: on a failed relink, actually clear the object's stale IFC link (IfcStore.unlink_element) instead of only logging it, rebuild the id/guid maps once after the loop, and report a real UI warning naming the detached objects instead of a console-only print.
- sync_object_placement: resolve the element through tool.Ifc.get_entity(obj), the same RuntimeError-swallowing lookup already used elsewhere in this codebase, instead of a raw self.file.by_id(...), and skip the one orphaned object with a warning rather than raising and aborting every other object's save.

Also removed a leftover duplicate results.append(result) in sync_all_objects, dead since materials stopped being synced there.

Reproduced live in headless Blender: built an old-vs-reloaded project pair where a wall type's GlobalId changes on reload, confirmed the exact reported crash before the fix, and a clean warned save after.

Generated with the assistance of an AI coding tool.