### PR TITLE
IfcConvert: fix 1000x scale error in STEP export unit handling

### DIFF
--- a/src/serializers/StepSerializer.h
+++ b/src/serializers/StepSerializer.h
@@ -54,7 +54,7 @@ public:
 	void setUnitNameAndMagnitude(const std::string& /*name*/, float magnitude) {
 		const char* symbol = getSymbolForUnitMagnitude(magnitude);
 		if (symbol) {
-			// Interface_Static::SetCVal("xstep.cascade.unit", symbol);
+			Interface_Static::SetCVal("xstep.cascade.unit", symbol);
 			Interface_Static::SetCVal("write.step.unit", symbol);
 		}
 	}


### PR DESCRIPTION
Fixes #6623.

setUnitNameAndMagnitude() in StepSerializer.h only set OpenCascade's write.step.unit (what unit the output STEP file declares). It used to also set xstep.cascade.unit (what unit the input TopoDS_Shape's coordinates are actually expressed in), but that line was commented out in 7b71e2ce2a ("Don't set xstep.cascade.unit as it appears to result in scaling during export #6623"), a same-day, admittedly speculative fix for this same issue that was never exhaustively tested.

xstep.cascade.unit defaults to millimetres inside OpenCascade itself when not set. ifcgeom's output is already real SI metres, so with that line commented out, GeomToStep_MakeCartesianPoint divided every already-correct metre coordinate by 1000 a second time, since it computed the conversion factor from a wrong millimetre assumption on the input side while correctly targeting metres on the output side. This affects any file converted with default settings, or with --convert-back-units on a metre-native file. It only happened to look correct for the one specific combination the original bug report and the April 2025 fix both tested, a millimetre-native file with --convert-back-units, where OpenCascade's hardcoded millimetre default coincidentally matched.

IgesSerializer.h, never touched by that commit, still sets both parameters symmetrically and is unaffected, which is corroborating evidence this was the wrong half of a two-parameter pair to remove.

Verified with the actual repro file from the issue plus a synthetic millimetre-native variant, across all four combinations of default/--convert-back-units and metre-native/millimetre-native input. All four now produce STEP coordinates matching the OBJ export exactly, in the correct declared unit.

Generated with the assistance of an AI coding tool.