### PR TITLE
docs(ifc2ca): fix script paths in README

### DIFF
--- a/src/ifc2ca/README.md
+++ b/src/ifc2ca/README.md
@@ -6,10 +6,10 @@ Files and scripts for the use of [`Code_Aster`](https://code-aster.org) in IFC-d
 ## Scripts:
 
 - [`ifc2ca.py`](ifc2ca.py): a python script to extract and create a `json` file from an `ifc` file
-- [`scriptSalome.py`](scriptSalome.py): a python script to run in the [`Salome-Meca`](https://www.code-aster.org/spip.php?article303) environment. Creates the geometry and the mesh of the structure
+- [`scriptSalome.py`](templates/salome/scriptSalome.py): a python script to run in the [`Salome-Meca`](https://www.code-aster.org/spip.php?article303) environment. Creates the geometry and the mesh of the structure
 - [`scriptCodeAster.py`](scriptCodeAster.py): a python script to create the input file (`.comm`) for Code_Aster
-- [`scriptSalomeBonded.py`](scriptSalomeBonded.py): a python script to run in the [`Salome-Meca`](https://www.code-aster.org/spip.php?article303) environment. Creates the geometry and the mesh of the structure by bonding together all structural elements (no connections are considered)
-- [`scriptCodeAsterBonded.py`](scriptCodeAsterBonded.py): a python script to create the input file (`.comm`) for Code_Aster for the "bonded" case
+- [`scriptSalomeBonded.py`](_deprecated/scriptSalomeBonded.py): a python script to run in the [`Salome-Meca`](https://www.code-aster.org/spip.php?article303) environment. Creates the geometry and the mesh of the structure by bonding together all structural elements (no connections are considered). Located under `_deprecated/`.
+- [`scriptCodeAsterBonded.py`](_deprecated/scriptCodeAsterBonded.py): a python script to create the input file (`.comm`) for Code_Aster for the "bonded" case. Located under `_deprecated/`.
 
 ## Analysis Models
 


### PR DESCRIPTION
## Summary

- Update `src/ifc2ca/README.md` script links to match the current file layout
- `scriptSalome.py` → `templates/salome/scriptSalome.py`
- Bonded Salome/Code_Aster scripts → `_deprecated/`

## Motivation

Several README entries linked scripts at the package root, but those files live under `templates/salome/` or `_deprecated/`, so the docs 404 for newcomers.

Orthogonal to #8736 (README website https).

## Verification

- Confirmed each linked path exists in the tree
- Docs-only change (no runtime code)

## AI disclosure

This entire PR is documentation-only and was prepared with the assistance of an AI coding tool (Hermes/Sera), human-reviewed before open. Per AGENTS.md: AI assistance noted in the commit body.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes campaign=construction-am pilot=1 -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h  
**Claim:** `sera` · pilot-1 construction-am