### PR TITLE
ifcgeom: keep unopened geometry when opening subtraction throws a non-std::exception

### DIFF
--- a/src/ifcgeom/Converter.cpp
+++ b/src/ifcgeom/Converter.cpp
@@ -212,7 +212,9 @@ IfcGeom::BRepElement* ifcopenshell::geometry::Converter::create_brep_for_represe
 			logger_.Message(Logger::LOG_ERROR, "GEO", 33, std::string("Error processing openings for: ") + e.what() + ":", product);
 			caught_error = true;
 		} catch (...) {
+			// Non-std::exception (e.g. OCCT's Standard_Failure) also counts as caught_error.
 			logger_.Message(Logger::LOG_ERROR, "GEO", 34, "Error processing openings for:", product);
+			caught_error = true;
 		}
 
 		if (!(caught_error && opened_shapes.size() < shapes.size())) {


### PR DESCRIPTION
Fixes #6391 (some walls disappear when a project is opened).

OCCT's `Standard_Failure` hierarchy derives from `Standard_Transient`, not `std::exception`, so a raw OCCT exception thrown while applying an element's openings is caught by the generic `catch (...)` in `Converter.cpp`. Unlike the `catch (const std::exception&)` branch beside it, that branch never set `caught_error`, which silently disabled the guard that keeps the product's unopened geometry on failure. The element ended up with zero faces and vanished from the viewport instead of degrading gracefully to its unclipped shape, the way every other failure path in this code already does.

Two-line change: set `caught_error = true` in `catch (...)` as well.

## Test plan
Built and tested against a real wall-with-through-hole IFC (authored via `ifcopenshell.api`, hole confirmed by the "Operand B creates a through hole" log line). A non-`std::exception` fault was injected at the entry of `convert_openings` purely for testing, behind an env var and never shipped:

| build | fault | result |
|---|---|---|
| origin/v0.8.0 | off | 48 verts / 32 faces, hole cut correctly |
| origin/v0.8.0 | **on** | **0 verts / 0 faces — wall vanishes** |
| patched | off | 48 verts / 32 faces, byte-identical to baseline |
| patched | **on** | 24 verts / 12 faces — falls back to the unclipped wall |

Regression: all 258 `test/input/*.ifc` fixtures converted with both the true baseline and the patched binary (no fault hook compiled in) — 244 byte-identical successes, 14 failing identically on both (pre-existing crash-repro fixtures), 0 diffs, 0 new failures.

Complementary to, not overlapping with, #8786 / #8778 / #8775 / #8772: those reduce how often failures occur inside `boolean_operation` and `convert_openings`; this ensures that when an exception still escapes, the product does not silently lose all its geometry.

Worth a separate follow-up: Bonsai's `create_products()` gives an element with no shape a mesh-less placeholder object with no warning at all, unlike the existing "excessive voids" path which does warn. That is a Bonsai-side gap, out of scope here.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.