### PR TITLE
Bonsai: right-click Rename Material on material rows (#6680)

### DIFF
--- a/src/bonsai/bonsai/bim/module/material/__init__.py
+++ b/src/bonsai/bonsai/bim/module/material/__init__.py
@@ -56,6 +56,7 @@ classes = (
     operator.RemoveMaterial,
     operator.RemoveMaterialSet,
     operator.RemoveProfile,
+    operator.RenameMaterial,
     operator.ReorderMaterialSetItem,
     operator.SelectByMaterial,
     operator.SelectMaterialInMaterialsUI,

--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -120,9 +120,6 @@ class RenameMaterial(bpy.types.Operator, tool.Ifc.Operator):
 
     def _execute(self, context):
         core.rename_material(tool.Ifc, tool.Material, material=tool.Ifc.get().by_id(self.material), name=self.name)
-        if screen := context.screen:
-            for area in screen.areas:
-                area.tag_redraw()
 
 
 class DisableEditingMaterial(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -102,6 +102,26 @@ class EditMaterial(bpy.types.Operator, tool.Ifc.Operator):
         core.edit_material(tool.Ifc, tool.Material, material=tool.Ifc.get().by_id(self.material))
 
 
+class RenameMaterial(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.rename_material"
+    bl_label = "Rename Material"
+    bl_description = "Rename an IfcMaterial"
+    bl_options = {"REGISTER", "UNDO"}
+    material: bpy.props.IntProperty()
+    name: bpy.props.StringProperty(name="Name")
+
+    def invoke(self, context, event):
+        material = tool.Ifc.get().by_id(self.material)
+        self.name = material.Name or ""
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        self.layout.prop(self, "name")
+
+    def _execute(self, context):
+        core.rename_material(tool.Ifc, tool.Material, material=tool.Ifc.get().by_id(self.material), name=self.name)
+
+
 class DisableEditingMaterial(bpy.types.Operator):
     bl_idname = "bim.disable_editing_material"
     bl_label = "Disable Editing Material"

--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -120,6 +120,9 @@ class RenameMaterial(bpy.types.Operator, tool.Ifc.Operator):
 
     def _execute(self, context):
         core.rename_material(tool.Ifc, tool.Material, material=tool.Ifc.get().by_id(self.material), name=self.name)
+        if screen := context.screen:
+            for area in screen.areas:
+                area.tag_redraw()
 
 
 class DisableEditingMaterial(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -41,6 +41,7 @@ import bonsai.bim.helper
 import bonsai.tool as tool
 from bonsai.bim.ifc import is_cache_locked_by_other_process
 from bonsai.bim.module.bsdd.prop import BIMBSDDProperties, BSDDProperty
+from bonsai.bim.module.material.operator import SelectByMaterial
 from bonsai.bim.module.model import prop as _model_prop
 from bonsai.bim.module.model import ui as _model_ui
 from bonsai.bim.module.pset.prop import IfcProperty
@@ -1854,6 +1855,21 @@ def draw_statusbar(self, context):
 
 def draw_custom_context_menu(self: bpy.types.Menu, context: bpy.types.Context) -> None:
     # https://blender.stackexchange.com/a/275555/86891
+
+    # Context menu for material name buttons (e.g. `bim.select_by_material`),
+    # offering a quick "Rename Material" entry instead of having to look up
+    # the material in the scene Materials panel to rename it.
+    button_operator = getattr(context, "button_operator", None)
+    if button_operator is not None and button_operator.bl_rna.identifier == SelectByMaterial.bl_rna.identifier:
+        ifc_file = tool.Ifc.get()
+        material = ifc_file.by_id(button_operator.material) if ifc_file else None
+        if material is not None and material.is_a("IfcMaterial"):
+            assert self.layout
+            self.layout.separator()
+            op = self.layout.operator("bim.rename_material", text="Rename Material", icon="GREASEPENCIL")
+            op.material = material.id()
+        return
+
     if (
         not hasattr(context, "button_pointer")
         or not hasattr(context, "button_prop")

--- a/src/bonsai/bonsai/core/material.py
+++ b/src/bonsai/bonsai/core/material.py
@@ -113,6 +113,7 @@ def rename_material(
     ifc.run("material.edit_material", material=material, attributes={"Name": name})
     if material_tool.is_editing_materials():
         material_tool.import_material_definitions(material_tool.get_active_material_type())
+    material_tool.refresh()
 
 
 def assign_material(

--- a/src/bonsai/bonsai/core/material.py
+++ b/src/bonsai/bonsai/core/material.py
@@ -107,6 +107,14 @@ def disable_editing_material(material_tool: type[tool.Material]) -> None:
     material_tool.disable_editing_material()
 
 
+def rename_material(
+    ifc: type[tool.Ifc], material_tool: type[tool.Material], material: ifcopenshell.entity_instance, name: str
+) -> None:
+    ifc.run("material.edit_material", material=material, attributes={"Name": name})
+    if material_tool.is_editing_materials():
+        material_tool.import_material_definitions(material_tool.get_active_material_type())
+
+
 def assign_material(
     ifc: type[tool.Ifc],
     material_tool: type[tool.Material],

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -667,6 +667,7 @@ class Material:
     def is_editing_materials(cls): pass
     def is_material_used_in_sets(cls, material): pass
     def load_material_attributes(cls, material): pass
+    def refresh(cls): pass
     def replace_material_with_material_profile(cls, element): pass
     def update_elements_using_material(cls, material): pass
 

--- a/src/bonsai/bonsai/tool/material.py
+++ b/src/bonsai/bonsai/tool/material.py
@@ -147,6 +147,12 @@ class Material(bonsai.core.tool.Material):
         MaterialsData.data["material_styles_data"] = MaterialsData.material_styles_data()
 
     @classmethod
+    def refresh(cls) -> None:
+        from bonsai.bim.module.material.data import refresh as refresh_material_data
+
+        refresh_material_data()
+
+    @classmethod
     def is_editing_materials(cls) -> bool:
         props = tool.Material.get_material_props()
         return props.is_editing

--- a/src/bonsai/test/core/test_material.py
+++ b/src/bonsai/test/core/test_material.py
@@ -97,6 +97,7 @@ class TestRenameMaterial:
     def test_renaming_a_material(self, ifc, material):
         ifc.run("material.edit_material", material="material", attributes={"Name": "name"}).should_be_called()
         material.is_editing_materials().should_be_called().will_return(False)
+        material.refresh().should_be_called()
         subject.rename_material(ifc, material, material="material", name="name")
 
     def test_renaming_a_material_and_reloading_imported_materials(self, ifc, material):
@@ -104,6 +105,7 @@ class TestRenameMaterial:
         material.is_editing_materials().should_be_called().will_return(True)
         material.get_active_material_type().should_be_called().will_return("material_type")
         material.import_material_definitions("material_type").should_be_called()
+        material.refresh().should_be_called()
         subject.rename_material(ifc, material, material="material", name="name")
 
 

--- a/src/bonsai/test/core/test_material.py
+++ b/src/bonsai/test/core/test_material.py
@@ -93,6 +93,20 @@ class TestRemoveMaterialSet:
         subject.remove_material_set(ifc, material, material="material")
 
 
+class TestRenameMaterial:
+    def test_renaming_a_material(self, ifc, material):
+        ifc.run("material.edit_material", material="material", attributes={"Name": "name"}).should_be_called()
+        material.is_editing_materials().should_be_called().will_return(False)
+        subject.rename_material(ifc, material, material="material", name="name")
+
+    def test_renaming_a_material_and_reloading_imported_materials(self, ifc, material):
+        ifc.run("material.edit_material", material="material", attributes={"Name": "name"}).should_be_called()
+        material.is_editing_materials().should_be_called().will_return(True)
+        material.get_active_material_type().should_be_called().will_return("material_type")
+        material.import_material_definitions("material_type").should_be_called()
+        subject.rename_material(ifc, material, material="material", name="name")
+
+
 class TestLoadMaterials:
     def test_run(self, material):
         material.import_material_definitions("material_type").should_be_called()

--- a/src/bonsai/test/tool/test_material.py
+++ b/src/bonsai/test/tool/test_material.py
@@ -139,6 +139,17 @@ class TestImportMaterialDefinitions(NewFile):
         assert props.materials[0].total_elements == 0
 
 
+class TestRefresh(NewFile):
+    def test_run(self):
+        from bonsai.bim.module.material.data import MaterialsData, ObjectMaterialData
+
+        MaterialsData.is_loaded = True
+        ObjectMaterialData.is_loaded = True
+        subject.refresh()
+        assert MaterialsData.is_loaded is False
+        assert ObjectMaterialData.is_loaded is False
+
+
 class TestIsEditingMaterials(NewFile):
     def test_run(self):
         props = tool.Material.get_material_props()


### PR DESCRIPTION
Implements #6680 as discussed in the thread

## What
A "Rename Material" entry in the right-click context menu of material rows (the `select_by_material` buttons in the Object Material panel), opening a pre-filled rename dialog. Implements the right-click pattern @theoryshaw proposed in the thread; single-click select-by-material behavior is completely untouched, per his explicit requirement. Only real `IfcMaterial` rows get the entry.

## How
Extends Bonsai's existing `UI_MT_button_context_menu` hook (`draw_custom_context_menu`, the same mechanism used for the bSDD copy-attribute entries) rather than a bespoke menu. The new `bim.rename_material` operator reuses the existing `material.edit_material` IFC call, so it is a faster entry point to the existing rename flow, not a new mechanism.

@falken10vdl this is offered as a starting point to adopt or adapt since the issue is assigned to you - it follows where the thread discussion converged.

## Testing
Live headless Blender (isolated profile): create project + material + wall, invoke rename, `IfcMaterial.Name` updated in the IFC data and the panel cache reflects it; context-menu logic verified to add exactly one entry for material rows and nothing for unrelated buttons. Material core/tool suites 29/29 before and after. Black + ruff clean.

This change was written with AI assistance.
