### PR TITLE
docs: add Eigen to Linux install deps

### DIFF
--- a/src/ifcopenshell-python/docs/ifcopenshell/installation.rst
+++ b/src/ifcopenshell-python/docs/ifcopenshell/installation.rst
@@ -60,7 +60,7 @@ operating systems. GCC (4.7 or newer) or Clang (any version) is required.
 
    .. code-block:: bash
 
-       sudo apt-get install git cmake gcc g++ libboost-all-dev libcgal-dev
+       sudo apt-get install git cmake gcc g++ libboost-all-dev libcgal-dev libeigen3-dev
 
    The CGAL version that ships with Ubuntu 20.04 is too old. Users on Ubuntu 20.04 are advised to manually install CGAL 5.3.
 


### PR DESCRIPTION
## Summary

- Add `libeigen3-dev` to the Linux "basic dependencies" `apt-get install` line in `src/ifcopenshell-python/docs/ifcopenshell/installation.rst`.

## Motivation

`src/ifcgeom/CMakeLists.txt` does `find_package(Eigen3 REQUIRED)`, so Eigen is a hard build dependency. The Linux docs listed boost/CGAL but not Eigen; the cmake example already passes `-DEIGEN_DIR=/usr/include/eigen3`, and the macOS Homebrew line already installs `eigen`.

Closes #6903 (fact-checked actionable on current `v0.8.0` by BIMvoice).

## Verification

- Confirmed `find_package(Eigen3 REQUIRED)` + `Eigen3::Eigen` link in `src/ifcgeom/CMakeLists.txt`
- Confirmed Ubuntu package name `libeigen3-dev` provides headers under `/usr/include/eigen3`
- Docs-only: single package add on the existing apt line; no runtime/code change
- No open PR already targeting this path/issue

## AI disclosure

Docs-only change prepared with assistance of an AI coding tool (Hermes/Sera), human-reviewed. AI note is in the commit body per AGENTS.md.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes campaign=construction-am pilot=1 -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 72h  
**Claim:** `sera` · pilot-1 construction-am
