### PR TITLE
Bonsai: key USERDEFINED task animation colour by ObjectType

### DIFF
--- a/src/bonsai/bonsai/bim/module/sequence/__init__.py
+++ b/src/bonsai/bonsai/bim/module/sequence/__init__.py
@@ -24,6 +24,7 @@ from . import operator, prop, ui
 
 classes = (
     operator.AddAnimationCamera,
+    operator.AddAnimationTaskTypeColor,
     operator.AddSummaryTask,
     operator.AddTask,
     operator.AddTaskBars,
@@ -96,6 +97,7 @@ classes = (
     operator.LoadProductTasks,
     operator.LoadTaskProperties,
     operator.RecalculateSchedule,
+    operator.RemoveAnimationTaskTypeColor,
     operator.RemoveTask,
     operator.RemoveTaskCalendar,
     operator.RemoveTaskColumn,

--- a/src/bonsai/bonsai/bim/module/sequence/operator.py
+++ b/src/bonsai/bonsai/bim/module/sequence/operator.py
@@ -1615,6 +1615,40 @@ class LoadAnimationColorScheme(bpy.types.Operator, tool.Ifc.Operator):
         return context.window_manager.invoke_props_dialog(self)
 
 
+class AddAnimationTaskTypeColor(bpy.types.Operator):
+    bl_idname = "bim.add_animation_task_type_color"
+    bl_label = "Add Colour"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = (
+        "Adds a colour keyed by an ObjectType, used for tasks whose PredefinedType is USERDEFINED "
+        "and whose ObjectType matches"
+    )
+    group: bpy.props.StringProperty()
+    object_type: bpy.props.StringProperty(name="ObjectType")
+
+    def execute(self, context):
+        core.add_animation_task_type_color(tool.Sequence, group=self.group, object_type=self.object_type)
+        return {"FINISHED"}
+
+    def draw(self, context):
+        self.layout.prop(self, "object_type")
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+
+class RemoveAnimationTaskTypeColor(bpy.types.Operator):
+    bl_idname = "bim.remove_animation_task_type_color"
+    bl_label = "Remove Colour"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Removes the active colour from the list"
+    group: bpy.props.StringProperty()
+
+    def execute(self, context):
+        core.remove_animation_task_type_color(tool.Sequence, group=self.group)
+        return {"FINISHED"}
+
+
 class CopyTask(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.duplicate_task"
     bl_label = "Copy Task"

--- a/src/bonsai/bonsai/bim/module/sequence/ui.py
+++ b/src/bonsai/bonsai/bim/module/sequence/ui.py
@@ -662,7 +662,8 @@ class BIM_PT_animation_Color_Scheme(Panel):
         row1 = col.row(align=True)
         row1.label(text="INPUT COLORS", icon="COLLECTION_COLOR_01")
         row1 = col.row()
-        row1.template_list(
+        split = row1.split(factor=0.9)
+        split.template_list(
             BIM_UL_animation_colors.__name__,
             BIM_UL_animation_colors.__name__ + "_task_input_colors",
             self.animation_props,
@@ -670,11 +671,17 @@ class BIM_PT_animation_Color_Scheme(Panel):
             self.animation_props,
             "active_color_component_inputs_index",
         )
+        button_col = split.column(align=True)
+        op = button_col.operator("bim.add_animation_task_type_color", text="", icon="ADD")
+        op.group = "input"
+        op = button_col.operator("bim.remove_animation_task_type_color", text="", icon="REMOVE")
+        op.group = "input"
         col = grid.column()
         row1 = col.row(align=True)
         row1.label(text="OUTPUT COLORS", icon="COLLECTION_COLOR_04")
         row1 = col.row()
-        row1.template_list(
+        split = row1.split(factor=0.9)
+        split.template_list(
             BIM_UL_animation_colors.__name__,
             BIM_UL_animation_colors.__name__ + "_task_output_colors",
             self.animation_props,
@@ -682,6 +689,11 @@ class BIM_PT_animation_Color_Scheme(Panel):
             self.animation_props,
             "active_color_component_outputs_index",
         )
+        button_col = split.column(align=True)
+        op = button_col.operator("bim.add_animation_task_type_color", text="", icon="ADD")
+        op.group = "output"
+        op = button_col.operator("bim.remove_animation_task_type_color", text="", icon="REMOVE")
+        op.group = "output"
 
 
 class BIM_PT_task_icom(Panel):

--- a/src/bonsai/bonsai/core/sequence.py
+++ b/src/bonsai/bonsai/core/sequence.py
@@ -593,6 +593,14 @@ def load_default_animation_color_scheme(sequence: type[tool.Sequence]) -> None:
     sequence.load_default_animation_color_scheme()
 
 
+def add_animation_task_type_color(sequence: type[tool.Sequence], group: str, object_type: str) -> None:
+    sequence.add_animation_task_type_color(group, object_type)
+
+
+def remove_animation_task_type_color(sequence: type[tool.Sequence], group: str) -> None:
+    sequence.remove_animation_task_type_color(group)
+
+
 def visualise_work_schedule_date_range(
     sequence: type[tool.Sequence], work_schedule: ifcopenshell.entity_instance
 ) -> None:

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -921,6 +921,7 @@ class Search:
 @interface
 class Sequence:
     def add_animation_camera(cls): pass
+    def add_animation_task_type_color(cls, group, object_type): pass
     def add_task_column(cls, column_type, name, data_type): pass
     def add_text_animation_handler(cls, settings): pass
     def animate_consumption(cls, obj, start_frame, product_frame, color, animation_type): pass
@@ -988,6 +989,7 @@ class Sequence:
     def get_task_resources(cls, task):pass
     def get_task_time_attributes(cls): pass
     def get_task_time(cls, task): pass
+    def get_task_type_color(cls, colors, product_frame): pass
     def get_tasks_for_product(cls, product, work_schedule): pass
     def get_user_predefined_type(cls): pass
     def get_work_calendar_attributes(cls): pass
@@ -1019,6 +1021,7 @@ class Sequence:
     def load_work_time_attributes(cls, work_time): pass
     def process_construction_state(cls, work_schedule, date): pass
     def process_task_status(cls, task, date): pass
+    def remove_animation_task_type_color(cls, group): pass
     def remove_task_column(cls, name): pass
     def reset_time_period(cls): pass
     def save_animation_color_scheme(cls, name): pass

--- a/src/bonsai/bonsai/tool/sequence.py
+++ b/src/bonsai/bonsai/tool/sequence.py
@@ -1172,6 +1172,31 @@ class Sequence(bonsai.core.tool.Sequence):
                 predefined_type_item.color = data["Color"]
 
     @classmethod
+    def add_animation_task_type_color(cls, group: str, object_type: str) -> None:
+        object_type = object_type.strip()
+        if not object_type:
+            return
+        props = cls.get_animation_props()
+        colors = props.task_input_colors if group == "input" else props.task_output_colors
+        if object_type in colors:
+            return
+        item = colors.add()
+        item.name = object_type
+        item.color = (1.0, 1.0, 1.0)
+
+    @classmethod
+    def remove_animation_task_type_color(cls, group: str) -> None:
+        props = cls.get_animation_props()
+        if group == "input":
+            colors = props.task_input_colors
+            index = props.active_color_component_inputs_index
+        else:
+            colors = props.task_output_colors
+            index = props.active_color_component_outputs_index
+        if 0 <= index < len(colors):
+            colors.remove(index)
+
+    @classmethod
     def get_start_date(cls) -> Union[datetime, None]:
         props = cls.get_work_schedule_props()
         start = parser.parse(props.visualisation_start, dayfirst=True, fuzzy=True)
@@ -1339,14 +1364,15 @@ class Sequence(bonsai.core.tool.Sequence):
             if not start or not finish:
                 return
             for output in ifcopenshell.util.sequence.get_task_outputs(task):
-                add_product_frame(output.id(), task.PredefinedType, start, finish, "output")
+                add_product_frame(output.id(), task.PredefinedType, task.ObjectType, start, finish, "output")
             for input in cls.get_task_inputs(task):
-                add_product_frame(input.id(), task.PredefinedType, start, finish, "input")
+                add_product_frame(input.id(), task.PredefinedType, task.ObjectType, start, finish, "input")
 
-        def add_product_frame(product_id, type, product_start, product_finish, relationship):
+        def add_product_frame(product_id, type, object_type, product_start, product_finish, relationship):
             product_frames.setdefault(product_id, []).append(
                 {
                     "type": type,
+                    "object_type": object_type,
                     "relationship": relationship,
                     "STARTED": round(
                         settings["start_frame"]
@@ -1416,9 +1442,19 @@ class Sequence(bonsai.core.tool.Sequence):
         bpy.context.scene.frame_end = int(settings["start_frame"] + settings["total_frames"] + 1)
 
     @classmethod
+    def get_task_type_color(cls, colors, product_frame):
+        """Pick a colour for a product frame, preferring a colour keyed by the task's
+        ObjectType over the generic USERDEFINED colour, so that users can assign distinct
+        colours to tasks that share PredefinedType USERDEFINED but differ by ObjectType."""
+        object_type = product_frame.get("object_type")
+        if product_frame["type"] == "USERDEFINED" and object_type and object_type in colors:
+            return colors[object_type].color
+        return colors[product_frame["type"]].color
+
+    @classmethod
     def animate_input(cls, obj, start_frame, product_frame, animation_type):
         props = cls.get_animation_props()
-        color = props.task_input_colors[product_frame["type"]].color
+        color = cls.get_task_type_color(props.task_input_colors, product_frame)
         if product_frame["type"] in ["LOGISTIC", "MOVE", "DISPOSAL"]:
             cls.animate_destruction(obj, start_frame, product_frame, color, animation_type)
         else:
@@ -1427,7 +1463,7 @@ class Sequence(bonsai.core.tool.Sequence):
     @classmethod
     def animate_output(cls, obj, start_frame, product_frame, animation_type):
         props = cls.get_animation_props()
-        color = props.task_output_colors[product_frame["type"]].color
+        color = cls.get_task_type_color(props.task_output_colors, product_frame)
         if product_frame["type"] in ["CONSTRUCTION", "INSTALLATION", "NOTDEFINED"]:
             cls.animate_creation(obj, start_frame, product_frame, color)
         elif product_frame["type"] in ["DEMOLITION", "DISMANTLE", "DISPOSAL", "REMOVAL"]:

--- a/src/bonsai/bonsai/tool/sequence.py
+++ b/src/bonsai/bonsai/tool/sequence.py
@@ -1443,9 +1443,6 @@ class Sequence(bonsai.core.tool.Sequence):
 
     @classmethod
     def get_task_type_color(cls, colors, product_frame):
-        """Pick a colour for a product frame, preferring a colour keyed by the task's
-        ObjectType over the generic USERDEFINED colour, so that users can assign distinct
-        colours to tasks that share PredefinedType USERDEFINED but differ by ObjectType."""
         object_type = product_frame.get("object_type")
         if product_frame["type"] == "USERDEFINED" and object_type and object_type in colors:
             return colors[object_type].color

--- a/src/bonsai/test/tool/test_sequence.py
+++ b/src/bonsai/test/tool/test_sequence.py
@@ -71,3 +71,69 @@ class TestAssignStatus(NewFile):
 
         bpy.ops.bim.assign_status(status="EXISTING", should_unassign_status=True)
         assert subject.get_element_status(element) == set()
+
+
+class TestGetTaskTypeColor(NewFile):
+    """A task's PredefinedType USERDEFINED collapses every custom task into a single
+    grey colour. These tests cover ObjectType being consulted as a finer colour key
+    in that case, per https://github.com/IfcOpenShell/IfcOpenShell/issues/2748."""
+
+    def test_uses_the_object_type_colour_when_predefined_type_is_userdefined_and_it_exists(self):
+        from unittest.mock import Mock
+
+        colors = {"USERDEFINED": Mock(color="grey"), "COLORRED": Mock(color="red")}
+        product_frame = {"type": "USERDEFINED", "object_type": "COLORRED"}
+        assert subject.get_task_type_color(colors, product_frame) == "red"
+
+    def test_falls_back_to_the_userdefined_colour_when_no_object_type_colour_exists(self):
+        from unittest.mock import Mock
+
+        colors = {"USERDEFINED": Mock(color="grey")}
+        product_frame = {"type": "USERDEFINED", "object_type": "COLORRED"}
+        assert subject.get_task_type_color(colors, product_frame) == "grey"
+
+    def test_falls_back_to_the_userdefined_colour_when_object_type_is_empty(self):
+        from unittest.mock import Mock
+
+        colors = {"USERDEFINED": Mock(color="grey")}
+        product_frame = {"type": "USERDEFINED", "object_type": ""}
+        assert subject.get_task_type_color(colors, product_frame) == "grey"
+
+    def test_ignores_object_type_for_a_regular_predefined_type(self):
+        from unittest.mock import Mock
+
+        colors = {"CONSTRUCTION": Mock(color="green"), "COLORRED": Mock(color="red")}
+        product_frame = {"type": "CONSTRUCTION", "object_type": "COLORRED"}
+        assert subject.get_task_type_color(colors, product_frame) == "green"
+
+
+class TestAddAnimationTaskTypeColor(NewFile):
+    def test_adds_a_new_colour_keyed_by_object_type(self):
+        bpy.ops.bim.create_project()
+        props = tool.Sequence.get_animation_props()
+        subject.add_animation_task_type_color("input", "COLORRED")
+        assert "COLORRED" in props.task_input_colors
+        assert "COLORRED" not in props.task_output_colors
+
+    def test_does_not_add_a_blank_object_type(self):
+        bpy.ops.bim.create_project()
+        props = tool.Sequence.get_animation_props()
+        subject.add_animation_task_type_color("output", "  ")
+        assert len(props.task_output_colors) == 0
+
+    def test_does_not_duplicate_an_existing_entry(self):
+        bpy.ops.bim.create_project()
+        props = tool.Sequence.get_animation_props()
+        subject.add_animation_task_type_color("input", "COLORRED")
+        subject.add_animation_task_type_color("input", "COLORRED")
+        assert len(props.task_input_colors) == 1
+
+
+class TestRemoveAnimationTaskTypeColor(NewFile):
+    def test_removes_the_active_colour(self):
+        bpy.ops.bim.create_project()
+        props = tool.Sequence.get_animation_props()
+        subject.add_animation_task_type_color("input", "COLORRED")
+        props.active_color_component_inputs_index = 0
+        subject.remove_animation_task_type_color("input")
+        assert "COLORRED" not in props.task_input_colors


### PR DESCRIPTION
Fixes #2748.

The 4D animation colour scheme keys every colour lookup strictly on IfcTask.PredefinedType, a fixed IFC enum, so every task with PredefinedType == "USERDEFINED" collapses into one grey colour. ObjectType, the free-text field this issue asked to use as a finer key (e.g. "COLORRED"), was never read anywhere in the colour-mapping or animation code.

get_task_type_color() now prefers an ObjectType-keyed colour when PredefinedType == "USERDEFINED" and a match exists, falling back to the generic USERDEFINED colour otherwise. New bim.add_animation_task_type_color/bim.remove_animation_task_type_color operators (Add/Remove buttons next to the Input/Output colour lists) let a user actually register a colour under a custom ObjectType key, since there was previously no way to do that at all.

Tested live in headless Blender: two tasks with PredefinedType=USERDEFINED and different ObjectTypes, assigned to different walls, produce distinct animated colours end to end.

Generated with the assistance of an AI coding tool.