### PR TITLE
Bonsai: add a selector query filter for cost item quantity assignment

### DIFF
--- a/src/bonsai/bonsai/bim/module/cost/prop.py
+++ b/src/bonsai/bonsai/bim/module/cost/prop.py
@@ -257,6 +257,10 @@ class BIMCostProperties(PropertyGroup):
     active_column_index: IntProperty(name="Active Column Index")
     cost_item_products: CollectionProperty(name="Cost Item Products", type=CostItemQuantity)
     active_cost_item_product_index: IntProperty(name="Active Cost Item Product Index")
+    cost_item_products_query: StringProperty(
+        name="Query",
+        description="A selector query to select elements to assign to the active cost item, e.g. IfcWall, material=Concrete",
+    )
     cost_item_processes: CollectionProperty(name="Cost Item Processes", type=CostItemQuantity)
     active_cost_item_process_index: IntProperty(name="Active Cost Item Process Index")
     cost_item_resources: CollectionProperty(name="Cost Item Resources", type=CostItemQuantity)
@@ -317,6 +321,7 @@ class BIMCostProperties(PropertyGroup):
         active_column_index: int
         cost_item_products: bpy.types.bpy_prop_collection_idprop[CostItemQuantity]
         active_cost_item_product_index: int
+        cost_item_products_query: str
         cost_item_processes: bpy.types.bpy_prop_collection_idprop[CostItemQuantity]
         active_cost_item_process_index: int
         cost_item_resources: bpy.types.bpy_prop_collection_idprop[CostItemQuantity]

--- a/src/bonsai/bonsai/bim/module/cost/ui.py
+++ b/src/bonsai/bonsai/bim/module/cost/ui.py
@@ -465,6 +465,12 @@ class BIM_PT_cost_item_quantities(Panel):
         op = row2.operator("bim.select_cost_item_products", icon="RESTRICT_SELECT_OFF", text="")
         op.cost_item = cost_item.ifc_definition_id
 
+        row2 = col.row(align=True)
+        row2.prop(self.props, "cost_item_products_query", text="", icon="VIEWZOOM")
+        op = row2.operator("bim.select_query_elements", text="", icon="RESTRICT_SELECT_OFF")
+        op.query = self.props.cost_item_products_query
+        op.clear_previous_selection = True
+
         if context.selected_objects:
             if has_quantity_names:
                 op = row2.operator("bim.assign_cost_item_quantity", text="", icon="PROPERTIES")

--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -800,16 +800,25 @@ class SelectQueryElements(Operator):
     bl_options = {"REGISTER", "UNDO"}
 
     query: StringProperty(name="Query")
+    clear_previous_selection: BoolProperty(
+        name="Clear Previous Selection",
+        description="Replace the current selection with the query results instead of adding to it",
+        default=False,
+    )
 
     if TYPE_CHECKING:
         query: str
+        clear_previous_selection: bool
 
     def execute(self, context) -> set["rna_enums.OperatorReturnItems"]:
         results = ifcopenshell.util.selector.filter_elements(tool.Ifc.get(), self.query)
         objs = [obj for e in results if isinstance(obj := tool.Ifc.get_object(e), bpy.types.Object)]
-        active_object = context.active_object or next(iter(objs), None)
+        if self.clear_previous_selection:
+            active_object = next(iter(objs), None)
+        else:
+            active_object = context.active_object or next(iter(objs), None)
         selection = tool.Blender.validate_object_selection(context, active_object, objs)
-        tool.Blender.set_objects_selection(*selection, clear_previous_selection=False)
+        tool.Blender.set_objects_selection(*selection, clear_previous_selection=self.clear_previous_selection)
         self.report({"INFO"}, f"{len(results)} Results, {len(selection.selected_objects)} Objects Selected")
         return {"FINISHED"}
 


### PR DESCRIPTION
Adds a query filter to the Cost Items Quantities panel so products can be selected by IFC query (e.g. `IfcWall`, `IfcWall, material=concrete`) right where quantities get assigned, as requested in #5390.

Also fixes a selection-semantics bug this surfaced in `bim.select_query_elements`: its add-to-selection default could silently include a stale, deselected active object in follow-up operations. New opt-in `clear_previous_selection` flag, default off, existing callers unchanged.

Live-verified headless: query selects only matching products, and `bim.assign_cost_item_quantity` afterward assigns only from the query result. Fixes #5390.

This PR was generated with AI assistance.
