### PR TITLE
Bonsai: fix clash pin drifting away when a false origin is active

### DIFF
--- a/src/bonsai/bonsai/bim/module/clash/operator.py
+++ b/src/bonsai/bonsai/bim/module/clash/operator.py
@@ -428,10 +428,10 @@ class SelectClash(bpy.types.Operator):
 
         tool.Spatial.select_products(products, unhide=True)
         ClashDecorator.install(bpy.context)
-        target = Vector(clash["p1"])
+        target = tool.Clash.convert_clash_point_to_blender(clash["p1"])
         tool.Clash.look_at(target, target + Vector((5, 5, 5)))
-        self.props.p1 = clash["p1"]
-        self.props.p2 = clash["p2"]
+        self.props.p1 = target
+        self.props.p2 = tool.Clash.convert_clash_point_to_blender(clash["p2"])
         self.props.active_clash_text = clash["type"].title() + " " + str(round(clash["distance"] * 1000)) + "mm"
         return {"FINISHED"}
 

--- a/src/bonsai/bonsai/tool/clash.py
+++ b/src/bonsai/bonsai/tool/clash.py
@@ -22,6 +22,9 @@ import json
 from typing import TYPE_CHECKING, Literal, Union
 
 import bpy
+import ifcopenshell.util.geolocation
+import ifcopenshell.util.unit
+import numpy as np
 from ifcclash import ifcclash
 from ifcclash.ifcclash import ClashSource
 from mathutils import Vector
@@ -128,6 +131,25 @@ class Clash(bonsai.core.tool.Clash):
         """
         with open(fn) as f:
             ClashStore.clash_sets = json.load(f)
+
+    @classmethod
+    def convert_clash_point_to_blender(cls, point: Union[list[float], tuple[float, float, float]]) -> Vector:
+        """Convert a raw ifcclash point into Bonsai's displayed viewport coordinates."""
+        props = tool.Georeference.get_georeference_props()
+        if not props.has_blender_offset:
+            return Vector(point)
+        unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
+        matrix = np.eye(4)
+        matrix[:3, 3] = point
+        matrix = ifcopenshell.util.geolocation.global2local(
+            matrix,
+            float(props.blender_offset_x) * unit_scale,
+            float(props.blender_offset_y) * unit_scale,
+            float(props.blender_offset_z) * unit_scale,
+            float(props.blender_x_axis_abscissa),
+            float(props.blender_x_axis_ordinate),
+        )
+        return Vector(matrix[:3, 3])
 
     @classmethod
     def look_at(cls, target: Vector, location: Vector) -> None:


### PR DESCRIPTION
Fixes #7178

## Problem
Clash results select fine, but the clash pin can appear a very long way from the actual geometry.

## Root cause
`ifcclash` computes the clash points p1/p2 directly from the IFC file's true SI-metre coordinates. On import, every other object receives Bonsai's false origin / georeferencing offset on its `matrix_world`, but `SelectClash` assigned the raw ifcclash points straight to the viewport with no such conversion. Whenever a false origin is active, the pin lands off by the full offset (translation plus project-north rotation), which can be enormous on real georeferenced projects.

This also corrects an earlier diagnosis of ours on the issue that blamed a feet-vs-mm unit scaling bug. Live testing (real ifcclash plus the real Bonsai import pipeline in headless Blender) showed ifcclash already returns correct SI metres regardless of the project's unit system, so units were never the cause.

## Fix
Add `Clash.convert_clash_point_to_blender()`, which runs a clash point through the same `global2local` conversion the importer applies to geometry, and route both p1 and p2 through it before placing the pin.

## Testing
Reproduced with synthetic IFC models driven through real ifcclash and the real Bonsai import pipeline in headless Blender. With a false origin active, the pin previously landed off by the full offset; after the fix it lands on the geometry. Feet and mm projects produce identical, correct pin placement. No-false-origin projects are unaffected.

This change was written with AI assistance.
