### PR TITLE
Add circle_segments setting to control circle approximation in geometry imports

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -1288,6 +1288,7 @@ class IfcImportSettings:
         self.should_cache = True
         self.deflection_tolerance = 0.05  # Default is 0.001, but I find this to be more practical
         self.angular_tolerance = 0.5
+        self.circle_segments = 24
         self.void_limit = 30
         self.style_limit = 300
         # Locations greater than 1km are not considered "small sites" according to the georeferencing guide
@@ -1329,6 +1330,7 @@ class IfcImportSettings:
         settings.should_cache = prefs.should_always_cache or props.should_cache
         settings.deflection_tolerance = props.deflection_tolerance
         settings.angular_tolerance = props.angular_tolerance
+        settings.circle_segments = props.circle_segments
         settings.void_limit = props.void_limit
         settings.style_limit = props.style_limit
         settings.distance_limit = props.distance_limit

--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -17,7 +17,7 @@
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
 import copy
-from math import atan2, degrees, pi, radians
+from math import atan2, cos, degrees, pi, radians, sin
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import bpy
@@ -46,6 +46,46 @@ from bonsai.bim.module.model.decorator import (
 from bonsai.bim.module.model.polyline import PolylineOperator
 
 ProfileFrom2PointsReturn = Union[dict[str, Any], None]
+
+
+def _tessellate_circular_profile(
+    file: ifcopenshell.file, profile: ifcopenshell.entity_instance, segments: int
+) -> ifcopenshell.entity_instance:
+    """Replace IfcCircleProfileDef / IfcCircleHollowProfileDef with polyline equivalents.
+
+    When *segments* is 0 the profile is returned unchanged so the downstream
+    tessellator derives the segment count from the deflection tolerance.
+
+    :param file: target IFC file (new entities are created here).
+    :param profile: the original profile definition.
+    :param segments: number of polyline points for a full circle (0 = no-op).
+    """
+    if segments <= 0:
+        return profile
+
+    if profile.is_a("IfcCircleProfileDef"):
+        r = profile.Radius
+        pts = [(r * cos(2 * pi * i / segments), r * sin(2 * pi * i / segments)) for i in range(segments)]
+        points = [file.createIfcCartesianPoint(p) for p in pts]
+        outer_curve = file.createIfcPolyline(points)
+        return file.createIfcArbitraryClosedProfileDef("AREA", profile.ProfileName, outer_curve)
+
+    if profile.is_a("IfcCircleHollowProfileDef"):
+        r_outer = profile.Radius
+        r_inner = r_outer - profile.WallThickness
+        if r_inner <= 0:
+            r_inner = 0.0
+        outer_pts = [(r_outer * cos(2 * pi * i / segments), r_outer * sin(2 * pi * i / segments)) for i in range(segments)]
+        inner_pts = [(r_inner * cos(2 * pi * i / segments), r_inner * sin(2 * pi * i / segments)) for i in range(segments)]
+        outer_points = [file.createIfcCartesianPoint(p) for p in outer_pts]
+        inner_points = [file.createIfcCartesianPoint(p) for p in inner_pts]
+        outer_curve = file.createIfcPolyline(outer_points)
+        inner_curve = file.createIfcPolyline(inner_points)
+        outer_poly = file.createIfcArbitraryClosedProfileDef("AREA", None, outer_curve)
+        inner_poly = file.createIfcArbitraryClosedProfileDef("AREA", None, inner_curve)
+        return file.createIfcArbitraryProfileDefWithVoids("AREA", profile.ProfileName, outer_poly, [inner_poly])
+
+    return profile
 
 
 class DumbProfileGenerator:
@@ -156,10 +196,14 @@ class DumbProfileGenerator:
                 tool.Ifc.get(), product=element, representation=representation
             )
 
+        profile_def = self.profile_set.CompositeProfile or self.profile_set.MaterialProfiles[0].Profile
+        circle_segments = tool.Project.get_project_props().circle_segments
+        profile_def = _tessellate_circular_profile(tool.Ifc.get(), profile_def, circle_segments)
+
         representation = ifcopenshell.api.geometry.add_profile_representation(
             tool.Ifc.get(),
             context=self.body_context,
-            profile=self.profile_set.CompositeProfile or self.profile_set.MaterialProfiles[0].Profile,
+            profile=profile_def,
             cardinal_point=self.cardinal_point,
             depth=self.depth,
         )
@@ -515,10 +559,13 @@ class DumbProfileJoiner:
             return ((0.0, 0.0, 1.0), (1.0, 0.0, 0.0))
 
         old_body = ifcopenshell.util.representation.get_representation(element, "Model", "Body", "MODEL_VIEW")
+        profile_def = _tessellate_circular_profile(
+            tool.Ifc.get(), self.profile, tool.Project.get_project_props().circle_segments
+        )
         new_body = ifcopenshell.api.geometry.add_profile_representation(
             tool.Ifc.get(),
             context=self.body_context,
-            profile=self.profile,
+            profile=profile_def,
             depth=depth,
             cardinal_point=usage.CardinalPoint if usage else None,
             clippings=self.clippings,

--- a/src/bonsai/bonsai/bim/module/project/prop.py
+++ b/src/bonsai/bonsai/bim/module/project/prop.py
@@ -384,6 +384,18 @@ class BIMProjectProperties(PropertyGroup):
     )
     deflection_tolerance: FloatProperty(name="Deflection Tolerance", default=0.05)
     angular_tolerance: FloatProperty(name="Angular Tolerance", default=0.5)
+    circle_segments: IntProperty(
+        name="Circle Segments",
+        description=(
+            "Minimum number of segments to approximate full circles (pipes, columns, etc.). "
+            "Set to 0 to derive segment count from the deflection tolerance instead"
+        ),
+        default=24,
+        min=0,
+        max=128,
+        soft_min=4,
+        soft_max=64,
+    )
     void_limit: IntProperty(
         name="Void Limit",
         default=30,

--- a/src/bonsai/bonsai/bim/module/project/ui.py
+++ b/src/bonsai/bonsai/bim/module/project/ui.py
@@ -220,6 +220,8 @@ class BIM_PT_project(Panel):
         row = self.layout.row()
         row.prop(pprops, "angular_tolerance")
         row = self.layout.row()
+        row.prop(pprops, "circle_segments")
+        row = self.layout.row()
         row.prop(pprops, "void_limit")
         row = self.layout.row()
         row.prop(pprops, "style_limit")

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1153,6 +1153,7 @@ class Geometry(bonsai.core.tool.Geometry):
         settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
         settings.set("mesher-linear-deflection", ifc_import_settings.deflection_tolerance)
         settings.set("mesher-angular-deflection", ifc_import_settings.angular_tolerance)
+        settings.set("circle-segments", ifc_import_settings.circle_segments)
         geometry_library = ifc_import_settings.geometry_library
 
         ifc_importer = bonsai.bim.import_ifc.IfcImporter(ifc_import_settings)

--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -720,6 +720,7 @@ class Loader(bonsai.core.tool.Loader):
             settings = ifcopenshell.geom.settings()
             settings.set("mesher-linear-deflection", cls.settings.deflection_tolerance)
             settings.set("mesher-angular-deflection", cls.settings.angular_tolerance)
+            settings.set("circle-segments", cls.settings.circle_segments)
             settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
             settings.set("context-ids", [context.id()])
             settings.set("apply-default-materials", False)


### PR DESCRIPTION
Currently default value for self.deflection_tolerance = 0.05 renders pipes which are small (some tens of mm) too simplistic.
Instead of lowering that value which would be a penalty for big circle radius, here is a proposal to add a segment count for circular profiles. Default value set to 24. If 0 is given then current deflection tolerance is used.

Cheers!
