### PR TITLE
ci: fix compile-and-test failures on v0.8.0 (validate_stub crash + missing Optimise test deps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,7 @@ jobs:
           cd ../bsdd && make test || ERROR=1
           pip install deepdiff
           cd ../ifcdiff && make test || ERROR=1
+          pip install toposort igraph
           cd ../ifcpatch && make test || ERROR=1
           pip install -e ../ifc5d --no-deps
           pip install odfpy xlsxwriter

--- a/src/ifcopenshell-python/ifcopenshell/ifcopenshell_wrapper.pyi
+++ b/src/ifcopenshell-python/ifcopenshell/ifcopenshell_wrapper.pyi
@@ -484,6 +484,26 @@ class Settings:
     def set_(self, *args): ...
     def setting_names(self): ...
 
+class SvgEmitFlushEdges:
+    defaultvalue: Any
+    description: Any
+    name: Any
+
+class SvgRenderCreaseEdges:
+    defaultvalue: Any
+    description: Any
+    name: Any
+
+class SvgRenderSharpEdges:
+    defaultvalue: Any
+    description: Any
+    name: Any
+
+class SvgRidgeAngleMinDegrees:
+    defaultvalue: Any
+    description: Any
+    name: Any
+
 class SvgSerializer(WriteOnlyGeometrySerializer):
     def __init__(self, out_filename, geometry_settings, settings, logger=None): ...
     SH_NONE: Any
@@ -547,6 +567,16 @@ class SvgSerializer(WriteOnlyGeometrySerializer):
     def start_path(self, *args): ...
     def write(self, *args): ...
     def writeHeader(self): ...
+
+class SvgUseEdgeClassification:
+    defaultvalue: Any
+    description: Any
+    name: Any
+
+class SvgValleyAngleMinDegrees:
+    defaultvalue: Any
+    description: Any
+    name: Any
 
 class SwigPyIterator:
     def __init__(self, *args, **kwargs): ...

--- a/src/ifcwrap/IfcGeomWrapper.i
+++ b/src/ifcwrap/IfcGeomWrapper.i
@@ -794,11 +794,11 @@ struct ShapeRTTI : public boost::static_visitor<PyObject*>
 	%pythoncode %{
         # Hide the getters with read-only property implementations
         # Keep the owning element alive while its geometry is referenced (#1124).
-        def _geometry_with_backref(self, _f=geometry):
+        def geometry_with_backref_(self, _f=geometry):
             result = _f(self)
             result._parent = self
             return result
-        geometry = property(_geometry_with_backref)
+        geometry = property(geometry_with_backref_)
 	%}
 };
 
@@ -806,11 +806,11 @@ struct ShapeRTTI : public boost::static_visitor<PyObject*>
 	%pythoncode %{
         # Hide the getters with read-only property implementations
         # Keep the owning element alive while its geometry is referenced (#1124).
-        def _geometry_with_backref(self, _f=geometry):
+        def geometry_with_backref_(self, _f=geometry):
             result = _f(self)
             result._parent = self
             return result
-        geometry = property(_geometry_with_backref)
+        geometry = property(geometry_with_backref_)
 	%}
 };
 
@@ -836,11 +836,11 @@ struct ShapeRTTI : public boost::static_visitor<PyObject*>
     %pythoncode %{
         # Hide the getters with read-only property implementations
         # Keep the owning element alive while its geometry is referenced (#1124).
-        def _geometry_with_backref(self, _f=geometry):
+        def geometry_with_backref_(self, _f=geometry):
             result = _f(self)
             result._parent = self
             return result
-        geometry = property(_geometry_with_backref)
+        geometry = property(geometry_with_backref_)
         volume = property(calc_volume_)
         surface_area = property(calc_surface_area_)
     %}


### PR DESCRIPTION
Fixes the `ci` workflow's `compile-and-test` job, red since two of our own earlier commits landed. Two unrelated failures in the same "Test ifcopenshell-python" step:

**1. validate_stub crash.** #1124's fix (824c1fc280) named its pythoncode backref helper `_geometry_with_backref` with a leading underscore. `validate_stub.py`'s `get_function_node_name()` intentionally skips any leading-underscore name (its only exception is `_is`), so the helper never lands in its parsed `subnames` set, and the assertion in `find_method_by_name()` raises a bare `AssertionError` instead of the intended clean stub/wrapper diff, crashing `make test-parallel` on every push since. Renamed to `geometry_with_backref_` (trailing underscore), matching the existing local convention in the same class bodies (`calc_volume_`, `calc_surface_area_`). Also synced six SVG edge-classification settings-flag classes into `ifcopenshell_wrapper.pyi` that were added to the C++/SWIG side but never synced to the stub, which `validate_stub` would otherwise flag once the crash above is fixed.

**2. Missing test dependencies.** `test_Optimise.py` (added in 57cfd9d1fd) exercises `Optimise`'s `patch()`, which since 7ebdd046b6 hard-requires `toposort` as its fallback backend. `ci.yml` never installed it, so every `ifcpatch` test run since has failed with `ModuleNotFoundError`. Added the missing `pip install toposort igraph` before that test step.

Verified both by reproducing the exact CI failure locally: built against the exact CI-tested commit (`c68e4a0eee`) with SWIG 4.1.0 (matching `ci.yml`'s pinned build-from-source version), confirmed `validate_stub.py` crashes identically before the fix and passes cleanly after, and confirmed `test_Optimise.py`'s 6 tests fail with `ModuleNotFoundError` without the packages and pass with them.

Checked for prior aothms guidance on this code area before implementing: his only stated intent for #1124 was "establish a backreference to the parent element from the geometry," no naming requirement, so the rename doesn't conflict with his design.

Not addressed here, flagged as a separate, chronic, pre-existing issue: `test_bsdd.py`'s two tests hit a live `429 Too Many Requests` from the real `bsdd.buildingsmart.org` API, present in CI well before these commits. That needs a design decision (retry/backoff/credentials), not a quick patch, and is out of scope for this PR.

This contribution was produced with the assistance of an AI coding tool.