### PR TITLE
ifcopenshell.api: don't cascade a reassigned occurrence's class onto its shared type and siblings

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -115,13 +115,14 @@ class ReassignClass(bpy.types.Operator, tool.Ifc.Operator):
         if predefined_type == "USERDEFINED":
             predefined_type = root_props.ifc_userdefined_type
 
-        # NOTE: root.reassign_class
-        # automatically will reassign class for other occurrences of the type
-        # so we need to run it only for the types or non-typed elements
+        # NOTE: root.reassign_class on a type automatically reassigns the class
+        # of all its occurrences, so when every occurrence of a type is selected
+        # we reassign the type once instead of each occurrence individually
         elements_to_reassign: dict[ifcopenshell.entity_instance, str] = dict()
         # need to update blender object name
         # for all elements that were changed in the process
         elements_to_update: set[ifcopenshell.entity_instance] = set()
+        selected_elements = set(e for o in objects if (e := tool.Ifc.get_entity(o)))
         for obj in objects:
             element = tool.Ifc.get_entity(obj)
             if not element:
@@ -157,9 +158,15 @@ class ReassignClass(bpy.types.Operator, tool.Ifc.Operator):
                 elements_to_update.update(ifcopenshell.util.element.get_types(element))
                 continue
             elif same_ifc_product and (element_type := ifcopenshell.util.element.get_type(element)):
-                assert type_ifc_class
-                elements_to_reassign[element_type] = type_ifc_class
-                elements_to_update.update(ifcopenshell.util.element.get_types(element_type))
+                occurrences = set(ifcopenshell.util.element.get_types(element_type))
+                if occurrences <= selected_elements:
+                    assert type_ifc_class
+                    elements_to_reassign[element_type] = type_ifc_class
+                    elements_to_update.update(occurrences)
+                else:
+                    # only some occurrences of the type are selected - reassign
+                    # just those, root.reassign_class will detach them from the type
+                    elements_to_reassign[element] = ifc_class
                 continue
 
             # non-typed element

--- a/src/bonsai/test/bim/module/root/test_reassign_class_occurrence.py
+++ b/src/bonsai/test/bim/module/root/test_reassign_class_occurrence.py
@@ -1,0 +1,159 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Contract tests for ``ReassignClass._execute``'s occurrence handling.
+
+Reassigning the class of one occurrence that shares its type with siblings
+must not redirect to the type (which would cascade the new class onto every
+sibling, issue #2831). The type redirect is only valid when the user selected
+every occurrence of that type, in which case reassigning the type once is
+the sensible batch behavior."""
+
+from unittest import mock
+
+import pytest
+
+pytestmark = pytest.mark.root
+
+
+@pytest.fixture(autouse=True)
+def _require_real_bpy():
+    import types as _types
+
+    import bpy
+
+    if not isinstance(bpy, _types.ModuleType) or hasattr(bpy, "_mock_name"):
+        pytest.skip("requires real Blender (bpy is mocked or absent)")
+
+
+@pytest.fixture
+def fresh_ifc():
+    import ifcopenshell
+
+    from bonsai.bim.ifc import IfcStore
+
+    previous_file = IfcStore.file
+    previous_schema = IfcStore.schema
+    IfcStore.file = ifcopenshell.file(schema="IFC4")
+    IfcStore.schema = None
+    try:
+        yield IfcStore.file
+    finally:
+        IfcStore.file = previous_file
+        IfcStore.schema = previous_schema
+
+
+def _make_object(name, element):
+    """Build a real bpy.types.Object linked to an IFC entity via
+    tool.Ifc.link, so tool.Ifc.get_entity(obj) resolves correctly."""
+    import bpy
+
+    import bonsai.tool as tool
+
+    obj = bpy.data.objects.new(name, None)
+    tool.Ifc.link(element, obj)
+    return obj
+
+
+def _make_root_props(ifc_product, ifc_class):
+    return mock.Mock(
+        ifc_product=ifc_product,
+        ifc_class=ifc_class,
+        ifc_predefined_type="",
+        ifc_userdefined_type="",
+    )
+
+
+def _fake_operator():
+    """Satisfy the attribute reads ``ReassignClass._execute`` makes on
+    ``self`` (``obj``, ``file``, ``report``)."""
+    op = mock.MagicMock()
+    op.obj = ""
+    op.report = mock.Mock()
+    return op
+
+
+def _run_reassign(selected_objects, ifc_class="IfcSlab"):
+    from bonsai.bim.module.root.operator import ReassignClass
+
+    op = _fake_operator()
+    with mock.patch(
+        "bonsai.bim.module.root.operator.tool.Blender.get_selected_objects", return_value=selected_objects
+    ), mock.patch(
+        "bonsai.bim.module.root.operator.tool.Root.get_root_props",
+        return_value=_make_root_props("IfcElement", ifc_class),
+    ), mock.patch(
+        "bonsai.bim.module.root.operator.tool.Root.set_object_name"
+    ), mock.patch(
+        "bonsai.bim.module.root.operator.tool.Collector.assign"
+    ):
+        return ReassignClass._execute(op, mock.Mock())
+
+
+def _typed_walls(ifc_file, count=3):
+    import ifcopenshell.api.root
+    import ifcopenshell.api.type
+
+    wall_type = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWallType")
+    walls = [
+        ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name=f"Wall{i + 1}") for i in range(count)
+    ]
+    ifcopenshell.api.type.assign_type(ifc_file, related_objects=walls, relating_type=wall_type)
+    return wall_type, walls
+
+
+def test_reassigning_one_occurrence_among_siblings_leaves_type_and_siblings_untouched(fresh_ifc):
+    import ifcopenshell.util.element
+
+    wall_type, walls = _typed_walls(fresh_ifc)
+    objs = [_make_object(f"IfcWall/Wall{i + 1}", wall) for i, wall in enumerate(walls)]
+    wall1_id = walls[0].id()
+
+    result = _run_reassign([objs[0]])
+
+    assert result == {"FINISHED"}
+    slab = fresh_ifc.by_id(wall1_id)
+    assert slab.is_a("IfcSlab")
+    # reassigned occurrence is detached from the now-mismatched type
+    assert ifcopenshell.util.element.get_type(slab) is None
+    # shared type and sibling occurrences are untouched
+    assert wall_type.is_a("IfcWallType")
+    assert set(ifcopenshell.util.element.get_types(wall_type)) == {walls[1], walls[2]}
+    assert walls[1].is_a("IfcWall") and walls[2].is_a("IfcWall")
+    assert len(fresh_ifc.by_type("IfcSlabType")) == 0
+
+
+def test_reassigning_all_occurrences_of_a_type_reassigns_the_type_once(fresh_ifc):
+    import ifcopenshell.util.element
+
+    wall_type, walls = _typed_walls(fresh_ifc)
+    objs = [_make_object(f"IfcWall/Wall{i + 1}", wall) for i, wall in enumerate(walls)]
+    wall_type_id = wall_type.id()
+
+    result = _run_reassign(objs)
+
+    assert result == {"FINISHED"}
+    slab_type = fresh_ifc.by_id(wall_type_id)
+    assert slab_type.is_a("IfcSlabType")
+    occurrences = ifcopenshell.util.element.get_types(slab_type)
+    assert len(occurrences) == 3
+    assert all(o.is_a("IfcSlab") for o in occurrences)
+    assert len(fresh_ifc.by_type("IfcWall")) == 0
+    assert len(fresh_ifc.by_type("IfcWallType")) == 0

--- a/src/bonsai/test/tool/test_root.py
+++ b/src/bonsai/test/tool/test_root.py
@@ -211,7 +211,46 @@ class TestReassignClass(NewFile):
             assert isinstance(obj := tool.Ifc.get_object(wall), bpy.types.Object)
             assert obj.name.startswith("IfcWall/")
 
-    def test_reassigning_multiple_occurrences_of_the_same_type(self):
+    def test_reassigning_some_occurrences_of_the_same_type_keeps_the_others_untouched(self):
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc_file = tool.Ifc.get()
+        context = bpy.context
+        relating_type = ifc_file.by_type("IfcSlabType")[0]
+        relating_type_id = relating_type.id()
+        n_wall_types = len(ifc_file.by_type("IfcWallType"))
+        n_slab_types = len(ifc_file.by_type("IfcSlabType"))
+
+        # create 3 slabs
+        bpy.ops.bim.add_occurrence(relating_type_id=relating_type_id)
+        bpy.ops.bim.add_occurrence(relating_type_id=relating_type_id)
+        bpy.ops.bim.add_occurrence(relating_type_id=relating_type_id)
+
+        slabs = [
+            obj for e in ifc_file.by_type("IfcSlab") if isinstance(obj := tool.Ifc.get_object(e), bpy.types.Object)
+        ]
+        assert len(slabs) == 3
+        # select only 2 of the 3 occurrences
+        tool.Blender.set_objects_selection(context, slabs[0], (slabs[1],))
+
+        props = tool.Root.get_root_props()
+        props.ifc_product = "IfcElement"
+        props.ifc_class = "IfcWall"
+        bpy.ops.bim.reassign_class()
+
+        # only the selected occurrences are reassigned, detached from their type
+        walls = ifc_file.by_type("IfcWall")
+        assert len(walls) == 2
+        assert all(ifcopenshell.util.element.get_type(wall) is None for wall in walls)
+
+        # the unselected occurrence and the shared type are untouched
+        remaining_slabs = ifc_file.by_type("IfcSlab")
+        assert len(remaining_slabs) == 1
+        assert ifcopenshell.util.element.get_type(remaining_slabs[0]) == relating_type
+        assert len(ifc_file.by_type("IfcWallType")) == n_wall_types
+        assert len(ifc_file.by_type("IfcSlabType")) == n_slab_types
+
+    def test_reassigning_all_occurrences_of_the_same_type_reassigns_the_type(self):
         tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
         bpy.ops.bim.create_project()
         ifc_file = tool.Ifc.get()
@@ -229,7 +268,7 @@ class TestReassignClass(NewFile):
             obj for e in ifc_file.by_type("IfcSlab") if isinstance(obj := tool.Ifc.get_object(e), bpy.types.Object)
         ]
         assert len(slabs) == 3
-        tool.Blender.set_objects_selection(context, slabs[0], (slabs[1],))
+        tool.Blender.set_objects_selection(context, slabs[0], slabs[1:])
 
         props = tool.Root.get_root_props()
         props.ifc_product = "IfcElement"

--- a/src/ifcopenshell-python/ifcopenshell/api/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/__init__.py
@@ -232,6 +232,10 @@ def extract_docs(module: str, usecase: str) -> dict[str, Any]:
 
 def serialise_settings(settings):
     def serialise_entity_instance(entity):
+        # entity.id() crashes if the underlying instance was since deleted;
+        # entity.wrapped_data.id_ is a plain, crash-safe attribute read.
+        if entity.wrapped_data.id_ == 0:
+            return {"cast_type": "entity_instance", "value": None, "Name": "<stale reference>"}
         return {"cast_type": "entity_instance", "value": entity.id(), "Name": getattr(entity, "Name", None)}
 
     vcs_settings = settings.copy()

--- a/src/ifcopenshell-python/ifcopenshell/api/root/reassign_class.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/root/reassign_class.py
@@ -49,10 +49,15 @@ def reassign_class(
     If you are reassigning a type, the occurrence classes are also
     reassigned to maintain validity.
 
-    Vice versa, if you are reassigning an occurrence, the type is also
-    reassigned in IFC4 and up. In IFC2X3, this may not occur if the type
-    cannot be unambiguously derived, so you are required to manually check
-    this.
+    Vice versa, if you are reassigning an occurrence which is the only
+    occurrence of its type, the type is also reassigned in IFC4 and up.
+    In IFC2X3, this may not occur if the type cannot be unambiguously
+    derived, so you are required to manually check this.
+
+    If the occurrence's type has other occurrences, neither the type nor
+    the other occurrences are modified. Instead, the reassigned occurrence
+    is unassigned from the type (a mismatched type is invalid in IFC4 and
+    up), leaving it untyped. Assign a new type manually if needed.
 
     Reassigning type class to occurrence (and vice versa) is supported.
 
@@ -208,13 +213,15 @@ class Usecase:
         else:
             element_type = ifcopenshell.util.element.get_type(element)
             if element_type:
-                ifc_class_ = next(iter(ifcopenshell.util.type.get_applicable_types(ifc_class, self.file.schema)))
-                element_type = self.reassign_class(element_type, ifc_class_, predefined_type)
-                ifc_class = element.is_a()
-                for occurrence in ifcopenshell.util.element.get_types(element_type):
-                    if occurrence == element:
-                        continue
-                    self.reassign_class(occurrence, ifc_class, predefined_type)
+                occurrences = ifcopenshell.util.element.get_types(element_type)
+                if any(occurrence != element for occurrence in occurrences):
+                    # The type is shared with other occurrences, so reassigning it
+                    # (or them) is not allowed - the caller asked to change only this
+                    # element. Detach the element from the now-mismatched type instead.
+                    ifcopenshell.api.type.unassign_type(self.file, [element])
+                else:
+                    ifc_class_ = next(iter(ifcopenshell.util.type.get_applicable_types(ifc_class, self.file.schema)))
+                    self.reassign_class(element_type, ifc_class_, predefined_type)
         return element
 
     def reassign_class(

--- a/src/ifcopenshell-python/test/api/root/test_reassign_class.py
+++ b/src/ifcopenshell-python/test/api/root/test_reassign_class.py
@@ -78,27 +78,44 @@ class TestReassignClass(test.bootstrap.IFC4):
         assert len(self.file.by_type("IfcWall")) == 0
         assert len(self.file.by_type("IfcWallType")) == 0
 
-    def test_reassigning_type_class_and_its_occurrences_classes_if_entity_was_typed(self):
+    def test_reassigning_type_class_if_entity_was_the_only_occurrence_of_the_type(self):
         element_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
-        element1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
-        ifcopenshell.api.type.assign_type(self.file, related_objects=[element1], relating_type=element_type)
-        element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
-        ifcopenshell.api.type.assign_type(self.file, related_objects=[element2], relating_type=element_type)
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=element_type)
 
-        element1 = ifcopenshell.api.root.reassign_class(self.file, product=element1, ifc_class="IfcSlab")
+        element = ifcopenshell.api.root.reassign_class(self.file, product=element, ifc_class="IfcSlab")
 
         # occurrence type has reassigned class
-        element_type = ifcopenshell.util.element.get_type(element1)
+        element_type = ifcopenshell.util.element.get_type(element)
         assert element_type.is_a("IfcSlabType")
-
-        # other type occurrences have reassigned classes
-        occurrences = ifcopenshell.util.element.get_types(element_type)
-        assert len(occurrences) == 2
-        assert all(o.is_a("IfcSlab") for o in occurrences)
+        assert list(ifcopenshell.util.element.get_types(element_type)) == [element]
 
         # original clases are gone
         assert len(self.file.by_type("IfcWall")) == 0
         assert len(self.file.by_type("IfcWallType")) == 0
+
+    def test_reassigning_one_occurrence_of_a_shared_type_without_affecting_other_occurrences(self):
+        element_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        wall1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall", name="Wall1")
+        wall2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall", name="Wall2")
+        wall3 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall", name="Wall3")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[wall1, wall2, wall3], relating_type=element_type)
+
+        slab = ifcopenshell.api.root.reassign_class(self.file, product=wall1, ifc_class="IfcSlab")
+
+        # only the requested occurrence is reassigned,
+        # and it's detached from the now-mismatched type
+        assert slab.is_a("IfcSlab")
+        assert ifcopenshell.util.element.get_type(slab) is None
+
+        # shared type and its other occurrences are untouched
+        assert element_type.is_a("IfcWallType")
+        assert set(ifcopenshell.util.element.get_types(element_type)) == {wall2, wall3}
+        assert wall2.is_a("IfcWall") and wall3.is_a("IfcWall")
+        assert len(self.file.by_type("IfcWall")) == 2
+        assert len(self.file.by_type("IfcWallType")) == 1
+        assert len(self.file.by_type("IfcSlab")) == 1
+        assert len(self.file.by_type("IfcSlabType")) == 0
 
     # Switching between occurrence / type classes.
     def test_unassign_type_from_occurrences_if_switching_from_type_class_to_occurrence_class(self):


### PR DESCRIPTION
Fixes #2831.

Reassigning the class of one occurrence used to mutate its shared type in place and then reassign every other occurrence of that type too, silently reclassifying elements the caller never touched. The cascade (added in 03809b3d5e) exists to satisfy IFC4+'s type/occurrence class-parity WHERE rules, but parity only constrains the reassigned occurrence itself. When the type has other occurrences, `root.reassign_class` now detaches just the target occurrence from the now-mismatched type (leaving it untyped) instead of touching the type or its siblings. When the occurrence is the type's sole occurrence, the previous behavior (reassign the type in place) is unchanged.

Bonsai's `ReassignClass` operator rode the old cascade by redirecting typed occurrences to their type; it now redirects to the type only when every occurrence of that type is selected (so a batch reassignment across a whole type still happens as one type-level call), otherwise it reassigns the selected occurrences themselves.

Also included: while investigating this, found that a usecase which recreates an entity in place under the same id (as `ifcopenshell.util.schema.reassign_class` does) can leave a stale Python reference that later crashes the whole process if it reaches a different `ifcopenshell.api.*` call, since Bonsai's action-logging pre-listener (registered on every call) tries to serialise it via `entity.id()`, which dereferences the deleted native instance. `entity.wrapped_data.id_` is a plain attribute read that IfcOpenShell resets to 0 on removal and is safe to check first. This doesn't make every stale-reference access safe (a usecase that receives a stale entity as its own primary argument still needs to dereference it for real work), it only stops best-effort logging from turning a latent staleness bug into a guaranteed crash.

Verified live in headless Blender: reassigning one of three occurrences sharing a wall type correctly detaches only that occurrence (type and the other two occurrences untouched, no new type created), while selecting all occurrences of a type still reassigns the type once as before. Confirmed the logging-path fix with a before/after: the crash reproduces on the unpatched line and is resolved by the new guard. Lint (black + ruff) clean.

This contribution was produced with the assistance of an AI coding tool.