### PR TITLE
ci-lint: black-format two files that drifted on v0.8.0

### DIFF
--- a/src/bonsai/bonsai/bim/module/type/operator.py
+++ b/src/bonsai/bonsai/bim/module/type/operator.py
@@ -117,9 +117,7 @@ class UnassignType(bpy.types.Operator, tool.Ifc.Operator):
         related_object: str
 
     @staticmethod
-    def _reattach_styles(
-        file: ifcopenshell.file, copied_entities: dict[int, ifcopenshell.entity_instance]
-    ) -> None:
+    def _reattach_styles(file: ifcopenshell.file, copied_entities: dict[int, ifcopenshell.entity_instance]) -> None:
         """copy_deep only follows forward references, so IfcStyledItem (an inverse,
         ``StyledByItem``) is not carried onto the copied geometry. Re-create a
         styled item on each copy that points at the same presentation styles as

--- a/src/ifcopenshell-python/test/test_parse.py
+++ b/src/ifcopenshell-python/test/test_parse.py
@@ -21,7 +21,9 @@ END-ISO-10303-21;
 
 
 def test_reference_to_undefined_owning_instance():
-    data = "ISO-10303-21;HEADER;FILE_DESCRIPTION();FILE_NAME();FILE_SCHEMA(('IFC4'));#=IFCRELAGGREGATES((#))#5=IFCPOINT)"
+    data = (
+        "ISO-10303-21;HEADER;FILE_DESCRIPTION();FILE_NAME();FILE_SCHEMA(('IFC4'));#=IFCRELAGGREGATES((#))#5=IFCPOINT)"
+    )
     ifcopenshell.file.from_string(data)
     print(ifcopenshell.get_log())
 


### PR DESCRIPTION
## Summary
`src/bonsai/bonsai/bim/module/type/operator.py` and `src/ifcopenshell-python/test/test_parse.py` were merged unformatted, so the Black formatter step fails on every branch and keeps ci-lint red repo-wide (every open PR currently inherits this failure regardless of its own content). Formatting-only change, verified with the CI-exact black 26.5.1 in repo context.

Note: after this lands, ci-lint still has two `ty` failures on base that are separate issues (a `list[Object]` declaration error in bonsai, and `ty (ios)` flagging an `arrange_polygons` argument-count mismatch plus an unresolved `igraph` import) — will follow up on those separately since they're type-correctness questions, not formatting.

## Test plan
- `black --check` (26.5.1, matching `psf/black@stable`) on both files in repo context: clean after this change, failing before.
- Diff is exclusively line-wrapping; no semantic change.

This PR contains AI-generated code (formatting only), generated with the assistance of an AI coding tool.