### PR TITLE
Bonsai: capture BCF snapshot from the active viewport, not the parked camera

### DIFF
--- a/src/bonsai/bonsai/bim/module/bcf/operator.py
+++ b/src/bonsai/bonsai/bim/module/bcf/operator.py
@@ -555,6 +555,15 @@ class AddBcfViewpoint(bpy.types.Operator):
         blender_topic = props.active_topic
         topic = bcfxml.topics[blender_topic.name]
 
+        # Align the camera to the active 3D view for the snapshot, then restore it.
+        assert isinstance(blender_camera.data, bpy.types.Camera)
+        original_matrix_world = blender_camera.matrix_world.copy()
+        original_ortho_scale = blender_camera.data.ortho_scale
+        space = tool.Blender.get_view3d_space()
+        if space and space.region_3d.view_perspective != "CAMERA":
+            with context.temp_override(**tool.Blender.get_viewport_context()):
+                bpy.ops.view3d.camera_to_view()
+
         direction = blender_camera.matrix_world.to_quaternion() @ Vector((0.0, 0.0, -1.0))
         up = blender_camera.matrix_world.to_quaternion() @ Vector((0.0, 1.0, 0.0))
 
@@ -626,6 +635,9 @@ class AddBcfViewpoint(bpy.types.Operator):
         with open(blender_render.filepath, "rb") as f:
             snapshot = f.read()
         # viewpoint.snapshot = blender_render.filepath
+
+        blender_camera.matrix_world = original_matrix_world
+        blender_camera.data.ortho_scale = original_ortho_scale
 
         if isinstance(visualization_info, bcf.v2.model.VisualizationInfo):
             vizinfo = bcf.v2.visinfo.VisualizationInfoHandler(visualization_info=visualization_info, snapshot=snapshot)


### PR DESCRIPTION
Fixes part of #6981

## Problem
BCF viewpoint snapshots are often framed from far away and don't show what the user is looking at. `AddBcfViewpoint` built the viewpoint camera from `scene.camera.matrix_world` (wherever that camera object happens to sit), unrelated to the current 3D view, so unless the user manually aligned the camera first the snapshot could come from anywhere.

## Fix
Before capturing, align the scene camera to the active 3D view, then restore its original transform immediately after the render. No effect when already in camera view or when no 3D viewport is available (falls back to prior behavior). Restoration is verified for both perspective and orthographic cameras, so drawing/print cameras are unaffected.

## Testing
Headless Blender, isolated profile: with the viewport centered on an element at distance 3.0, the resulting BCF viewpoint camera was 71.58 units away before the fix and 3.0 after, matching the viewport. Scene camera transform confirmed restored afterward.

This change was written with AI assistance.
