### PR TITLE
Bonsai: show IfcSurfaceFeature in linked models

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1398,7 +1398,8 @@ class LinkIfc(bpy.types.Operator, ImportHelper, tool.Ifc.Operator):
         name="Query",
         description=(
             "Custom selector query to use to load element from a linked model. E.g. 'IfcElement'.\n\n"
-            "Default query - IfcElement, but excluding IfcProxy, IfcSpatialStructureElement, IfcSpatialElement, IfcFeatureElement."
+            "Default query - IfcElement plus IfcProxy and spatial elements, "
+            "excluding IfcFeatureElement (except IfcSurfaceFeature)."
         ),
     )
 
@@ -1708,7 +1709,8 @@ class ReloadLink(bpy.types.Operator):
         name="Query",
         description=(
             "Custom selector query to use to load element from a linked model. E.g. 'IfcElement'.\n\n"
-            "Default query - IfcElement, but excluding IfcProxy, IfcSpatialStructureElement, IfcSpatialElement, IfcFeatureElement."
+            "Default query - IfcElement plus IfcProxy and spatial elements, "
+            "excluding IfcFeatureElement (except IfcSurfaceFeature)."
         ),
     )
 
@@ -2351,7 +2353,7 @@ class LoadLinkedProject(bpy.types.Operator, ImportHelper):
                 self.elements |= set(self.file.by_type("IfcSpatialStructureElement"))
             else:
                 self.elements |= set(self.file.by_type("IfcSpatialElement"))
-            self.elements -= set(self.file.by_type("IfcFeatureElement"))
+            self.elements -= {e for e in self.file.by_type("IfcFeatureElement") if not e.is_a("IfcSurfaceFeature")}
 
         if tool.Loader.settings.false_origin_mode == "MANUAL" and tool.Loader.settings.false_origin:
             tool.Loader.set_manual_blender_offset(self.file)


### PR DESCRIPTION
Fixes #6382

### Problem
IfcSurfaceFeature elements (e.g. PAVEMENTSURFACEMARKING road markings, as reported by @steverugi) never appear when a model is loaded as a link, unless the user knows to type a custom selector query.

### Root cause
The default element selection of `bim.load_linked_project` subtracts all `IfcFeatureElement` instances (`src/bonsai/bonsai/bim/module/project/operator.py`). That is correct for subtraction features whose geometry is baked into the voided host, but `IfcSurfaceFeature` carries its own additive geometry. The regular project loader has deliberately kept surface features since #4565 (`import_ifc.py` filters with `not IfcFeatureElement or IfcSurfaceFeature`), and the light module does the same. The link loader was the one place still dropping them wholesale.

### Fix
Mirror the established filter in the linked-model default selection, and correct the query tooltip on Link IFC / Reload Link, which described included types (IfcProxy, spatial elements) as excluded.

### Verification (live, headless Blender)
Generated an IFC4X3 file with a slab and an adhered IfcSurfaceFeature marking, then ran `bim.load_linked_project` with the default query. Before: only the slab loads (8-vert chunk). After: slab plus marking load (16-vert chunk). Link feature scenarios show no new failures against baseline.

Generated with the assistance of an AI coding tool.
