### PR TITLE
Bonsai: harden BBIM_Boolean.Data parsing against non-list payloads

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -944,7 +944,7 @@ class Model(bonsai.core.tool.Model):
         if pset_data:
             representation = tool.Geometry.get_body_representation(wall)
             chain_ids = {b.id() for b in cls.get_booleans(wall, representation)} if representation else set()
-            stored_ids = set(json.loads(pset_data["Data"]))
+            stored_ids = set(cls.parse_manual_boolean_ids(pset_data["Data"]))
             stale_ids = stored_ids - chain_ids
             if stale_ids:
                 cls.unmark_manual_booleans(wall, list(stale_ids))
@@ -975,13 +975,29 @@ class Model(bonsai.core.tool.Model):
                 tool.Geometry.remove_representation_item(sec, wall)
 
     @classmethod
+    def parse_manual_boolean_ids(cls, data: str) -> list[int]:
+        """Decode a ``BBIM_Boolean.Data`` payload into a list of boolean ids.
+
+        The payload is expected to be a JSON list of ids, but legacy/corrupt
+        files have been seen storing a JSON object instead (which used to crash
+        the boolean machinery with ``'dict' object has no attribute 'extend'``).
+        Coerce anything that isn't a list into an empty list so the callers can
+        rebuild from scratch rather than raise.
+        """
+        parsed = json.loads(data)
+        if not isinstance(parsed, list):
+            print(f"WARNING: unexpected BBIM_Boolean.Data payload {parsed!r}, ignoring it")
+            return []
+        return parsed
+
+    @classmethod
     def get_manual_booleans(
         cls, element: ifcopenshell.entity_instance, representation: Optional[ifcopenshell.entity_instance] = None
     ) -> list[ifcopenshell.entity_instance]:
         pset = ifcopenshell.util.element.get_pset(element, "BBIM_Boolean")
         if not pset:
             return []
-        boolean_ids = json.loads(pset["Data"])
+        boolean_ids = cls.parse_manual_boolean_ids(pset["Data"])
         if representation is None:
             representation = tool.Geometry.get_body_representation(element)
             if not representation:
@@ -998,7 +1014,7 @@ class Model(bonsai.core.tool.Model):
         boolean_ids = [b.id() for b in booleans]
         if pset_data:
             pset = tool.Ifc.get().by_id(pset_data["id"])
-            data = json.loads(pset_data["Data"])
+            data = cls.parse_manual_boolean_ids(pset_data["Data"])
             data.extend(boolean_ids)
             data = list(set(data))
         else:
@@ -1018,7 +1034,7 @@ class Model(bonsai.core.tool.Model):
         pset = ifcopenshell.util.element.get_pset(element, "BBIM_Boolean")
         if not pset:
             return
-        data = set(json.loads(pset["Data"]))
+        data = set(cls.parse_manual_boolean_ids(pset["Data"]))
         data -= set(boolean_ids)
         data = list(data)
         pset = tool.Ifc.get().by_id(pset["id"])


### PR DESCRIPTION
## Description

**Extend Walls To Underside** (the `S_E` hotkey) crashed with:

```
AttributeError: 'dict' object has no attribute 'extend'
```

in `Model.mark_manual_booleans`, which reads a wall's `BBIM_Boolean.Data`, `json.loads`es it, and calls `.extend()` on the result. That result is expected to be a JSON **list** of boolean ids, but on the affected wall it decoded to a `dict`.

Every writer of `BBIM_Boolean.Data` stores a list, and every reader (`get_manual_booleans`, `mark_manual_booleans`, `unmark_manual_booleans`, and the duplicate-sweep path) assumes a list — so any wall with a non-list payload crashes the boolean machinery. The origin of the non-list payload is unknown (no code path writes a dict), so it appears to come from a legacy or externally-modified file.

## Fix

Add a single defensive parser, `Model.parse_manual_boolean_ids()`, that coerces a non-list payload to an empty list (and prints a warning) instead of raising, and route all four readers through it. A malformed pset then self-heals by rebuilding from the current operation rather than hard-crashing; the geometry booleans in the representation chain are untouched.

## Notes

- The same `json.loads(pset["Data"])` assumption also lives in the `ifcopenshell` library (`api/geometry/regenerate_wall_representation.py`, `api/geometry/clip_solid.py`) and would fail identically during regeneration — left out of scope here since the reported crash is in `bonsai`.

Fixes #8821

🤖 Generated with [Claude Code](https://claude.com/claude-code)
