### PR TITLE
Bonsai: stop writing IFC4.3-deprecated IfcStairFlight attributes

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/stair.py
+++ b/src/bonsai/bonsai/bim/module/model/stair.py
@@ -98,8 +98,6 @@ def update_ifc_stair_props(obj: bpy.types.Object) -> None:
     if tool.Ifc.get_schema() != "IFC2X3" and element.is_a("IfcStairFlight"):
         element.PredefinedType = "STRAIGHT"
     number_of_risers = props.number_of_treads + 1
-    # update IfcStairFlight properties (seems already deprecated but keep it for now)
-    # http://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcStairFlight.htm
 
     si_conversion = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
     riser_height = props.height / number_of_risers / si_conversion
@@ -107,14 +105,22 @@ def update_ifc_stair_props(obj: bpy.types.Object) -> None:
     nosing_length = props.nosing_length / si_conversion
 
     if element.is_a("IfcStairFlight"):
-        if tool.Ifc.get_schema() == "IFC2X3":
-            element.NumberOfRiser = number_of_risers
+        # NumberOfRisers/NumberOfTreads/RiserHeight/TreadLength are deprecated
+        # in IFC4.3 in favour of Pset_StairFlightCommon, which is set below.
+        if tool.Ifc.get_schema() == "IFC4X3":
+            element.NumberOfRisers = None
+            element.NumberOfTreads = None
+            element.RiserHeight = None
+            element.TreadLength = None
         else:
-            element.NumberOfRisers = number_of_risers
+            if tool.Ifc.get_schema() == "IFC2X3":
+                element.NumberOfRiser = number_of_risers
+            else:
+                element.NumberOfRisers = number_of_risers
 
-        element.NumberOfTreads = props.number_of_treads
-        element.RiserHeight = riser_height
-        element.TreadLength = tread_length
+            element.NumberOfTreads = props.number_of_treads
+            element.RiserHeight = riser_height
+            element.TreadLength = tread_length
 
     # update pset with ifc properties
     pset_common = tool.Pset.get_element_pset(element, "Pset_StairFlightCommon")


### PR DESCRIPTION
## Problem
Bonsai's stair tool writes four attributes directly onto every `IfcStairFlight`: `NumberOfRisers`, `NumberOfTreads`, `RiserHeight`, `TreadLength`. IFC 4.3 deprecated these in favour of `Pset_StairFlightCommon`, and the buildingSMART validation service flags them (normative rule IFC102, "Absence of deprecated entities"). The code even carried a comment acknowledging the deprecation ("seems already deprecated but keep it for now").

They remain valid in IFC2X3 and IFC4, so they must keep being written there.

## Fix
Make the write schema-version-aware in `update_ifc_stair_props` (`model/stair.py`): on IFC4X3, leave the four deprecated attributes unset; on IFC4 and IFC2X3, write them exactly as before (respecting the IFC2X3 singular `NumberOfRiser` spelling). `Pset_StairFlightCommon` is written in all schemas and already carries the same values, so no data is lost.

## Testing
Real headless Blender, isolated profile, driving the actual add-stair operator end to end:
- IFC4X3 before: `IfcStairFlight(...,7,6,0.1428...,0.25,.STRAIGHT.)`; after: `IfcStairFlight(...,$,$,$,$,.STRAIGHT.)`, with `Pset_StairFlightCommon` still `NumberOfRiser=7, NumberOfTreads=6, RiserHeight=0.1428..., TreadLength=0.25`.
- IFC4 after (unchanged): still writes `...,7,6,0.1428...,0.25,...`.
- IFC2X3 after (unchanged): still writes the four attributes (singular `NumberOfRiser`).

Regression: `test_stair_gizmos.py` + `test_model.py` (45 tests incl. stair param/profile tests) pass identically before and after (45/45).

This change was written with AI assistance.
