### PR TITLE
ifcopenshell.util.element: dedupe SET-typed attributes in replace_attribute

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/element.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/element.py
@@ -16,12 +16,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import functools
 from collections import namedtuple
 from collections.abc import Callable, Generator, Sequence
 from typing import Any, Literal, Optional, Union, overload
 
 import ifcopenshell
 import ifcopenshell.guid
+import ifcopenshell.ifcopenshell_wrapper
 import ifcopenshell.util.element
 import ifcopenshell.util.representation
 
@@ -1590,10 +1592,36 @@ def replace_element(element: ifcopenshell.entity_instance, replacement: ifcopens
         replace_attribute(inverse, element, replacement)
 
 
+@functools.cache
+def _is_set_attribute(schema_identifier: str, ifc_class: str, index: int) -> bool:
+    """Whether attribute `index` of `ifc_class` is declared as an EXPRESS SET.
+
+    SET aggregates may not contain duplicate members, whereas LIST and BAG
+    aggregates may, so only SET-typed attributes are safe to deduplicate.
+    """
+    declaration = ifcopenshell.ifcopenshell_wrapper.schema_by_name(schema_identifier).declaration_by_name(ifc_class)
+    attribute = declaration.attribute_by_index(index)
+    aggregation = attribute.type_of_attribute().as_aggregation_type()
+    return aggregation is not None and aggregation.type_of_aggregation_string() == "set"
+
+
 def replace_attribute(element: ifcopenshell.entity_instance, old: Any, new: Any) -> None:
     for i, attribute_value in enumerate(element):
         if has_element_reference(attribute_value, old):
-            element[i] = element.walk(lambda v: v == old, lambda v: new, attribute_value)
+            new_value = element.walk(lambda v: v == old, lambda v: new, attribute_value)
+            if (
+                isinstance(attribute_value, tuple)
+                and has_element_reference(attribute_value, new)
+                and _is_set_attribute(element.file.schema_identifier, element.is_a(), i)
+            ):
+                seen: set[Any] = set()
+                deduplicated = []
+                for v in new_value:
+                    if v not in seen:
+                        seen.add(v)
+                        deduplicated.append(v)
+                new_value = tuple(deduplicated)
+            element[i] = new_value
 
 
 def has_element_reference(value: Any, element: ifcopenshell.entity_instance) -> bool:

--- a/src/ifcopenshell-python/test/util/test_element.py
+++ b/src/ifcopenshell-python/test/util/test_element.py
@@ -1244,6 +1244,22 @@ class TestReplaceAttributeIFC4(test.bootstrap.IFC4):
         subject.replace_attribute(rel, old, new)
         assert rel.RelatedObjects == (new,)
 
+    def test_replacing_into_a_set_deduplicates_the_survivor(self):
+        old = self.file.createIfcWall()
+        new = self.file.createIfcWall()
+        rel = self.file.createIfcRelAggregates()
+        rel.RelatedObjects = [old, new]
+        subject.replace_attribute(rel, old, new)
+        assert rel.RelatedObjects == (new,)
+
+    def test_replacing_into_a_list_keeps_legitimate_duplicates(self):
+        p1 = self.file.createIfcCartesianPoint((0.0, 0.0, 0.0))
+        p2 = self.file.createIfcCartesianPoint((1.0, 0.0, 0.0))
+        p3 = self.file.createIfcCartesianPoint((2.0, 0.0, 0.0))
+        polyline = self.file.createIfcPolyline([p1, p2, p3, p1])
+        subject.replace_attribute(polyline, p2, p3)
+        assert polyline.Points == (p1, p3, p3, p1)
+
 
 class TestHasElementReferenceIFC4(test.bootstrap.IFC4):
     def test_if_a_element_attribute_references_another_element(self):


### PR DESCRIPTION
@Moult you asked on #8706 for the duplicate-reference problem to be fixed at a more fundamental level than the recipe, with due consideration to performance. This is an attempt at that, offered in case it is useful — @theoryshaw, this is your thread and your request from Moult, so please feel free to take this over, adapt it, or close it if you are already working the same ground.

## Root cause
`replace_attribute` in `util/element.py` rewrites references with `element[i] = element.walk(lambda v: v == old, lambda v: new, attribute_value)`. That substitutes positionally and never checks whether `new` was already present elsewhere in the same aggregate, so it can end up listed twice. Reproduced directly: an `IfcProject.RepresentationContexts` SET holding `[ctx_a, ctx_b]`, then `replace_element(ctx_a, ctx_b)`, yields `[ctx_b, ctx_b]`.

## SET vs LIST/BAG
A blanket dedupe would be wrong, since duplicates are illegal in a SET but legal in a LIST or BAG. The aggregate kind is therefore taken from the schema at runtime, not guessed from the value: `declaration_by_name(cls).attribute_by_index(i).type_of_attribute().as_aggregation_type().type_of_aggregation_string()` returns `"set"` / `"list"` / `"bag"` / `"array"`. Verified `IfcProject.RepresentationContexts` and `IfcRelAggregates.RelatedObjects` are sets, while `IfcPolyline.Points` and `IfcCompositeCurve.Segments` are lists, and an `IfcPolyline` with legitimately repeated points is left untouched.

## Performance
Gated so the expensive path is rarely reached: dedupe runs only if the attribute is a tuple, a cheap linear pre-check (`has_element_reference`, already used in this function) shows the value was already present, and a `functools.cache`d schema lookup keyed on `(schema, class, index)` confirms SET. Non-aggregates and LIST/BAG attributes pay nothing; a SET with no duplicate pays one O(n) scan; only a genuine duplicate pays the hash rebuild, which is cheap since `entity_instance.__hash__` is O(1).

Measured against baseline `origin/v0.8.0`:
- 104 MB / 2.4M-entity IFC4 model, 373-member SET: no-duplicate 774µs → 1013µs per call; duplicate case 11325µs → 10728µs (faster).
- 23 MB / 431k-entity IFC2X3 model, worst-case 1020-member SET: no-duplicate 2267µs → 2998µs; duplicate case unchanged.
- The scenario from #8706 itself (20-member `RepresentationContexts`): 55µs → 52µs, no measurable overhead, and it now correctly collapses to 1 survivor instead of 20.

## Verification
Reproduction fixed; LIST/BAG negative case preserved; simulating `MergeDuplicateContexts.patch()` *without* its manual `dedupe_references()` step now produces a clean SET on its own, so that step becomes redundant for this scenario. Full `test/util` (362 passed, same 6 pre-existing environment-only failures as baseline), `ifcpatch` recipe tests 26/26, `test/api/{context,geometry,project,aggregate}` 364/364 — all matching baseline exactly. Two new tests added. black+ruff clean.

Note on scope: this does not address the separate `remove_deep2` order-sensitivity in `MergeProjects.reuse_existing_contexts` that #8707 works around — that is a distinct defect.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.