### PR TITLE
docs(readme): use https for IfcOpenShell website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and many other libraries, CLI apps, and more. Support is also provided for auxil
 
 For more information, see:
 
-* [IfcOpenShell Website](http://ifcopenshell.org)
+* [IfcOpenShell Website](https://ifcopenshell.org)
 * [IfcOpenShell Documentation](https://docs.ifcopenshell.org)
   * [IfcOpenShell C++ Installation](https://docs.ifcopenshell.org/ifcopenshell/installation.html)
   * [IfcOpenShell Python Installation](https://docs.ifcopenshell.org/ifcopenshell-python/installation.html)


### PR DESCRIPTION
## Summary
- Point the README website link at `https://ifcopenshell.org` (HTTP already redirects; avoids mixed content / unnecessary hop).

## Verification
- `http://ifcopenshell.org` → 200/`https://ifcopenshell.org/`.

## Claim
`Claim: bartok` (seed). Follow-ups: `Claim:sera`.

## AI assistance
- None for this one-line docs change; human-authored.
