### PR TITLE
Bonsai: add Filter From Selection query builder to Search panel

### DIFF
--- a/src/bonsai/bonsai/bim/module/search/__init__.py
+++ b/src/bonsai/bonsai/bim/module/search/__init__.py
@@ -28,6 +28,7 @@ classes = (
     operator.ApplyFilterFromText,
     operator.ColourByProperty,
     operator.EditFilterQuery,
+    operator.FilterFromSelection,
     operator.FilterValueSuggestions,
     operator.LoadColourscheme,
     operator.LoadSearch,

--- a/src/bonsai/bonsai/bim/module/search/operator.py
+++ b/src/bonsai/bonsai/bim/module/search/operator.py
@@ -1443,6 +1443,51 @@ class ShowAllElements(Operator):
         return {"FINISHED"}
 
 
+class FilterFromSelection(Operator):
+    bl_idname = "bim.filter_from_selection"
+    bl_label = "Filter From Selection"
+    bl_description = (
+        "Build a search query from the selected objects,"
+        " combining their IFC classes with the container and type values they all share"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        if not context.selected_objects:
+            cls.poll_message_set("No selected objects found.")
+            return False
+        return True
+
+    def execute(self, context):
+        elements = []
+        for obj in context.selected_objects:
+            if element := tool.Ifc.get_entity(obj):
+                elements.append(element)
+        if not elements:
+            self.report({"WARNING"}, "No IFC elements in the selection.")
+            return {"CANCELLED"}
+
+        def quote(value: str) -> str:
+            value = value.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"{value}"'
+
+        common_facets: list[str] = []
+        containers = {ifcopenshell.util.element.get_container(element) for element in elements}
+        if len(containers) == 1 and (container := next(iter(containers))) is not None and container.Name:
+            common_facets.append(f"location={quote(container.Name)}")
+        types = {ifcopenshell.util.element.get_type(element) for element in elements}
+        if len(types) == 1 and (relating_type := next(iter(types))) is not None and relating_type.Name:
+            common_facets.append(f"type={quote(relating_type.Name)}")
+
+        ifc_classes = sorted({element.is_a() for element in elements})
+        query = " + ".join(", ".join([ifc_class] + common_facets) for ifc_class in ifc_classes)
+        props = tool.Search.get_search_props()
+        tool.Search.import_filter_query(query, props.filter_groups)
+        self.report({"INFO"}, f"Filter set to: {query}")
+        return {"FINISHED"}
+
+
 class SelectSimilar(Operator):
     bl_idname = "bim.select_similar"
     bl_label = "Select Similar"

--- a/src/bonsai/bonsai/bim/module/search/ui.py
+++ b/src/bonsai/bonsai/bim/module/search/ui.py
@@ -53,6 +53,9 @@ class BIM_PT_search(Panel):
 
         props = tool.Search.get_search_props()
 
+        row = self.layout.row(align=True)
+        row.operator("bim.filter_from_selection", icon="EYEDROPPER")
+
         bonsai.bim.helper.draw_filter(self.layout, props.filter_groups, SearchData, "search")
 
         if len(props.filter_groups):


### PR DESCRIPTION
Adds a "Filter From Selection" button (eyedropper icon) to the Grouping and Filtering > Search panel. It builds a search filter query from the selected objects: the union of their IFC classes, with the values shared by the whole selection (spatial container as `location`, relating type as `type`) appended to every class group. Selecting a wall and a slab contained in storey G1 produces `IfcSlab, location="G1" + IfcWall, location="G1"`, ready to search for similar elements, which is the workflow requested in #7901. The query is imported through the strict selector grammar so the generated string is always parseable, and the query language itself is unchanged. Verified live in headless Blender (heterogeneous selection, no-common-container, shared-type, and non-IFC-selection cases). Complementary to #7940, which concatenates per-key Select Similar clipboard queries; this builds a multi-facet Search panel filter. Fixes #7901.

This PR contains AI-generated code (Claude) supervised by Petru Conduraru.
