### PR TITLE
Bonsai: add a display length unit preference (#6400)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/helper.py
+++ b/src/bonsai/bonsai/bim/module/drawing/helper.py
@@ -346,7 +346,7 @@ def format_distance(
                 tx_dist += str(frac) + "/" + str(base)
             if add_inches or frac:
                 # Only add inch symbol if we actually added inch content
-                if inches > 0 or frac > 0 or feet == 0:
+                if inches > 0 or frac or feet == 0:
                     tx_dist += '"'
 
             if precision == "12" and unit_system == "IMPERIAL":

--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -50,7 +50,6 @@ from bonsai.bim.module.drawing.gizmos import (
     DOOR_SWING_ANGLE_MAX,
     DOOR_SWING_ANGLE_MIN,
 )
-from bonsai.bim.module.drawing.helper import format_distance
 
 
 def highlight_color(color, alpha=0.1):
@@ -1875,7 +1874,7 @@ class BoundingBoxDecorator(tool.Blender.ViewportDecorator):
         for axis, (screen_co, value) in screen_coords.items():
             blf.position(font_id, screen_co.x, screen_co.y, 0)
             blf.color(font_id, 1, 1, 1, 1)
-            value_str = f"D{axis.lower()}: " + format_distance(value, hide_units=False)
+            value_str = f"D{axis.lower()}: " + tool.Unit.format_distance(value, hide_units=False)
             text_length = blf.dimensions(font_id, value_str)
             self.draw_text_background(context, screen_co, text_length)
             blf.draw(font_id, value_str)
@@ -1886,7 +1885,7 @@ class BoundingBoxDecorator(tool.Blender.ViewportDecorator):
         font_id = 0
         text_dimensions = {}
         for axis, (screen_co, value) in screen_coords.items():
-            value_str = f"D{axis.lower()}: " + format_distance(value, hide_units=False)
+            value_str = f"D{axis.lower()}: " + tool.Unit.format_distance(value, hide_units=False)
             text_dimensions[axis] = blf.dimensions(font_id, value_str)
 
         min_spacing = 5

--- a/src/bonsai/bonsai/bim/module/unit/prop.py
+++ b/src/bonsai/bonsai/bim/module/unit/prop.py
@@ -65,6 +65,25 @@ class Unit(PropertyGroup):
 
 class BIMUnitProperties(PropertyGroup):
     is_editing: BoolProperty(name="Is Editing")
+    display_length_unit: EnumProperty(
+        name="Display Length Unit",
+        description=(
+            "Unit used when Bonsai displays lengths in the interface. "
+            "Purely visual, the project length unit and all stored IFC values are unchanged"
+        ),
+        items=[
+            ("PROJECT", "Project Unit", "Display lengths in the project length unit"),
+            ("MILLIMETERS", "Millimeters", "Display lengths in millimeters"),
+            ("CENTIMETERS", "Centimeters", "Display lengths in centimeters"),
+            ("DECIMETERS", "Decimeters", "Display lengths in decimeters"),
+            ("METERS", "Meters", "Display lengths in meters"),
+            ("FEET_FRACTIONAL", "Feet and Inches - Fractional", "Display lengths in feet and fractional inches"),
+            ("FEET_DECIMAL", "Feet - Decimal", "Display lengths in decimal feet"),
+            ("INCHES_FRACTIONAL", "Inches - Fractional", "Display lengths in fractional inches"),
+            ("INCHES_DECIMAL", "Inches - Decimal", "Display lengths in decimal inches"),
+        ],
+        default="PROJECT",
+    )
     units: CollectionProperty(name="Units", type=Unit)
     active_unit_index: IntProperty(name="Active Unit Index")
     active_unit_id: IntProperty(name="Active Unit Id")
@@ -75,6 +94,7 @@ class BIMUnitProperties(PropertyGroup):
 
     if TYPE_CHECKING:
         is_editing: bool
+        display_length_unit: str
         units: bpy.types.bpy_prop_collection_idprop[Unit]
         active_unit_index: int
         active_unit_id: int

--- a/src/bonsai/bonsai/bim/module/unit/ui.py
+++ b/src/bonsai/bonsai/bim/module/unit/ui.py
@@ -73,6 +73,10 @@ class BIM_PT_units(Panel):
             row = self.layout.row(align=True)
             row.label(text="Volume Unit", icon="EMPTY_ARROWS")
             row.label(text=str(UnitsData.data["volume_unit"]))
+
+            row = self.layout.row(align=True)
+            row.label(text="Display Length", icon="HIDE_OFF")
+            row.prop(self.props, "display_length_unit", text="")
             return
 
         row = self.layout.row(align=True)

--- a/src/bonsai/bonsai/tool/unit.py
+++ b/src/bonsai/bonsai/tool/unit.py
@@ -34,14 +34,30 @@ import bonsai.tool as tool
 if TYPE_CHECKING:
     from bonsai.bim.module.unit.prop import BIMUnitProperties
 
+DISPLAY_LENGTH_CUSTOM_UNITS = {
+    "MILLIMETERS": "Millimeters",
+    "CENTIMETERS": "Centimeters",
+    "DECIMETERS": "Decimeters",
+    "METERS": "Meters",
+    "FEET_FRACTIONAL": "Feet and Inches - Fractional",
+    "FEET_DECIMAL": "Feet - Decimal",
+    "INCHES_FRACTIONAL": "Inches - Fractional",
+    "INCHES_DECIMAL": "Inches - Decimal",
+}
+
 
 class Unit(bonsai.core.tool.Unit):
     UNIT_TYPE = Literal["LENGTHUNIT", "AREAUNIT", "VOLUMEUNIT", "MASSUNIT", "TIMEUNIT"]
 
-    @staticmethod
-    def format_distance(meters: float, use_imperial: bool = None, **kwargs) -> str:
+    @classmethod
+    def format_distance(cls, meters: float, use_imperial: bool = None, **kwargs) -> str:
         """
-        Format a distance value in meters to a string in the project's unit system.
+        Format a distance value in meters to a display string.
+
+        Lengths are formatted in the project's unit system unless the user
+        chose a different display length unit in the Units panel or the caller
+        passes an explicit ``custom_unit``. Display only, stored values are
+        never converted.
 
         :param meters: The distance value in meters
         :param use_imperial: If True, format as imperial; if False, format as metric; if None, auto-detect from scene
@@ -49,18 +65,20 @@ class Unit(bonsai.core.tool.Unit):
                     (hide_units, precision, decimal_places, etc.)
         :return: Formatted string with units
         """
-        # Import the comprehensive format_distance from the helper module
         from bonsai.bim.module.drawing import helper
 
-        # The comprehensive function expects value in scene units, not meters
-        # So we pass meters directly since it handles unit conversion internally
-        return helper.format_distance(
-            meters,
-            hide_units=kwargs.get("hide_units", False),
-            precision=kwargs.get("precision"),
-            decimal_places=kwargs.get("decimal_places"),
-            **kwargs,
-        )
+        kwargs.setdefault("hide_units", False)
+        if "custom_unit" not in kwargs and (custom_unit := cls.get_display_length_custom_unit()):
+            kwargs["custom_unit"] = custom_unit
+            kwargs.setdefault("suppress_zero_inches", True)
+            if custom_unit.startswith(("Feet", "Inches")) and kwargs.get("precision") is None:
+                kwargs["precision"] = tool.Blender.get_addon_preferences().doc.imperial_precision
+        return helper.format_distance(meters, **kwargs)
+
+    @classmethod
+    def get_display_length_custom_unit(cls) -> Union[str, None]:
+        """Map the display length unit preference to a format_distance custom unit, None means project unit."""
+        return DISPLAY_LENGTH_CUSTOM_UNITS.get(cls.get_unit_props().display_length_unit)
 
     @classmethod
     def parse_distance_string(cls, input_string: str, use_project_unit: bool = True) -> tuple[bool, float]:

--- a/src/bonsai/test/tool/test_unit.py
+++ b/src/bonsai/test/tool/test_unit.py
@@ -448,3 +448,55 @@ class TestSetActiveUnit(NewFile):
         subject.set_active_unit(unit)
         props = tool.Unit.get_unit_props()
         assert props.active_unit_id == unit.id()
+
+
+class TestFormatDistance(NewFile):
+    def create_project(self, ifc: ifcopenshell.file, unit: ifcopenshell.entity_instance) -> None:
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(ifc, units=[unit])
+
+    def create_millimeters_project(self) -> None:
+        tool.Ifc.set(ifc := ifcopenshell.file())
+        self.create_project(ifc, ifcopenshell.api.unit.add_si_unit(ifc, unit_type="LENGTHUNIT", prefix="MILLI"))
+
+    def test_formatting_in_the_project_unit_by_default(self):
+        self.create_millimeters_project()
+        assert subject.format_distance(2.0) == "2000 mm"
+
+    def test_display_length_unit_overrides_the_project_unit(self):
+        self.create_millimeters_project()
+        props = subject.get_unit_props()
+        props.display_length_unit = "METERS"
+        assert subject.format_distance(2.0) == "2.000 m"
+        props.display_length_unit = "CENTIMETERS"
+        assert subject.format_distance(2.0) == "200.0 cm"
+        props.display_length_unit = "FEET_FRACTIONAL"
+        assert subject.format_distance(0.3048, precision="1/32") == "1'"
+        props.display_length_unit = "FEET_DECIMAL"
+        assert subject.format_distance(0.3048) == "1.0'"
+        assert subject.format_distance(0.3048, suppress_zero_inches=False) == "1.0' - 0"
+
+    def test_an_explicit_custom_unit_wins_over_the_display_unit(self):
+        self.create_millimeters_project()
+        props = subject.get_unit_props()
+        props.display_length_unit = "METERS"
+        assert subject.format_distance(2.0, custom_unit="Millimeters") == "2000 mm"
+
+    def test_display_length_unit_on_an_imperial_project(self):
+        tool.Ifc.set(ifc := ifcopenshell.file())
+        self.create_project(ifc, ifcopenshell.api.unit.add_conversion_based_unit(ifc, name="foot"))
+        assert subject.format_distance(0.3048) == "1' - 0"
+        props = subject.get_unit_props()
+        props.display_length_unit = "MILLIMETERS"
+        assert subject.format_distance(0.3048) == "305 mm"
+
+
+class TestGetDisplayLengthCustomUnit(NewFile):
+    def test_run(self):
+        props = subject.get_unit_props()
+        assert props.display_length_unit == "PROJECT"
+        assert subject.get_display_length_custom_unit() is None
+        props.display_length_unit = "FEET_FRACTIONAL"
+        assert subject.get_display_length_custom_unit() == "Feet and Inches - Fractional"
+        props.display_length_unit = "MILLIMETERS"
+        assert subject.get_display_length_custom_unit() == "Millimeters"


### PR DESCRIPTION
Builds the display units layer RickBrice proposed in #6400: the IFC file keeps its project unit and every stored value, while the user picks what unit Bonsai displays lengths in. Complements #8795 (which warns before the destructive unit reassignment the issue was opened about).

## What it does
A new "Display Length" option in the Units panel (default "Project Unit", no behaviour change) formats lengths shown in the Bonsai UI (viewport measurement gizmos, wall/stair/roof/railing parameter labels, storey elevations, dimension component labels) in the chosen unit. Purely visual: the project unit assignment and all IfcLengthMeasures are untouched, verified live (project unit entity identical before and after toggling).

## How
`tool.Unit.format_distance` resolves the preference into the existing `custom_unit` override of the drawing helper formatter, so all wrapper call sites follow it with no other changes. Imperial display formats default to the documentation imperial precision preference. Drawing output (svgwriter and its viewport decoration) intentionally keeps project units, documents should not change with a viewer preference.

Two latent crashes on this path are fixed: the wrapper raised a duplicate keyword TypeError when callers passed hide_units/precision/decimal_places, and the helper's imperial branch compared None > 0 for decimal formats at whole feet values.

## Testing
Five new tests in test/tool/test_unit.py (project default, each override class, explicit custom_unit precedence, imperial project, crash regression). Full test/tool: 833 passed, zero new failures (6 pre-existing failures in classification/ifcgit/project reproduce identically without this change). Live verified headless: metric project renders 2.000 m / 200.0 cm / 6' - 6 3/4" / 6.562' / 78.74" as the preference changes, stored unit unchanged.

This change was written with AI assistance.
