### PR TITLE
ifcgeom: avoid degenerate cross product in SvgSerializer for vertical section-line curves

### DIFF
--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -642,8 +642,14 @@ void SvgSerializer::write(const IfcGeom::BRepElement* brep_obj) {
 				gp_Pnt P;
 				gp_Vec V;
 				crv->D1((u0 + u1) / 2., P, V);
-				auto N = V.Crossed(gp::DZ());
-				pln = gp_Pln(gp_Ax3(P, N, V));
+				if (V.Magnitude() > Precision::Confusion()) {
+					// Avoid a degenerate cross product when V is (anti-)parallel to Z,
+					// same fallback axis as OpenCascadeConversionResult.cpp.
+					const gp_Dir V_dir(V);
+					const gp_Dir& ref_axis = std::fabs(V_dir.Z()) < 0.5 ? gp::DZ() : gp::DY();
+					auto N = V.Crossed(ref_axis);
+					pln = gp_Pln(gp_Ax3(P, N, V));
+				}
 			}
 		}
 		else if (boost::optional<box_t> b = box_from_compound(compound_local)) {


### PR DESCRIPTION
## Root cause
`SvgSerializer::write()` builds a drawing plane from a section/elevation
reference curve's tangent `V` via `V.Crossed(gp::DZ())`. When `V` is
(anti-)parallel to the global Z axis, the resulting normal is the zero
vector, and constructing `gp_Ax3` from it throws `Standard_ConstructionError`
("gp_Dir() - input vector has zero norm"), crashing the whole print/export
job on a single degenerate element (reported upstream as `RuntimeError: An
unknown error occurred` through the Python/SWIG wrapper).

sboddy's diagnosis on the issue correctly identified the general failure
mode (a degenerate cross product against Z); the exact throwing statement
is the very next line (`gp_Ax3` construction), not `Crossed()` itself,
which never throws.

## Fix
Reuses the exact fallback pattern already established elsewhere in this
codebase (`OpenCascadeConversionResult.cpp`'s edge-arrow direction code):
when the tangent is nearly parallel to Z, cross against `gp::DY()` instead.
This fixes the actual degenerate computation at its source rather than
catching the exception after the fact.

## Verification
- Reproduced the exact crash class with a minimal repro (a vertical
  section-line annotation): `Standard_ConstructionError` before the fix,
  clean conversion after, confirmed via a from-scratch rebuild.
- Confirmed the fallback produces dimensionally correct output: a
  3.0m-wide × 2.5m-tall wall's elevation renders as an exact 2.5×3.0
  rectangle through the fixed plane construction, not just a non-crashing
  but meaningless result.
- Regression: ran all 83 `test/input/*wall*.ifc` fixtures through SVG
  plan output, no new failures (one pre-existing, unrelated, self-described
  infinite-loop fixture times out on both old and new code).

Fixes #8049

Generated with the assistance of an AI coding tool.