### PR TITLE
Bonsai: reorient converted-mesh walls so local X carries the length

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+from math import radians
 from typing import TYPE_CHECKING
 
 import bmesh
@@ -32,7 +33,7 @@ import ifcopenshell.util.schema
 import ifcopenshell.util.shape_builder
 import ifcopenshell.util.type
 import ifcopenshell.util.unit
-from mathutils import Vector
+from mathutils import Matrix, Vector
 
 import bonsai.bim.module.root.prop as root_prop
 import bonsai.core.geometry
@@ -323,6 +324,19 @@ class AssignClass(bpy.types.Operator, tool.Ifc.Operator):
                     if is_negative and bpy.app.version >= (5, 1, 0):
                         for polygon in obj.data.polygons:
                             polygon.flip()
+
+                # Realign so the longer footprint axis carries local X, per tool.Model.get_wall_axis's convention.
+                if ifc_class == "IfcWall":
+                    xs = [v[0] for v in obj.bound_box]
+                    ys = [v[1] for v in obj.bound_box]
+                    x_extent = max(xs) - min(xs)
+                    y_extent = max(ys) - min(ys)
+                    if y_extent > x_extent * (1 + 1e-4):
+                        ensure_single_user_mesh(obj.data)
+                        rotation = Matrix.Rotation(radians(90.0), 4, "Z")
+                        obj.data.transform(rotation)
+                        obj.data.update()
+                        obj.matrix_world = obj.matrix_world @ rotation.inverted()
 
                 if tool.Geometry.mesh_has_loose_geometry(obj.data):
                     self.report(

--- a/src/bonsai/test/bim/module/root/__init__.py
+++ b/src/bonsai/test/bim/module/root/__init__.py
@@ -1,0 +1,19 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.

--- a/src/bonsai/test/bim/module/root/test_operator.py
+++ b/src/bonsai/test/bim/module/root/test_operator.py
@@ -1,0 +1,107 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression tests for #7453: converting an arbitrary mesh into an IfcWall
+must line up the mesh's actual longest horizontal dimension with Bonsai's
+wall-length convention (local +X = length/axis, local Y = thickness, see
+``tool.Model.get_wall_axis``), instead of blindly trusting whichever local
+axis the mesh happened to be authored along. Getting this wrong swaps the
+wall's effective length and thickness for every downstream consumer of that
+convention (window/door snapping, layer offsets, etc)."""
+
+import bpy
+import pytest
+from mathutils import Vector
+
+import bonsai.tool as tool
+from test.bim.bootstrap import NewIfc
+
+pytestmark = pytest.mark.root
+
+
+def _convert_cube_to_wall(dimensions: tuple[float, float, float]) -> bpy.types.Object:
+    bpy.ops.mesh.primitive_cube_add(size=2.0, location=(0, 0, dimensions[2] / 2))
+    obj = bpy.context.active_object
+    obj.dimensions = dimensions
+    bpy.context.view_layer.update()
+    bpy.ops.bim.assign_class(ifc_class="IfcWall", predefined_type="", userdefined_type="")
+    return obj
+
+
+def _local_xy_extents(obj: bpy.types.Object) -> tuple[float, float]:
+    xs = [v[0] for v in obj.bound_box]
+    ys = [v[1] for v in obj.bound_box]
+    return max(xs) - min(xs), max(ys) - min(ys)
+
+
+class TestAssignClassWallOrientation(NewIfc):
+    def test_swapped_footprint_is_reoriented_so_local_x_is_the_long_axis(self):
+        # Authored with the long (3m) dimension along local Y and the short
+        # (300mm) dimension along local X - the exact #7453 repro shape.
+        obj = _convert_cube_to_wall((0.3, 3.0, 3.0))
+
+        x_extent, y_extent = _local_xy_extents(obj)
+        assert x_extent == pytest.approx(3.0, abs=1e-3), "local X should now carry the wall's long dimension"
+        assert y_extent == pytest.approx(0.3, abs=1e-3), "local Y should now carry the wall's short dimension"
+
+        element = tool.Ifc.get_entity(obj)
+        layers = tool.Model.get_material_layer_parameters(element)
+        axes = tool.Model.get_wall_axis(obj, layers=layers)
+        reference_length = (axes["reference"][1] - axes["reference"][0]).length
+        assert reference_length == pytest.approx(
+            3.0, abs=1e-3
+        ), "wall axis snapping must use the real 3m length, not the 300mm thickness"
+
+        # World-space footprint (what the user actually sees/authored) must be unchanged.
+        world_pts = [obj.matrix_world @ Vector(v) for v in obj.bound_box]
+        world_x = max(p[0] for p in world_pts) - min(p[0] for p in world_pts)
+        world_y = max(p[1] for p in world_pts) - min(p[1] for p in world_pts)
+        assert world_x == pytest.approx(0.3, abs=1e-3)
+        assert world_y == pytest.approx(3.0, abs=1e-3)
+
+    def test_already_correct_footprint_is_left_untouched(self):
+        # Long dimension already along local X - must not be rotated at all.
+        obj = _convert_cube_to_wall((3.0, 0.3, 3.0))
+
+        x_extent, y_extent = _local_xy_extents(obj)
+        assert x_extent == pytest.approx(3.0, abs=1e-3)
+        assert y_extent == pytest.approx(0.3, abs=1e-3)
+        assert tuple(obj.rotation_euler) == (0.0, 0.0, 0.0)
+
+    def test_square_footprint_is_left_as_is(self):
+        # No unambiguous "longer" axis - must not crash and must not rotate.
+        obj = _convert_cube_to_wall((2.0, 2.0, 3.0))
+
+        x_extent, y_extent = _local_xy_extents(obj)
+        assert x_extent == pytest.approx(2.0, abs=1e-3)
+        assert y_extent == pytest.approx(2.0, abs=1e-3)
+
+    def test_non_wall_class_is_not_reoriented(self):
+        # The convention (and this fix) is wall-specific. A swapped-looking
+        # footprint on another class must be imported as-is.
+        bpy.ops.mesh.primitive_cube_add(size=2.0, location=(0, 0, 1.5))
+        obj = bpy.context.active_object
+        obj.dimensions = (0.3, 3.0, 3.0)
+        bpy.context.view_layer.update()
+        bpy.ops.bim.assign_class(ifc_class="IfcSlab", predefined_type="", userdefined_type="")
+
+        x_extent, y_extent = _local_xy_extents(obj)
+        assert x_extent == pytest.approx(0.3, abs=1e-3)
+        assert y_extent == pytest.approx(3.0, abs=1e-3)


### PR DESCRIPTION
## Root cause
Converting an arbitrary mesh to an IfcWall (bim.assign_class) kept whatever local axes the mesh happened to be authored with. Every downstream consumer of wall geometry (tool.Model.get_wall_axis, window/door snapping via FilledOpeningGenerator, layer offsets) assumes local +X is the wall's length/axis direction and local Y is its thickness. A mesh resized with its long dimension along Y instead of X converted into a wall whose effective length and thickness were swapped for all of those consumers, even though the mesh's own world-space footprint was authored correctly.

Reproduced live: converting a 0.3m×3.0m×3.0m box gave get_wall_axis a reference length of 0.3m (should be 3.0m), and three window placements aimed at different points along the true 3m face all collapsed to the same spot.

## Fix
When assign_class converts a mesh into an IfcWall, rotate the mesh data 90 degrees about local Z whenever the horizontal footprint is longer along Y than along X, compensating the object's world matrix so its placement and visual footprint are unchanged. A square footprint (no unambiguous longer axis) is left as-is.

## Verification
- Verified live: reference length became 3.0m after the fix, window placements correctly spread across the true face.
- Regression: an already-correctly-authored wall is untouched (no rotation); a square footprint is untouched; world-space footprint of the fixed wall is unchanged; a non-wall class (IfcSlab) with the same swapped dimensions is correctly left untouched.
- Added 4 regression tests covering all of the above.

Fixes #7453

Generated with the assistance of an AI coding tool.