### PR TITLE
Fix leak of IfcSpfLexer when read_from_stream returns early or throws

### DIFF
--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -1584,7 +1584,12 @@ void IfcParse::impl::in_memory_file_storage::read_from_stream(IfcParse::FileRead
         return;
     }
 
-    tokens = new IfcSpfLexer(s, logger());
+    // Owned via RAII so that any early return or exception while scanning
+    // the file (e.g. a malformed header, see fuzzer-z6u) still frees the
+    // lexer instead of leaking it; `tokens` itself stays a raw pointer since
+    // it's read by in_memory_file_storage::load() during the scan below.
+    std::unique_ptr<IfcSpfLexer> tokens_owner(new IfcSpfLexer(s, logger()));
+    tokens = tokens_owner.get();
 
     std::vector<std::string> schemas;
 
@@ -1689,7 +1694,8 @@ void IfcParse::impl::in_memory_file_storage::read_from_stream(IfcParse::FileRead
 
     logger().Status("\rDone scanning file   ");
 
-    delete tokens;
+    tokens_owner.reset();
+    tokens = nullptr;
 
     if (good_ != file_open_status::SUCCESS) {
         return;

--- a/src/ifcparse/IfcParse.cpp
+++ b/src/ifcparse/IfcParse.cpp
@@ -1584,10 +1584,6 @@ void IfcParse::impl::in_memory_file_storage::read_from_stream(IfcParse::FileRead
         return;
     }
 
-    // Owned via RAII so that any early return or exception while scanning
-    // the file (e.g. a malformed header, see fuzzer-z6u) still frees the
-    // lexer instead of leaking it; `tokens` itself stays a raw pointer since
-    // it's read by in_memory_file_storage::load() during the scan below.
     std::unique_ptr<IfcSpfLexer> tokens_owner(new IfcSpfLexer(s, logger()));
     tokens = tokens_owner.get();
 
@@ -1693,9 +1689,6 @@ void IfcParse::impl::in_memory_file_storage::read_from_stream(IfcParse::FileRead
     }
 
     logger().Status("\rDone scanning file   ");
-
-    tokens_owner.reset();
-    tokens = nullptr;
 
     if (good_ != file_open_status::SUCCESS) {
         return;


### PR DESCRIPTION
## Summary
- `in_memory_file_storage::read_from_stream()` allocated its `IfcSpfLexer` with a raw `new` and only freed it with an explicit `delete` at the very end of the function.
- Every early-return path (`NO_HEADER`, `UNSUPPORTED_SCHEMA`, no matching schema — i.e. almost any malformed STEP input) skipped that `delete` and leaked it, and any exception escaping `readInstance()` mid-scan did too.
- Own the allocation with a local `std::unique_ptr` for the duration of the function instead, so every exit path frees it automatically.

Found by fuzzing `IfcFile` construction directly with a libFuzzer harness (ASan/UBSan build, `ASAN_OPTIONS=detect_leaks=1`) — confirmed leak on the vast majority of malformed inputs, and empirically responsible for a long-running single-worker fuzzing session hitting libFuzzer's default 2048MB RSS cap after ~4 hours / 1.6M executions with completely flat coverage (i.e. slow cumulative leak growth, not a single bad allocation).

## Test plan
- [x] Rebuilt the fuzzer harness (Clang + ASan/UBSan) with this change
- [x] `ASAN_OPTIONS=detect_leaks=1 ./ifcparse_fuzzer -runs=1 <previously-leaking malformed-header input>` now exits clean with no leak report
- [x] `ASAN_OPTIONS=detect_leaks=1 ./ifcparse_fuzzer -runs=0 corpus/` no longer reports this leak (a separate, unrelated leak in entity-parsing was also found and filed separately, not fixed by this PR)