### PR TITLE
Bonsai: category-level select-all and clearer headers in the Drawings list

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/__init__.py
+++ b/src/bonsai/bonsai/bim/module/drawing/__init__.py
@@ -108,6 +108,7 @@ classes = (
     operator.SelectAssignedProduct,
     operator.SelectSimilarTextLiteralValue,
     operator.ToggleTargetView,
+    operator.ToggleDrawingCategorySelection,
     operator.OpenDocumentationWebUi,
     operator.FilterSelectedObjectsIfIntersectedByCamera,
     prop.Variable,

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3874,6 +3874,26 @@ class ToggleTargetView(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class ToggleDrawingCategorySelection(bpy.types.Operator):
+    bl_idname = "bim.toggle_drawing_category_selection"
+    bl_label = "Toggle Category Selection"
+    bl_description = "Select or deselect all drawings in this view category"
+    bl_options = {"REGISTER", "UNDO"}
+
+    target_view: bpy.props.StringProperty()
+
+    if TYPE_CHECKING:
+        target_view: str
+
+    def execute(self, context):
+        drawings = tool.Drawing.get_visible_drawings_in_category(self.target_view)
+        # If everything visible in the category is already selected, deselect all; otherwise select all.
+        new_state = not all(d.is_selected for d in drawings)
+        for drawing in drawings:
+            drawing.is_selected = new_state
+        return {"FINISHED"}
+
+
 class ExpandSheet(bpy.types.Operator):
     bl_idname = "bim.expand_sheet"
     bl_label = "Expand Sheet"

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -874,8 +874,8 @@ class BIM_UL_drawinglist(bpy.types.UIList):
             layout.label(text="", translate=False)
             return
 
-        row = layout.row(align=True)
         if item.is_drawing:
+            row = layout.row(align=True)
             row.label(text="", icon="BLANK1")
             selected_icon = "CHECKBOX_HLT" if item.is_selected else "CHECKBOX_DEHLT"
             row.prop(item, "is_selected", text="", icon=selected_icon, emboss=False)
@@ -896,6 +896,9 @@ class BIM_UL_drawinglist(bpy.types.UIList):
                     item.ifc_definition_id
                 )
         else:
+            # Give category headers a distinct inset background so they stand out from drawing rows.
+            box = layout.box()
+            row = box.row(align=True)
             if item.target_view == "PLAN_VIEW":
                 icon = "UV_FACESEL"
             elif item.target_view == "ELEVATION_VIEW":
@@ -916,7 +919,19 @@ class BIM_UL_drawinglist(bpy.types.UIList):
                 op = row.operator("bim.toggle_target_view", text="", emboss=False, icon="DISCLOSURE_TRI_RIGHT")
                 op.target_view = item.target_view
                 op.option = "EXPAND"
-            row.prop(item, "name", text="", icon=icon, emboss=False)
+            group = tool.Drawing.get_visible_drawings_in_category(item.target_view)
+            all_selected = bool(group) and all(d.is_selected for d in group)
+            row.operator(
+                "bim.toggle_drawing_category_selection",
+                text="",
+                icon="CHECKBOX_HLT" if all_selected else "CHECKBOX_DEHLT",
+                emboss=False,
+            ).target_view = item.target_view
+            row.separator(factor=0.5, type="SPACE")
+            # Clicking the header name toggles expand/contract, same as the disclosure triangle.
+            op = row.operator("bim.toggle_target_view", text=item.name, icon=icon, emboss=False)
+            op.target_view = item.target_view
+            op.option = "CONTRACT" if item.is_expanded else "EXPAND"
 
     def filter_items(self, context, data: DocProperties, propname: str):
         drawings = getattr(data, propname)

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2909,6 +2909,29 @@ class Drawing(bonsai.core.tool.Drawing):
         return result
 
     @classmethod
+    def get_visible_drawings_in_category(cls, target_view: str) -> list[DrawingProperties]:
+        """Get the drawing items in a target view category that are currently visible in the drawing list.
+
+        Grouping is positional: individual drawing items don't carry their own ``target_view``, they belong to
+        the most recent header item above them. Only expanded categories contribute drawing items to the
+        collection, so a collapsed category yields an empty list. Respects the ``show_drawings_on_sheets_only``
+        filter so that select-all only affects visible drawings.
+        """
+        props = cls.get_document_props()
+        drawings: list[DrawingProperties] = []
+        in_category = False
+        for item in props.drawings:
+            if not item.is_drawing:
+                # Header row: we're inside the requested category until the next header.
+                in_category = item.target_view == target_view
+            elif in_category:
+                drawings.append(item)
+        if props.show_drawings_on_sheets_only:
+            sheeted_ids = cls.get_sheeted_drawing_ids()
+            drawings = [d for d in drawings if d.ifc_definition_id in sheeted_ids]
+        return drawings
+
+    @classmethod
     def get_camera_matrix(cls, camera: bpy.types.Object) -> Matrix:
         matrix_world = camera.matrix_world.copy().normalized()
         location, rotation, scale = matrix_world.decompose()


### PR DESCRIPTION
## Summary

Adds a category-level select-all to the Drawings list (`BIM_UL_drawinglist`) and makes the category headers clearer.

- **Category select-all checkbox** — each target-view header (Model/Plan/Section/Elevation/Reflected Plan View) gets an "Is Selected" checkbox. Clicking it toggles selection for all drawings in that category: if all are selected it deselects them, otherwise it selects them all. The header checkbox reflects the aggregate selection state of its drawings.
- **Respects the visible set** — the toggle only affects drawings currently visible in the list, honoring the `show_drawings_on_sheets_only` filter (#8824), so drawings hidden by that filter aren't silently selected.
- **Clearer headers** — category headers are wrapped in a `box()` for a distinct inset background so they stand out from drawing rows.
- **Clickable header name** — clicking the header name now expands/contracts the category (same as the disclosure triangle), enlarging the click target.

## Implementation notes

- New helper `Drawing.get_visible_drawings_in_category()` walks the list positionally (individual drawing items don't carry their own `target_view` — they belong to the nearest header above them) and applies the sheet-only filter, so the operator and the header checkbox icon agree on what "visible" means.
- New operator `bim.toggle_drawing_category_selection`.

## Known limitation

Grouping in the list is positional and collapsed categories contribute no drawing items to the collection, so the category checkbox currently only affects drawings in **expanded** categories. Extending it to collapsed categories is possible but would require reading category membership from IFC and writing into the preserved `drawing_selected_states` map — happy to add if wanted.

Closes #8825
