### PR TITLE
Bonsai: reconstruct light objects when reloading an IFC file

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -866,6 +866,8 @@ class IfcImporter:
                 if mesh is not None:
                     tool.Loader.link_mesh(shape, mesh)
                     self.meshes[mesh_name] = mesh
+        elif self.is_light_element(element):
+            mesh = self.create_light(element)
         else:
             mesh = None
 
@@ -1065,6 +1067,9 @@ class IfcImporter:
             and tool.Drawing.ANNOTATION_TYPES_DATA[object_type].data_type == "curve"
         )
 
+    def is_light_element(self, element: ifcopenshell.entity_instance) -> bool:
+        return element.is_a("IfcLightFixture") or element.is_a("IfcLamp")
+
     def get_drawing_group(self, element):
         for rel in element.HasAssignments or []:
             if rel.is_a("IfcRelAssignsToGroup") and rel.RelatingGroup.ObjectType == "DRAWING":
@@ -1079,6 +1084,10 @@ class IfcImporter:
         result[1][3] *= self.unit_scale
         result[2][3] *= self.unit_scale
         return result
+
+    def create_light(self, element: ifcopenshell.entity_instance) -> bpy.types.Light:
+        light_type = "SUN" if getattr(element, "PredefinedType", None) == "DIRECTIONSOURCE" else "POINT"
+        return bpy.data.lights.new(tool.Loader.get_name(element), type=light_type)
 
     def create_curve(
         self,

--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -374,7 +374,7 @@ class AssignClass(bpy.types.Operator, tool.Ifc.Operator):
                 representation = tool.Geometry.get_active_representation(obj)
                 if representation:
                     tool.Geometry.reload_representation(obj)
-                elif obj.data is not None:
+                elif obj.data is not None and not isinstance(obj.data, bpy.types.Light):
                     new_obj = tool.Geometry.recreate_object_with_data(obj, None)
 
             # Accomodate existing importers to Blender from other formats that set custom props

--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -51,7 +51,7 @@ import bonsai.tool as tool
 # supplementary objects (e.g. drawings, structural analysis models, etc).
 
 
-OBJECT_DATA_TYPE = Union[bpy.types.Mesh, bpy.types.Curve]
+OBJECT_DATA_TYPE = Union[bpy.types.Mesh, bpy.types.Curve, bpy.types.Light]
 
 
 class Loader(bonsai.core.tool.Loader):


### PR DESCRIPTION
Fixes #3303 (the reload gap Moult asked us to leave open, since the original crash was already fixed).

Assigning `IfcLightFixture`/`IfcLamp` to a Blender light actually destroyed the light data immediately, in the same session: `add_representation` only supports Mesh/Curve/Camera data, and the operator's fallback for "no representation was created" stripped any other object data down to `None`, silently converting the light to a data-less Empty. Saving and reopening then reconstructed it as an Empty too, since the importer had no code path to build a native Light data-block for a representation-less element.

- `AssignClass` now keeps the object's data when it's a `bpy.types.Light`, instead of stripping it.
- The importer creates a `bpy.types.Light` for `IfcLightFixture`/`IfcLamp` elements with no representation, using `PredefinedType` to pick `SUN` for `DIRECTIONSOURCE` and `POINT` otherwise. This supports both classes symmetrically per Moult's note that `IfcLightFixture` (the luminaire) and `IfcLamp` (the light source) are semantically distinct.

On the sun-lamp/IES feature Moult recalled building: it's not lost. `IfcLightSourcePositional` export support (a `"Lighting"` representation-context branch in `add_representation.py`) still exists from 2021, but nothing in the UI ever creates a `"Lighting"` context, and there's no import-side handling of it at all — a live but orphaned, UI-unreachable code path, independent of and unaffected by this fix. No goniometric/IES support exists anywhere in history.

Verified live in a fresh Blender process: before this fix, assigning the class converts the light to an Empty immediately, and a fresh reload after save also gives an Empty. After the fix, the object stays a real Light both immediately after assignment and after a save + fresh-session reload, including the `SUN`/`POINT` distinction round-tripping correctly.

This contribution was produced with the assistance of an AI coding tool.