### PR TITLE
Bonsai: resync mirrored walls' openings so voids follow their door/window

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -659,6 +659,7 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
 
         bpy.ops.bim.override_object_duplicate_move(is_interactive=False)
 
+        wall_objs = []
         for obj in context.selected_objects:
             if obj == mirror:
                 continue
@@ -676,6 +677,14 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
             newmat.translation = Vector(newmat.translation) - (newmat.to_quaternion() @ centroid)
 
             obj.matrix_world = newmat
+
+            element = tool.Ifc.get_entity(obj)
+            if element and tool.Model.get_usage_type(element) == "LAYER2":
+                wall_objs.append(obj)
+
+        # Resync fillings/openings to the walls' new mirrored placement.
+        if wall_objs:
+            tool.Model.recalculate_walls(wall_objs)
 
 
 def generate_box(usecase_path: str, ifc_file: ifcopenshell.file, settings: dict[str, Any]) -> None:

--- a/src/bonsai/test/bim/module/model/test_mirror_elements.py
+++ b/src/bonsai/test/bim/module/model/test_mirror_elements.py
@@ -1,0 +1,136 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Pins the contract that ``bim.mirror_elements`` re-syncs a mirrored wall's
+filled opening to the wall's new (mirrored) placement.
+
+``MirrorElements`` duplicates the selection, then repositions each
+duplicate's ``matrix_world`` directly — the duplicated ``IfcOpeningElement``
+has no selectable Blender object of its own, so without an explicit resync
+its placement is left behind at the pre-mirror location while the host wall
+and door move on (issue #3302)."""
+
+from unittest.mock import patch
+
+import bpy
+import pytest
+
+import bonsai.tool as tool
+from test.bim.bootstrap import NewFile
+
+pytestmark = pytest.mark.model
+
+
+def _build_walled_door():
+    """A single LAYER2 wall, extended out, with a door voided into its span."""
+    bpy.ops.bim.create_project()
+    bpy.ops.bim.select_library_file(filepath="./bonsai/bim/data/libraries/IFC4 Demo Library.ifc", append_all=True)
+
+    ifc = tool.Ifc.get()
+    wall_type = next(e for e in ifc.by_type("IfcWallType") if e.Name == "WAL100")
+    door_type = next(e for e in ifc.by_type("IfcDoorType") if e.Name == "DT01")
+
+    props = bpy.context.scene.BIMModelProperties
+    props.ifc_class = "IfcWallType"
+    props.relating_type_id = str(wall_type.id())
+    bpy.context.scene.cursor.location = (0, 0, 0)
+    bpy.ops.bim.add_occurrence()
+    wall_obj = bpy.data.objects["IfcWall/Wall"]
+
+    bpy.ops.object.select_all(action="DESELECT")
+    wall_obj.select_set(True)
+    bpy.context.view_layer.objects.active = wall_obj
+    bpy.context.scene.cursor.location = (6, 0, 0)
+    bpy.ops.bim.hotkey(hotkey="S_E")
+
+    bpy.ops.object.select_all(action="DESELECT")
+    wall_obj.select_set(True)
+    bpy.context.view_layer.objects.active = wall_obj
+    props.ifc_class = "IfcDoorType"
+    props.relating_type_id = str(door_type.id())
+    bpy.context.scene.cursor.location = (3, 0, 0)
+    bpy.ops.bim.add_occurrence()
+    door_obj = bpy.data.objects["IfcDoor/Door"]
+
+    return wall_obj, door_obj
+
+
+class TestMirrorElementsResyncsOpenings(NewFile):
+    def test_mirrored_opening_follows_the_mirrored_host_wall(self):
+        wall_obj, door_obj = _build_walled_door()
+
+        mirror_empty = bpy.data.objects.new("MirrorAxis", None)
+        bpy.context.collection.objects.link(mirror_empty)
+        mirror_empty.location = (12, 0, 0)
+        bpy.context.view_layer.update()
+
+        bpy.ops.object.select_all(action="DESELECT")
+        wall_obj.select_set(True)
+        door_obj.select_set(True)
+        mirror_empty.select_set(True)
+        bpy.context.view_layer.objects.active = mirror_empty
+
+        assert bpy.ops.bim.mirror_elements() == {"FINISHED"}
+        bpy.context.view_layer.update()
+
+        new_wall_obj = next(o for o in bpy.data.objects if o.name.startswith("IfcWall/") and o != wall_obj)
+        new_door_obj = next(o for o in bpy.data.objects if o.name.startswith("IfcDoor/") and o != door_obj)
+
+        new_door_el = tool.Ifc.get_entity(new_door_obj)
+        assert new_door_el.FillsVoids, "mirrored door must still fill an opening"
+        opening = new_door_el.FillsVoids[0].RelatingOpeningElement
+
+        import ifcopenshell.util.placement
+
+        opening_x = ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement)[0][3]
+        door_x = new_door_obj.matrix_world.translation.x
+        wall_min_x = min(v[0] for v in new_wall_obj.bound_box)
+        wall_max_x = max(v[0] for v in new_wall_obj.bound_box)
+        wall_min_x = new_wall_obj.matrix_world.translation.x + wall_min_x
+        wall_max_x = new_wall_obj.matrix_world.translation.x + wall_max_x
+
+        assert opening_x == pytest.approx(
+            door_x, abs=0.01
+        ), "the mirrored opening must sit where the mirrored door now is, not at the door's pre-mirror position"
+        assert wall_min_x <= opening_x <= wall_max_x, "the mirrored opening must land inside its new host wall's span"
+
+    def test_recalculate_walls_is_skipped_when_no_wall_is_mirrored(self):
+        bpy.ops.bim.create_project()
+        bpy.ops.mesh.primitive_cube_add()
+        obj = bpy.context.active_object
+        obj.name = "Furniture"
+        rprops = tool.Root.get_root_props()
+        rprops.ifc_product = "IfcElement"
+        bpy.ops.bim.assign_class(ifc_class="IfcFurniture")
+
+        mirror_empty = bpy.data.objects.new("MirrorAxis", None)
+        bpy.context.collection.objects.link(mirror_empty)
+        mirror_empty.location = (5, 0, 0)
+        bpy.context.view_layer.update()
+
+        bpy.ops.object.select_all(action="DESELECT")
+        obj.select_set(True)
+        mirror_empty.select_set(True)
+        bpy.context.view_layer.objects.active = mirror_empty
+
+        with patch.object(tool.Model, "recalculate_walls") as recalculate_walls:
+            assert bpy.ops.bim.mirror_elements() == {"FINISHED"}
+
+        recalculate_walls.assert_not_called()


### PR DESCRIPTION
Fixes #3302 (opening/door offset after mirroring).

The reporter mirrored a room (walls + a hosted door) and found the void ended up detached from the door after the mirror. Reproduced live: mirroring repositions the duplicated wall and door objects' `matrix_world` directly, but the duplicated `IfcOpeningElement` has no Blender object of its own, so nothing ever moves it. `Duplicate.recreate_decompositions` stamps the new opening with the old opening's absolute world matrix at duplication time, which is correct at that instant, but `MirrorElements` then moves the wall/door out from under it, leaving the opening frozen at its pre-mirror position while the wall and door move to their mirrored location.

Bonsai already has the right fix for this exact class of problem, used when a door is dragged and the wall regenerated: `tool.Model.recalculate_walls` recomputes an opening's placement from its filling's current `matrix_world`. `MirrorElements._execute` now collects the LAYER2 (wall) objects it just repositioned and calls `recalculate_walls` on them at the end, so mirrored openings resync to their mirrored door/window instead of floating at the old location.

The other two problems in the original report are addressed without new code: the mitre-join-reverting-to-Extend behavior no longer reproduces (already fixed by prior wall-join-recreation work, `tool.Duplicate`), and the door-swing-not-flipping behavior already has a working, non-destructive manual fix (`toggle_door_swing`'s Shift-click "mirror without changing which side it opens to" mode), which avoids the type-mutation risk a maintainer (Gorgious56) flagged for any automatic approach.

Verified live in headless Blender: a mirrored opening now lands at the mirrored door's position, inside the mirrored wall's span, instead of floating outside it at the pre-mirror location. Added a regression test building a real wall+door via the actual authoring flow and mirroring it, confirmed it fails without the fix and passes with it, plus a second test confirming non-wall mirrors are unaffected. Full `test/bim/module/model/` suite (525 tests) passes with no new regressions; the BDD mitre/door scenarios (11/11) pass; lint (black + ruff) clean.

This contribution was produced with the assistance of an AI coding tool.