### PR TITLE
ifcconvert: default --threads to auto-detected CPU count (#2709)

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -297,8 +297,9 @@ int main(int argc, char** argv) {
 	geom_options.add_options()
 		("kernel", po::value<std::string>(&geometry_kernel)->default_value(default_kernel),
 			"Geometry kernel to use (opencascade, cgal, cgal-simple, hybrid-cgal-simple-opencascade).")
-		("threads,j", po::value<int>(&num_threads)->default_value(1),
-			"Number of parallel processing threads for geometry interpretation.")
+		("threads,j", po::value<int>(&num_threads)->default_value(0),
+			"Number of parallel processing threads for geometry interpretation. "
+			"Defaults to 0, which auto-detects the number of concurrent threads supported by the system.")
 		("center-model",
             "Centers the elements by applying the center point of all placements as an offset."
             "Can take several minutes on large models.")

--- a/src/ifcopenshell-python/docs/ifcconvert/usage.rst
+++ b/src/ifcopenshell-python/docs/ifcconvert/usage.rst
@@ -16,12 +16,11 @@ you provide for the output file determines what format the IFC is converted to.
     On Windows, you can drag and drop a ``.ifc`` file on the ``IfcConvert.exe``
     file to automatically convert it to an ``.obj`` file.
 
-For any conversion, it is recommended to use multiple cores to speed up
-processing:
+By default, IfcConvert uses all available CPU cores to speed up processing. To
+use a specific number of threads instead:
 
 .. code-block:: bash
 
-    # Change "7" to the number of CPU cores you have then plus one.
     IfcConvert -j 7 /path/to/input.ifc /path/to/output.dae
 
 By default, units are converted to meters. If you want to retain the original units:
@@ -112,8 +111,11 @@ CLI Manual
       --kernel arg (=opencascade)           Geometry kernel to use (opencascade, 
                                             cgal, cgal-simple, hybrid-cgal-simple-o
                                             pencascade).
-      -j [ --threads ] arg (=1)             Number of parallel processing threads 
-                                            for geometry interpretation.
+      -j [ --threads ] arg (=0)             Number of parallel processing threads
+                                            for geometry interpretation. Defaults
+                                            to 0, which auto-detects the number
+                                            of concurrent threads supported by
+                                            the system.
       --center-model                        Centers the elements by applying the 
                                             center point of all placements as an 
                                             offset.Can take several minutes on 

--- a/src/ifcopenshell-python/docs/ifcopenshell/geometry_settings.rst
+++ b/src/ifcopenshell-python/docs/ifcopenshell/geometry_settings.rst
@@ -93,7 +93,7 @@ num_threads
 +------+-------------------------+---------+
 | Type | IfcConvert Option       | Default |
 +======+=========================+=========+
-| INT  | ``--threads`` or ``-j`` | 1       |
+| INT  | ``--threads`` or ``-j`` | 0       |
 +------+-------------------------+---------+
 
 Number of parallel processing threads for geometry interpretation.


### PR DESCRIPTION
## Summary
Changes the `IfcConvert --threads`/`-j` default from `1` to `0`, which the existing code already treats as "auto-detect via `std::thread::hardware_concurrency()`" (`IfcConvert.cpp`, a few lines below the option definition). Previously users had to pass `--threads 0` (or an explicit count) to get multi-threaded geometry processing; now that's the default, matching what @aothms said in #2709 back in 2023: "we'll do so in the next release 0.8." Explicit `--threads N` values are unaffected.

Also updates the CLI usage docs and the `num_threads` reference table to reflect the new default.

Fixes #2709.

## Test plan
- Built `IfcConvert` and ran `test/input/faceted_brep.ifc` through it:
  - no `--threads` flag → resolves to this machine's real core count (`hardware_concurrency()`)
  - `--threads 1` → stays `1` (explicit override still respected)
  - `--threads 0` → unchanged behavior (already worked)
  - `--threads 4` → stays `4` (explicit override still respected)
  - `--help` output shows the new default and description

This PR contains AI-generated code (the `--threads` default change and doc updates), generated with the assistance of an AI coding tool.