### PR TITLE
ifcgeomserver, examples: finish renaming stray Ifc-prefixed internal classes (#1330)

### DIFF
--- a/src/examples/profiles.cpp
+++ b/src/examples/profiles.cpp
@@ -37,9 +37,10 @@
 #include INCLUDE_SCHEMA_DEFINITIONS(ifcparse/schemas, IfcSchema)
 
 #include "ifcparse/hierarchy_helper.h"
+#include "ifcparse/global_id.h"
 
 typedef std::string S;
-typedef IfcWrite::IfcGuidHelper guid;
+typedef ifcopenshell::global_id guid;
 boost::none_t const null = (static_cast<boost::none_t>(0));
 
 #ifdef SCHEMA_IfcUShapeProfileDef_HAS_CentreOfGravityInX

--- a/src/ifcgeomserver/IfcGeomServer.cpp
+++ b/src/ifcgeomserver/IfcGeomServer.cpp
@@ -208,7 +208,7 @@ public:
 	More(bool more) : Command(MORE), more(more) {}
 };
 
-class IfcModel : public Command {
+class Model : public Command {
 private:
 	std::string str;
 protected:
@@ -220,7 +220,7 @@ protected:
 	}
 public:
 	const std::string& string() { return str; }
-	IfcModel() : Command(IFC_MODEL) {};
+	Model() : Command(IFC_MODEL) {};
 };
 
 class Get : public Command {
@@ -578,7 +578,7 @@ int main () {
 		const int32_t msg_type = sread<int32_t>(std::cin);
 		switch (msg_type) {
 		case IFC_MODEL: {
-			IfcModel m; m.read(std::cin);
+			Model m; m.read(std::cin);
 			std::string::size_type len = m.string().size();
 			char* data = new char[len];
 			memcpy(data, m.string().c_str(), len);

--- a/src/ifcparse/character_decoder.h
+++ b/src/ifcparse/character_decoder.h
@@ -80,6 +80,6 @@ class IFC_PARSE_API character_encoder {
     operator std::string();
 };
 
-} // namespace IfcWrite
+} // namespace ifcopenshell
 
 #endif


### PR DESCRIPTION
Small cleanup found while auditing #1330's status on this branch (see the issue comment for the full audit).

- \`IfcGeomServer.cpp\`'s local protocol-command class was still \`IfcModel\`, inconsistent with its siblings (\`Hello\`, \`More\`, \`Get\`, \`WriteLog\`), which never had the prefix. Renamed to \`Model\`.
- \`src/examples/profiles.cpp\` (not part of the default build) still referenced the pre-rename \`IfcWrite::IfcGuidHelper\`, which no longer exists. Updated to \`ifcopenshell::global_id\`.
- \`src/ifcparse/character_decoder.h\` had a stray \`} // namespace IfcWrite\` closing comment left over from that namespace's earlier rename.

Verified: built \`IfcGeomServer\` and its full dependency chain, exit code 0, ran the resulting binary and confirmed its expected \`Hello\` handshake.

This contribution was produced with the assistance of an AI coding tool.