### PR TITLE
Bonsai: don't let a broken natsort disable the whole addon

### DIFF
--- a/src/bonsai/bonsai/bim/module/document/data.py
+++ b/src/bonsai/bonsai/bim/module/document/data.py
@@ -19,7 +19,12 @@
 import os
 
 import bpy
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.tool as tool
 

--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -26,7 +26,12 @@ import ifcopenshell.util.classification
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
 import ifcopenshell.util.unit
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.tool as tool
 

--- a/src/bonsai/bonsai/bim/module/material/data.py
+++ b/src/bonsai/bonsai/bim/module/material/data.py
@@ -22,7 +22,12 @@ import bpy
 import ifcopenshell
 import ifcopenshell.util.doc
 import ifcopenshell.util.element
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.tool as tool
 from bonsai.bim.module.drawing.helper import format_distance

--- a/src/bonsai/bonsai/bim/module/model/data.py
+++ b/src/bonsai/bonsai/bim/module/model/data.py
@@ -26,7 +26,12 @@ import ifcopenshell
 import ifcopenshell.util.element
 import ifcopenshell.util.schema
 from ifcopenshell.util.doc import get_entity_doc
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.tool as tool
 

--- a/src/bonsai/bonsai/bim/module/owner/data.py
+++ b/src/bonsai/bonsai/bim/module/owner/data.py
@@ -21,7 +21,12 @@ from typing import Any, Union
 import bpy
 import ifcopenshell
 from ifcopenshell.util.doc import get_entity_doc
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.tool as tool
 

--- a/src/bonsai/bonsai/bim/module/search/data.py
+++ b/src/bonsai/bonsai/bim/module/search/data.py
@@ -20,7 +20,12 @@ import json
 
 import bpy
 import ifcopenshell.util.element
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.tool as tool
 

--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -34,7 +34,12 @@ from bpy.props import (
     StringProperty,
 )
 from bpy.types import Operator
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.core.search as core
 import bonsai.tool as tool

--- a/src/bonsai/bonsai/bim/operator.py
+++ b/src/bonsai/bonsai/bim/operator.py
@@ -38,7 +38,12 @@ import bpy
 import ifcopenshell
 from bpy_extras.io_utils import ImportHelper
 from mathutils import Euler, Vector
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.bim
 import bonsai.bim.handler

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -34,7 +34,12 @@ from ifcopenshell.util.doc import (
     get_type_doc,
 )
 from ifcopenshell.util.file import IfcHeaderExtractor
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.bim
 import bonsai.bim.helper

--- a/src/bonsai/bonsai/tool/document.py
+++ b/src/bonsai/bonsai/tool/document.py
@@ -23,7 +23,12 @@ from typing import TYPE_CHECKING, Any, Union
 
 import bpy
 import ifcopenshell.util.system
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.bim.helper
 import bonsai.core.tool

--- a/src/bonsai/bonsai/tool/group.py
+++ b/src/bonsai/bonsai/tool/group.py
@@ -23,7 +23,12 @@ from typing import TYPE_CHECKING, Literal, Union, assert_never
 
 import bpy
 import ifcopenshell
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 
 import bonsai.core.tool
 import bonsai.tool as tool

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -41,7 +41,12 @@ import numpy as np
 import shapely
 import shapely.ops
 from mathutils import Matrix, Vector
-from natsort import natsorted
+
+try:
+    from natsort import natsorted
+except Exception:
+    # See #6900: don't let a broken natsort disable all of Bonsai.
+    natsorted = sorted
 from shapely import Polygon
 
 import bonsai.core.geometry

--- a/src/bonsai/test/bim/test_natsort_import_forward_compat.py
+++ b/src/bonsai/test/bim/test_natsort_import_forward_compat.py
@@ -1,0 +1,78 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Forward-compat AST contract for the optional ``natsort`` dependency.
+
+``natsorted`` is only used for cosmetic natural-sort ordering of UI dropdown
+and enum lists (see #6900). A bare module-level ``from natsort import
+natsorted`` makes ALL of Bonsai's addon registration hostage to natsort:
+if natsort is missing, or left partially initialized by some unrelated
+package colliding on ``sys.path`` (e.g. Sverchok's Conda "Python Path"
+feature dropping a `.pth` file), the resulting ``ImportError``/
+``AttributeError`` propagates out of ``bonsai.bim``'s module-level imports
+and silently disables the whole addon, not just natural sorting.
+
+Every module-level natsort import must therefore be guarded by a
+``try/except`` that falls back to the stdlib ``sorted()``."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.contract_guard
+
+ADDON_ROOT = Path(__file__).parent.parent.parent / "bonsai"
+
+
+def _is_natsort_import(node: ast.stmt) -> bool:
+    if isinstance(node, ast.ImportFrom):
+        return node.module == "natsort"
+    if isinstance(node, ast.Import):
+        return any(alias.name == "natsort" or alias.name.startswith("natsort.") for alias in node.names)
+    return False
+
+
+def _try_guards_natsort(node: ast.Try) -> bool:
+    has_import = any(_is_natsort_import(stmt) for stmt in node.body)
+    return has_import and bool(node.handlers)
+
+
+def test_no_module_level_natsort_import_is_unguarded() -> None:
+    offenders: list[str] = []
+    for path in sorted(ADDON_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:  # module-level statements only
+            if isinstance(node, ast.Try):
+                if any(_is_natsort_import(stmt) for stmt in node.body) and not _try_guards_natsort(node):
+                    rel = path.relative_to(ADDON_ROOT)
+                    offenders.append(f"{rel.as_posix()}:{node.lineno}: try-block imports natsort without except")
+                continue
+            if _is_natsort_import(node):
+                rel = path.relative_to(ADDON_ROOT)
+                offenders.append(f"{rel.as_posix()}:{node.lineno}: unguarded module-level natsort import")
+    if offenders:
+        listing = "\n  ".join(offenders)
+        pytest.fail(
+            "Unguarded module-level natsort import(s) found. Wrap in "
+            "`try: from natsort import natsorted\\nexcept Exception: natsorted = sorted` "
+            "so a missing/broken natsort degrades to plain sort() instead of disabling all "
+            "of Bonsai:\n  " + listing
+        )


### PR DESCRIPTION
## Root cause
Bonsai has 12 module-level `from natsort import natsorted` sites, eagerly imported during addon registration (either directly or through the modules import loop). natsort is only used for cosmetic natural-sort ordering of UI dropdown/enum lists. If natsort is missing, or left partially initialized by some unrelated package colliding on sys.path (e.g. a third-party addon's Conda pythonpath integration writing an unscoped .pth file), the resulting ImportError/AttributeError propagates out of these module-level imports and silently disables all of Bonsai, not just natural sorting.

Confirmed via issue #6900's reporter's own screenshot: `AttributeError: partially initialized module 'natsort' has no attribute 'compat' (most likely due to a circular import)`.

## Fix
Each of the 12 sites now does:
```python
try:
    from natsort import natsorted
except Exception:
    natsorted = sorted
```
`except Exception` (not `except ImportError`) is required: a partially-initialized/circular-import failure raises `AttributeError`, which a narrower `ImportError` guard would not catch. Verified this empirically with a real circular-import fixture.

Added an AST-based contract test that scans every file in the addon and fails if any module-level natsort import isn't guarded, so this can't silently regress.

## Verification
Live in headless Blender, full 2x2 matrix (natsort healthy/broken x before/after fix): before the fix, a broken natsort crashes registration entirely and the addon doesn't appear in sys.modules at all, reproducing the reported symptom exactly. After the fix, registration succeeds either way, degrading to plain lexicographic sort when natsort is unavailable, with natural sort unaffected when it's healthy.

Fixes #6900

Generated with the assistance of an AI coding tool.