### PR TITLE
util.selector: metric/imperial_length pass through non-numeric values (#5297)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -345,8 +345,15 @@ class FormatTransformer(lark.Transformer):
 
     def metric_length(self, args):
         value, precision, decimal_places = args
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError):
+            # A non-numeric value (e.g. N/A, or a text property) cannot be
+            # formatted as a length. Pass it through unchanged rather than
+            # failing the whole format expression (#5297).
+            return value
         return ifcopenshell.util.unit.format_length(
-            float(value), float(precision), int(decimal_places), unit_system="metric"
+            numeric_value, float(precision), int(decimal_places), unit_system="metric"
         )
 
     def imperial_length(self, args):
@@ -368,8 +375,15 @@ class FormatTransformer(lark.Transformer):
             input_unit = "inch" if input_unit == "inch" else "foot"
             output_unit = "inch" if output_unit == "inch" else "foot"
 
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError):
+            # A non-numeric value (e.g. N/A, or a text property) cannot be
+            # formatted as a length. Pass it through unchanged rather than
+            # failing the whole format expression (#5297).
+            return value
         return ifcopenshell.util.unit.format_length(
-            float(value),
+            numeric_value,
             int(precision),
             suppress_zero_inches=(suppress_zero_inches if suppress_zero_inches is not None else False),
             unit_system="imperial",

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -80,6 +80,9 @@ class TestFormat(test.bootstrap.IFC4):
         assert subject.format('imperial_length(3.0, 4, "foot", "foot", True)') == "3'"
         assert subject.format('imperial_length(3.0, 4, "foot", "foot", false)') == "3' - 0\""
         assert subject.format('imperial_length(3.0, 4, "foot", "foot", False)') == "3' - 0\""
+        # Non-numeric values must pass through unchanged instead of crashing (#5297).
+        assert subject.format('metric_length("N/A", 0.1, 1)') == "N/A"
+        assert subject.format('imperial_length("N/A", 2)') == "N/A"
 
     def test_variable_formatting(self):
         assert subject.format("{{undefined}}") is None


### PR DESCRIPTION
Fixes #5297

## Problem
`metric_length` and `imperial_length` selector format functions crash with `could not convert string to float` when the value is non-numeric (e.g. "N/A"), breaking spreadsheet export of columns with mixed content, exactly as reported.

## Root cause and correction of an earlier claim
An earlier comment of ours on #5297 pointed at PR #8297 as the fix; that was wrong. #8297 only touches `round`, `number` and `int` (for #6776), never the two length formatters. This PR fixes the actual reported functions: `float(value)` in both is now wrapped with the same pass-through convention `round()` already uses, so non-numeric values flow through unformatted while numeric values format exactly as before.

## Testing
Live: `metric_length("N/A", 0.1, 1)` crashed before, passes through after; numeric formatting unchanged. Regression tests added for both functions; full `test_selector.py` suite passes. Black + ruff clean.

This change was written with AI assistance.
