### PR TITLE
Bonsai: carry diameter on distribution ports and connect two ports with a segment

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/mep.py
+++ b/src/bonsai/bonsai/bim/module/model/mep.py
@@ -268,6 +268,8 @@ class MEPGenerator:
             return
 
         # adjust current segment ports and related flow segments
+        for port in ports:
+            tool.System.sync_port_size(port, segment)
         segment_data = self.get_segment_data(segment)
 
         for port_position in ("start_port", "end_port"):

--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -54,8 +54,10 @@ class DumbProfileGenerator:
         self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
 
     def generate(
-        self, insertion_type: Literal["CURSOR", "POLYLINE"] = "CURSOR"
-    ) -> Union[tuple[list[ProfileFrom2PointsReturn], bool], bpy.types.Object, None]:
+        self,
+        insertion_type: Literal["CURSOR", "POLYLINE"] = "CURSOR",
+        coords: Optional[tuple[Vector, Vector]] = None,
+    ) -> Union[tuple[list[ProfileFrom2PointsReturn], bool], ProfileFrom2PointsReturn, bpy.types.Object, None]:
         self.insertion_type = insertion_type
         self.file = tool.Ifc.get()
         self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
@@ -79,6 +81,9 @@ class DumbProfileGenerator:
         self.rotation = 0
         self.location = Vector((0, 0, 0))
         self.cardinal_point = int(props.cardinal_point)
+        if coords is not None:
+            self.insertion_type = "POLYLINE"
+            return self.create_profile_from_2_points(coords)
         if self.insertion_type == "POLYLINE":
             return self.derive_from_polyline()
         elif self.insertion_type == "CURSOR":

--- a/src/bonsai/bonsai/bim/module/system/__init__.py
+++ b/src/bonsai/bonsai/bim/module/system/__init__.py
@@ -42,6 +42,7 @@ classes = (
     operator.LoadSystems,
     operator.LoadZones,
     operator.MEPConnectElements,
+    operator.MEPConnectPorts,
     operator.RemovePort,
     operator.RemoveSystem,
     operator.RemoveZone,

--- a/src/bonsai/bonsai/bim/module/system/data.py
+++ b/src/bonsai/bonsai/bim/module/system/data.py
@@ -187,6 +187,7 @@ class PortData:
                     "FlowDirection": port.FlowDirection,
                     "port_obj_name": port_obj_name,
                     "connected_obj_name": connected_obj_name,
+                    "size_label": tool.System.get_port_size_label(port),
                 }
             )
         return data

--- a/src/bonsai/bonsai/bim/module/system/operator.py
+++ b/src/bonsai/bonsai/bim/module/system/operator.py
@@ -16,17 +16,21 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+from math import pi
 from typing import TYPE_CHECKING
 
 import bpy
 import ifcopenshell.api.attribute
 import ifcopenshell.api.system
+import ifcopenshell.util.element
 import ifcopenshell.util.system
+from mathutils import Quaternion, Vector
 
 import bonsai.bim.helper
 import bonsai.core.system as core
 import bonsai.tool as tool
 from bonsai.bim.module.system.data import PortData, SystemData
+from bonsai.tool.system import direction_from_port_pair
 
 
 class LoadSystems(bpy.types.Operator):
@@ -373,6 +377,165 @@ class MEPConnectElements(bpy.types.Operator, tool.Ifc.Operator):
         direction = closest_ports[0].FlowDirection or "NOTDEFINED"
         core.connect_port(tool.Ifc, *closest_ports, direction=direction)
         bpy.ops.bim.regenerate_distribution_element()
+        return {"FINISHED"}
+
+
+class MEPConnectPorts(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.mep_connect_ports"
+    bl_label = "Connect Ports With Segment"
+    bl_description = (
+        "Connect two selected free ports with a new flow segment.\n"
+        "A transition fitting is inserted when the joined segment profiles differ.\n"
+        "The segment type is taken from a port's flow segment, "
+        "or from the active relating type when neither port belongs to one"
+    )
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        if len(context.selected_objects) != 2:
+            cls.poll_message_set("Select two port objects")
+            return False
+        return True
+
+    @staticmethod
+    def get_profiled_segment_type(element):
+        if element is None:
+            return None
+        element_type = ifcopenshell.util.element.get_type(element)
+        if element_type and element_type.is_a("IfcFlowSegmentType"):
+            material = ifcopenshell.util.element.get_material(element_type)
+            if material and material.is_a("IfcMaterialProfileSet"):
+                return element_type
+        return None
+
+    @staticmethod
+    def profiles_match(profile1, profile2):
+        if profile1 is None or profile2 is None:
+            return True
+        if profile1 == profile2:
+            return True
+        if profile1.is_a() != profile2.is_a():
+            return False
+        if profile1.is_a("IfcCircleProfileDef"):
+            return tool.Cad.is_x(profile1.Radius, profile2.Radius)
+        if profile1.is_a("IfcRectangleProfileDef"):
+            return tool.Cad.is_x(profile1.XDim, profile2.XDim) and tool.Cad.is_x(profile1.YDim, profile2.YDim)
+        return True
+
+    def _execute(self, context):
+        # Lazy imports to avoid a circular dependency at addon load.
+        from bonsai.bim.module.model.mep import MEPGenerator
+        from bonsai.bim.module.model.profile import DumbProfileGenerator
+
+        obj1 = context.active_object
+        obj2 = next((o for o in context.selected_objects if o != obj1), None)
+        port1 = tool.Ifc.get_entity(obj1) if obj1 else None
+        port2 = tool.Ifc.get_entity(obj2) if obj2 else None
+        if not port1 or not port2 or not port1.is_a("IfcDistributionPort") or not port2.is_a("IfcDistributionPort"):
+            self.report({"ERROR"}, "Select exactly two ports (use Show Ports on MEP elements first).")
+            return {"CANCELLED"}
+        if tool.System.get_connected_port(port1) or tool.System.get_connected_port(port2):
+            self.report({"ERROR"}, "Both ports need to be free to connect them.")
+            return {"CANCELLED"}
+
+        element1 = tool.System.get_port_relating_element(port1)
+        element2 = tool.System.get_port_relating_element(port2)
+        if element1 == element2:
+            self.report({"ERROR"}, "Both ports belong to the same element.")
+            return {"CANCELLED"}
+
+        tool.Model.sync_object_ifc_position(obj1)
+        tool.Model.sync_object_ifc_position(obj2)
+        p1 = obj1.matrix_world.translation.copy()
+        p2 = obj2.matrix_world.translation.copy()
+
+        if (p2 - p1).length < 1e-5:
+            direction = direction_from_port_pair(port1, port2)
+            core.connect_port(tool.Ifc, port1=port1, port2=port2, direction=direction)
+            PortData.is_loaded = False
+            return {"FINISHED"}
+
+        relating_type = self.get_profiled_segment_type(element1)
+        if not relating_type and (relating_type := self.get_profiled_segment_type(element2)):
+            obj1, obj2 = obj2, obj1
+            port1, port2 = port2, port1
+            element1, element2 = element2, element1
+            p1, p2 = p2, p1
+        if not relating_type:
+            props = tool.Model.get_model_props()
+            if props.relating_type_id:
+                candidate = tool.Ifc.get().by_id(int(props.relating_type_id))
+                if candidate.is_a("IfcFlowSegmentType"):
+                    material = ifcopenshell.util.element.get_material(candidate)
+                    if material and material.is_a("IfcMaterialProfileSet"):
+                        relating_type = candidate
+        if not relating_type:
+            self.report(
+                {"ERROR"},
+                "No flow segment type with a profile found on either port. "
+                "Select a pipe or duct type in the Add tool first.",
+            )
+            return {"CANCELLED"}
+
+        data = DumbProfileGenerator(relating_type).generate(coords=(p1, p2))
+        if not data or not data.get("obj"):
+            self.report({"ERROR"}, "Failed to generate a connecting segment.")
+            return {"CANCELLED"}
+        segment_obj = data["obj"]
+        segment = tool.Ifc.get_entity(segment_obj)
+
+        # When the run continues a parallel segment, match its roll so a transition can be fitted.
+        element2_obj = tool.Ifc.get_object(element2)
+        direction_vec = (p2 - p1).normalized()
+        if element2 is not None and element2.is_a("IfcFlowSegment") and element2_obj:
+            element2_quat = element2_obj.matrix_world.to_quaternion()
+            element2_axis = element2_quat @ Vector((0.0, 0.0, 1.0))
+            dot = element2_axis.dot(direction_vec)
+            if abs(abs(dot) - 1) < 1e-4:
+                quat = element2_quat if dot > 0 else element2_quat @ Quaternion((1.0, 0.0, 0.0), pi)
+                matrix = quat.to_matrix().to_4x4()
+                matrix.translation = p1
+                segment_obj.matrix_world = matrix
+                bpy.context.view_layer.update()
+                tool.System.run_geometry_edit_object_placement(segment_obj)
+
+        MEPGenerator(relating_type).setup_ports(segment_obj)
+        segment_data = MEPGenerator.get_segment_data(segment)
+        start_port = segment_data.get("start_port")
+        end_port = segment_data.get("end_port")
+        if not start_port or not end_port:
+            self.report({"ERROR"}, "Generated segment is missing ports.")
+            return {"CANCELLED"}
+
+        core.connect_port(
+            tool.Ifc, port1=start_port, port2=port1, direction=direction_from_port_pair(start_port, port1)
+        )
+
+        profile1 = tool.Model.get_flow_segment_profile(segment)
+        profile2 = (
+            tool.Model.get_flow_segment_profile(element2)
+            if element2 is not None and element2.is_a("IfcFlowSegment")
+            else None
+        )
+        if profile2 is not None and not self.profiles_match(profile1, profile2) and element2_obj:
+            axes_parallel = tool.Cad.are_edges_parallel(
+                tool.Model.get_flow_segment_axis(segment_obj), tool.Model.get_flow_segment_axis(element2_obj)
+            )
+            if axes_parallel:
+                try:
+                    result = bpy.ops.bim.mep_add_transition(start_segment_id=segment.id(), end_segment_id=element2.id())
+                except RuntimeError:
+                    result = {"CANCELLED"}
+                if "FINISHED" in result:
+                    PortData.is_loaded = False
+                    return {"FINISHED"}
+            self.report(
+                {"INFO"}, "Segment profiles differ but no transition could be fitted; ports connected directly."
+            )
+
+        core.connect_port(tool.Ifc, port1=end_port, port2=port2, direction=direction_from_port_pair(end_port, port2))
+        PortData.is_loaded = False
         return {"FINISHED"}
 
 

--- a/src/bonsai/bonsai/bim/module/system/ui.py
+++ b/src/bonsai/bonsai/bim/module/system/ui.py
@@ -198,12 +198,13 @@ class BIM_PT_ports(Panel):
                 op = cols[1].operator("bim.cycle_flow_direction", text="", icon=flow_direction_icon, emboss=True)
                 op.port_id = port_data["id"]
 
+            size_suffix = f" ({port_data['size_label']})" if port_data["size_label"] else ""
             if port_data["port_obj_name"]:
                 cols[2].operator("bim.select_entity", text="", icon="RESTRICT_SELECT_OFF").ifc_id = port_data["id"]
-                cols[3].label(text=port_data["port_obj_name"])
+                cols[3].label(text=port_data["port_obj_name"] + size_suffix)
             else:
                 cols[2].label(text="", icon="HIDE_ON")
-                cols[3].label(text="Port is hidden")
+                cols[3].label(text="Port is hidden" + size_suffix)
 
             if port_data["connected_obj_name"]:
                 connected_obj = bpy.data.objects[port_data["connected_obj_name"]]
@@ -294,6 +295,14 @@ class BIM_PT_port(Panel):
         row.operator("bim.remove_port", icon="X", text="")
 
         element = tool.Ifc.get_entity(context.active_object)
+
+        size_label = tool.System.get_port_size_label(element)
+        if size_label:
+            row = layout.row(align=True)
+            row.label(text=f"Size: {size_label}", icon="DRIVER_DISTANCE")
+
+        row = layout.row(align=True)
+        row.operator("bim.mep_connect_ports", icon="TRACKING")
 
         row = layout.row(align=True)
         cols = [row.column(align=True) for i in range(10)]

--- a/src/bonsai/bonsai/tool/system.py
+++ b/src/bonsai/bonsai/tool/system.py
@@ -25,10 +25,12 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 import bpy
 import ifcopenshell.api.geometry
+import ifcopenshell.api.pset
 import ifcopenshell.api.system
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
 import ifcopenshell.util.system
+import ifcopenshell.util.unit
 from mathutils import Matrix, Vector
 
 import bonsai.bim.helper
@@ -95,6 +97,7 @@ class System(bonsai.core.tool.System):
             port.FlowDirection = "NOTDEFINED"
             port.PredefinedType = tool.System.get_port_predefined_type(mep_element)
             ifcopenshell.api.geometry.edit_object_placement(ifc_file, product=port, matrix=matrix, is_si=True)
+            cls.sync_port_size(port, mep_element)
             return port
 
         # make sure obj.dimensions and .matrix_world has valid data
@@ -146,8 +149,86 @@ class System(bonsai.core.tool.System):
         matrix.translation = bpy.context.scene.cursor.matrix.translation
 
         ifcopenshell.api.geometry.edit_object_placement(ifc_file, product=port, matrix=matrix, is_si=True)
+        cls.sync_port_size(port, element)
 
         return port
+
+    @classmethod
+    def get_port_size_properties(
+        cls, port: ifcopenshell.entity_instance, mep_element: Optional[ifcopenshell.entity_instance] = None
+    ) -> Union[tuple[str, dict[str, float]], None]:
+        """Derive the port's size pset name and properties (in project units)
+        from the relating element's material profile. Returns None when not derivable."""
+        if mep_element is None:
+            mep_element = ifcopenshell.util.system.get_port_element(port)
+        if mep_element is None:
+            return None
+        material = ifcopenshell.util.element.get_material(mep_element, should_skip_usage=True)
+        if not material or not material.is_a("IfcMaterialProfileSet") or len(material.MaterialProfiles) != 1:
+            return None
+        profile = material.MaterialProfiles[0].Profile
+        if profile is None:
+            return None
+        kind = cls.get_port_predefined_type(mep_element)
+        if kind == "PIPE" and profile.is_a("IfcCircleProfileDef"):
+            return "Pset_DistributionPortTypePipe", {"NominalDiameter": profile.Radius * 2}
+        if kind == "DUCT" and profile.is_a("IfcCircleProfileDef"):
+            return "Pset_DistributionPortTypeDuct", {"NominalWidth": profile.Radius * 2}
+        if kind == "DUCT" and profile.is_a("IfcRectangleProfileDef"):
+            return "Pset_DistributionPortTypeDuct", {"NominalWidth": profile.XDim, "NominalHeight": profile.YDim}
+        return None
+
+    @classmethod
+    def sync_port_size(
+        cls, port: ifcopenshell.entity_instance, mep_element: Optional[ifcopenshell.entity_instance] = None
+    ) -> None:
+        """Write the size derived from the relating element's profile onto the port's pset."""
+        if tool.Ifc.get_schema() == "IFC2X3":
+            # IFC2X3 distribution port psets define no size properties.
+            return
+        result = cls.get_port_size_properties(port, mep_element)
+        if not result:
+            return
+        pset_name, properties = result
+        ifc_file = tool.Ifc.get()
+        pset = ifcopenshell.util.element.get_pset(port, pset_name)
+        if pset:
+            pset = ifc_file.by_id(pset["id"])
+        else:
+            pset = ifcopenshell.api.pset.add_pset(ifc_file, product=port, name=pset_name)
+        ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties=properties)
+
+    @classmethod
+    def get_port_size_values(cls, port: ifcopenshell.entity_instance) -> dict[str, float]:
+        """Port size from its pset if set, falling back to the size derived from the profile."""
+        pset = ifcopenshell.util.element.get_pset(port, "Pset_DistributionPortTypePipe")
+        if pset and pset.get("NominalDiameter") is not None:
+            return {"NominalDiameter": pset["NominalDiameter"]}
+        pset = ifcopenshell.util.element.get_pset(port, "Pset_DistributionPortTypeDuct")
+        if pset and pset.get("NominalWidth") is not None:
+            values = {"NominalWidth": pset["NominalWidth"]}
+            if pset.get("NominalHeight") is not None:
+                values["NominalHeight"] = pset["NominalHeight"]
+            return values
+        derived = cls.get_port_size_properties(port)
+        return derived[1] if derived else {}
+
+    @classmethod
+    def get_port_size_label(cls, port: ifcopenshell.entity_instance) -> str:
+        """Human readable port size, e.g. ``⌀100 mm`` or ``200x100 mm``. Empty when unknown."""
+        values = cls.get_port_size_values(port)
+        if not values:
+            return ""
+        unit = ifcopenshell.util.unit.get_project_unit(tool.Ifc.get(), "LENGTHUNIT")
+        symbol = ifcopenshell.util.unit.get_unit_symbol(unit) if unit else ""
+        fmt = lambda v: f"{v:g}"
+        if "NominalDiameter" in values:
+            return f"⌀{fmt(values['NominalDiameter'])} {symbol}".strip()
+        width = values["NominalWidth"]
+        height = values.get("NominalHeight")
+        if height is not None:
+            return f"{fmt(width)}x{fmt(height)} {symbol}".strip()
+        return f"⌀{fmt(width)} {symbol}".strip()
 
     @classmethod
     def delete_element_objects(cls, elements: list[ifcopenshell.entity_instance]) -> None:

--- a/src/bonsai/test/tool/test_system.py
+++ b/src/bonsai/test/tool/test_system.py
@@ -23,6 +23,7 @@ import ifcopenshell
 import ifcopenshell.api
 import ifcopenshell.api.root
 import ifcopenshell.api.system
+import ifcopenshell.util.element
 import ifcopenshell.util.representation
 import ifcopenshell.util.system
 import ifcopenshell.util.unit
@@ -457,3 +458,145 @@ class TestFlowElementAndControls(NewFile):
         controls = subject.get_flow_element_controls(flow_element)
         assert set(controls) == set((flow_control, flow_control1))
         assert subject.get_flow_control_flow_element(flow_control) == flow_element
+
+
+# The port-size and port-connect tests below were generated with the assistance
+# of an AI coding tool.
+def _add_profiled_segment_type(
+    ifc: ifcopenshell.file, ifc_class: str, profile: ifcopenshell.entity_instance, name: str = "TYPE"
+) -> ifcopenshell.entity_instance:
+    """Create a flow segment type carrying a single-profile material set."""
+    import ifcopenshell.api.material
+
+    segment_type = ifcopenshell.api.root.create_entity(ifc, ifc_class=ifc_class, name=name)
+    material = ifcopenshell.api.material.add_material(ifc, name=name)
+    profile_set = ifcopenshell.api.material.add_material_set(ifc, name=name, set_type="IfcMaterialProfileSet")
+    ifcopenshell.api.material.add_profile(ifc, profile_set=profile_set, material=material, profile=profile)
+    ifcopenshell.api.material.assign_material(
+        ifc, products=[segment_type], type="IfcMaterialProfileSet", material=profile_set
+    )
+    return segment_type
+
+
+class TestPortSizeSync(NewFile):
+    def test_pipe_segment_ports_carry_nominal_diameter(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        profile = ifc.create_entity("IfcCircleProfileDef", ProfileType="AREA", ProfileName="DN100", Radius=50.0)
+        segment_type = _add_profiled_segment_type(ifc, "IfcPipeSegmentType", profile)
+        bpy.ops.bim.add_occurrence(relating_type_id=segment_type.id())
+        element = tool.Ifc.get_entity(bpy.context.active_object)
+        ports = ifcopenshell.util.system.get_ports(element)
+        assert len(ports) == 2
+        for port in ports:
+            pset = ifcopenshell.util.element.get_pset(port, "Pset_DistributionPortTypePipe")
+            assert pset and pset["NominalDiameter"] == 100.0
+            symbol = ifcopenshell.util.unit.get_unit_symbol(ifcopenshell.util.unit.get_project_unit(ifc, "LENGTHUNIT"))
+            assert subject.get_port_size_label(port) == f"⌀100 {symbol}"
+
+    def test_rectangular_duct_ports_carry_width_and_height(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        profile = ifc.create_entity("IfcRectangleProfileDef", ProfileType="AREA", XDim=200.0, YDim=100.0)
+        segment_type = _add_profiled_segment_type(ifc, "IfcDuctSegmentType", profile)
+        bpy.ops.bim.add_occurrence(relating_type_id=segment_type.id())
+        element = tool.Ifc.get_entity(bpy.context.active_object)
+        ports = ifcopenshell.util.system.get_ports(element)
+        assert len(ports) == 2
+        for port in ports:
+            pset = ifcopenshell.util.element.get_pset(port, "Pset_DistributionPortTypeDuct")
+            assert pset and pset["NominalWidth"] == 200.0 and pset["NominalHeight"] == 100.0
+            symbol = ifcopenshell.util.unit.get_unit_symbol(ifcopenshell.util.unit.get_project_unit(ifc, "LENGTHUNIT"))
+            assert subject.get_port_size_label(port) == f"200x100 {symbol}"
+
+    def test_ports_without_profile_get_no_size(self):
+        bpy.ops.bim.create_project()
+        bpy.ops.mesh.primitive_cube_add(size=1)
+        obj = bpy.data.objects["Cube"]
+        bpy.ops.bim.assign_class(ifc_class="IfcPipeSegment", predefined_type="RIGIDSEGMENT", userdefined_type="")
+        ports = subject.add_ports(obj)
+        assert len(ports) == 2
+        for port in ports:
+            assert ifcopenshell.util.element.get_pset(port, "Pset_DistributionPortTypePipe") is None
+            assert subject.get_port_size_label(port) == ""
+
+
+class TestMEPConnectPorts(NewFile):
+    def _pipe_occurrence(self, segment_type):
+        bpy.ops.bim.add_occurrence(relating_type_id=segment_type.id())
+        obj = bpy.context.active_object
+        return obj, tool.Ifc.get_entity(obj)
+
+    def _free_port_objects(self, seg_a, seg_b):
+        """Show ports and return the (end port of A, start port of B) pair with their objects."""
+        from bonsai.bim.module.model.mep import MEPGenerator
+
+        for segment in (seg_a, seg_b):
+            tool.Blender.select_and_activate_single_object(bpy.context, tool.Ifc.get_object(segment))
+            bpy.ops.bim.show_ports()
+        port_a = MEPGenerator.get_segment_data(seg_a)["end_port"]
+        port_b = MEPGenerator.get_segment_data(seg_b)["start_port"]
+        port_a_obj = tool.Ifc.get_object(port_a)
+        port_b_obj = tool.Ifc.get_object(port_b)
+        assert port_a_obj and port_b_obj
+        bpy.ops.object.select_all(action="DESELECT")
+        port_a_obj.select_set(True)
+        port_b_obj.select_set(True)
+        bpy.context.view_layer.objects.active = port_a_obj
+        return port_a, port_b
+
+    def _make_collinear_segments(self, type_a, type_b, gap_factor=1.0):
+        obj_a, seg_a = self._pipe_occurrence(type_a)
+        obj_b, seg_b = self._pipe_occurrence(type_b)
+        axis_start, axis_end = tool.Model.get_flow_segment_axis(obj_a)
+        axis_dir = (axis_end - axis_start).normalized()
+        length = (axis_end - axis_start).length
+        obj_b.matrix_world = obj_a.matrix_world.copy()
+        obj_b.matrix_world.translation = axis_end + axis_dir * length * gap_factor
+        bpy.context.view_layer.update()
+        tool.System.run_geometry_edit_object_placement(obj_b)
+        return (obj_a, seg_a), (obj_b, seg_b)
+
+    def test_connect_same_profile_ports_with_bridging_segment(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        profile = ifc.create_entity("IfcCircleProfileDef", ProfileType="AREA", ProfileName="DN100", Radius=50.0)
+        type_a = _add_profiled_segment_type(ifc, "IfcPipeSegmentType", profile, name="A")
+        (obj_a, seg_a), (obj_b, seg_b) = self._make_collinear_segments(type_a, type_a)
+        port_a, port_b = self._free_port_objects(seg_a, seg_b)
+
+        assert bpy.ops.bim.mep_connect_ports() == {"FINISHED"}
+
+        bridge_port = ifcopenshell.util.system.get_connected_port(port_a)
+        assert bridge_port
+        bridge = ifcopenshell.util.system.get_port_element(bridge_port)
+        assert bridge.is_a("IfcPipeSegment") and bridge not in (seg_a, seg_b)
+        assert ifcopenshell.util.element.get_type(bridge) == type_a
+        far_port = ifcopenshell.util.system.get_connected_port(port_b)
+        assert far_port and ifcopenshell.util.system.get_port_element(far_port) == bridge
+        assert len(ifc.by_type("IfcPipeFitting")) == 0
+        pset = ifcopenshell.util.element.get_pset(bridge_port, "Pset_DistributionPortTypePipe")
+        assert pset and pset["NominalDiameter"] == 100.0
+
+    def test_connect_differing_profiles_inserts_transition(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        profile_a = ifc.create_entity("IfcCircleProfileDef", ProfileType="AREA", ProfileName="DN100", Radius=0.05)
+        profile_b = ifc.create_entity("IfcCircleProfileDef", ProfileType="AREA", ProfileName="DN50", Radius=0.025)
+        type_a = _add_profiled_segment_type(ifc, "IfcPipeSegmentType", profile_a, name="A")
+        type_b = _add_profiled_segment_type(ifc, "IfcPipeSegmentType", profile_b, name="B")
+        (obj_a, seg_a), (obj_b, seg_b) = self._make_collinear_segments(type_a, type_b)
+        port_a, port_b = self._free_port_objects(seg_a, seg_b)
+
+        assert bpy.ops.bim.mep_connect_ports() == {"FINISHED"}
+
+        bridge_port = ifcopenshell.util.system.get_connected_port(port_a)
+        assert bridge_port
+        bridge = ifcopenshell.util.system.get_port_element(bridge_port)
+        assert bridge.is_a("IfcPipeSegment") and ifcopenshell.util.element.get_type(bridge) == type_a
+
+        fittings = ifc.by_type("IfcPipeFitting")
+        assert len(fittings) == 1
+        assert ifcopenshell.util.element.get_predefined_type(fittings[0]) == "TRANSITION"
+        far_port = ifcopenshell.util.system.get_connected_port(port_b)
+        assert far_port and ifcopenshell.util.system.get_port_element(far_port) == fittings[0]


### PR DESCRIPTION
Fixes #8085. First slice of #6521.

Bonsai already creates IfcDistributionPorts on every generated pipe/duct segment and can show them as selectable points (Show Ports, plus the Services overlay). What was missing was the size: no port ever carried a diameter, the IFC4 slots for it (Pset_DistributionPortTypePipe.NominalDiameter, Pset_DistributionPortTypeDuct.NominalWidth/NominalHeight) were never written, and the Ports UI showed no size.

This PR makes the port data complete and then uses it:

* Every port created by Bonsai (auto segment ports, manual cursor ports) now derives its size from the relating element's material profile and stores it in the standard pset. Sizes resync when segments are edited. IFC2X3 is skipped (its port psets define no size properties).
* The Ports panels show each port's size (stored value first, live profile fallback, project units) and the values remain editable through the normal pset UI, which also covers ports on equipment where no profile exists.
* New operator `bim.mep_connect_ports`: select two free ports, click connect. A flow segment is generated between the two points ("free connection in space"), both ends are connected with IfcRelConnectsPorts, and when the profiles differ on parallel runs the existing Add Transition machinery inserts the reducer automatically. The generated run is a regular typed segment, so all existing MEP editing (gizmos, regenerate, fittings) applies to it.

Scope notes: multi-bend orthogonal routing and obstacle avoidance (the rest of #6521) are intentionally out of scope here; this slice provides the port data and the direct connect they need. Fitting insertion reuses the machinery from #2181 rather than duplicating it.

Tests: 5 new tests in test/tool/test_system.py (port sizes for pipe/duct/profile-less, bridge connect, transition insertion); full model+system suites pass (594 tests, no new failures). Verified live in headless Blender: DN100 to DN50 two-click connect produces the bridge plus TRANSITION fitting with full connectivity.

This PR was generated with the assistance of an AI coding tool.
