### PR TITLE
ifc5d: annotation boundary calculator for space areas (#8570 prototype)

### DIFF
--- a/src/ifc5d/ifc5d/IFC4QtoBaseQuantitiesAnnotation.json
+++ b/src/ifc5d/ifc5d/IFC4QtoBaseQuantitiesAnnotation.json
@@ -1,0 +1,25 @@
+{
+    "name": "IFC4 Space Areas - Boundary Annotations",
+    "description": "This ruleset copies areas measured from closed boundary annotation polygons (assigned with IfcRelAssignsToProduct) onto their spaces, so legally sensitive space areas follow an explicit measurement convention instead of being derived from geometry.",
+    "calculators": {
+        "Annotation": {
+            "IfcSpace": {
+                "Qto_SpaceBaseQuantities": {
+                    "FinishCeilingHeight": null,
+                    "FinishFloorHeight": null,
+                    "GrossCeilingArea": null,
+                    "GrossFloorArea": "get_boundary_area",
+                    "GrossPerimeter": null,
+                    "GrossVolume": null,
+                    "GrossWallArea": null,
+                    "Height": null,
+                    "NetCeilingArea": null,
+                    "NetFloorArea": null,
+                    "NetPerimeter": null,
+                    "NetVolume": null,
+                    "NetWallArea": null
+                }
+            }
+        }
+    }
+}

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesAnnotation.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesAnnotation.json
@@ -1,0 +1,25 @@
+{
+    "name": "IFC4X3 Space Areas - Boundary Annotations",
+    "description": "This ruleset copies areas measured from closed boundary annotation polygons (assigned with IfcRelAssignsToProduct) onto their spaces, so legally sensitive space areas follow an explicit measurement convention instead of being derived from geometry.",
+    "calculators": {
+        "Annotation": {
+            "IfcSpace": {
+                "Qto_SpaceBaseQuantities": {
+                    "FinishCeilingHeight": null,
+                    "FinishFloorHeight": null,
+                    "GrossCeilingArea": null,
+                    "GrossFloorArea": "get_boundary_area",
+                    "GrossPerimeter": null,
+                    "GrossVolume": null,
+                    "GrossWallArea": null,
+                    "Height": null,
+                    "NetCeilingArea": null,
+                    "NetFloorArea": null,
+                    "NetPerimeter": null,
+                    "NetVolume": null,
+                    "NetWallArea": null
+                }
+            }
+        }
+    }
+}

--- a/src/ifc5d/ifc5d/qto.py
+++ b/src/ifc5d/ifc5d/qto.py
@@ -24,7 +24,9 @@ import os
 import types
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Any, Literal, NamedTuple, Union, get_args
+from typing import Any, Literal, NamedTuple, Optional, Union, get_args
+
+import numpy as np
 
 import ifcopenshell
 import ifcopenshell.api.pset
@@ -45,8 +47,10 @@ class Function(NamedTuple):
 
 RULE_SET = Literal[
     "IFC4QtoBaseQuantities",
+    "IFC4QtoBaseQuantitiesAnnotation",
     "IFC4QtoBaseQuantitiesBlender",
     "IFC4X3QtoBaseQuantities",
+    "IFC4X3QtoBaseQuantitiesAnnotation",
     "IFC4X3QtoBaseQuantitiesBlender",
 ]
 rules: dict[RULE_SET, dict[str, Any]] = {}
@@ -686,7 +690,133 @@ class Blender(QtoCalculator):
                 del results[element]
 
 
+class AnnotationBoundary(QtoCalculator):
+    """Copies areas measured from boundary annotations onto their assigned products.
+
+    Spaces are not quantified from their own geometry. Instead, the user draws
+    an IfcAnnotation polygon along the legally relevant boundary convention
+    (e.g. wall centrelines) and assigns it to the space with
+    IfcRelAssignsToProduct. This calculator measures the polygon and writes
+    the area to the assigned product, so the quantity always reflects an
+    explicit, auditable boundary rather than an automatic guess.
+    """
+
+    functions: dict[str, Function] = {
+        "get_boundary_area": Function(
+            "IfcAreaMeasure",
+            "Boundary Area",
+            "Total area of closed boundary annotation polygons assigned to the product with IfcRelAssignsToProduct",
+        ),
+    }
+
+    @classmethod
+    def calculate(
+        cls,
+        ifc_file: ifcopenshell.file,
+        elements: Iterable[ifcopenshell.entity_instance],
+        qtos: QtosFormulas,
+        results: ResultsDict,
+    ) -> None:
+        unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
+        unit_converter = SI2ProjectUnitConverter(ifc_file)
+        for element in elements:
+            area = cls.get_boundary_area(element)
+            if area is None:
+                continue
+            area = unit_converter.convert(area * unit_scale**2, "IfcAreaMeasure")
+            for name, quantities in qtos.items():
+                qto_results = {}
+                for quantity, formula in quantities.items():
+                    if not formula:
+                        continue
+                    if formula not in cls.functions:
+                        print(f"WARNING. Unexpected formula: '{formula}' ({name}.{quantity}).")
+                        continue
+                    qto_results[quantity] = area
+                if qto_results:
+                    results.setdefault(element, {}).setdefault(name, {}).update(qto_results)
+
+    @classmethod
+    def get_boundary_area(cls, element: ifcopenshell.entity_instance) -> Optional[float]:
+        """Get the total area of the element's assigned boundary annotations.
+
+        :param element: IFC product the boundary annotations are assigned to.
+        :return: ``float`` area in project units, or ``None`` if no assigned
+            annotation contains a closed boundary polygon.
+        """
+        total = 0.0
+        found = False
+        for rel in getattr(element, "ReferencedBy", None) or ():
+            for related in rel.RelatedObjects:
+                if not related.is_a("IfcAnnotation"):
+                    continue
+                representation = ifcopenshell.util.representation.get_representation(
+                    related, "Plan", "Annotation"
+                ) or ifcopenshell.util.representation.get_representation(related, "Model", "Annotation")
+                if not representation:
+                    continue
+                representation = ifcopenshell.util.representation.resolve_representation(representation)
+                if area := sum(cls.get_item_area(item) for item in representation.Items or ()):
+                    found = True
+                    total += area
+        return total if found else None
+
+    @classmethod
+    def get_item_area(cls, item: ifcopenshell.entity_instance) -> float:
+        if item.is_a("IfcMappedItem"):
+            scale = item.MappingTarget.Scale or 1.0
+            source = item.MappingSource.MappedRepresentation
+            return scale * scale * sum(cls.get_item_area(i) for i in source.Items or ())
+        if item.is_a("IfcAnnotationFillArea"):
+            area = cls.get_curve_area(item.OuterBoundary, assume_closed=True)
+            for inner in item.InnerBoundaries or ():
+                area -= cls.get_curve_area(inner, assume_closed=True)
+            return max(area, 0.0)
+        if item.is_a("IfcGeometricSet"):
+            return sum(cls.get_item_area(i) for i in item.Elements or ())
+        if item.is_a("IfcCurve"):
+            return cls.get_curve_area(item)
+        return 0.0
+
+    @classmethod
+    def get_curve_area(cls, curve: ifcopenshell.entity_instance, assume_closed: bool = False) -> float:
+        points = cls.get_curve_points(curve)
+        if points is None or len(points) < 3:
+            return 0.0
+        tolerance = 1e-6 * max(float(np.ptp(points, axis=0).max()), 1.0)
+        if float(np.linalg.norm(points[0] - points[-1])) <= tolerance:
+            points = points[:-1]
+        elif not assume_closed:
+            return 0.0
+        if len(points) < 3:
+            return 0.0
+        if points.shape[1] == 2:
+            x, y = points[:, 0], points[:, 1]
+            return float(abs(x @ np.roll(y, -1) - y @ np.roll(x, -1)) / 2)
+        cross = np.cross(points, np.roll(points, -1, axis=0))
+        return float(np.linalg.norm(cross.sum(axis=0)) / 2)
+
+    @staticmethod
+    def get_curve_points(curve: ifcopenshell.entity_instance) -> Optional[np.ndarray]:
+        if curve.is_a("IfcPolyline"):
+            return np.array([p.Coordinates for p in curve.Points], dtype=float)
+        if curve.is_a("IfcIndexedPolyCurve"):
+            coords = np.array(curve.Points.CoordList, dtype=float)
+            if not curve.Segments:
+                return coords
+            path: list[int] = []
+            for segment in curve.Segments:
+                # Arc segments are measured by their chords.
+                indices = list(segment[0])
+                if path and path[-1] == indices[0]:
+                    indices = indices[1:]
+                path.extend(indices)
+            return coords[np.array(path) - 1]
+        return None
+
+
 calculators: dict[str, type[QtoCalculator]] = {
+    "Annotation": AnnotationBoundary,
     "Blender": Blender,
     "IfcOpenShell": IfcOpenShell,
 }

--- a/src/ifc5d/test/test_qto.py
+++ b/src/ifc5d/test/test_qto.py
@@ -18,10 +18,14 @@
 
 # This file was generated with the assistance of an AI coding tool.
 
+from typing import Optional
+
 import ifcopenshell
 import ifcopenshell.api.context
+import ifcopenshell.api.drawing
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
+import ifcopenshell.util.element
 import pytest
 
 import ifc5d.qto
@@ -90,3 +94,92 @@ class TestOpeningQuantities:
         assert quantities["Depth"] == pytest.approx(0.3)
         assert quantities["Area"] == pytest.approx(0.5)
         assert quantities["Volume"] == pytest.approx(0.15)
+
+
+class TestAnnotationBoundaryQuantities:
+    """Space areas copied from boundary annotations assigned with IfcRelAssignsToProduct (#8570)."""
+
+    def setup_method(self):
+        self.setup_file()
+
+    def setup_file(self, length_prefix: Optional[str] = None):
+        f = self.file = ifcopenshell.file(schema="IFC4")
+        ifcopenshell.api.root.create_entity(f, ifc_class="IfcProject", name="Test")
+        units = [
+            f.createIfcSIUnit(None, "LENGTHUNIT", length_prefix, "METRE"),
+            f.createIfcSIUnit(None, "AREAUNIT", None, "SQUARE_METRE"),
+        ]
+        ifcopenshell.api.unit.assign_unit(f, units=units)
+        plan = ifcopenshell.api.context.add_context(f, context_type="Plan")
+        self.annotation_context = ifcopenshell.api.context.add_context(
+            f, context_type="Plan", context_identifier="Annotation", target_view="PLAN_VIEW", parent=plan
+        )
+        self.space = ifcopenshell.api.root.create_entity(f, ifc_class="IfcSpace", name="Space")
+
+    def add_boundary_annotation(self, items) -> ifcopenshell.entity_instance:
+        f = self.file
+        annotation = ifcopenshell.api.root.create_entity(f, ifc_class="IfcAnnotation")
+        rep = f.createIfcShapeRepresentation(self.annotation_context, "Annotation", "Annotation2D", items)
+        annotation.Representation = f.createIfcProductDefinitionShape(None, None, [rep])
+        ifcopenshell.api.drawing.assign_product(f, relating_product=self.space, related_object=annotation)
+        return annotation
+
+    def create_rectangle_curve(self, size_x: float, size_y: float) -> ifcopenshell.entity_instance:
+        # The closed IfcIndexedPolyCurve pattern Bonsai writes for annotations.
+        f = self.file
+        points = f.createIfcCartesianPointList2D(((0.0, 0.0), (size_x, 0.0), (size_x, size_y), (0.0, size_y)))
+        segments = [f.createIfcLineIndex((i, i % 4 + 1)) for i in range(1, 5)]
+        return f.createIfcIndexedPolyCurve(points, segments)
+
+    def quantify(self) -> ifc5d.qto.ResultsDict:
+        rules = ifc5d.qto.rules["IFC4QtoBaseQuantitiesAnnotation"]
+        return ifc5d.qto.quantify(self.file, {self.space}, rules)
+
+    def test_closed_polycurve_boundary(self):
+        f = self.file
+        curve_set = f.createIfcGeometricCurveSet([self.create_rectangle_curve(4.0, 3.0)])
+        self.add_boundary_annotation([curve_set])
+        results = self.quantify()
+        assert results[self.space]["Qto_SpaceBaseQuantities"] == {"GrossFloorArea": pytest.approx(12.0)}
+
+    def test_fill_area_with_inner_boundary(self):
+        f = self.file
+        outer = f.createIfcPolyline(
+            [f.createIfcCartesianPoint(p) for p in ((0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0), (0.0, 0.0))]
+        )
+        fill_area = f.createIfcAnnotationFillArea(outer, [self.create_rectangle_curve(2.0, 3.0)])
+        self.add_boundary_annotation([fill_area])
+        results = self.quantify()
+        assert results[self.space]["Qto_SpaceBaseQuantities"] == {"GrossFloorArea": pytest.approx(94.0)}
+
+    def test_open_polyline_is_ignored(self):
+        f = self.file
+        polyline = f.createIfcPolyline([f.createIfcCartesianPoint(p) for p in ((0.0, 0.0), (4.0, 0.0), (4.0, 3.0))])
+        self.add_boundary_annotation([f.createIfcGeometricCurveSet([polyline])])
+        assert self.quantify() == {}
+
+    def test_space_without_boundary_annotation_is_not_quantified(self):
+        assert self.quantify() == {}
+
+    def test_multiple_boundary_annotations_are_summed(self):
+        f = self.file
+        self.add_boundary_annotation([f.createIfcGeometricCurveSet([self.create_rectangle_curve(4.0, 3.0)])])
+        self.add_boundary_annotation([f.createIfcGeometricCurveSet([self.create_rectangle_curve(2.0, 1.0)])])
+        results = self.quantify()
+        assert results[self.space]["Qto_SpaceBaseQuantities"] == {"GrossFloorArea": pytest.approx(14.0)}
+
+    def test_millimetre_project_units(self):
+        self.setup_file(length_prefix="MILLI")
+        f = self.file
+        curve_set = f.createIfcGeometricCurveSet([self.create_rectangle_curve(4000.0, 3000.0)])
+        self.add_boundary_annotation([curve_set])
+        results = self.quantify()
+        # Boundary drawn in millimetres, area reported in the project's m2 unit.
+        assert results[self.space]["Qto_SpaceBaseQuantities"] == {"GrossFloorArea": pytest.approx(12.0)}
+
+    def test_quantities_are_written_to_the_file(self):
+        f = self.file
+        self.add_boundary_annotation([f.createIfcGeometricCurveSet([self.create_rectangle_curve(4.0, 3.0)])])
+        ifc5d.qto.edit_qtos(f, self.quantify())
+        qto = ifcopenshell.util.element.get_pset(self.space, "Qto_SpaceBaseQuantities")
+        assert qto["GrossFloorArea"] == pytest.approx(12.0)


### PR DESCRIPTION
Prototype of the workflow @Moult proposed in #8570. Instead of automatically deriving legally sensitive space areas from geometry (which #8578 and my earlier #8572 attempted, and which Dion flagged as unsafe because gross/net floor areas follow strict legal measurement rules), the user draws an IfcAnnotation polygon along the chosen convention (wall centreline, interior face of exterior wall, etc), assigns it to the space with IfcRelAssignsToProduct, and a new ifc5d "Annotation" calculator measures that polygon and copies the area onto the space. This mirrors the Revit "Areas" workflow Dion described.

What this adds:
- `AnnotationBoundary` calculator in `ifc5d.qto`. It understands the representations Bonsai already writes for annotations: IfcAnnotationFillArea (outer boundary minus inner boundaries), closed IfcPolyline and IfcIndexedPolyCurve items, geometric sets of those, and mapped items with uniform scale. Open curves are ignored so only deliberate closed boundaries produce a value, and a space with no assigned boundary annotation is left unquantified rather than guessed. Values are converted to the project area unit. Arcs are measured by their chords for now.
- `IFC4QtoBaseQuantitiesAnnotation` and `IFC4X3QtoBaseQuantitiesAnnotation` rulesets, mapping only `Qto_SpaceBaseQuantities.GrossFloorArea`. Bonsai's Quantity Take-off UI picks the rulesets up automatically, so the whole flow already works in Bonsai today with the existing FILL_AREA annotation type and Assign Product: verified end to end in Blender 5.2 (plan drawing, FILL_AREA annotation, assign to space, run QTO, GrossFloorArea appears on the space).
- Tests covering fill areas with holes, closed and open polylines, indexed polycurves, multiple summed boundaries, and mm-unit projects.

Open design questions I would value direction on before going further:
1. Which quantity should a boundary feed. GrossFloorArea only for now; should the convention (gross vs net, centreline vs face) be marked on the annotation itself, for example via ObjectType or a pset, so one space can carry both a gross and a net boundary?
2. Should a dedicated annotation ObjectType (for example AREA) exist in Bonsai instead of reusing FILL_AREA, possibly with a decorator showing the live measured value on the drawing?
3. Should the copied value land on the space automatically whenever the annotation changes, or stay an explicit QTO action as here?

Fixes #8570 (prototype slice).

This PR was written with the assistance of an AI coding tool.
