### PR TITLE
ifcpatch: stop MergeProjects leaving duplicate representation contexts

### DIFF
--- a/docs/dev-notes/fix-mergeprojects-dup-contexts.md
+++ b/docs/dev-notes/fix-mergeprojects-dup-contexts.md
@@ -1,0 +1,111 @@
+<!-- This file was generated with the assistance of an AI coding tool. -->
+
+# MergeProjects duplicate representation contexts (+ MergeDuplicateContexts recipe)
+
+> **Living dev note** for the `fix-mergeprojects-dup-contexts` branch/PR (stacked on
+> `merge-duplicate-contexts`). Read before working on the feature; append decisions and
+> findings as the PR is refined. This is *not* user documentation — at merge it is
+> removed or its durable parts promoted to code comments. See [README.md](README.md)
+> for the convention.
+
+Covers two stacked PRs:
+
+- **#8701 → PR #8706** (`merge-duplicate-contexts`): new `MergeDuplicateContexts`
+  ifcpatch recipe (the cleanup tool).
+- **#8700 → PR #8707** (this branch): use that recipe to stop `MergeProjects` emitting
+  duplicate contexts (the root-cause fix).
+
+## Problem / symptom
+
+A layered wall with per-layer material styles renders in the 3D viewport with a
+**single style for the whole wall**. Root cause chain:
+
+- `bonsai.tool.Loader.slice_layerset_mesh()` resolves each layer's style via
+  `ifcopenshell.util.representation.get_material_style(layer.Material, body)` where
+  `body = get_context(ifc, "Model", "Body", "MODEL_VIEW")`.
+- `get_context()` returns only the **first** context matching those attributes. The
+  file had **two** `Model/Body/MODEL_VIEW` contexts; the material styles'
+  `IfcStyledRepresentation`s hung off the *second*, so `get_material_style` returned
+  `None` for every layer → one style.
+
+The duplicate contexts came from the **`MergeProjects` ifcpatch recipe**, not from the
+clipboard (an earlier hypothesis — the clipboard engine was investigated and cleared).
+
+## Root cause (MergeProjects)
+
+`MergeProjects.reuse_existing_contexts()` repoints each merged-in context that
+duplicates an existing one, adds it to a `to_delete` **set**, then removes each via
+`remove_deep2`. Two compounding issues:
+
+1. `remove_deep2` **silently returns without deleting** any element that still has an
+   inverse not contained in its traversal subgraph (documented contract), and the
+   recipe wraps it in a bare `except: pass`.
+2. Depending on iteration order, the repoint loop leaves a **residual inverse** on a
+   matched context, so `remove_deep2` skips it and it survives as an orphaned
+   duplicate.
+
+Captured trace (survivors are exactly the contexts that still held an inverse):
+
+```
+[MergeProjects] === removal loop (order-sensitive) ===
+  #142 Model/Body    inv_before=1  refs=[IfcShapeRepresentation]              -> SURVIVED
+  #150 Plan/Axis     inv_before=1  refs=[IfcShapeRepresentation]              -> SURVIVED
+  #123 Model parent  inv_before=8  refs=[IfcGeometricRepresentationSubContext]-> SURVIVED
+  #127 Plan parent   inv_before=4  refs=[IfcGeometricRepresentationSubContext]-> SURVIVED
+[MergeProjects] === after merge: 2 Model/Body/MODEL_VIEW context(s) -> [20, 142] ===
+```
+
+## Why it is a safety-net fix, not a rewrite of the removal
+
+The failure is **nondeterministic and could not be reproduced in a fresh process** —
+important context so nobody wastes time trying:
+
+- Not in the file bytes: a `to_string()`-saved copy of the live model is byte-identical
+  to the disk file and merges **clean**.
+- Not `PYTHONHASHSEED` (41 seeds, all clean) and not matching/removal order in a fresh
+  parse (200 randomized orders, all clean). Manual parent-first vs child-first: clean.
+- An `entity_instance`'s hash embeds the **file's C++ pointer**, so `set` iteration
+  order varies with process/memory state. Bonsai's long-running, heavily-edited process
+  hits a failing order; short-lived fresh processes do not. The same input reproduces
+  in Bonsai but not standalone.
+
+Because the failing order is not reproducible on demand, a "fix the removal ordering"
+change can't be verified against a failing case. So the fix makes the **outcome**
+robust instead: run `MergeDuplicateContexts` once after all merges (in `patch()`),
+collapsing whatever slipped through `reuse_existing_contexts`. Verified it collapses the
+real merged files and is a no-op on clean merges.
+
+`MergeDuplicateContexts` itself keeps the first context per
+`(ContextType, ContextIdentifier, TargetView)`, repoints references via
+`ifcopenshell.util.element.replace_element`, removes the duplicates, and dedupes
+SET-typed aggregates (e.g. `IfcProject.RepresentationContexts`). Subcontexts and parent
+contexts are handled in separate passes so a subcontext is never merged into a parent.
+
+## Files
+
+- `src/ifcpatch/ifcpatch/recipes/MergeDuplicateContexts.py` — new recipe (PR #8706).
+- `src/ifcpatch/ifcpatch/recipes/MergeProjects.py` — import + one call after the merge
+  loop (this PR).
+- Tests: `test_MergeDuplicateContexts.py` (new); `test_MergeProject.py` gains
+  `test_never_emits_duplicate_contexts`, which injects a duplicate the reuse pass never
+  touches (so it fails without the dedupe, passes with it).
+
+## Test checklist
+
+- [x] `MergeDuplicateContexts`: collapse + reference repoint + project-aggregate dedup,
+      IFC4 and IFC2X3; no-op when there are no duplicates.
+- [x] `MergeProjects`: new regression test passes with the fix (1 Body), fails without (2).
+- [x] No regression: `test_reusing_geometric_contexts` (contexts == 2),
+      `test_using_the_georeferencing` (CRS == 1, MapConversion == 1).
+- [x] Repairs the real captured files (`merged.ifc`, `testymerge.ifc`): 2 Body → 1,
+      styles preserved, legitimately-empty subcontexts left alone.
+- [ ] Not yet exercised: a merge that genuinely triggers the order-dependent skip inside
+      a fresh process (see reproduction caveats above) — covered only indirectly.
+
+## Open questions / follow-ups
+
+- A proper root fix for `reuse_existing_contexts` (make the removal order-independent —
+  e.g. fully repoint via `replace_element`, remove child-first, drop the bare `except`)
+  would let the safety-net be removed. Deferred because it is unverifiable without a
+  deterministic repro. The same fragile pattern exists in
+  `ifcopenshell.api.project.append_asset.reuse_existing_contexts`; worth auditing.

--- a/docs/dev-notes/merge-duplicate-contexts.md
+++ b/docs/dev-notes/merge-duplicate-contexts.md
@@ -29,9 +29,12 @@ tool to repair such a file.
 For each `(ContextType, ContextIdentifier, TargetView)` key: keep the first context,
 repoint every reference off the duplicates onto that survivor via
 `ifcopenshell.util.element.replace_element` (generic — handles representations'
-`ContextOfItems`, subcontexts' `ParentContext`, coordinate operations, etc.), remove the
-duplicates, and dedupe any SET-typed aggregate (e.g. `IfcProject.RepresentationContexts`)
-that would otherwise list the survivor twice.
+`ContextOfItems`, subcontexts' `ParentContext`, coordinate operations, etc.), then remove
+the duplicates. `replace_element`/`replace_attribute` deduplicate SET-typed attributes
+themselves (e.g. `IfcProject.RepresentationContexts`), so the survivor is never listed
+twice — this recipe no longer needs its own SET-dedupe pass (dropped in review; see the
+core fix that added it: `ifcopenshell.util.element: dedupe SET-typed attributes in
+replace_attribute`).
 
 Top-level contexts and subcontexts are keyed and processed in **separate passes** so a
 subcontext is never merged into a parent context, and a surviving subcontext keeps a

--- a/docs/dev-notes/merge-duplicate-contexts.md
+++ b/docs/dev-notes/merge-duplicate-contexts.md
@@ -1,0 +1,50 @@
+<!-- This file was generated with the assistance of an AI coding tool. -->
+
+# MergeDuplicateContexts recipe
+
+> **Living dev note** for the `merge-duplicate-contexts` branch/PR. Read before working
+> on the feature; append decisions and findings as the PR is refined. This is *not* user
+> documentation — at merge it is removed or its durable parts promoted to code comments.
+> See [README.md](README.md) for the convention.
+
+PR #8706 → closes #8701. Also the cleanup half of #8700 (the root-cause fix lives on the
+stacked `fix-mergeprojects-dup-contexts` branch, PR #8707, whose dev-note has the full
+investigation).
+
+## Problem
+
+A well-formed IFC has a single geometric representation context per
+`(ContextType, ContextIdentifier, TargetView)` (e.g. one `Model/Body/MODEL_VIEW`).
+Merges, round-trips, and some exporters — and, concretely, the `MergeProjects` recipe
+(see #8700) — leave two or more that are identical in all three. This is non-conformant
+and breaks code that resolves a context by attributes:
+`ifcopenshell.util.representation.get_context()` returns only the **first** match, so
+geometry, material styles, or annotations attached to the others are silently orphaned.
+Visible symptom: a layered wall renders with a single material style because each
+layer's style hangs off a second, never-matched, Body context. There was no user-facing
+tool to repair such a file.
+
+## Design
+
+For each `(ContextType, ContextIdentifier, TargetView)` key: keep the first context,
+repoint every reference off the duplicates onto that survivor via
+`ifcopenshell.util.element.replace_element` (generic — handles representations'
+`ContextOfItems`, subcontexts' `ParentContext`, coordinate operations, etc.), remove the
+duplicates, and dedupe any SET-typed aggregate (e.g. `IfcProject.RepresentationContexts`)
+that would otherwise list the survivor twice.
+
+Top-level contexts and subcontexts are keyed and processed in **separate passes** so a
+subcontext is never merged into a parent context, and a surviving subcontext keeps a
+valid `ParentContext`.
+
+Takes no arguments → appears in the Bonsai IFC Patch dropdown with nothing to configure,
+mirroring `MergeDuplicateTypes` / `MergeStyles`.
+
+## Test checklist
+
+- [x] IFC4 + IFC2X3: collapse two duplicate Body subcontexts + duplicate parent
+      contexts; representation on the duplicate is repointed onto the survivor; project
+      aggregate deduped to a single entry.
+- [x] No-op when there are no duplicates (distinct subcontexts preserved).
+- [x] Repairs real captured files (`merged.ifc`, `testymerge.ifc`): 2 Body → 1, styles
+      preserved, legitimately-empty subcontexts left untouched.

--- a/src/ifcpatch/ifcpatch/recipes/MergeDuplicateContexts.py
+++ b/src/ifcpatch/ifcpatch/recipes/MergeDuplicateContexts.py
@@ -17,7 +17,7 @@
 # along with IfcPatch.  If not, see <http://www.gnu.org/licenses/>.
 
 from logging import Logger
-from typing import Any, Union
+from typing import Any
 
 import ifcopenshell
 import ifcopenshell.util.element
@@ -82,30 +82,16 @@ class Patcher:
                         # and replace_element -> get_inverse also raises; either way
                         # there is nothing valid to collapse, so skip it.
                         duplicate = self.file.by_id(duplicate.id())
+                        # replace_element repoints every reference onto the survivor,
+                        # including SET-typed attributes (e.g.
+                        # IfcProject.RepresentationContexts), which it deduplicates so
+                        # the survivor is never listed twice.
                         ifcopenshell.util.element.replace_element(duplicate, survivor)
                         self.file.remove(duplicate)
                     except RuntimeError:
                         self.logger.warning(
                             "MergeDuplicateContexts: skipping context the file cannot resolve (%s)", key
                         )
-                # Repointing may leave the survivor listed twice in a SET-typed
-                # attribute (e.g. IfcProject.RepresentationContexts), which is
-                # non-conformant. Dedupe those aggregates.
-                self.dedupe_references(survivor)
-
-    def dedupe_references(self, element: ifcopenshell.entity_instance) -> None:
-        for inverse in self.file.get_inverse(element):
-            for i, value in enumerate(inverse):
-                if not isinstance(value, tuple) or value.count(element) < 2:
-                    continue
-                # Keep the first occurrence of the survivor, drop the rest;
-                # leave every other member untouched and in order.
-                deduped = []
-                for v in value:
-                    if v == element and element in deduped:
-                        continue
-                    deduped.append(v)
-                inverse[i] = deduped
 
     def get_key(self, context: ifcopenshell.entity_instance) -> tuple[Any, ...]:
         # ContextIdentifier / TargetView are None on plain contexts; that is a

--- a/src/ifcpatch/ifcpatch/recipes/MergeDuplicateContexts.py
+++ b/src/ifcpatch/ifcpatch/recipes/MergeDuplicateContexts.py
@@ -74,8 +74,20 @@ class Patcher:
                     "Merging %s duplicate(s) of %s into #%s", len(duplicates), key, survivor.id()
                 )
                 for duplicate in duplicates:
-                    ifcopenshell.util.element.replace_element(duplicate, survivor)
-                    self.file.remove(duplicate)
+                    try:
+                        # An upstream partial removal (e.g. MergeProjects'
+                        # order-sensitive remove_deep2 cleanup) can leave an entity
+                        # that by_type still returns but that the file can no longer
+                        # resolve. Re-fetching by id raises for such a stale entity,
+                        # and replace_element -> get_inverse also raises; either way
+                        # there is nothing valid to collapse, so skip it.
+                        duplicate = self.file.by_id(duplicate.id())
+                        ifcopenshell.util.element.replace_element(duplicate, survivor)
+                        self.file.remove(duplicate)
+                    except RuntimeError:
+                        self.logger.warning(
+                            "MergeDuplicateContexts: skipping context the file cannot resolve (%s)", key
+                        )
                 # Repointing may leave the survivor listed twice in a SET-typed
                 # attribute (e.g. IfcProject.RepresentationContexts), which is
                 # non-conformant. Dedupe those aggregates.

--- a/src/ifcpatch/ifcpatch/recipes/MergeDuplicateContexts.py
+++ b/src/ifcpatch/ifcpatch/recipes/MergeDuplicateContexts.py
@@ -1,0 +1,105 @@
+# IfcPatch - IFC patching utiliy
+# Copyright (C) 2020-2022 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcPatch.
+#
+# IfcPatch is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcPatch is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcPatch.  If not, see <http://www.gnu.org/licenses/>.
+
+from logging import Logger
+from typing import Any, Union
+
+import ifcopenshell
+import ifcopenshell.util.element
+
+
+class Patcher:
+    def __init__(self, file: ifcopenshell.file, logger: Logger):
+        """Merge duplicate geometric representation contexts
+
+        A well-formed IFC has a single geometric representation context for each
+        combination of context type, identifier, and target view (e.g. one
+        Model/Body/MODEL_VIEW). Some authoring tools, or files that have been
+        merged or round-tripped, end up with two or more contexts that are
+        identical in all three. This is non-conformant and breaks code that
+        looks a context up by its attributes: only the first is ever found, so
+        anything (geometry, material styles, annotations) attached to the others
+        is silently orphaned. A common symptom is a layered wall rendering with
+        a single material style because each layer's style hangs off the second,
+        never-matched, Body context.
+
+        This patch keeps the first context for each
+        (ContextType, ContextIdentifier, TargetView) key, repoints everything
+        referencing the duplicates onto that survivor, and removes the
+        duplicates. Top-level contexts and subcontexts are handled separately so
+        a subcontext is never merged into a parent context.
+
+        Example:
+
+        .. code:: python
+
+            ifcpatch.execute({"file": model, "recipe": "MergeDuplicateContexts", "arguments": []})
+        """
+        self.file = file
+        self.logger = logger
+
+    def patch(self) -> None:
+        # Subcontexts first, then top-level contexts, so the two kinds are never
+        # merged together and a surviving subcontext keeps a valid ParentContext.
+        for ifc_class in ("IfcGeometricRepresentationSubContext", "IfcGeometricRepresentationContext"):
+            if ifc_class == "IfcGeometricRepresentationContext":
+                contexts = self.file.by_type(ifc_class, include_subtypes=False)
+            else:
+                contexts = self.file.by_type(ifc_class)
+
+            groups: dict[Any, list[ifcopenshell.entity_instance]] = {}
+            for context in contexts:
+                groups.setdefault(self.get_key(context), []).append(context)
+
+            for key, group in groups.items():
+                if len(group) < 2:
+                    continue
+                survivor, *duplicates = group
+                self.logger.info(
+                    "Merging %s duplicate(s) of %s into #%s", len(duplicates), key, survivor.id()
+                )
+                for duplicate in duplicates:
+                    ifcopenshell.util.element.replace_element(duplicate, survivor)
+                    self.file.remove(duplicate)
+                # Repointing may leave the survivor listed twice in a SET-typed
+                # attribute (e.g. IfcProject.RepresentationContexts), which is
+                # non-conformant. Dedupe those aggregates.
+                self.dedupe_references(survivor)
+
+    def dedupe_references(self, element: ifcopenshell.entity_instance) -> None:
+        for inverse in self.file.get_inverse(element):
+            for i, value in enumerate(inverse):
+                if not isinstance(value, tuple) or value.count(element) < 2:
+                    continue
+                # Keep the first occurrence of the survivor, drop the rest;
+                # leave every other member untouched and in order.
+                deduped = []
+                for v in value:
+                    if v == element and element in deduped:
+                        continue
+                    deduped.append(v)
+                inverse[i] = deduped
+
+    def get_key(self, context: ifcopenshell.entity_instance) -> tuple[Any, ...]:
+        # ContextIdentifier / TargetView are None on plain contexts; that is a
+        # valid, stable part of the key.
+        return (
+            context.ContextType,
+            getattr(context, "ContextIdentifier", None),
+            getattr(context, "TargetView", None),
+        )

--- a/src/ifcpatch/ifcpatch/recipes/MergeProjects.py
+++ b/src/ifcpatch/ifcpatch/recipes/MergeProjects.py
@@ -28,6 +28,7 @@ import ifcopenshell.util.unit
 import numpy as np
 
 import ifcpatch
+from ifcpatch.recipes.MergeDuplicateContexts import Patcher as MergeDuplicateContexts
 from ifcpatch.recipes.SetFalseOrigin import Patcher as SetFalseOrigin
 
 
@@ -78,6 +79,16 @@ class Patcher(ifcpatch.BasePatcher):
                 assert isinstance(other, ifcopenshell.file)
 
             self.merge(other)
+
+        # reuse_existing_contexts() removes each merged-in context that
+        # duplicates an existing one, but its removal (remove_deep2 over an
+        # unordered set) is order-sensitive and, depending on the in-memory
+        # entity layout, can silently leave a matched context behind as an
+        # orphaned duplicate. That yields two equivalent contexts (e.g. two
+        # Model/Body/MODEL_VIEW), which is non-conformant and breaks lookups
+        # that resolve a context by attributes. Collapse any that slipped
+        # through so the merge output never contains duplicate contexts.
+        MergeDuplicateContexts(self.file, self.logger).patch()
 
     def merge(self, other: ifcopenshell.file) -> None:
         if (main_unit := self.get_unit_name(self.file)) != self.get_unit_name(other):

--- a/src/ifcpatch/test/test_MergeDuplicateContexts.py
+++ b/src/ifcpatch/test/test_MergeDuplicateContexts.py
@@ -1,0 +1,84 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2022 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import ifcopenshell.guid
+
+import ifcpatch
+import test.bootstrap
+
+
+class TestMergeDuplicateContexts(test.bootstrap.IFC4):
+    def test_run(self):
+        f = self.file
+        project = f.by_type("IfcProject")
+        project = project[0] if project else f.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new())
+
+        parent1 = f.createIfcGeometricRepresentationContext(ContextType="Model")
+        parent2 = f.createIfcGeometricRepresentationContext(ContextType="Model")
+        body1 = f.createIfcGeometricRepresentationSubContext(
+            ContextType="Model", ContextIdentifier="Body", TargetView="MODEL_VIEW", ParentContext=parent1
+        )
+        body2 = f.createIfcGeometricRepresentationSubContext(
+            ContextType="Model", ContextIdentifier="Body", TargetView="MODEL_VIEW", ParentContext=parent2
+        )
+        # A representation hangs off the duplicate subcontext; it must be
+        # repointed onto the survivor, not orphaned.
+        rep = f.createIfcShapeRepresentation(ContextOfItems=body2)
+        # Both parents are listed on the project; the SET must not end up with
+        # the survivor twice.
+        project.RepresentationContexts = [parent1, parent2]
+
+        output = ifcpatch.execute({"file": f, "recipe": "MergeDuplicateContexts", "arguments": []})
+
+        # One Body subcontext and one Model parent context survive.
+        bodies = [
+            c
+            for c in output.by_type("IfcGeometricRepresentationSubContext")
+            if c.ContextIdentifier == "Body" and c.TargetView == "MODEL_VIEW"
+        ]
+        parents = output.by_type("IfcGeometricRepresentationContext", include_subtypes=False)
+        assert len(bodies) == 1
+        assert len(parents) == 1
+
+        survivor_body = bodies[0]
+        survivor_parent = parents[0]
+
+        # The representation was repointed onto the surviving subcontext.
+        assert rep.ContextOfItems == survivor_body
+        # The surviving subcontext hangs off the surviving parent.
+        assert survivor_body.ParentContext == survivor_parent
+        # The project references the survivor exactly once (no SET duplicates).
+        assert list(output.by_type("IfcProject")[0].RepresentationContexts) == [survivor_parent]
+
+    def test_no_duplicates_is_a_noop(self):
+        f = self.file
+        parent = f.createIfcGeometricRepresentationContext(ContextType="Model")
+        f.createIfcGeometricRepresentationSubContext(
+            ContextType="Model", ContextIdentifier="Body", TargetView="MODEL_VIEW", ParentContext=parent
+        )
+        f.createIfcGeometricRepresentationSubContext(
+            ContextType="Model", ContextIdentifier="Axis", TargetView="GRAPH_VIEW", ParentContext=parent
+        )
+        before = len(f.by_type("IfcGeometricRepresentationContext"))
+        output = ifcpatch.execute({"file": f, "recipe": "MergeDuplicateContexts", "arguments": []})
+        assert len(output.by_type("IfcGeometricRepresentationContext")) == before
+
+
+class TestMergeDuplicateContextsIFC2X3(test.bootstrap.IFC2X3, TestMergeDuplicateContexts):
+    pass

--- a/src/ifcpatch/test/test_MergeProject.py
+++ b/src/ifcpatch/test/test_MergeProject.py
@@ -81,6 +81,32 @@ class TestMergeProjects(test.bootstrap.IFC4):
         output = ifcpatch.execute({"file": self.file, "recipe": "MergeProjects", "arguments": [second_file]})
         assert len(output.by_type("IfcGeometricRepresentationContext")) == 2
 
+    def test_never_emits_duplicate_contexts(self):
+        # The merge must never leave duplicate geometric contexts. Its own
+        # context reuse (remove_deep2 over an unordered set) is order-sensitive
+        # and can silently leave a merged-in context behind, and the input may
+        # already contain duplicates; either way the output must be collapsed.
+        # See #8700. A pre-existing duplicate in the main file is a
+        # deterministic stand-in - reuse_existing_contexts only touches
+        # merged-in contexts, so without the final dedupe it survives.
+        self.file = self.setup_project(self.file)
+        body = ifcopenshell.util.representation.get_context(self.file, "Model", "Body", "MODEL_VIEW")
+        self.file.create_entity(
+            "IfcGeometricRepresentationSubContext",
+            ContextType="Model",
+            ContextIdentifier="Body",
+            TargetView="MODEL_VIEW",
+            ParentContext=body.ParentContext,
+        )
+        second_file = self.setup_project()
+        output = ifcpatch.execute({"file": self.file, "recipe": "MergeProjects", "arguments": [second_file]})
+        bodies = [
+            c
+            for c in output.by_type("IfcGeometricRepresentationSubContext")
+            if c.ContextType == "Model" and c.ContextIdentifier == "Body" and c.TargetView == "MODEL_VIEW"
+        ]
+        assert len(bodies) == 1
+
     def test_using_the_georeferencing_of_the_original_project(self):
         if self.file.schema == "IFC2X3":
             return


### PR DESCRIPTION
**Stacked on #8706 — please review/merge that first.** Until it lands, the diff here also shows the `MergeDuplicateContexts` recipe commit; it will reduce to just the `MergeProjects` change once #8706 is merged.

### Problem

`MergeProjects.reuse_existing_contexts()` repoints each merged-in context that duplicates an existing one and removes it via `remove_deep2` over an **unordered `set`**. Per its contract, `remove_deep2` silently returns without deleting an element that still has an inverse, and the bare `except: pass` hides the rest. Depending on the in-memory entity layout, the repoint loop leaves a **residual inverse** on a matched context, so it is skipped and survives as an orphaned duplicate — two equivalent contexts (e.g. two `Model/Body/MODEL_VIEW`).

This is non-conformant and breaks anything that resolves a context by attributes. Visible symptom: a layered wall renders with a single material style, because `get_material_style` looks the styles up on the first Body context while they hang off the second.

Captured trace (every survivor still held an inverse at removal time):

```
#142 Model/Body    inv_before=1  refs=[IfcShapeRepresentation]              -> SURVIVED
#150 Plan/Axis     inv_before=1  refs=[IfcShapeRepresentation]              -> SURVIVED
#123 Model parent  inv_before=8  refs=[IfcGeometricRepresentationSubContext]-> SURVIVED
#127 Plan parent   inv_before=4  refs=[IfcGeometricRepresentationSubContext]-> SURVIVED
```

It's intermittent: the failing order depends on `set` iteration, and an `entity_instance`'s hash embeds the file's C++ pointer, so iteration order varies per process. The same input reproduces in Bonsai's long-running process but merges cleanly in a fresh `ifcopenshell` process (verified the trigger isn't the file bytes, `PYTHONHASHSEED`, or matching/removal order in a fresh parse).

### Fix

Rather than depend on the fragile removal order, run the `MergeDuplicateContexts` recipe (#8706) once after all merges, collapsing any context that slipped through reuse. The output can no longer contain duplicate contexts.

`test_MergeProject.py` gains a deterministic regression test: it injects a duplicate context that `reuse_existing_contexts` never touches (it only handles merged-in contexts), so the test fails without the fix (2 Body contexts) and passes with it (1). Existing `MergeProjects` tests still pass (context reuse = 2, georeferencing MapConversion = 1).

Fixes #8700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)