### PR TITLE
Bonsai: support aligning a hosted window/door to its wall's exterior/centerline/interior face

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -654,7 +654,7 @@ class AlignWall(bpy.types.Operator):
     bl_idname = "bim.align_wall"
     bl_label = "Align Wall"
     bl_options = {"REGISTER", "UNDO"}
-    bl_description = """ Align the selected walls to the active wall:
+    bl_description = """ Align the selected walls (or hosted windows/doors) to the active wall:
     'Ext.': align to the EXTERIOR face
     'C/L': align to wall CENTER
     'Int.': align to the INTERIOR face"""

--- a/src/bonsai/bonsai/core/model.py
+++ b/src/bonsai/bonsai/core/model.py
@@ -132,23 +132,30 @@ def align_walls(
     reference_obj = blender.get_active_object(is_selected=True)
     if not reference_obj or not (e := ifc.get_entity(reference_obj)) or not model.get_usage_type(e) == "LAYER2":
         reference_obj = None
-    objs = [
-        o
-        for o in blender.get_selected_objects()
-        if o != reference_obj and (e := ifc.get_entity(o)) and model.get_usage_type(e) == "LAYER2"
-    ]
-    if not reference_obj or not objs:
+    objs: list[bpy.types.Object] = []
+    # Fills (windows/doors) get moved like any other selected object, then their opening is resynced separately.
+    fills: list[bpy.types.Object] = []
+    for o in blender.get_selected_objects():
+        if o == reference_obj or not (e := ifc.get_entity(o)):
+            continue
+        if model.get_usage_type(e) == "LAYER2":
+            objs.append(o)
+        elif model.get_filling_host(e):
+            fills.append(o)
+    if not reference_obj or not (objs or fills):
         raise RequireAtLeastTwoLayeredElements(
             "At least two vertically layered elements must be selected to match alignments."
         )
     aligner.set_reference_wall(reference_obj)
-    for obj in objs:
+    for obj in objs + fills:
         if align_type == "CENTER":
             aligner.align_centerline(obj)
         elif align_type == "EXTERIOR":
             aligner.align_first_layer(obj)
         elif align_type == "INTERIOR":
             aligner.align_last_layer(obj)
+    if fills:
+        model.recalculate_fillings(fills)
 
 
 def align_objects(

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -1083,6 +1083,12 @@ class Model(bonsai.core.tool.Model):
                 return "PROFILE"
 
     @classmethod
+    def get_filling_host(cls, element: ifcopenshell.entity_instance) -> Optional[ifcopenshell.entity_instance]:
+        """Return the wall/element whose void ``element`` fills, or ``None`` if it fills nothing."""
+        opening = ifcopenshell.util.element.get_filled_void(element)
+        return ifcopenshell.util.element.get_voided_element(opening) if opening else None
+
+    @classmethod
     def get_wall_axis(
         cls, obj: bpy.types.Object, layers: Optional[MaterialLayerParameters] = None
     ) -> dict[str, list[Vector]]:
@@ -2172,6 +2178,15 @@ class Model(bonsai.core.tool.Model):
             cls.regenerate_filling_opening_body(filling)
 
         return voided_objs
+
+    @classmethod
+    def recalculate_fillings(cls, objs: Iterable[bpy.types.Object]) -> None:
+        """Resync moved fillings' openings, reusing ``bim.recalculate_fill``."""
+        objs = list(objs)
+        if not objs:
+            return
+        with bpy.context.temp_override(selected_objects=objs):
+            bpy.ops.bim.recalculate_fill()
 
     @classmethod
     def update_simple_openings(cls, element: ifcopenshell.entity_instance) -> None:

--- a/src/bonsai/test/bim/feature/model.feature
+++ b/src/bonsai/test/bim/feature/model.feature
@@ -385,6 +385,52 @@ Scenario: Align elements - fail due to selection criteria
     When the object "IfcDoor/Door" is selected
     Then I press "bim.hotkey(hotkey='S_C')" and expect error "Error: At least two objects must be selected to match alignments."
 
+Scenario: Align a window hosted in a wall to the wall's exterior, centerline and interior faces
+    Given an empty IFC project
+    And I load the demo construction library
+    And I set "scene.BIMModelProperties.ifc_class" to "IfcWallType"
+    And the variable "wall_type" is "[e for e in {ifc}.by_type('IfcWallType') if e.Name == 'WAL300'][0].id()"
+    And I set "scene.BIMModelProperties.relating_type_id" to "{wall_type}"
+    And I press "bim.add_occurrence"
+    And the object "IfcWall/Wall" is selected
+    And I set "scene.BIMModelProperties.ifc_class" to "IfcWindowType"
+    And the variable "window_type" is "[e for e in {ifc}.by_type('IfcWindowType') if e.Name == 'WT01'][0].id()"
+    And I set "scene.BIMModelProperties.relating_type_id" to "{window_type}"
+    And I press "bim.add_occurrence"
+    Then the object "IfcWindow/Window" bottom left corner is at "0,0,1"
+    And the object "IfcWindow/Window" top right corner is at "0.9,0.05,2.2"
+    And the object "IfcWindow/Window" filling opening is in sync
+    When the object "IfcWindow/Window" is selected
+    And additionally the object "IfcWall/Wall" is selected
+    And I press "bim.hotkey(hotkey='S_V')"
+    Then the object "IfcWindow/Window" bottom left corner is at "0,0.25,1"
+    And the object "IfcWindow/Window" top right corner is at "0.9,0.3,2.2"
+    And the object "IfcWindow/Window" filling opening is in sync
+    When I press "bim.hotkey(hotkey='S_C')"
+    Then the object "IfcWindow/Window" bottom left corner is at "0,0.125,1"
+    And the object "IfcWindow/Window" top right corner is at "0.9,0.175,2.2"
+    And the object "IfcWindow/Window" filling opening is in sync
+    When I press "bim.hotkey(hotkey='S_X')"
+    Then the object "IfcWindow/Window" bottom left corner is at "0,0,1"
+    And the object "IfcWindow/Window" top right corner is at "0.9,0.05,2.2"
+    And the object "IfcWindow/Window" filling opening is in sync
+
+Scenario: Align a window with no host - fail due to selection criteria
+    Given an empty IFC project
+    And I load the demo construction library
+    And I set "scene.BIMModelProperties.ifc_class" to "IfcWallType"
+    And the variable "wall_type" is "[e for e in {ifc}.by_type('IfcWallType') if e.Name == 'WAL300'][0].id()"
+    And I set "scene.BIMModelProperties.relating_type_id" to "{wall_type}"
+    And I press "bim.add_occurrence"
+    And I deselect all objects
+    And I set "scene.BIMModelProperties.ifc_class" to "IfcWindowType"
+    And the variable "window_type" is "[e for e in {ifc}.by_type('IfcWindowType') if e.Name == 'WT01'][0].id()"
+    And I set "scene.BIMModelProperties.relating_type_id" to "{window_type}"
+    And I press "bim.add_occurrence"
+    When the object "IfcWindow/Window" is selected
+    And additionally the object "IfcWall/Wall" is selected
+    Then I press "bim.hotkey(hotkey='S_C')" and expect error "Error: At least two vertically layered elements must be selected to match alignments."
+
 Scenario: Add a slab
     Given an empty IFC project
     And I load the demo construction library

--- a/src/bonsai/test/bim/test_feature.py
+++ b/src/bonsai/test/bim/test_feature.py
@@ -35,7 +35,9 @@ from typing import Any, Union, cast
 import bpy
 import ifcopenshell
 import ifcopenshell.util.element
+import ifcopenshell.util.placement
 import ifcopenshell.util.representation
+import ifcopenshell.util.unit
 import numpy as np
 import pytest
 from mathutils import Vector
@@ -1715,6 +1717,18 @@ def the_object_name_bottom_left_corner_is_at_location(name, location):
     assert (
         obj_corner - Vector([float(co) for co in location.split(",")])
     ).length < 0.05, f"Object has bottom left corner {obj_corner} instead of {location}"
+
+
+@then(parsers.parse('the object "{name}" filling opening is in sync'))
+def the_object_name_filling_opening_is_in_sync(name):
+    obj = the_object_name_exists(name)
+    opening = ifcopenshell.util.element.get_filled_void(tool.Ifc.get_entity(obj))
+    assert opening, f'Object "{name}" does not fill any opening'
+    unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
+    placement = ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement)
+    opening_co = Vector(placement[:3, 3].tolist()) * unit_scale
+    delta = (opening_co - obj.matrix_world.translation).length
+    assert delta < 1e-4, f'Object "{name}"\'s opening drifted from its filling by {delta}'
 
 
 @then(parsers.parse('the object "{name}" is contained in "{container_name}"'))


### PR DESCRIPTION
Fixes #7490. The exterior/centerline/interior alignment tools only worked on layered wall objects (`LAYER2` usage), rejecting a hosted window/door with "At least two vertically layered elements must be selected." The underlying alignment math (`DumbWallAligner`) was already generic, it only reads bounding-box/world-matrix, so the fix is a minimal extension: `align_walls()` now also accepts selected objects that fill a void (windows/doors), aligns them the same way, then resyncs their opening via the existing `bim.recalculate_fill` mechanism so the host wall's cut tracks the fill's new position. Unhosted fills and non-wall references still hit the original rejection.

Generated with the assistance of an AI coding tool.