### PR TITLE
Bonsai: wire Shift+K to split pipe/duct segments

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -930,6 +930,12 @@ class EditObjectUI:
                 row.label(text="", icon="BLANK1") if ui_context != "TOOL_HEADER" else row
                 row.label(text="", icon="BLANK1") if ui_context != "TOOL_HEADER" else row
 
+                if AuthoringData.data["active_class"] in ("IfcDuctSegment", "IfcPipeSegment"):
+                    row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
+                    add_layout_hotkey_operator(
+                        row, "Split", "S_K", "Split selected segment into two at the cursor location", ui_context
+                    )
+
             else:
                 add_layout_hotkey_operator(row, "Edit Axis", "A_E", "", ui_context)
                 row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
@@ -1367,6 +1373,10 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
             return
         if self.active_material_usage == "LAYER2":
             bpy.ops.bim.split_wall()
+        elif self.active_class == "IfcPipeSegment":
+            bpy.ops.bim.split_pipe_segment_at_cursor()
+        elif self.active_class == "IfcDuctSegment":
+            bpy.ops.bim.split_duct_segment_at_cursor()
 
     def hotkey_S_T(self):
         if not bpy.context.selected_objects:

--- a/src/bonsai/test/bim/module/model/test_mep_segment_split_integration.py
+++ b/src/bonsai/test/bim/module/model/test_mep_segment_split_integration.py
@@ -1,0 +1,139 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end integration tests for ``mep.split_mep_segment`` (#3941).
+
+Builds a real pipe run through the actual authoring flow — ``bim.add_default_type``
++ ``bim.add_occurrence`` (the same path ``DrawOccurrence`` uses) — three
+segments long: an upstream segment, the segment under test, and a
+downstream segment, joined end to end via real ``IfcRelConnectsPorts``.
+Then calls ``mep.split_mep_segment`` on the middle segment and pins:
+
+- both halves get the correct extruded length (geometry, not just IFC
+  attribute bookkeeping),
+- the new joint between the two halves is connected,
+- the original upstream/downstream connections survive untouched.
+
+None of this had a live-fixture test before (see the "deferred to a later
+integration session" note in ``test_mep_segment_edition.py``); this fills
+that gap for the split path specifically, since it's the one operator
+in this file with no test coverage at all prior to #3941."""
+
+import bpy
+import ifcopenshell.api.system
+import pytest
+from mathutils import Vector
+
+import bonsai.tool as tool
+from bonsai.bim.module.model import mep
+from test.bim.bootstrap import NewFile
+
+pytestmark = pytest.mark.model
+
+
+class TestMEPSegmentSplitIntegration(NewFile):
+    def _make_pipe_type(self):
+        bpy.ops.bim.add_default_type(ifc_element_type="IfcPipeSegmentType")
+        return tool.Ifc.get_entity(bpy.context.active_object)
+
+    def _place_segment(self, type_element, cursor_xy, depth):
+        """Places one occurrence of ``type_element`` through the real
+        ``bim.add_occurrence`` authoring path (``DumbProfileGenerator`` +
+        ``MEPGenerator.setup_ports``), at ``cursor_xy`` with the given
+        extrusion depth. Segments extrude along the type's default axis
+        from the cursor location, so laying out non-overlapping segments
+        along that axis is done by spacing ``cursor_xy`` accordingly."""
+        props = tool.Model.get_model_props()
+        props.relating_type_id = str(type_element.id())
+        props.extrusion_depth = depth
+        bpy.context.scene.cursor.location = Vector((cursor_xy[0], cursor_xy[1], 0.0))
+        bpy.ops.bim.add_occurrence()
+        obj = bpy.context.active_object
+        return obj, tool.Ifc.get_entity(obj)
+
+    def _axis_len(self, obj):
+        bpy.context.view_layer.update()
+        start, end = tool.Model.get_flow_segment_axis(obj)
+        return (end - start).length
+
+    def _setup_three_segment_run(self):
+        """Builds up -> mid -> down, each 2m long, connected end to end,
+        and returns (mid_obj, up_data, mid_data, down_data)."""
+        bpy.ops.bim.create_project()
+        pipe_type = self._make_pipe_type()
+
+        up_obj, up_elem = self._place_segment(pipe_type, (-2.0, 0.0), 2.0)
+        mid_obj, mid_elem = self._place_segment(pipe_type, (0.0, 0.0), 2.0)
+        down_obj, down_elem = self._place_segment(pipe_type, (2.0, 0.0), 2.0)
+
+        up_data = mep.MEPGenerator.get_segment_data(up_elem)
+        mid_data = mep.MEPGenerator.get_segment_data(mid_elem)
+        down_data = mep.MEPGenerator.get_segment_data(down_elem)
+
+        ifcopenshell.api.system.connect_port(
+            tool.Ifc.get(), port1=up_data["end_port"], port2=mid_data["start_port"], direction="NOTDEFINED"
+        )
+        ifcopenshell.api.system.connect_port(
+            tool.Ifc.get(), port1=mid_data["end_port"], port2=down_data["start_port"], direction="NOTDEFINED"
+        )
+        return mid_obj, up_data, mid_data, down_data
+
+    def test_split_produces_correctly_sized_halves(self):
+        mid_obj, up_data, mid_data, down_data = self._setup_three_segment_run()
+        assert self._axis_len(mid_obj) == pytest.approx(2.0, abs=0.01)
+
+        new_obj = mep.split_mep_segment(mid_obj, 0.8)
+        assert new_obj is not None
+
+        assert self._axis_len(mid_obj) == pytest.approx(0.8, abs=0.01)
+        assert self._axis_len(new_obj) == pytest.approx(1.2, abs=0.01)
+
+    def test_split_connects_the_new_joint_and_preserves_original_connections(self):
+        mid_obj, up_data, mid_data, down_data = self._setup_three_segment_run()
+
+        new_obj = mep.split_mep_segment(mid_obj, 0.8)
+        assert new_obj is not None
+
+        mid_elem_after = tool.Ifc.get_entity(mid_obj)
+        new_elem = tool.Ifc.get_entity(new_obj)
+        mid_data_after = mep.MEPGenerator.get_segment_data(mid_elem_after)
+        new_data = mep.MEPGenerator.get_segment_data(new_elem)
+
+        # Original start of the split segment is untouched: still wired to
+        # whatever was upstream before the split.
+        assert tool.System.get_connected_port(mid_data_after["start_port"]) == up_data["end_port"]
+
+        # The new joint between the two halves is connected both ways.
+        assert tool.System.get_connected_port(mid_data_after["end_port"]) == new_data["start_port"]
+        assert tool.System.get_connected_port(new_data["start_port"]) == mid_data_after["end_port"]
+
+        # Original end of the split segment is preserved on the new half:
+        # still wired to whatever was downstream before the split.
+        assert tool.System.get_connected_port(new_data["end_port"]) == down_data["start_port"]
+
+    def test_split_rejects_cut_too_close_to_an_endpoint(self):
+        """``split_mep_segment`` rejects cuts within 0.01m of either
+        endpoint rather than producing a degenerate zero-length half."""
+        mid_obj, up_data, mid_data, down_data = self._setup_three_segment_run()
+
+        assert mep.split_mep_segment(mid_obj, 0.005) is None
+        assert mep.split_mep_segment(mid_obj, 1.995) is None
+        # segment itself must be untouched by the rejected attempts
+        assert self._axis_len(mid_obj) == pytest.approx(2.0, abs=0.01)

--- a/src/bonsai/test/bim/module/model/test_workspace_split_hotkey_dispatch.py
+++ b/src/bonsai/test/bim/module/model/test_workspace_split_hotkey_dispatch.py
@@ -1,0 +1,105 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Dispatch-wiring test for ``Hotkey.hotkey_S_K`` (#3941).
+
+Walls already had a Shift+K split path (``bim.split_wall``, dispatched off
+``active_material_usage == "LAYER2"``); pipe and duct segments had the
+underlying split operators (``bim.split_pipe_segment_at_cursor`` /
+``bim.split_duct_segment_at_cursor``, exercised via the cursor-anchored
+gizmo icon) but ``hotkey_S_K`` never dispatched to them, so Shift+K was a
+no-op on a selected segment. This pins the dispatch table so a future
+regression (e.g. reordering the elif chain, or a typo in the operator
+name) is caught without needing a live Blender scene."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+pytestmark = pytest.mark.model
+
+
+def _hotkey_self(*, active_class=None, active_material_usage=None):
+    """Duck-typed stand-in for a ``Hotkey`` operator instance mid-``_execute``
+    — only the two attributes ``hotkey_S_K`` reads are set."""
+    fake = Mock()
+    fake.active_class = active_class
+    fake.active_material_usage = active_material_usage
+    return fake
+
+
+@pytest.mark.parametrize(
+    "active_class,active_material_usage,expected_op",
+    [
+        ("IfcWall", "LAYER2", "split_wall"),
+        ("IfcPipeSegment", "PROFILE", "split_pipe_segment_at_cursor"),
+        ("IfcDuctSegment", "PROFILE", "split_duct_segment_at_cursor"),
+    ],
+)
+def test_hotkey_s_k_dispatches_to_the_matching_split_operator(active_class, active_material_usage, expected_op):
+    from bonsai.bim.module.model import workspace
+
+    fake_self = _hotkey_self(active_class=active_class, active_material_usage=active_material_usage)
+
+    with patch("bpy.context") as mock_context, patch("bpy.ops.bim") as mock_bim_ops:
+        mock_context.selected_objects = [Mock()]
+        workspace.Hotkey.hotkey_S_K(fake_self)
+
+    called_op = getattr(mock_bim_ops, expected_op)
+    called_op.assert_called_once()
+
+    # None of the sibling split operators should have fired.
+    for other_op in ("split_wall", "split_pipe_segment_at_cursor", "split_duct_segment_at_cursor"):
+        if other_op == expected_op:
+            continue
+        assert not getattr(mock_bim_ops, other_op).called, f"{other_op} should not have been dispatched"
+
+
+@pytest.mark.parametrize(
+    "active_class,active_material_usage",
+    [
+        (None, None),  # no IFC entity (context.active_object had none)
+        ("IfcColumn", "PROFILE"),  # PROFILE usage, but not a pipe/duct segment
+        ("IfcCableSegment", "PROFILE"),  # MEP segment class the split operators don't cover
+    ],
+)
+def test_hotkey_s_k_is_a_no_op_for_unsupported_classes(active_class, active_material_usage):
+    from bonsai.bim.module.model import workspace
+
+    fake_self = _hotkey_self(active_class=active_class, active_material_usage=active_material_usage)
+
+    with patch("bpy.context") as mock_context, patch("bpy.ops.bim") as mock_bim_ops:
+        mock_context.selected_objects = [Mock()]
+        workspace.Hotkey.hotkey_S_K(fake_self)
+
+    for op in ("split_wall", "split_pipe_segment_at_cursor", "split_duct_segment_at_cursor"):
+        assert not getattr(mock_bim_ops, op).called
+
+
+def test_hotkey_s_k_does_nothing_without_a_selection():
+    from bonsai.bim.module.model import workspace
+
+    fake_self = _hotkey_self(active_class="IfcPipeSegment", active_material_usage="PROFILE")
+
+    with patch("bpy.context") as mock_context, patch("bpy.ops.bim") as mock_bim_ops:
+        mock_context.selected_objects = []
+        workspace.Hotkey.hotkey_S_K(fake_self)
+
+    assert not mock_bim_ops.split_pipe_segment_at_cursor.called


### PR DESCRIPTION
Fixes #3941.

The split-at-cursor logic for MEP pipe/duct segments already exists and shipped via #8155 (correct geometry resize, correct port reconnection at the new joint, preserved upstream/downstream connections), but it was only reachable through the viewport gizmo's cursor-anchored split icon. The Shift+K keyboard shortcut, which already works for walls, was never wired up for MEP segments, and there was no matching "Split" toolbar button in the pipe/duct panel. This adds both, dispatching to the existing `bim.split_pipe_segment_at_cursor`/`bim.split_duct_segment_at_cursor` operators, no new split logic introduced.

Verified live in headless Blender through the actual `bpy.ops.bim.hotkey(hotkey="S_K")` path (not a direct function call) on a real connected pipe run (upstream segment, mid segment, downstream segment, real ports connected via `ifcopenshell.api.system.connect_port`): pipe count increases by 1, resulting segment lengths are correct, the new mid-joint connects both new segments, and the original upstream/downstream connections survive untouched. Repeated for duct segments. Added integration tests exercising the real authoring + split flow, plus a hotkey-dispatch test, both run through the actual pytest-blender harness. Lint (black + ruff) clean.

Note: this issue is currently assigned to @Andrej730. Opening this in case it's useful, apologies if it overlaps with work already in progress, happy to close if so.

This contribution was produced with the assistance of an AI coding tool.