### PR TITLE
ifcgeom: fail the whole boolean when CGAL's base operand can't be preprocessed

### DIFF
--- a/src/ifcgeom/kernels/cgal/CgalKernel.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalKernel.cpp
@@ -2115,6 +2115,8 @@ bool CgalKernel::convert_impl(const taxonomy::boolean_result::ptr br, Conversion
 	*/
 
 	first = true;
+	// Whether the base operand ever contributed a Nef polyhedron to `a`.
+	bool base_operand_succeeded = false;
 
 	std::list<cgal_shape_t> ops;
 	std::list<CGAL::Nef_polyhedron_3<Kernel_>> nefops;
@@ -2137,6 +2139,7 @@ bool CgalKernel::convert_impl(const taxonomy::boolean_result::ptr br, Conversion
 
 			if (first) {
 				a = nef;
+				base_operand_succeeded = true;
 			} else {
 				if (br->operation == taxonomy::boolean_result::SUBTRACTION) {
 					second_operand_collector.add_polyhedron(nef);
@@ -2151,6 +2154,11 @@ bool CgalKernel::convert_impl(const taxonomy::boolean_result::ptr br, Conversion
 		}
 
 		first = false;
+	}
+
+	if (!base_operand_succeeded && br->operation != taxonomy::boolean_result::UNION) {
+        logger().Message(Logger::LOG_ERROR, "GEO", 105, "Could not process base operand of boolean operation:", br->instance);
+		return false;
 	}
 
 	if (br->operation == taxonomy::boolean_result::SUBTRACTION && second_operand_collector_size) {


### PR DESCRIPTION
## Problem
`CgalKernel::convert_impl(taxonomy::boolean_result)` could silently return empty-but-"successful" geometry. When `preprocess_boolean_operand()` rejected the base (first) operand (self-intersecting, not closed, etc.), the code skipped it with a bare `continue` without recording that the accumulator `a` never received its first Nef polyhedron. For SUBTRACTION and INTERSECTION, later operands were then combined against that empty, uninitialized `a`, and the function still returned `true`.

Under a hybrid kernel chain this is worse than a local failure: because CgalKernel reported success, there was no escalation to the next kernel, so the wrong (empty) result was kept.

## Fix
Only combine into `a` once the base operand has actually contributed a Nef polyhedron; if it never does, fail the whole boolean outright (logged) rather than emitting wrong-but-successful geometry. UNION is left untouched: it is commutative, so whichever operand succeeds first is a correct seed.

## Testing
Reproduced with a synthetic self-intersecting-overall closed solid as the first operand of an IfcBooleanResult DIFFERENCE:

| kernel | before | after |
|---|---|---|
| opencascade | 136 v | 136 v (unchanged) |
| cgal | 0 v | 0 v, now a logged GEO105 failure instead of silent "success" |
| hybrid-cgal-opencascade | 0 v | 136 v (escalates to OCCT, matches plain opencascade) |
| hybrid-cgal-simple-opencascade | 136 v | 136 v (unaffected) |

Same result for a non-closed self-intersecting-loop variant (IfcBooleanClippingResult) and for a plain-box second operand. Regression: full sweep of the 258 test/input fixtures under both kernels, no changes to previously-passing geometry.

This change was written with AI assistance.
