### PR TITLE
Bonsai: fix grid axis annotations missing on imperial-units drawings

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1998,8 +1998,10 @@ class Drawing(bonsai.core.tool.Drawing):
         verts = ifcopenshell.util.shape.get_vertices(geometry)
         grid = (axis.PartOfU or axis.PartOfV or axis.PartOfW)[0]
         m = ifcopenshell.util.placement.get_local_placement(grid.ObjectPlacement)
+        # Convert from project units (e.g. feet) to meters for Blender world space.
+        unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
         im = camera.matrix_world.inverted()
-        v1, v2 = [im @ Vector((m @ np.append(v, 1.0))[:3]) for v in verts[:2]]
+        v1, v2 = [im @ Vector((m @ np.append(v, 1.0))[:3] * unit_scale) for v in verts[:2]]
 
         target_view = tool.Drawing.get_drawing_target_view(drawing)
         if target_view in ("PLAN_VIEW", "REFLECTED_PLAN_VIEW"):


### PR DESCRIPTION
Fixes #7639

## Problem
Grid axis bubble annotations ("01", "02", "A", etc.) that render correctly in Bonsai v0.8.1 are silently missing from drawings in current versions. The reporter's before/after screenshots show a real regression.

## Root cause
`Drawing.generate_grid_axis_reference_points()` in `tool/drawing.py` computes a grid axis's position by combining `ifcopenshell.util.placement.get_local_placement(grid.ObjectPlacement)` (raw IFC project-unit coordinates, e.g. feet) directly with `camera.matrix_world` (always SI metres in Blender), with no unit conversion.

Its sibling `generate_storey_points()`, a few dozen lines above, does convert (with an explicit "Convert RL from project units (feet) to meters for Blender world space" comment) — this function never got the same treatment. On a metric project (`unit_scale == 1.0`) the omission is a no-op and invisible; on an imperial project the computed point is off by `1/unit_scale` (~3.28x), always lands outside the camera view frustum, and the grid annotation is silently never generated.

## Fix
Apply the same project-units-to-metres conversion the sibling function already uses, so grid axis reference points land in Blender world space regardless of project units.

## Testing
Live before/after on the reporter's actual attached IFC file (imperial project, unit_scale 0.3048), headless Blender:
- Before: `sync_references()` on drawing "EXISTING PLAN - BASEMENT" created 0 grid annotations.
- After: 3 grid annotations created (01, 02, A), matching the reporter's v0.8.1 screenshot exactly.

No behaviour change on metric projects (multiply by 1.0). Black + ruff clean (CI-exact venv). The function has no existing test coverage; verified by direct live repro against the real file.

This change was written with AI assistance.
