### PR TITLE
win: do not close the calling console when build-deps.cmd finishes

### DIFF
--- a/win/build-deps.cmd
+++ b/win/build-deps.cmd
@@ -837,7 +837,7 @@ echo Build ended at %END_TIME%. Time elapsed %hh%:%mm%:%ss%.%cc%.
 :BuildTimeSkipped
 set PATH=%ORIGINAL_PATH%
 cd "%~dp0"
-exit %IFCOS_SCRIPT_RET%
+exit /b %IFCOS_SCRIPT_RET%
 
 ::::::::::::::::::::::::::::::::::::: Subroutines :::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
## Summary
Resolves the remaining open item in #7413 (the Release/Debug coexistence and ccache concerns there were already fixed by @Andrej730 and confirmed by @RickBrice): running `build-deps.cmd` from a Visual Studio command prompt closed the window the moment the script finished, making any errors unreadable.

Root cause is the bare `exit %IFCOS_SCRIPT_RET%` at the end of the `:Finish` block — a bare `exit` terminates the entire cmd.exe process, taking the interactive console with it. Changed to `exit /b %IFCOS_SCRIPT_RET%`, which returns from the script with the same exit code and leaves the shell open. This is exactly the fix @aothms prescribed in the thread ("I think that has to be `exit /b %IFCOS_SCRIPT_RET%`"). All 12 other exit points in the script already use `exit /b`; this was the sole stray.

Fixes #7413.

## Test plan
One-line batch semantics change following the maintainer's explicit prescription; standard cmd.exe behavior (`exit` kills the process, `exit /b` returns from the script). Not runtime-tested on Windows from this machine (macOS) — @RickBrice, a quick confirm that the VS prompt now stays open after a run would be appreciated.

This PR contains AI-generated code (one line), generated with the assistance of an AI coding tool.