### PR TITLE
Bonsai: apply a new Pset/Qto to the whole selection, not just the active object

### DIFF
--- a/src/bonsai/bonsai/bim/module/pset/operator.py
+++ b/src/bonsai/bonsai/bim/module/pset/operator.py
@@ -18,7 +18,7 @@
 
 import json
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import bpy
 import ifcopenshell.api
@@ -104,18 +104,6 @@ class EditPset(bpy.types.Operator, tool.Ifc.Operator):
         element = tool.Ifc.get().by_id(ifc_definition_id)
         properties = {}
 
-        pset_id = self.pset_id or props.active_pset_id
-        if pset_id:
-            pset = self.file.by_id(pset_id)
-        elif props.active_pset_type == "PSET":
-            pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name=props.active_pset_name)
-            props.active_pset_id = pset.id()
-        elif props.active_pset_type == "QTO":
-            pset = ifcopenshell.api.pset.add_qto(self.file, product=element, name=props.active_pset_name)
-            props.active_pset_id = pset.id()
-        else:
-            assert False
-
         if self.properties:
             properties = json.loads(self.properties)
         else:
@@ -128,32 +116,94 @@ class EditPset(bpy.types.Operator, tool.Ifc.Operator):
                         e[value_name] for e in prop.enumerated_value.enumerated_values if e.is_selected
                     ]
 
+        pset_id = self.pset_id or props.active_pset_id
+        is_new_pset = not pset_id
+        pset = self.apply_pset(element, pset_id, props.active_pset_type, props.active_pset_name, properties)
+        if is_new_pset:
+            props.active_pset_id = pset.id()
+
+        # A brand new pset is only proposed for the active object, so apply it to
+        # the rest of the current selection too, matching bim.assign_type's behaviour.
+        # Editing an already existing pset (pset_id truthy) is left untouched: if
+        # that pset is shared between elements, editing it already updates all of them.
+        if is_new_pset and self.obj_type == "Object":
+            self.apply_new_pset_to_selection(element, props.active_pset_type, props.active_pset_name, properties)
+
+        bpy.ops.bim.disable_pset_editing(obj=self.obj, obj_type=self.obj_type)
+        tool.Blender.update_viewport()
+
+    def apply_pset(
+        self,
+        element: ifcopenshell.entity_instance,
+        pset_id: int,
+        pset_type: str,
+        pset_name: str,
+        properties: dict[str, Any],
+    ) -> ifcopenshell.entity_instance:
+        if pset_id:
+            pset = self.file.by_id(pset_id)
+        elif pset_type == "PSET":
+            pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name=pset_name)
+        elif pset_type == "QTO":
+            pset = ifcopenshell.api.pset.add_qto(self.file, product=element, name=pset_name)
+        else:
+            assert False
+
         if pset.is_a() in ("IfcPropertySet", "IfcMaterialProperties", "IfcProfileProperties"):
             ifcopenshell.api.pset.edit_pset(
                 self.file,
                 pset=pset,
-                name=props.active_pset_name,
+                name=pset_name,
                 properties=properties,
-                pset_template=bonsai.bim.schema.ifc.psetqto.get_by_name(props.active_pset_name),
+                pset_template=bonsai.bim.schema.ifc.psetqto.get_by_name(pset_name),
             )
         else:
-            for key, value in properties.items():
+            qto_properties = dict(properties)
+            for key, value in qto_properties.items():
                 if value is None:
                     continue
                 if isinstance(value, float):
-                    properties[key] = round(value, 4)
+                    qto_properties[key] = round(value, 4)
                 elif not isinstance(value, int):
-                    properties[key] = 0
+                    qto_properties[key] = 0
             ifcopenshell.api.pset.edit_qto(
                 self.file,
                 qto=pset,
-                name=props.active_pset_name,
-                properties=properties,
+                name=pset_name,
+                properties=qto_properties,
             )
             if tool.Cost.has_schedules():
                 tool.Cost.update_cost_items(pset=pset)
-        bpy.ops.bim.disable_pset_editing(obj=self.obj, obj_type=self.obj_type)
-        tool.Blender.update_viewport()
+        return pset
+
+    def apply_new_pset_to_selection(
+        self,
+        active_element: ifcopenshell.entity_instance,
+        pset_type: str,
+        pset_name: str,
+        properties: dict[str, Any],
+    ) -> None:
+        elements_changed = 0
+        for obj in tool.Blender.get_selected_objects():
+            if obj.name == self.obj:
+                continue
+            other_element = tool.Ifc.get_entity(obj)
+            if not other_element or other_element == active_element:
+                continue
+            if not tool.Pset.is_pset_applicable(other_element, pset_name, pset_type):
+                continue
+            existing = ifcopenshell.util.element.get_psets(
+                other_element,
+                psets_only=pset_type == "PSET",
+                qtos_only=pset_type == "QTO",
+                should_inherit=False,
+            )
+            if pset_name in existing:
+                continue
+            self.apply_pset(other_element, 0, pset_type, pset_name, properties)
+            elements_changed += 1
+        if elements_changed:
+            self.report({"INFO"}, f"Added '{pset_name}' to {elements_changed} other selected object(s).")
 
 
 class RemovePset(bpy.types.Operator, tool.Ifc.Operator):

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -829,7 +829,7 @@ class Pset:
     def import_pset_from_existing(cls, pset, props): pass
     def import_pset_from_template(cls, pset_template, pset, props): pass
     def import_single_value_from_template(cls, pset_template, prop_template, data, props): pass
-    def is_pset_applicable(cls,element, pset_name): pass
+    def is_pset_applicable(cls,element, pset_name, pset_type="PSET"): pass
     def set_active_pset(cls, props, pset, has_template): pass
 
 

--- a/src/bonsai/bonsai/tool/pset.py
+++ b/src/bonsai/bonsai/tool/pset.py
@@ -138,7 +138,9 @@ class Pset(bonsai.core.tool.Pset):
         return name
 
     @classmethod
-    def is_pset_applicable(cls, element: ifcopenshell.entity_instance, pset_name: str) -> bool:
+    def is_pset_applicable(
+        cls, element: ifcopenshell.entity_instance, pset_name: str, pset_type: PSET_TYPE = "PSET"
+    ) -> bool:
         if element.is_a("IfcMaterialDefinition"):
             predefined_type = getattr(element, "Category", None)
         else:
@@ -146,7 +148,11 @@ class Pset(bonsai.core.tool.Pset):
         return bool(
             pset_name
             in bonsai.bim.schema.ifc.psetqto.get_applicable_names(
-                element.is_a(), predefined_type, pset_only=True, schema=tool.Ifc.get_schema()
+                element.is_a(),
+                predefined_type,
+                pset_only=pset_type == "PSET",
+                qto_only=pset_type == "QTO",
+                schema=tool.Ifc.get_schema(),
             )
         )
 

--- a/src/bonsai/test/bim/feature/pset.feature
+++ b/src/bonsai/test/bim/feature/pset.feature
@@ -35,6 +35,63 @@ Scenario: Add pset - multiple objects
     When I press "bim.add_pset(obj='IfcWall/Cube', obj_type='Object')"
     Then nothing happens
 
+Scenario: Edit pset - multiple objects applies a new pset to the whole selection
+    Given an empty IFC project
+    And I add a cube
+    And the object "Cube" is selected
+    And I look at the "Class" panel
+    And I set the "Products" property to "IfcElement"
+    And I set the "Class" property to "IfcWall"
+    And I click "Assign IFC Class"
+    And the object "IfcWall/Cube" is selected
+    And I add a cube
+    And the object "Cube" is selected
+    And I look at the "Class" panel
+    And I set the "Products" property to "IfcElement"
+    And I set the "Class" property to "IfcWall"
+    And I click "Assign IFC Class"
+    And the object "IfcWall/Cube.001" is selected
+    And additionally the object "IfcWall/Cube" is selected
+    And I set "active_object.PsetProperties.pset_name" to "Pset_WallCommon"
+    And I press "bim.add_pset(obj='IfcWall/Cube', obj_type='Object')"
+    And I set "active_object.PsetProperties.properties['FireRating'].metadata.string_value" to "2HR"
+    When I press "bim.edit_pset(obj='IfcWall/Cube', obj_type='Object')"
+    And the variable "other_wall" is "tool.Ifc.get_entity(bpy.data.objects['IfcWall/Cube.001'])"
+    And the variable "fire_rating" is "ifcopenshell.util.element.get_pset({other_wall}, 'Pset_WallCommon', 'FireRating', should_inherit=False)"
+    Then the variable "fire_rating" equals "'2HR'"
+
+Scenario: Edit pset - multiple objects does not clobber an element's own existing pset
+    Given an empty IFC project
+    And I add a cube
+    And the object "Cube" is selected
+    And I look at the "Class" panel
+    And I set the "Products" property to "IfcElement"
+    And I set the "Class" property to "IfcWall"
+    And I click "Assign IFC Class"
+    And the object "IfcWall/Cube" is selected
+    And I add a cube
+    And the object "Cube" is selected
+    And I look at the "Class" panel
+    And I set the "Products" property to "IfcElement"
+    And I set the "Class" property to "IfcWall"
+    And I click "Assign IFC Class"
+    And the object "IfcWall/Cube.001" is selected
+    And I set "active_object.PsetProperties.pset_name" to "Pset_WallCommon"
+    And I press "bim.add_pset(obj='IfcWall/Cube.001', obj_type='Object')"
+    And I set "active_object.PsetProperties.properties['Reference'].metadata.string_value" to "EXISTING"
+    And I press "bim.edit_pset(obj='IfcWall/Cube.001', obj_type='Object')"
+    And the object "IfcWall/Cube.001" is selected
+    And additionally the object "IfcWall/Cube" is selected
+    And I set "active_object.PsetProperties.pset_name" to "Pset_WallCommon"
+    And I press "bim.add_pset(obj='IfcWall/Cube', obj_type='Object')"
+    And I set "active_object.PsetProperties.properties['FireRating'].metadata.string_value" to "1HR"
+    When I press "bim.edit_pset(obj='IfcWall/Cube', obj_type='Object')"
+    And the variable "other_wall" is "tool.Ifc.get_entity(bpy.data.objects['IfcWall/Cube.001'])"
+    And the variable "other_reference" is "ifcopenshell.util.element.get_pset({other_wall}, 'Pset_WallCommon', 'Reference', should_inherit=False)"
+    And the variable "other_fire_rating" is "ifcopenshell.util.element.get_pset({other_wall}, 'Pset_WallCommon', 'FireRating', should_inherit=False)"
+    Then the variable "other_reference" equals "'EXISTING'"
+    And the variable "other_fire_rating" equals "None"
+
 Scenario: Enable pset editing - object
     Given an empty IFC project
     And I add a cube


### PR DESCRIPTION
## Root cause
EditPset._execute derived its target element solely from the active object, so adding a new pset with multiple objects selected only ever applied to one of them, unlike type assignment which already applies to every selected object. core.add_pset's existing loop over selected elements was dead code: it re-invoked enable_pset_editing with the same obj_name/obj_type every iteration without touching per-element state.

## Fix
Extracted the per-element create/edit logic into apply_pset(), and, only when a new pset/qto is being created (not when editing an existing one, where IFC's native pset sharing already keeps things in sync), added apply_new_pset_to_selection() which iterates the rest of the selected objects. For each, skips it if the pset name isn't applicable to that element's class, skips it if it already has its own occurrence-level pset of that name (matching RemovePset's existing convention, so an element that already carries the pset is left untouched rather than overwritten), and otherwise creates/edits it with the same values entered for the active object.

## Verification
Verified live in headless Blender: multi-select add (all get it), a mixed selection where one element already has its own pset of that name (left untouched, others still get it), single-object selection (unchanged), a mixed wall+door selection (door correctly skipped as not applicable), and Qto multi-select (also propagates, since it shares this operator). Added two BDD regression scenarios.

Fixes #7462

Generated with the assistance of an AI coding tool.