### PR TITLE
Bonsai: add a heavy-model generator and visibility benchmark harness

### DIFF
--- a/src/bonsai/test/performance/README.md
+++ b/src/bonsai/test/performance/README.md
@@ -1,0 +1,151 @@
+<!-- This file was generated with the assistance of an AI coding tool. -->
+
+# Bonsai performance-regression testing utility
+
+Tools for answering a specific kind of question: "does this Bonsai change
+introduce a meaningful performance regression on a large, real-world-sized
+model?" A functional fix can pass every unit test and still turn an O(1)
+Blender operator call into an O(n) Python loop that is fine on a 20-element
+test file and slow on a 5000-element real project. These two scripts let you
+measure that, with real before/after numbers instead of a guess.
+
+There are two independent pieces:
+
+1. `generate_heavy_model.py` — builds a large, IFC-valid synthetic model
+   (no `bpy` dependency, just `ifcopenshell`).
+2. `benchmark_visibility.py` — loads a generated model into headless Blender
+   and times a Bonsai operator. This one *does* need `bpy`, since it is
+   timing real Bonsai/Blender behaviour, not bare `ifcopenshell`.
+
+Neither script is specific to one bug. `generate_heavy_model.py` is a
+general-purpose heavy-fixture generator; `benchmark_visibility.py` currently
+times the spatial-visibility operator (`bim.set_element_visibility`) but is
+a short, readable template for timing any other Bonsai operator the same
+way — swap out the scenario functions in `main()`.
+
+## 1. Generating a heavy fixture
+
+```sh
+cd src/bonsai/test/performance
+python3 generate_heavy_model.py --out /tmp/heavy.ifc --walls 3000 --storeys 10
+```
+
+This produces a Project > Site > Building > N Storeys hierarchy. Each storey
+is a rectangular grid of walls (real body geometry via
+`ifcopenshell.api.geometry.add_wall_representation`/`create_2pt_wall`, so
+representations aren't empty shells), some interior grid cells get an
+`IfcSpace`, and a configurable fraction of walls get an `IfcDoor` or
+`IfcWindow` filling (with their own body representations, related via
+`IfcRelVoidsElement`/`IfcRelFillsElement`).
+
+Useful flags (all have defaults, none are hardcoded):
+
+- `--walls N` — target total wall count across the whole model.
+- `--storeys N` — number of `IfcBuildingStorey` elements.
+- `--spaces-per-storey N` — `IfcSpace` count per storey.
+- `--door-every N` / `--window-every N` — insert a filling every Nth
+  interior/perimeter wall segment (0 disables).
+- `--schema IFC4|IFC4X3|...`
+
+Or call it as a library:
+
+```python
+from generate_heavy_model import generate_heavy_model
+stats = generate_heavy_model("/tmp/heavy.ifc", wall_count=5000, storeys=15)
+```
+
+**Do not commit the generated `.ifc` file.** It's a throwaway fixture,
+regenerate it whenever you need one. A 3000-wall / 10-storey file takes
+about 8 seconds to generate and is ~5.7 MB.
+
+## 2. Benchmarking before vs after
+
+The harness assumes you have two code states to compare — typically a
+pre-fix and a post-fix checkout of `src/bonsai`. The cleanest way to get
+both without disturbing your main working copy is two separate git
+worktrees:
+
+```sh
+git worktree add ../wt-before <pre-fix-ref>
+git worktree add ../wt-after  <post-fix-ref>   # or your current branch
+```
+
+`benchmark_visibility.py` needs `bpy`, so it must run inside a real Blender
+binary, not bare Python. It resolves the `bonsai` package from whatever
+`--src-bonsai` path you give it (by shadowing `sys.path` and clearing
+`sys.modules`), so **the same script, unmodified, can benchmark two
+different worktrees** just by pointing `--src-bonsai` at each in turn:
+
+```sh
+BLENDER=/Applications/Blender.app/Contents/MacOS/Blender   # adjust for your platform
+
+$BLENDER -b -P benchmark_visibility.py -- \
+  --ifc /tmp/heavy.ifc --src-bonsai /path/to/wt-before/src/bonsai \
+  --out /tmp/result_before.json --repeats 7
+
+$BLENDER -b -P benchmark_visibility.py -- \
+  --ifc /tmp/heavy.ifc --src-bonsai /path/to/wt-after/src/bonsai \
+  --out /tmp/result_after.json --repeats 7
+```
+
+Note the literal `--` before the script's own arguments — that's Blender's
+argument separator, without it Blender tries to parse your flags itself.
+
+This script requires a Blender extension entry named
+`bl_ext.raw_githubusercontent_com.bonsai` to already be registered in your
+Blender profile (any dev checkout registered as an unofficial/URL
+extension works; only its `register()`/`unregister()` hooks are used — the
+actual `bonsai` package is then imported fresh from `--src-bonsai`, not from
+the registered extension's own files). If your local Blender profile uses a
+different extension module name for this purpose, adjust the two
+`bpy.ops.preferences.addon_*` calls in `_load_bonsai_from()` accordingly.
+
+Each run: loads the heavy file via `bpy.ops.bim.load_project`, populates the
+Spatial Manager container tree via `bpy.ops.bim.import_spatial_decomposition`,
+then times three scenarios with `time.perf_counter()`, each preceded by one
+untimed warm-up call and followed by a full visibility reset (not counted):
+
+- `isolate_one_storey` — Isolate a single storey out of the whole model
+  (small filtered set, large total element count). This is the scenario
+  that exposes a per-element loop over *every* element in the file, even
+  though only a small subset is the target.
+- `isolate_whole_building` — Isolate the whole building (filtered set ~=
+  total element count).
+- `hide_one_storey` — Hide a single storey (no "isolate" full-file scan,
+  just the per-filtered-element write path).
+
+Compare the **relative** delta between the two JSON results, not their
+absolute values — absolute timings are noisy across machines, thermal
+state, and background load. Re-run a couple of times if the two numbers are
+close; system noise on a shared/laptop machine can easily be tens of percent
+run-to-run for the same code.
+
+## Worked example: PR #8720
+
+PR #8720 ("compose element visibility with the Status filter instead of
+overwriting it") rewrote `SetElementVisibility`'s Isolate mode from two bulk
+`bpy.ops.object.hide_view_set` calls to an explicit Python loop over every
+`IfcProduct` in the file. Benchmarked on this machine with the tools above
+(3000-wall and 6000-wall generated models, 7 timed repeats each, before =
+`v0.8.0` HEAD at the PR's merge-base, after = the PR's branch tip):
+
+| Scenario | Products | Before (median) | After (median) | Delta |
+|---|---|---|---|---|
+| Isolate 1 storey | 4172 | 0.162 s | 0.431 s | **+166%** |
+| Isolate 1 storey | 8138 | 0.382 s | 1.481 s | **+288%** |
+| Isolate whole building | 4172 | 0.671 s | 0.858 s | +28% |
+| Isolate whole building | 8138 | 2.564 s | 2.928 s | +14% |
+| Hide 1 storey | 4172 | 0.161 s | 0.156 s | ~0% (noise) |
+| Hide 1 storey | 8138 | 0.376 s | 0.400 s | +6% |
+
+The regression is real, and it gets worse as the model grows: isolating one
+small storey out of a bigger file went from a 166% slowdown at ~4200
+elements to a 288% slowdown at ~8100 elements, consistent with the fix's new
+loop being O(total elements in file) rather than O(filtered elements),
+whereas the old `hide_view_set`-based code paid a roughly constant cost
+regardless of how many elements were outside the isolated set. Isolating the
+*whole* building (where the filtered set is nearly the whole file) and
+plain Hide/Show (no full-file scan at all) show only a modest, largely
+noise-level difference, because those paths don't hit the new full-scan
+loop, or both old and new code already paid a similar per-element cost
+there.

--- a/src/bonsai/test/performance/benchmark_visibility.py
+++ b/src/bonsai/test/performance/benchmark_visibility.py
@@ -1,0 +1,217 @@
+# This file was generated with the assistance of an AI coding tool.
+#
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 IfcOpenShell contributors
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Benchmark a Bonsai spatial-visibility operator against a heavy IFC file.
+
+This script must be run *inside* headless Blender (it imports ``bpy``),
+since it is timing a real Bonsai operator, not bare ifcopenshell. See
+``test/performance/README.md`` in this directory for the full before/after
+workflow: this same script is run unmodified once per code state (e.g. once
+with ``SRC_BONSAI`` pointing at a pre-fix worktree, once at a post-fix
+worktree), and the two JSON results are compared.
+
+Example::
+
+    /Applications/Blender5.2.app/Contents/MacOS/Blender -b -P benchmark_visibility.py \\
+        -- --ifc /tmp/heavy_3000.ifc --src-bonsai /path/to/worktree/src/bonsai \\
+           --out /tmp/result_after.json
+
+Everything the script needs is passed after a literal ``--`` (Blender's own
+argument separator), so Blender doesn't try to parse them itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+
+
+def _parse_args():
+    argv = sys.argv
+    if "--" in argv:
+        argv = argv[argv.index("--") + 1 :]
+    else:
+        argv = []
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ifc", required=True, help="Path to the heavy .ifc file to load")
+    parser.add_argument("--src-bonsai", required=True, help="Path to a src/bonsai checkout to benchmark")
+    parser.add_argument("--out", required=True, help="Where to write the JSON result")
+    parser.add_argument("--repeats", type=int, default=7, help="Timed repeats per scenario (default: 7)")
+    parser.add_argument(
+        "--small-container-name",
+        default=None,
+        help="Name of a single small container (e.g. one storey) to isolate. "
+        "Defaults to the middle storey found in the file.",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_bonsai_from(src_bonsai: str):
+    """Force `import bonsai` to resolve from `src_bonsai`, per this repo's dev-loop convention.
+
+    A dev extension named `bl_ext.raw_githubusercontent_com.bonsai` is expected to already be
+    registered in Blender's user extensions (see test/performance/README.md for setup). We only
+    use it to get Blender to run the addon's register() hooks; the actual `bonsai` package is
+    then imported fresh from whichever `src_bonsai` checkout the caller points at, by shadowing
+    sys.path, so the same script can benchmark two different code states without reinstalling
+    anything.
+    """
+    import bpy
+
+    for mod in ("bl_ext.user_default.bonsai", "bl_ext.raw_githubusercontent_com_001.bonsaiPR"):
+        try:
+            bpy.ops.preferences.addon_disable(module=mod)
+        except Exception:
+            pass
+    for name in [m for m in list(sys.modules) if m == "bonsai" or m.startswith("bonsai.")]:
+        del sys.modules[name]
+    try:
+        bpy.app.translations.unregister("bonsai")
+    except Exception:
+        pass
+
+    if src_bonsai in sys.path:
+        sys.path.remove(src_bonsai)
+    sys.path.insert(0, src_bonsai)
+
+    bpy.ops.preferences.addon_enable(module="bl_ext.raw_githubusercontent_com.bonsai")
+    import bonsai  # noqa: F401
+
+    assert bonsai.__file__.startswith(src_bonsai), f"bonsai loaded from {bonsai.__file__}, expected {src_bonsai}"
+
+
+def _reset_visibility():
+    import bpy
+
+    for obj in bpy.data.objects:
+        if obj.type != "MESH":
+            continue
+        try:
+            obj.hide_set(False)
+        except Exception:
+            pass
+        bim_props = getattr(obj, "BIMObjectProperties", None)
+        if bim_props is not None:
+            if hasattr(bim_props, "is_manually_hidden"):
+                bim_props.is_manually_hidden = False
+            if hasattr(bim_props, "is_hidden_by_status"):
+                bim_props.is_hidden_by_status = False
+
+
+def _time_operator(fn, repeats: int) -> dict:
+    # One untimed warm-up call to avoid attributing first-call caching effects to the fix itself.
+    fn()
+    _reset_visibility()
+    samples = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - t0)
+        _reset_visibility()
+    return {
+        "samples": samples,
+        "min": min(samples),
+        "median": statistics.median(samples),
+        "mean": statistics.mean(samples),
+    }
+
+
+def main():
+    args = _parse_args()
+    _load_bonsai_from(args.src_bonsai)
+
+    import bpy
+    import ifcopenshell.util.element
+
+    import bonsai.tool as tool
+
+    bpy.ops.bim.load_project(filepath=args.ifc, is_advanced=False, should_start_fresh_session=True)
+    ifc = tool.Ifc.get()
+    total_products = len(ifc.by_type("IfcProduct"))
+
+    bpy.ops.bim.import_spatial_decomposition()
+    props = tool.Spatial.get_spatial_props()
+
+    containers = list(props.containers)
+    storeys = [c for c in containers if c.ifc_class == "IfcBuildingStorey"]
+    building_index, building = next((i, c) for i, c in enumerate(containers) if c.ifc_class == "IfcBuilding")
+
+    if args.small_container_name:
+        small_index, small = next(
+            (i, c)
+            for i, c in enumerate(containers)
+            if c.ifc_class == "IfcBuildingStorey" and c.name == args.small_container_name
+        )
+    else:
+        small = storeys[len(storeys) // 2]
+        small_index = containers.index(small)
+
+    small_entity = ifc.by_id(small.ifc_definition_id)
+    small_element_count = len(set(ifcopenshell.util.element.get_decomposition(small_entity)))
+
+    result = {
+        "ifc_path": args.ifc,
+        "src_bonsai": args.src_bonsai,
+        "total_products": total_products,
+        "small_container_name": small.name,
+        "small_container_element_count": small_element_count,
+        "repeats": args.repeats,
+        "scenarios": {},
+    }
+
+    # Scenario 1: isolate ONE small storey out of a large multi-storey model.
+    # This is the case sboddy's concern targets: a small filtered set, but the fix's
+    # ISOLATE loop walks every IfcProduct in the whole file to decide what to re-show.
+    props.active_container_index = small_index
+    props.should_include_children = True
+
+    def isolate_small():
+        bpy.ops.bim.set_element_visibility(mode="ISOLATE", should_filter=False)
+
+    result["scenarios"]["isolate_one_storey"] = _time_operator(isolate_small, args.repeats)
+
+    # Scenario 2: isolate the WHOLE building (filtered set ~= total element count).
+    props.active_container_index = building_index
+    props.should_include_children = True
+
+    def isolate_building():
+        bpy.ops.bim.set_element_visibility(mode="ISOLATE", should_filter=False)
+
+    result["scenarios"]["isolate_whole_building"] = _time_operator(isolate_building, args.repeats)
+
+    # Scenario 3: HIDE the one small storey (no isolate loop, just the filtered-set write path).
+    props.active_container_index = small_index
+
+    def hide_small():
+        bpy.ops.bim.set_element_visibility(mode="HIDE", should_filter=False)
+
+    result["scenarios"]["hide_one_storey"] = _time_operator(hide_small, args.repeats)
+
+    with open(args.out, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"Wrote {args.out}")
+    print(json.dumps(result["scenarios"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bonsai/test/performance/generate_heavy_model.py
+++ b/src/bonsai/test/performance/generate_heavy_model.py
@@ -1,0 +1,346 @@
+# This file was generated with the assistance of an AI coding tool.
+#
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 IfcOpenShell contributors
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Generate a large, synthetic, IFC-valid model for performance testing.
+
+This is a standalone generator: it only depends on ``ifcopenshell`` (no
+``bpy``), so it can be run with plain Python to produce a throwaway ``.ifc``
+fixture for benchmarking. See ``test/performance/README.md`` in this
+directory for the full workflow (including the headless-Blender benchmark
+harness that consumes the files this script produces).
+
+The model has a real spatial hierarchy (Project > Site > Building > N
+Storeys), each storey is a grid of load-bearing/partition walls forming
+actual rooms, some of those rooms are represented as IfcSpaces, and a
+fraction of the walls have a door or window filling. All elements have real
+3D body geometry (via ``ifcopenshell.api.geometry``), so operations that
+touch representations or object placements are not exercising empty shells.
+
+Do not commit generated ``.ifc`` files: regenerate them from this script
+whenever a heavy fixture is needed. Nothing here is hardcoded to a
+particular element count; pass ``--walls`` (CLI) or ``wall_count``
+(function call) to scale the model up or down.
+
+Usage::
+
+    python generate_heavy_model.py --walls 3000 --out /tmp/heavy.ifc
+
+or programmatically::
+
+    from generate_heavy_model import generate_heavy_model
+    stats = generate_heavy_model("/tmp/heavy.ifc", wall_count=3000)
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import time
+from dataclasses import dataclass, field
+
+import ifcopenshell
+import ifcopenshell.api.aggregate
+import ifcopenshell.api.context
+import ifcopenshell.api.feature
+import ifcopenshell.api.geometry
+import ifcopenshell.api.owner
+import ifcopenshell.api.project
+import ifcopenshell.api.root
+import ifcopenshell.api.spatial
+import ifcopenshell.api.unit
+from ifcopenshell.api.geometry.create_2pt_wall import create_2pt_wall
+
+BAY_SIZE = 4.0  # metres, length of one wall segment / grid cell edge
+WALL_HEIGHT = 3.0
+WALL_THICKNESS = 0.2
+STOREY_HEIGHT = 3.5
+DOOR_HEIGHT = 2.0
+DOOR_WIDTH = 0.9
+WINDOW_HEIGHT = 1.2
+WINDOW_WIDTH = 1.2
+WINDOW_SILL = 0.9
+
+
+@dataclass
+class ModelStats:
+    storeys: int = 0
+    walls: int = 0
+    spaces: int = 0
+    doors: int = 0
+    windows: int = 0
+    grid_rows: int = 0
+    grid_cols: int = 0
+    generation_seconds: float = 0.0
+    segments: list = field(default_factory=list)
+
+
+def _grid_dims_for_wall_count(walls_per_storey: int) -> tuple[int, int]:
+    """Pick a (rows, cols) grid whose edge-segment count is close to walls_per_storey.
+
+    A rows x cols grid of square cells has (rows + 1) horizontal wall-runs of
+    `cols` segments each, and (cols + 1) vertical wall-runs of `rows`
+    segments each: total segments = 2*rows*cols + rows + cols.
+    """
+    if walls_per_storey < 4:
+        return 1, 1
+    best = (1, 1)
+    best_diff = None
+    approx = max(1, int(math.sqrt(walls_per_storey / 2)))
+    for rows in range(max(1, approx - 3), approx + 4):
+        for cols in range(max(1, approx - 3), approx + 4):
+            total = 2 * rows * cols + rows + cols
+            diff = abs(total - walls_per_storey)
+            if best_diff is None or diff < best_diff:
+                best_diff = diff
+                best = (rows, cols)
+    return best
+
+
+def _iter_grid_segments(rows: int, cols: int):
+    """Yield (p1, p2, is_perimeter) for every wall segment in a rows x cols grid."""
+    # Horizontal runs (constant y), at y = 0..rows, each split into `cols` segments.
+    for r in range(rows + 1):
+        y = r * BAY_SIZE
+        is_perimeter_run = r == 0 or r == rows
+        for c in range(cols):
+            x1, x2 = c * BAY_SIZE, (c + 1) * BAY_SIZE
+            yield (x1, y), (x2, y), is_perimeter_run
+    # Vertical runs (constant x), at x = 0..cols, each split into `rows` segments.
+    for c in range(cols + 1):
+        x = c * BAY_SIZE
+        is_perimeter_run = c == 0 or c == cols
+        for r in range(rows):
+            y1, y2 = r * BAY_SIZE, (r + 1) * BAY_SIZE
+            yield (x, y1), (x, y2), is_perimeter_run
+
+
+def generate_heavy_model(
+    out_path: str,
+    wall_count: int = 3000,
+    storeys: int = 10,
+    schema: str = "IFC4",
+    spaces_per_storey: int = 4,
+    door_every: int = 6,
+    window_every: int = 4,
+    seed: int = 0,
+) -> ModelStats:
+    """Build and save a large synthetic IFC model.
+
+    :param out_path: Where to write the generated ``.ifc`` file.
+    :param wall_count: Target total number of IfcWall elements across the
+        whole model (split evenly across storeys). Not hit exactly, since
+        walls are laid out on a rectangular grid per storey; the actual
+        count is returned in the stats.
+    :param storeys: Number of IfcBuildingStorey elements.
+    :param schema: IFC schema version, e.g. "IFC4" or "IFC4X3".
+    :param spaces_per_storey: How many IfcSpace elements to add per storey
+        (one per interior grid cell, capped by however many cells exist).
+    :param door_every: Insert an IfcDoor filling on every Nth interior
+        (non-perimeter) wall segment. Use 0 to disable doors entirely.
+    :param window_every: Insert an IfcWindow filling on every Nth perimeter
+        wall segment. Use 0 to disable windows entirely.
+    :param seed: Unused placeholder for reproducibility of future random
+        variation; the layout is currently fully deterministic.
+    :return: A ModelStats summary of what was actually generated.
+    """
+    t0 = time.time()
+    stats = ModelStats(storeys=storeys)
+
+    model = ifcopenshell.api.project.create_file(version=schema)
+    project = ifcopenshell.api.root.create_entity(model, ifc_class="IfcProject", name="Heavy Perf Test Model")
+    ifcopenshell.api.unit.assign_unit(model, length={"is_metric": True, "raw": "METERS"})
+
+    model3d = ifcopenshell.api.context.add_context(model, context_type="Model")
+    body = ifcopenshell.api.context.add_context(
+        model, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=model3d
+    )
+
+    site = ifcopenshell.api.root.create_entity(model, ifc_class="IfcSite", name="Site")
+    building = ifcopenshell.api.root.create_entity(model, ifc_class="IfcBuilding", name="Building")
+    ifcopenshell.api.aggregate.assign_object(model, products=[site], relating_object=project)
+    ifcopenshell.api.aggregate.assign_object(model, products=[building], relating_object=site)
+
+    walls_per_storey = max(4, wall_count // max(1, storeys))
+    rows, cols = _grid_dims_for_wall_count(walls_per_storey)
+    stats.grid_rows, stats.grid_cols = rows, cols
+
+    for storey_index in range(storeys):
+        elevation = storey_index * STOREY_HEIGHT
+        storey = ifcopenshell.api.root.create_entity(
+            model, ifc_class="IfcBuildingStorey", name=f"Storey {storey_index}"
+        )
+        ifcopenshell.api.aggregate.assign_object(model, products=[storey], relating_object=building)
+
+        storey_walls = []
+        interior_i = 0
+        perimeter_i = 0
+        for p1, p2, is_perimeter in _iter_grid_segments(rows, cols):
+            wall = ifcopenshell.api.root.create_entity(model, ifc_class="IfcWall", name="Wall")
+            wall_rep = create_2pt_wall(model, wall, body, p1, p2, elevation, WALL_HEIGHT, WALL_THICKNESS)
+            ifcopenshell.api.geometry.assign_representation(model, product=wall, representation=wall_rep)
+            storey_walls.append(wall)
+            stats.walls += 1
+
+            if is_perimeter:
+                perimeter_i += 1
+                if window_every and perimeter_i % window_every == 0:
+                    _add_window_filling(model, body, wall, p1, p2, elevation)
+                    stats.windows += 1
+            else:
+                interior_i += 1
+                if door_every and interior_i % door_every == 0:
+                    _add_door_filling(model, body, wall, p1, p2, elevation)
+                    stats.doors += 1
+
+        ifcopenshell.api.spatial.assign_container(model, products=storey_walls, relating_structure=storey)
+
+        n_spaces = min(spaces_per_storey, rows * cols)
+        space_products = []
+        placed = 0
+        for r in range(rows):
+            if placed >= n_spaces:
+                break
+            for c in range(cols):
+                if placed >= n_spaces:
+                    break
+                space = _create_space(model, body, r, c, elevation)
+                space_products.append(space)
+                placed += 1
+                stats.spaces += 1
+        if space_products:
+            ifcopenshell.api.aggregate.assign_object(model, products=space_products, relating_object=storey)
+
+    model.write(out_path)
+    stats.generation_seconds = time.time() - t0
+    return stats
+
+
+def _create_space(model, body, row: int, col: int, elevation: float):
+    space = ifcopenshell.api.root.create_entity(model, ifc_class="IfcSpace", name=f"Room {row}-{col}")
+    profile = model.create_entity(
+        "IfcRectangleProfileDef", ProfileType="AREA", XDim=BAY_SIZE * 0.9, YDim=BAY_SIZE * 0.9
+    )
+    solid = model.create_entity(
+        "IfcExtrudedAreaSolid",
+        SweptArea=profile,
+        Position=model.create_entity(
+            "IfcAxis2Placement3D", Location=model.create_entity("IfcCartesianPoint", Coordinates=(0.0, 0.0, 0.0))
+        ),
+        ExtrudedDirection=model.create_entity("IfcDirection", DirectionRatios=(0.0, 0.0, 1.0)),
+        Depth=WALL_HEIGHT,
+    )
+    rep = model.create_entity(
+        "IfcShapeRepresentation",
+        ContextOfItems=body,
+        RepresentationIdentifier="Body",
+        RepresentationType="SweptSolid",
+        Items=(solid,),
+    )
+    space.Representation = model.create_entity("IfcProductDefinitionShape", Representations=(rep,))
+    cx = col * BAY_SIZE + BAY_SIZE / 2
+    cy = row * BAY_SIZE + BAY_SIZE / 2
+    ifcopenshell.api.geometry.edit_object_placement(
+        model,
+        product=space,
+        matrix=[[1, 0, 0, cx], [0, 1, 0, cy], [0, 0, 1, elevation], [0, 0, 0, 1]],
+    )
+    return space
+
+
+def _midpoint_matrix(p1, p2, elevation, cx_offset=0.0):
+    mx = (p1[0] + p2[0]) / 2
+    my = (p1[1] + p2[1]) / 2
+    return [[1, 0, 0, mx], [0, 1, 0, my], [0, 0, 1, elevation + cx_offset], [0, 0, 0, 1]]
+
+
+def _add_door_filling(model, body, wall, p1, p2, elevation):
+    opening = ifcopenshell.api.root.create_entity(model, ifc_class="IfcOpeningElement", name="Opening")
+    opening_rep = ifcopenshell.api.geometry.add_wall_representation(
+        model, context=body, length=DOOR_WIDTH, height=DOOR_HEIGHT, thickness=WALL_THICKNESS * 2
+    )
+    ifcopenshell.api.geometry.assign_representation(model, product=opening, representation=opening_rep)
+    ifcopenshell.api.geometry.edit_object_placement(model, product=opening, matrix=_midpoint_matrix(p1, p2, elevation))
+    ifcopenshell.api.feature.add_feature(model, feature=opening, element=wall)
+
+    door = ifcopenshell.api.root.create_entity(model, ifc_class="IfcDoor", name="Door")
+    door_rep = ifcopenshell.api.geometry.add_door_representation(
+        model, context=body, overall_height=DOOR_HEIGHT, overall_width=DOOR_WIDTH
+    )
+    if door_rep is not None:
+        ifcopenshell.api.geometry.assign_representation(model, product=door, representation=door_rep)
+    ifcopenshell.api.geometry.edit_object_placement(model, product=door, matrix=_midpoint_matrix(p1, p2, elevation))
+    ifcopenshell.api.feature.add_filling(model, opening=opening, element=door)
+    return door
+
+
+def _add_window_filling(model, body, wall, p1, p2, elevation):
+    opening = ifcopenshell.api.root.create_entity(model, ifc_class="IfcOpeningElement", name="Opening")
+    opening_rep = ifcopenshell.api.geometry.add_wall_representation(
+        model, context=body, length=WINDOW_WIDTH, height=WINDOW_HEIGHT, thickness=WALL_THICKNESS * 2
+    )
+    ifcopenshell.api.geometry.assign_representation(model, product=opening, representation=opening_rep)
+    ifcopenshell.api.geometry.edit_object_placement(
+        model, product=opening, matrix=_midpoint_matrix(p1, p2, elevation, cx_offset=WINDOW_SILL)
+    )
+    ifcopenshell.api.feature.add_feature(model, feature=opening, element=wall)
+
+    window = ifcopenshell.api.root.create_entity(model, ifc_class="IfcWindow", name="Window")
+    window_rep = ifcopenshell.api.geometry.add_window_representation(
+        model, context=body, overall_height=WINDOW_HEIGHT, overall_width=WINDOW_WIDTH
+    )
+    if window_rep is not None:
+        ifcopenshell.api.geometry.assign_representation(model, product=window, representation=window_rep)
+    ifcopenshell.api.geometry.edit_object_placement(
+        model, product=window, matrix=_midpoint_matrix(p1, p2, elevation, cx_offset=WINDOW_SILL)
+    )
+    ifcopenshell.api.feature.add_filling(model, opening=opening, element=window)
+    return window
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="Output .ifc path")
+    parser.add_argument("--walls", type=int, default=3000, help="Target total wall count (default: 3000)")
+    parser.add_argument("--storeys", type=int, default=10, help="Number of building storeys (default: 10)")
+    parser.add_argument("--schema", default="IFC4", help="IFC schema version (default: IFC4)")
+    parser.add_argument("--spaces-per-storey", type=int, default=4, help="IfcSpace count per storey (default: 4)")
+    parser.add_argument("--door-every", type=int, default=6, help="Add a door every Nth interior wall (0=disable)")
+    parser.add_argument("--window-every", type=int, default=4, help="Add a window every Nth perimeter wall (0=disable)")
+    args = parser.parse_args()
+
+    stats = generate_heavy_model(
+        args.out,
+        wall_count=args.walls,
+        storeys=args.storeys,
+        schema=args.schema,
+        spaces_per_storey=args.spaces_per_storey,
+        door_every=args.door_every,
+        window_every=args.window_every,
+    )
+    print(f"Wrote {args.out}")
+    print(
+        f"storeys={stats.storeys} walls={stats.walls} spaces={stats.spaces} "
+        f"doors={stats.doors} windows={stats.windows} grid={stats.grid_rows}x{stats.grid_cols} "
+        f"generation_seconds={stats.generation_seconds:.2f}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Per @sboddy's suggestion on #8720: a reusable way to catch performance regressions on bulk-visibility-style operators before they merge, rather than after the fact.

- `generate_heavy_model.py`: standalone generator (`ifcopenshell` only, no `bpy`) that builds a Project > Site > Building > N Storeys model, each storey a configurable wall grid with real body geometry, interior spaces, and a configurable fraction of door/window fillings. All counts are CLI args. Validated with `ifcopenshell.validate` at both smoke and heavy sizes.
- `benchmark_visibility.py`: runs inside real headless Blender, loads a generated file, and times `bim.set_element_visibility` across a few scenarios (isolate one storey, isolate whole building, hide one storey), each with an untimed warm-up and a full reset between repeats. Points at a `--src-bonsai` path via `sys.path` shadowing, so the same script benchmarks two different worktrees/branches without modification.
- `README.md`: usage docs for both scripts, plus the worked #8720 example.

Used this to get real before/after numbers for #8720, posted there.

One thing worth knowing before relying on this elsewhere: `benchmark_visibility.py` assumes a dev extension named `bl_ext.raw_githubusercontent_com.bonsai` is already registered in your Blender profile (documented in the README as a setup step); it doesn't auto-detect an arbitrary enabled bonsai-like extension.

Generated with the assistance of an AI coding tool.