### PR TITLE
[Concept] Generic cross-schema apply_visitor for #1333

### DIFF
--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -98,3 +98,12 @@ if("4x3_add2" IN_LIST SCHEMA_VERSIONS)
     build_example(IfcAlignment)
     build_example(IfcSimplifiedAlignment)
 endif()
+
+# Unlike the other examples above, this one is compiled once (no per-schema
+# -DIfcSchema= build trick) and dispatches across IFC2X3, IFC4 and
+# IFC4X3_ADD2 at runtime from within the same binary. See schema_visitor.h
+# and schema_visitor_demo.cpp for the IfcOpenShell/IfcOpenShell#1333
+# ("Template programming for schema independent code") prototype.
+if("2x3" IN_LIST SCHEMA_VERSIONS AND "4" IN_LIST SCHEMA_VERSIONS AND "4x3_add2" IN_LIST SCHEMA_VERSIONS)
+    build_example(schema_visitor_demo)
+endif()

--- a/src/examples/schema_visitor.h
+++ b/src/examples/schema_visitor.h
@@ -1,0 +1,80 @@
+#ifndef SCHEMA_VISITOR_H
+#define SCHEMA_VISITOR_H
+
+// This file was generated with the assistance of an AI coding tool.
+
+// Prototype for IfcOpenShell/IfcOpenShell#1333 ("Template programming for
+// schema independent code"). See schema_visitor_demo.cpp for a runnable
+// example against real IFC2X3 / IFC4 / IFC4X3_ADD2 files.
+//
+// The issue's stuck point was item (3) in the report: a hand-written
+// apply_visitor() that dynamic_casts across schemas works for one entity
+// class (IfcSpace), but the reporter could not find a way to reuse it
+// generically for other classes without rewriting the whole if/else chain.
+//
+// The key fact that makes this solvable with plain C++17 (no boost::mpl)
+// is that the generated per-schema "namespaces" (Ifc2x3, Ifc4, ...) are
+// not namespaces at all: they are ordinary structs, and IfcSpace etc. are
+// ordinary nested classes of those structs. Ordinary struct types can be
+// template arguments, so a schema can be a template parameter like any
+// other type.
+
+#include "../ifcparse/IfcBaseClass.h"
+
+#include <utility>
+
+namespace schema_visitor {
+
+// Compile-time list of schema "tag" types, e.g. schema_list<Ifc2x3, Ifc4>.
+template <typename... Schemas>
+struct schema_list {};
+
+namespace detail {
+
+    template <template <typename> class Selector, typename Fn>
+    inline bool apply_visitor_impl(schema_list<>, IfcUtil::IfcBaseClass*, Fn&&) {
+        return false;
+    }
+
+    template <template <typename> class Selector, typename Schema, typename... Rest, typename Fn>
+    inline bool apply_visitor_impl(schema_list<Schema, Rest...>, IfcUtil::IfcBaseClass* inst, Fn&& fn) {
+        if (auto* p = inst->as<typename Selector<Schema>::type>()) {
+            std::forward<Fn>(fn)(p);
+            return true;
+        }
+        return apply_visitor_impl<Selector>(schema_list<Rest...>{}, inst, std::forward<Fn>(fn));
+    }
+
+} // namespace detail
+
+// Generic runtime dispatch across an arbitrary compile-time list of schemas.
+//
+// - SchemaList: e.g. schema_list<Ifc2x3, Ifc4, Ifc4x3_add2>
+// - Selector:   a class template with a nested `::type`, naming the
+//               concrete per-schema class for one entity class. Written
+//               ONCE per entity class name (see IFC_SCHEMA_CLASS below),
+//               then reusable for any class and any schema list - this is
+//               precisely the piece the issue was missing.
+// - fn:         a generic callable, invoked with the entity cast to its
+//               real, schema-specific pointer type as soon as a schema
+//               match is found.
+//
+// Returns false if `inst` does not match any schema's variant of the
+// requested class (e.g. it is some unrelated entity type).
+template <typename SchemaList, template <typename> class Selector, typename Fn>
+inline bool apply_visitor(IfcUtil::IfcBaseClass* inst, Fn&& fn) {
+    return detail::apply_visitor_impl<Selector>(SchemaList{}, inst, std::forward<Fn>(fn));
+}
+
+} // namespace schema_visitor
+
+// Declares a reusable class selector for entity class `Name`. One line,
+// independent of how many schemas exist or which ones a given call site
+// wants to dispatch over.
+#define IFC_SCHEMA_CLASS(Name)               \
+    template <typename Schema>               \
+    struct Name##_selector {                 \
+        using type = typename Schema::Name;  \
+    }
+
+#endif

--- a/src/examples/schema_visitor_demo.cpp
+++ b/src/examples/schema_visitor_demo.cpp
@@ -1,0 +1,103 @@
+// This file was generated with the assistance of an AI coding tool.
+
+// Prototype / demonstration for IfcOpenShell/IfcOpenShell#1333
+// ("Template programming for schema independent code").
+//
+// Unlike the other examples in this directory, this file is NOT compiled
+// once per schema via the `-DIfcSchema=IfcNNN` build-system trick (see
+// ../ifcgeom/mapping/CMakeLists.txt for that pattern). It is compiled ONCE
+// and, in that single binary, can open an .ifc file of *any* schema and
+// dispatch generically to the right per-schema C++ type at runtime - which
+// is what the issue actually asked for.
+//
+// See schema_visitor.h for the generic apply_visitor() implementation and
+// commentary on why it works, and the PR/commit message on branch
+// concept-1333-schema-visitor for the write-up of what already existed in
+// the codebase versus what is new here.
+
+#include "../ifcparse/IfcFile.h"
+#include "../ifcparse/Ifc2x3.h"
+#include "../ifcparse/Ifc4.h"
+#include "../ifcparse/Ifc4x3_add2.h"
+#include "schema_visitor.h"
+
+#include <iostream>
+#include <string>
+#include <type_traits>
+
+// One line, written once, reusable for apply_visitor<..., IfcSpace_selector>
+// with any schema list - this is the piece the original issue reporter said
+// they had not found a way to make generic across entity classes.
+IFC_SCHEMA_CLASS(IfcSpace);
+
+using AllSchemas = schema_visitor::schema_list<Ifc2x3, Ifc4, Ifc4x3_add2>;
+
+namespace {
+
+// A single call site, compiled exactly once, used below for files of any of
+// the three schemas in AllSchemas. No per-schema branching is visible here.
+void print_space(IfcUtil::IfcBaseClass* inst) {
+    bool matched = schema_visitor::apply_visitor<AllSchemas, IfcSpace_selector>(inst, [](auto* space) {
+        // `space` is Ifc2x3::IfcSpace*, Ifc4::IfcSpace* or
+        // Ifc4x3_add2::IfcSpace*, depending on which schema this file
+        // turned out to be. GlobalId()/Name() have an identical signature
+        // on IfcRoot in every schema, so this generic lambda body is
+        // literally shared, unmodified, across all three schemas.
+        std::cout << "  " << space->GlobalId() << ": "
+                  << (space->Name() ? *space->Name() : std::string("<no name>")) << "\n";
+
+        // Divergence *does* exist below IfcRoot, and no amount of generic
+        // programming makes that go away: IFC2X3's IfcSpace has a required
+        // InteriorOrExteriorSpace enum attribute that IFC4 replaced with an
+        // optional PredefinedType. Those are genuinely different members on
+        // genuinely different, unrelated C++ types. `if constexpr`, keyed
+        // on the now-concrete type, is the honest way to keep this in one
+        // generic lambda body instead of one bespoke dispatch chain per
+        // attribute:
+        using T = std::remove_pointer_t<decltype(space)>;
+        if constexpr (std::is_same_v<T, Ifc2x3::IfcSpace>) {
+            std::cout << "    (2X3-only attribute) InteriorOrExteriorSpace\n";
+        } else {
+            std::cout << "    (IFC4+ attribute) PredefinedType is "
+                      << (space->PredefinedType() ? "set" : "not set") << "\n";
+        }
+    });
+
+    if (!matched) {
+        std::cout << "  (not an IfcSpace in any schema tried)\n";
+    }
+}
+
+void run(const std::string& path) {
+    std::cout << "Opening " << path << "\n";
+    IfcParse::IfcFile file(path);
+    if (!file.good()) {
+        std::cerr << "  failed to parse " << path << "\n";
+        return;
+    }
+    std::cout << "  schema: " << file.schema()->name() << "\n";
+
+    // Runtime, string-keyed lookup - this part of IfcOpenShell already knows
+    // how to fetch "all instances of a class" without the caller knowing
+    // the schema at compile time. What it does *not* give you is a
+    // strongly-typed pointer to operate on; that's what apply_visitor adds.
+    auto spaces = file.instances_by_type("IfcSpace");
+    if (spaces) {
+        for (auto it = spaces->begin(); it != spaces->end(); ++it) {
+            print_space(*it);
+        }
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: " << argv[0] << " <file.ifc> [<file2.ifc> ...]\n";
+        return 1;
+    }
+    for (int i = 1; i < argc; ++i) {
+        run(argv[i]);
+    }
+    return 0;
+}

--- a/src/examples/schema_visitor_demo_2x3.ifc
+++ b/src/examples/schema_visitor_demo_2x3.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('schema_visitor_demo_2x3.ifc','2026-07-19T00:00:00',(''),(''),'IfcOpenShell','IfcOpenShell','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCSPACE('1YHntSGZL5FhdY1nlqZa0',$,'Kitchen (2X3)',$,$,$,$,$,.ELEMENT.,.INTERNAL.,$);
+#2=IFCSPACE('1YHntSGZL5FhdY1nlqZa1',$,'Lounge (2X3)',$,$,$,$,$,.ELEMENT.,.INTERNAL.,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/examples/schema_visitor_demo_4.ifc
+++ b/src/examples/schema_visitor_demo_4.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('schema_visitor_demo_4.ifc','2026-07-19T00:00:00',(''),(''),'IfcOpenShell','IfcOpenShell','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCSPACE('1YHntSGZL5FhdY1nlqZa0',$,'Kitchen (IFC4)',$,$,$,$,$,$,$,$);
+#2=IFCSPACE('1YHntSGZL5FhdY1nlqZa1',$,'Lounge (IFC4)',$,$,$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/examples/schema_visitor_demo_4x3.ifc
+++ b/src/examples/schema_visitor_demo_4x3.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('schema_visitor_demo_4x3.ifc','2026-07-19T00:00:00',(''),(''),'IfcOpenShell','IfcOpenShell','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCSPACE('1YHntSGZL5FhdY1nlqZa0',$,'Kitchen (4X3)',$,$,$,$,$,$,$,$);
+#2=IFCSPACE('1YHntSGZL5FhdY1nlqZa1',$,'Lounge (4X3)',$,$,$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;


### PR DESCRIPTION
Concept/proof-of-concept for #1333 ("Template programming for schema independent code"). Opening as draft, for evaluation, not proposing this as a final API.

The issue's stuck point was item (3) in the report: a hand-written `apply_visitor()` dynamic-casting across schemas works for one entity class (`IfcSpace`), but the reporter couldn't find a way to reuse it generically for other classes without rewriting the whole dispatch chain, and speculated a `boost::mpl`-based "meta schema" might be the only way.

Checked what already exists first: the `mapping/*.cpp` layer's `IfcSchema::` alias (compiled once per schema, dispatched at file-open granularity through a string-keyed factory) solves a different problem (write once, compile N times) than what's asked here (one binary, runtime dispatch per entity class). `IfcBaseInterface::as<T>()` is the reporter's own item-2 idea, just wrapped. `IfcFile::instances_by_type(name)` gives runtime schema-agnostic lookup, but only as untyped `IfcBaseClass*`. None of these give a reusable, generic visitor.

Turns out no `boost::mpl` is needed: the generated per-schema types (`Ifc2x3`, `Ifc4`, ...) are ordinary structs, and their entity classes are ordinary nested classes, not namespace members, so a schema can be an ordinary template parameter. `schema_visitor.h` implements `apply_visitor<SchemaList, ClassSelector>(entity, fn)` with plain C++17 (variadic templates, template template parameters, `if constexpr`), plus a one-line `IFC_SCHEMA_CLASS(Name)` macro declaring a reusable per-class selector, written once per class name, then reusable for any schema list. That's the missing piece.

`schema_visitor_demo.cpp` is a single compiled binary (not the per-schema build trick) that opens an IFC2X3, IFC4, and IFC4X3_ADD2 fixture through one shared call site and one generic lambda, reading `Name`/`GlobalId` off `IfcSpace` regardless of which schema the file turned out to be. `if constexpr` is used only where the schemas genuinely diverge below `IfcRoot` (IFC2X3's required `InteriorOrExteriorSpace` vs IFC4+'s optional `PredefinedType`), an honest illustration of a real limit, not something genericity can wish away.

Verified by compiling and running the demo against all three fixture files: the same generic lambda dispatches to `Ifc2x3::IfcSpace*`, `Ifc4::IfcSpace*`, and `Ifc4x3_add2::IfcSpace*` correctly in each run.

@aothms's linked reference (tumcms/OpenInfraPlatform's `EMTIfcEntityTypes.h`) is a code-generation-based trait/type-map approach for a different codebase; looked at it for context but didn't adopt it verbatim, since IfcOpenShell's schemas-as-structs already make a lighter, hand-written template solution sufficient without needing that project's generator machinery.

This contribution was produced with the assistance of an AI coding tool.