### PR TITLE
Bonsai: don't blow up a vertical AXIS3 element when its layers change

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -271,14 +271,21 @@ class DumbSlabPlaner:
                 # For instances, a 30 degrees angled extrusion with positive direction has the same extrusion direction as a
                 # -150 degrees angled extrusion with negative direction. The difference lies in the object's rotation.
                 # This means that things can get messy if the user changes the object x angle somehow. We have to figure out an alternative approach.
+                direction_ratios = Vector(extrusion.ExtrudedDirection.DirectionRatios)
+
+                # No depth can realise the requested thickness once the extrusion runs
+                # perpendicular to the layer axis, so leave the representation alone.
+                layer_axis_ratio = direction_ratios.normalized().z
+                if tool.Cad.is_x(abs(layer_axis_ratio), 0, tolerance=0.001):
+                    return
+
                 existing_x_angle = tool.Model.get_existing_x_angle(extrusion)
                 existing_x_angle = 0 if tool.Cad.is_x(existing_x_angle, 0, tolerance=0.001) else existing_x_angle
                 existing_x_angle = 0 if tool.Cad.is_x(existing_x_angle, pi, tolerance=0.001) else existing_x_angle
                 existing_x_angle = 0 if tool.Cad.is_x(existing_x_angle, 2 * pi, tolerance=0.001) else existing_x_angle
-                direction_ratios = Vector(extrusion.ExtrudedDirection.DirectionRatios)
                 offset_direction = direction_ratios.copy()
-                perpendicular_depth = thickness * abs(1 / cos(existing_x_angle))
-                perpendicular_offset = layer_offset * abs(1 / cos(existing_x_angle)) / self.unit_scale
+                perpendicular_depth = thickness / abs(layer_axis_ratio)
+                perpendicular_offset = layer_offset / abs(layer_axis_ratio) / self.unit_scale
 
                 # Check angle and z direction to determine whether the extrusion direction is positive or negative
                 if (abs(existing_x_angle) < (pi / 2) and direction_ratios.z > 0) or (


### PR DESCRIPTION
Fixes #7146.

Editing the material layer set of an `IfcMaterialLayerSetUsage` AXIS3 element that stands vertically inflated it to kilometre scale, or crashed with `ValueError: zero length vectors have no valid angle`.

`DumbSlabPlaner.change_thickness` rewrote the body extrusion assuming the extrusion axis is the layer axis, scaling the depth by an unbounded `1 / cos(x_angle)`. Once the extrusion runs perpendicular to the profile plane normal that factor diverges.

The scale is now derived from the normalised extrusion direction's z component. It is identical to `1 / cos(x_angle)` for every direction the parametric slab tool produces, stays correct when the direction carries an x component, and makes the degenerate case explicit: when the component vanishes no depth can realise the requested thickness, so the representation is left untouched rather than rewritten to garbage.

Note on scope: @theoryshaw's literal screencast case was already half-fixed by 937270fc49 (which swapped `obj.rotation_euler.x` for `get_existing_x_angle`), a commit that postdates the build he filed against. The same user action on the same class of vertical AXIS3 element still corrupts or crashes on current v0.8.0, which is what this closes.

## Test plan
Live headless Blender (Blender 5.2, deployed Bonsai), synthetic fixtures matching the state read off the attached video (`IfcFurniture` + AXIS3 layer set usage, 2" thick, object turned vertical — the linked hub.openingdesign.com model is inaccessible, Cloudflare 403 on every route including git clone):

| fixture | current v0.8.0 | with fix |
|---|---|---|
| flat slab | 0.0508 | 0.0508 |
| local-Z extrusion, object rotated X 90° | 0.0508 | 0.0508 |
| local-Y extrusion, vertical | **1162168** | 0.0508 |
| local-X extrusion, vertical | **ValueError** | 0.0508 |

Regression, old vs new code side by side, doubling the layer thickness: flat `0.1016`, 30°-angled `0.11732` (= 0.1016/cos30), negative-Z `0.1016`, 60°-angled `0.2032` (= 0.1016/cos60) — byte-identical.

black+ruff clean. Caveat: the behave/pytest-blender suite could not run in this environment (`pytest-blender` not installed in the Blender used), so verification is the live execution above rather than the BIM feature tests.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.