### PR TITLE
Bonsai: generalise representation item deletion to nested items

### DIFF
--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1785,6 +1785,7 @@ class Geometry(bonsai.core.tool.Geometry):
         [consider_inverses.append(texture := t) for t in getattr(representation_item, "HasTextures", [])]
 
         representation = None
+        containers: list[ifcopenshell.entity_instance] = []
         boolean_results_to_remove: set[ifcopenshell.entity_instance] = set()
         for inverse in ifc_file.get_inverse(representation_item):
             if inverse.is_a("IfcShapeRepresentation"):
@@ -1806,6 +1807,8 @@ class Geometry(bonsai.core.tool.Geometry):
                     elif inverse2.is_a("IfcShapeRepresentation"):
                         inverse2.Items = tuple(set(inverse2.Items) - {inverse} | {other_operand})
                 boolean_results_to_remove.add(inverse)
+            elif inverse.is_a("IfcRepresentationItem") and not inverse.is_a("IfcStyledItem"):
+                containers.append(inverse)
 
         if styled_item:
             consider_inverses.remove(styled_item)
@@ -1828,12 +1831,44 @@ class Geometry(bonsai.core.tool.Geometry):
             if not new_items:
                 return
             representation.Items = new_items
+
+        emptied_containers = [c for c in containers if cls.detach_representation_item(representation_item, c)]
+
         also_consider = list(consider_inverses)
         ifcopenshell.util.element.remove_deep2(ifc_file, representation_item, also_consider=also_consider)
+
+        for container in emptied_containers:
+            cls.remove_representation_item(container, element)
 
         tool.Model.unmark_manual_booleans(element, [b.id() for b in boolean_results_to_remove])
         for boolean_result in boolean_results_to_remove:
             cls.remove_representation_item(boolean_result, element)
+
+    @classmethod
+    def detach_representation_item(
+        cls, representation_item: ifcopenshell.entity_instance, container: ifcopenshell.entity_instance
+    ) -> bool:
+        """Clear references to an item from another item that nests it.
+
+        Covers containers such as IfcGeometricSet.Elements,
+        IfcShellBasedSurfaceModel.SbsmBoundary or IfcCsgSolid.TreeRootExpression.
+
+        :param representation_item: item to detach.
+        :param container: item referencing ``representation_item``.
+        :return: whether ``container`` is left invalid and has to be removed too.
+        """
+        is_emptied = False
+        for i in range(len(container)):
+            value = container[i]
+            if value == representation_item:
+                container[i] = None
+                is_emptied = True
+            elif isinstance(value, tuple) and any(v == representation_item for v in value):
+                value = tuple(v for v in value if v != representation_item)
+                container[i] = value
+                if not value:
+                    is_emptied = True
+        return is_emptied
 
     @classmethod
     def create_shape_aspect(


### PR DESCRIPTION
@carlopav, as requested on #8392 — this replaces that edge-case fix with a general one, so #8392 can be closed.

## The asymmetry
The import side is already fully general. `process_mapping` in `src/ifcgeom/mapping/mapping.h` tags every mapped `IfcRepresentationItem` with its instance id, and container items are mapped through the same `map_to_collection` helper that `IfcRepresentation.Items` uses, so their children fall out of the generic recursion as individually editable items with no special casing. Only deletion special-cased: `remove_representation_item` assumed an item's parent is the `IfcShapeRepresentation` (or an `IfcBooleanResult`), so an item nested in a container was detached from nothing, stayed in the file, and got re-imported on leaving item mode.

## The fix
Any inverse that is itself a representation item is now treated as a container, and the item is cleared from whichever attribute references it, found by attribute index rather than by a hardcoded per-class list. A container left with nothing in it is removed in turn, recursively, so it is detached from its own parent too.

This turns out to cover three container families, not one: `IfcGeometricSet`/`IfcGeometricCurveSet` `Elements` (the case in #6591), `IfcShellBasedSurfaceModel` `SbsmBoundary`, and `IfcFaceBasedSurfaceModel` `FbsmFaces`. On current v0.8.0 all three leak the deleted item back on reload. `IfcConnectedFaceSet`, `IfcManifoldSolidBrep` and `IfcEdgeLoop` are not in scope: the mapper fuses their children into a single geometry node, so the children are never separately selectable items.

## Two decisions worth flagging
Items referenced by more than one container are detached from all of them, because item mode dedups by item id and presents exactly one object per item, so a partial detach would make the item reappear. This is a genuine behavior choice rather than a forced one — if Bonsai ever moves to per-container item objects it would need revisiting, so flagging it explicitly for review.

Boolean operands keep their existing handling (the surviving operand is promoted into the result's place) rather than being folded into the generic path, since a boolean missing an operand is meaningless rather than merely empty. Verified byte-identical to current behavior.

## Verification
Driven live in headless Blender through the real operators (`bim.import_representation_items` then `bim.override_object_delete`), writing and reloading the file each time: the three nesting families, a plain top-level item, a container that empties out, a boolean operand, an item shared between two sets on one element, and an item shared across two elements. All validate clean, and all three nesting families were confirmed broken on an unpatched v0.8.0 baseline. Also confirmed against the reporter's `prova.ifc`: `#1404` stays out of `#1413`'s `Elements` after reload and the Model view representation is untouched. 78 existing geometry tests pass; black+ruff clean.

Fixes #6591

This PR contains AI-generated code, generated with the assistance of an AI coding tool.