### PR TITLE
win: document LNK1248 causes and the USE_CCACHE escape hatch

### DIFF
--- a/win/readme.md
+++ b/win/readme.md
@@ -119,3 +119,22 @@ Directory Structure
 \---patches                         - Contains patches for the dependencies
 \---utils                           - Contains various utilities for the build scripts
 ```
+
+Troubleshooting
+---------------
+
+### fatal error LNK1248: image size exceeds maximum
+
+Building `IfcGeom` with many schemas can exceed the 4GB image size limit of
+MSVC's librarian in two situations, both tracked in issue 7461:
+
+- **Debug or RelWithDebInfo builds with ccache enabled.** ccache requires the
+  embedded `/Z7` debug information format, which bloats object files compared
+  to the default `/Zi` PDB format. Configure with `-DUSE_CCACHE=OFF` (added to
+  `run-cmake.bat` arguments) to restore the PDB format, or reduce the number
+  of schemas with `-DSCHEMA_VERSIONS`.
+- **Release builds with `ENABLE_BUILD_OPTIMIZATIONS`.** The `/GL` whole-program
+  optimization flag makes the per-schema mapping objects very large. The build
+  now automatically compiles each schema mapping as a separate static library
+  on MSVC in this configuration, which avoids the limit; no action is needed on
+  a current checkout.


### PR DESCRIPTION
## Summary
Closes the documentation gap left in #7461. Both technical halves of that issue are already resolved in the tree:

- the `/Z7` Embedded debug format is only applied when ccache is in use, and `USE_CCACHE` is an option (default ON) since b1b67de42 — so `-DUSE_CCACHE=OFF` restores the normal `/Zi` PDB format, exactly the resolution @aothms proposed in the thread;
- the `/GL` mapping-library bloat is handled automatically: `src/ifcgeom/mapping/CMakeLists.txt` builds each schema mapping as a separate static library under `ENABLE_BUILD_OPTIMIZATIONS` on MSVC to stay under the 4GB librarian limit.

What was missing is discoverability: a Windows developer hitting `fatal error LNK1248` had no pointer to either mechanism. This adds a Troubleshooting section to `win/readme.md` describing both situations and their remedies.

Addresses #7461 (leaving the close decision to the maintainers, since @aothms framed the ccache-with-all-schemas case as a deliberate developer tradeoff).

## Test plan
Documentation only; facts cross-checked against `cmake/CMakeLists.txt:147-160` (ccache gating) and `src/ifcgeom/mapping/CMakeLists.txt:3-10` (static mapping split) on current v0.8.0.

This PR contains AI-generated content (documentation only), generated with the assistance of an AI coding tool.