### PR TITLE
ifcgeom: keep one copy of repeated faces in faceset helper duplicate removal

### DIFF
--- a/src/ifcgeom/kernels/opencascade/OpenCascadeKernel.h
+++ b/src/ifcgeom/kernels/opencascade/OpenCascadeKernel.h
@@ -86,6 +86,7 @@ private:
 	private:
 		OpenCascadeKernel* kernel_;
 		std::set<int> duplicates_;
+		std::map<int, int> duplicate_skips_remaining_;
 		std::map<int, int> vertex_mapping_;
 		std::map<std::pair<int, int>, TopoDS_Edge> edges_;
 		double eps_;

--- a/src/ifcgeom/kernels/opencascade/faceset_helper.cpp
+++ b/src/ifcgeom/kernels/opencascade/faceset_helper.cpp
@@ -108,6 +108,7 @@ IfcGeom::OpenCascadeKernel::faceset_helper::faceset_helper(
 
 		vertex_mapping_.clear();
 		duplicates_.clear();
+		duplicate_skips_remaining_.clear();
 
 		edge_use.clear();
 
@@ -174,6 +175,7 @@ IfcGeom::OpenCascadeKernel::faceset_helper::faceset_helper(
 			if (edge_sets.find({loop->external.get_value_or(false), segment_set}) != edge_sets.end()) {
 				duplicate_faces++;
 				duplicates_.insert(loop->identity());
+				duplicate_skips_remaining_[loop->identity()]++;
 				continue;
 			}
             edge_sets.insert({loop->external.get_value_or(false), segment_set});
@@ -250,7 +252,10 @@ bool IfcGeom::OpenCascadeKernel::faceset_helper::wire(const ifcopenshell::geomet
 }
 
 bool IfcGeom::OpenCascadeKernel::faceset_helper::wires(const ifcopenshell::geometry::taxonomy::loop::ptr loop, NCollection_List<TopoDS_Shape>& wires) {
-	if (duplicates_.find(loop->identity()) != duplicates_.end()) {
+	// Skip only the redundant occurrences, keep one copy of the face.
+	auto it = duplicate_skips_remaining_.find(loop->identity());
+	if (it != duplicate_skips_remaining_.end() && it->second > 0) {
+		--it->second;
 		return false;
 	}
 	TopoDS_Wire wire;


### PR DESCRIPTION
## Summary
When an `IfcConnectedFaceSet` lists the same `IfcFace` multiple times (e.g. Solibri-IFC-Optimizer output), the faceset helper flagged the repeated loop identity in `duplicates_`, and `wires()` then skipped **every** occurrence of that identity — so the face vanished from the shell entirely instead of being deduplicated to one copy. The resulting shell had holes, sewing produced a non-manifold boolean operand, and opening subtraction was correctly discarded by the non-manifold safety check ("Boolean operation yields non-manifold result"), leaving the element with no geometry.

The fix counts how many occurrences of a loop identity are redundant and skips only that many, so exactly one copy of each repeated face is still built. Geometrically-identical-but-distinct-instance duplicates behave exactly as before, and the non-manifold result rejection in `boolean_utils.cpp` is untouched — this fixes the operand, per the same design direction as `--make-volume` and the duplicate-loop work in #8140.

Found in `test/input/418--walls--segfault.ifc` (issue #418's file, segfault long fixed, this was the remaining residual): wall `#2543`'s opening repeats 84 of its shell's 350 unique faces across 518 entries, which previously yielded a 0-vertex wall.

## Test plan
- Wall `#2543` now produces a closed body: 318 verts / 208 faces, bbox 3.400 × 0.200 × 0.950 m matching its `IfcExtrudedAreaSolid` exactly, watertight (every edge used exactly twice), volume 0.6457 m³ vs 0.6460 gross (the opening is a small cast-in groove, so a small cut is correct). All non-manifold warnings gone for the file.
- Before/after sweep over all 258 files in `test/input`: zero output changes other than wall `#2543` gaining geometry.
- `Covering_with_3_openings.ifc` (#8140's regression file): byte-identical output.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.