### PR TITLE
ci: push the latest tag when publishing the docker image

### DIFF
--- a/.github/workflows/ci-ifcopenshell-docker.yml
+++ b/.github/workflows/ci-ifcopenshell-docker.yml
@@ -116,6 +116,6 @@ jobs:
         repository: aecgeeks/ifcopenshell
         # Since the dispatch is set to `tag`, `github.ref_name` should evaluate to the pushed tag
         # On a workflow dispatch, `ref_name` will take on the value from the dispatch payload
-        tags: aecgeeks/ifcopenshell:${{ github.ref_name }}${{ github.ref_name == github.event.repository.default_branch && ',aecgeeks/ifcopenshell:22.04' }}
+        tags: aecgeeks/ifcopenshell:${{ github.ref_name }},aecgeeks/ifcopenshell:latest${{ github.ref_name == github.event.repository.default_branch && ',aecgeeks/ifcopenshell:22.04' || '' }}
         file: ./Dockerfile
         push: true


### PR DESCRIPTION
## Summary
Fixes #6488.

The docker deliver job's tag list only contained `aecgeeks/ifcopenshell:${{ github.ref_name }}` plus a conditional `:22.04` — `:latest` was never in the list, so the tag the documentation tells users to run (`docker run aecgeeks/ifcopenshell ...`) has been frozen on a 2024 Ubuntu 20.04 image whose wrapper was compiled for Python 3.10 while the OS ships 3.8, producing exactly the ImportError in the report. @aothms observed the symptom in the thread ("somehow the image is not pushed to the latest tag") — the cause is simply that the workflow never asked for it.

Evidence from the Docker Hub API: `latest` last pushed 2024-06-08, while `v0.8.0` and `22.04` were pushed 2025-04-04 by the manually-triggered run — same workflow, `latest` absent from its tag list.

Also guards the existing conditional with `|| ''` so a false condition can't render the literal string `false` into the tag list (a known GitHub-expressions hazard).

After merge, the next `v0.*` tag push (or a manual dispatch) will update `latest` alongside the version tag.

## Test plan
- YAML validated.
- Tag expression reviewed against both trigger paths: tag push `v0.8.1` → `aecgeeks/ifcopenshell:v0.8.1,aecgeeks/ifcopenshell:latest`; dispatch from the default branch → `aecgeeks/ifcopenshell:v0.8.0,aecgeeks/ifcopenshell:latest,aecgeeks/ifcopenshell:22.04`.
- Not runtime-testable outside the repo's CI (requires the Docker Hub token); the change is a tag-list edit only.

This PR contains AI-generated changes, generated with the assistance of an AI coding tool.