### PR TITLE
GltfSerializer: fix hierarchy group node names, add opt-in --gltf-extras

### DIFF
--- a/src/ifcgeom/GeometrySerializer.h
+++ b/src/ifcgeom/GeometrySerializer.h
@@ -68,6 +68,13 @@ inline namespace settings {
 		static constexpr bool defaultvalue = false;
 	};
 
+	struct GltfExtras : public SettingBase<GltfExtras, bool> {
+		static constexpr const char* const name = "gltf-extras";
+		static constexpr const char* const description = "Write the IFC GlobalId, entity type and name of every element into the "
+			"glTF node extras, so the output is self-describing without a sidecar file. Applicable to GLB output.";
+		static constexpr bool defaultvalue = false;
+	};
+
 	struct FloatingPointDigits : public SettingBase<FloatingPointDigits, int> {
 		static constexpr const char* const name = "digits";
 		static constexpr const char* const description = "Sets the precision to be used to format floating-point values, 15 by default. "
@@ -97,7 +104,7 @@ inline namespace settings {
 
 class SerializerSettings : public SettingsContainer <
 	// @todo should we use tuple_cat here to unify the settings into a single class?
-    std::tuple<UseElementNames, UseElementGuids, UseElementStepIds, UseElementTypes, UseYUp, WriteGltfEcef, FloatingPointDigits, BaseUri, WktUseSection, SeparateZUpNode>>
+    std::tuple<UseElementNames, UseElementGuids, UseElementStepIds, UseElementTypes, UseYUp, WriteGltfEcef, GltfExtras, FloatingPointDigits, BaseUri, WktUseSection, SeparateZUpNode>>
 {};
 
 }

--- a/src/serializers/GltfSerializer.cpp
+++ b/src/serializers/GltfSerializer.cpp
@@ -249,7 +249,7 @@ void GltfSerializer::write(const IfcGeom::TriangulationElement* o) {
             size_t new_node_index = json_["nodes"].size();
             node_indices_[(*it)->product()] = new_node_index;
             node_array_.push_back(new_node_index);
-            parent_node["name"] = object_id(o);
+            parent_node["name"] = object_id(*it);
             parent_node["children"] = json::array({current_node_index});
             json_["nodes"].push_back(parent_node);
 

--- a/src/serializers/GltfSerializer.cpp
+++ b/src/serializers/GltfSerializer.cpp
@@ -250,6 +250,9 @@ void GltfSerializer::write(const IfcGeom::TriangulationElement* o) {
             node_indices_[(*it)->product()] = new_node_index;
             node_array_.push_back(new_node_index);
             parent_node["name"] = object_id(*it);
+            if (settings_.get<ifcopenshell::geometry::settings::GltfExtras>().get()) {
+                parent_node["extras"] = { {"GlobalId", (*it)->guid()}, {"IfcType", (*it)->type()}, {"Name", (*it)->name()} };
+            }
             parent_node["children"] = json::array({current_node_index});
             json_["nodes"].push_back(parent_node);
 
@@ -290,7 +293,10 @@ void GltfSerializer::write(const IfcGeom::TriangulationElement* o) {
 		}
 	}
 	node["name"] = object_id(o);
-	
+	if (settings_.get<ifcopenshell::geometry::settings::GltfExtras>().get()) {
+		node["extras"] = { {"GlobalId", o->guid()}, {"IfcType", o->type()}, {"Name", o->name()} };
+	}
+
 	int current_mesh_index;
 
 	// See if this mesh has already been processed


### PR DESCRIPTION
## Summary
Two glTF serializer improvements found while verifying #790 against a multi-storey model:

**1. Group node naming fix.** With `--element-hierarchy`, the intermediate glTF nodes representing the spatial structure (storey, building, site) were all named after whichever leaf element happened to trigger their creation: `GltfSerializer.cpp` used `object_id(o)` (the leaf being written) inside the ancestor loop, where `object_id(*it)` (the ancestor at the current tree level) is what identifies the group node. After the fix every group node carries its own entity's identifier (verified against `test/input/474--walls--missing-subtractions--1--augmented.ifc`: storey groups named `0dE6wkqkT5Mw7IM14CiFDw`/`3ijyWwTIL3bvPei_iSfArm`, building `1jM4hGl9LE8RsEoteDunrQ`, root site `01uPthe3Uixx0TRWar3Vt8`, matching the source IFC exactly). Tree structure, leaf naming, and matrices unchanged.

**2. Opt-in `--gltf-extras`.** #790 asked for IFC metadata in glTF `node.extras` so the glb is self-describing without a sidecar file. This adds a new serializer setting, off by default so file size is unchanged unless requested (addressing the size concern raised in that issue). When enabled, every node, including hierarchy group nodes, gets `extras: {GlobalId, IfcType, Name}` with the literal base64 IFC GlobalId. Verified: with the flag all 9 nodes of the test model carry correct extras cross-checked against the source IFC; without the flag output is unchanged.

Addresses #790.

## Test plan
- Rebuilt `Serializers` + `IfcConvert`, converted the multi-storey fixture with `--element-hierarchy`, `--element-hierarchy --use-element-guids`, and `--element-hierarchy --gltf-extras`; parsed the glb JSON and cross-checked every node name and extras entry against the IFC entities' GlobalIds/types/names.
- Confirmed default output (no flags) is unchanged.

This PR contains AI-generated code (both commits), generated with the assistance of an AI coding tool.