### PR TITLE
Fix all remaining ty type-check failures on ci-lint

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -413,12 +413,13 @@ class UnlinkObject(bpy.types.Operator, tool.Ifc.Operator):
     skip_invoke: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
 
     def _execute(self, context):
+        objects: list[bpy.types.Object]
         if self.obj:
-            objects = [bpy.data.objects.get(self.obj)]
+            requested_obj = bpy.data.objects.get(self.obj)
+            objects = [requested_obj] if requested_obj is not None else []
         else:
             objects = context.selected_objects
 
-        objects: list[bpy.types.Object]
         for obj in objects:
             was_active_object = obj == context.active_object
 

--- a/src/bonsai/bonsai/tool/sequence.py
+++ b/src/bonsai/bonsai/tool/sequence.py
@@ -1159,11 +1159,11 @@ class Sequence(bonsai.core.tool.Sequence):
         props.task_input_colors.clear()
         for group, data in groups.items():
             for predefined_type in data["PredefinedType"]:
-                if group in ["CREATION", "OPERATION", "MOVEMENT_TO"]:
+                if group in ("CREATION", "OPERATION", "MOVEMENT_TO"):
                     predefined_type_item = props.task_output_colors.add()
-                elif group in ["MOVEMENT_FROM"]:
+                elif group in ("MOVEMENT_FROM",):
                     predefined_type_item = props.task_input_colors.add()
-                elif group in ["USERDEFINED", "DESTRUCTION"]:
+                elif group in ("USERDEFINED", "DESTRUCTION"):
                     predefined_type_item = props.task_input_colors.add()
                     predefined_type_item2 = props.task_output_colors.add()
                     predefined_type_item2.name = predefined_type

--- a/src/ifcopenshell-python/ifcopenshell/draw.py
+++ b/src/ifcopenshell-python/ifcopenshell/draw.py
@@ -42,7 +42,7 @@ WHITE = numpy.array((1.0, 1.0, 1.0))
 
 DO_NOTHING = lambda *args: None
 
-ARRANGE_POLYGON_SETTINGS = W.arrange_polygon_settings() if hasattr(W, "arrange_polygon_settings") else None
+ARRANGE_POLYGON_SETTINGS = W.arrange_polygon_settings()
 
 
 @dataclass
@@ -546,11 +546,7 @@ def main(
                     *(tup for i, tup in enumerate(zip(path_objects, section_polies, polies)) if has_relevant_zone(i))
                 )
 
-            arranged = W.arrange_polygons(
-                *filter(None, (ARRANGE_POLYGON_SETTINGS,)),
-                polies,
-                *((logger,) if logger is not None else ()),
-            )
+            arranged = W.arrange_polygons(ARRANGE_POLYGON_SETTINGS, polies, logger)
             svg_data_3 = W.polygons_to_svg(arranged, False)
             dom3 = parseString(svg_data_3)
             svg3 = dom3.childNodes[0]

--- a/src/ifcopenshell-python/type-check-requirements.txt
+++ b/src/ifcopenshell-python/type-check-requirements.txt
@@ -3,6 +3,7 @@ cjio >=0.8, <0.10
 deepdiff
 docutils
 flask
+igraph
 isodate
 jinja2
 lark


### PR DESCRIPTION
## Summary
The ci-lint workflow is red on every branch because base v0.8.0 fails the two ty steps (4 diagnostics total). Together with #8777 (black drift), this makes ci-lint green again.

**ty check (bonsai):**
- `root/operator.py`: `bpy.data.objects.get()` can return None, so `bim.unlink_object` with an unknown object name would crash on the first attribute access. Handle the miss explicitly — this was a real latent bug, not just a typing issue.
- `tool/sequence.py`: ty does not narrow Literal types through membership tests on list literals, flagging the `assert_never` exhaustiveness check. Tuple literals narrow correctly and keep the check intact.

**ty check (ios):**
- `draw.py`: `arrange_polygons` was called through conditional argument splats so the same call site could serve pre-April-2026 wrappers without `arrange_polygon_settings`. No runtime bug on current builds, but untypeable against the fixed 3-parameter signature. Dropped the old-build workaround and call the current signature directly, following the precedent of 3d8115ebc5 (dropping similar old-build workarounds in ifcopenshell.file). Verified against a current wrapper build that the direct call arranges polygons and serializes to SVG, with and without a logger.
- `igraph` was missing from the ios type-check venv. It is an optional dependency in ifcpatch's Optimise recipe with a guarded import, and its fallback (`toposort`) was already listed, so add it to `type-check-requirements.txt`.

After this, `poe ty-bonsai` and `poe ty-ios` both pass cleanly (verified with the CI-exact ty 0.0.59 toolchain), and black+ruff are clean on all touched files.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.