### PR TITLE
ifcgeom: don't silently accept implausible empty opening subtractions (#5779)

### DIFF
--- a/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
+++ b/src/ifcgeom/kernels/opencascade/boolean_utils.cpp
@@ -10,6 +10,7 @@
 #include <TopExp.hxx>
 #include <TopoDS.hxx>
 #include <Bnd_Box.hxx>
+#include <BRepBndLib.hxx>
 #include <Extrema_ExtPC.hxx>
 #include <Geom_Plane.hxx>
 #include <Geom_BSplineCurve.hxx>
@@ -832,6 +833,34 @@ bool IfcGeom::util::points_on_planar_face_generator::operator()(gp_Pnt& p) {
 }
 
 
+namespace {
+	// An empty subtraction result is only plausible when the second operands
+	// can jointly cover the first operand, both in bounding box and in volume. #5779
+	bool empty_cut_result_plausible(double tolerance, const TopoDS_Shape& a, const NCollection_List<TopoDS_Shape>& b) {
+		Bnd_Box A, B;
+		BRepBndLib::Add(a, A);
+		double volume_b = 0.;
+		for (NCollection_List<TopoDS_Shape>::Iterator it(b); it.More(); it.Next()) {
+			BRepBndLib::Add(it.Value(), B);
+			volume_b += std::abs(IfcGeom::util::shape_volume(it.Value()));
+		}
+		if (A.IsVoid() || B.IsVoid()) {
+			return false;
+		}
+		B.Enlarge(tolerance);
+		double axmin, aymin, azmin, axmax, aymax, azmax;
+		double bxmin, bymin, bzmin, bxmax, bymax, bzmax;
+		A.Get(axmin, aymin, azmin, axmax, aymax, azmax);
+		B.Get(bxmin, bymin, bzmin, bxmax, bymax, bzmax);
+		if (!(bxmin <= axmin && bymin <= aymin && bzmin <= azmin &&
+			axmax <= bxmax && aymax <= bymax && azmax <= bzmax)) {
+			return false;
+		}
+		const double volume_a = IfcGeom::util::shape_volume(a);
+		return volume_b >= volume_a * (1. - 1.e-6);
+	}
+}
+
 bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const TopoDS_Shape& a_input, const NCollection_List<TopoDS_Shape>& b_input, BOPAlgo_Operation op, TopoDS_Shape& result, double fuzziness) {
 	using namespace std::string_literals;
 
@@ -1332,7 +1361,10 @@ bool IfcGeom::util::boolean_operation(const boolean_settings& settings, const To
 					int result_n_faces = count(r, TopAbs_FACE);
 					int first_op_n_faces = count(a, TopAbs_FACE);
 
-					if (op == BOPAlgo_CUT && has_open_shells && all_faces_included_in_result && result_n_faces > first_op_n_faces) {
+					if (op == BOPAlgo_CUT && result_n_faces == 0 && first_op_n_faces > 0 && !empty_cut_result_plausible(settings.precision + fuzziness, a, b)) {
+						success = false;
+						settings.log().Notice("GEO", 405, "Empty subtraction result discarded because second operands do not enclose first operand");
+					} else if (op == BOPAlgo_CUT && has_open_shells && all_faces_included_in_result && result_n_faces > first_op_n_faces) {
 						success = false;
 						settings.log().Notice("GEO", 149, "Boolean result discarded because subtractions results in only the addition of faces");
 					} else {


### PR DESCRIPTION
## Summary
Fixes #5779.

An opening subtraction that bogusly collapses to an empty shape passed every post-boolean sanity check — validity, manifoldness, and interference checks are all vacuous on an empty compound — so the empty result was accepted as success and the element silently vanished from the output with no log message. In the attached model, 9 of 56 IfcMembers (handrail bars voided by non-manifold faceted-brep openings at their ends) disappeared this way, while 39 others already failed loudly and correctly fell back to unsubtracted geometry.

The fix adds a plausibility gate as the first check in the existing result-discard chain: an empty CUT result is accepted only when the subtraction operands can plausibly consume the first operand — their combined bounding box must enclose it (with `precision + fuzziness` tolerance) and their total volume must cover its volume. The volume test matters: in the reported model, the two tiny end-cap openings' *combined* AABB happens to span the whole pipe, so a bbox-only test is insufficient. Implausible empty results are discarded into the existing fuzziness-retry ladder and ultimately the GEO192 unsubtracted fallback, the same path as every other subtraction failure. Zero cost on healthy models — the check only runs when the result is empty.

Note: textually adjacent to #8778 in the same file (different failure path — this is the vacuous-success path, that is the operand-refused path); whichever lands second has a trivial context merge, no logical interaction.

## Test plan
- The issue's attached model: 47/56 members in GLB before → 56/56 after; the 52 previously-present nodes have identical per-node vertex/face counts; the vanishing member `0FVvn8$6P4YPtgToXsYJFv` goes from 0 verts to 212 verts / 208 faces (GEO405 fires through the retry ladder, then GEO192 fallback). Outputs md5-stable across runs.
- Regression, normal openings (`project0-openings.ifc`): byte-identical output.
- Regression, genuinely fully-voided element (synthetic enclosing frustum opening, forced down the 3D boolean path): still correctly resolves to empty — the gate does not fire.
- Performance: unchanged except the retry ladder on the 9 recovered elements of the pathological model.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.