### PR TITLE
ifcsverchok: recognize sverchok-master installs and fix stale unassign API calls (#6741)

### DIFF
--- a/src/ifcsverchok/__init__.py
+++ b/src/ifcsverchok/__init__.py
@@ -30,6 +30,7 @@ bl_info = {
 
 import importlib
 import logging
+import sys
 import types
 
 import bpy
@@ -40,11 +41,23 @@ logger = logging.getLogger("sverchok.ifc")
 
 def get_blender_addon_package_by_name(addon_name: str) -> types.ModuleType:
     # Check for legacy addons.
-    # Make an exception for sverchok as it keeps getting installed by all kind of names
-    # and then hacks `sverchok` into `sys.modules`.
-    if addon_name in bpy.context.preferences.addons or addon_name == "sverchok":
+    if addon_name in bpy.context.preferences.addons:
         return importlib.import_module(addon_name)
-    elif bpy.app.version < (4, 2, 0):
+
+    # Make an exception for sverchok as it keeps getting installed by all kind of names,
+    # e.g. a GitHub zip download installs as "sverchok-master". Look for any enabled
+    # addon whose module name is a variant of it, rather than assuming it has already
+    # hacked itself into `sys.modules["sverchok"]`, since that only happens once
+    # Sverchok's own registration code has actually run (which depends on addon enable
+    # order and may not have happened yet).
+    if addon_name == "sverchok":
+        for package_name in bpy.context.preferences.addons.keys():
+            if package_name.startswith(("sverchok-", "sverchok_")):
+                return importlib.import_module(package_name)
+        if "sverchok" in sys.modules:
+            return sys.modules["sverchok"]
+
+    if bpy.app.version < (4, 2, 0):
         raise ModuleNotFoundError
 
     # Check for Blender extensions.

--- a/src/ifcsverchok/nodes/ifc/add_spatial_element.py
+++ b/src/ifcsverchok/nodes/ifc/add_spatial_element.py
@@ -169,13 +169,11 @@ class SvIfcAddSpatialElement(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.h
                             ifcopenshell.api.aggregate.unassign_object(
                                 self.file,
                                 products=[removed_element],
-                                relating_object=result,
                             )
                         else:
                             ifcopenshell.api.spatial.unassign_container(
                                 self.file,
                                 products=[removed_element],
-                                relating_object=result,
                             )
                     for added_element in element_set - subelements:
                         if added_element.is_a("IfcSpatialElement") or added_element.is_a("IfcSpatialStructureElement"):


### PR DESCRIPTION
Fixes #6741

## Two defects, both from the issue

**1. Sverchok installed as `sverchok-master` (GitHub zip) not recognized.** The activation check special-cased the literal name `sverchok` and relied on Sverchok's own bootstrap having already aliased itself into `sys.modules`. That only holds if Sverchok's registration ran first, which depends on Blender's addon-enable order, so a `sverchok-master` install could fail activation with "Addon sverchok is not installed" despite being installed and enabled. The check now searches enabled addons for any `sverchok-`/`sverchok_` prefixed entry and imports it by its real name, with the old alias check as fallback.

**2. Bundled example fails with `unassign_container() got an unexpected keyword argument 'relating_object'`.** Audited every `ifcopenshell.api` call in the module against current signatures: exactly two were stale, both in `add_spatial_element.py`'s `edit()` (`aggregate.unassign_object` and `spatial.unassign_container`, whose current signatures take only `(file, products)`). All other calls, including `aggregate.assign_object(relating_object=...)` and `spatial.assign_container(relating_structure=...)`, are current and untouched.

## Testing
Isolated Blender profile with Sverchok freshly installed from GitHub master under the exact folder name `sverchok-master`:
- Activation: before, module not recognized; after, found and imported. The ordinary install-order path works before and after.
- Example path: drove `SvIfcAddSpatialElement.create()` then `.edit()` in a real node tree against a real file: before, the reporter's exact TypeError; after, success with correct decomposition.
- All 31 registered ifcsverchok node classes instantiate cleanly after the change. Black + ruff clean.

This change was written with AI assistance.
