### PR TITLE
ifcgeom: fall back to unopened geometry when convert_openings() cleanly fails

### DIFF
--- a/src/ifcgeom/Converter.cpp
+++ b/src/ifcgeom/Converter.cpp
@@ -205,8 +205,10 @@ IfcGeom::BRepElement* ifcopenshell::geometry::Converter::create_brep_for_represe
 
 			if (opening_items.empty()) {
 				opened_shapes = shapes;
-			} else {
-				kernel_->convert_openings(product, opening_items, shapes, *place, opened_shapes);
+			} else if (!kernel_->convert_openings(product, opening_items, shapes, *place, opened_shapes)) {
+				// A clean `false` return is a failure just like a thrown exception.
+				logger_.Message(Logger::LOG_ERROR, "GEO", 34, "Error processing openings for:", product);
+				caught_error = true;
 			}
 		} catch (const std::exception& e) {
 			logger_.Message(Logger::LOG_ERROR, "GEO", 33, std::string("Error processing openings for: ") + e.what() + ":", product);


### PR DESCRIPTION
Fixes #5880.

`Converter::create_brep_for_representation()` called `kernel_->convert_openings(...)` without checking its return value. When every candidate kernel *cleanly* rejects the opening-cut operands — CGAL's Nef conversion refusing self-intersecting geometry, logged as GEO094 rather than thrown — the resulting empty `opened_shapes` silently overwrote the product's valid unopened solid. That is exactly what the reporter described: no error, empty geometry, no fallback.

The call is now checked; a clean `false` is logged (GEO034) and sets `caught_error`, routing through the same guard that already protects the exception path (added for #6391 in the sibling PR #8811).

## Test plan
Built a real IfcConvert from this tree and ran the reporter's attached `MessedUpWindow_simplified.ifc`:

| kernel | baseline | patched |
|---|---|---|
| `opencascade` | 152 verts | 152 verts (unchanged) |
| `cgal` | **0 verts, silent** | **268 verts**, self-intersection now logged, window kept |
| `hybrid-cgal-opencascade` | **0 verts, silent** | **268 verts** |
| `hybrid-cgal-simple-opencascade` | 152 verts | 152 verts, byte-identical |

Bonsai's default kernel string (`hybrid-cgal-simple-opencascade`) was already unaffected for this particular file, because `HybridKernel::convert()` skips the non-boolean CGAL-simple kernel for elements with openings and goes straight to OpenCASCADE. The plain `cgal` and `hybrid-cgal-opencascade` configurations are genuinely broken today and are what this addresses. Also re-verified byte-identical on the second attached file (`IFCfile.txt`, a roof).

Regression: full sweep of all 258 `test/input/*.ifc` fixtures, unpatched vs patched, `--kernel hybrid-cgal-simple-opencascade` — 244 byte-identical, the other 14 failing identically on both sides (pre-existing `segfault`/`outOfMemory`/`infiniteLoop`/`invalid` repro fixtures producing no output on either binary). Zero new failures, zero diffs on any successfully-converting fixture.

Flagging a related defect found while investigating, deliberately *not* fixed here since I could not reproduce it failing: `CgalKernel::convert_impl(taxonomy::boolean_result)` silently `continue`s past a self-intersecting first operand rather than failing the whole boolean, which could produce empty-but-"successful" geometry for native boolean/clipping trees such as sloped roof cuts. That may relate to the later comments in this thread about roof geometry vanishing, which may be a distinct manifestation from the window case fixed here.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.