### PR TITLE
Bonsai: fix profile/curve reconstruction after duplicating a circle or arc in Edit Mode

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -93,6 +93,30 @@ def _stroke_lines_alpha(
     gpu.state.blend_set("NONE")
 
 
+def _connected_components(
+    vertex_groups: dict[int, list[bmesh.types.BMVert]],
+) -> list[list[bmesh.types.BMVert]]:
+    """Split each vertex group's members into their connected components,
+    since a duplicated arc/circle loop shares its source loop's group index."""
+    components = []
+    for verts in vertex_groups.values():
+        remaining = set(verts)
+        while remaining:
+            seed = remaining.pop()
+            stack = [seed]
+            component = [seed]
+            while stack:
+                v = stack.pop()
+                for edge in v.link_edges:
+                    other = edge.other_vert(v)
+                    if other in remaining:
+                        remaining.discard(other)
+                        stack.append(other)
+                        component.append(other)
+            components.append(component)
+    return components
+
+
 class ProfileDecorator:
     installed = None
 
@@ -265,7 +289,7 @@ class ProfileDecorator:
         # Draw arcs
         arc_centroids = []
         arc_segments = []
-        for arc in arcs.values():
+        for arc in _connected_components(arcs):
             if len(arc) != 3:
                 continue
             sorted_arc = [None, None, None]
@@ -292,7 +316,7 @@ class ProfileDecorator:
         # Draw circles
         circle_centroids = []
         circle_segments = []
-        for circle in circles.values():
+        for circle in _connected_components(circles):
             if len(circle) != 2:
                 continue
             p1 = obj.matrix_world @ circle[0].co

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2528,26 +2528,10 @@ class Model(bonsai.core.tool.Model):
         deform_layer = bm.verts.layers.deform.active
 
         # Sanity check
-        group_verts = {"IFCARCINDEX": {}, "IFCCIRCLE": {}}
         if deform_layer:
             for vert in bm.verts:
-                vert_group_indices = tool.Blender.bmesh_get_vertex_groups(vert, deform_layer)
-                for group_index in vert_group_indices:
-                    group_type = "IFCARCINDEX" if group_index in groups["IFCARCINDEX"] else "IFCCIRCLE"
-                    group_verts[group_type].setdefault(group_index, 0)
-                    group_verts[group_type][group_index] += 1
                 if len(vert.link_edges) > 2:  # Forked loop
                     return (False, "FORKED_LOOP")
-
-        for group_type, group_counts in group_verts.items():
-            if group_type == "IFCARCINDEX":
-                for group_count in group_counts.values():
-                    if group_count != 3:  # Each arc needs 3 verts
-                        return (False, "3POINT_ARC")
-            elif group_type == "IFCCIRCLE":
-                for group_count in group_counts.values():
-                    if group_count != 2:  # Each circle needs 2 verts
-                        return (False, "CIRCLE")
 
         loop_edges = list(bm.edges)
 
@@ -2570,6 +2554,28 @@ class Model(bonsai.core.tool.Model):
                         loop_edges.remove(edge)
                         has_found_connected_edge = True
             loops.append(loop)
+
+        # Sanity check, per loop rather than across the whole mesh
+        if deform_layer:
+            for loop in loops:
+                loop_group_counts = {"IFCARCINDEX": {}, "IFCCIRCLE": {}}
+                loop_verts = {v for edge in loop for v in edge.verts}
+                for vert in loop_verts:
+                    for group_index in tool.Blender.bmesh_get_vertex_groups(vert, deform_layer):
+                        if group_index in groups["IFCARCINDEX"]:
+                            group_type = "IFCARCINDEX"
+                        elif group_index in groups["IFCCIRCLE"]:
+                            group_type = "IFCCIRCLE"
+                        else:
+                            continue
+                        loop_group_counts[group_type].setdefault(group_index, 0)
+                        loop_group_counts[group_type][group_index] += 1
+                for group_count in loop_group_counts["IFCARCINDEX"].values():
+                    if group_count != 3:  # Each arc needs 3 verts
+                        return (False, "3POINT_ARC")
+                for group_count in loop_group_counts["IFCCIRCLE"].values():
+                    if group_count != 2:  # Each circle needs 2 verts
+                        return (False, "CIRCLE")
 
         tmp = ifcopenshell.file(schema=tool.Ifc.get().schema)
 

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2292,31 +2292,17 @@ class Model(bonsai.core.tool.Model):
         deform_layer = bm.verts.layers.deform.active
 
         # Sanity check
-        group_verts = {"IFCARCINDEX": {}, "IFCCIRCLE": {}}
         if deform_layer:
             for vert in bm.verts:
                 vert_group_indices = tool.Blender.bmesh_get_vertex_groups(vert, deform_layer)
-                is_circle = False
-                for group_index in vert_group_indices:
-                    group_type = "IFCARCINDEX" if group_index in groups["IFCARCINDEX"] else "IFCCIRCLE"
-                    group_verts[group_type].setdefault(group_index, 0)
-                    group_verts[group_type][group_index] += 1
-                    if group_type == "IFCCIRCLE":
-                        is_circle = True
+                is_circle = any(gi in groups["IFCCIRCLE"] for gi in vert_group_indices)
+                is_arc = any(gi in groups["IFCARCINDEX"] for gi in vert_group_indices)
+                if (is_circle or is_arc) and not vert.link_edges:
+                    return (False, "CIRCLE" if is_circle else "3POINT_ARC")
                 if is_circle:
                     pass  # Circles are allowed to be unclosed
                 elif len(vert.link_edges) != 2:  # Unclosed loop or forked loop
                     return (False, "UNCLOSED_LOOP")
-
-        for group_type, group_counts in group_verts.items():
-            if group_type == "IFCARCINDEX":
-                for group_count in group_counts.values():
-                    if group_count != 3:  # Each arc needs 3 verts
-                        return (False, "3POINT_ARC")
-            elif group_type == "IFCCIRCLE":
-                for group_count in group_counts.values():
-                    if group_count != 2:  # Each circle needs 2 verts
-                        return (False, "CIRCLE")
 
         loop_edges = list(bm.edges)
 
@@ -2339,6 +2325,28 @@ class Model(bonsai.core.tool.Model):
                         loop_edges.remove(edge)
                         has_found_connected_edge = True
             loops.append(loop)
+
+        # Sanity check, per loop rather than across the whole mesh
+        if deform_layer:
+            for loop in loops:
+                loop_group_counts = {"IFCARCINDEX": {}, "IFCCIRCLE": {}}
+                loop_verts = {v for edge in loop for v in edge.verts}
+                for vert in loop_verts:
+                    for group_index in tool.Blender.bmesh_get_vertex_groups(vert, deform_layer):
+                        if group_index in groups["IFCARCINDEX"]:
+                            group_type = "IFCARCINDEX"
+                        elif group_index in groups["IFCCIRCLE"]:
+                            group_type = "IFCCIRCLE"
+                        else:
+                            continue
+                        loop_group_counts[group_type].setdefault(group_index, 0)
+                        loop_group_counts[group_type][group_index] += 1
+                for group_count in loop_group_counts["IFCARCINDEX"].values():
+                    if group_count != 3:  # Each arc needs 3 verts
+                        return (False, "3POINT_ARC")
+                for group_count in loop_group_counts["IFCCIRCLE"].values():
+                    if group_count != 2:  # Each circle needs 2 verts
+                        return (False, "CIRCLE")
 
         tmp = ifcopenshell.file(schema=tool.Ifc.get().schema)
 

--- a/src/bonsai/test/bim/module/model/test_profile_decorator_duplicate_loop.py
+++ b/src/bonsai/test/bim/module/model/test_profile_decorator_duplicate_loop.py
@@ -1,0 +1,141 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression tests for ``ProfileDecorator``'s ``_connected_components`` helper.
+
+Duplicating a circle/arc void's loop in Edit Mode (Tab, Tab, select the
+loop, Shift+D) copies the ``IFCARCINDEX``/``IFCCIRCLE`` vertex-group
+weights onto the new geometry, since Blender's mesh duplicate never
+allocates a new vertex group. Before this fix, ``ProfileDecorator``
+grouped arc/circle vertices by group index alone, so the duplicate's
+vertices piled into the same entry as the source loop's, failing the
+"exactly 2/3 verts" check and silently dropping *both* loops from the
+decorator until the mesh was re-imported (e.g. by leaving and re-entering
+Edit Mode). ``_connected_components`` splits each group's vertices back
+into their connected loops so a duplicate is drawn immediately, see #6944."""
+
+import bmesh
+import bpy
+import pytest
+
+from bonsai.bim.module.model.decorator import _connected_components
+
+pytestmark = pytest.mark.model
+
+
+def _bm_with_groups(verts, edges, groups):
+    """Build a standalone bmesh with a deform layer, and populate ``groups``:
+    a list of (group_index, [vert_indices]) pairs, mirroring how
+    ``tool.Model.import_profile``/``convert_curve_to_mesh`` assign one
+    vertex group per circle/arc loop."""
+    bm = bmesh.new()
+    deform_layer = bm.verts.layers.deform.new()
+    bm_verts = [bm.verts.new(v) for v in verts]
+    bm.verts.ensure_lookup_table()
+    for a, b in edges:
+        bm.edges.new((bm_verts[a], bm_verts[b]))
+    bm.verts.ensure_lookup_table()
+    bm_verts = list(bm.verts)
+    for group_index, vert_indices in groups:
+        for vi in vert_indices:
+            bm_verts[vi][deform_layer][group_index] = 1.0
+    return bm, bm_verts, deform_layer
+
+
+def _group_dict(bm_verts, deform_layer, group_index, vert_indices):
+    return {group_index: [bm_verts[i] for i in vert_indices]}
+
+
+def test_single_circle_loop_is_one_component():
+    # A circle is exactly 2 verts joined by 1 edge (tool.Model.convert_curve_to_mesh).
+    bm, bm_verts, deform_layer = _bm_with_groups(
+        verts=[(0, -1, 0), (0, 1, 0)],
+        edges=[(0, 1)],
+        groups=[(0, [0, 1])],
+    )
+    circles = _group_dict(bm_verts, deform_layer, 0, [0, 1])
+    components = _connected_components(circles)
+    assert len(components) == 1
+    assert len(components[0]) == 2
+    bm.free()
+
+
+def test_single_arc_loop_is_one_component():
+    # An arc is exactly 3 verts: endpoint-midpoint-endpoint (2 edges).
+    bm, bm_verts, deform_layer = _bm_with_groups(
+        verts=[(0, -1, 0), (0, 0, 0.3), (0, 1, 0)],
+        edges=[(0, 1), (1, 2)],
+        groups=[(0, [0, 1, 2])],
+    )
+    arcs = _group_dict(bm_verts, deform_layer, 0, [0, 1, 2])
+    components = _connected_components(arcs)
+    assert len(components) == 1
+    assert len(components[0]) == 3
+    bm.free()
+
+
+def test_duplicated_circle_loop_splits_into_two_components():
+    # Duplicating verts 0-1 (Shift+D) yields verts 2-3, connected to each
+    # other but NOT to the source loop, while keeping the same group index
+    # (0) -- exactly what bmesh.ops.duplicate produces mid Edit-Mode.
+    bm, bm_verts, deform_layer = _bm_with_groups(
+        verts=[(0, -1, 0), (0, 1, 0), (5, -1, 0), (5, 1, 0)],
+        edges=[(0, 1), (2, 3)],
+        groups=[(0, [0, 1, 2, 3])],
+    )
+    circles = _group_dict(bm_verts, deform_layer, 0, [0, 1, 2, 3])
+    components = _connected_components(circles)
+    assert len(components) == 2
+    assert sorted(len(c) for c in components) == [2, 2]
+    bm.free()
+
+
+def test_duplicated_arc_loop_splits_into_two_components():
+    bm, bm_verts, deform_layer = _bm_with_groups(
+        verts=[(0, -1, 0), (0, 0, 0.3), (0, 1, 0), (5, -1, 0), (5, 0, 0.3), (5, 1, 0)],
+        edges=[(0, 1), (1, 2), (3, 4), (4, 5)],
+        groups=[(0, [0, 1, 2, 3, 4, 5])],
+    )
+    arcs = _group_dict(bm_verts, deform_layer, 0, [0, 1, 2, 3, 4, 5])
+    components = _connected_components(arcs)
+    assert len(components) == 2
+    assert sorted(len(c) for c in components) == [3, 3]
+    bm.free()
+
+
+def test_distinct_circle_groups_stay_separate_and_correctly_sized():
+    # Multiple genuinely different circles (distinct group indices) must
+    # each still resolve to their own single 2-vert component.
+    verts = []
+    edges = []
+    groups = []
+    for i in range(5):
+        base = len(verts)
+        verts += [(i * 3, -1, 0), (i * 3, 1, 0)]
+        edges.append((base, base + 1))
+        groups.append((i, [base, base + 1]))
+    bm, bm_verts, deform_layer = _bm_with_groups(verts, edges, groups)
+    circles = {}
+    for group_index, vert_indices in groups:
+        circles[group_index] = [bm_verts[i] for i in vert_indices]
+    components = _connected_components(circles)
+    assert len(components) == 5
+    assert all(len(c) == 2 for c in components)
+    bm.free()


### PR DESCRIPTION
Fixes #6944.

Duplicating a circular or filleted-arc void in Edit Mode (Tab, Tab into the profile/curve editor, select a hole's loop, Shift+D) reused the same `IFCCIRCLE`/`IFCARCINDEX` vertex group index for the new geometry, since Blender's mesh duplicate copies vertex group weights but doesn't allocate a new group. On exit from Edit Mode, the reconstruction code's sanity check tallied group membership across the whole mesh rather than per loop, so a group meant to hold exactly 2 (circle) or 3 (arc) vertices ended up with double that, failing the check and blocking the edit with an "INVALID PROFILE" popup.

Scoped the sanity check to each connected edge loop instead, in both `auto_detect_profiles` (the reported repro, profile voids) and `auto_detect_curves` (the identical defect in the sibling function used for curve/annotation editing).

Verified live in headless Blender against the issue's attached repro file: before this change, duplicating one void's loop and moving it produced "INVALID PROFILE"; after, it produces a valid profile with the duplicate as an additional void or separate solid profile depending on final position. Also verified `auto_detect_curves` directly: two duplicate circle loops sharing one vertex group index now correctly produce two valid `IfcCircle` curves instead of being rejected.

`test/tool/test_model.py` passes unchanged (32 passed, 1 pre-existing unrelated failure present identically before and after).

This contribution was produced with the assistance of an AI coding tool.