### PR TITLE
ifcgeom: map IfcSphericalSurface so advanced-brep spheres render (#586)

### DIFF
--- a/src/ifcgeom/mapping/IfcSphericalSurface.cpp
+++ b/src/ifcgeom/mapping/IfcSphericalSurface.cpp
@@ -24,16 +24,10 @@ using namespace ifcopenshell::geometry;
 #ifdef SCHEMA_HAS_IfcSphericalSurface
 
 taxonomy::ptr mapping::map_impl(const IfcSchema::IfcSphericalSurface* inst) {
-	return nullptr;
-
-	/*
-	gp_Trsf trsf;
-	IfcGeom::Kernel::convert(inst->Position(), trsf);
-
-	// IfcElementarySurface.Position has unit scale factor
-	face = BRepBuilderAPI_MakeFace(new Geom_SphericalSurface(gp::XOY(), inst->Radius() * length_unit_), getValue(GV_PRECISION)).Face().Moved(trsf);
-	return true;
-	*/
+	auto s = taxonomy::make<taxonomy::sphere>();
+	s->radius = inst->Radius() * length_unit_;
+	s->matrix = taxonomy::cast<taxonomy::matrix4>(map(inst->Position()));
+	return s;
 }
 
 #endif


### PR DESCRIPTION
Addresses #586 (the Sphere case; see the comment on the issue for the full per-file status)

## Problem
`IfcSphericalSurface`'s mapping was a dead stub returning `nullptr` (the 0.5-era implementation left commented out against a removed kernel API), so any IfcAdvancedBrep face on a spherical surface failed to convert - the Sphere from the Allplan free-form models attached to #586.

## Fix
Map it to `taxonomy::sphere`, mirroring the existing `IfcCylindricalSurface`/`IfcToroidalSurface` mappings (4 lines). This activates the kernel's existing single-face spherical-solid shortcut (`BRepPrimAPI_MakeSphere`); that path is only reachable from `IfcManifoldSolidBrep` closed shells and CSG primitives, so it can only fire on the genuine full-sphere pattern - audited, not a correctness risk for partial caps.

## Testing
Real IFC4-only build: the Sphere example fails on baseline, converts after (13294 verts; bbox diameter equals 2x radius to 13 significant figures). The other #586 files are unaffected (they never reach this mapping). No existing test exercises `IfcSphericalSurface`; noted for reviewers.

This change was written with AI assistance.
