### PR TITLE
Bonsai: load projects with a nameless LENGTHUNIT instead of crashing

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/helper.py
+++ b/src/bonsai/bonsai/bim/module/drawing/helper.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import math
 
 import bpy
@@ -25,6 +26,12 @@ import mathutils.geometry
 from mathutils import Vector
 
 import bonsai.tool as tool
+
+logger = logging.getLogger(__name__)
+
+# Files whose LENGTHUNIT is missing a Name are schema-non-conformant. Warn about
+# them once per file instead of once per formatted distance (#8885).
+_warned_nameless_length_units: set[tuple[int, int]] = set()
 
 # Code taken and updated from https://blenderartists.org/t/detecting-intersection-of-bounding-boxes/457520/2
 
@@ -181,30 +188,41 @@ def format_distance(
     area_unit_symbol = " m2" if unit_system == "METRIC" else " ft2"
 
     # Get IFC Unit Settings
-    if tool.Ifc.get():
+    ifc_file = tool.Ifc.get()
+    if ifc_file:
         unit_scale = 1
-        if length_unit := ifcopenshell.util.unit.get_project_unit(tool.Ifc.get(), "LENGTHUNIT"):
-            unit_system = "METRIC" if length_unit.Name == "METRE" else "IMPERIAL"
-            unit_length = length_unit.Name.upper()
-            if hasattr(length_unit, "Prefix") and length_unit.Prefix:
-                unit_length = length_unit.Prefix + length_unit.Name
-            unit_length_mapping = {
-                "MILE": "MILES",
-                "FOOT": "FEET",
-                "INCH": "INCHES",
-                "KILOMETRE": "KILOMETERS",
-                "METRE": "METERS",
-                "DECIMETRE": "DECIMETERS",
-                "CENTIMETRE": "CENTIMETERS",
-                "MILLIMETRE": "MILLIMETERS",
-                "MICROMETRE": "MICROMETERS",
-            }
-            # Fall through for units without a dedicated formatter (e.g.
-            # HECTOMETRE) so they use the adaptive branch instead of a
-            # KeyError (#8255).
-            unit_length = unit_length_mapping.get(unit_length, unit_length)
+        if length_unit := ifcopenshell.util.unit.get_project_unit(ifc_file, "LENGTHUNIT"):
+            if length_unit.Name is None:
+                warn_key = (id(ifc_file), length_unit.id())
+                if warn_key not in _warned_nameless_length_units:
+                    _warned_nameless_length_units.add(warn_key)
+                    logger.warning(
+                        "IfcSIUnit #%d (LENGTHUNIT) has no Name, which is not schema-conformant. "
+                        "Falling back to Blender's scene unit settings for distance formatting.",
+                        length_unit.id(),
+                    )
+            else:
+                unit_system = "METRIC" if length_unit.Name == "METRE" else "IMPERIAL"
+                unit_length = length_unit.Name.upper()
+                if hasattr(length_unit, "Prefix") and length_unit.Prefix:
+                    unit_length = length_unit.Prefix + length_unit.Name
+                unit_length_mapping = {
+                    "MILE": "MILES",
+                    "FOOT": "FEET",
+                    "INCH": "INCHES",
+                    "KILOMETRE": "KILOMETERS",
+                    "METRE": "METERS",
+                    "DECIMETRE": "DECIMETERS",
+                    "CENTIMETRE": "CENTIMETERS",
+                    "MILLIMETRE": "MILLIMETERS",
+                    "MICROMETRE": "MICROMETERS",
+                }
+                # Fall through for units without a dedicated formatter (e.g.
+                # HECTOMETRE) so they use the adaptive branch instead of a
+                # KeyError (#8255).
+                unit_length = unit_length_mapping.get(unit_length, unit_length)
         # For now we only format area in IFC Units
-        if area_unit := ifcopenshell.util.unit.get_project_unit(tool.Ifc.get(), "AREAUNIT"):
+        if area_unit := ifcopenshell.util.unit.get_project_unit(ifc_file, "AREAUNIT"):
             area_unit_symbol = " " + ifcopenshell.util.unit.get_unit_symbol(area_unit)
 
     unit_fraction = True if unit_system == "IMPERIAL" else False

--- a/src/bonsai/test/bim/module/drawing/test_helper.py
+++ b/src/bonsai/test/bim/module/drawing/test_helper.py
@@ -1,0 +1,74 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import types
+
+import bpy
+import ifcopenshell
+import ifcopenshell.api.unit
+import ifcopenshell.guid
+import pytest
+
+import bonsai.tool as tool
+from bonsai.bim.module.drawing import helper
+from test.bim.bootstrap import NewFile
+
+pytestmark = pytest.mark.drawing
+
+
+@pytest.fixture(autouse=True)
+def _require_real_bpy():
+    if not isinstance(bpy, types.ModuleType) or hasattr(bpy, "_mock_name"):
+        pytest.skip("requires real Blender (bpy is mocked or absent)")
+
+
+class TestFormatDistanceNamelessLengthUnit(NewFile):
+    def test_it_does_not_crash_and_warns_once(self, caplog):
+        ifc = ifcopenshell.file(schema="IFC4")
+        ifc.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new())
+        tool.Ifc.set(ifc)
+        # A schema-non-conformant LENGTHUNIT with no Name, as produced by some
+        # third-party exporters (#8885). ifcopenshell.file permits this on
+        # creation even though IfcSIUnit.Name is not officially optional.
+        length_unit = ifc.create_entity("IfcSIUnit", UnitType="LENGTHUNIT")
+        ifcopenshell.api.unit.assign_unit(ifc, units=[length_unit])
+        helper._warned_nameless_length_units.clear()
+
+        with caplog.at_level("WARNING", logger="bonsai.bim.module.drawing.helper"):
+            result = helper.format_distance(3.0)
+            helper.format_distance(3.0)
+
+        assert isinstance(result, str)
+        warnings = [r for r in caplog.records if "IfcSIUnit" in r.message]
+        assert len(warnings) == 1, "expected exactly one warning across both calls"
+
+    def test_it_still_formats_when_length_unit_has_a_name(self, caplog):
+        ifc = ifcopenshell.file(schema="IFC4")
+        ifc.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new())
+        tool.Ifc.set(ifc)
+        length_unit = ifc.create_entity("IfcSIUnit", UnitType="LENGTHUNIT", Name="METRE")
+        ifcopenshell.api.unit.assign_unit(ifc, units=[length_unit])
+        helper._warned_nameless_length_units.clear()
+
+        with caplog.at_level("WARNING", logger="bonsai.bim.module.drawing.helper"):
+            result = helper.format_distance(3.0)
+
+        assert "3" in result
+        assert not [r for r in caplog.records if "IfcSIUnit" in r.message]

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -395,7 +395,8 @@ def get_unit_name_universal(text: str) -> Union[str, None]:
 
 def get_full_unit_name(unit: ifcopenshell.entity_instance) -> str:
     prefix = getattr(unit, "Prefix", None) or ""
-    return prefix + unit.Name.upper()
+    # unit.Name may be None for a schema-non-conformant unit; fall back to "UNKNOWN".
+    return prefix + (unit.Name.upper() if unit.Name else "UNKNOWN")
 
 
 def get_si_dimensions(name):
@@ -622,12 +623,14 @@ def get_symbol_quantity_class(symbol: Optional[str] = None) -> QUANTITY_CLASS:
 
 
 def get_unit_symbol(unit: ifcopenshell.entity_instance) -> str:
+    # unit.Name may be None for a schema-non-conformant unit; fall back to "?".
     symbol: str = ""
     if unit.is_a("IfcSIUnit"):
         symbol += prefix_symbols.get(unit.Prefix, "")
-    symbol += unit_symbols.get(unit.Name.replace("METER", "METRE"), "?")
+    name = unit.Name
+    symbol += unit_symbols.get(name.replace("METER", "METRE"), "?") if name else "?"
     if unit.is_a("IfcContextDependentUnit") and unit.UnitType == "USERDEFINED":
-        symbol = unit.Name
+        symbol = name or "?"
     return symbol
 
 
@@ -649,7 +652,13 @@ def mm_to_m(value: float) -> float:
     return value / 1000
 
 
-def convert(value: float, from_prefix: Optional[str], from_unit: str, to_prefix: Optional[str], to_unit: str) -> float:
+def convert(
+    value: float,
+    from_prefix: Optional[str],
+    from_unit: Optional[str],
+    to_prefix: Optional[str],
+    to_unit: Optional[str],
+) -> float:
     """Converts between length, area, and volume units
 
     In this case, you manually specify the names and (optionally) prefixes to
@@ -658,27 +667,30 @@ def convert(value: float, from_prefix: Optional[str], from_unit: str, to_prefix:
 
     :param value: The numeric value you want to convert
     :param from_prefix: A prefix from IfcSIPrefix. Can be None
-    :param from_unit: IfcSIUnitName or IfcConversionBasedUnit.Name
+    :param from_unit: IfcSIUnitName or IfcConversionBasedUnit.Name. Can be
+        None for a schema-non-conformant unit, in which case no scaling is
+        applied for that side of the conversion.
     :param to_prefix: A prefix from IfcSIPrefix. Can be None
-    :param to_unit: IfcSIUnitName or IfcConversionBasedUnit.Name
+    :param to_unit: IfcSIUnitName or IfcConversionBasedUnit.Name. Can be
+        None, see `from_unit`.
     :return: The converted value.
     """
-    if from_unit.lower() in si_conversions:
+    if from_unit and from_unit.lower() in si_conversions:
         value *= si_conversions[from_unit.lower()]
     elif from_prefix:
         value *= get_prefix_multiplier(from_prefix)
-        if "SQUARE" in from_unit:
+        if from_unit and "SQUARE" in from_unit:
             value *= get_prefix_multiplier(from_prefix)
-        elif "CUBIC" in from_unit:
+        elif from_unit and "CUBIC" in from_unit:
             value *= get_prefix_multiplier(from_prefix)
             value *= get_prefix_multiplier(from_prefix)
-    if to_unit.lower() in si_conversions:
+    if to_unit and to_unit.lower() in si_conversions:
         return value * (1 / si_conversions[to_unit.lower()])
     elif to_prefix:
         value *= 1 / get_prefix_multiplier(to_prefix)
-        if "SQUARE" in from_unit:
+        if from_unit and "SQUARE" in from_unit:
             value *= 1 / get_prefix_multiplier(to_prefix)
-        elif "CUBIC" in from_unit:
+        elif from_unit and "CUBIC" in from_unit:
             value *= 1 / get_prefix_multiplier(to_prefix)
             value *= 1 / get_prefix_multiplier(to_prefix)
     return value

--- a/src/ifcopenshell-python/test/util/test_unit.py
+++ b/src/ifcopenshell-python/test/util/test_unit.py
@@ -186,6 +186,50 @@ class TestConvert(test.bootstrap.IFC4):
         assert subject.convert(1, None, "SQUARE_METRE", "MILLI", "SQUARE_METRE") == 1000000
         assert subject.convert(1, None, "CUBIC_METRE", "MILLI", "CUBIC_METRE") == 1000000000
 
+    def test_a_nameless_unit_does_not_crash(self):
+        # Some third-party exporters (e.g. SolidWorks) write American unit
+        # spellings such as "METER" instead of the ISO "METRE", which is not
+        # a valid IfcSIUnitName and gets parsed as a None Name (#8885).
+        assert subject.convert(1, None, None, None, "METRE") == 1
+        assert subject.convert(1, None, "METRE", None, None) == 1
+        assert subject.convert(1, None, None, None, None) == 1
+
+
+class TestGetUnitSymbol(test.bootstrap.IFC4):
+    def test_run(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        length = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="LENGTHUNIT")
+        assert subject.get_unit_symbol(length) == "m"
+
+    def test_a_nameless_unit_falls_back_to_a_placeholder_symbol(self):
+        # A schema-non-conformant unit with no Name, as produced by some
+        # third-party exporters writing e.g. "METER" instead of the ISO
+        # "METRE" (#8885). create_entity() permits omitting Name even though
+        # it is not officially optional for IfcSIUnit.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        length = self.file.create_entity("IfcSIUnit", UnitType="LENGTHUNIT")
+        assert length.Name is None
+        assert subject.get_unit_symbol(length) == "?"
+
+    def test_a_nameless_context_dependent_unit_falls_back_to_a_placeholder_symbol(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        unit = self.file.create_entity("IfcContextDependentUnit", UnitType="USERDEFINED")
+        assert unit.Name is None
+        assert subject.get_unit_symbol(unit) == "?"
+
+
+class TestGetFullUnitName(test.bootstrap.IFC4):
+    def test_run(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        length = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="LENGTHUNIT", prefix="MILLI")
+        assert subject.get_full_unit_name(length) == "MILLIMETRE"
+
+    def test_a_nameless_unit_falls_back_to_unknown(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        length = self.file.create_entity("IfcSIUnit", UnitType="LENGTHUNIT")
+        assert length.Name is None
+        assert subject.get_full_unit_name(length) == "UNKNOWN"
+
 
 class TestCalculateUnitScale(test.bootstrap.IFC4):
     def test_prefix_and_conversion_based_units_are_considered(self):


### PR DESCRIPTION
**Root cause:** `format_distance()` in `bonsai/bim/module/drawing/helper.py` unconditionally called `length_unit.Name.upper()` after fetching the project's LENGTHUNIT. Some third-party exporters (e.g. SolidWorks/SwIFC IFC2X3) write an `IfcSIUnit` for LENGTHUNIT with `Name` unset, which `ifcopenshell` accepts on load even though it is not schema-conformant. The very first storey elevation formatted during spatial-decomposition import then raised `AttributeError: 'NoneType' object has no attribute 'upper'`, aborting the entire project load.

**Fix:** skip the IFC-unit override when `length_unit.Name` is `None` and fall back to Blender's existing scene unit settings, which is the function's behavior when no project is loaded at all. Log a warning once per (file, unit) so the malformed data stays visible without spamming per element.

**Verification:** reproduced the crash end-to-end against stock v0.8.0 with a synthetic malformed IFC2X3 file loaded through the real `bim.load_project` operator; confirmed it now loads cleanly with a single warning. Added unit tests in `test/bim/module/drawing/test_helper.py` (fail on stock v0.8.0, pass with the fix). Full `test/bim/module/drawing/` suite: 30/30 before, 32/32 after.

Fixes #8885.

This PR was written with the assistance of an AI coding tool.
