### PR TITLE
ifcgeom: fix --site-local-placement breaking relative positions with nested IfcSites

### DIFF
--- a/src/ifcgeom/mapping/IfcObjectPlacement.cpp
+++ b/src/ifcgeom/mapping/IfcObjectPlacement.cpp
@@ -24,6 +24,42 @@ using namespace ifcopenshell::geometry;
 #include <deque>
 
 taxonomy::ptr mapping::map_impl(const IfcSchema::IfcObjectPlacement* inst) {
+    auto places_ignored_object = [this](const IfcSchema::IfcObjectPlacement* placement) {
+        auto places = placement->PlacesObject();
+        for (auto iter = places->begin(); iter != places->end(); ++iter) {
+            if ((placement_rel_to_type_ && (*iter)->declaration().is(*placement_rel_to_type_)) ||
+                (placement_rel_to_instance_ && (*iter)->as<IfcUtil::IfcBaseEntity>() == placement_rel_to_instance_)) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    auto placement_parent = [](const IfcSchema::IfcObjectPlacement* placement) -> const IfcSchema::IfcObjectPlacement* {
+#ifdef SCHEMA_IfcObjectPlacement_HAS_PlacementRelTo
+        return placement->PlacementRelTo();
+#else
+        if (auto local = placement->as<IfcSchema::IfcLocalPlacement>()) {
+            return local->PlacementRelTo();
+        }
+        return nullptr;
+#endif
+    };
+
+    // Only the outermost matching placement is ignored, so that with nested
+    // sites all products remain positioned in one common coordinate system.
+    auto is_outermost_match = [&](const IfcSchema::IfcObjectPlacement* placement) {
+        if (!places_ignored_object(placement)) {
+            return false;
+        }
+        for (auto parent = placement_parent(placement); parent; parent = placement_parent(parent)) {
+            if (places_ignored_object(parent)) {
+                return false;
+            }
+        }
+        return true;
+    };
+
     if (placement_rel_to_type_ || placement_rel_to_instance_) {
         using QueueItem = std::pair<const IfcUtil::IfcBaseEntity*, int>;
         std::deque<QueueItem> q = {{inst, 0}};
@@ -36,12 +72,8 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcObjectPlacement* inst) {
                 continue;
             }
 
-            auto self_places = placement->PlacesObject();
-            for (auto iter = self_places->begin(); iter != self_places->end(); ++iter) {
-                if ((placement_rel_to_type_ && (*iter)->declaration().is(*placement_rel_to_type_)) ||
-                    (placement_rel_to_instance_ && (*iter)->as<IfcUtil::IfcBaseEntity>() == placement_rel_to_instance_)) {
-                    return taxonomy::make<taxonomy::matrix4>();
-                }
+            if (is_outermost_match(placement)) {
+                return taxonomy::make<taxonomy::matrix4>();
             }
 
 			// Look for two levels deep, we want to know if we're at or *above* the 
@@ -93,13 +125,7 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcObjectPlacement* inst) {
 
 	bool parent_placement_ignored = false;
 	if (relative_to && (placement_rel_to_type_ || placement_rel_to_instance_)) {
-		IfcSchema::IfcProduct::list::ptr parent_places = relative_to->PlacesObject();
-		for (auto iter = parent_places->begin(); iter != parent_places->end(); ++iter) {
-			if ((placement_rel_to_type_ && (*iter)->declaration().is(*placement_rel_to_type_)) ||
-				(placement_rel_to_instance_ && (*iter)->as<IfcUtil::IfcBaseEntity>() == placement_rel_to_instance_)) {
-				parent_placement_ignored = true;
-			}
-		}
+		parent_placement_ignored = is_outermost_match(relative_to);
 	}
 
 	taxonomy::matrix4::ptr result;


### PR DESCRIPTION
## Summary
Fixes #6102.

With decomposed sites (IfcSite nested under IfcSite, as in the buildingSMART PCERT Infra-Rail sample), `--site-local-placement` truncated each product's placement chain at its *nearest* IfcSite ancestor. Products under different sub-sites were therefore expressed in different coordinate frames, destroying their relative positions (the two rail tracks, 20 m apart, ended up 1.5 m apart — matching the reporter's screenshot).

This change ignores only the *outermost* matching placement in the chain (a matching placement counts only if no placement higher in its `PlacementRelTo` chain also places a matching product), so all products end up in the single root-site coordinate system and relative positioning is preserved. This follows the direction of the existing TODO note in a4d5d4e19a about tracking whether an element sits above the element whose placement is being ignored. Single-site models are unaffected (the only site is the outermost match), and `--building-local-placement` semantics are untouched.

## Test plan
- Infra-Rail IFC4, `--site-local-placement`: tracks restored to exactly 20.000 m apart, 0/73 relative-position errors (was 72/73 displaced, worst 53.0 m), output expressed exactly in the root site frame.
- Infra-Rail IFC4X3_ADD2 (exercises the `SCHEMA_IfcObjectPlacement_HAS_PlacementRelTo` path): 0/73 relative errors.
- #7654 regression guard (GEOREF_00_Gladilova_AR, single site with terrain geometry, 2426 elements): every element including the site's own mesh equals `inv(site_world) * default` to 0.000000 m — the site-geometry behavior introduced for #7654 is preserved.
- No-flag output byte-equivalent before/after; `--building-local-placement` output unchanged.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.