### PR TITLE
Bonsai: resync door and window openings after wall layer edits

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1468,7 +1468,9 @@ class DumbWallPlaner:
             else:
                 for rel in inverse.AssociatedTo:
                     walls.extend([tool.Ifc.get_object(e) for e in rel.RelatedObjects])
-        tool.Model.recalculate_walls([w for w in set(walls) if w])
+        walls = [w for w in set(walls) if w]
+        tool.Model.recalculate_walls(walls)
+        tool.Model.resync_hosted_fillings([e for w in walls if (e := tool.Ifc.get_entity(w))])
 
 
 def _opening_axis_extent(opening, axis_reference, unit_scale):

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2184,6 +2184,26 @@ class Model(bonsai.core.tool.Model):
                 bpy.ops.bim.recalculate_fill()
 
     @classmethod
+    def resync_hosted_fillings(cls, elements: Iterable[ifcopenshell.entity_instance]) -> None:
+        """Refresh every filled opening voiding any of ``elements``.
+
+        Meant to run after a host's layer thickness changed (e.g. an edit to
+        an ``IfcWallType``'s ``IfcMaterialLayerSet``), so doors and windows
+        already placed in that host keep cutting all the way through its new
+        body instead of being left at their old depth."""
+        fillings = []
+        for element in elements:
+            for rel in getattr(element, "HasOpenings", None) or []:
+                for fill_rel in getattr(rel.RelatedOpeningElement, "HasFillings", None) or []:
+                    obj = tool.Ifc.get_object(fill_rel.RelatedBuildingElement)
+                    if obj:
+                        fillings.append(obj)
+        if not fillings:
+            return
+        with bpy.context.temp_override(selected_objects=fillings):
+            bpy.ops.bim.recalculate_fill()
+
+    @classmethod
     def apply_ifc_material_changes(
         cls,
         elements: list[ifcopenshell.entity_instance],


### PR DESCRIPTION
Fixes #3157.

Editing an IfcMaterialLayerSet's layer thickness (add/remove/edit a layer) already regenerates the wall's own body via regenerate_from_layer_set, but nothing resized the depth of any door or window opening already cut into that wall. An opening's depth is fixed at creation time to max(1.2m, 2x wall thickness), a generous safety margin, so most everyday residential wall-thickness edits happen to stay within it and the bug goes unnoticed. It fails whenever a wall grows thicker than that frozen depth, for example editing a masonry or retaining wall from 0.5m to 1.5m, leaving the opening cutting only partway through the new body.

tool.Model.resync_hosted_fillings walks a wall's HasOpenings for filled openings and reuses the existing bim.recalculate_fill operator to rebuild each one against the wall's current thickness. regenerate_from_layer_set now calls it after recalculating the walls, so every layer-editing operator picks it up.

Scoped to IfcWallType only, matching the issue. The same gap exists for slabs, but investigating it surfaced a separate, pre-existing bug there (regenerate_filling_opening_body hardcodes the wall's Y-axis dimension for opening depth, which is wrong for a slab's Z-axis thickness), so extending this fix to slabs was left out rather than shipping a half broken path. That is a distinct issue worth its own fix.

Tested live in headless Blender: built a 0.5m wall type, added an occurrence, filled an opening with a door, then edited the type's LayerThickness to 1.5m. Before the fix the opening stayed frozen at 1.2m depth, cutting only partway through the new 1.5m wall. After the fix the opening depth updates to 1.5m, cutting all the way through. Editing LayerThickness on a wall with no openings does not crash.

Generated with the assistance of an AI coding tool.