### PR TITLE
Bonsai: add Height setting for spaces generated from cursor

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/prop.py
+++ b/src/bonsai/bonsai/bim/module/model/prop.py
@@ -330,6 +330,14 @@ class BIMModelProperties(PropertyGroup):
     rl2: bpy.props.FloatProperty(name="RL", default=1, subtype="DISTANCE", description="Z offset for windows")
     # Used for plan calculation points such as in room generation
     rl3: bpy.props.FloatProperty(name="RL", default=1, subtype="DISTANCE", description="Z offset for space calculation")
+    # Used for spaces generated from the cursor, where there is no active object to take the height from
+    space_height: bpy.props.FloatProperty(
+        name="Height",
+        default=3,
+        min=0.001,
+        subtype="DISTANCE",
+        description="Height of spaces generated from the cursor",
+    )
     type_page: bpy.props.IntProperty(name="Type Page", default=1, min=1, update=update_type_page)
     x_angle: bpy.props.FloatProperty(
         name="X Angle",
@@ -419,6 +427,7 @@ class BIMModelProperties(PropertyGroup):
         rl1: float
         rl2: float
         rl3: float
+        space_height: float
         type_page: int
         x_angle: float
         type_name: str

--- a/src/bonsai/bonsai/bim/module/spatial/workspace.py
+++ b/src/bonsai/bonsai/bim/module/spatial/workspace.py
@@ -86,6 +86,8 @@ class SpatialToolUI:
         row = cls.layout.row(align=True)
         row.prop(data=cls.model_props, property="rl3", text="RL")
         row = cls.layout.row(align=True)
+        row.prop(data=cls.model_props, property="space_height", text="Height")
+        row = cls.layout.row(align=True)
         op_name = lambda op: op.get_rna_type().name
         if AuthoringData.data["active_class"] == "IfcWall" and context.selected_objects:
             add_layout_hotkey(

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -907,14 +907,14 @@ class Spatial(bonsai.core.tool.Spatial):
         """
         `x`, `y` - from cursor;\n
         `z` - from default container Z location (if set);\n
-        `h` - default value of 3;\n
+        `h` - from the space height setting (default value of 3);\n
         `mat` - identity matrix
         """
         x, y, z = bpy.context.scene.cursor.location.xyz
         if tool.Root.get_default_container():
             z = tool.Root.get_default_container_elevation()
         mat = Matrix()
-        h = 3
+        h = tool.Model.get_model_props().space_height
         return x, y, z, h, mat
 
     @classmethod


### PR DESCRIPTION
Fixes #4817.

Generate Space from Cursor always extruded new spaces to a hardcoded 3m. This adds a Height setting to the Spatial Tool, next to RL, exactly as @steverugi mocked up, so the desired space height can be set before generating. Spaces generated or regenerated from an active object still take their height from that object.

Verified headless in Blender 5.2: generating a space inside four walls with Height 2.5 produces a 2.5m IfcSpace, and a second room after changing the setting to 4.2 produces a 4.2m space.

This PR is entirely AI generated, reviewed and tested by BIMvoice.
