### PR TITLE
Bonsai: regenerate a wall's join neighbours when unjoining it

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -20,7 +20,6 @@
 #
 # pyright: reportUnnecessaryTypeIgnoreComment=error
 
-import copy
 import math
 import weakref
 from collections.abc import Iterable
@@ -1538,13 +1537,25 @@ class DumbWallJoiner:
         if not element1:
             return
 
+        # Collect the walls joined to element1 before disconnecting, so their
+        # geometry can be regenerated too, not just element1's.
+        neighbours = set()
+        for rel in element1.ConnectedTo:
+            if rel.is_a("IfcRelConnectsPathElements") and rel.RelatingConnectionType in ("ATSTART", "ATEND"):
+                neighbours.add(rel.RelatedElement)
+        for rel in element1.ConnectedFrom:
+            if rel.is_a("IfcRelConnectsPathElements") and rel.RelatedConnectionType in ("ATSTART", "ATEND"):
+                neighbours.add(rel.RelatingElement)
+
         ifcopenshell.api.geometry.disconnect_path(tool.Ifc.get(), element=element1, connection_type="ATSTART")
         ifcopenshell.api.geometry.disconnect_path(tool.Ifc.get(), element=element1, connection_type="ATEND")
 
-        axis1 = tool.Model.get_wall_axis(wall1)
-        axis = copy.deepcopy(axis1["reference"])
-        body = copy.deepcopy(axis1["reference"])
         tool.Model.recreate_wall(element1, wall1)
+
+        for neighbour in neighbours:
+            neighbour_obj = tool.Ifc.get_object(neighbour)
+            if neighbour_obj:
+                tool.Model.recreate_wall(neighbour, neighbour_obj)
 
     def split(self, wall1: bpy.types.Object, target: Vector) -> "bpy.types.Object | None":
         unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())


### PR DESCRIPTION
Addresses one item from #6643 (a bundled 5-part new-user report). Two of the other items were already correctly answered in the thread (Merge only supports exactly 2 elements, Backspace already undoes the last drawn point), one needs a real screenshot to chase further (blank toolbar icons), and one (a snap indicator flicker while drawing) needs interactive windowed testing this environment can't do headlessly, so it's left as an unverified finding rather than a forced fix.

The real, fixed bug: unjoining three walls that were joined end to end left some of them with stale mitred cross-sections even though the model no longer records any connection. DumbWallJoiner.unjoin() disconnected the selected wall's own ATSTART/ATEND path connections and regenerated only that wall's mesh, but disconnecting also severs the join on whatever wall sits at the other end, and that neighbour was never regenerated, so it kept displaying its old mitred geometry.

Reproduced live in headless Blender: joined three angled walls A, B, C end to end, then unjoined only the middle wall B. Before the fix, B squared off correctly but A and C kept stale mitred ends despite zero surviving IfcRelConnectsPathElements on any of them, matching the report exactly. Fix collects the joined neighbour elements before disconnecting, then regenerates their geometry too, verified across every selection-subset case (single wall, two of three, all three).

Also dropped a dead copy.deepcopy computation left over from an earlier version of this function.

Generated with the assistance of an AI coding tool.