### PR TITLE
Bonsai: add Hour zoom level to the interactive Gantt chart

### DIFF
--- a/src/bonsai/bonsai/bim/data/webui/static/js/gantt.js
+++ b/src/bonsai/bonsai/bim/data/webui/static/js/gantt.js
@@ -244,7 +244,7 @@ function addGanttElement(blenderId, tasks, workSched, filename) {
       vShowTaskInfoLink: 1, // Show link in tool tip (0/1)
       vShowEndWeekDate: 0, // Show/Hide the date for the last day of the week in header for daily
       vUseSingleCell: 10000, // Set the threshold cell per table row (Helps performance for large data.
-      vFormatArr: ["Day", "Week", "Month", "Quarter"], // Even with setUseSingleCell using Hour format on such a large chart can cause issues in some browsers,
+      vFormatArr: ["Hour", "Day", "Week", "Month", "Quarter"], // vUseSingleCell keeps Hour usable on large charts.
       vShowRes: true, // Disable the resource column.
       vShowComp: false, // Disable the completion column.
       vShowDur: false, // Disable the duration column, because jsgantt doesn't calculate durations the way we want.

--- a/src/bonsai/bonsai/bim/module/sequence/gantt/index.js
+++ b/src/bonsai/bonsai/bim/module/sequence/gantt/index.js
@@ -12,7 +12,7 @@ function create_gantt_chart(json_data) {
         vShowTaskInfoLink: 1, // Show link in tool tip (0/1)
         vShowEndWeekDate: 0,  // Show/Hide the date for the last day of the week in header for daily
         vUseSingleCell: 10000, // Set the threshold cell per table row (Helps performance for large data.
-        vFormatArr: ['Day', 'Week', 'Month', 'Quarter'], // Even with setUseSingleCell using Hour format on such a large chart can cause issues in some browsers,
+        vFormatArr: ['Hour', 'Day', 'Week', 'Month', 'Quarter'], // vUseSingleCell keeps Hour usable on large charts.
         vShowRes: true, // Disable the resource column.
         vShowComp: false, // Disable the completion column.
         vShowDur: false, // Disable the duration column, because jsgantt doesn't calculate durations the way we want.


### PR DESCRIPTION
Addresses #2772.

The vendored Gantt library (jsGantt-improved) already fully supports Hour as a zoom level, column widths, per-language labels, hour-aware rendering math all included. Bonsai's own config hardcoded the format list to Day/Week/Month/Quarter, excluding Hour, citing a performance concern in a comment ("even with setUseSingleCell using Hour format on such a large chart can cause issues in some browsers").

Tested that claim directly with headless Chrome against the same library version and Bonsai's actual vUseSingleCell: 10000 setting: Hour format renders cleanly from typical schedules (40 tasks/3mo, 44ms) through fairly extreme ones (5000 tasks/3yr, ~2.4s). The catastrophic case (2.6M DOM nodes, 60s+ hang) only happens with vUseSingleCell disabled, which is not how Bonsai configures it. The objection was stale.

Task start/finish data already carries full datetime precision end to end, this was a UI-exposed-granularity gap, not a data gap, so no Python changes are needed, just the format list.

This is a partial fix, not a full one: it lets users view hour-precision data that already exists in a model (imported from MS Project/P6/Excel, or authored via ifcopenshell-python), but ifcopenshell.api.sequence.edit_task_time still hardcodes task times to 9am/5pm and IfcWorkTime only encodes working days, not working hours, so authoring a genuine night-shift schedule through Bonsai's own editing UI is still not possible. That's a real calendar/duration-model decision for a maintainer, not something this PR attempts.

Verified live: built a night-shift schedule (23:00 to 05:00, crossing midnight, the exact use case raised in the issue thread) and drove the actual rendered Hour button via a real browser click, confirmed correct hourly gridlines, correct midnight-crossing bars, correct dependency arrows, zero console errors.

Generated with the assistance of an AI coding tool.