### PR TITLE
Fix --no-normals ignored by CGAL kernel for OBJ output (#8861)

### DIFF
--- a/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
@@ -382,6 +382,7 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 	}
 
 	const bool setting_use_original_edges = settings.get<ifcopenshell::geometry::settings::CgalEmitOriginalEdges>().get();
+	const bool calculate_normals = !settings.get<ifcopenshell::geometry::settings::DontEmitNormals>().get();
 	
 	std::set<std::set<Kernel_::Point_3>> original_edges;
 	if (setting_use_original_edges) {
@@ -541,11 +542,13 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 				);
 				welds.insert({ pn, vidx });
 
-				auto nx = CGAL::to_double(face_normals_map[face].cartesian(0));
-				auto ny = CGAL::to_double(face_normals_map[face].cartesian(1));
-				auto nz = CGAL::to_double(face_normals_map[face].cartesian(2));
+				if (calculate_normals) {
+					auto nx = CGAL::to_double(face_normals_map[face].cartesian(0));
+					auto ny = CGAL::to_double(face_normals_map[face].cartesian(1));
+					auto nz = CGAL::to_double(face_normals_map[face].cartesian(2));
 
-				t->addNormal(nx, ny, nz);
+					t->addNormal(nx, ny, nz);
+				}
 			} else {
 				vidx = it->second;
 			}


### PR DESCRIPTION
Fixes #8861

## Problem
Converting to OBJ with the CGAL kernel still writes vertex normals (`vn` lines) when `--no-normals` is passed; the OpenCascade kernel honors the flag correctly.

## Root cause
`CgalShape::Triangulate()` (`src/ifcgeom/kernels/cgal/CgalConversionResult.cpp`) unconditionally calls `addNormal(...)` for every welded vertex, never consulting the `DontEmitNormals` setting that `--no-normals` maps to. The OpenCascade kernel already gates its equivalent normal computation on `!WeldVertices && !DontEmitNormals`. Since the OBJ serializer emits `vn` based purely on whether the triangulation carries normals, the kernel is the correct fix point.

## Fix
Gate the CGAL kernel's `addNormal` call on `DontEmitNormals`, mirroring the existing OpenCascade behavior. The weld-key computation is untouched (vertex uniqueness is a separate CGAL concept, unrelated to normal emission), so the change is scoped strictly to normal output.

## Testing
Real IFC4 build. Before: CGAL + `--no-normals` = 24 `vn` lines (bug); after: 0. CGAL without the flag still emits 24; OpenCascade unchanged in both cases. OpenCascade corpus output byte-identical across all 32 fixtures with and without the flag. glTF (CGAL) verified: succeeds with and without normals, no crash.

This change was written with AI assistance.
