### PR TITLE
Bonsai: add 1.3 mm and 1.5 mm annotation text sizes

### DIFF
--- a/src/bonsai/bonsai/bim/data/assets/default.css
+++ b/src/bonsai/bonsai/bim/data/assets/default.css
@@ -79,6 +79,8 @@ text.header, tspan.header { /* 5mm */ font-size: 8.25px; }
 text.large, tspan.large { /* 3.5mm */ font-size: 5.78px; }
 text.regular, tspan.regular { /* 2.5mm */ font-size: 4.13px; }
 text.small, tspan.small { /* 1.8mm */ font-size: 2.97px; }
+text.tiny, tspan.tiny { /* 1.5mm */ font-size: 2.48px; }
+text.mini, tspan.mini { /* 1.3mm */ font-size: 2.15px; }
 text.GRID, tspan.GRID { /* 5mm */ font-size: 8.25px; }
 .material-blank { fill: white; }
 .material-diagonal1 { fill: url(#diagonal1); }

--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -224,6 +224,8 @@ class DocumentsData:
 
 
 FONT_SIZES = {
+    "mini": 1.3,
+    "tiny": 1.5,
     "small": 1.8,
     "regular": 2.5,
     "large": 3.5,

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -917,6 +917,8 @@ class BIMTextProperties(PropertyGroup):
     )
     font_size: EnumProperty(
         items=[
+            ("1.3", "1.3 - Mini", ""),
+            ("1.5", "1.5 - Tiny", ""),
             ("1.8", "1.8 - Small", ""),
             ("2.5", "2.5 - Regular", ""),
             ("3.5", "3.5 - Large", ""),

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -851,6 +851,25 @@ class TestEditText(NewFile):
         assert "title" in annotation_classes
         assert DecoratorData.get_text_data(obj)["FontSize"] == 7.0
 
+    @pytest.mark.parametrize("font_size, class_name", [("1.3", "mini"), ("1.5", "tiny")])
+    def test_change_text_font_size_to_small_sizes(self, font_size, class_name):
+        TestGetTextLiteral().test_run()
+        obj = bpy.data.objects["Object"]
+
+        with bpy.context.temp_override(active_object=obj):
+            bpy.ops.bim.enable_editing_text()
+            props = tool.Drawing.get_text_props(obj)
+            props.font_size = font_size
+            bpy.ops.bim.edit_text()
+
+        annotation_classes = ifcopenshell.util.element.get_pset(tool.Ifc.get_entity(obj), "EPset_Annotation", "Classes")
+        assert class_name in annotation_classes.split()
+        assert DecoratorData.get_text_data(obj)["FontSize"] == float(font_size)
+
+        # Font size round-trips back into the property.
+        subject.import_text_attributes(obj)
+        assert tool.Drawing.get_text_props(obj).font_size == font_size
+
     def test_add_second_literal(self, setup=True):
         if setup:
             TestGetTextLiteral().test_run()


### PR DESCRIPTION
## Summary
Builds on @jes-r's #6437, which is still open as a draft. The class names (`mini`, `tiny`), the mm values and the CSS pixel values are his and are kept exactly as he wrote them. This PR carries that work forward against current v0.8.0, where his branch no longer applies cleanly.

Annotation text only offered 1.8/2.5/3.5/5.0/7.0 mm. Smaller sizes could already be added to a custom stylesheet, but the viewport still drew them at regular size, because `DecoratorData.get_text_data` falls back to `"regular"` for any class missing from `FONT_SIZES`. That is the behaviour @jes-r reported in #6426 with screenshots.

Changes:
- `FONT_SIZES` gains `mini` (1.3 mm) and `tiny` (1.5 mm), which fixes the viewport size.
- The `font_size` enum gains `1.3` and `1.5`.
- `default.css` gains matching `text.mini`/`text.tiny` rules at 2.15px and 2.48px, on the existing 2.5 mm to 4.13px scale, which is what the SVG output resolves against.

Relative to #6437: the unrelated whitespace changes to `operator.py` are left out (they conflict with current HEAD and add trailing whitespace), and regression tests are added covering both new sizes end to end (pset class written, decorator mm value, round trip back into the property).

This is item 05 of the funded Drawings and Documentation Phase 1 program (@theoryshaw). The linetype half of #6426, which @jes-r also raised, is not addressed here and is worth splitting into its own issue as he suggested, since the scale-dependence question there is still open.

Fixes #6426

## Test plan
Verified in headless Blender against a real project (create project, `bim.edit_text` through the actual operator, IFC written and reread from disk):
- Both sizes appear in the enum and in `FONT_SIZES`; setting 1.3/1.5 writes `mini`/`tiny` to `EPset_Annotation.Classes`, the decorator reports 1.3/1.5 mm, and the value round-trips back into the property.
- Class survives an IFC write and reread; `get_attribute_classes` emits it into the SVG class list, with the matching CSS rule resolving to 2.15px / 2.48px.
- 3 unit tests pass; black+ruff clean.

Full drawing SVG generation needs a camera/drawing context that headless cannot provide, so both ends of that path (emitted class list, matching stylesheet rule) were verified instead.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.