### PR TITLE
Bonsai: independent locks for the first and last stair tread

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/prop.py
+++ b/src/bonsai/bonsai/bim/module/model/prop.py
@@ -541,13 +541,28 @@ class BIMStairProperties(PropertyGroup):
             self["nosing_length"] = 0
         update_stair(self, context)
 
-    def update_custom_tread_lock(self, context: bpy.types.Context) -> None:
-        """When lock is enabled, sync custom treads with tread_run"""
-        if self.custom_tread_lock:
-            self["custom_first_last_tread_run"] = (self.tread_run, self.tread_run)
+    def update_custom_first_tread_lock(self, context: bpy.types.Context) -> None:
+        """When lock is enabled, sync the first custom tread with tread_run"""
+        if self.custom_first_tread_lock:
+            current = self.custom_first_last_tread_run
+            self["custom_first_last_tread_run"] = (self.tread_run, current[1])
         update_stair(self, context)
 
-    non_si_units_props = ("is_editing", "number_of_treads", "has_top_nib", "stair_type", "custom_tread_lock")
+    def update_custom_last_tread_lock(self, context: bpy.types.Context) -> None:
+        """When lock is enabled, sync the last custom tread with tread_run"""
+        if self.custom_last_tread_lock:
+            current = self.custom_first_last_tread_run
+            self["custom_first_last_tread_run"] = (current[0], self.tread_run)
+        update_stair(self, context)
+
+    non_si_units_props = (
+        "is_editing",
+        "number_of_treads",
+        "has_top_nib",
+        "stair_type",
+        "custom_first_tread_lock",
+        "custom_last_tread_lock",
+    )
 
     is_editing: bpy.props.BoolProperty(default=False)
     width: bpy.props.FloatProperty(name="Width", default=1.2, min=0.01, subtype="DISTANCE", update=update_stair)
@@ -587,15 +602,22 @@ class BIMStairProperties(PropertyGroup):
         default="CONCRETE",
         update=validate_nosing_value,
     )
-    custom_tread_lock: bpy.props.BoolProperty(
-        name="Lock First/Last Treads to Tread Run",
-        description="When enabled, first and last treads automatically use the Tread Run value",
+    custom_first_tread_lock: bpy.props.BoolProperty(
+        name="Lock First Tread to Tread Run",
+        description="When enabled, the first tread automatically uses the Tread Run value",
         default=True,
-        update=update_custom_tread_lock,
+        update=update_custom_first_tread_lock,
+    )
+    custom_last_tread_lock: bpy.props.BoolProperty(
+        name="Lock Last Tread to Tread Run",
+        description="When enabled, the last tread automatically uses the Tread Run value",
+        default=True,
+        update=update_custom_last_tread_lock,
     )
     custom_first_last_tread_run: bpy.props.FloatVectorProperty(
         name="Custom First / Last Treads Widths",
-        description='Specify custom first / last treads widths, different from the general "Tread Run". Leave 0 to disable.',
+        description='Specify custom first / last treads widths, different from the general "Tread Run". '
+        "Only used for a tread whose lock (Lock First/Last Tread to Tread Run) is disabled.",
         default=(0, 0),
         min=0,
         unit="LENGTH",
@@ -634,7 +656,8 @@ class BIMStairProperties(PropertyGroup):
         top_slab_depth: float
         has_top_nib: bool
         stair_type: str
-        custom_tread_lock: bool
+        custom_first_tread_lock: bool
+        custom_last_tread_lock: bool
         custom_first_last_tread_run: tuple[float, float]
         nosing_length: float
         nosing_depth: float
@@ -674,12 +697,12 @@ class BIMStairProperties(PropertyGroup):
             stair_kwargs.update(generic_props)
 
         non_si_units_props = self.non_si_units_props
-        # If locked, use tread_run for both first and last treads
-        if self.custom_tread_lock:
+        # A locked side is encoded as `None` so the generator uses the default run.
+        first_run = None if self.custom_first_tread_lock else self.custom_first_last_tread_run[0]
+        last_run = None if self.custom_last_tread_lock else self.custom_first_last_tread_run[1]
+        stair_kwargs["custom_first_last_tread_run"] = (first_run, last_run)
+        if first_run is None and last_run is None:
             non_si_units_props += ("custom_first_last_tread_run",)
-            stair_kwargs["custom_first_last_tread_run"] = (None, None)
-        else:
-            stair_kwargs["custom_first_last_tread_run"] = self.custom_first_last_tread_run
 
         if not convert_to_project_units:
             return stair_kwargs
@@ -688,22 +711,32 @@ class BIMStairProperties(PropertyGroup):
         return stair_kwargs
 
     def get_props_kwargs_for_ifc_export(self, convert_to_project_units=False, stair_type=None):
-        """Get props including custom_tread_lock for saving to IFC"""
+        """Get props including the first/last tread locks for saving to IFC"""
         stair_kwargs = self.get_props_kwargs(convert_to_project_units, stair_type)
         # Add the lock state for IFC storage (after getting base kwargs to avoid passing to generate function)
-        stair_kwargs["custom_tread_lock"] = self.custom_tread_lock
+        stair_kwargs["custom_first_tread_lock"] = self.custom_first_tread_lock
+        stair_kwargs["custom_last_tread_lock"] = self.custom_last_tread_lock
         return stair_kwargs
 
     def set_props_kwargs_from_ifc_data(self, kwargs):
         kwargs = tool.Model.convert_data_to_si_units(kwargs, self.non_si_units_props)
         tread_run = kwargs.get("tread_run", 0.3)
 
-        # Determine lock state based on whether custom treads match tread_run
-        # If custom_tread_lock wasn't saved (old files), infer it from the data
-        if "custom_tread_lock" not in kwargs:
-            custom_treads = kwargs.get("custom_first_last_tread_run", (0.0, 0.0))
-            # Lock is off if either custom tread differs from tread_run and is not 0
-            kwargs["custom_tread_lock"] = all(ct not in (0.0, tread_run) for ct in custom_treads)
+        # Backwards compatibility with files saved before first/last treads had
+        # independent locks.
+        if "custom_first_tread_lock" not in kwargs or "custom_last_tread_lock" not in kwargs:
+            if "custom_tread_lock" in kwargs:
+                # A single combined lock was saved: both sides shared its state.
+                lock = kwargs["custom_tread_lock"]
+                kwargs.setdefault("custom_first_tread_lock", lock)
+                kwargs.setdefault("custom_last_tread_lock", lock)
+            else:
+                # Even older files never saved a lock at all: infer it per side
+                # from whether the custom value looks like a default one.
+                custom_treads = kwargs.get("custom_first_last_tread_run", (0.0, 0.0))
+                kwargs.setdefault("custom_first_tread_lock", custom_treads[0] in (None, 0.0, tread_run))
+                kwargs.setdefault("custom_last_tread_lock", custom_treads[1] in (None, 0.0, tread_run))
+        kwargs.pop("custom_tread_lock", None)
 
         if "custom_first_last_tread_run" in kwargs:
             custom_treads = kwargs["custom_first_last_tread_run"]
@@ -715,11 +748,17 @@ class BIMStairProperties(PropertyGroup):
 
     def copy_to(self, target_props: "BIMStairProperties") -> None:
         """Copy preset values to target stair properties."""
-        target_props.custom_tread_lock = self.custom_tread_lock
+        target_props.custom_first_tread_lock = self.custom_first_tread_lock
+        target_props.custom_last_tread_lock = self.custom_last_tread_lock
         for prop_name, prop_value in self.get_props_kwargs().items():
-            # Skip custom_first_last_tread_run if it contains None values (when lock is enabled)
-            if prop_name == "custom_first_last_tread_run" and None in prop_value:
-                continue
+            if prop_name == "custom_first_last_tread_run":
+                # Fall back to this side's tread_run wherever it's locked (`None`),
+                # so the value is sensible if the user unlocks it later.
+                first, last = prop_value
+                prop_value = (
+                    self.tread_run if first is None else first,
+                    self.tread_run if last is None else last,
+                )
             setattr(target_props, prop_name, prop_value)
 
     def is_concrete_stair(self) -> bool:
@@ -729,10 +768,16 @@ class BIMStairProperties(PropertyGroup):
         return self.nosing_length != 0.0 and self.stair_type != "WOOD/STEEL"
 
     def has_custom_treads(self) -> bool:
-        return not self.custom_tread_lock
+        return not self.custom_first_tread_lock or not self.custom_last_tread_lock
+
+    def has_custom_first_tread(self) -> bool:
+        return not self.custom_first_tread_lock
+
+    def has_custom_last_tread(self) -> bool:
+        return not self.custom_last_tread_lock
 
     def has_tread_run_gizmo(self) -> bool:
-        return self.custom_tread_lock or self.number_of_treads > 2
+        return self.custom_first_tread_lock or self.custom_last_tread_lock or self.number_of_treads > 2
 
     def has_tread_depth(self) -> bool:
         return self.stair_type != "GENERIC"
@@ -748,19 +793,20 @@ class BIMStairProperties(PropertyGroup):
     def get_total_run(self) -> float:
         """Calculate the total horizontal run of the stair.
 
-        Takes into account custom first/last tread runs when custom_tread_lock is False.
+        Takes into account a custom first tread run when ``custom_first_tread_lock``
+        is disabled, and a custom last tread run when ``custom_last_tread_lock`` is
+        disabled, independently of each other.
         """
         number_of_rises = self.number_of_treads + 1
         total_run = 0.0
         default_rises = number_of_rises
 
-        if not self.custom_tread_lock:
-            if self.custom_first_last_tread_run[0] is not None:  # May be 0 though
-                default_rises -= 1
-                total_run += self.custom_first_last_tread_run[0]
-            if self.custom_first_last_tread_run[1] is not None:  # May be 0 though
-                default_rises -= 1
-                total_run += self.custom_first_last_tread_run[1]
+        if not self.custom_first_tread_lock:
+            default_rises -= 1
+            total_run += self.custom_first_last_tread_run[0]
+        if not self.custom_last_tread_lock:
+            default_rises -= 1
+            total_run += self.custom_first_last_tread_run[1]
 
         total_run += self.tread_run * default_rises
         return total_run
@@ -780,18 +826,22 @@ class BIMStairProperties(PropertyGroup):
     def get_custom_tread_info(self) -> tuple[float, int]:
         """Calculate total custom tread length and count.
 
+        A tread counts as custom (excluded from the default tread_run
+        redistribution) purely based on whether its lock is disabled, so a
+        genuinely zero-width custom tread is handled the same as any other
+        custom value.
+
         Returns:
             Tuple of (custom_length, custom_count)
         """
         custom_length = 0.0
         custom_count = 0
-        if not self.custom_tread_lock:
-            if self.custom_first_last_tread_run[0] != 0:
-                custom_length += self.custom_first_last_tread_run[0]
-                custom_count += 1
-            if self.custom_first_last_tread_run[1] != 0:
-                custom_length += self.custom_first_last_tread_run[1]
-                custom_count += 1
+        if not self.custom_first_tread_lock:
+            custom_length += self.custom_first_last_tread_run[0]
+            custom_count += 1
+        if not self.custom_last_tread_lock:
+            custom_length += self.custom_first_last_tread_run[1]
+            custom_count += 1
         return custom_length, custom_count
 
     def calculate_total_length(self) -> float:

--- a/src/bonsai/bonsai/bim/module/model/stair.py
+++ b/src/bonsai/bonsai/bim/module/model/stair.py
@@ -211,7 +211,7 @@ class AddStair(bpy.types.Operator, tool.Ifc.Operator):
 
         tool.Blender.get_addon_preferences().default_parameters.stair.copy_to(props)
 
-        # Use the special method that includes custom_tread_lock for IFC storage
+        # Use the special method that includes the first/last tread locks for IFC storage
         stair_data = props.get_props_kwargs_for_ifc_export(convert_to_project_units=True)
         pset = tool.Pset.get_element_pset(element, "BBIM_Stair")
         if not pset:
@@ -268,7 +268,7 @@ class FinishEditingStair(bpy.types.Operator, tool.Ifc.Operator):
         assert element
         props = tool.Model.get_stair_props(obj)
 
-        # Use the special method that includes custom_tread_lock for IFC storage
+        # Use the special method that includes the first/last tread locks for IFC storage
         data = props.get_props_kwargs_for_ifc_export(convert_to_project_units=True)
         regenerate_stair_mesh(obj)
         tool.Model.add_body_representation(obj)
@@ -336,7 +336,16 @@ class ToggleStairProperty(bpy.types.Operator):
     # Map property names to their descriptions
     PROPERTY_DESCRIPTIONS: dict[str, str] = {
         "total_length_lock": "Lock/unlock total stair length. When locked, changing treads adjusts tread depth",
-        "custom_tread_lock": "Lock/unlock first and last tread dimensions. When unlocked, they can differ from other treads",
+        "custom_first_tread_lock": (
+            "Lock/unlock the first tread's run independently of the last tread. "
+            "When unlocked, it can be set to a custom value that stays fixed while "
+            "Total Length Target adjusts the other treads"
+        ),
+        "custom_last_tread_lock": (
+            "Lock/unlock the last tread's run independently of the first tread. "
+            "When unlocked, it can be set to a custom value that stays fixed while "
+            "Total Length Target adjusts the other treads"
+        ),
     }
 
     @classmethod
@@ -483,7 +492,7 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
     bl_options = {"3D", "PERSISTENT"}
 
     # === Stair-Specific Icon Layout ===
-    # Row order: [Validate] [Cancel] [Cycle] [TreadLock] [xN] [Plus] [Minus]
+    # Row order: [Validate] [Cancel] [Cycle] [FirstTreadLock] [LastTreadLock] [xN] [Plus] [Minus]
     # The base class assigns X positions from ``feature_slots`` tuple order —
     # adding an icon is a one-line append, no hardcoded X constant.
     ICON_PLUS_MINUS_SCALE = 0.24  # Scale for plus/minus icons (slightly larger)
@@ -493,12 +502,20 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
 
     feature_slots: ClassVar[tuple[IconSlot, ...]] = (
         IconSlot(
-            name="tread_lock",
+            name="first_tread_lock",
             gizmo_idname="VIEW3D_GT_lock",
             variants=("open", "closed"),
             operator="bim.toggle_stair_property",
             color=(1.0, 1.0, 1.0),
-            operator_props=(("property_name", "custom_tread_lock"),),
+            operator_props=(("property_name", "custom_first_tread_lock"),),
+        ),
+        IconSlot(
+            name="last_tread_lock",
+            gizmo_idname="VIEW3D_GT_lock",
+            variants=("open", "closed"),
+            operator="bim.toggle_stair_property",
+            color=(1.0, 1.0, 1.0),
+            operator_props=(("property_name", "custom_last_tread_lock"),),
         ),
         IconSlot(name="tread_count_label", placeholder=True),
         IconSlot(
@@ -561,9 +578,9 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
             min_value=0.01,
             visibility_condition=lambda p: p.has_tread_run_gizmo(),
             matrix_position=lambda p: V_(
-                0 if p.custom_tread_lock else p.custom_first_last_tread_run[0],
+                0 if p.custom_first_tread_lock else p.custom_first_last_tread_run[0],
                 0,
-                p.get_riser_height() if p.custom_tread_lock else p.get_riser_height() * 2,
+                p.get_riser_height() if p.custom_first_tread_lock else p.get_riser_height() * 2,
             ),
         ),
         DimensionGizmoConfig(
@@ -571,7 +588,7 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
             axis=(1, 0, 0),
             prop_name="First Tread",
             min_value=0.01,
-            visibility_condition=lambda p: p.has_custom_treads(),
+            visibility_condition=lambda p: p.has_custom_first_tread(),
             compute_value=_tread_run_accessors[0][0],
             apply_value=_tread_run_accessors[0][1],
             matrix_position=lambda p: V_(0, 0, p.get_riser_height()),
@@ -581,7 +598,7 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
             axis=(1, 0, 0),
             prop_name="Last Tread",
             min_value=0.01,
-            visibility_condition=lambda p: p.has_custom_treads(),
+            visibility_condition=lambda p: p.has_custom_last_tread(),
             compute_value=_tread_run_accessors[1][0],
             apply_value=_tread_run_accessors[1][1],
             matrix_position=lambda p: V_(p.get_total_run() - p.custom_first_last_tread_run[1], 0, p.height),
@@ -664,7 +681,8 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
         """Update stair-specific lock and tread count gizmos. Lock positioning is
         handled per-frame in the dimension-positioning hook."""
         self.update_lock_gizmo(props)
-        self.update_tread_lock_gizmo(props)
+        self.update_first_tread_lock_gizmo(props)
+        self.update_last_tread_lock_gizmo(props)
         self.update_tread_count_gizmos(props)
 
     def update_lock_gizmo(self, props: "BIMStairProperties") -> None:
@@ -680,20 +698,35 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
         self.total_length_lock_open_gizmo.hide = props.total_length_lock
         self.total_length_lock_closed_gizmo.hide = not props.total_length_lock
 
-    def update_tread_lock_gizmo(self, props: "BIMStairProperties") -> None:
-        """Show the open/closed lock variant matching ``props.custom_tread_lock``.
+    def update_first_tread_lock_gizmo(self, props: "BIMStairProperties") -> None:
+        """Show the open/closed lock variant matching ``props.custom_first_tread_lock``.
 
         Both pair members share an X position (set by the base's slot
         positioning); this picks which one is visible per frame so a state
         flip can't reveal both at once."""
-        if not hasattr(self, "tread_lock_open_gizmo"):
+        if not hasattr(self, "first_tread_lock_open_gizmo"):
             return
         if not props.is_editing:
-            self.tread_lock_open_gizmo.hide = True
-            self.tread_lock_closed_gizmo.hide = True
+            self.first_tread_lock_open_gizmo.hide = True
+            self.first_tread_lock_closed_gizmo.hide = True
             return
-        self.tread_lock_open_gizmo.hide = props.custom_tread_lock
-        self.tread_lock_closed_gizmo.hide = not props.custom_tread_lock
+        self.first_tread_lock_open_gizmo.hide = props.custom_first_tread_lock
+        self.first_tread_lock_closed_gizmo.hide = not props.custom_first_tread_lock
+
+    def update_last_tread_lock_gizmo(self, props: "BIMStairProperties") -> None:
+        """Show the open/closed lock variant matching ``props.custom_last_tread_lock``.
+
+        Both pair members share an X position (set by the base's slot
+        positioning); this picks which one is visible per frame so a state
+        flip can't reveal both at once."""
+        if not hasattr(self, "last_tread_lock_open_gizmo"):
+            return
+        if not props.is_editing:
+            self.last_tread_lock_open_gizmo.hide = True
+            self.last_tread_lock_closed_gizmo.hide = True
+            return
+        self.last_tread_lock_open_gizmo.hide = props.custom_last_tread_lock
+        self.last_tread_lock_closed_gizmo.hide = not props.custom_last_tread_lock
 
     def update_tread_count_gizmos(self, props: "BIMStairProperties") -> None:
         """Update visibility of the +/- tread count gizmos and the ``xN``
@@ -748,8 +781,8 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
         """Update tread-related dimension gizmos (tread_run, custom first/last tread)."""
         y_pos = self.get_y_position_for_view(props, viewing_from_negative_y, use_offset=False)
 
-        # tread_run position depends on custom_tread_lock state
-        if props.custom_tread_lock:
+        # tread_run position depends on custom_first_tread_lock state
+        if props.custom_first_tread_lock:
             tread_x, tread_z = 0, riser_height
         else:
             tread_x = props.custom_first_last_tread_run[0]
@@ -817,10 +850,20 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
             "cycle_gizmo", mw, self.ICON_CYCLE_X, y_pos, icon_z, billboard_rot, scale=self.ICON_CYCLE_SCALE
         )
         self.set_icon_gizmo_pair_position(
-            "tread_lock_open_gizmo",
-            "tread_lock_closed_gizmo",
+            "first_tread_lock_open_gizmo",
+            "first_tread_lock_closed_gizmo",
             mw,
-            slot_x["tread_lock"],
+            slot_x["first_tread_lock"],
+            y_pos,
+            icon_z - self.EDITING_ICON_SCALE / 2,
+            billboard_rot,
+            scale=self.EDITING_ICON_SCALE,
+        )
+        self.set_icon_gizmo_pair_position(
+            "last_tread_lock_open_gizmo",
+            "last_tread_lock_closed_gizmo",
+            mw,
+            slot_x["last_tread_lock"],
             y_pos,
             icon_z - self.EDITING_ICON_SCALE / 2,
             billboard_rot,

--- a/src/bonsai/bonsai/bim/module/model/ui.py
+++ b/src/bonsai/bonsai/bim/module/model/ui.py
@@ -826,29 +826,31 @@ def draw_roof_properties(layout: bpy.types.UILayout, props: module_prop.BIMRoofP
 def draw_stair_properties(layout: bpy.types.UILayout, props: module_prop.BIMStairProperties) -> None:
     """Draw stair properties UI (shared between properties panel and preferences)."""
     for prop_name in props.get_props_kwargs():
-        # Skip custom_tread_lock as it's handled with custom_first_last_tread_run
-        if prop_name == "custom_tread_lock":
-            continue
-
         prop_value = getattr(props, prop_name)
 
-        # Special handling for custom_first_last_tread_run
+        # First/last tread each get their own independent lock toggle + value.
         if prop_name == "custom_first_last_tread_run":
-            # Draw the lock toggle
-            row_lock = layout.row(align=True)
-            lock_text = "Lock First/Last Treads" if not props.custom_tread_lock else "Unlock First/Last Treads"
-            row_lock.prop(
+            row_first_lock = layout.row(align=True)
+            first_locked = props.custom_first_tread_lock
+            row_first_lock.prop(
                 props,
-                "custom_tread_lock",
-                text=lock_text,
-                icon="LOCKED" if props.custom_tread_lock else "UNLOCKED",
+                "custom_first_tread_lock",
+                text="Lock First Tread" if first_locked else "Unlock First Tread",
+                icon="LOCKED" if first_locked else "UNLOCKED",
             )
+            if not first_locked:
+                row_first_lock.prop(props, prop_name, index=0, text="First Tread Run")
 
-            # Only show the custom values input if unlocked
-            if not props.custom_tread_lock:
-                prop_readable_name = props.bl_rna.properties[prop_name].name
-                layout.label(text=f"{prop_readable_name}:")
-                layout.prop(props, prop_name, text="")
+            row_last_lock = layout.row(align=True)
+            last_locked = props.custom_last_tread_lock
+            row_last_lock.prop(
+                props,
+                "custom_last_tread_lock",
+                text="Lock Last Tread" if last_locked else "Unlock Last Tread",
+                icon="LOCKED" if last_locked else "UNLOCKED",
+            )
+            if not last_locked:
+                row_last_lock.prop(props, prop_name, index=1, text="Last Tread Run")
         elif isinstance(prop_value, Iterable) and not isinstance(prop_value, str):
             prop_readable_name = props.bl_rna.properties[prop_name].name
             layout.label(text=f"{prop_readable_name}:")

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -196,9 +196,11 @@ class Model(bonsai.core.tool.Model):
         for prop_name in data:
             if prop_name in non_si_props:
                 continue
-            prop_value = data[prop_name]
+            # `None` is used by `custom_first_last_tread_run` (e.g. a locked
+            # stair tread) and must be passed through unconverted.
+            prop_value: Iterable[float | None] | float = data[prop_name]
             if isinstance(prop_value, collections.abc.Iterable):
-                data[prop_name] = [v / si_conversion for v in prop_value]
+                data[prop_name] = [v if v is None else v / si_conversion for v in prop_value]
             else:
                 data[prop_name] = prop_value / si_conversion
         return data
@@ -1761,7 +1763,8 @@ class Model(bonsai.core.tool.Model):
 
         return bool((DoorData.is_loaded or not DoorData.load()) and DoorData.data["pset_data"])
 
-    CustomTreadRunType = Union[tuple[float, float], tuple[None, None]]
+    # Each side is independently `None` (follows tread_run) or a custom float.
+    CustomTreadRunType = Union[tuple[Optional[float], Optional[float]]]
 
     @classmethod
     def get_active_stair_calculated_params(cls, pset_data: Optional[dict[str, Any]] = None) -> dict[str, Any]:
@@ -1773,10 +1776,13 @@ class Model(bonsai.core.tool.Model):
             number_of_treads = props.number_of_treads
             height = props.height / si_conversion
             tread_run = props.tread_run / si_conversion
-            first_tread_run = props.custom_first_last_tread_run[0] / si_conversion
-            last_tread_run = props.custom_first_last_tread_run[1] / si_conversion
+            first_tread_run = (
+                None if props.custom_first_tread_lock else props.custom_first_last_tread_run[0] / si_conversion
+            )
+            last_tread_run = (
+                None if props.custom_last_tread_lock else props.custom_first_last_tread_run[1] / si_conversion
+            )
             nosing_length = props.nosing_length / si_conversion
-            use_custom_first_last_tread_run = not props.custom_tread_lock
         else:
             assert pset_data
             number_of_treads: int = pset_data["number_of_treads"]
@@ -1784,11 +1790,24 @@ class Model(bonsai.core.tool.Model):
             tread_run: float = pset_data["tread_run"]
             # use .get to not break the old .ifc models
             custom_first_last_tread_run: tool.Model.CustomTreadRunType = pset_data.get(
-                "custom_first_last_tread_run", (0, 0)
+                "custom_first_last_tread_run", (None, None)
             )
             first_tread_run, last_tread_run = custom_first_last_tread_run
             nosing_length = pset_data.get("nosing_length", 0)
-            use_custom_first_last_tread_run = not pset_data.get("custom_tread_lock", True)
+
+            # Migrated the same way as BIMStairProperties.set_props_kwargs_from_ifc_data.
+            if "custom_first_tread_lock" in pset_data and "custom_last_tread_lock" in pset_data:
+                first_locked = pset_data["custom_first_tread_lock"]
+                last_locked = pset_data["custom_last_tread_lock"]
+            elif "custom_tread_lock" in pset_data:
+                first_locked = last_locked = pset_data["custom_tread_lock"]
+            else:
+                first_locked = first_tread_run in (None, 0.0, tread_run)
+                last_locked = last_tread_run in (None, 0.0, tread_run)
+            if first_locked:
+                first_tread_run = None
+            if last_locked:
+                last_tread_run = None
 
         calculated_params: dict[str, Any] = {}
         number_of_rises = number_of_treads + 1
@@ -1798,10 +1817,10 @@ class Model(bonsai.core.tool.Model):
         # Calculate total length taking into account custom first/last tread runs :
         length = 0.0
         default_rises = number_of_rises
-        if use_custom_first_last_tread_run and first_tread_run is not None:
+        if first_tread_run is not None:
             default_rises -= 1
             length += first_tread_run
-        if use_custom_first_last_tread_run and last_tread_run is not None:
+        if last_tread_run is not None:
             default_rises -= 1
             length += last_tread_run
         length += tread_run * default_rises
@@ -1864,7 +1883,7 @@ class Model(bonsai.core.tool.Model):
         has_top_nib: Union[bool, None] = None,
         top_slab_depth: Union[float, None] = None,
         base_slab_depth: Union[float, None] = None,
-        custom_first_last_tread_run: Union[tuple[float, float], tuple[None, None]] = (None, None),
+        custom_first_last_tread_run: tuple[Optional[float], Optional[float]] = (None, None),
         nosing_length: float = 0.0,
         # CONCRETE GENERIC STAIR ARGUMENTS
         nosing_depth: float = 0.0,

--- a/src/bonsai/test/bim/module/model/test_stair_gizmos.py
+++ b/src/bonsai/test/bim/module/model/test_stair_gizmos.py
@@ -155,9 +155,11 @@ def test_count_label_gizmo_is_registered():
 
 def test_stair_edit_row_reserves_label_slot_between_tread_lock_and_plus():
     """The ``tread_count_label`` placeholder slot must sit one
-    ``ICON_ARRAY_GAP`` past the tread-lock and one gap before the plus
+    ``ICON_ARRAY_GAP`` past the last tread lock and one gap before the plus
     icon, so the layout naturally allocates the count label's X without
-    any subclass-side gap math."""
+    any subclass-side gap math. The first and last tread locks are
+    independent slots (separate locks, issue #7484) and must themselves be
+    one gap apart."""
     from bonsai.bim.module.drawing.gizmos import BaseParametricGizmoGroup
     from bonsai.bim.module.model.stair import GizmoStairEdition
 
@@ -165,7 +167,8 @@ def test_stair_edit_row_reserves_label_slot_between_tread_lock_and_plus():
     gap = BaseParametricGizmoGroup.ICON_ARRAY_GAP
 
     assert "tread_count_label" in slot_x
-    assert slot_x["tread_count_label"] - slot_x["tread_lock"] == pytest.approx(gap)
+    assert slot_x["last_tread_lock"] - slot_x["first_tread_lock"] == pytest.approx(gap)
+    assert slot_x["tread_count_label"] - slot_x["last_tread_lock"] == pytest.approx(gap)
     assert slot_x["plus"] - slot_x["tread_count_label"] == pytest.approx(gap)
     assert slot_x["minus"] - slot_x["plus"] == pytest.approx(gap)
 

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -219,6 +219,37 @@ class TestStairCalculatedParams(NewFile):
         calculated_data["Length"] += 0.1 * pset_data["number_of_treads"]
         self.compare_data(pset_data, calculated_data)
 
+        # Independent first/last locks (#7484): only the first tread is
+        # customized (locked=False), the last tread stays locked to the
+        # default tread_run even though a leftover custom value is present.
+        pset_data = pset_data_base.copy()
+        calculated_data = calculated_data_base.copy()
+        pset_data["custom_first_last_tread_run"] = (0.1, 0.4)
+        pset_data["custom_first_tread_lock"] = False
+        pset_data["custom_last_tread_lock"] = True
+        calculated_data["Length"] = 0.1 + 0.3 * 3  # first=0.1 custom, 3 default treads at 0.3
+        self.compare_data(pset_data, calculated_data)
+
+        # Same custom values, but this time only the last tread is
+        # customized and the first stays locked.
+        pset_data = pset_data_base.copy()
+        calculated_data = calculated_data_base.copy()
+        pset_data["custom_first_last_tread_run"] = (0.1, 0.4)
+        pset_data["custom_first_tread_lock"] = True
+        pset_data["custom_last_tread_lock"] = False
+        calculated_data["Length"] = 0.4 + 0.3 * 3  # last=0.4 custom, 3 default treads at 0.3
+        self.compare_data(pset_data, calculated_data)
+
+        # Both independently unlocked/customized (equivalent to the old
+        # combined-unlock behaviour, exercised through the new per-side keys).
+        pset_data = pset_data_base.copy()
+        calculated_data = calculated_data_base.copy()
+        pset_data["custom_first_last_tread_run"] = (0.1, 0.4)
+        pset_data["custom_first_tread_lock"] = False
+        pset_data["custom_last_tread_lock"] = False
+        calculated_data["Length"] = 0.1 + 0.4 + 0.3 * 2
+        self.compare_data(pset_data, calculated_data)
+
 
 class TestGenerateStair2DProfile(NewFile):
     def compare_data(self, generated_profile, expected_profile):


### PR DESCRIPTION
## Root cause
Bonsai's parametric stair had a single custom_tread_lock covering both the first and last tread together. There was no way to fix one end's run length while leaving the other to keep following Tread Run (and thus Total Length Target). Working around this by trying to set one side to a "disable" sentinel actually created a genuinely degenerate near-zero-width tread instead, since set_custom_tread_run() clamps to a 0.01 minimum and any non-None float is treated as a deliberate custom value.

## Fix
Replaced the single lock with two independent booleans, custom_first_tread_lock / custom_last_tread_lock (both default True, preserving current behavior for existing stairs). When a side is locked it follows Tread Run; when unlocked it uses its own fixed custom value, entirely independently of the other side. This threads through property storage/callbacks, the total-run and custom-tread-length calculations, IFC export/import (with backward-compatible migration for files saved with the old combined lock, and even older files that predate any lock), the 3D-viewport gizmo icons (split into two independent per-side lock toggles), and the properties panel UI.

## Verification
- Live in headless Blender: locking the last tread and fixing the first to a custom length, then raising Total Length Target, confirms the first tread stays exactly fixed while tread_run recalculates for the rest — no degenerate tread. Verified the symmetric case, both-locked (regression, matches old behavior exactly), and both-unlocked.
- Full IFC save/reload round-trip preserves state correctly; migration tested for old-combined-lock=True, old-combined-lock=False, and pre-lock-era files.
- Existing test suite (TestStairCalculatedParams, TestGenerateStair2DProfile, all stair gizmo tests) re-run directly against real Blender: no regressions. Added 3 new test cases for independent lock combinations.

Fixes #7484

Generated with the assistance of an AI coding tool.