### PR TITLE
Bonsai: orient MEP bend fittings correctly between mitred run segments

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/mep.py
+++ b/src/bonsai/bonsai/bim/module/model/mep.py
@@ -1349,7 +1349,12 @@ class MEPAddBend(bpy.types.Operator, tool.Ifc.Operator):
 
         angle, rotation_axis = get_bend_rotation()
 
-        lateral_sign = tool.Cad.sign(bend_vector[lateral_axis])
+        # The turn direction comes from the end segment's outgoing axis, not
+        # from bend_vector - mesh endpoints of mitred run segments overshoot
+        # the corner and would flip the sign read from the point offset.
+        lateral_sign = tool.Cad.sign(z_axis_end_object_local[lateral_axis] * -end_segment_sign)
+        if tool.Cad.sign(bend_vector[lateral_axis]) != lateral_sign:
+            bend_vector[lateral_axis] *= -1
         radial_offset = V(0, 0, 0)
         ref_point_radius = self.radius + profile_dim[lateral_axis]
         radial_offset[lateral_axis] = ref_point_radius * (1 - cos(angle)) * lateral_sign
@@ -1423,6 +1428,8 @@ class MEPAddBend(bpy.types.Operator, tool.Ifc.Operator):
         # Without that offset the bend's leg endpoints fall short of the
         # extended segment by ``profile_dim * tan(angle/2)`` and a visible
         # gap appears at each joint.
+        # ``near_tolerance`` admits mitred run segments whose meshes overhang
+        # the axis intersection by up to the miter apex length.
         _bend_centerline_world = compute_bend_preview_polylines(
             start_object,
             end_object,
@@ -1430,6 +1437,7 @@ class MEPAddBend(bpy.types.Operator, tool.Ifc.Operator):
             self.end_length,
             self.radius + profile_dim[lateral_axis],
             arc_resolution=24,
+            near_tolerance=profile_dim[lateral_axis] * tan(angle / 2) + 1e-4,
         )
         if _bend_centerline_world["valid"]:
             # The bend fitting covers the straight start_length leg, the arc,
@@ -1765,15 +1773,17 @@ def _is_bend_fitting(element) -> bool:
     return getattr(element_type, "PredefinedType", None) == "BEND"
 
 
-def _intersection_past_near(intersection: Vector, near: Vector, far: Vector) -> bool:
+def _intersection_past_near(intersection: Vector, near: Vector, far: Vector, tolerance: float = 0.0) -> bool:
     """True iff ``intersection`` lies past ``near`` away from ``far`` — i.e.
     on the bend-corner side of the segment. Used to reject configurations
     where the axes meet INSIDE one of the segments (the bend fitting
-    wouldn't physically fit)."""
+    wouldn't physically fit). ``tolerance`` admits a bounded overshoot of
+    ``near`` past the intersection, e.g. the apex of a mitred run segment
+    whose mesh overhangs the axis intersection."""
     base = near - far
     if base.length < 1e-6:
         return False
-    return (intersection - near).dot(base.normalized()) > 1e-6
+    return (intersection - near).dot(base.normalized()) > 1e-6 - tolerance
 
 
 def compute_bend_preview_polylines(
@@ -1783,9 +1793,14 @@ def compute_bend_preview_polylines(
     end_length: float,
     radius: float,
     arc_resolution: int = 24,
+    near_tolerance: float = 0.0,
 ):
     """Compute the centerline polylines visualising a bend between two MEP
     segments WITHOUT mutating IFC or Blender state.
+
+    ``near_tolerance`` admits segment meshes overhanging the axis
+    intersection by up to that distance (mitred run segments) without
+    flagging the intersection as inside the segment.
 
     Returns a dict with keys:
 
@@ -1819,7 +1834,7 @@ def compute_bend_preview_polylines(
         (end_far, intersection_point),
     ]
 
-    if not _intersection_past_near(intersection_point, start_near, start_far):
+    if not _intersection_past_near(intersection_point, start_near, start_far, tolerance=near_tolerance):
         return {
             "valid": False,
             "reason": "intersection_inside_start",
@@ -1828,7 +1843,7 @@ def compute_bend_preview_polylines(
             "arc": [],
             "invalid_axes": invalid_axes,
         }
-    if not _intersection_past_near(intersection_point, end_near, end_far):
+    if not _intersection_past_near(intersection_point, end_near, end_far, tolerance=near_tolerance):
         return {
             "valid": False,
             "reason": "intersection_inside_end",
@@ -1838,8 +1853,11 @@ def compute_bend_preview_polylines(
             "invalid_axes": invalid_axes,
         }
 
-    dir_into_start = start_near - intersection_point
-    dir_into_end = end_near - intersection_point
+    # Derive the leg directions from the far endpoints - the near endpoint of
+    # a mitred run segment can sit past the intersection, which would flip
+    # the direction read from it.
+    dir_into_start = start_far - intersection_point
+    dir_into_end = end_far - intersection_point
     if dir_into_start.length < 1e-6 or dir_into_end.length < 1e-6:
         return {"valid": False, "leg_a": None, "leg_b": None, "arc": []}
     dir_into_start.normalize()

--- a/src/bonsai/test/bim/module/model/test_mep_bend_preview.py
+++ b/src/bonsai/test/bim/module/model/test_mep_bend_preview.py
@@ -216,6 +216,70 @@ def test_intersection_past_near(intersection, near, far, expected):
     assert _intersection_past_near(Vector(intersection), Vector(near), Vector(far)) is expected
 
 
+def test_intersection_past_near_tolerance_admits_miter_overhang():
+    """A mitred run segment's mesh overhangs the axis intersection by up to
+    the miter apex length, putting ``near`` slightly PAST the intersection.
+    ``tolerance`` admits that bounded overshoot without opening the door to
+    genuinely in-segment intersections (issue #7030)."""
+    from mathutils import Vector
+
+    from bonsai.bim.module.model.mep import _intersection_past_near
+
+    intersection = Vector((5, 0, 0))
+    near = Vector((5.2, 0, 0))  # 0.2 overhang past the intersection
+    far = Vector((0, 0, 0))
+
+    assert _intersection_past_near(intersection, near, far) is False
+    assert _intersection_past_near(intersection, near, far, tolerance=0.25) is True
+    assert _intersection_past_near(intersection, near, far, tolerance=0.1) is False
+    # A genuinely in-segment intersection stays rejected.
+    assert _intersection_past_near(Vector((2.5, 0, 0)), near, far, tolerance=0.25) is False
+
+
+def test_compute_bend_preview_polylines_mitred_overhang_within_tolerance():
+    """Mitred L-run reproduction of issue #7030: the start segment's mesh
+    overhangs the corner by half the profile width and the end segment's
+    origin is pulled back behind it. ``near_tolerance`` must admit the
+    configuration, and the leg directions must come from the FAR endpoints
+    so the arc bulges into the actual corner instead of mirroring outward."""
+    from math import isclose
+
+    from mathutils import Vector
+
+    from bonsai import tool
+    from bonsai.bim.module.model.mep import compute_bend_preview_polylines
+
+    # Seg1 runs +X and overhangs the corner at (5,0,0) by 0.2; Seg2 runs +Y
+    # with its mitred origin pulled back to (5,-0.2,0).
+    start_obj, start_pair = _mock_obj_with_axis((0, 0, 0), (5.2, 0, 0))
+    end_obj, end_pair = _mock_obj_with_axis((5, -0.2, 0), (5, 5, 0))
+    intersection = (Vector((5, 0, 0)), Vector((5, 0, 0)))
+
+    def by_distance(p, axis):
+        return tuple(sorted(axis, key=lambda v: (v - p).length))
+
+    with _with_axis_patches(start_pair, end_pair):
+        with patch.object(tool.Cad, "intersect_edges", return_value=intersection):
+            with patch.object(tool.Cad, "closest_and_furthest_vectors", side_effect=by_distance):
+                rejected = compute_bend_preview_polylines(start_obj, end_obj, 0.5, 0.5, 0.2)
+                result = compute_bend_preview_polylines(start_obj, end_obj, 0.5, 0.5, 0.2, near_tolerance=0.21)
+
+    assert rejected["valid"] is False
+    assert rejected["reason"] == "intersection_inside_start"
+
+    assert result["valid"] is True
+    _leg_a_far, leg_a_endpoint = result["leg_a"]
+    _leg_b_far, leg_b_endpoint = result["leg_b"]
+    # tangent_offset = radius * tan(90deg / 2) = 0.2; legs are 0.5 long.
+    assert isclose(leg_a_endpoint.x, 5 - 0.7, abs_tol=1e-6)
+    assert isclose(leg_a_endpoint.y, 0.0, abs_tol=1e-6)
+    assert isclose(leg_b_endpoint.x, 5.0, abs_tol=1e-6)
+    assert isclose(leg_b_endpoint.y, 0.7, abs_tol=1e-6)
+    arc = result["arc"]
+    assert isclose((arc[0] - Vector((4.8, 0, 0))).length, 0.0, abs_tol=1e-6)
+    assert isclose((arc[-1] - Vector((5, 0.2, 0))).length, 0.0, abs_tol=1e-6)
+
+
 # ---------------------------------------------------------------------------
 # Registration probes
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #7030 (the remaining half, the backwards fitting; the crash half was already fixed in `handler.py`).

Adding a bend or fitting between two duct segments that were already joined at the corner came out mirrored, bulging away from the corner, while the same operation on two untouched segments worked.

Root cause: segments joined by `DumbProfileJoiner.join_V` (used by the polyline drawing flow and the Extend tool) get mitred meshes. The start segment's bounding box then overhangs the axis intersection by the miter apex and the end segment's origin sits behind the corner. `MEPAddBend` derived the turn direction from the offset between those mesh endpoints, so the lateral sign flipped and both `mep_bend_shape` and the fitting placement built the bend mirrored. The tessellation capture also rejected the configuration as "intersection inside segment" for the same reason.

The fix derives the turn direction from the end segment's outgoing axis, which is well defined regardless of how the meshes were cut, reconciles `bend_vector` with it, derives the tessellation leg directions from the far axis endpoints, and admits a bounded miter overhang (profile halfwidth times tan(angle/2)) in the in-segment intersection guard. Preview decorator callers keep the strict default.

Verified live in headless Blender: a mitred L run reproduces the mirrored fitting on v0.8.0 and produces a fitting identical to the untouched control after the fix, for both turn directions, both selection orders, port preconnection in every direction, and the fitting type reuse path. BDD scenario placement and dimension values are unchanged. Model module tests pass, including 2 new regression tests. CI-exact black and ruff clean on touched files.

This change was generated with the assistance of an AI coding tool.
