### PR TITLE
Bonsai: add one-click Convert to Type for untyped occurrences

### DIFF
--- a/src/bonsai/bonsai/bim/module/type/__init__.py
+++ b/src/bonsai/bonsai/bim/module/type/__init__.py
@@ -23,6 +23,7 @@ from . import operator, prop, ui
 classes = (
     operator.AssignType,
     operator.AutoRenameOccurrences,
+    operator.ConvertToType,
     operator.DisableEditingType,
     operator.DisableEditingTypeAttributes,
     operator.DuplicateType,
@@ -43,7 +44,9 @@ classes = (
 
 def register():
     bpy.types.Object.BIMTypeProperties = bpy.props.PointerProperty(type=prop.BIMTypeProperties)
+    bpy.types.VIEW3D_MT_object_context_menu.append(ui.object_context_menu)
 
 
 def unregister():
     del bpy.types.Object.BIMTypeProperties
+    bpy.types.VIEW3D_MT_object_context_menu.remove(ui.object_context_menu)

--- a/src/bonsai/bonsai/bim/module/type/operator.py
+++ b/src/bonsai/bonsai/bim/module/type/operator.py
@@ -20,10 +20,12 @@ from typing import TYPE_CHECKING
 
 import bpy
 import ifcopenshell.api.attribute
+import ifcopenshell.api.geometry
 import ifcopenshell.api.material
 import ifcopenshell.api.type
 import ifcopenshell.util.element
 import ifcopenshell.util.representation
+import ifcopenshell.util.type
 
 import bonsai.bim.helper
 import bonsai.core.geometry
@@ -106,6 +108,103 @@ class AssignType(bpy.types.Operator, tool.Ifc.Operator):
                 obj.name = tool.Model.generate_occurrence_name(relating_type, element.is_a())
 
 
+class ConvertToType(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.convert_to_type"
+    bl_label = "Convert to Type"
+    bl_description = (
+        "Create a new type from this object's own geometry, and assign this object to it.\n\n"
+        "Equivalent to launching the Type Manager, creating a type using this object's tessellation, "
+        "then assigning this object to that type."
+    )
+    bl_options = {"REGISTER", "UNDO"}
+    name: bpy.props.StringProperty(name="Name")
+
+    if TYPE_CHECKING:
+        name: str
+
+    @classmethod
+    def poll(cls, context):
+        if not (obj := context.active_object):
+            return False
+        if not (element := tool.Ifc.get_entity(obj)):
+            return False
+        if not element.is_a("IfcProduct") or element.is_a("IfcTypeProduct"):
+            return False
+        if not element.Representation:
+            cls.poll_message_set("Object has no geometry to convert into a type.")
+            return False
+        if ifcopenshell.util.element.get_type(element):
+            cls.poll_message_set("Object already has a type. Unassign it first, or duplicate its type instead.")
+            return False
+        if not ifcopenshell.util.type.get_applicable_types(element.is_a(), tool.Ifc.get().schema):
+            cls.poll_message_set(f"{element.is_a()} has no applicable type class.")
+            return False
+        return True
+
+    def invoke(self, context, event):
+        assert (obj := context.active_object)
+        element = tool.Ifc.get_entity(obj)
+        assert element
+        self.name = element.Name or "Unnamed"
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        self.layout.prop(self, "name")
+
+    def _execute(self, context):
+        assert (obj := context.active_object)
+        element = tool.Ifc.get_entity(obj)
+        assert element
+        ifc_file = tool.Ifc.get()
+
+        type_class = ifcopenshell.util.type.get_applicable_types(element.is_a(), ifc_file.schema)[0]
+
+        ifc_context = None
+        if active_representation := tool.Geometry.get_active_representation(obj):
+            ifc_context = active_representation.ContextOfItems
+        ifc_context = ifc_context or tool.Type.get_body_context()
+        if not ifc_context:
+            self.report({"ERROR"}, "No representation context is available to build the type's geometry.")
+            return {"CANCELLED"}
+
+        predefined_type = ifcopenshell.util.element.get_predefined_type(element)
+
+        type_obj = bpy.data.objects.new(self.name or "Unnamed", bpy.data.meshes.new("Mesh"))
+        type_element = bonsai.core.root.assign_class(
+            tool.Ifc,
+            tool.Collector,
+            tool.Root,
+            obj=type_obj,
+            ifc_class=type_class,
+            predefined_type=predefined_type,
+            should_add_representation=False,
+        )
+        assert type_element
+
+        type_obj.matrix_world = obj.matrix_world.copy()
+        type_obj.scale = (1, 1, 1)
+        representation = tool.Geometry.export_mesh_to_tessellation(obj, ifc_context)
+        ifcopenshell.api.geometry.assign_representation(ifc_file, type_element, representation)
+        bonsai.core.geometry.switch_representation(
+            tool.Ifc,
+            tool.Geometry,
+            obj=type_obj,
+            representation=representation,
+        )
+
+        context.view_layer.update()  # Ensures type_obj.matrix_world is correct
+        bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=type_obj)
+
+        core.assign_type(tool.Ifc, tool.Model, tool.Type, element=element, type=type_element)
+
+        prefs = tool.Blender.get_addon_preferences()
+        if prefs.occurrence_name_style == "TYPE":
+            obj.name = tool.Model.generate_occurrence_name(type_element, element.is_a())
+
+        bpy.ops.bim.load_type_thumbnails()
+        self.report({"INFO"}, f"Created and assigned type '{type_element.Name or 'Unnamed'}'.")
+
+
 class UnassignType(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.unassign_type"
     bl_label = "Unassign Type"
@@ -117,9 +216,7 @@ class UnassignType(bpy.types.Operator, tool.Ifc.Operator):
         related_object: str
 
     @staticmethod
-    def _reattach_styles(
-        file: ifcopenshell.file, copied_entities: dict[int, ifcopenshell.entity_instance]
-    ) -> None:
+    def _reattach_styles(file: ifcopenshell.file, copied_entities: dict[int, ifcopenshell.entity_instance]) -> None:
         """copy_deep only follows forward references, so IfcStyledItem (an inverse,
         ``StyledByItem``) is not carried onto the copied geometry. Re-create a
         styled item on each copy that points at the same presentation styles as

--- a/src/bonsai/bonsai/bim/module/type/ui.py
+++ b/src/bonsai/bonsai/bim/module/type/ui.py
@@ -17,6 +17,7 @@
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
 import bpy
+import ifcopenshell.util.element
 from bpy.types import Panel
 
 import bonsai.bim.module.type.prop as type_prop
@@ -106,6 +107,7 @@ class BIM_PT_type(Panel):
             else:
                 row.label(text="No Relating Type")
                 row.operator("bim.enable_editing_type", icon="GREASEPENCIL", text="")
+                row.operator("bim.convert_to_type", icon="ADD", text="Convert to Type")
 
 
 class BIM_PT_type_attributes(Panel):
@@ -159,3 +161,15 @@ class BIM_PT_type_attributes(Panel):
 
 def add_object_button(self, context):
     self.layout.operator("bim.add_occurrence", icon="PLUGIN")
+
+
+def object_context_menu(self, context):
+    obj = context.active_object
+    if not (obj and (element := tool.Ifc.get_entity(obj))):
+        return
+    if not element.is_a("IfcProduct") or element.is_a("IfcTypeProduct"):
+        return
+    if ifcopenshell.util.element.get_type(element):
+        return
+    self.layout.separator()
+    self.layout.operator("bim.convert_to_type", icon="PLUGIN")


### PR DESCRIPTION
Fixes #3406.

The existing way to turn a bespoke, typeless occurrence into a proper IFC type is to launch the Type Manager, pick the "Tessellation From Object" template with the occurrence as the source object, save the new type, then go back and manually assign that type to the occurrence. The reporter and a maintainer (Moult) both confirmed this is a valid workflow, and another maintainer (Gorgious56) flagged the multi-step process as "cumbersome... too many clicks and muscle memory."

`ConvertToType` automates that exact same chain in one operator call: it builds the new type's geometry via the same `tool.Geometry.export_mesh_to_tessellation()` + `assign_representation` path `AddElement`'s OBJ template already uses, then calls `core.type.assign_type()` (the same function `AssignType` uses) to attach the occurrence to it. No new type-creation mechanism is introduced, this is purely a convenience that chains the existing, already-validated pieces.

The operator is disabled once an occurrence already has a type (use Duplicate Type instead) or has no geometry to copy. It's exposed both in the object's Type properties panel (next to the existing "No Relating Type" row) and in the viewport's object right-click menu, following the same `icon="PLUGIN"` convention used by other one-click IFC conveniences in the geometry module.

Verified live in headless Blender: created a bespoke `IfcBuildingElementProxy` occurrence with custom mesh geometry and no type, ran the new operator, confirmed a new `IfcBuildingElementProxyType` is created with the requested name, `ifcopenshell.util.element.get_type()` returns it, and the occurrence's resolved representation is the *same entity* as the type's mapped representation (true sharing, not a copy). Also confirmed the existing manual workflow (Tessellation From Object template + separate Assign Type) still works unchanged.

This contribution was produced with the assistance of an AI coding tool.