### PR TITLE
Bonsai: stop merged cut linework leaking classes onto disjoint pieces

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1708,7 +1708,7 @@ class CreateDrawing(bpy.types.Operator):
                             coords.append(coords[0])
                         if len(coords) > 2 and coords[0] == coords[-1]:
                             is_closed_polygon = True
-                            queue.append((shapely.Polygon(coords), classes))
+                            queue.append((shapely.Polygon(coords), set(classes)))
                 if is_closed_polygon:
                     el.getparent().remove(el)
 


### PR DESCRIPTION
In `merge_linework_and_add_metadata` every closed subpath of an element group was queued with a *reference* to the same class set, so when one subpath was unioned with a neighbouring element the in-place `polygon_classes.update()` also rewrote the classes of that element's other, geometrically unrelated subpaths. A wall split by an opening could therefore emit a piece carrying a neighbour's GlobalId, status and metadata classes, styling it from the wrong CSS rules. Queue a copy of the class set per polygon so each merged polygon owns its own classes.

Demonstrated with the exact loop code — a disjoint piece belonging only to element B was emitted carrying element A's guid:

```
before:  polygon x=5.0..7.0  classes=['cut', 'guidA', 'guidB']   # wrong
after:   polygon x=5.0..7.0  classes=['cut', 'guidB']
```

## Test plan
Verified live in headless Blender against four generated multi-layer-wall models (real `IfcMaterialLayerSet` + `IfcMaterialLayerSetUsage`, walls straddling the cut plane, some voided by openings), driven through the real `bim.create_drawing` pipeline: path geometry byte-identical before and after, and class sets identical, so unaffected drawings render the same. black+ruff clean.

## Relationship to #7369
Relates to #7369, but does not close it. That issue's own reported symptom (material layers merging into one group) was already fixed by #7700 — I could not reproduce it on current v0.8.0, and temporarily reverting the single line #7700 added (`"Material.Name"` in `join_criteria`) reproduces it exactly, including the two-layer-materials-in-one-group signature from the reporter's devtools screenshot. This PR fixes a separate, still-live defect found in the same merge loop.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.