### PR TITLE
Bonsai: regression test for foreign representation-item id on cross-file duplicate (#7351)

### DIFF
--- a/src/bonsai/test/tool/test_geometry.py
+++ b/src/bonsai/test/tool/test_geometry.py
@@ -135,6 +135,45 @@ class TestGetRepresentationData(NewFile):
         assert subject.get_representation_data(representation) == data
 
 
+class TestGetRepresentationItem(NewFile):
+    def test_returns_the_item_for_a_live_representation_item_id(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        item = ifc.createIfcExtrudedAreaSolid()
+        data = bpy.data.meshes.new("Mesh")
+        subject.get_mesh_props(data).ifc_definition_id = item.id()
+        obj = bpy.data.objects.new("Object", data)
+        assert subject.get_representation_item(obj) == item
+        assert subject.is_representation_item(obj) is True
+
+    def test_returns_none_for_a_live_id_that_is_not_a_representation_item(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        data = bpy.data.meshes.new("Mesh")
+        subject.get_mesh_props(data).ifc_definition_id = wall.id()
+        obj = bpy.data.objects.new("Object", data)
+        assert subject.get_representation_item(obj) is None
+        assert subject.is_representation_item(obj) is False
+
+    def test_returns_none_instead_of_raising_for_an_id_from_a_different_file(self):
+        # Regression test for #7351: an object duplicated/pasted in from a
+        # different IFC session can keep an ifc_definition_id that only
+        # existed in that other file. Against the current file that id is
+        # simply missing, and this must be treated as "not a representation
+        # item of this file" rather than crash with `by_id`'s RuntimeError.
+        other_ifc = ifcopenshell.file()
+        foreign_item = other_ifc.createIfcExtrudedAreaSolid()
+
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        data = bpy.data.meshes.new("Mesh")
+        subject.get_mesh_props(data).ifc_definition_id = foreign_item.id()
+        obj = bpy.data.objects.new("Object", data)
+        assert subject.get_representation_item(obj) is None
+        assert subject.is_representation_item(obj) is False
+
+
 class TestGetActiveRepresentation(NewFile):
     def test_returns_representation_for_live_id(self):
         ifc = ifcopenshell.file()


### PR DESCRIPTION
Adds regression coverage for #7351.

## Context
#7351 was a crash (`RuntimeError: Instance #1260 not found`) when duplicating a Blender object that originated in a different loaded IFC file into the active file: the pasted object still carried an `ifc_definition_id` pointing at an instance that only exists in the source file, and `Geometry.get_representation_item()` looked that id up against the active file with an unguarded `by_id()`.

The crash itself is already fixed on current `v0.8.0`: `get_representation_item()` now wraps the lookup in `try/except RuntimeError` (this landed incidentally via 36372627db). Because that guard arrived as a side effect of an unrelated change rather than a deliberate fix, it has no test protecting it from silent regression.

## This PR
Adds `TestGetRepresentationItem` to `test/tool/test_geometry.py` with three cases:
- a valid in-file representation item resolves;
- a valid in-file non-representation-item entity returns None;
- the #7351 case: an id that only exists in a different `ifcopenshell.file()` resolves to None/False instead of raising.

Test-only change, no production code touched. Black + ruff clean.

This change was written with AI assistance.
