### PR TITLE
ifcgeom: defer partial CGAL shells to the next hybrid kernel (fixes #8052)

### DIFF
--- a/src/ifcgeom/kernels/cgal/CgalKernel.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalKernel.cpp
@@ -208,6 +208,7 @@ bool CgalKernel::convert(const taxonomy::shell::ptr l, cgal_shape_t& shape) {
 	}
 
 	std::list<cgal_face_t> face_list;
+	bool any_face_failed = false;
 	for (auto& f : l->children) {
 		bool success = false;
 		try {
@@ -216,6 +217,7 @@ bool CgalKernel::convert(const taxonomy::shell::ptr l, cgal_shape_t& shape) {
 
 		if (!success) {
 			logger().Message(Logger::LOG_WARNING, "GEO", 79, "Failed to convert face:", f->instance);
+			any_face_failed = true;
 			continue;
 		}
 
@@ -223,6 +225,15 @@ bool CgalKernel::convert(const taxonomy::shell::ptr l, cgal_shape_t& shape) {
 		//    for (auto &point: face.outer) {
 		//      std::cout << "\tPoint(" << point << ")" << std::endl;
 		//    }
+	}
+
+	// If any face was dropped and this kernel is not the final fallback in a
+	// hybrid chain (partial_success_is_success == false), report failure so the
+	// hybrid kernel escalates the whole shell to a later kernel (e.g. OpenCASCADE)
+	// rather than silently returning an incomplete shell. See hybrid_kernel.h,
+	// where partial_success_is_success is set false for every non-final kernel.
+	if (any_face_failed && !partial_success_is_success) {
+		return false;
 	}
 
 	shape = utils::create_polyhedron(face_list);


### PR DESCRIPTION
## Summary

Fixes #8052 — geometry loaded with the default `hybrid-cgal-simple-opencascade` kernel is silently incomplete for shells whose faces CGAL can't build (self-intersecting projected face boundaries, common in `IfcAdvancedBrep`). The hybrid chain accepts cgal-simple's partial result and never falls back to OpenCASCADE.

This implements the fallback @aothms described in the issue thread:

> "cgal-simple currently doesn't have the means to resolve self-intersecting face boundaries. I was able to change this so that at least hybrid-cgal-simple-opencascade defers to opencascade so that you get the full shape."

## ⚠️ Needs testing

Reviewed by inspection; **not yet runtime-verified** — I did not have an ifcgeom build environment set up. Please rebuild and confirm the hybrid backend now returns the full shape on the #8052 sample models before merging.

## Root cause

`CgalKernel::convert(shell, cgal_shape_t&)` skips any face that fails to convert and reports success as long as ≥1 facet survives:

```cpp
if (!success) {
    logger().Message(Logger::LOG_WARNING, "GEO", 79, "Failed to convert face:", f->instance);
    continue;                       // drop the face
}
...
return shape.size_of_facets();      // "success" if anything survived
```

The framework already carries the correct intent via `partial_success_is_success`, which `hybrid_kernel.h` sets `false` for every non-final kernel in the chain. But that flag is only ever consulted in `AbstractKernel::convert_impl(taxonomy::collection…)` — and a shell/solid is a `collection_base<face>`/`<shell>`, **not** a `taxonomy::collection`, so its face loop never sees the flag. Result: cgal-simple returns a partial shell as success, and `HybridKernel::convert()` returns on the first success, never reaching OpenCASCADE.

## Fix

Track dropped faces in the shell loop and, when this kernel is **not** the final fallback (`!partial_success_is_success`), return `false` so the hybrid kernel escalates the whole shell to the next kernel. Both `convert_impl(shell)` and `convert_impl(solid)` route through this helper, so both are covered. Pure `cgal` / `cgal-simple` (flag stays `true`) keep their existing best-effort behavior — no regression for users who deliberately choose a CGAL-only backend.

## Reproduction

With `1amAV6DjTEyRV0F$mCo3HF` (an `IfcLightFixture` whose type is 15 `IfcAdvancedBrep`s), vert counts per backend before the fix:

| Backend | Verts |
|---|---|
| `opencascade` | 1190 (full) |
| `cgal` / `cgal-simple` | 702 (partial) |
| `hybrid-cgal-simple-opencascade` (default) | 702 (partial) |

After the fix, `hybrid-…` should return **1190** while `cgal`/`cgal-simple` stay 702.

## Notes for reviewers

- Independent of the two other open hybrid-kernel PRs (#7523 sigsegv recovery, #8722 OCC→CGAL coincident-faces) — different failure modes, different file, no conflict.
- If #8722 lands first, this could alternatively be folded into its `logger_flags_suspicious_result()` mechanism by treating the `GEO 79` dropped-face warning as suspicious, rather than returning `false` from the kernel. Happy to reframe it that way if preferred.
- A secondary gap remains: `utils::create_polyhedron` can drop faces during non-manifold stitching even when every face converted. Left out to keep this minimal; can add an input-vs-output facet-count check if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
