### PR TITLE
Bonsai: clear occurrence PredefinedType when a type's PredefinedType is edited to a concrete value

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/attribute/edit_attributes.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/attribute/edit_attributes.py
@@ -38,6 +38,10 @@ def edit_attributes(file: ifcopenshell.file, product: ifcopenshell.entity_instan
     - PredefinedType to be "NOTDEFINED" if ElementType/ObjectType is None
     - PredefinedType to be "USERDEFINED" if ElementType/ObjectType is not None
 
+    If a type's own PredefinedType becomes a concrete value, its already
+    typed occurrences have their PredefinedType/ObjectType cleared to forbid
+    double typing (see #7006).
+
     :param product: The product you want to edit. This may be any rooted IFC
         entity.
     :param attributes: a dictionary of attribute names and values.
@@ -69,6 +73,19 @@ def edit_attributes(file: ifcopenshell.file, product: ifcopenshell.entity_instan
                 product.PredefinedType = "NOTDEFINED"
             elif element_type and predefined_type != "USERDEFINED":
                 product.PredefinedType = "USERDEFINED"
+
+            # Remove occurrences' PredefinedType / ObjectType to forbid double typing (see #7006)
+            type_predefined_type = ifcopenshell.util.element.get_predefined_type(product)
+            if type_predefined_type not in ("NOTDEFINED", None):
+                if hasattr(product, "ObjectTypeOf"):
+                    types_rel = next(iter(product.ObjectTypeOf), None)
+                else:
+                    types_rel = next(iter(getattr(product, "Types", ())), None)
+                if types_rel:
+                    for obj in types_rel.RelatedObjects:
+                        obj.ObjectType = None
+                        if hasattr(obj, "PredefinedType"):
+                            obj.PredefinedType = None
 
         elif (object_type := getattr_safe(product, "ObjectType")) is not ...:
             relating_type = ifcopenshell.util.element.get_type(product)


### PR DESCRIPTION
## Problem
The buildingSMART validation service flags normative rule OJT001 (Object Predefined Type): when an `IfcTypeObject` has a concrete `PredefinedType`, the related occurrence's `PredefinedType` must be empty (unset). An occurrence carrying an explicit `.NOTDEFINED.` value is a violation.

`ifcopenshell.api.type.assign_type` already clears an occurrence's `PredefinedType`/`ObjectType` at assignment time when the type is concrete (see #7006 / #7011). But if a type's own `PredefinedType` is edited to a concrete value *after* its occurrences are already typed, nothing reconciles those occurrences, so an occurrence left at explicit `.NOTDEFINED.` stays that way and fails OJT001.

## Fix
In `edit_attributes.py`'s type-editing branch, when a type's resolved `PredefinedType` becomes concrete (not NOTDEFINED/None), clear the `ObjectType`/`PredefinedType` of its occurrences (via `Types` on IFC4+, `ObjectTypeOf` on IFC2X3), mirroring `assign_type`'s existing logic and `hasattr` guards. Occurrences of a type that is itself NOTDEFINED/untyped are left untouched (they are allowed to carry their own value), and untyped elements are unaffected.

## Scope
This covers the authoring path (editing a type's PredefinedType after typing occurrences). It intentionally does NOT add export-time normalization, so models where the inconsistency was baked in purely by import (e.g. a Revit IFC export with an occurrence already `.NOTDEFINED.` under a concretely-typed type) and never touched via Bonsai's type editing are out of scope here; that would be a separate, deliberate export-normalization decision.

## Testing
- Before: `IfcWall(...,.NOTDEFINED.)` under `IfcWallType(...,.MOVABLE.)` (OJT001 fail).
- After: `IfcWall(...,$)`, type unchanged, `ifcopenshell.util.element.get_predefined_type()` still resolves to `MOVABLE` (no data loss).
- Untyped wall keeps its own PredefinedType; wall under a NOTDEFINED type keeps its own value; multiple occurrences all cleared consistently; IfcBeam/IfcBeamType behave the same; IFC2X3 path guarded (no occurrence PredefinedType there).
- `test/api/type/` + `test/api/root/` (191 tests) and full `test/api/` suite: no new failures.

This change was written with AI assistance.
