### PR TITLE
Bonsai: exclude status-filtered openings from boolean cuts (in-memory)

### DIFF
--- a/src/bonsai/bonsai/bim/export_ifc.py
+++ b/src/bonsai/bonsai/bim/export_ifc.py
@@ -46,6 +46,10 @@ class IfcExporter:
         IfcStore.update_cache()
         self.sync_all_objects()
         extension = self.ifc_export_settings.output_file.split(".")[-1].lower()
+        with tool.Sequence.opening_representations_restored():
+            self.write_file(extension)
+
+    def write_file(self, extension: str) -> None:
         if extension == "ifczip":
             with tempfile.TemporaryDirectory() as unzipped_path:
                 filename, ext = os.path.splitext(os.path.basename(self.ifc_export_settings.output_file))

--- a/src/bonsai/bonsai/tool/sequence.py
+++ b/src/bonsai/bonsai/tool/sequence.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
+from contextlib import contextmanager
 from datetime import datetime
 from datetime import time as datetime_time
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union, assert_never
@@ -1874,6 +1875,85 @@ class Sequence(bonsai.core.tool.Sequence):
             if not element or not element.is_a("IfcProduct"):
                 continue
             obj.hide_set(element not in visible_elements)
+
+        cls.apply_visibility_to_voids(visible_elements)
+
+    _hidden_opening_reps: dict[int, int] = {}
+    """Voiding openings hidden by the status filter: opening id -> stashed
+    IfcProductDefinitionShape id. While stashed, ``opening.Representation`` is
+    None in the in-memory model so the geometry kernel skips the boolean
+    subtraction. Restored on unhide/disable, and around IFC writes by
+    ``opening_representations_restored``."""
+
+    _hidden_opening_reps_file: Optional[ifcopenshell.file] = None
+
+    @classmethod
+    def apply_visibility_to_voids(cls, visible_elements: set[ifcopenshell.entity_instance]) -> None:
+        """Sync voiding opening representations with the status filter.
+
+        Hidden openings get their Representation temporarily set to None in the
+        in-memory model (so their boolean cut disappears from hosts and from any
+        drawing generated while the filter is active); openings visible again
+        get it restored. Affected hosts are recut."""
+        ifc_file = tool.Ifc.get()
+        if cls._hidden_opening_reps_file is not ifc_file:
+            cls._hidden_opening_reps.clear()
+        cls._hidden_opening_reps_file = ifc_file
+
+        affected_hosts: set[ifcopenshell.entity_instance] = set()
+        openings = {o.id(): o for o in ifc_file.by_type("IfcOpeningElement")}
+        for opening_id in set(cls._hidden_opening_reps) - set(openings):
+            del cls._hidden_opening_reps[opening_id]
+        for opening_id, opening in openings.items():
+            rels = opening.VoidsElements
+            if not rels:
+                continue
+            host = rels[0].RelatingBuildingElement
+            if host is None:
+                continue
+            if opening not in visible_elements:
+                if opening.Representation is not None:
+                    cls._hidden_opening_reps[opening_id] = opening.Representation.id()
+                    opening.Representation = None
+                    affected_hosts.add(host)
+            elif opening_id in cls._hidden_opening_reps:
+                opening.Representation = ifc_file.by_id(cls._hidden_opening_reps.pop(opening_id))
+                affected_hosts.add(host)
+
+        if not cls._hidden_opening_reps:
+            cls._hidden_opening_reps_file = None
+        if not affected_hosts:
+            return
+        with tool.Geometry.batch_host_recut():
+            for host in affected_hosts:
+                host_obj = tool.Ifc.get_object(host)
+                if not isinstance(host_obj, bpy.types.Object) or not host_obj.data:
+                    continue
+                representation = tool.Geometry.get_active_representation(host_obj)
+                if representation is not None:
+                    tool.Geometry.recut_host(host_obj, representation)
+
+    @classmethod
+    @contextmanager
+    def opening_representations_restored(cls) -> Generator[None, None, None]:
+        """Temporarily restore status-hidden opening representations, so IFC
+        data written to disk is unaffected by the viewport status filter."""
+        ifc_file = tool.Ifc.get()
+        restored: list[int] = []
+        if cls._hidden_opening_reps_file is ifc_file:
+            for opening_id, rep_id in cls._hidden_opening_reps.items():
+                try:
+                    opening = ifc_file.by_id(opening_id)
+                    rep = ifc_file.by_id(rep_id)
+                except RuntimeError:
+                    continue
+                opening.Representation = rep
+                restored.append(opening_id)
+        try:
+            yield
+        finally:
+            for opening_id in restored:
+                ifc_file.by_id(opening_id).Representation = None
 
     @classmethod
     def copy_work_schedule(cls, work_schedule: ifcopenshell.entity_instance) -> None:

--- a/src/bonsai/test/tool/test_sequence.py
+++ b/src/bonsai/test/tool/test_sequence.py
@@ -21,6 +21,7 @@ import os
 import bpy
 import ifcopenshell
 import ifcopenshell.api
+import ifcopenshell.api.feature
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
 
@@ -71,3 +72,64 @@ class TestAssignStatus(NewFile):
 
         bpy.ops.bim.assign_status(status="EXISTING", should_unassign_status=True)
         assert subject.get_element_status(element) == set()
+
+
+class TestApplyVisibilityToVoids(NewFile):
+    def create_wall_with_opening(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        wall = ifcopenshell.api.root.create_entity(ifc, "IfcWall")
+        opening = ifcopenshell.api.root.create_entity(ifc, "IfcOpeningElement")
+        opening.Representation = ifc.createIfcProductDefinitionShape()
+        ifcopenshell.api.feature.add_feature(ifc, feature=opening, element=wall)
+        return wall, opening
+
+    def test_hiding_a_voiding_opening_nulls_its_representation_and_restores_it(self):
+        wall, opening = self.create_wall_with_opening()
+        rep = opening.Representation
+        subject.apply_visibility_to_voids(set())
+        assert opening.Representation is None
+        subject.apply_visibility_to_voids({wall, opening})
+        assert opening.Representation == rep
+
+    def test_openings_that_void_nothing_are_untouched(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        opening = ifcopenshell.api.root.create_entity(ifc, "IfcOpeningElement")
+        rep = ifc.createIfcProductDefinitionShape()
+        opening.Representation = rep
+        subject.apply_visibility_to_voids(set())
+        assert opening.Representation == rep
+
+    def test_already_hidden_openings_are_not_restashed(self):
+        wall, opening = self.create_wall_with_opening()
+        rep = opening.Representation
+        subject.apply_visibility_to_voids(set())
+        subject.apply_visibility_to_voids(set())
+        subject.apply_visibility_to_voids({wall, opening})
+        assert opening.Representation == rep
+
+
+class TestOpeningRepresentationsRestored(NewFile):
+    def test_representations_are_restored_during_the_context_and_renulled_after(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        wall = ifcopenshell.api.root.create_entity(ifc, "IfcWall")
+        opening = ifcopenshell.api.root.create_entity(ifc, "IfcOpeningElement")
+        rep = ifc.createIfcProductDefinitionShape()
+        opening.Representation = rep
+        ifcopenshell.api.feature.add_feature(ifc, feature=opening, element=wall)
+
+        subject.apply_visibility_to_voids(set())
+        assert opening.Representation is None
+        with subject.opening_representations_restored():
+            assert opening.Representation == rep
+        assert opening.Representation is None
+
+        subject.apply_visibility_to_voids({wall, opening})
+        assert opening.Representation == rep
+
+    def test_no_stashed_representations_is_a_noop(self):
+        bpy.ops.bim.create_project()
+        with subject.opening_representations_restored():
+            pass


### PR DESCRIPTION
Fixes #7472.

The Element Statuses filter (Costing and Scheduling tab) only ever called `obj.hide_set()`, so an `IfcOpeningElement` tagged NEW voiding an EXISTING wall kept its boolean cut applied to the wall regardless of the active filter. This affected both the viewport and drawings, since drawing linework is generated from the same in-memory model (the reporter's case: a new opening appearing on both the "existing" and "new" floorplans).

This implements the approach @aothms suggested in the thread: the addon registers this view state with the geometry kernel through the in-memory IFC model itself. When the status filter hides a voiding opening, its `Representation` is temporarily set to None and affected hosts are recut (the kernel already skips openings without a representation, see `Converter.cpp`, so no kernel changes and no new settings are involved). The representation is restored, and hosts recut again, when the opening becomes visible or filters are disabled. Regenerating a drawing while a status filter is active now also excludes hidden openings' cuts.

Because the nulling is view state, `IfcExporter.export()` restores all stashed representations around the file write, so saved IFC data is always complete regardless of the active filter.

Verified live in headless Blender 4.5.8: hiding NEW recuts the host wall from 16 to 8 verts, saving mid-filter keeps the opening representation on disk while the viewport stays filtered, and re-showing or disabling filters restores the void. Tool tests added for the stash/restore lifecycle and the export guard.

Note on semantics: the filter now genuinely reflects phase state for voids, so unchecking "No Status" also suppresses voids of unstatused openings, consistent with how the filter treats the openings themselves. Known limit: the reconcile runs outside the IFC undo transaction history, so a Ctrl+Z straight after a filter toggle is reconciled on the next toggle rather than instantly.

This PR is AI-generated with human review and live testing.
