### PR TITLE
docs: cover the Blender 5.1 / Python 3.13 transition in installation guides

### DIFF
--- a/src/bonsai/docs/guides/development/installation.rst
+++ b/src/bonsai/docs/guides/development/installation.rst
@@ -24,13 +24,7 @@ Blender versions:
 - 64-bit MacOS Intel (``macos-x64``)
 - 64-bit MacOS Silicon (``macos-arm64``)
 - 64-bit Windows (``windows-x64``)
-- Blender 5.0 or older with Python 3.11
-- Blender 5.1 or newer with Python 3.13
-
-The Python version of a Bonsai build must match the Python version of your
-Blender. Installing through ``Get Extensions`` (or the unstable repository)
-picks the correct build automatically; manually installing a downloaded zip
-does not check this and fails at enable time with an "incompatible" error.
+- Blender 5.1 or 5.2 with Python 3.13
 
 Developer builds may exist for different versions of Python but there will be
 no guarantee of the uptime or stability of these builds.

--- a/src/bonsai/docs/guides/development/installation.rst
+++ b/src/bonsai/docs/guides/development/installation.rst
@@ -24,7 +24,13 @@ Blender versions:
 - 64-bit MacOS Intel (``macos-x64``)
 - 64-bit MacOS Silicon (``macos-arm64``)
 - 64-bit Windows (``windows-x64``)
-- Blender 4.3, 4.4, or 4.5 with Python 3.11
+- Blender 5.0 or older with Python 3.11
+- Blender 5.1 or newer with Python 3.13
+
+The Python version of a Bonsai build must match the Python version of your
+Blender. Installing through ``Get Extensions`` (or the unstable repository)
+picks the correct build automatically; manually installing a downloaded zip
+does not check this and fails at enable time with an "incompatible" error.
 
 Developer builds may exist for different versions of Python but there will be
 no guarantee of the uptime or stability of these builds.

--- a/src/bonsai/docs/quickstart/installation.rst
+++ b/src/bonsai/docs/quickstart/installation.rst
@@ -37,17 +37,6 @@ Your interface will now look similar to below. If you check the ``File`` menu yo
 
 You can enable add-ons permanently by using ``Save User Settings`` from the Addons menu.
 
-.. note::
-
-    **Upgrading Blender?** When a new Blender version changes its Python
-    version (for example Blender 5.1 moved from Python 3.11 to 3.13),
-    importing your preferences from the previous Blender carries over a
-    Bonsai build that is incompatible with the new Python. Bonsai will
-    silently not load, or show an "incompatible" error when enabled. To fix
-    this, go to ``Preferences > Get Extensions``, uninstall Bonsai, and
-    install it again: the correct build for your Blender is picked
-    automatically.
-
 .. seealso::
 
     If you are a poweruser, you may be interested in the :ref:`guides/development/installation:Unstable installation` to help with testing.

--- a/src/bonsai/docs/quickstart/installation.rst
+++ b/src/bonsai/docs/quickstart/installation.rst
@@ -37,6 +37,17 @@ Your interface will now look similar to below. If you check the ``File`` menu yo
 
 You can enable add-ons permanently by using ``Save User Settings`` from the Addons menu.
 
+.. note::
+
+    **Upgrading Blender?** When a new Blender version changes its Python
+    version (for example Blender 5.1 moved from Python 3.11 to 3.13),
+    importing your preferences from the previous Blender carries over a
+    Bonsai build that is incompatible with the new Python. Bonsai will
+    silently not load, or show an "incompatible" error when enabled. To fix
+    this, go to ``Preferences > Get Extensions``, uninstall Bonsai, and
+    install it again: the correct build for your Blender is picked
+    automatically.
+
 .. seealso::
 
     If you are a poweruser, you may be interested in the :ref:`guides/development/installation:Unstable installation` to help with testing.


### PR DESCRIPTION
Updates the supported-versions line in the development installation guide to Blender 5.1 and 5.2 with Python 3.13, dropping Python 3.11, per review. Related to #7623.

This PR contains AI-generated content (documentation only), generated with the assistance of an AI coding tool.