### PR TITLE
Bonsai: stop rasterizing fill-bg annotation text on PDF export

### DIFF
--- a/src/bonsai/bonsai/bim/data/assets/markers.svg
+++ b/src/bonsai/bonsai/bim/data/assets/markers.svg
@@ -97,11 +97,7 @@
         </g>
     </marker>
     <filter x="0" y="0" width="1" height="1" id="fill-background">
-      <feFlood flood-color="white" result="bg" />
-      <feMerge>
-        <feMergeNode in="bg"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
+      <feFlood flood-color="white" />
     </filter>
 
 </svg>


### PR DESCRIPTION
Fixes #5719

## Problem
Annotation text with `EPset_Annotation.Classes = fill-bg` renders blurred/pixelated in PDF exports.

## Root cause
`SvgWriter.add_fill_bg` draws the background using the `fill-background` SVG filter (`markers.svg`), which combined `feFlood` with `feMerge(bg, SourceGraphic)`. PDF has no native SVG-filter support, so Inkscape rasterizes any filtered element on export. Merging `SourceGraphic` baked a second, misaligned raster copy of the glyphs into the background, sitting under the crisp vector text copy drawn separately, producing the reported ghosting/blur.

## Fix
Drop the `feMerge` and keep only `feFlood`, so the filter produces just the flat background fill and no rasterized text copy. This is the fix @sboddy verified in the issue thread and @theoryshaw endorsed.

## Testing
Real Inkscape SVG->PDF at 600 DPI, isolated Blender profile, driving the actual `create_text_tag(..., fill_bg=True)` path: the blur halo in a fixed crop dropped from 14.66% to 2.38% (horizontal) and 5.68% to 0.92% (rotated). Generated SVG is byte-identical except inside the `fill-background` filter definition.

## Scope
This resolves the reported blur. It does not address the separate later report of rotated `fill-bg` backgrounds squaring off, nor the broader ask for a CSS-configurable background colour/border.

This change was written with AI assistance.
