### PR TITLE
project.append_asset: reject GlobalId matches across incompatible classes

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -237,11 +237,15 @@ class Usecase:
             self.target_class = "IfcPresentationStyle"
             return self.append_presentation_style()
 
-    def by_guid(self, guid: str) -> Union[ifcopenshell.entity_instance, None]:
+    def by_guid(self, guid: str, ifc_class: Optional[str] = None) -> Union[ifcopenshell.entity_instance, None]:
         try:
-            return self.file.by_guid(guid)
+            existing = self.file.by_guid(guid)
         except RuntimeError:
             return None
+        # A GlobalId collision with an incompatible class is not the same asset.
+        if ifc_class is not None and not existing.is_a(ifc_class):
+            return None
+        return existing
 
     def material_sets_are_equal(self, set1: ifcopenshell.entity_instance, set2: ifcopenshell.entity_instance) -> bool:
         """Check if two material sets are structurally equivalent."""
@@ -310,7 +314,7 @@ class Usecase:
         if element.id() in self.added_elements:
             return self.added_elements[element.id()]
         if element.is_a("IfcRoot"):
-            return self.by_guid(element.GlobalId)
+            return self.by_guid(element.GlobalId, element.is_a())
         elif not self.assume_asset_uniqueness_by_name:
             return None
         elif element.is_a("IfcMaterial"):
@@ -523,7 +527,7 @@ class Usecase:
             # Currently known cases requiring attributes reassignment are rels.
             if not new.is_a("IfcRelationship"):
                 return
-        elif element.is_a("IfcRelationship") and (existing_rel := self.by_guid(element.GlobalId)):
+        elif element.is_a("IfcRelationship") and (existing_rel := self.by_guid(element.GlobalId, element.is_a())):
             new = existing_rel
         else:
             new = self.file.create_entity(element.is_a())
@@ -569,7 +573,7 @@ class Usecase:
         """Is IFC entity from inverse attribute is another asset to append that should be skipped."""
         if element == self.settings["element"]:
             return False
-        elif element.is_a("IfcRoot") and self.by_guid(element.GlobalId) is not None:
+        elif element.is_a("IfcRoot") and self.by_guid(element.GlobalId, element.is_a()) is not None:
             return False
         elif element.is_a("IfcDistributionPort"):
             return False

--- a/src/ifcopenshell-python/test/api/project/test_append_asset.py
+++ b/src/ifcopenshell-python/test/api/project/test_append_asset.py
@@ -843,3 +843,21 @@ class TestAppendAssetIFC4(test.bootstrap.IFC4, TestAppendAssetIFC2X3):
         ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialProfileSet", name="TestProfileSet")
         ifcopenshell.api.project.append_asset(self.file, library, column_type, assume_asset_uniqueness_by_name=False)
         assert len(self.file.by_type("IfcMaterialProfileSet")) == 2
+
+    def test_a_guid_collision_with_an_unrelated_class_is_not_reused_as_the_same_asset(self):
+        # Regression test for #8667: get_existing_element used to match an
+        # IfcRoot purely by GlobalId, so a colliding GlobalId on an unrelated
+        # class (e.g. Revit-style reused GUIDs) got treated as the same asset.
+        library = ifcopenshell.api.project.create_file(version=self.file.schema)
+        occurrence = ifcopenshell.api.root.create_entity(library, ifc_class="IfcSanitaryTerminal")
+        occurrence_type = ifcopenshell.api.root.create_entity(library, ifc_class="IfcSanitaryTerminalType")
+        ifcopenshell.api.type.assign_type(library, related_objects=[occurrence], relating_type=occurrence_type)
+
+        unrelated = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcFlowTerminal")
+        unrelated.GlobalId = occurrence_type.GlobalId
+
+        result = ifcopenshell.api.project.append_asset(self.file, library=library, element=occurrence)
+        assert result.is_a("IfcSanitaryTerminal")
+        result_type = ifcopenshell.util.element.get_type(result)
+        assert result_type.is_a("IfcSanitaryTerminalType")
+        assert result_type != unrelated


### PR DESCRIPTION
Fixes #8667.

## Problem

`get_existing_element` matched any `IfcRoot` purely by `GlobalId`, regardless of class. If a colliding `GlobalId` already existed in the destination file on an unrelated class (e.g. Revit-style reused GUIDs), that unrelated element was silently treated as the same asset. Depending on where the collision landed, this could either abort the whole append with a `TypeError` (as reported in #8667) or, more severely, silently return the unrelated pre-existing element as the result while the actual asset being appended was never added at all.

This is the complementary fix flagged in [this comment](https://github.com/IfcOpenShell/IfcOpenShell/pull/8669#issuecomment-5012498138) on #8669: that PR guards the specific `assign_type` failure mode so a colliding type doesn't abort the batch, but doesn't address the root cause in `get_existing_element` itself, which is also reachable via the occurrence's own `GlobalId`, not just its type's.

## Fix

`by_guid` now takes an optional `ifc_class` argument and returns `None` if the matched entity's class doesn't match. Its three call sites (`get_existing_element`, `add_inverse_element`, `is_another_asset`) now pass `element.is_a()` so a `GlobalId` collision with an incompatible class is never treated as a reuse.

## Testing

Added a regression test covering the type-collision case from the issue. Also manually verified in a headless Blender session (with the actual compiled `ifcopenshell` extension) that:
- The type-GlobalId-collision repro from the issue now appends cleanly and produces a genuinely new type, distinct from the unrelated colliding element.
- The occurrence's-own-GlobalId-collision variant (wall vs. door) from the linked PR comment also now appends cleanly and produces a genuinely new element, distinct from the unrelated colliding element.
- The full `test/api/project/test_append_asset.py` suite (78 tests) passes.

This PR is entirely AI-generated (Claude Code), including the fix, test, and this description.