### PR TITLE
Bonsai: draw the wall tool's void-edit confirm/cancel buttons last

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -756,6 +756,7 @@ class EditObjectUI:
             cls.draw_aggregation(context)
             cls.draw_qto(context)
             cls.draw_modes(context)
+            cls.draw_void_edit_actions(context)
 
         if context.region.type in ("UI", "WINDOW"):
             text = format_ifc_camel_case(AuthoringData.data["active_class"])
@@ -767,6 +768,7 @@ class EditObjectUI:
             cls.draw_aggregation(context)
             cls.draw_qto(context)
             cls.draw_modes(context)
+            cls.draw_void_edit_actions(context)
 
     @classmethod
     def draw_parameter_adjustments(cls, context):
@@ -1001,6 +1003,12 @@ class EditObjectUI:
             if ui_context != "TOOL_HEADER":
                 row.label(text="", icon="EVENT_SHIFT")
                 row.label(text="", icon="EVENT_O")
+
+    @classmethod
+    def draw_void_edit_actions(cls, context):
+        # Drawn last so these buttons don't shift earlier ones like Toggle Openings.
+        ui_context = str(context.region.type)
+        IS_TOOL_HEADER = ui_context == "TOOL_HEADER"
 
         if AuthoringData.data["is_voidable_element"]:
             if AuthoringData.data["has_visible_openings"]:


### PR DESCRIPTION
## Root cause
EditObjectUI.draw() called draw_void(context, row) before draw_align/draw_aggregation/draw_qto/draw_modes. draw_void included both the always-present "Add/Apply Void" button and, conditionally, the "Edit Openings" (tick) / "Hide Openings" (X) confirm/cancel buttons that only appear once openings are visible. Since those conditional buttons were drawn from that same early position, toggling openings visible/invisible inserted or removed two buttons mid-row, shifting every button after them (including "Toggle Openings" itself) left/right.

## Fix
Extracted the conditional tick/X block into a new draw_void_edit_actions() classmethod and call it last, after draw_modes(context), in both the TOOL_HEADER and UI/WINDOW draw branches. The always-present "Add/Apply Void" button stays in its original early position (unaffected by the bug); only the conditional confirm/cancel buttons move to the end.

## Verification
Live in headless Blender: recorded the exact sequence of operator draws with a stub UILayout, toggling has_visible_openings False→True. Before the fix, the tick/X buttons inserted at position 2, pushing every later button (Align/Aggregation/Qto/Modes/Toggle Openings) two slots right. After the fix, the first 10 draw calls are identical in both states; the tick/X buttons only ever append at the end.

Fixes #7481

Generated with the assistance of an AI coding tool.