### PR TITLE
Bonsai: fix lag when panning a view with the cut decorator active

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -1677,6 +1677,12 @@ class CutDecorator:
         selected_elements_color = self.addon_prefs.decorator_color_selected
         self.fallback_colour = (0.3, 0.3, 0.3, 1)
 
+        # Evaluate camera movement once per redraw rather than twice per object: is_camera_moved()
+        # runs eval()/numpy on the camera matrix and, as a side effect, refreshes the stored
+        # checksum on the first True result - so calling it per object also made the second call
+        # (fill) see an already-updated checksum and skip recalculating when it shouldn't.
+        self.camera_moved = self.is_camera_moved()
+
         all_vertices = []
         all_edges = []
         selected_vertices = []
@@ -1803,9 +1809,9 @@ class CutDecorator:
         # Currently selected objects must be recalculated as they may be being moved / edited.
         # If the camera is selected, we also recalculate as the user may be moving the camera.
 
-        if not has_cut_cache or obj.select_get() or self.is_camera_moved():
+        if not has_cut_cache or obj.select_get() or self.camera_moved:
             self.recalculate_cut(context, obj, element)
-        if not has_fill_cache or obj.select_get() or self.is_camera_moved():
+        if not has_fill_cache or obj.select_get() or self.camera_moved:
             self.recalculate_fill(context, obj, element)
 
     def recalculate_cut(self, context, obj: bpy.types.Object, element: ifcopenshell.entity_instance) -> None:

--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -1808,23 +1808,35 @@ class CutDecorator:
 
         # Currently selected objects must be recalculated as they may be being moved / edited.
         # If the camera is selected, we also recalculate as the user may be moving the camera.
+        is_selected = obj.select_get()
+        recalc_cut = not has_cut_cache or is_selected or self.camera_moved
+        recalc_fill = not has_fill_cache or is_selected or self.camera_moved
+        if not (recalc_cut or recalc_fill):
+            return
 
-        if not has_cut_cache or obj.select_get() or self.camera_moved:
-            self.recalculate_cut(context, obj, element)
-        if not has_fill_cache or obj.select_get() or self.camera_moved:
-            self.recalculate_fill(context, obj, element)
+        # The intersection test builds a bmesh and scans every vertex; both recalculations need
+        # the same answer, so compute it once here rather than once in each.
+        is_intersecting = tool.Drawing.is_intersecting_camera(obj, context.scene.camera)
+        if recalc_cut:
+            self.recalculate_cut(context, obj, element, is_intersecting)
+        if recalc_fill:
+            self.recalculate_fill(context, obj, element, is_intersecting)
 
-    def recalculate_cut(self, context, obj: bpy.types.Object, element: ifcopenshell.entity_instance) -> None:
-        if tool.Drawing.is_intersecting_camera(obj, context.scene.camera):
+    def recalculate_cut(
+        self, context, obj: bpy.types.Object, element: ifcopenshell.entity_instance, is_intersecting: bool
+    ) -> None:
+        if is_intersecting:
             verts, edges = tool.Drawing.bisect_mesh(obj, context.scene.camera)
             DecoratorData.cut_cache[element.id()] = (verts, edges)
         else:
             DecoratorData.cut_cache[element.id()] = (False, False)
 
-    def recalculate_fill(self, context, obj: bpy.types.Object, element: ifcopenshell.entity_instance) -> None:
+    def recalculate_fill(
+        self, context, obj: bpy.types.Object, element: ifcopenshell.entity_instance, is_intersecting: bool
+    ) -> None:
         element_id = element.id()
 
-        if not tool.Drawing.is_intersecting_camera(obj, context.scene.camera):
+        if not is_intersecting:
             DecoratorData.fill_cache[element_id] = {}
             return
 


### PR DESCRIPTION
Closes #8745.

`CutDecorator` did redundant per-object work every redraw:

- `is_camera_moved()` was evaluated twice per object; now evaluated once
  per redraw and reused. This also fixes a staleness bug: the function
  refreshes its checksum on the first `True`, so previously only the first
  object's cut recalculated on a moved frame while every fill and other
  element stayed stale.
- The cut/fill intersection test (builds a bmesh + scans all verts) ran
  twice per object; now computed once in `decorate()` and passed to both,
  and skipped entirely when neither recalculation is needed.

No change to the caching model or draw output, beyond fill/cut now
updating together when the camera moves.

Analysis done with Claude Opus.