### PR TITLE
SvgSerializer: emit machine-readable space area attribute; fix double-escaped area label (#1308)

### DIFF
--- a/src/serializers/SvgSerializer.cpp
+++ b/src/serializers/SvgSerializer.cpp
@@ -1933,7 +1933,9 @@ void SvgSerializer::write(const geometry_data& data) {
 					const double area = prop.Mass();
 					std::stringstream ss;
 					ss << std::setprecision(2) << std::fixed << std::showpoint << area;
-					labels.push_back(ss.str() + "m&#178;");
+					// UTF-8 for U+00B2, not an "&#178;" entity, to avoid double-escaping below.
+					labels.push_back(ss.str() + "m\xc2\xb2");
+					po()->first += " " + namespace_prefix_ + "area=\"" + ss.str() + "\"";
 				}
 
 				util::string_buffer path;


### PR DESCRIPTION
Fixes #1308

## What
With `--print-space-areas`, each IfcSpace's group now carries its computed area as a machine-readable attribute alongside the existing visible label: `data-area="68.44"` (or `ifc:area` under `--svg-xmlns`), consistent with the existing `data-name`/`data-guid` convention on the same group.

Also fixes a pre-existing bug in the same code path: the area label pre-baked the `&#178;` entity, which `escape_xml()` then double-escaped, rendering as literal `m&amp;#178;` in the SVG. The label now emits raw UTF-8 (`m²`), which escape_xml leaves intact.

## Design note
This reuses the existing `--print-space-areas` flag (no new CLI surface) and the existing group-attribute convention, the minimal step consistent with what is already there. The broader idea discussed in the thread in 2021 (a generic property-to-SVG-attribute mechanism) remains open and is not attempted here.

## Testing
Clean IFC4 build. `TestModel_IFC4Add2.ifc`: baseline shows no area attribute and the double-escaped label; patched shows `data-area="68.44"` and `68.44m²`, in both plain and `--svg-xmlns` modes. Without the flag, output is byte-identical across six option variants; structurally guaranteed too, since the change lives entirely inside the `print_space_areas_` conditional.

This change was written with AI assistance.
