### PR TITLE
cost: don't leave copied cost items in the copied schedule (#8851)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/cost/copy_cost_schedule.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cost/copy_cost_schedule.py
@@ -45,5 +45,6 @@ def copy_cost_schedule(
             if isinstance(duplicated_cost_item, list):
                 # All other nested items are not connected to the cost schedule explicitly.
                 duplicated_cost_item = duplicated_cost_item[0]
+            ifcopenshell.api.control.unassign_control(file, cost_schedule, [duplicated_cost_item])
             ifcopenshell.api.control.assign_control(file, new_schedule, [duplicated_cost_item])
     return new_schedule

--- a/src/ifcopenshell-python/test/api/cost/test_copy_cost_schedule.py
+++ b/src/ifcopenshell-python/test/api/cost/test_copy_cost_schedule.py
@@ -40,6 +40,9 @@ class TestCopyCostSchedule(test.bootstrap.IFC4):
         assert len(new_cost_items) == 2
         assert len(new_cost_items.intersection(old_cost_items)) == 0
 
+        # The copies should be removed from the original schedule.
+        assert set(ifcopenshell.util.cost.get_schedule_cost_items(schedule)) == old_cost_items
+
 
 class TestCopyCostScheduleIFC2X3(test.bootstrap.IFC2X3, TestCopyCostSchedule):
     pass


### PR DESCRIPTION
Fixes #8851.

Duplicating a cost schedule assigned the copied root cost items to **both** the original and the new schedule (the same entities), so deleting them from one schedule removed them from the other.

`copy_cost_item` appends the copy to the inverse relationships of the original cost item. For a root cost item that includes the source schedule's `IfcRelAssignsToControl`, so the copy stays in the source schedule — which is the desired behaviour for the standalone `bim.copy_cost_item` operator, but not when copying a whole schedule. `copy_cost_schedule` then assigned that same item to the new schedule as well.

`IfcRelNests` already escapes this via the `nest.unassign_object`/`assign_object` pair in `copy_cost_item`; the control relationship had no such cleanup.

The fix unassigns the copy from the source schedule before assigning it to the new one — one line, leaving `copy_cost_item`'s generic inverse fallback untouched so the single-item copy operator keeps working as before.

Reproduction, before the fix:

```python
schedule = ifcopenshell.api.cost.add_cost_schedule(f, name="Original")
for i in range(3):
    root = ifcopenshell.api.cost.add_cost_item(f, cost_schedule=schedule)
    ifcopenshell.api.cost.add_cost_item(f, cost_item=root)  # Subitem.

new_schedule = ifcopenshell.api.cost.copy_cost_schedule(f, schedule)
# Original: roots=6 items=12   <- the 3 copies leaked in
# Copy:     roots=3 items=6
```

After: `Original roots=3 items=6`, and deleting the originals leaves the copy intact.

Tested in Bonsai via `bim.copy_cost_schedule` as well.

`sequence/copy_work_schedule.py`, which shares this code shape, was checked and does not have the bug — `duplicate_task` handles the assignment itself.

The regression test in `test_copy_cost_schedule.py` was verified to fail without the change. All tests under `test/api/cost`, `test/api/control` and `test/api/sequence` pass (103).

cc @myoualid

🤖 Generated with [Claude Code](https://claude.com/claude-code)