### PR TITLE
Bonsai: mark predefined property sets as read only in the pset editor

### DIFF
--- a/src/bonsai/bonsai/bim/module/pset/data.py
+++ b/src/bonsai/bonsai/bim/module/pset/data.py
@@ -72,6 +72,7 @@ class Data:
                     "Properties": [{"Name": k, "NominalValue": v} for k, v in sorted(data.items()) if k != "id"],
                     "shared_pset_uses": len(pset_uses),
                     "has_template": has_template,
+                    "is_editable": tool.Pset.is_editable(pset),
                 }
             )
         return sorted(results, key=lambda v: v["Name"])

--- a/src/bonsai/bonsai/bim/module/pset/operator.py
+++ b/src/bonsai/bonsai/bim/module/pset/operator.py
@@ -114,6 +114,11 @@ class EditPset(bpy.types.Operator, tool.Ifc.Operator):
             pset = ifcopenshell.api.pset.add_qto(self.file, product=element, name=props.active_pset_name)
             props.active_pset_id = pset.id()
 
+        if not tool.Pset.is_editable(pset):
+            self.report({"WARNING"}, f"Editing '{pset.is_a()}' is not supported yet.")
+            bpy.ops.bim.disable_pset_editing(obj=self.obj, obj_type=self.obj_type)
+            return
+
         if self.properties:
             properties = json.loads(self.properties)
         else:

--- a/src/bonsai/bonsai/bim/module/pset/ui.py
+++ b/src/bonsai/bonsai/bim/module/pset/ui.py
@@ -139,10 +139,11 @@ def draw_psetqto_ui(
             op.obj = obj_name
             op.obj_type = obj_type
 
-        op = row.operator("bim.enable_pset_editing", icon="GREASEPENCIL", text="")
-        op.pset_id = pset_id
-        op.obj = obj_name
-        op.obj_type = obj_type
+        if pset["is_editable"]:
+            op = row.operator("bim.enable_pset_editing", icon="GREASEPENCIL", text="")
+            op.pset_id = pset_id
+            op.obj = obj_name
+            op.obj_type = obj_type
         if pset["has_template"]:
             row.label(text="", icon="ASSET_MANAGER")
             op = row.operator("bim.pset_templates_ui_select", text="", icon="ZOOM_SELECTED")

--- a/src/bonsai/bonsai/tool/pset.py
+++ b/src/bonsai/bonsai/tool/pset.py
@@ -157,6 +157,18 @@ class Pset(bonsai.core.tool.Pset):
         return True
 
     @classmethod
+    def is_editable(cls, pset: ifcopenshell.entity_instance) -> bool:
+        """Whether bim.edit_pset can edit this pset or qto.
+
+        IfcPreDefinedPropertySet occurrences (eg. IfcDoorPanelProperties,
+        IfcDoorLiningProperties) store their data as direct entity attributes
+        instead of a list of IfcProperty or IfcPhysicalQuantity entities, so
+        the generic pset/qto editor does not support them yet and they are
+        shown as read only.
+        """
+        return not pset.is_a("IfcPreDefinedPropertySet")
+
+    @classmethod
     def enable_pset_editing(
         cls, pset_id: int, pset_name: str, pset_type: PSET_TYPE, obj: str, obj_type: tool.Ifc.OBJECT_TYPE
     ) -> None:

--- a/src/bonsai/test/bim/feature/pset.feature
+++ b/src/bonsai/test/bim/feature/pset.feature
@@ -232,6 +232,20 @@ Scenario: Edit qto - object
     And I press "bim.edit_pset(obj='IfcWall/Cube', obj_type='Object')"
     Then nothing happens
 
+Scenario: Edit pset - predefined property set is not editable
+    Given an empty IFC project
+    And I add a cube
+    And the object "Cube" is selected
+    And I set "scene.BIMRootProperties.ifc_product" to "IfcElementType"
+    And I set "scene.BIMRootProperties.ifc_class" to "IfcDoorType"
+    And I press "bim.assign_class"
+    And the variable "panel_pset" is "{ifc}.create_entity('IfcDoorPanelProperties', GlobalId=ifcopenshell.guid.new(), Name='IfcDoorPanelProperties', PanelOperation='NOTDEFINED', PanelPosition='NOTDEFINED').id()"
+    And the variable "_" is "ifcopenshell.api.pset.assign_pset({ifc}, products=[{ifc}.by_type('IfcDoorType')[-1]], pset={ifc}.by_id({panel_pset}))"
+    When I press "bim.edit_pset(pset_id={panel_pset}, obj='IfcDoorType/Cube', obj_type='Object')"
+    Then nothing happens
+    And the variable "panel_pset_attributes" is "{ifc}.by_id({panel_pset}).PanelOperation"
+    And the variable "panel_pset_attributes" equals "'NOTDEFINED'"
+
 Scenario: Edit pset - material
     Given an empty IFC project
     And I press "bim.add_material()"

--- a/src/bonsai/test/tool/test_pset.py
+++ b/src/bonsai/test/tool/test_pset.py
@@ -52,3 +52,18 @@ class TestIsPsetEmpty(NewFile):
         assert subject.is_pset_empty(pset) is False
         ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"Foo": None})
         assert subject.is_pset_empty(pset) is True
+
+
+class TestIsEditable(NewFile):
+    def test_run(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        element = ifc.createIfcWall()
+        pset = ifcopenshell.api.pset.add_pset(ifc, product=element, name="Foo")
+        assert subject.is_editable(pset) is True
+        qto = ifcopenshell.api.pset.add_qto(ifc, product=element, name="Bar")
+        assert subject.is_editable(qto) is True
+        panel_pset = ifc.createIfcDoorPanelProperties(
+            GlobalId=ifcopenshell.guid.new(), Name="IfcDoorPanelProperties", PanelOperation="NOTDEFINED"
+        )
+        assert subject.is_editable(panel_pset) is False


### PR DESCRIPTION
Fixes #2438.

The original 2022 report was a KeyError trying to edit IfcDoorPanelProperties. The code has changed since, but the underlying bug is still there today, just with a different symptom. EditPset._execute classifies any pset that is not literally IfcPropertySet/IfcMaterialProperties/IfcProfileProperties as a quantity set and routes it through ifcopenshell.api.pset.edit_qto, which assumes a fixed attribute index holds a Quantities list. For IfcDoorPanelProperties that index is actually PanelOperation, a plain enum string, so this either crashes with AttributeError iterating the string character by character, or silently overwrites PanelOperation with an empty list if it was unset, an invalid value per the schema.

IfcPreDefinedPropertySet occurrences like IfcDoorPanelProperties and IfcDoorLiningProperties store their data as direct entity attributes, not a list of IfcProperty/IfcPhysicalQuantity entities, so the generic editor was never built to support them. Maintainer Moult's original position was that editing these was never implemented and is low priority since they're being phased out upstream in favor of normal psets, only viewing was ever intended.

This makes the UI match that intent instead of offering an edit action that corrupts data: a new Pset.is_editable() classifier hides the Edit button for IfcPreDefinedPropertySet occurrences, and EditPset._execute gained a defense in depth guard that reports a warning and backs out cleanly if a non-editable pset ever reaches it anyway.

Actual editing support for the panel/lining attributes themselves is a real, separate feature Moult explicitly deferred, not attempted here.

Reproduced live in headless Blender 5.2: built a door type with an attached IfcDoorPanelProperties pset, drove the real bim.enable_pset_editing/bim.edit_pset operators, confirmed the crash on unmodified code and clean warned behavior with the fix, PanelOperation left untouched either way.

Generated with the assistance of an AI coding tool.