### PR TITLE
resource: allow physical base quantities on subcontract resources

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/resource/add_resource_quantity.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/resource/add_resource_quantity.py
@@ -40,7 +40,9 @@ def add_resource_quantity(
         IfcQuantityArea (for material), IfcQuantityCount (for products),
         IfcQuantityLength (for material), IfcQuantityTime (for equipment or
         labour), IfcQuantityVolume (for material), and IfcQuantityWeight
-        (for material).
+        (for material). Subcontract resources may be quantified in time or,
+        since subcontracts are commonly let per unit of work, in any
+        physical quantity.
     :return: The newly created quantity depending on the IFC class
 
     Example:

--- a/src/ifcopenshell-python/ifcopenshell/util/resource.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/resource.py
@@ -27,7 +27,15 @@ PRODUCTIVITY_PSET_DATA = Union[dict[str, Any], None]
 RESOURCES_TO_QUANTITIES: dict[str, tuple[str, ...]] = {
     "IfcCrewResource": ("IfcQuantityTime",),
     "IfcLaborResource": ("IfcQuantityTime",),
-    "IfcSubContractResource": ("IfcQuantityTime",),
+    # Subcontracts are commonly let per unit of work, so physical quantities are also allowed
+    "IfcSubContractResource": (
+        "IfcQuantityTime",
+        "IfcQuantityLength",
+        "IfcQuantityArea",
+        "IfcQuantityVolume",
+        "IfcQuantityWeight",
+        "IfcQuantityCount",
+    ),
     "IfcConstructionEquipmentResource": ("IfcQuantityTime",),
     "IfcConstructionMaterialResource": (
         "IfcQuantityVolume",

--- a/src/ifcopenshell-python/test/api/resource/test_add_resource_quantity.py
+++ b/src/ifcopenshell-python/test/api/resource/test_add_resource_quantity.py
@@ -59,6 +59,24 @@ class TestAddResourceQuantity(test.bootstrap.IFC4):
 
             ifcopenshell.api.resource.remove_resource(self.file, resource)
 
+    def test_subcontract_resources_support_physical_quantities(self):
+        self.file.create_entity("IfcProject")  # add_resource
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcSubContractResource")
+
+        for quantity_type in (
+            "IfcQuantityTime",
+            "IfcQuantityLength",
+            "IfcQuantityArea",
+            "IfcQuantityVolume",
+            "IfcQuantityWeight",
+            "IfcQuantityCount",
+        ):
+            quantity = ifcopenshell.api.resource.add_resource_quantity(
+                self.file, resource=resource, ifc_class=quantity_type
+            )
+            assert quantity.is_a(quantity_type)
+            assert resource.BaseQuantity == quantity
+
 
 class TestAddResourceQuantityIFC2X3(test.bootstrap.IFC2X3, TestAddResourceQuantity):
     pass


### PR DESCRIPTION
Addresses #5157.

@steverugi points out that subcontracts are typically let per unit of work (length, area, volume) rather than per time, but both the API and the Bonsai dropdown only allow IfcQuantityTime for IfcSubContractResource.

The schema places no formal constraint on IfcConstructionResource.BaseQuantity, so files with a physical subcontract quantity are valid IFC, and ifcopenshell's cost and quantity utilities already read BaseQuantity generically. The current restriction mirrors the informative note in the IFC documentation, so I am raising this as a proposal rather than a plain fix: @Andrej730, since you added the strict validation in resource.add_resource_quantity, are you open to relaxing it for subcontract resources only? (cc @Moult in case you don't have bandwidth) Time remains the first option and the default. The productivity pset path is not an alternative here because it is limited to labour and equipment resources in the UI, and it drives schedule duration rather than unit pricing.

Tests: the add_resource_quantity suite passes (including a new test covering all six quantity types on a subcontract resource across IFC2X3, IFC4 and IFC4X3), and the Bonsai dropdown picks the new types up automatically.

This PR is entirely AI generated, reviewed and tested by BIMvoice.
