### PR TITLE
ifcgeom: detect and recover from OCCT's silent no-op boolean cut

### DIFF
--- a/src/ifcgeom/kernels/CMakeLists.txt
+++ b/src/ifcgeom/kernels/CMakeLists.txt
@@ -41,6 +41,12 @@ foreach(kernel ${GEOMETRY_KERNELS})
     endif()
 endforeach()
 
+if("opencascade" IN_LIST GEOMETRY_KERNELS AND "cgal" IN_LIST GEOMETRY_KERNELS)
+    # Used by boolean_cgal_fallback.cpp.
+    target_link_libraries(geometry_kernel_opencascade IFCOPENSHELL_CGAL)
+    set_property(TARGET geometry_kernel_opencascade APPEND_STRING PROPERTY COMPILE_FLAGS " -DCGAL_HAS_THREADS")
+endif()
+
 set(kernel_libraries ${kernel_libraries} PARENT_SCOPE)
 
 install(FILES ifc_geomlibrary_api.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ifcgeom/kernels/")

--- a/src/ifcgeom/kernels/opencascade/base_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/base_utils.cpp
@@ -1,5 +1,9 @@
 #include "base_utils.h"
 
+#include <array>
+#include <cmath>
+#include <map>
+
 #include "../../../ifcparse/IfcLogger.h"
 #include "OpenCascadeConversionResult.h"
 #include "boolean_utils.h"
@@ -133,6 +137,49 @@ bool IfcGeom::util::is_manifold(const TopoDS_Shape& a) {
 	}
 }
 
+
+namespace {
+	std::array<long long, 3> rounded_key(const gp_Pnt& p, double tol) {
+		return {
+			(long long) std::llround(p.X() / tol),
+			(long long) std::llround(p.Y() / tol),
+			(long long) std::llround(p.Z() / tol)
+		};
+	}
+}
+
+bool IfcGeom::util::has_coincident_edges(const TopoDS_Shape& a, double tol) {
+	NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher> map;
+	TopExp::MapShapesAndAncestors(a, TopAbs_EDGE, TopAbs_FACE, map);
+
+	std::map<std::pair<std::array<long long, 3>, std::array<long long, 3>>, int> face_count_by_location;
+
+	for (int i = 1; i <= map.Extent(); ++i) {
+		const TopoDS_Edge& e = TopoDS::Edge(map.FindKey(i));
+
+		TopoDS_Vertex v0, v1;
+		TopExp::Vertices(e, v0, v1);
+		if (v0.IsNull() || v1.IsNull() || v0.IsSame(v1)) {
+			continue;
+		}
+
+		auto k0 = rounded_key(BRep_Tool::Pnt(v0), tol);
+		auto k1 = rounded_key(BRep_Tool::Pnt(v1), tol);
+		if (k1 < k0) {
+			std::swap(k0, k1);
+		}
+
+		face_count_by_location[{k0, k1}] += map.FindFromIndex(i).Extent();
+	}
+
+	for (auto& kv : face_count_by_location) {
+		if (kv.second > 2) {
+			return true;
+		}
+	}
+
+	return false;
+}
 
 bool IfcGeom::util::is_nested_compound_of_solid(const TopoDS_Shape& s, int depth) {
 	if (s.ShapeType() == TopAbs_COMPOUND) {

--- a/src/ifcgeom/kernels/opencascade/base_utils.h
+++ b/src/ifcgeom/kernels/opencascade/base_utils.h
@@ -33,6 +33,10 @@ namespace IfcGeom {
 
 		IFC_GEOMLIBRARY_API bool is_manifold(const TopoDS_Shape& a);
 
+		// Detects distinct edges that spatially coincide and together carry
+		// more than 2 faces, which is_manifold() does not catch per-edge.
+		IFC_GEOMLIBRARY_API bool has_coincident_edges(const TopoDS_Shape& a, double tol);
+
 		// For axis placements detect equality early in order for the
 		// relatively computionaly expensive gp_Trsf calculation to be skipped
 		IFC_GEOMLIBRARY_API bool axis_equal(const gp_Ax3& a, const gp_Ax3& b, double tolerance);

--- a/src/ifcgeom/kernels/opencascade/boolean_cgal_fallback.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_cgal_fallback.cpp
@@ -1,0 +1,256 @@
+// This file was generated with the assistance of an AI coding tool.
+
+#include "boolean_cgal_fallback.h"
+#include "base_utils.h"
+
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Wire.hxx>
+#include <TopoDS_Shell.hxx>
+#include <TopoDS_Compound.hxx>
+#include <BRep_Tool.hxx>
+#include <BRep_Builder.hxx>
+#include <BRepTools.hxx>
+#include <BRepTools_WireExplorer.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_Sewing.hxx>
+#include <BRepBuilderAPI_MakeSolid.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <ShapeFix_Shape.hxx>
+#include <Geom_Plane.hxx>
+#include <gp_Pnt.hxx>
+
+#ifdef IFOPSH_WITH_CGAL
+
+// The rest of this file only deals with plain CGAL types, so the OCCT
+// Handle(...) macro is no longer needed and would clash with CGAL/boost.
+#undef Handle
+
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Nef_polyhedron_3.h>
+#include <CGAL/Polygon_mesh_processing/repair_polygon_soup.h>
+#include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
+#include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
+#include <CGAL/Polygon_mesh_processing/orientation.h>
+#include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
+#include <CGAL/number_utils.h>
+
+namespace {
+
+	typedef CGAL::Exact_predicates_exact_constructions_kernel fallback_kernel_t;
+	typedef fallback_kernel_t::Point_3 fallback_point_t;
+	typedef CGAL::Polyhedron_3<fallback_kernel_t> fallback_polyhedron_t;
+	typedef CGAL::Nef_polyhedron_3<fallback_kernel_t> fallback_nef_t;
+
+	bool shape_has_only_planar_faces(const TopoDS_Shape& s) {
+		for (TopExp_Explorer exp(s, TopAbs_FACE); exp.More(); exp.Next()) {
+			auto surf = BRep_Tool::Surface(TopoDS::Face(exp.Current()));
+			if (surf.IsNull() || surf->DynamicType() != STANDARD_TYPE(Geom_Plane)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// Builds a polygon soup from the outer wire of every face. Faces with
+	// inner wires (holes) are not supported and cause this to fail, leaving
+	// the caller to fall back to the pre-existing behaviour.
+	bool shape_to_polyhedron(const TopoDS_Shape& s, fallback_polyhedron_t& poly) {
+		std::vector<fallback_point_t> points;
+		std::vector<std::vector<std::size_t>> polygons;
+
+		for (TopExp_Explorer fexp(s, TopAbs_FACE); fexp.More(); fexp.Next()) {
+			const TopoDS_Face& f = TopoDS::Face(fexp.Current());
+
+			int num_wires = 0;
+			for (TopExp_Explorer wexp(f, TopAbs_WIRE); wexp.More(); wexp.Next()) {
+				++num_wires;
+			}
+			if (num_wires != 1) {
+				return false;
+			}
+
+			TopoDS_Wire w = BRepTools::OuterWire(f);
+
+			std::vector<std::size_t> face_indices;
+			for (BRepTools_WireExplorer we(w, f); we.More(); we.Next()) {
+				gp_Pnt p = BRep_Tool::Pnt(we.CurrentVertex());
+				points.emplace_back(p.X(), p.Y(), p.Z());
+				face_indices.push_back(points.size() - 1);
+			}
+
+			if (face_indices.size() < 3) {
+				return false;
+			}
+
+			polygons.push_back(std::move(face_indices));
+		}
+
+		if (polygons.empty()) {
+			return false;
+		}
+
+		CGAL::Polygon_mesh_processing::repair_polygon_soup(points, polygons);
+
+		if (!CGAL::Polygon_mesh_processing::is_polygon_soup_a_polygon_mesh(polygons)) {
+			CGAL::Polygon_mesh_processing::orient_polygon_soup(points, polygons);
+		}
+
+		poly.clear();
+		CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, polygons, poly);
+
+		return poly.size_of_facets() > 0;
+	}
+
+	bool shape_to_nef(const TopoDS_Shape& s, fallback_nef_t& nef) {
+		fallback_polyhedron_t poly;
+		if (!shape_to_polyhedron(s, poly)) {
+			return false;
+		}
+
+		if (!poly.is_closed()) {
+			return false;
+		}
+
+		try {
+			if (!CGAL::Polygon_mesh_processing::is_outward_oriented(poly)) {
+				CGAL::Polygon_mesh_processing::reverse_face_orientations(poly);
+			}
+			CGAL::Polygon_mesh_processing::triangulate_faces(poly);
+			nef = fallback_nef_t(poly);
+		} catch (...) {
+			return false;
+		}
+
+		return !nef.is_empty();
+	}
+
+	bool polyhedron_to_shape(fallback_polyhedron_t& poly, TopoDS_Shape& result, double tol) {
+		if (poly.size_of_facets() == 0) {
+			return false;
+		}
+
+		BRep_Builder builder;
+		TopoDS_Compound comp;
+		builder.MakeCompound(comp);
+
+		for (auto fit = poly.facets_begin(); fit != poly.facets_end(); ++fit) {
+			BRepBuilderAPI_MakePolygon mp;
+			auto h = fit->facet_begin();
+			auto h0 = h;
+			do {
+				const auto& p = h->vertex()->point();
+				mp.Add(gp_Pnt(CGAL::to_double(p.x()), CGAL::to_double(p.y()), CGAL::to_double(p.z())));
+				++h;
+			} while (h != h0);
+
+			if (!mp.IsDone()) {
+				return false;
+			}
+			mp.Close();
+
+			BRepBuilderAPI_MakeFace mf(mp.Wire());
+			if (!mf.IsDone()) {
+				return false;
+			}
+
+			builder.Add(comp, mf.Face());
+		}
+
+		BRepBuilderAPI_Sewing sewing(tol);
+		sewing.Add(comp);
+		sewing.Perform();
+
+		TopoDS_Shape sewn = sewing.SewedShape();
+
+		TopoDS_Shape solid_or_shell = sewn;
+		if (sewn.ShapeType() == TopAbs_SHELL) {
+			BRepBuilderAPI_MakeSolid ms(TopoDS::Shell(sewn));
+			if (ms.IsDone()) {
+				solid_or_shell = ms.Solid();
+			}
+		}
+
+		ShapeFix_Shape fix(solid_or_shell);
+		fix.SetMaxTolerance(tol);
+		fix.Perform();
+
+		result = fix.Shape();
+		return true;
+	}
+
+}
+
+bool IfcGeom::util::boolean_operation_cgal_fallback(const TopoDS_Shape& a, const NCollection_List<TopoDS_Shape>& b, BOPAlgo_Operation op, TopoDS_Shape& result, double tol) {
+	if (op != BOPAlgo_CUT && op != BOPAlgo_FUSE && op != BOPAlgo_COMMON) {
+		return false;
+	}
+
+	if (!shape_has_only_planar_faces(a)) {
+		return false;
+	}
+
+	fallback_nef_t nef_a;
+	if (!shape_to_nef(a, nef_a)) {
+		return false;
+	}
+
+	NCollection_List<TopoDS_Shape>::Iterator it(b);
+	for (; it.More(); it.Next()) {
+		if (!shape_has_only_planar_faces(it.Value())) {
+			return false;
+		}
+
+		fallback_nef_t nef_b;
+		if (!shape_to_nef(it.Value(), nef_b)) {
+			return false;
+		}
+
+		if (op == BOPAlgo_CUT) {
+			nef_a -= nef_b;
+		} else if (op == BOPAlgo_FUSE) {
+			nef_a += nef_b;
+		} else {
+			nef_a *= nef_b;
+		}
+	}
+
+	if (!nef_a.is_simple()) {
+		return false;
+	}
+
+	fallback_polyhedron_t poly;
+	try {
+		nef_a.convert_to_polyhedron(poly);
+	} catch (...) {
+		return false;
+	}
+
+	TopoDS_Shape shape;
+	if (!polyhedron_to_shape(poly, shape, tol)) {
+		return false;
+	}
+
+	BRepCheck_Analyzer ana(shape);
+	if (!ana.IsValid()) {
+		return false;
+	}
+
+	if (!is_manifold(shape) || has_coincident_edges(shape, tol)) {
+		return false;
+	}
+
+	result = shape;
+	return true;
+}
+
+#else
+
+bool IfcGeom::util::boolean_operation_cgal_fallback(const TopoDS_Shape&, const NCollection_List<TopoDS_Shape>&, BOPAlgo_Operation, TopoDS_Shape&, double) {
+	return false;
+}
+
+#endif

--- a/src/ifcgeom/kernels/opencascade/boolean_cgal_fallback.h
+++ b/src/ifcgeom/kernels/opencascade/boolean_cgal_fallback.h
@@ -1,0 +1,41 @@
+/********************************************************************************
+ *                                                                              *
+ * This file is part of IfcOpenShell.                                          *
+ *                                                                              *
+ * IfcOpenShell is free software: you can redistribute it and/or modify        *
+ * it under the terms of the Lesser GNU General Public License as published by *
+ * the Free Software Foundation, either version 3.0 of the License, or         *
+ * (at your option) any later version.                                        *
+ *                                                                              *
+ * IfcOpenShell is distributed in the hope that it will be useful,             *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of              *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                *
+ * Lesser GNU General Public License for more details.                         *
+ *                                                                              *
+ * You should have received a copy of the Lesser GNU General Public License    *
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+ *                                                                              *
+ ********************************************************************************/
+
+// This file was generated with the assistance of an AI coding tool.
+
+#ifndef BOOLEAN_CGAL_FALLBACK_H
+#define BOOLEAN_CGAL_FALLBACK_H
+
+#include "boolean_utils.h"
+
+namespace IfcGeom {
+	namespace util {
+
+		// Recomputes a boolean operation through the exact arithmetic CGAL kernel,
+		// used as a fallback for cases where OCCT produces a non-manifold result
+		// that cannot be trusted. Only planar-faced operands are supported, since
+		// the conversion goes through a CGAL Nef polyhedron. Returns false when
+		// the fallback is not available or not applicable, leaving result
+		// untouched.
+		bool boolean_operation_cgal_fallback(const TopoDS_Shape& a, const NCollection_List<TopoDS_Shape>& b, BOPAlgo_Operation op, TopoDS_Shape& result, double tol);
+
+	}
+}
+
+#endif

--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -1301,6 +1301,27 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 					success = operands_nonmanifold;
 				}
 
+				if (success && op == BOPAlgo_CUT && !is_2d) {
+					PERF("boolean operation: cut no-op check");
+
+					// Tool operands surviving the elimination steps above genuinely
+					// overlap operand A's volume, so a real cut must remove material.
+					const double vol_a = shape_volume(a);
+					const double vol_r = shape_volume(r);
+
+					if (vol_a > Precision::Confusion() && (vol_a - vol_r) < vol_a * 1.e-9) {
+						Logger::Root().Notice("GEO", 403, "Boolean cut result has unchanged volume despite overlapping operands, suspected silent no-op cut");
+
+						TopoDS_Shape cgal_result;
+						if (boolean_operation_cgal_fallback(a, b, op, cgal_result, fuzz)) {
+							Logger::Root().Notice("GEO", 404, "Recovered a cut boolean operation result using the CGAL kernel");
+							r = cgal_result;
+						} else {
+							success = false;
+						}
+					}
+				}
+
 				if (success) {
 
 					bool all_faces_included_in_result = true;

--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -1,4 +1,5 @@
 #include "boolean_utils.h"
+#include "boolean_cgal_fallback.h"
 
 #include "IfcGeomTree.h"
 #include "base_utils.h"
@@ -1223,7 +1224,21 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 				{
 					PERF("boolean operation: manifoldness check");
 
-					success = !is_manifold(a) || is_manifold(r);
+					success = !is_manifold(a) || (is_manifold(r) && !has_coincident_edges(r, Precision::Confusion()));
+				}
+
+				if (!success) {
+					PERF("boolean operation: cgal fallback");
+
+					// Recompute through the exact arithmetic CGAL kernel and use
+					// that result when it is actually clean, before falling back
+					// to the heuristic exemption below.
+					TopoDS_Shape cgal_result;
+					if (boolean_operation_cgal_fallback(a, b, op, cgal_result, Precision::Confusion())) {
+						Logger::Root().Notice("GEO", 155, "Boolean operation result had coincident faces, recovered a manifold result using the CGAL kernel");
+						r = cgal_result;
+						success = true;
+					}
 				}
 
 				if (!success) {


### PR DESCRIPTION
## Root cause
Cutting a hip roof shell with an opening cutter can make BRepAlgoAPI_Cut
report IsDone() with a valid, manifold result that is in fact just the
first operand unchanged, when the section curve computation between the
cutter and the shell fails to produce intersection edges near a cluster
of coincident or near-coincident edges. That no-op result passes every
existing manifoldness and interference check, so no error is logged and
the opening is silently not voided.

Reproduced against the reporter's attached IFC file by sweeping the
opening position: a sub-0.2 foot move flips the cut result between the
no-op (matching the volume of the roof with the opening completely
disabled) and a correctly voided roof, with the CGAL kernel cutting
correctly and continuously across the entire sweep.

## Fix
Scoped to 3D BOPAlgo_CUT operations: once a tool operand has survived the
existing disjoint bounding box and touching-operand elimination, it
provably overlaps the first operand's volume, so a real cut must reduce
that volume. When the result's volume is unchanged, retry the same
operation through the CGAL fallback added in #8722 and use that result
when it comes back clean.

**Depends on #8722** (adds the CGAL fallback this reuses). This branch is
stacked on that commit; please review/merge #8722 first.

## Verification
- Re-ran the position sweep against the fixed binary: no more
  discontinuity, values match the CGAL kernel to about 5 decimal places
  across the full swept range.
- Regression: 90 test/input fixtures exercising boolean operations, 85
  identical to baseline, 0 new crashes. Of the 5 that differ: 4 are
  attributable to #8722 alone (already covered there), and one
  (1948--wall--wrong-geometry, whose name matches this exact bug class)
  is independently improved further by this fix on top of #8722's
  cleanup, recovering additional volume beyond what #8722 alone fixes.

Fixes #7815

Generated with the assistance of an AI coding tool.