### PR TITLE
ifc5d: compute footing gross area, volume and outer surface on the ifcopenshell engine (#6305)

### DIFF
--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantities.json
@@ -315,14 +315,14 @@
             "IfcFooting": {
                 "Qto_FootingBaseQuantities": {
                     "CrossSectionArea": null,
-                    "GrossSurfaceArea": null,
-                    "GrossVolume": null,
+                    "GrossSurfaceArea": "gross_get_area",
+                    "GrossVolume": "gross_get_volume",
                     "GrossWeight": "gross_get_weight",
                     "Height": "net_get_footing_height",
                     "Length": "net_get_footing_length",
                     "NetVolume": "net_get_volume",
                     "NetWeight": "net_get_weight",
-                    "OuterSurfaceArea": null,
+                    "OuterSurfaceArea": "net_get_outer_surface_area",
                     "Width": "net_get_footing_width"
                 }
             },

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
@@ -360,14 +360,14 @@
             "IfcFooting + IfcFootingType": {
                 "Qto_FootingBaseQuantities": {
                     "CrossSectionArea": null,
-                    "GrossSurfaceArea": null,
-                    "GrossVolume": null,
+                    "GrossSurfaceArea": "gross_get_area",
+                    "GrossVolume": "gross_get_volume",
                     "GrossWeight": "gross_get_weight",
                     "Height": "net_get_footing_height",
                     "Length": "net_get_footing_length",
                     "NetVolume": "net_get_volume",
                     "NetWeight": "net_get_weight",
-                    "OuterSurfaceArea": null,
+                    "OuterSurfaceArea": "net_get_outer_surface_area",
                     "Width": "net_get_footing_width"
                 }
             },


### PR DESCRIPTION
Fixes the remaining part of #6305 (the axis mapping half was fixed by #8365, verified by the reporter on #4783)

## Problem
On the IfcOpenShell take-off engine, `Qto_FootingBaseQuantities.GrossSurfaceArea`, `GrossVolume` and `OuterSurfaceArea` were never computed for footings: the JSON rule sets simply did not wire them up, unlike sibling classes (Beam, Column, Member) which map the same generic functions. The Blender engine computed them, the ifcopenshell engine returned n/a.

## Fix
Wire the three quantities to the existing generic functions (`gross_get_area`, `gross_get_volume`, `net_get_outer_surface_area`) in the IFC4 and IFC4X3 rule sets, matching the sibling classes.

## Testing
Live on the reporter's exact table dimensions (FOOTING_BEAM/STRIP_FOOTING 0.25x0.50 profile x4m; PAD_FOOTING 2x3x0.2m): baseline 6/10 quantities correct on the ifcopenshell engine, 9/10 after (CrossSectionArea remains engine-wide unimplemented, not footing-specific). Note: for PAD_FOOTING the computed OuterSurfaceArea follows the buildingSMART definition (perimeter x thickness, excluding end caps), which corrects a value in the issue's reference table. ifc5d suite passes; JSON valid.

This change was written with AI assistance.
