### PR TITLE
Bonsai: fail with an actionable error instead of a bare KeyError when addon preferences can't be found

### DIFF
--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -1915,7 +1915,17 @@ class Blender(bonsai.core.tool.Blender):
     @classmethod
     def get_addon_preferences(cls) -> bonsai.bim.ui.BIM_ADDON_preferences:
         blender_package_name = cls.get_blender_addon_package_name()
-        return bpy.context.preferences.addons[blender_package_name].preferences
+        addon = bpy.context.preferences.addons.get(blender_package_name)
+        if addon is None:
+            raise RuntimeError(
+                f"Bonsai's addon preferences could not be found: Bonsai registered itself as "
+                f"'{blender_package_name}', but that is not a currently enabled Blender addon. "
+                "This usually means the Bonsai install is broken or in an inconsistent state, for "
+                "example if it was moved to a different extension repository without restarting "
+                "Blender. Please restart Blender, or reinstall the Bonsai extension from "
+                "Preferences > Get Extensions."
+            )
+        return addon.preferences
 
     @classmethod
     def get_addon(cls, name: str) -> Union[types.ModuleType, None]:

--- a/src/bonsai/test/tool/test_blender.py
+++ b/src/bonsai/test/tool/test_blender.py
@@ -237,3 +237,20 @@ class TestGetObjectFromGuidMissing(NewFile):
         bpy.ops.bim.create_project()
         assert tool.Ifc.get() is not None
         assert subject.get_object_from_guid("3iyt7r$Hf4_hQYNhBIDJI4") is None
+
+
+class TestGetAddonPreferences(NewFile):
+    """``get_addon_preferences`` looks up Bonsai's own cached registration name in
+    ``bpy.context.preferences.addons``. If Bonsai's install ends up in an
+    inconsistent state (e.g. moved to a different extension repository without
+    restarting Blender), that cached name stops matching any enabled addon. This
+    must fail with an actionable ``RuntimeError``, not the bare ``KeyError`` a raw
+    dict-style lookup would raise."""
+
+    def test_returns_preferences_for_the_currently_registered_addon(self):
+        assert subject.get_addon_preferences() is not None
+
+    def test_raises_actionable_error_when_registered_name_is_stale(self, monkeypatch):
+        monkeypatch.setattr(bonsai, "REGISTERED_BBIM_PACKAGE", "bl_ext.some_other_repo.bonsai")
+        with pytest.raises(RuntimeError, match="bl_ext.some_other_repo.bonsai"):
+            subject.get_addon_preferences()


### PR DESCRIPTION
Fixes #7288.

`Blender.get_addon_preferences()` did a raw dict-style lookup, `bpy.context.preferences.addons[blender_package_name]`, using a package name Bonsai caches for itself at `register()` time. If that cached name stops matching a currently-enabled Blender addon — for example the extension moving between the `bl_ext.user_default.*` and `bl_ext.blender_org.*` repos without a Blender restart — the lookup raises a bare `KeyError`. That propagates out of `import_ifc.py`'s `create_spatial_elements` and aborts the entire project load, so a mis-registered install presents to the user as "opening this IFC crashes", which is exactly how #7288 was reported.

Now uses `.get(...)` and raises a `RuntimeError` naming the mismatch and the remedy (restart Blender, or reinstall from Preferences > Get Extensions).

Deliberate choice: fail loudly and clearly rather than silently resolving some other addon entry. @Moult's diagnosis on #7288 was "bad install, reinstall" — this genuinely is an inconsistent state, and guessing a replacement entry would mask it rather than telling the user their install needs attention. Checked all ~130 call sites of `get_addon_preferences()`: none catches `KeyError` specifically, so changing the exception type is not a behavioural break anywhere.

## Test plan
Live headless Blender against the machine's actually-deployed, currently-enabled nightly extension (in-process monkeypatching only, no deployed files modified, cached package name restored before exit):
- Before: staging a stale cached name reproduces `KeyError('bpy_prop_collection[key]: key "..." not found')`, matching the original traceback's error class and format.
- After: the same stale name produces a clear `RuntimeError` with the actionable message.
- After, with the healthy name restored: still returns a real preferences object, so unaffected behaviour is unchanged.

Adds a `TestGetAddonPreferences` regression test in `src/bonsai/test/tool/test_blender.py`, following that file's existing `NewFile`-fixture conventions (runs under `make test-tool`). black+ruff clean before and after.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.