### PR TITLE
ifcopenshell.util.element: a filling element's own container is authoritative over a shared opening's other hosts

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/element.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/element.py
@@ -1151,8 +1151,26 @@ def get_decomposition(element: ifcopenshell.entity_instance, is_recursive=True) 
         element = file.by_type("IfcProject")[0]
         decomposition = ifcopenshell.util.element.get_decomposition(element)
     """
+
+    def add_fillings(opening: ifcopenshell.entity_instance, host_container: Union[ifcopenshell.entity_instance, None]):
+        for fill_rel in getattr(opening, "HasFillings", []):
+            filling = fill_rel.RelatedBuildingElement
+            filling_container = get_container(filling, should_get_direct=True)
+            if host_container is not None and filling_container is not None and filling_container != host_container:
+                # A single opening may void multiple elements across different
+                # containers, e.g. a continuous opening cutting through walls
+                # on separate storeys. The filling element's (e.g. a window's)
+                # own explicit container is authoritative and takes priority
+                # over an unrelated container that the shared opening also
+                # happens to void. See #6770.
+                continue
+            queue.append(filling)
+            results.add(filling)
+
     queue = [element]
     results = set()
+    if element.is_a("IfcOpeningElement"):
+        add_fillings(element, get_container(element, should_get_direct=True))
     while queue:
         element = queue.pop()
         for rel in getattr(element, "ContainsElements", []):
@@ -1167,10 +1185,7 @@ def get_decomposition(element: ifcopenshell.entity_instance, is_recursive=True) 
             related = rel.RelatedOpeningElement
             queue.append(related)
             results.add(related)
-        for rel in getattr(element, "HasFillings", []):
-            related = rel.RelatedBuildingElement
-            queue.append(related)
-            results.add(related)
+            add_fillings(related, get_container(element, should_get_direct=True))
         for rel in getattr(element, "IsNestedBy", []):
             related = rel.RelatedObjects
             queue.extend(related)

--- a/src/ifcopenshell-python/test/util/test_element.py
+++ b/src/ifcopenshell-python/test/util/test_element.py
@@ -1047,6 +1047,36 @@ class TestGetDecompositionIFC4(test.bootstrap.IFC4):
         assert subelement in results
         assert subsubelement in results
 
+    def test_a_filling_elements_own_container_takes_priority_over_an_opening_voiding_multiple_hosts(self):
+        # See https://github.com/IfcOpenShell/IfcOpenShell/issues/6770 : a single
+        # opening voiding walls on two different storeys ("void through walls")
+        # must not make a window belong to a storey it isn't actually in, just
+        # because the shared opening also happens to void an element there.
+        storey1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        storey2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        wall1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        wall2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        window = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWindow")
+        opening = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcOpeningElement")
+
+        ifcopenshell.api.spatial.assign_container(self.file, products=[wall1], relating_structure=storey1)
+        ifcopenshell.api.spatial.assign_container(self.file, products=[wall2], relating_structure=storey2)
+        ifcopenshell.api.spatial.assign_container(self.file, products=[window], relating_structure=storey1)
+
+        # ifcopenshell.api.feature.add_feature only supports a single host per
+        # opening, replacing any prior host. The "void through walls" pattern
+        # from #6770 has the same opening void two hosts at once, so the two
+        # IfcRelVoidsElement relationships are created directly.
+        self.file.create_entity("IfcRelVoidsElement", ifcopenshell.guid.new(), None, None, None, wall1, opening)
+        self.file.create_entity("IfcRelVoidsElement", ifcopenshell.guid.new(), None, None, None, wall2, opening)
+        ifcopenshell.api.feature.add_filling(self.file, element=window, opening=opening)
+
+        # The window's own explicit container (storey1, via wall1) is authoritative.
+        assert window in subject.get_decomposition(storey1)
+        assert window in subject.get_decomposition(wall1)
+        assert window not in subject.get_decomposition(storey2)
+        assert window not in subject.get_decomposition(wall2)
+
 
 class TestGetGroupsIFC4(test.bootstrap.IFC4):
     def test_run(self):

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -360,6 +360,31 @@ class TestFilterElements(test.bootstrap.IFC4):
         assert subject.filter_elements(self.file, "IfcWall, parent=Element2") == {element2, element3}
         assert subject.filter_elements(self.file, "IfcWall, parent=Space") == {element}
 
+    def test_selecting_by_parent_excludes_a_filling_element_hosted_by_a_different_storey(self):
+        # See https://github.com/IfcOpenShell/IfcOpenShell/issues/6770 : a
+        # window on storey 1 was incorrectly excluded by `parent="storey 2"`
+        # because the opening it fills also happens to void a wall on
+        # storey 2 ("void through walls" technique).
+        storey1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey", name="Storey 1")
+        storey2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey", name="Storey 2")
+        wall1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall", name="Wall1")
+        wall2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall", name="Wall2")
+        window = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWindow", name="Window")
+        opening = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcOpeningElement")
+
+        ifcopenshell.api.spatial.assign_container(self.file, products=[wall1], relating_structure=storey1)
+        ifcopenshell.api.spatial.assign_container(self.file, products=[wall2], relating_structure=storey2)
+        ifcopenshell.api.spatial.assign_container(self.file, products=[window], relating_structure=storey1)
+
+        # The same opening voids both walls, on two different storeys.
+        self.file.create_entity("IfcRelVoidsElement", ifcopenshell.guid.new(), None, None, None, wall1, opening)
+        self.file.create_entity("IfcRelVoidsElement", ifcopenshell.guid.new(), None, None, None, wall2, opening)
+        ifcopenshell.api.feature.add_filling(self.file, element=window, opening=opening)
+
+        elements = {wall1, wall2, window}
+        assert subject.filter_elements(self.file, 'parent="Storey 2"', elements) == {wall2}
+        assert elements - subject.filter_elements(self.file, 'parent="Storey 2"', elements) == {wall1, window}
+
     def test_selecting_multiple_filter_groups(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         element.Name = "Foo"


### PR DESCRIPTION
## Root cause
Bonsai's drawing exclude filter (`parent=`) calls `get_decomposition()` on
the excluded storey to find its "children." When walking through an
opening's `HasFillings`, it unconditionally attributed the filling element
(e.g. a window) to whichever host happened to have the opening — even when
that host was reached only because the same `IfcOpeningElement` also voids
an unrelated element on a different storey ("void through walls": one
opening cutting through walls on two separate storeys). The window's own
explicit, unambiguous `IfcRelContainedInSpatialStructure` was never
consulted, so it got swept into the wrong storey's decomposition and
incorrectly excluded from a drawing it should appear in.

## Fix
`get_decomposition()` now only attributes a filling element to a host's
decomposition tree if the filling element's own direct container agrees
with (or is unset, preserving prior behavior for files that don't directly
contain their fillings) the host's own direct container. The common case
(a window's container already matches its host wall's storey, how Bonsai
authors windows by default) is unaffected.

## Verification
- Reproduced live in headless Blender with the reporter's real IFC file:
  before the fix, a "1st floor" drawing with `Exclude: parent="2nd floor"`
  incorrectly omitted the window (directly contained in 1st floor, filling
  an opening that also voids a 2nd-floor wall); after the fix, it correctly
  appears, while the 2nd floor wall/slab remain correctly excluded.
- Added regression tests for both `get_decomposition()` and
  `filter_elements()`/`parent=`, reproducing the exact multi-storey-void
  scenario; both pass, independently re-verified in a fresh environment.
- Existing test suite: 191/194 pass (3 pre-existing unrelated failures
  confirmed present on a clean baseline too).

Fixes #6770

Generated with the assistance of an AI coding tool.