### PR TITLE
Bonsai: preserve occurrence-local representations; type/occurrence tooling

### DIFF
--- a/docs/dev-notes/occurrence-representations.md
+++ b/docs/dev-notes/occurrence-representations.md
@@ -1,0 +1,149 @@
+<!-- This file was generated with the assistance of an AI coding tool. -->
+
+# Occurrence representations — copy-drop fix, Type/Occurrence panel split, promote & add-to-occurrence
+
+> **Living dev note** for the `occurrence-representations` branch/PR. Read before working
+> on the feature; append decisions and findings as the PR is refined. This is *not* user
+> documentation — at merge it is removed or its durable parts promoted to code comments.
+> See [README.md](README.md) for the convention.
+
+Tracking issue: [#8788](https://github.com/IfcOpenShell/IfcOpenShell/issues/8788) (copy-drop
+bug + the four related feature requests). The PR should close it (`Closes #8788`).
+
+Stacked on top of `dev-notes-system` (#8201) → `opening-template-on-type` (#8200) →
+`select-by-representation-type` (#7916), because it shares the Representations panel and
+`RepresentationsData`. The panel here already carries the stack's header row +
+`RepresentationIdentifier` column + `bim.select_by_representation_type` button; this branch
+adds the Type/Occurrence split, the promote button, and the add dialog toggle on top.
+
+## Problem
+
+Copying an occurrence that is connected to a type **drops** any occurrence-local
+representation whose context the type has no `RepresentationMap` for — e.g. a per-occurrence
+`Model/Body/PLAN_VIEW`. Repro: an `IfcFurniture` occurrence with a mapped `Body/MODEL_VIEW`
++ `Box/MODEL_VIEW` from the type **and** its own local `Body/PLAN_VIEW`; Shift+D loses the
+PLAN_VIEW.
+
+Root cause: `core.root.copy_class` takes the type branch and calls
+`type.map_type_representations`, which **wipes all of the occurrence's representations and
+re-maps only the type's** `RepresentationMaps`. Anything the occurrence had that the type
+doesn't provide is gone. (The no-type branch, `copy_representation`, copies everything
+faithfully — hence the asymmetry.)
+
+## Key facts established
+
+- Schema (IFC4 ADD2 TC1): an occurrence **may** carry representations the type has no map
+  for. `IfcProduct.Representation` is its own attribute; the only WHERE rule is
+  `PlacementForShapeRepresentation`. Nothing forces occurrence reps to derive from the type —
+  the type→occurrence `IfcMappedItem` mapping is *convention*, not a constraint. So a local
+  `PLAN_VIEW` on one occurrence is spec-valid, not corruption.
+- `root.copy_class` (the IFC API) explicitly `remove_representations` on the copy, so the new
+  element starts with **zero** reps; the type branch then re-maps only the type's.
+- `geometry.assign_representation` **redirects a non-mapped rep to the type** when the product
+  is an occurrence whose type has `RepresentationMaps` (and isn't a profile/layer-set type;
+  see #6934). This is a landmine: you cannot "add a rep to an occurrence" through that API in
+  the typed case — it silently lands on the type and maps to every occurrence. Bypassed here
+  by appending straight to the occurrence's `IfcProductDefinitionShape`.
+- The panel's old `*` suffix on `RepresentationType` (data.py) was the *only* signal that a
+  rep was mapped/inherited, and nothing parsed it — confirmed (all functional readers use
+  `representation.RepresentationType` off the entity, not the panel dict string). Removed in
+  favour of the explicit Type/Occurrence split.
+- Interaction with #8200: this branch's `map_type_representations.py` already skips `Reference`
+  maps. Complementary — my `copy_class` fix re-adds occurrence-only reps *after*
+  `map_type_representations` runs; it keys off "context not in the type's `RepresentationMaps`",
+  so a type `Reference` map in the same context is *not* re-added as an occurrence rep.
+
+## Design
+
+Four connected pieces, all around occurrence-local vs type-mapped reps.
+
+### 1. Copy-drop fix
+
+`tool.Root.copy_occurrence_only_representations(source, dest, relating_type)` runs in
+`copy_class` right after `map_type_representations`. It deep-copies (sharing contexts,
+preserving named profiles) each source rep whose `ContextOfItems` is **not** among the type's
+`RepresentationMaps` contexts, and **appends directly** to `dest.Representation` — *not* via
+`geometry.assign_representation` (which would redirect onto the type; see landmine above).
+
+### 2. Type / Occurrence panel split
+
+`RepresentationsData` (geometry/data.py) gains `is_mapped`
+(`resolve_representation(rep) != rep`, i.e. the rep is an `IfcMappedItem` from the type),
+`element_is_type`, and `element_has_type`. `BIM_PT_representations` (geometry/ui.py) lists
+mapped reps under a **Type** header (`LINKED`) and local reps under an **Occurrence** header
+(`OBJECT_DATA`); a type element shows a flat list. Rows are drawn via a shared
+`draw_representation_row` helper that also carries the stack's `RepresentationIdentifier`
+column + `select_by_representation_type` button.
+
+### 3. Promote to Type
+
+`bim.promote_representation_to_type` (`EXPORT` icon on Occurrence rows, only when
+`element_has_type`) → `core.geometry.promote_representation_to_type`. Copies the local rep onto
+the type as a new `RepresentationMap` (`tool.Geometry.add_type_representation_map`), then for
+each occurrence of the type in the same context:
+
+- **identical** local rep → removed (`core.remove_representation`), occurrence inherits the
+  type's mapped rep (`map_representation` + `assign_representation`, which does *not* redirect
+  because the rep is now a `MappedRepresentation`);
+- **divergent** local rep → left entirely untouched (keeps its override, is not mapped);
+- **no** local rep → inherits the mapped rep.
+
+"Identical" = `tool.Geometry.representations_are_identical`: canonical serialization ignoring
+STEP ids and the shared context; styles (inverse `IfcStyledItem`) are not compared. Comparison
+is against the **type copy**, not the original — the original is removed mid-loop when the
+source occurrence is processed. User chose "only identical ones" removed (vs "all in context"
+or "only this occurrence"); divergent occurrences stay exactly as they were.
+
+### 4. "Add to Occurrence" toggle
+
+`bim.add_representation` gains `add_to_occurrence` (default **off**, `SKIP_SAVE`), shown in the
+add dialog only for an occurrence with a type. `core.geometry.add_representation` gains
+`add_to_occurrence=False`; when True (and not a type element) it calls
+`tool.Geometry.assign_representation_to_occurrence` (direct shape append) to bypass the
+redirect-to-type. **Off preserves existing behaviour exactly** (assign_representation decides,
+redirecting to the type only when the type already has maps; an empty type still lands on the
+occurrence) so the many internal callers of `add_representation` are unaffected. On = force a
+local occurrence override.
+
+## Status — implemented (algorithm verified standalone; not yet driven in live Blender)
+
+- `core/root.py` `copy_class`: calls `copy_occurrence_only_representations`; **diagnostic
+  `print("[copy_class] …")` statements + `_ctx_str` helper are still in** (kept intentionally
+  for repro — strip before merge).
+- `tool/root.py`: `copy_occurrence_only_representations`.
+- `tool/geometry.py`: `copy_representation_deep`, `assign_representation_to_occurrence`,
+  `add_type_representation_map`, `representations_are_identical`.
+- `core/geometry.py`: `promote_representation_to_type`; `add_representation` gains
+  `add_to_occurrence`.
+- `core/tool.py`: interface decls for the four new `Geometry` methods.
+- `bim/module/geometry/operator.py`: `PromoteRepresentationToType`; `AddRepresentation`
+  `add_to_occurrence` prop + dialog + pass-through.
+- `bim/module/geometry/{data,ui}.py`: `is_mapped` / `element_is_type` / `element_has_type`;
+  Type/Occurrence grouping merged with the stack's panel columns; `*` suffix removed.
+- `bim/module/geometry/__init__.py`: register `PromoteRepresentationToType`.
+
+Standalone check (installed ifcopenshell 0.8.0; repo src isn't compiled for this Python, and
+`api.geometry` won't import standalone due to a broken `mathutils` shim) reproduced source +
+identical + divergent occurrences: identical consolidate to mapped, divergent keeps its local
+override, type ends with both maps; comparator returns identical-across-separate-graphs = True,
+divergent = False, context-ignored = True.
+
+## Things to test / verify
+
+- Shift+D an occurrence with a local `PLAN_VIEW` the type lacks → the copy keeps the PLAN_VIEW
+  and it renders in a plan drawing.
+- Copy fix vs #8200: an occurrence with a type `Reference` opening template — confirm the copy
+  doesn't spuriously re-add a `Reference` occurrence rep, and openings still boolean.
+- Promote: identical siblings consolidate and their drawings still show the plan; a **divergent**
+  sibling keeps its own geometry and does *not* pick up the type's; the source occurrence ends
+  with only the mapped rep. Exercise `remove_representation`'s Blender mesh/data-link side
+  effects (the standalone test doesn't cover those).
+- `representations_are_identical` on real authored geometry (float exactness): separately
+  authored "same" plans may compare unequal → treated as divergent (safe direction, no delete).
+- Add-to-Occurrence off → typed occurrence rep lands on the type (existing behaviour); on →
+  stays local; toggle hidden for typeless elements and for type elements. Confirm no regression
+  in internal `add_representation` callers (wall/opening creation, `assign_class`).
+- Panel: Type vs Occurrence grouping correct for occurrence, typed occurrence with no local
+  reps (only Type header), typeless element (only Occurrence), and a type element (flat list);
+  columns still align with the stack's header row.
+- Strip the `copy_class` diagnostic prints before merge.

--- a/docs/dev-notes/occurrence-representations.md
+++ b/docs/dev-notes/occurrence-representations.md
@@ -107,9 +107,8 @@ local occurrence override.
 
 ## Status — implemented (algorithm verified standalone; not yet driven in live Blender)
 
-- `core/root.py` `copy_class`: calls `copy_occurrence_only_representations`; **diagnostic
-  `print("[copy_class] …")` statements + `_ctx_str` helper are still in** (kept intentionally
-  for repro — strip before merge).
+- `core/root.py` `copy_class`: calls `copy_occurrence_only_representations` (diagnostic
+  `[copy_class]` prints removed).
 - `tool/root.py`: `copy_occurrence_only_representations`.
 - `tool/geometry.py`: `copy_representation_deep`, `assign_representation_to_occurrence`,
   `add_type_representation_map`, `representations_are_identical`.
@@ -146,4 +145,3 @@ divergent = False, context-ignored = True.
 - Panel: Type vs Occurrence grouping correct for occurrence, typed occurrence with no local
   reps (only Type header), typeless element (only Occurrence), and a type element (flat list);
   columns still align with the stack's header row.
-- Strip the `copy_class` diagnostic prints before merge.

--- a/src/bonsai/bonsai/bim/module/geometry/__init__.py
+++ b/src/bonsai/bonsai/bim/module/geometry/__init__.py
@@ -63,6 +63,7 @@ classes = (
     operator.OverrideOriginSet,
     operator.OverrideOutlinerDelete,
     operator.OverridePasteBuffer,
+    operator.PromoteRepresentationToType,
     operator.PurgeUnusedRepresentations,
     operator.RefreshLinkedAggregate,
     operator.RemoveConnection,

--- a/src/bonsai/bonsai/bim/module/geometry/data.py
+++ b/src/bonsai/bonsai/bim/module/geometry/data.py
@@ -102,11 +102,31 @@ class RepresentationsData:
     def load(cls):
         cls.data = {"representations": cls.representations()}
         cls.data["contexts"] = cls.contexts()
+        cls.data["element_is_type"] = cls.element_is_type()
+        cls.data["element_has_type"] = cls.element_has_type()
 
         # Only after cls.representations().
         cls.data["shape_aspects"] = cls.shape_aspects()
 
         cls.is_loaded = True
+
+    @classmethod
+    def element_is_type(cls) -> bool:
+        obj = tool.Geometry.get_active_or_representation_obj()
+        assert obj
+        element = tool.Ifc.get_entity(obj)
+        return bool(element and element.is_a("IfcTypeProduct"))
+
+    @classmethod
+    def element_has_type(cls) -> bool:
+        """True when the active element is an occurrence with a type — i.e. a
+        local representation could be promoted onto that type."""
+        obj = tool.Geometry.get_active_or_representation_obj()
+        assert obj
+        element = tool.Ifc.get_entity(obj)
+        if not element or element.is_a("IfcTypeProduct"):
+            return False
+        return bool(ifcopenshell.util.element.get_type(element))
 
     @classmethod
     def representations(cls) -> list[dict[str, Any]]:
@@ -122,11 +142,8 @@ class RepresentationsData:
             active_representation_id = active_representation.id()
 
         for representation in tool.Geometry.get_representations_iter(element):
-            representation_type = representation.RepresentationType
             resolved_representation = ifcopenshell.util.representation.resolve_representation(representation)
-
-            if resolved_representation != representation:
-                representation_type = resolved_representation.RepresentationType + "*"
+            representation_type = resolved_representation.RepresentationType
 
             is_active = (
                 representation.id() == active_representation_id
@@ -145,6 +162,10 @@ class RepresentationsData:
                 "RepresentationIdentifier": representation.RepresentationIdentifier or "",
                 "RepresentationType": representation_type or "",
                 "is_active": is_active,
+                # True when this representation is an IfcMappedItem resolving to
+                # the type's MappedRepresentation, i.e. inherited from the type
+                # rather than local to the occurrence.
+                "is_mapped": resolved_representation != representation,
             }
             if representation.ContextOfItems.is_a("IfcGeometricRepresentationSubContext"):
                 data["ContextIdentifier"] = representation.ContextOfItems.ContextIdentifier or ""

--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -314,6 +314,16 @@ class AddRepresentation(bpy.types.Operator, tool.Ifc.Operator):
         ],
         name="Representation Conversion Method",
     )
+    add_to_occurrence: bpy.props.BoolProperty(
+        name="Add to Occurrence",
+        description=(
+            "Keep the new representation local to this occurrence instead of adding it to its type.\n"
+            "By default a representation added to a typed occurrence is placed on the type so all\n"
+            "occurrences inherit it; enable this to create an occurrence-specific override"
+        ),
+        default=False,
+        options={"SKIP_SAVE"},
+    )
 
     def _execute(self, context):
         obj = context.active_object
@@ -382,6 +392,7 @@ class AddRepresentation(bpy.types.Operator, tool.Ifc.Operator):
                 context=ifc_context,
                 ifc_representation_class=None,
                 profile_set_usage=None,
+                add_to_occurrence=self.add_to_occurrence,
             )
             # Object might be recreated, need to set it as active again.
             if context.active_object != obj:
@@ -406,6 +417,15 @@ class AddRepresentation(bpy.types.Operator, tool.Ifc.Operator):
         if self.representation_conversion_method == "OBJECT":
             row = self.layout.row()
             row.prop(props, "representation_from_object", text="")
+        # Only meaningful for an occurrence that has a type to add to.
+        obj = context.active_object
+        if (
+            obj
+            and (element := tool.Ifc.get_entity(obj))
+            and not element.is_a("IfcTypeProduct")
+            and ifcopenshell.util.element.get_type(element)
+        ):
+            self.layout.prop(self, "add_to_occurrence")
 
 
 class SelectConnection(bpy.types.Operator, tool.Ifc.Operator):
@@ -543,6 +563,36 @@ class RemoveRepresentation(bpy.types.Operator, tool.Ifc.Operator):
         operator_time = time() - start_time
         if operator_time > 10:
             self.report({"INFO"}, f"{self.bl_label} was finished in {operator_time:.2f} seconds.")
+
+
+class PromoteRepresentationToType(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.promote_representation_to_type"
+    bl_label = "Promote Representation to Type"
+    bl_description = (
+        "Move this occurrence-local representation onto its type so occurrences can inherit it.\n"
+        "Occurrences with an identical local representation inherit from the type;\n"
+        "occurrences with a divergent local representation keep their own override"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+    representation_id: bpy.props.IntProperty()
+
+    if TYPE_CHECKING:
+        representation_id: int
+
+    def _execute(self, context):
+        assert context.active_object
+        counts = core.promote_representation_to_type(
+            tool.Ifc,
+            tool.Geometry,
+            obj=context.active_object,
+            representation=tool.Ifc.get().by_id(self.representation_id),
+        )
+        self.report(
+            {"INFO"},
+            "Representation promoted to type. "
+            f"{counts['removed']} occurrence representation(s) consolidated, "
+            f"{counts['kept']} divergent override(s) kept.",
+        )
 
 
 class PurgeUnusedRepresentations(bpy.types.Operator, tool.Ifc.Operator):

--- a/src/bonsai/bonsai/bim/module/geometry/ui.py
+++ b/src/bonsai/bonsai/bim/module/geometry/ui.py
@@ -159,7 +159,7 @@ class BIM_PT_representations(Panel):
         header.label(text="", icon="BLANK1")
         header.label(text="", icon="BLANK1")
 
-        for representation in RepresentationsData.data["representations"]:
+        def draw_representation_row(representation, allow_promote=False):
             row = self.layout.row(align=True)
             row.label(text=representation["ContextType"])
             row.label(text=representation["ContextIdentifier"])
@@ -171,6 +171,10 @@ class BIM_PT_representations(Panel):
                 emboss=False,
             )
             op.representation_type = representation["RepresentationType"]
+            if allow_promote:
+                row.operator(
+                    "bim.promote_representation_to_type", icon="EXPORT", text=""
+                ).representation_id = representation["id"]
             op = row.operator(
                 "bim.switch_representation",
                 icon="FILE_REFRESH" if representation["is_active"] else "OUTLINER_DATA_MESH",
@@ -179,6 +183,28 @@ class BIM_PT_representations(Panel):
             op.ifc_definition_id = representation["id"]
             op.disable_opening_subtractions = False
             row.operator("bim.remove_representation", icon="X", text="").representation_id = representation["id"]
+
+        representations = RepresentationsData.data["representations"]
+        # For a type element every representation is its own; for an occurrence
+        # split them into those inherited from the type (mapped) vs those local
+        # to the occurrence, so it's clear which are driven by the type.
+        if RepresentationsData.data["element_is_type"]:
+            for representation in representations:
+                draw_representation_row(representation)
+        else:
+            type_representations = [r for r in representations if r["is_mapped"]]
+            occurrence_representations = [r for r in representations if not r["is_mapped"]]
+            # A local representation can be promoted onto the type only when the
+            # occurrence actually has a type to promote it onto.
+            allow_promote = RepresentationsData.data["element_has_type"]
+            if type_representations:
+                self.layout.label(text="Type", icon="LINKED")
+                for representation in type_representations:
+                    draw_representation_row(representation)
+            if occurrence_representations:
+                self.layout.label(text="Occurrence", icon="OBJECT_DATA")
+                for representation in occurrence_representations:
+                    draw_representation_row(representation, allow_promote=allow_promote)
 
         # Presentation layers.
         self.layout.separator()

--- a/src/bonsai/bonsai/core/geometry.py
+++ b/src/bonsai/bonsai/core/geometry.py
@@ -61,8 +61,15 @@ def add_representation(
     context: ifcopenshell.entity_instance,
     ifc_representation_class: Optional[str] = None,
     profile_set_usage: Optional[ifcopenshell.entity_instance] = None,
+    add_to_occurrence: bool = False,
 ) -> Union[ifcopenshell.entity_instance, None]:
-    """Add IFC representation based on object `.data`."""
+    """Add IFC representation based on object `.data`.
+
+    :param add_to_occurrence: Force the representation to stay local to this
+        occurrence. By default (``False``) ``geometry.assign_representation``
+        may redirect it onto the element's type so all occurrences inherit it;
+        set ``True`` to bypass that and keep it as an occurrence override.
+    """
     element = ifc.get_entity(obj)
     if not element:
         return
@@ -100,7 +107,10 @@ def add_representation(
         )
         geometry.record_object_materials(obj)
 
-    ifc.run("geometry.assign_representation", product=element, representation=representation)
+    if add_to_occurrence and not element.is_a("IfcTypeProduct"):
+        geometry.assign_representation_to_occurrence(element, representation)
+    else:
+        ifc.run("geometry.assign_representation", product=element, representation=representation)
 
     if data:
         data = geometry.duplicate_object_data(obj)
@@ -174,6 +184,77 @@ def remove_representation(
 
     if data and not data_removed_by_switch_representation:
         geometry.delete_data(data)
+
+
+def promote_representation_to_type(
+    ifc: type[tool.Ifc],
+    geometry: type[tool.Geometry],
+    obj: bpy.types.Object,
+    representation: ifcopenshell.entity_instance,
+) -> dict[str, int]:
+    """Move an occurrence-local representation onto its type.
+
+    The representation is copied onto the type as a mapped representation so
+    that occurrences can inherit it. For every occurrence of the type, in the
+    same context:
+
+    - an occurrence with a geometrically identical local representation has it
+      removed and inherits the type's mapped representation instead;
+    - an occurrence with a divergent local representation keeps its own and is
+      left untouched (it continues to override the type);
+    - an occurrence with no local representation in that context inherits the
+      type's mapped representation.
+
+    :return: counts dict with ``removed`` (identical locals consolidated) and
+        ``kept`` (divergent overrides preserved).
+    """
+    element = ifc.get_entity(obj)
+    assert element
+    element_type = geometry.get_element_type(element)
+    assert element_type, "Cannot promote a representation without a type."
+    context = representation.ContextOfItems
+
+    # Snapshot each occurrence's local (non-mapped) reps in this context before
+    # we add the type-mapped rep (which would otherwise match the filter).
+    occurrence_local_reps: dict[ifcopenshell.entity_instance, list[ifcopenshell.entity_instance]] = {}
+    for occurrence in geometry.get_elements_of_type(element_type):
+        locals_in_context = [
+            r
+            for r in geometry.get_representations_iter(occurrence)
+            if r.ContextOfItems == context and not geometry.is_mapped_representation(r)
+        ]
+        occurrence_local_reps[occurrence] = locals_in_context
+
+    # Copy onto the type as an independent representation map. A copy is used so
+    # removing a source occurrence's local rep below can't delete the type's
+    # geometry (the source rep would otherwise become the map's target).
+    type_representation = geometry.copy_representation_deep(representation)
+    geometry.add_type_representation_map(element_type, type_representation)
+
+    # Compare against the type copy, not the original: the original is removed
+    # mid-loop when the source occurrence is processed, and the copy is its
+    # geometric twin.
+    counts = {"removed": 0, "kept": 0}
+    for occurrence, locals_in_context in occurrence_local_reps.items():
+        divergent = [
+            r for r in locals_in_context if not geometry.representations_are_identical(r, type_representation)
+        ]
+        if divergent:
+            # Custom override -> leave the occurrence exactly as it was: keep its
+            # local rep(s) and do not map the type's representation onto it.
+            counts["kept"] += len(divergent)
+            continue
+
+        occurrence_obj = ifc.get_object(occurrence)
+        # Remove any identical local reps, then inherit from the type.
+        for identical_rep in locals_in_context:
+            if occurrence_obj:
+                remove_representation(ifc, geometry, obj=occurrence_obj, representation=identical_rep)
+            counts["removed"] += 1
+        mapped_representation = ifc.run("geometry.map_representation", representation=type_representation)
+        ifc.run("geometry.assign_representation", product=occurrence, representation=mapped_representation)
+
+    return counts
 
 
 def purge_unused_representations(ifc: type[tool.Ifc], geometry: type[tool.Geometry]) -> int:

--- a/src/bonsai/bonsai/core/root.py
+++ b/src/bonsai/bonsai/core/root.py
@@ -42,29 +42,15 @@ def copy_class(
         ifc.link(new, obj)
         return new
     representation = root.get_object_representation(obj)
-
-    def _ctx_str(rep):
-        c = rep.ContextOfItems
-        return f"{c.ContextType}/{c.ContextIdentifier}/{getattr(c, 'TargetView', None)}"
-
-    _src_reps = element.Representation.Representations if element.Representation else []
-    print(f"[copy_class] source {element.is_a()} #{element.id()} reps: {[_ctx_str(r) for r in _src_reps]}")
-
     new = ifc.run("root.copy_class", product=element)
     ifc.link(new, obj)
     relating_type = root.get_element_type(new)
     if relating_type and root.does_type_have_representations(relating_type):
-        _type_ctxs = [_ctx_str(rm.MappedRepresentation) for rm in (relating_type.RepresentationMaps or [])]
-        print(f"[copy_class] TYPE branch: type #{relating_type.id()} RepresentationMaps ctxs: {_type_ctxs}")
-        _dropped = [_ctx_str(r) for r in _src_reps if _ctx_str(r) not in _type_ctxs]
-        print(f"[copy_class] TYPE branch: occurrence-only reps that will be DROPPED: {_dropped}")
         ifc.run("type.map_type_representations", related_object=new, relating_type=relating_type)
         # map_type_representations wipes the occurrence's own representations and
         # only re-maps the type's, so occurrence-specific representations (e.g. a
         # per-occurrence Model/Body/PLAN_VIEW) would be lost. Re-add them.
         root.copy_occurrence_only_representations(element, new, relating_type)
-        _new_reps = new.Representation.Representations if new.Representation else []
-        print(f"[copy_class] TYPE branch: new #{new.id()} reps after mapping+merge: {[_ctx_str(r) for r in _new_reps]}")
         root.link_object_data(ifc.get_object(relating_type), obj)
     elif representation:
         copied_entities = root.copy_representation(element, new)

--- a/src/bonsai/bonsai/core/root.py
+++ b/src/bonsai/bonsai/core/root.py
@@ -42,11 +42,29 @@ def copy_class(
         ifc.link(new, obj)
         return new
     representation = root.get_object_representation(obj)
+
+    def _ctx_str(rep):
+        c = rep.ContextOfItems
+        return f"{c.ContextType}/{c.ContextIdentifier}/{getattr(c, 'TargetView', None)}"
+
+    _src_reps = element.Representation.Representations if element.Representation else []
+    print(f"[copy_class] source {element.is_a()} #{element.id()} reps: {[_ctx_str(r) for r in _src_reps]}")
+
     new = ifc.run("root.copy_class", product=element)
     ifc.link(new, obj)
     relating_type = root.get_element_type(new)
     if relating_type and root.does_type_have_representations(relating_type):
+        _type_ctxs = [_ctx_str(rm.MappedRepresentation) for rm in (relating_type.RepresentationMaps or [])]
+        print(f"[copy_class] TYPE branch: type #{relating_type.id()} RepresentationMaps ctxs: {_type_ctxs}")
+        _dropped = [_ctx_str(r) for r in _src_reps if _ctx_str(r) not in _type_ctxs]
+        print(f"[copy_class] TYPE branch: occurrence-only reps that will be DROPPED: {_dropped}")
         ifc.run("type.map_type_representations", related_object=new, relating_type=relating_type)
+        # map_type_representations wipes the occurrence's own representations and
+        # only re-maps the type's, so occurrence-specific representations (e.g. a
+        # per-occurrence Model/Body/PLAN_VIEW) would be lost. Re-add them.
+        root.copy_occurrence_only_representations(element, new, relating_type)
+        _new_reps = new.Representation.Representations if new.Representation else []
+        print(f"[copy_class] TYPE branch: new #{new.id()} reps after mapping+merge: {[_ctx_str(r) for r in _new_reps]}")
         root.link_object_data(ifc.get_object(relating_type), obj)
     elif representation:
         copied_entities = root.copy_representation(element, new)

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -445,6 +445,10 @@ class Geometry:
     def clear_modifiers(cls, obj): pass
     def clear_scale(cls, obj): pass
     def copy_data_links(cls, data, copied_entities) -> None: pass
+    def copy_representation_deep(cls, representation): pass
+    def assign_representation_to_occurrence(cls, element, representation): pass
+    def add_type_representation_map(cls, element_type, representation): pass
+    def representations_are_identical(cls, a, b): pass
     def delete_data(cls, data): pass
     def delete_ifc_object(cls, obj): pass
     def delete_opening_object_placement(cls, opening): pass
@@ -890,6 +894,7 @@ class Root:
     def add_tracked_opening(cls, obj): pass
     def assign_body_styles(cls, element, obj): pass
     def copy_representation(cls, source, dest): pass
+    def copy_occurrence_only_representations(cls, source, dest, relating_type): pass
     def does_type_have_representations(cls, element): pass
     def get_default_container(cls): pass
     def get_element_representation(cls, element, context): pass

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -889,6 +889,76 @@ class Geometry(bonsai.core.tool.Geometry):
         return ifcopenshell.util.representation.get_representation(element, context)
 
     @classmethod
+    def copy_representation_deep(cls, representation: ifcopenshell.entity_instance) -> ifcopenshell.entity_instance:
+        """Deep copy a representation, sharing geometric contexts and preserving
+        named profiles (mirrors ``tool.Root.copy_representation``'s exclusions)."""
+
+        def exclude_callback(attribute: ifcopenshell.entity_instance) -> bool:
+            return attribute.is_a("IfcProfileDef") and attribute.ProfileName
+
+        return ifcopenshell.util.element.copy_deep(
+            tool.Ifc.get(),
+            representation,
+            exclude=["IfcGeometricRepresentationContext"],
+            exclude_callback=exclude_callback,
+        )
+
+    @classmethod
+    def assign_representation_to_occurrence(
+        cls, element: ifcopenshell.entity_instance, representation: ifcopenshell.entity_instance
+    ) -> None:
+        """Append ``representation`` directly to an occurrence's shape, bypassing
+        ``geometry.assign_representation``'s redirect-to-type behaviour so the
+        representation stays local to this occurrence."""
+        ifc_file = tool.Ifc.get()
+        definition = element.Representation
+        if not definition:
+            definition = ifc_file.createIfcProductDefinitionShape()
+            element.Representation = definition
+        definition.Representations = list(definition.Representations or []) + [representation]
+
+    @classmethod
+    def add_type_representation_map(
+        cls, element_type: ifcopenshell.entity_instance, representation: ifcopenshell.entity_instance
+    ) -> ifcopenshell.entity_instance:
+        """Register ``representation`` on ``element_type`` as a new
+        ``IfcRepresentationMap`` (mapping origin at the type's local origin).
+        Subsequent ``geometry.map_representation`` calls reuse this map."""
+        ifc_file = tool.Ifc.get()
+        origin = ifc_file.createIfcAxis2Placement3D(
+            ifc_file.createIfcCartesianPoint((0.0, 0.0, 0.0)),
+            ifc_file.createIfcDirection((0.0, 0.0, 1.0)),
+            ifc_file.createIfcDirection((1.0, 0.0, 0.0)),
+        )
+        rep_map = ifc_file.createIfcRepresentationMap(origin, representation)
+        element_type.RepresentationMaps = list(element_type.RepresentationMaps or []) + [rep_map]
+        return rep_map
+
+    @classmethod
+    def representations_are_identical(
+        cls, a: ifcopenshell.entity_instance, b: ifcopenshell.entity_instance
+    ) -> bool:
+        """True if two representations have identical geometry, ignoring entity
+        identity (STEP ids) and their shared geometric context. Styles, which
+        attach via inverse ``IfcStyledItem``, are not part of this comparison."""
+
+        def canon(inst: Any, seen: frozenset[int]) -> Any:
+            if isinstance(inst, ifcopenshell.entity_instance):
+                if inst.is_a("IfcRepresentationContext"):
+                    return ("<context>",)
+                eid = inst.id()
+                if eid and eid in seen:
+                    return ("<cycle>", inst.is_a())
+                if eid:
+                    seen = seen | {eid}
+                return (inst.is_a(), tuple(canon(inst[i], seen) for i in range(len(inst))))
+            if isinstance(inst, (list, tuple)):
+                return tuple(canon(x, seen) for x in inst)
+            return inst
+
+        return canon(a, frozenset()) == canon(b, frozenset())
+
+    @classmethod
     def get_cartesian_point_offset(cls, obj: bpy.types.Object) -> npt.NDArray[np.float64] | None:
         props = tool.Blender.get_object_bim_props(obj)
         if props.blender_offset_type == "CARTESIAN_POINT" and props.cartesian_point_offset:

--- a/src/bonsai/bonsai/tool/root.py
+++ b/src/bonsai/bonsai/tool/root.py
@@ -118,6 +118,52 @@ class Root(bonsai.core.tool.Root):
         return copied_entities
 
     @classmethod
+    def copy_occurrence_only_representations(
+        cls,
+        source: ifcopenshell.entity_instance,
+        dest: ifcopenshell.entity_instance,
+        relating_type: ifcopenshell.entity_instance,
+    ) -> None:
+        """Re-add representations that belong to the occurrence but not the type.
+
+        ``type.map_type_representations`` rebuilds ``dest``'s representations
+        purely from the type's ``RepresentationMaps``, discarding any
+        occurrence-specific representation (e.g. a per-occurrence
+        Model/Body/PLAN_VIEW). This copies those occurrence-only
+        representations from ``source`` onto ``dest`` so a duplicated
+        occurrence keeps them."""
+        if not source.Representation:
+            return
+        type_contexts = {
+            rm.MappedRepresentation.ContextOfItems
+            for rm in (relating_type.RepresentationMaps or [])
+            if rm.MappedRepresentation
+        }
+
+        def exclude_callback(attribute: ifcopenshell.entity_instance) -> bool:
+            return attribute.is_a("IfcProfileDef") and attribute.ProfileName
+
+        for representation in source.Representation.Representations:
+            if representation.ContextOfItems in type_contexts:
+                continue
+            copied = ifcopenshell.util.element.copy_deep(
+                tool.Ifc.get(),
+                representation,
+                exclude=["IfcGeometricRepresentationContext"],
+                exclude_callback=exclude_callback,
+            )
+            # Append directly rather than via geometry.assign_representation:
+            # that API redirects a non-mapped representation to the type when
+            # the occurrence has a type with RepresentationMaps, which would
+            # wrongly push this occurrence-only representation onto the type
+            # (and thus onto every occurrence).
+            definition = dest.Representation
+            if not definition:
+                definition = tool.Ifc.get().createIfcProductDefinitionShape()
+                dest.Representation = definition
+            definition.Representations = list(definition.Representations or []) + [copied]
+
+    @classmethod
     def does_type_have_representations(cls, element: ifcopenshell.entity_instance) -> bool:
         return bool(element.RepresentationMaps)
 


### PR DESCRIPTION
Closes #8788.

> **Stacked PR** — based on `dev-notes-system` (#8201) → `opening-template-on-type` (#8200) → `select-by-representation-type` (#7916), because it shares the Representations panel and `RepresentationsData`. Review/merge the stack first; this branch is the two commits on top.

## Problem

Duplicating (Shift+D) an occurrence connected to a type **drops** any representation that lives only on the occurrence — one whose context the type has no `RepresentationMap` for, e.g. a per-occurrence `Model/Body/PLAN_VIEW`. `copy_class`'s type branch calls `type.map_type_representations`, which wipes the occurrence's reps and re-maps only the type's. Occurrence-local reps are spec-valid (IFC4 has no WHERE rule tying occurrence reps to the type), so they should survive a copy.

## What this does

1. **Preserve occurrence-local reps on duplicate** — `copy_class` re-adds occurrence-only reps after `map_type_representations` via `tool.Root.copy_occurrence_only_representations` (direct shape append, bypassing `assign_representation`'s redirect-to-type).
2. **Type / Occurrence panel split** — the Representations panel groups rows under **Type** (mapped/inherited) vs **Occurrence** (local) headers and drops the cryptic `*` suffix. Adds `is_mapped` / `element_is_type` / `element_has_type` to `RepresentationsData`.
3. **Promote to Type** (`bim.promote_representation_to_type`) — move a local rep onto the type; occurrences with a geometrically **identical** local rep are consolidated to inherit it, while **divergent** overrides are left untouched.
4. **"Add to Occurrence" toggle** on `bim.add_representation` (default off) — force a new rep to stay local to the occurrence instead of redirecting onto the type.

## Notes

- Design/decisions recorded in `docs/dev-notes/occurrence-representations.md` (per the dev-notes convention).
- The copy fix is complementary to #8200's `map_type_representations` `Reference`-skip; both handle occurrence reps around `map_type_representations`.
- Algorithm verified standalone; **still needs a pass in live Blender** (the four behaviors + `remove_representation`'s mesh/data-link side effects). See the dev-note's test checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
