### PR TITLE
Bonsai: orient new door/window fillings by the wall's direction sense (#6588)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -1554,16 +1554,26 @@ class ProductDecorator(tool.Blender.ViewportDecorator):
             axis_side = axes["side"]
             point_on_base_axis = tool.Cad.point_on_edge(mouse_point, axis_base)
             point_on_side_axis = tool.Cad.point_on_edge(mouse_point, axis_side)
+            # Match FilledOpeningGenerator.generate: the filling faces the
+            # wall body from whichever face is snapped, so a NEGATIVE
+            # direction sense inverts which face needs the 180 degree turn.
+            flipped_wall = layers["direction_sense"] == "NEGATIVE"
             if (point_on_base_axis - mouse_point).length_squared <= (point_on_side_axis - mouse_point).length_squared:
-                # mouse is snapped to the base axis, the preview looks exactly like the placed door / window
-                rot_mat = snap_obj.matrix_world
+                # mouse is snapped to the base axis
+                rotate_filling = flipped_wall
             else:
-                # mouse is snapped to the side axis, the preview is inverted, rotate it now and correct x position later
+                # mouse is snapped to the side axis
+                rotate_filling = not flipped_wall
+            if rotate_filling:
+                # the preview is inverted, rotate it now and correct x position later
                 rot_mat = (
                     (snap_obj.matrix_world.to_quaternion() @ Quaternion(Vector((0, 0, 1)), radians(180)))
                     .to_matrix()
                     .to_4x4()
                 )
+            else:
+                # the preview looks exactly like the placed door / window
+                rot_mat = snap_obj.matrix_world
 
             mouse_point.z = snap_obj.matrix_world.translation.z
 

--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -303,12 +303,19 @@ class FilledOpeningGenerator:
                 new_matrix = voided_obj.matrix_world.copy()
                 point_on_base_axis = tool.Cad.point_on_edge(target, axis_base)
                 point_on_side_axis = tool.Cad.point_on_edge(target, axis_side)
+                # The filling faces the wall body from whichever face was
+                # clicked, so a NEGATIVE direction sense (body on the wall's
+                # local -Y) inverts which face needs the 180 degree turn.
+                flipped_wall = layers["direction_sense"] == "NEGATIVE"
                 if (point_on_base_axis - target).length <= (point_on_side_axis - target).length:
                     new_matrix.translation.x = point_on_base_axis.x
                     new_matrix.translation.y = point_on_base_axis.y
+                    rotate_filling = flipped_wall
                 else:
                     new_matrix.translation.x = point_on_side_axis.x
                     new_matrix.translation.y = point_on_side_axis.y
+                    rotate_filling = not flipped_wall
+                if rotate_filling:
                     new_matrix = new_matrix @ Matrix.Rotation(radians(180.0), 4, "Z")
 
                 if should_set_z_level:


### PR DESCRIPTION
## Summary
Implements #6588 (@theoryshaw): doors/windows now accommodate the wall's direction sense at insertion.

`FilledOpeningGenerator.generate` decided a new filling's facing purely from which wall axis the click snapped to: base axis kept the wall's orientation, side axis rotated 180° about Z. That convention hard-codes the wall body lying on the +Y side of the base axis, which is only true for `DirectionSense = POSITIVE`. Flipping a wall toggles DirectionSense and shifts the origin (geometry stays put), putting the body on local −Y — but the insertion logic never consulted `direction_sense`, so on a flipped wall every new door/window faced out of the wall with the lining protruding, and the user had to run Flip Fill after each insertion.

The fix XORs the wall's flip state into the facing decision at the only two decision sites: the placement logic in `opening.py` and the hover ghost preview in `decorator.py` (updated identically so the preview matches what gets placed). No IFC semantics touched; regeneration reuses the stored opening placement; the void extrusion is rotation-invariant.

## Test plan
Live headless Blender 5.2, real operators (`bim.create_project`, `bim.add_occurrence`, `bim.flip_wall`), measuring the door's +Y axis in the wall frame:

| Wall state | Clicked face | Faces into body (before) | Faces into body (after) |
|---|---|---|---|
| POSITIVE | base | yes | yes (byte-identical) |
| POSITIVE | side | yes | yes (byte-identical) |
| NEGATIVE | base | no | yes |
| NEGATIVE | side | no | yes |

- Wall mesh cut verified in all four cases; window on a flipped wall faces into the body with sill height preserved; Flip Fill on a flipped-wall door still mirrors correctly.
- The #8113 fix's test suite (`test_transform_modal_gate.py`) 10/10; wall split/merge with filled openings, opening decoration, door decorator/gizmos, recalculate-fill, wall gizmos: 130 passed (remaining failures are pre-existing local-harness drift unrelated to the changed code).
- black+ruff clean (CI-exact toolchain).

Design note: the hinge-side/X-extent convention is deliberately unchanged (door body still grows along its local +X from the click point). If the request also implies hinge-side stability under direction sense, that's a separate UX decision — happy to follow up.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.