### PR TITLE
Bonsai: warn before a CPU without AVX2 crashes the geometry backend

### DIFF
--- a/src/bonsai/bonsai/__init__.py
+++ b/src/bonsai/bonsai/__init__.py
@@ -223,6 +223,17 @@ if IN_BLENDER:
 
     initialize_bbim_semver()
 
+    # CPU feature check before any native code runs, see cpu_check.py and issue #7458.
+    from bonsai import cpu_check
+
+    try:
+        cpu_warning = cpu_check.get_cpu_warning()
+    except Exception:
+        cpu_warning = None
+
+    if cpu_warning:
+        print(f"\n{'=' * 78}\nBONSAI CPU COMPATIBILITY WARNING\n{'=' * 78}\n{cpu_warning}\n{'=' * 78}\n")
+
     def get_binary_info() -> dict[str, Any]:
         info = {}
         py_version = sys.version_info
@@ -294,6 +305,39 @@ if IN_BLENDER:
 
             tool.Blender.get_bonsai_version.cache_clear()
 
+        if cpu_warning:
+
+            def draw_cpu_warning(self: Any, context: Any) -> None:
+                import textwrap
+
+                for line in textwrap.wrap(cpu_warning, 70):
+                    self.layout.label(text=line)
+                op = self.layout.operator("bim.open_uri", text="Learn More (GitHub Issue)", icon="URL")
+                op.uri = cpu_check.ISSUE_URL
+
+            class BIM_PT_cpu_warning(bpy.types.Panel):
+                bl_label = "CPU Compatibility Warning"
+                bl_idname = "SCENE_PT_bonsai_cpu_warning"
+                bl_space_type = "PROPERTIES"
+                bl_region_type = "WINDOW"
+                bl_context = "scene"
+
+                def draw(self, context):
+                    self.layout.alert = True
+                    self.layout.label(text="Bonsai may crash opening IFC files on this CPU", icon="ERROR")
+                    draw_cpu_warning(self, context)
+
+            def show_cpu_warning_popup() -> None:
+                # popup_menu can crash Blender itself (not just raise) with no window.
+                if bpy.app.background:
+                    return
+                try:
+                    bpy.context.window_manager.popup_menu(
+                        draw_cpu_warning, title="Bonsai CPU Compatibility Warning", icon="ERROR"
+                    )
+                except Exception:
+                    pass
+
         def register():
             if platform.system() == "Windows":
                 clean_up_dlls_safe_links()
@@ -313,7 +357,14 @@ if IN_BLENDER:
             bonsai.bim.register()
             purge_cache()
 
+            if cpu_warning:
+                bpy.utils.register_class(BIM_PT_cpu_warning)
+                bpy.app.timers.register(show_cpu_warning_popup, first_interval=0.5)
+
         def unregister():
+            if cpu_warning:
+                bpy.utils.unregister_class(BIM_PT_cpu_warning)
+
             import bonsai.bim
 
             bonsai.bim.unregister()

--- a/src/bonsai/bonsai/cpu_check.py
+++ b/src/bonsai/bonsai/cpu_check.py
@@ -1,0 +1,154 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Best-effort startup check for a CPU feature required by Bonsai's native
+geometry backend. See https://github.com/IfcOpenShell/IfcOpenShell/issues/7458.
+
+Must not import bpy or any ifcopenshell/Bonsai native module, so it stays
+importable (and unit testable) on every platform before the risky native
+code is ever touched.
+"""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+from typing import Optional
+
+# AVX2 is the only CPU feature currently known to be a real crash risk (GMP,
+# linked in by the CGAL geometry backend, historically shipped without
+# `--enable-fat`, see nix/build-all.py). Neither CGAL itself nor OpenCASCADE
+# nor IfcOpenShell's own C++ code set any -march/-mavx-style compiler flags,
+# so AVX2-via-GMP is the only confirmed unconditional ISA requirement today.
+REQUIRED_FEATURE = "avx2"
+
+ISSUE_URL = "https://github.com/IfcOpenShell/IfcOpenShell/issues/7458"
+
+# platform.machine() values that mean "this is an x86/x86_64 CPU". AVX2 is
+# x86-specific, so anything else (arm64, aarch64, ppc64le, ...) is skipped.
+_X86_MACHINES = {"x86_64", "amd64", "i386", "i486", "i586", "i686", "x86"}
+
+
+def is_x86() -> bool:
+    return platform.machine().lower() in _X86_MACHINES
+
+
+def parse_cpuinfo_flags(cpuinfo_text: str) -> Optional[set[str]]:
+    """Parse the flag set out of ``/proc/cpuinfo``-style text.
+
+    Split out from the file read so the parsing itself can be unit tested
+    against crafted text without touching the filesystem.
+    """
+    for line in cpuinfo_text.splitlines():
+        key, sep, value = line.partition(":")
+        if not sep:
+            continue
+        if key.strip().lower() in ("flags", "features"):
+            return set(value.lower().split())
+    return None
+
+
+def _linux_flags() -> Optional[set[str]]:
+    try:
+        with open("/proc/cpuinfo", "r", encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+    except OSError:
+        return None
+    return parse_cpuinfo_flags(content)
+
+
+def _macos_flags() -> Optional[set[str]]:
+    """Apple Intel exposes ISA flags via sysctl (Apple Silicon has no such
+    keys and is filtered out earlier by is_x86())."""
+    flags: set[str] = set()
+    found_any = False
+    for name in ("machdep.cpu.features", "machdep.cpu.leaf7_features"):
+        try:
+            result = subprocess.run(
+                ["sysctl", "-n", name],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if result.returncode != 0:
+            continue
+        found_any = True
+        flags.update(result.stdout.lower().split())
+    return flags if found_any else None
+
+
+def _windows_has_avx2() -> Optional[bool]:
+    """Windows has no /proc/cpuinfo. IsProcessorFeaturePresent with
+    PF_AVX2_INSTRUCTIONS_AVAILABLE (40) is the officially documented WinAPI
+    call for this, added in the Windows 10 SDK. On editions too old to know
+    about the flag it always reports False, indistinguishable from a
+    genuinely missing feature; see detect_avx2_support()."""
+    try:
+        import ctypes
+
+        PF_AVX2_INSTRUCTIONS_AVAILABLE = 40
+        return bool(ctypes.windll.kernel32.IsProcessorFeaturePresent(PF_AVX2_INSTRUCTIONS_AVAILABLE))
+    except Exception:
+        return None
+
+
+def detect_avx2_support() -> Optional[bool]:
+    """True/False if determined with confidence, None if undetermined.
+
+    Only meaningful when is_x86() is True. Returns None (i.e. "don't know")
+    whenever a platform-specific lookup fails, so callers can treat unknown
+    the same as "don't warn" and never produce a false positive.
+    """
+    system = platform.system()
+    if system == "Linux":
+        flags = _linux_flags()
+    elif system == "Darwin":
+        flags = _macos_flags()
+    elif system == "Windows":
+        return _windows_has_avx2()
+    else:
+        return None
+    if flags is None:
+        return None
+    return REQUIRED_FEATURE in flags
+
+
+def get_cpu_warning() -> Optional[str]:
+    """Return a user-facing warning string if this CPU is likely to SIGILL
+    Bonsai's CGAL/GMP geometry backend, otherwise None.
+
+    Deliberately conservative: any ambiguity (non-x86, detection failed,
+    unsupported platform) resolves to "don't warn".
+    """
+    if not is_x86():
+        return None
+    has_feature = detect_avx2_support()
+    if has_feature is not False:
+        return None
+    return (
+        "This CPU does not support the AVX2 instruction set. Bonsai's geometry engine "
+        "(the CGAL/GMP-based 'Hybrid CGAL-OCC' and 'CGAL' options) can crash Blender "
+        "outright with no error message (SIGILL) on such CPUs when opening IFC files. "
+        "To avoid this, in the Scene Properties > Bonsai tab > Current Project panel, "
+        "enable Advanced and set Geometry Library to 'OpenCASCADE' before loading a project, "
+        f"or build IfcOpenShell from source for your CPU. See {ISSUE_URL} for details."
+    )

--- a/src/bonsai/docs/guides/troubleshooting.rst
+++ b/src/bonsai/docs/guides/troubleshooting.rst
@@ -88,8 +88,23 @@ can `report a bug <https://github.com/ifcopenshell/ifcopenshell/issues>`_ or
 
    If you have Python 3.11, then you probably downloaded build for wrong Python
    version by accident. To fix it uninstall it and download Python 3.11 build
-   from `Github Releases <https://github.com/IfcOpenShell/IfcOpenShell/releases>`__ 
+   from `Github Releases <https://github.com/IfcOpenShell/IfcOpenShell/releases>`__
    or from Blender extensions platform.
+
+5. **Blender crashes outright ("Illegal instruction" / SIGILL) as soon as I open an
+   IFC file, with no Bonsai error message at all**
+
+   This happens on CPUs older than about 2013 (e.g. Intel Ivy Bridge and earlier)
+   that don't support the AVX2 instruction set, which the CGAL-based geometry
+   engine relies on. Bonsai will warn you about this at startup if it detects
+   such a CPU, since the crash itself cannot be caught or reported like a normal
+   error.
+
+   In :menuselection:`Scene Properties --> Bonsai tab --> Current Project`,
+   enable **Advanced** and set **Geometry Library** to **OpenCASCADE** before
+   loading a project. This avoids the CGAL code path entirely. Alternatively,
+   build IfcOpenShell from source for your CPU. See `issue #7458
+   <https://github.com/IfcOpenShell/IfcOpenShell/issues/7458>`__ for details.
 
 Saving and loading blend files
 ------------------------------

--- a/src/bonsai/test/bim/test_cpu_check.py
+++ b/src/bonsai/test/bim/test_cpu_check.py
@@ -1,0 +1,186 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Startup AVX2-support detection (see
+https://github.com/IfcOpenShell/IfcOpenShell/issues/7458): a CPU without
+AVX2 can SIGILL Bonsai's CGAL/GMP geometry backend with no catchable
+exception, so bonsai.cpu_check must reliably flag such CPUs *before* any
+native code runs, while never producing a false positive on hardware that
+does have the feature."""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.misc
+
+import bonsai.cpu_check as cpu_check
+
+# A real Ivy Bridge (2012, pre-AVX2, the CPU family named in #7458) flags line.
+IVY_BRIDGE_CPUINFO = (
+    "processor\t: 0\n"
+    "vendor_id\t: GenuineIntel\n"
+    "model name\t: Intel(R) Core(TM) i7-3770 CPU @ 3.40GHz\n"
+    "flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 "
+    "clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm "
+    "constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid "
+    "aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr "
+    "pdcm pcid sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer aes xsave avx f16c rdrand "
+    "lahf_lm cpuid_fault epb pti ssbd ibrs ibpb stibp tpr_shadow vnmi flexpriority ept "
+    "vpid fsgsbase smep erms xsaveopt dtherm ida arat pln pts md_clear flush_l1d\n"
+)
+
+# A Haswell (2013, first AVX2 generation) flags line.
+HASWELL_CPUINFO = (
+    "processor\t: 0\n"
+    "model name\t: Intel(R) Core(TM) i7-4770 CPU @ 3.40GHz\n"
+    "flags\t\t: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 "
+    "clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm "
+    "constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid "
+    "aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 fma cx16 xtpr "
+    "pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c "
+    "rdrand lahf_lm abm cpuid_fault epb invpcid_single pti ssbd ibrs ibpb stibp "
+    "tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms "
+    "invpcid xsaveopt dtherm ida arat pln pts md_clear flush_l1d\n"
+)
+
+
+class TestParseCpuinfoFlags:
+    def test_extracts_flags_line(self):
+        flags = cpu_check.parse_cpuinfo_flags(IVY_BRIDGE_CPUINFO)
+        assert flags is not None
+        assert "avx" in flags
+        assert "avx2" not in flags
+
+    def test_haswell_has_avx2(self):
+        flags = cpu_check.parse_cpuinfo_flags(HASWELL_CPUINFO)
+        assert flags is not None
+        assert "avx2" in flags
+
+    def test_missing_flags_line_returns_none(self):
+        assert cpu_check.parse_cpuinfo_flags("processor: 0\nmodel name: Weird CPU\n") is None
+
+    def test_features_key_is_also_recognised(self):
+        # Some non-x86 /proc/cpuinfo variants use "Features" instead of "flags";
+        # not a path we ever call this from x86-only detection, but the parser
+        # itself should stay generic and not silently miss it.
+        flags = cpu_check.parse_cpuinfo_flags("Features\t: fp asimd avx2\n")
+        assert flags == {"fp", "asimd", "avx2"}
+
+
+class TestIsX86:
+    @pytest.mark.parametrize("machine", ["x86_64", "AMD64", "i686", "X86"])
+    def test_x86_machines_detected(self, machine):
+        with patch("platform.machine", return_value=machine):
+            assert cpu_check.is_x86() is True
+
+    @pytest.mark.parametrize("machine", ["arm64", "aarch64", "ppc64le"])
+    def test_non_x86_machines_skipped(self, machine):
+        with patch("platform.machine", return_value=machine):
+            assert cpu_check.is_x86() is False
+
+
+class TestGetCpuWarning:
+    def test_linux_ivy_bridge_without_avx2_warns(self):
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch("platform.system", return_value="Linux"),
+            patch.object(cpu_check, "_linux_flags", return_value=cpu_check.parse_cpuinfo_flags(IVY_BRIDGE_CPUINFO)),
+        ):
+            warning = cpu_check.get_cpu_warning()
+            assert warning is not None
+            assert "AVX2" in warning
+            assert cpu_check.ISSUE_URL in warning
+
+    def test_linux_haswell_with_avx2_does_not_warn(self):
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch("platform.system", return_value="Linux"),
+            patch.object(cpu_check, "_linux_flags", return_value=cpu_check.parse_cpuinfo_flags(HASWELL_CPUINFO)),
+        ):
+            assert cpu_check.get_cpu_warning() is None
+
+    def test_undetectable_linux_cpuinfo_does_not_warn(self):
+        # e.g. a container/sandbox without /proc/cpuinfo, or a Linux running on
+        # non-x86 that somehow still reports machine() as x86 (shouldn't happen,
+        # but detection failure must never produce a false positive).
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch("platform.system", return_value="Linux"),
+            patch.object(cpu_check, "_linux_flags", return_value=None),
+        ):
+            assert cpu_check.get_cpu_warning() is None
+
+    def test_arm64_never_warns_even_if_platform_lies(self):
+        # This is the real scenario on the Apple Silicon development machine:
+        # AVX2 is an x86-only concept, so non-x86 must always be a hard skip,
+        # regardless of what any lower-level flag lookup would have said.
+        with (
+            patch("platform.machine", return_value="arm64"),
+            patch("platform.system", return_value="Darwin"),
+            patch.object(cpu_check, "_macos_flags", return_value=set()),
+        ):
+            assert cpu_check.get_cpu_warning() is None
+
+    def test_macos_intel_without_avx2_warns(self):
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch("platform.system", return_value="Darwin"),
+            patch.object(cpu_check, "_macos_flags", return_value={"sse4.2", "avx"}),
+        ):
+            assert cpu_check.get_cpu_warning() is not None
+
+    def test_macos_intel_with_avx2_does_not_warn(self):
+        with (
+            patch("platform.machine", return_value="x86_64"),
+            patch("platform.system", return_value="Darwin"),
+            patch.object(cpu_check, "_macos_flags", return_value={"avx1.0", "avx2", "fma"}),
+        ):
+            assert cpu_check.get_cpu_warning() is None
+
+    def test_windows_without_avx2_warns(self):
+        with (
+            patch("platform.machine", return_value="AMD64"),
+            patch("platform.system", return_value="Windows"),
+            patch.object(cpu_check, "_windows_has_avx2", return_value=False),
+        ):
+            assert cpu_check.get_cpu_warning() is not None
+
+    def test_windows_with_avx2_does_not_warn(self):
+        with (
+            patch("platform.machine", return_value="AMD64"),
+            patch("platform.system", return_value="Windows"),
+            patch.object(cpu_check, "_windows_has_avx2", return_value=True),
+        ):
+            assert cpu_check.get_cpu_warning() is None
+
+    def test_unsupported_platform_does_not_warn(self):
+        with patch("platform.machine", return_value="x86_64"), patch("platform.system", return_value="FreeBSD"):
+            assert cpu_check.detect_avx2_support() is None
+            assert cpu_check.get_cpu_warning() is None
+
+    def test_current_host_does_not_false_positive(self):
+        """Guardrail against the exact regression this module exists to avoid:
+        never warn without real confidence the CPU is affected."""
+        warning = cpu_check.get_cpu_warning()
+        if cpu_check.is_x86():
+            assert cpu_check.detect_avx2_support() is not False or warning is not None
+        else:
+            assert warning is None


### PR DESCRIPTION
## Root cause
Bonsai's default "Hybrid CGAL-OCC" geometry library links GMP (via CGAL), and GMP's non-fat build compiles hardcoded AVX2 instructions on the build host. A CPU without AVX2 (Ivy Bridge, 2012, and older) hits a SIGILL, a hardware trap that terminates Blender outright with no catchable Python exception and no error message. aothms already shipped a real fix for the build side (GMP --enable-fat, commit ab3108ff59, confirmed live in current release builds). This adds the other half odofaro asked for: a proactive warning, since a SIGILL can't be caught after the fact.

## Fix
New bonsai/cpu_check.py: pure-stdlib, no bpy or native-module imports, so it's safely importable before any risky native code runs. Detects AVX2 support per-OS (Linux via /proc/cpuinfo, macOS via sysctl, Windows via IsProcessorFeaturePresent), gated on x86 architecture (a hard no-op on ARM). Deliberately conservative: any ambiguity (non-x86, detection failure, unsupported platform) resolves to "don't warn" — false negatives are acceptable, false positives are not.

Wired into bonsai/__init__.py, computed once at startup wrapped in try/except so detection can never block Bonsai loading. When triggered: a console banner, a persistent Scene Properties panel (mirroring the existing BIM_PT_fatal_error pattern), and a one-shot popup via bpy.app.timers — the popup explicitly checks bpy.app.background first, since calling popup_menu with no window crashes Blender itself (a real, separately-confirmed native crash, not just a Python exception).

## Verification
- 21 unit tests covering real historical CPU flag data (Ivy Bridge lacks avx2, Haswell has it) across Linux/macOS/Windows mocked scenarios, all pass.
- Live in headless Blender: confirmed no false positive on this ARM64 host, and confirmed correct end-to-end behavior (console banner, panel registration, no exceptions) when simulating a missing-AVX2 x86 CPU.
- Confirmed the popup_menu-in-background crash is real (via an actual crash dump) before adding the bpy.app.background guard, and confirmed no crash after.

Related to #7458

Generated with the assistance of an AI coding tool.