### PR TITLE
Bonsai tests: make boolean.feature survive STEP id drift

### DIFF
--- a/src/bonsai/test/bim/feature/boolean.feature
+++ b/src/bonsai/test/bim/feature/boolean.feature
@@ -12,16 +12,19 @@ Scenario: Ensure added booleans are marked as manual
     And I click "OK"
     And the object "IfcFurniture/Unnamed" exists
     And I toggle edit mode
-    And the object "Item/IfcExtrudedAreaSolid/73" exists
+    And the variable "extrusion" is "{ifc}.by_type('IfcExtrudedAreaSolid')[0].id()"
+    And the object "Item/IfcExtrudedAreaSolid/{extrusion}" exists
     And I open the "Add Item" menu
     When I click "Half Space Solid"
-    And the object "Item/IfcHalfSpaceSolid/90" exists
+    And the variable "half_space" is "{ifc}.by_type('IfcHalfSpaceSolid')[0].id()"
+    And the variable "boolean" is "{ifc}.by_type('IfcBooleanResult')[0].id()"
+    And the object "Item/IfcHalfSpaceSolid/{half_space}" exists
     And I deselect all objects
     And I toggle edit mode
     And I select the object "IfcFurniture/Unnamed"
     And I look at the "Property Sets" panel
     Then I see "BBIM_Boolean"
-    And I see "[91]"
+    And I see "[{boolean}]"
 
 Scenario: Ensure removed booleans are unmarked as manual
     Given an empty IFC project
@@ -33,17 +36,20 @@ Scenario: Ensure removed booleans are unmarked as manual
     And I click "OK"
     And the object "IfcFurniture/Unnamed" exists
     And I toggle edit mode
-    And the object "Item/IfcExtrudedAreaSolid/73" exists
+    And the variable "extrusion" is "{ifc}.by_type('IfcExtrudedAreaSolid')[0].id()"
+    And the object "Item/IfcExtrudedAreaSolid/{extrusion}" exists
     And I open the "Add Item" menu
     And I click "Half Space Solid"
+    And the variable "half_space" is "{ifc}.by_type('IfcHalfSpaceSolid')[0].id()"
+    And the variable "boolean" is "{ifc}.by_type('IfcBooleanResult')[0].id()"
     And I deselect all objects
     And I toggle edit mode
     And I select the object "IfcFurniture/Unnamed"
     And I toggle edit mode
-    And I select the object "Item/IfcHalfSpaceSolid/90"
+    And I select the object "Item/IfcHalfSpaceSolid/{half_space}"
     When I delete the selected objects
     And I toggle edit mode
     And I select the object "IfcFurniture/Unnamed"
     And I look at the "Property Sets" panel
     Then I don't see "BBIM_Boolean"
-    And I don't see "[91]"
+    And I don't see "[{boolean}]"

--- a/src/bonsai/test/bim/stub.py
+++ b/src/bonsai/test/bim/stub.py
@@ -21,6 +21,10 @@ from typing import Any, Optional, Union
 
 
 class bSDDClientStub:
+    def __init__(self):
+        # Mirrors bsdd.Client so tool.Bsdd.identifier_url() works against the stub.
+        self.baseurl = "https://api.bsdd.buildingsmart.org/api/"
+
     def get_dictionary(self, dictionary_uri=None, include_test_dictionaries=False):
         dicts = {
             "dictionaries": [

--- a/src/bonsai/test/bim/test_feature.py
+++ b/src/bonsai/test/bim/test_feature.py
@@ -453,6 +453,7 @@ def i_trigger_operator(operator):
 @then(parsers.parse('I see "{text}"'))
 def i_see_text(text):
     assert panel_spy
+    text = replace_variables(text)
     panel_spy.refresh_spy()
     assert [l for l in panel_spy.spied_labels if text in l], f"Text {text} not found in {panel_spy.spied_labels}"
 
@@ -587,6 +588,7 @@ def i_select_the_row_where_i_see_text_in_the_nth_list(text, nth):
 @then(parsers.parse('I don\'t see "{text}"'))
 def i_dont_see_text(text):
     assert panel_spy
+    text = replace_variables(text)
     panel_spy.refresh_spy()
     assert not [l for l in panel_spy.spied_labels if text in l], f"Text {text} found in {panel_spy.spied_labels}"
 
@@ -1073,6 +1075,7 @@ def then_the_object_name_is_placed_in_the_collection_collection(name: str, colle
 @given(parsers.parse('additionally the object "{name}" is selected'))
 @when(parsers.parse('additionally the object "{name}" is selected'))
 def additionally_the_object_name_is_selected(name):
+    name = replace_variables(name)
     obj = bpy.context.scene.objects.get(name)
     if not obj:
         total = len(bpy.context.scene.objects)
@@ -1153,6 +1156,7 @@ def nothing_happens():
 @when(parsers.parse('the object "{name}" exists'))
 @then(parsers.parse('the object "{name}" exists'))
 def the_object_name_exists(name: str) -> bpy.types.Object:
+    name = replace_variables(name)
     # Some objects from linked collections may share the same name. This disambiguates them.
     if name.startswith("Col:"):
         _, collection_name, name = name.split(":")
@@ -1167,6 +1171,7 @@ def the_object_name_exists(name: str) -> bpy.types.Object:
 
 @then(parsers.parse('the object "{name}" does not exist'))
 def the_object_name_does_not_exist(name) -> None:
+    name = replace_variables(name)
     obj = bpy.data.objects.get(name)
     assert obj is None, f'The object "{name}" exists'
 


### PR DESCRIPTION
Fixes the ci-bonsai-daily boolean.feature cluster (2 scenarios) that broke when hardcoded STEP ids drifted (Item/IfcHalfSpaceSolid/90 became 86 after #8577). These scenarios pinned representation items and the BBIM_Boolean pset text ([91]) by absolute STEP id, so they re-break every time any earlier entity allocation in an empty project changes.

Instead of renumbering, this makes the cluster id tolerant:

1. The object name and panel text BDD steps now run their argument through replace_variables, the same substitution "the variable" and the connection steps already use. Substitution is a no-op for every existing feature string without a {variable} placeholder, and the steps stay strict, the substituted name must still resolve to exactly the named object (no wildcard matching).
2. boolean.feature captures the real ids from the IFC file (by_type(...)[0].id()) into variables at the point the entities are created and references those, so the scenarios are immune to future id drift.

Fixing the id failures surfaced a second latent bug the ids had been masking: tool.Bsdd.identifier_url() reads client.baseurl unconditionally (pset name check in the Property Sets panel draw), but the test bSDDClientStub never had that attribute, so any stubbed scenario opening that panel died with AttributeError. The stub now mirrors the real bsdd.Client default.

Verified in headless Blender 5.1.2 against current v0.8.0: the two scenarios go from 2 failed (at the stale Item/IfcHalfSpaceSolid/90 lookups) to 2 passed. Regression check on the geometry and material features shows identical results before and after (all remaining failures pre-existing, the material ones are the ones #8571 addresses).

This change was made with the assistance of an AI tool.
