### PR TITLE
Bonsai: render text decorators for foreign-authored annotations with IfcTextLiteral

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -866,6 +866,11 @@ class DecoratorData:
                     results.append((obj, handler.decorators["HIDDEN_LINE"]))
                 else:
                     results.append((obj, handler.decorators["MISC"]))
+            elif tool.Drawing.get_text_literal(obj, return_list=True):
+                # Annotations authored outside Bonsai's own PredefinedType vocabulary (e.g.
+                # imported from ArchiCAD) still carry real IfcTextLiteral items even though
+                # they have no matching decorator key and no mesh geometry.
+                results.append((obj, handler.decorators["TEXT"]))
 
         return results
 


### PR DESCRIPTION
## Summary
- `object_decorators()` only dispatched a viewport text decorator when an `IfcAnnotation`'s `PredefinedType` matched Bonsai's own authoring vocabulary or the object had mesh data. Annotations imported from other tools (e.g. ArchiCAD) with only `IfcTextLiteralWithExtent` items matched neither, so their text silently never rendered even though the text-sourcing code already reads it generically from raw IFC attributes.
- Add a fallback that dispatches to `TextDecorator` whenever the object carries a real `IfcTextLiteral`, regardless of `PredefinedType`.

Fixes #4708

## Test plan
- [x] Live headless Blender: built a foreign-style `IfcAnnotation` (`PredefinedType="NOTDEFINED"`) with a real `IfcTextLiteralWithExtent`, confirmed it is silently dropped from `object_decorators()` pre-fix and correctly dispatched to `TextDecorator` post-fix.
- [x] Lint (black, ruff) clean.

Generated with the assistance of an AI coding tool.
