### PR TITLE
Fix null reference bind in header parsing

### DIFF
--- a/src/ifcparse/IfcSpfHeader.cpp
+++ b/src/ifcparse/IfcSpfHeader.cpp
@@ -35,7 +35,13 @@ namespace {
             parse_context pc;
             storage->tokens->Next();
             storage->load(-1, nullptr, pc, -1);
-            return pc.construct(boost::none, *storage->references_to_resolve, decl, decl->as_entity()->attribute_count(), -1, logger);
+            // references_to_resolve is unset while reading the header (header
+            // entities such as FILE_DESCRIPTION never reference other
+            // instances), so fall back to a throwaway list instead of
+            // dereferencing a null pointer.
+            unresolved_references no_references;
+            unresolved_references& references = storage->references_to_resolve ? *storage->references_to_resolve : no_references;
+            return pc.construct(boost::none, references, decl, decl->as_entity()->attribute_count(), -1, logger);
         } else {
             // std::unreachable();
             return IfcEntityInstanceData(in_memory_attribute_storage(10));


### PR DESCRIPTION
## Summary

`read_from_spf_file()` in `src/ifcparse/IfcSpfHeader.cpp` unconditionally
dereferences `storage->references_to_resolve` to bind it to a reference
parameter:

```cpp
return pc.construct(boost::none, *storage->references_to_resolve, decl, ...);
```

That member is never set while parsing header entities (`FILE_DESCRIPTION`,
`FILE_NAME`, `FILE_SCHEMA` don't carry forward instance references), so this
binds a reference to a null pointer — undefined behaviour per the standard,
since compilers are permitted to assume references are never null.

Fix: fall back to an empty, throwaway `unresolved_references` list when
`references_to_resolve` is unset.

## Reproduction

This triggers on **any** file with a header, not just malformed input, but
only surfaces under UBSan. It was found via a new coverage-guided libFuzzer
harness for `IfcParse::IfcFile` (not yet upstreamed).

Build with UBSan and parse any valid IFC file:

```bash
mkdir build-fuzz && cd build-fuzz
cmake ../cmake \
  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
  -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -g -O1" \
  -DCMAKE_C_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -g -O1" \
  -DBUILD_IFCGEOM=OFF -DWITH_OPENCASCADE=OFF -DBUILD_ONLY_COMMON_SCHEMAS=ON
cmake --build . --target IfcConvert -- -j$(nproc)
UBSAN_OPTIONS=print_stacktrace=1 ./ifcconvert/IfcConvert any_file.ifc /dev/null
```

Before the fix:

```
src/ifcparse/IfcSpfHeader.cpp:38:46: runtime error: reference binding to null
pointer of type 'unresolved_references' ...
```

After the fix: clean exit, no UBSan report.

No dedicated regression test is included — the code path is already
exercised by every existing test that opens a file; the bug only manifests
under a sanitizer build, so verification is via the UBSan repro above.

## AI-generated content

This change (diagnosis and fix) was generated with the assistance of an AI
coding tool, per AGENTS.md.