### PR TITLE
Fix null-pointer derefs in reference resolution

### DIFF
--- a/src/ifcopenshell-python/test/test_parse.py
+++ b/src/ifcopenshell-python/test/test_parse.py
@@ -18,3 +18,15 @@ END-ISO-10303-21;
     f = ifcopenshell.file.from_string(data)
     print(ifcopenshell.get_log())
     f.by_id(5)
+
+
+def test_reference_to_undefined_owning_instance():
+    data = "ISO-10303-21;HEADER;FILE_DESCRIPTION();FILE_NAME();FILE_SCHEMA(('IFC4'));#=IFCRELAGGREGATES((#))#5=IFCPOINT)"
+    ifcopenshell.file.from_string(data)
+    print(ifcopenshell.get_log())
+
+
+def test_reference_to_undefined_owning_instance_simple_type():
+    data = "ISO-10303-21;HEADER;FILE_DESCRIPTION();FILE_NAME();FILE_SCHEMA(('IFC4'));#=IFCPROJECT((#))#4=IFCSIUNIT("
+    ifcopenshell.file.from_string(data)
+    print(ifcopenshell.get_log())

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -1700,6 +1700,14 @@ void IfcParse::impl::in_memory_file_storage::read_from_stream(IfcParse::FileRead
     for (const auto& p : streamer.references()) {
         const auto& ref = p.first.name_;
         const auto& refattr = p.first.index_;
+
+        auto owner_it = byid_.find(ref);
+        if (owner_it == byid_.end()) {
+            logger().Error("SYN", 28, "Instance #" + std::to_string(ref) + " referenced at attribute index " + std::to_string(refattr) + " not found");
+            continue;
+        }
+        IfcUtil::IfcBaseClass* owner = owner_it->second;
+
         if (auto* v = std::get_if<reference_or_simple_type>(&p.second)) {
             if (auto* name = std::get_if<InstanceReference>(v)) {
                 if (std::binary_search(bypassed.begin(), bypassed.end(), *name)) {
@@ -1709,12 +1717,12 @@ void IfcParse::impl::in_memory_file_storage::read_from_stream(IfcParse::FileRead
                 if (it == byid_.end()) {
                     logger().Error("SYN", 19, "Instance reference #" + std::to_string(*name) + " used by instance #" + std::to_string(ref) + " at attribute index " + std::to_string(refattr) + " not found at offset " + std::to_string(name->file_offset));
                 } else {
-                    auto* storage = &byid_[p.first.name_]->data();
+                    auto* storage = &owner->data();
                     auto attr_index = p.first.index_;
                     
                     if (storage->has_attribute_value<IfcUtil::IfcBaseClass*>(nullptr, nullptr, 0, attr_index)) {
                         IfcUtil::IfcBaseClass* inst = storage->get_attribute_value(nullptr, nullptr, 0, attr_index);
-                        if (!inst->declaration().as_entity()) {
+                        if (inst != nullptr && !inst->declaration().as_entity()) {
                             // Probably a case of IfcPropertySetDefinitionSet, divert storage of reference to the simply type instance
                             storage = &inst->data();
                             attr_index = 0;
@@ -1728,7 +1736,7 @@ void IfcParse::impl::in_memory_file_storage::read_from_stream(IfcParse::FileRead
                     }
                 }
             } else if (auto* inst = std::get_if<IfcUtil::IfcBaseClass*>(v)) {
-                byid_[p.first.name_]->data().set_attribute_value(nullptr, nullptr, 0, p.first.index_, *inst);
+                owner->data().set_attribute_value(nullptr, nullptr, 0, p.first.index_, *inst);
             }
         } else if (auto* vv = std::get_if<std::vector<reference_or_simple_type>>(&p.second)) {
             aggregate_of_instance::ptr instances(new aggregate_of_instance);
@@ -1749,12 +1757,12 @@ void IfcParse::impl::in_memory_file_storage::read_from_stream(IfcParse::FileRead
                 }
             }
 
-            auto* storage = &byid_[p.first.name_]->data();
+            auto* storage = &owner->data();
             auto attr_index = p.first.index_;
             
             if (storage->has_attribute_value<IfcUtil::IfcBaseClass*>(nullptr, nullptr, 0, attr_index)) {
                 IfcUtil::IfcBaseClass* inst = storage->get_attribute_value(nullptr, nullptr, 0, attr_index);
-                if (!inst->declaration().as_entity()) {
+                if (inst != nullptr && !inst->declaration().as_entity()) {
                     // Probably a case of IfcPropertySetDefinitionSet, divert storage of reference to the simply type instance
                     storage = &inst->data();
                     attr_index = 0;
@@ -1788,12 +1796,12 @@ void IfcParse::impl::in_memory_file_storage::read_from_stream(IfcParse::FileRead
                 instances->push(inner);
             }
 
-            auto* storage = &byid_[p.first.name_]->data();
+            auto* storage = &owner->data();
             auto attr_index = p.first.index_;
             
             if (storage->has_attribute_value<IfcUtil::IfcBaseClass*>(nullptr, nullptr, 0, attr_index)) {
                 IfcUtil::IfcBaseClass* inst = storage->get_attribute_value(nullptr, nullptr, 0, attr_index);
-                if (!inst->declaration().as_entity()) {
+                if (inst != nullptr && !inst->declaration().as_entity()) {
                     // Probably a case of IfcPropertySetDefinitionSet, divert storage of reference to the simply type instance
                     storage = &inst->data();
                     attr_index = 0;


### PR DESCRIPTION
## Summary

Two related null-pointer dereference bugs in
`in_memory_file_storage::read_from_stream`'s reference-resolution loop
(`src/ifcparse/IfcParse.cpp`, ~lines 1700-1810), both reachable from
malformed but otherwise well-formed-looking STEP input — real SIGSEGV-class
bugs in a non-sanitized build, not just sanitizer findings.

1. `has_attribute_value<IfcUtil::IfcBaseClass*>(...)` only confirms the
   attribute's stored *type* is an entity-reference slot, not that the value
   is non-null (e.g. the attribute is explicitly `$`). The following
   `get_attribute_value()` call can then return a null `IfcBaseClass*`, and
   `inst->declaration()` is a virtual call through that null pointer. Fixed
   at all three call sites with an `inst != nullptr &&` guard.

2. `byid_[p.first.name_]` uses `unordered_map::operator[]`, which
   default-inserts (and returns) a null `IfcBaseClass*` when the owning
   instance id isn't present in `byid_`, and the result was unconditionally
   dereferenced via `->data()`. Fixed by hoisting a single `byid_.find(ref)`
   lookup to the top of the loop, logging (`SYN` 28) and skipping when the
   owner isn't found — matching the existing error-handling style used
   elsewhere in the same function for missing referenced instances.

## Reproduction

Found via a new coverage-guided libFuzzer harness for `IfcParse::IfcFile`
(not yet upstreamed) — two independent fuzzing workers converged on this
within the first 30-45 minutes. Two minimized crash inputs (~100 bytes
each) reproduce the two call sites:

```
ISO-10303-21;HEADER;FILE_DESCRIPTION();FILE_NAME();FILE_SCHEMA(('IFC4'));#=IFCRELAGGREGATES((#))#5=IFCPOINT)
```
```
ISO-10303-21;HEADER;FILE_DESCRIPTION();FILE_NAME();FILE_SCHEMA(('IFC4'));#=IFCPROJECT((#))#4=IFCSIUNIT(
```

Before the fix, under UBSan:

```
src/ifcparse/IfcParse.cpp:1712:60: runtime error: member call on null pointer of type 'IfcUtil::IfcBaseClass'
src/ifcparse/IfcParse.cpp:1752:52: runtime error: member call on null pointer of type 'IfcUtil::IfcBaseClass'
```

In a plain (non-sanitized) build these are a real crash via a null vtable
dereference, not merely a diagnostic.

Regression tests are included in
`src/ifcopenshell-python/test/test_parse.py`, using the two inputs above via
`ifcopenshell.file.from_string()` — confirmed to reach the identical
in-memory `IfcFile` constructor path used by the fuzzer harness (see
`src/ifcwrap/IfcParseWrapper.i`'s `read()` wrapper).

## AI-generated content

This change (diagnosis, fix, and the added regression tests) was generated
with the assistance of an AI coding tool, per AGENTS.md.