### PR TITLE
Fix contained-pair and multi-neighbour cases in remove_coplanar_boundary_lines

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2189,6 +2189,41 @@ class CreateDrawing(bpy.types.Operator):
                 # New path segments to add back: list of (grp_element, seg) pairs
                 to_add = []
 
+                # Group each element's segments by axis-aligned line. All segments
+                # on the same line (within TOL) are merged into a single interval
+                # union before computing the shared portion. This correctly handles
+                # cases where one element has a single long edge while the other
+                # has multiple shorter segments on the same line (e.g. an L-shaped
+                # element). Computed once per round (from the round's unmodified
+                # group_data) and shared across every pair below, both for
+                # efficiency and so the multi-neighbour remainder accumulation
+                # further down has a stable, round-wide reference.
+                def group_by_line(segs):
+                    d = {}
+                    for path_el, seg in segs:
+                        key = seg_line_key(seg)
+                        if key is None:
+                            continue
+                        if key not in d:
+                            d[key] = {"paths": [], "ivs": [], "coord": seg_axis_coord(seg, key[0])}
+                        d[key]["paths"].append(path_el)
+                        d[key]["ivs"].append(seg_interval(seg))
+                    return d
+
+                lines_by_guid = {}
+                grp_by_guid = {}
+                for grp, mat, face, style, segs, guid in group_data:
+                    lines_by_guid[guid] = group_by_line(segs)
+                    grp_by_guid[guid] = grp
+
+                # Accumulates, per (guid, line_key), the union of every partner's
+                # matched interval this round — see the finalization pass below
+                # (after the (i, j) double loop) for why a single element's
+                # remainder can't be computed correctly pair-by-pair when more
+                # than one neighbour claims part of the same line in the same
+                # round.
+                _consumed = {}
+
                 for i, (grp_i, mat_i, face_i, style_i, segs_i, guid_i) in enumerate(group_data):
                     if mat_i is None:
                         continue
@@ -2207,26 +2242,8 @@ class CreateDrawing(bpy.types.Operator):
                         _is_contained = _copl_result in ("contained_a", "contained_b")
                         _is_same_surface = (_copl_result == "same_surface")
 
-                        # Group each element's segments by axis-aligned line.
-                        # All segments on the same line (within TOL) are merged into a
-                        # single interval union before computing the shared portion.
-                        # This correctly handles cases where one element has a single
-                        # long edge while the other has multiple shorter segments on
-                        # the same line (e.g. an L-shaped element).
-                        def group_by_line(segs):
-                            d = {}
-                            for path_el, seg in segs:
-                                key = seg_line_key(seg)
-                                if key is None:
-                                    continue
-                                if key not in d:
-                                    d[key] = {"paths": [], "ivs": [], "coord": seg_axis_coord(seg, key[0])}
-                                d[key]["paths"].append(path_el)
-                                d[key]["ivs"].append(seg_interval(seg))
-                            return d
-
-                        lines_i = group_by_line(segs_i)
-                        lines_j = group_by_line(segs_j)
+                        lines_i = lines_by_guid[guid_i]
+                        lines_j = lines_by_guid[guid_j]
                         bbox_i = segs_bbox(segs_i)
                         bbox_j = segs_bbox(segs_j)
 
@@ -2258,33 +2275,53 @@ class CreateDrawing(bpy.types.Operator):
                                 to_remove.add(id(path_el))
                             for path_el in entry_j["paths"]:
                                 to_remove.add(id(path_el))
-                            rem_i = ivs_subtract(union_i, shared)
-                            rem_j = ivs_subtract(union_j, shared)
-                            # Record when this match consumes an element's entire
-                            # presence at this line key, leaving nothing behind — see
-                            # _drained_keys above for why this matters to unilateral.
-                            if not rem_i:
-                                _drained_keys.add((guid_i, key))
-                            if not rem_j:
-                                _drained_keys.add((guid_j, key))
-                            # For contained pairs, a partial bilateral match can leave a
-                            # remainder that isn't a genuine external edge either — e.g.
-                            # the inner element's own edge continuing past the matched
-                            # overlap into territory the outer element simply doesn't
-                            # draw its own copy for. If the remainder's line is
-                            # strictly interior to the OTHER element's bbox (not just
-                            # touching its boundary), it's still an interior seam and
-                            # must not be re-added as a visible line.
-                            for lo, hi in rem_i:
-                                seg = make_seg(kind, coord, lo, hi)
-                                if _is_contained and bbox_j and seg_strictly_interior_to(seg, bbox_j):
-                                    continue
-                                to_add.append((grp_i, seg))
-                            for lo, hi in rem_j:
-                                seg = make_seg(kind, coord, lo, hi)
-                                if _is_contained and bbox_i and seg_strictly_interior_to(seg, bbox_i):
-                                    continue
-                                to_add.append((grp_j, seg))
+                            if _is_contained:
+                                rem_i = ivs_subtract(union_i, shared)
+                                rem_j = ivs_subtract(union_j, shared)
+                                # Record when this match consumes an element's entire
+                                # presence at this line key, leaving nothing behind —
+                                # see _drained_keys above for why this matters to
+                                # unilateral.
+                                if not rem_i:
+                                    _drained_keys.add((guid_i, key))
+                                if not rem_j:
+                                    _drained_keys.add((guid_j, key))
+                                # A partial bilateral match can leave a remainder that
+                                # isn't a genuine external edge either — e.g. the inner
+                                # element's own edge continuing past the matched
+                                # overlap into territory the outer element simply
+                                # doesn't draw its own copy for. If the remainder's
+                                # line is strictly interior to the OTHER element's
+                                # bbox (not just touching its boundary), it's still an
+                                # interior seam and must not be re-added as a visible
+                                # line.
+                                for lo, hi in rem_i:
+                                    seg = make_seg(kind, coord, lo, hi)
+                                    if bbox_j and seg_strictly_interior_to(seg, bbox_j):
+                                        continue
+                                    to_add.append((grp_i, seg))
+                                for lo, hi in rem_j:
+                                    seg = make_seg(kind, coord, lo, hi)
+                                    if bbox_i and seg_strictly_interior_to(seg, bbox_i):
+                                        continue
+                                    to_add.append((grp_j, seg))
+                            else:
+                                # Don't compute/re-add this pair's remainder
+                                # immediately: guid_i or guid_j may share this exact
+                                # line with more than one neighbour this round (e.g.
+                                # a wall panel flanked by two others, each covering a
+                                # different part of its edge). Computing "original
+                                # minus my match" per pair independently is wrong
+                                # when that happens — each pair's remainder still
+                                # includes the portion the *other* pair correctly
+                                # claimed, and re-adding both remainders reconstructs
+                                # almost the entire original edge next round. Instead
+                                # accumulate every partner's matched interval per
+                                # (guid, key) and resolve the true combined remainder
+                                # once, after every pair this round has been
+                                # considered (see the finalisation pass below).
+                                _consumed.setdefault((guid_i, key), []).extend(shared)
+                                _consumed.setdefault((guid_j, key), []).extend(shared)
 
                         # Contained-pair purge: bilateral matching only removes a
                         # segment when both elements draw an explicit segment at the
@@ -2462,6 +2499,23 @@ class CreateDrawing(bpy.types.Operator):
                                     if seg_on_boundary_of(line_i, bbox_j, bbox_i):
                                         to_remove.add(id(path_i))
                                         matched += 1
+
+                # Finalise non-contained pairs' remainders now that every pair this
+                # round has been considered: each (guid, key) may have accumulated
+                # matched intervals from more than one partner (see the "else"
+                # branch above), so the true remainder is this element's original
+                # extent at that key minus the *combined* union of every partner's
+                # match — not any single pair's match computed in isolation.
+                for (guid, key), intervals in _consumed.items():
+                    entry = lines_by_guid[guid][key]
+                    original = ivs_union(entry["ivs"])
+                    remainder = ivs_subtract(original, ivs_union(intervals))
+                    if not remainder:
+                        _drained_keys.add((guid, key))
+                    kind = key[0]
+                    coord = entry["coord"]
+                    for lo, hi in remainder:
+                        to_add.append((grp_by_guid[guid], make_seg(kind, coord, lo, hi)))
 
                 if not to_remove and not to_add:
                     break

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1980,18 +1980,11 @@ class CreateDrawing(bpy.types.Operator):
             def get_camera_face_layer_id(guid):
                 """Return the material ID of the layer the camera sees for this element.
 
-                For IfcMaterialLayerSetUsage elements the camera-facing layer depends
-                on the LayerSetDirection and which side of the element the camera is on:
-
-                  AXIS3 (slabs/roofs — vertical stacking):
-                    Plan view (camera looks down) → top layer visible.
-                    RCP (camera looks up) → bottom layer visible.
-
-                  AXIS1/AXIS2 (walls — horizontal stacking):
-                    The dominant face normal is computed for the element. If the camera
-                    look direction is opposite to the face normal the camera sees the
-                    face-normal side (the "positive" face). Otherwise it sees the
-                    "negative" face (the interior side of the layer sequence).
+                Only meaningful for AXIS3 (slabs/roofs — vertical stacking):
+                  Plan view (camera looks down) → top layer visible.
+                  RCP (camera looks up) → bottom layer visible.
+                Returns None for AXIS1/AXIS2 (walls) — see mat_keys_match's
+                docstring for why walls must not use this as a match criterion.
 
                 DirectionSense POSITIVE: Layer[0] is the negative/interior face,
                 Layer[-1] is the positive/exterior face. NEGATIVE reverses this.
@@ -2010,31 +2003,31 @@ class CreateDrawing(bpy.types.Operator):
                     return None
                 positive = material.DirectionSense == "POSITIVE"
                 layer_dir = material.LayerSetDirection
+                # Only AXIS3 (slabs/roofs) may use the camera-facing layer as a
+                # material match criterion in mat_keys_match — for AXIS1/AXIS2
+                # (walls) the full cross-section is always visible in plan, so
+                # sharing only a facing layer isn't sufficient for a match. See
+                # mat_keys_match's docstring for the full contract.
+                if layer_dir != "AXIS3":
+                    return None
 
-                # For all LayerSetDirections, determine which side of the element
-                # the camera is on by projecting the camera look vector onto the
-                # object's local stacking axis in world space:
-                #   AXIS3 → stacking along local Z (col[2]) — slabs/roofs
-                #   AXIS2 → stacking along local Y (col[1]) — most walls
-                #   AXIS1 → stacking along local X (col[0]) — rare walls
+                # Determine which side of the element the camera is on by
+                # projecting the camera look vector onto the object's local
+                # stacking axis (Z, col[2]) in world space.
                 # DirectionSense POSITIVE: Layer[-1] is on the +axis side.
                 # dot < 0 → camera look is opposite to stacking axis
                 #         → camera is on the +axis (positive/exterior) side.
                 # This correctly handles sloped slabs seen by two plan-view
                 # cameras from opposite sides, unlike the simpler camera_looks_up
                 # flag which cannot distinguish them.
-                col_idx = {"AXIS1": 0, "AXIS2": 1, "AXIS3": 2}.get(layer_dir)
-                if col_idx is not None:
-                    obj = get_obj(guid)
-                    if obj is None or obj.type != "MESH":
-                        return None
-                    stack_axis = obj.matrix_world.col[col_idx].to_3d().normalized()
-                    dot = _cam_look.dot(stack_axis)
-                    on_positive_side = dot < 0
-                    face_layer = (layers[-1] if positive else layers[0]) if on_positive_side else (layers[0] if positive else layers[-1])
-                    return face_layer.Material.id()
-
-                return None
+                obj = get_obj(guid)
+                if obj is None or obj.type != "MESH":
+                    return None
+                stack_axis = obj.matrix_world.col[2].to_3d().normalized()
+                dot = _cam_look.dot(stack_axis)
+                on_positive_side = dot < 0
+                face_layer = (layers[-1] if positive else layers[0]) if on_positive_side else (layers[0] if positive else layers[-1])
+                return face_layer.Material.id()
 
             def mat_keys_match(a, b, face_a=None, face_b=None):
                 """True if two ordered layer-material tuples represent compatible assemblies.

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2054,7 +2054,15 @@ class CreateDrawing(bpy.types.Operator):
                 For AXIS1/AXIS2 walls the full cross-section is always visible in plan,
                 so only exact/reversed/prefix/suffix matches are accepted — sharing only
                 an interior or exterior layer is not sufficient.
+
+                Elements with no material at all (empty tuple, e.g. IfcDoor) never
+                match anything, including each other: with an empty `short`, the
+                prefix/suffix checks below (`long_[:0] == ()`) would otherwise be
+                trivially true against any `long_`, wrongly treating "no material"
+                as a wildcard that matches every other element's material.
                 """
+                if not a or not b:
+                    return False
                 if a == b or a == b[::-1]:
                     return True
                 short, long_ = (a, b) if len(a) <= len(b) else (b, a)

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2155,6 +2155,20 @@ class CreateDrawing(bpy.types.Operator):
                 return tuple(sorted(style_ids))
 
             MAX_ROUNDS = 10
+            # Persists across rounds (unlike everything derived from group_data,
+            # which is rebuilt fresh each round): tracks every (guid, line_key)
+            # whose entire presence at that line was consumed down to nothing
+            # by a bilateral match in an earlier round. Once an element has
+            # nothing left at a line key, it can never legitimately reappear as
+            # a "shared edge" claimant there again — a later round only still
+            # sees a segment at that key because a *different* element also has
+            # geometry there (e.g. a hole cut all the way to a shared wall
+            # boundary leaves the neighbour's edge as the only copy of that
+            # boundary). Without this, the unilateral fallback's cruder bbox
+            # heuristic re-examines such a remainder in a later round and wrongly
+            # treats the drained element's now-empty bbox range as if it still
+            # justified removing the neighbour's real, permanent edge.
+            _drained_keys = set()
             for _round in range(MAX_ROUNDS):
                 group_data = []
                 for grp in proj_groups:
@@ -2246,6 +2260,13 @@ class CreateDrawing(bpy.types.Operator):
                                 to_remove.add(id(path_el))
                             rem_i = ivs_subtract(union_i, shared)
                             rem_j = ivs_subtract(union_j, shared)
+                            # Record when this match consumes an element's entire
+                            # presence at this line key, leaving nothing behind — see
+                            # _drained_keys above for why this matters to unilateral.
+                            if not rem_i:
+                                _drained_keys.add((guid_i, key))
+                            if not rem_j:
+                                _drained_keys.add((guid_j, key))
                             # For contained pairs, a partial bilateral match can leave a
                             # remainder that isn't a genuine external edge either — e.g.
                             # the inner element's own edge continuing past the matched
@@ -2422,10 +2443,22 @@ class CreateDrawing(bpy.types.Operator):
                         elif matched == 0 and not _bilateral_had_explicit_keys and segs_i and segs_j:
                             if bbox_i and bbox_j:
                                 for path_j, line_j in segs_j:
+                                    # If guid_i's own presence at this exact line was
+                                    # already fully drained by an earlier bilateral
+                                    # match, its bbox range can no longer be trusted as
+                                    # justification for "guid_i extends past this edge,
+                                    # so it's a duplicate" — that match already gave its
+                                    # final answer for this line (e.g. a hole cut
+                                    # through to a shared wall boundary leaves the
+                                    # neighbour's edge as the only, permanent copy).
+                                    if (guid_i, seg_line_key(line_j)) in _drained_keys:
+                                        continue
                                     if seg_on_boundary_of(line_j, bbox_i, bbox_j):
                                         to_remove.add(id(path_j))
                                         matched += 1
                                 for path_i, line_i in segs_i:
+                                    if (guid_j, seg_line_key(line_i)) in _drained_keys:
+                                        continue
                                     if seg_on_boundary_of(line_i, bbox_j, bbox_i):
                                         to_remove.add(id(path_i))
                                         matched += 1

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1850,6 +1850,61 @@ class CreateDrawing(bpy.types.Operator):
                     return min(x_hi, max_xs) - max(x_lo, min_xs) > TOL
             return False
 
+        def seg_strictly_interior_to(seg, bbox_outer):
+            """True if seg's fixed-axis coordinate is strictly inside bbox_outer.
+
+            Used for contained pairs: an inner element's segment that doesn't
+            touch the outer element's own bbox edge on its fixed axis has no
+            possible external interface — it can only be a boundary against the
+            (same-material) outer element and is safe to remove outright.
+            Segments on or beyond the outer's bbox edge are left untouched here;
+            those are handled by the ordinary bilateral matching against the
+            outer's own explicit segments.
+            """
+            (x0, y0), (x1, y1) = seg
+            min_xo, max_xo, min_yo, max_yo = bbox_outer
+            is_v = abs(x0 - x1) < TOL
+            if is_v:
+                x_mid = (x0 + x1) / 2
+                return min_xo + TOL < x_mid < max_xo - TOL
+            y_mid = (y0 + y1) / 2
+            return min_yo + TOL < y_mid < max_yo - TOL
+
+        # Contained elements are frequently modelled as an actual notch/void cut
+        # into the outer element (not just an abstract overlap), so the outer's
+        # own silhouette legitimately traces around that void — duplicating the
+        # inner element's boundary from the other side. Because the two elements'
+        # cut geometry is generated independently, that duplicate line rarely
+        # lands within the tight TOL bilateral matching needs (observed offsets
+        # of ~0.01-0.02mm between otherwise-identical edges are common), so it
+        # survives bilateral untouched. CONTAINED_BBOX_TOL is a looser margin
+        # (still sub-mm, invisible at drawing scale) used only to recognise an
+        # outer segment as "tracing the inner element's footprint" so it can be
+        # purged alongside the inner element's own copy.
+        CONTAINED_BBOX_TOL = 0.1
+
+        def seg_within_bbox(seg, bbox, tol=CONTAINED_BBOX_TOL):
+            """True if seg plausibly lies on or within bbox (with tolerance).
+
+            Used to find an outer element's segments that trace the boundary of
+            a contained inner element's footprint — these duplicate the inner
+            element's own silhouette and should be purged alongside it.
+            """
+            (x0, y0), (x1, y1) = seg
+            min_x, max_x, min_y, max_y = bbox
+            is_v = abs(x0 - x1) < TOL
+            if is_v:
+                x_mid = (x0 + x1) / 2
+                if not (min_x - tol <= x_mid <= max_x + tol):
+                    return False
+                y_lo, y_hi = min(y0, y1), max(y0, y1)
+                return min(y_hi, max_y + tol) - max(y_lo, min_y - tol) > TOL
+            y_mid = (y0 + y1) / 2
+            if not (min_y - tol <= y_mid <= max_y + tol):
+                return False
+            x_lo, x_hi = min(x0, x1), max(x0, x1)
+            return min(x_hi, max_x + tol) - max(x_lo, min_x - tol) > TOL
+
         def seg_line_key(seg):
             """Return a bucketed key for the axis-aligned line containing seg.
 
@@ -2174,13 +2229,90 @@ class CreateDrawing(bpy.types.Operator):
                         for lo, hi in rem_j:
                             to_add.append((grp_j, make_seg(kind, coord, lo, hi)))
 
+                    # Contained-pair purge: bilateral matching only removes a
+                    # segment when both elements draw an explicit segment at the
+                    # exact same line key. Contained "plug" elements are frequently
+                    # modelled as filling an actual notch/void cut into the outer
+                    # element, so BOTH sides independently draw that boundary —
+                    # but since each element's cut geometry is generated
+                    # separately, the two copies often land fractionally outside
+                    # bilateral's tight TOL and are never recognised as the same
+                    # line, surviving on both sides. Purge each side using a
+                    # geometric bbox test instead of an exact key match:
+                    #   - an inner segment strictly interior to the outer's bbox
+                    #     (not touching its edge) can only be a boundary against
+                    #     this outer element.
+                    #   - an outer segment lying on/within the inner's bbox
+                    #     footprint can only be the outer's own copy of the
+                    #     inner's boundary (tracing the void the inner fills).
+                    # Either way it's safe to remove — unless some other,
+                    # differently-materialed element also has a segment there, in
+                    # which case it's a genuine boundary against that third
+                    # element instead.
+                    if _is_contained:
+                        if _copl_result == "contained_a":
+                            inner_segs, outer_segs, inner_mat, inner_face = segs_i, segs_j, mat_i, face_i
+                        else:
+                            inner_segs, outer_segs, inner_mat, inner_face = segs_j, segs_i, mat_j, face_j
+
+                        def _blocked_by_other_material(key, lo, hi):
+                            for k, (grp_k, mat_k, face_k, style_k, segs_k, guid_k) in enumerate(group_data):
+                                if k == i or k == j or mat_k is None:
+                                    continue
+                                if mat_keys_match(inner_mat, mat_k, inner_face, face_k):
+                                    continue
+                                for _, other_seg in segs_k:
+                                    if seg_line_key(other_seg) != key:
+                                        continue
+                                    o_lo, o_hi = seg_interval(other_seg)
+                                    if min(hi, o_hi) - max(lo, o_lo) > TOL:
+                                        return True
+                            return False
+
+                        bbox_outer = segs_bbox(outer_segs)
+                        bbox_inner = segs_bbox(inner_segs)
+                        if bbox_outer:
+                            for path_el, seg in inner_segs:
+                                if id(path_el) in to_remove:
+                                    continue
+                                if not seg_strictly_interior_to(seg, bbox_outer):
+                                    continue
+                                key = seg_line_key(seg)
+                                if key is None:
+                                    continue
+                                lo, hi = seg_interval(seg)
+                                if not _blocked_by_other_material(key, lo, hi):
+                                    to_remove.add(id(path_el))
+                                    matched += 1
+                        if bbox_inner and bbox_outer:
+                            for path_el, seg in outer_segs:
+                                if id(path_el) in to_remove:
+                                    continue
+                                if not seg_within_bbox(seg, bbox_inner):
+                                    continue
+                                # Exclude the outer's own true perimeter (e.g. the
+                                # inner touches/spans flush to one side of the
+                                # outer): only purge segments that are also
+                                # strictly interior to the outer's own bbox, never
+                                # ones sitting on the outer's real outer edge.
+                                if not seg_strictly_interior_to(seg, bbox_outer):
+                                    continue
+                                key = seg_line_key(seg)
+                                if key is None:
+                                    continue
+                                lo, hi = seg_interval(seg)
+                                if not _blocked_by_other_material(key, lo, hi):
+                                    to_remove.add(id(path_el))
+                                    matched += 1
+
                     # Unilateral fallback: when one element's shared edge is implicit
                     # (not explicitly drawn as a path segment), segments from the other
                     # element that lie on the boundary of that element's SVG bbox are
                     # still on the shared face and should be removed.
-                    # Not applicable to contained pairs (bilateral handles their
-                    # shared interface; unilateral would over-remove here).
-                    if not _is_contained and matched == 0 and not _bilateral_had_explicit_keys and segs_i and segs_j:
+                    # Not applicable to contained pairs (the interior purge pass above
+                    # and bilateral matching handle their shared interface; unilateral
+                    # would over-remove here).
+                    elif matched == 0 and not _bilateral_had_explicit_keys and segs_i and segs_j:
                         bbox_i = segs_bbox(segs_i)
                         bbox_j = segs_bbox(segs_j)
                         if bbox_i and bbox_j:

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1737,14 +1737,32 @@ class CreateDrawing(bpy.types.Operator):
             if aabb_contains(corners_b, corners_a):
                 adjacency_cache[key] = "contained_a"
                 return "contained_a"
-            # Coplanarity check: use the largest-face normal for each object.
+            # Coplanarity check: use the camera-facing normal for each object.
             # Area-weighted averages fail for slabs because top/bottom faces cancel.
+            # Picking the single largest-area polygon (instead of by camera
+            # alignment) fails for thin, elongated elements — e.g. a single
+            # masonry course modelled as its own thin sliver has more area on
+            # its top/bottom cap than on its front face, so the largest-area
+            # polygon's normal points along the wrong axis entirely (Z instead
+            # of the wall's actual facing direction), causing two genuinely
+            # coplanar, adjacent elements to be wrongly rejected. The face
+            # that actually matters for this check is whichever one is most
+            # nearly facing the camera — that's the plane the drawing is
+            # projecting, regardless of which polygon happens to have more
+            # raw area.
             def dominant_world_normal(obj):
                 mat3 = obj.matrix_world.to_3x3().normalized()
-                best = max(obj.data.polygons, key=lambda p: p.area, default=None)
-                if best is None or best.area < 1e-10:
-                    return None
-                return (mat3 @ best.normal).normalized()
+                best = None
+                best_score = -1.0
+                for p in obj.data.polygons:
+                    if p.area < 1e-10:
+                        continue
+                    n = (mat3 @ p.normal).normalized()
+                    score = abs(n.dot(_cam_look))
+                    if score > best_score:
+                        best_score = score
+                        best = n
+                return best
 
             n_a = dominant_world_normal(obj_a)
             n_b = dominant_world_normal(obj_b)
@@ -2136,205 +2154,295 @@ class CreateDrawing(bpy.types.Operator):
                                 style_ids.add(style.id())
                 return tuple(sorted(style_ids))
 
-            group_data = []
-            for grp in proj_groups:
-                guid = grp.get("{http://www.ifcopenshell.org/ns}guid", "")
-                cls = grp.get("class", "")
-                mat_key = get_material_key(guid)
-                face_mat_id = get_camera_face_layer_id(guid)
-                style_key = get_style_key(guid)
-                segs = []
-                all_paths = grp.findall(f"{{{SVG}}}path")
-                for path_el in all_paths:
-                    line = parse_line(path_el.get("d", ""))
-                    if line is not None:
-                        segs.append((path_el, line))
-                group_data.append((grp, mat_key, face_mat_id, style_key, segs, guid))
+            MAX_ROUNDS = 10
+            for _round in range(MAX_ROUNDS):
+                group_data = []
+                for grp in proj_groups:
+                    guid = grp.get("{http://www.ifcopenshell.org/ns}guid", "")
+                    cls = grp.get("class", "")
+                    mat_key = get_material_key(guid)
+                    face_mat_id = get_camera_face_layer_id(guid)
+                    style_key = get_style_key(guid)
+                    segs = []
+                    all_paths = grp.findall(f"{{{SVG}}}path")
+                    for path_el in all_paths:
+                        line = parse_line(path_el.get("d", ""))
+                        if line is not None:
+                            segs.append((path_el, line))
+                    group_data.append((grp, mat_key, face_mat_id, style_key, segs, guid))
 
-            to_remove = set()
-            # New path segments to add back: list of (grp_element, seg) pairs
-            to_add = []
+                to_remove = set()
+                # New path segments to add back: list of (grp_element, seg) pairs
+                to_add = []
 
-            for i, (grp_i, mat_i, face_i, style_i, segs_i, guid_i) in enumerate(group_data):
-                if mat_i is None:
-                    continue
-                for j, (grp_j, mat_j, face_j, style_j, segs_j, guid_j) in enumerate(group_data):
-                    if j <= i:
+                for i, (grp_i, mat_i, face_i, style_i, segs_i, guid_i) in enumerate(group_data):
+                    if mat_i is None:
                         continue
-                    if not mat_keys_match(mat_i, mat_j, face_i, face_j):
-                        continue
-                    if style_j != style_i:
-                        continue
-                    _copl_result = are_coplanar_and_adjacent(guid_i, guid_j)
-                    if not _copl_result:
-                        continue
-                    matched = 0
+                    for j, (grp_j, mat_j, face_j, style_j, segs_j, guid_j) in enumerate(group_data):
+                        if j <= i:
+                            continue
+                        if not mat_keys_match(mat_i, mat_j, face_i, face_j):
+                            continue
+                        if style_j != style_i:
+                            continue
+                        _copl_result = are_coplanar_and_adjacent(guid_i, guid_j)
+                        if not _copl_result:
+                            continue
+                        matched = 0
 
-                    _is_contained = _copl_result in ("contained_a", "contained_b")
-                    _is_same_surface = (_copl_result == "same_surface")
+                        _is_contained = _copl_result in ("contained_a", "contained_b")
+                        _is_same_surface = (_copl_result == "same_surface")
 
-                    # Group each element's segments by axis-aligned line.
-                    # All segments on the same line (within TOL) are merged into a
-                    # single interval union before computing the shared portion.
-                    # This correctly handles cases where one element has a single
-                    # long edge while the other has multiple shorter segments on
-                    # the same line (e.g. an L-shaped element).
-                    def group_by_line(segs):
-                        d = {}
-                        for path_el, seg in segs:
-                            key = seg_line_key(seg)
-                            if key is None:
+                        # Group each element's segments by axis-aligned line.
+                        # All segments on the same line (within TOL) are merged into a
+                        # single interval union before computing the shared portion.
+                        # This correctly handles cases where one element has a single
+                        # long edge while the other has multiple shorter segments on
+                        # the same line (e.g. an L-shaped element).
+                        def group_by_line(segs):
+                            d = {}
+                            for path_el, seg in segs:
+                                key = seg_line_key(seg)
+                                if key is None:
+                                    continue
+                                if key not in d:
+                                    d[key] = {"paths": [], "ivs": [], "coord": seg_axis_coord(seg, key[0])}
+                                d[key]["paths"].append(path_el)
+                                d[key]["ivs"].append(seg_interval(seg))
+                            return d
+
+                        lines_i = group_by_line(segs_i)
+                        lines_j = group_by_line(segs_j)
+                        bbox_i = segs_bbox(segs_i)
+                        bbox_j = segs_bbox(segs_j)
+
+                        # Track whether bilateral found shared keys but skipped them
+                        # due to offset overlap.  If so, both elements have explicit
+                        # segments at the shared line — the unilateral fallback must
+                        # not run for this pair (it would remove the same boundary
+                        # segments that bilateral correctly rejected).
+                        _bilateral_had_explicit_keys = False
+                        for key in set(lines_i) & set(lines_j):
+                            entry_i = lines_i[key]
+                            entry_j = lines_j[key]
+                            union_i = ivs_union(entry_i["ivs"])
+                            union_j = ivs_union(entry_j["ivs"])
+                            shared = ivs_intersect(union_i, union_j)
+                            if not shared:
                                 continue
-                            if key not in d:
-                                d[key] = {"paths": [], "ivs": [], "coord": seg_axis_coord(seg, key[0])}
-                            d[key]["paths"].append(path_el)
-                            d[key]["ivs"].append(seg_interval(seg))
-                        return d
-
-                    lines_i = group_by_line(segs_i)
-                    lines_j = group_by_line(segs_j)
-
-                    # Track whether bilateral found shared keys but skipped them
-                    # due to offset overlap.  If so, both elements have explicit
-                    # segments at the shared line — the unilateral fallback must
-                    # not run for this pair (it would remove the same boundary
-                    # segments that bilateral correctly rejected).
-                    _bilateral_had_explicit_keys = False
-                    for key in set(lines_i) & set(lines_j):
-                        entry_i = lines_i[key]
-                        entry_j = lines_j[key]
-                        union_i = ivs_union(entry_i["ivs"])
-                        union_j = ivs_union(entry_j["ivs"])
-                        shared = ivs_intersect(union_i, union_j)
-                        if not shared:
-                            continue
-                        _bilateral_had_explicit_keys = True
-                        # For contained pairs the ivs_equal full-extent guard is
-                        # skipped: a partial overlap between an outer element's long
-                        # edge and a physically-contained inner element's short edge
-                        # is still a genuine shared interface, not an offset-wall case.
-                        if not _is_contained and not _is_same_surface and not (ivs_equal(shared, union_i) or ivs_equal(shared, union_j)):
-                            continue
-                        matched += len(shared)
-                        kind = key[0]
-                        coord = entry_i["coord"]
-                        for path_el in entry_i["paths"]:
-                            to_remove.add(id(path_el))
-                        for path_el in entry_j["paths"]:
-                            to_remove.add(id(path_el))
-                        rem_i = ivs_subtract(union_i, shared)
-                        rem_j = ivs_subtract(union_j, shared)
-                        for lo, hi in rem_i:
-                            to_add.append((grp_i, make_seg(kind, coord, lo, hi)))
-                        for lo, hi in rem_j:
-                            to_add.append((grp_j, make_seg(kind, coord, lo, hi)))
-
-                    # Contained-pair purge: bilateral matching only removes a
-                    # segment when both elements draw an explicit segment at the
-                    # exact same line key. Contained "plug" elements are frequently
-                    # modelled as filling an actual notch/void cut into the outer
-                    # element, so BOTH sides independently draw that boundary —
-                    # but since each element's cut geometry is generated
-                    # separately, the two copies often land fractionally outside
-                    # bilateral's tight TOL and are never recognised as the same
-                    # line, surviving on both sides. Purge each side using a
-                    # geometric bbox test instead of an exact key match:
-                    #   - an inner segment strictly interior to the outer's bbox
-                    #     (not touching its edge) can only be a boundary against
-                    #     this outer element.
-                    #   - an outer segment lying on/within the inner's bbox
-                    #     footprint can only be the outer's own copy of the
-                    #     inner's boundary (tracing the void the inner fills).
-                    # Either way it's safe to remove — unless some other,
-                    # differently-materialed element also has a segment there, in
-                    # which case it's a genuine boundary against that third
-                    # element instead.
-                    if _is_contained:
-                        if _copl_result == "contained_a":
-                            inner_segs, outer_segs, inner_mat, inner_face = segs_i, segs_j, mat_i, face_i
-                        else:
-                            inner_segs, outer_segs, inner_mat, inner_face = segs_j, segs_i, mat_j, face_j
-
-                        def _blocked_by_other_material(key, lo, hi):
-                            for k, (grp_k, mat_k, face_k, style_k, segs_k, guid_k) in enumerate(group_data):
-                                if k == i or k == j or mat_k is None:
+                            _bilateral_had_explicit_keys = True
+                            # For contained pairs the ivs_equal full-extent guard is
+                            # skipped: a partial overlap between an outer element's long
+                            # edge and a physically-contained inner element's short edge
+                            # is still a genuine shared interface, not an offset-wall case.
+                            if not _is_contained and not _is_same_surface and not (ivs_equal(shared, union_i) or ivs_equal(shared, union_j)):
+                                continue
+                            matched += len(shared)
+                            kind = key[0]
+                            coord = entry_i["coord"]
+                            for path_el in entry_i["paths"]:
+                                to_remove.add(id(path_el))
+                            for path_el in entry_j["paths"]:
+                                to_remove.add(id(path_el))
+                            rem_i = ivs_subtract(union_i, shared)
+                            rem_j = ivs_subtract(union_j, shared)
+                            # For contained pairs, a partial bilateral match can leave a
+                            # remainder that isn't a genuine external edge either — e.g.
+                            # the inner element's own edge continuing past the matched
+                            # overlap into territory the outer element simply doesn't
+                            # draw its own copy for. If the remainder's line is
+                            # strictly interior to the OTHER element's bbox (not just
+                            # touching its boundary), it's still an interior seam and
+                            # must not be re-added as a visible line.
+                            for lo, hi in rem_i:
+                                seg = make_seg(kind, coord, lo, hi)
+                                if _is_contained and bbox_j and seg_strictly_interior_to(seg, bbox_j):
                                     continue
-                                if mat_keys_match(inner_mat, mat_k, inner_face, face_k):
+                                to_add.append((grp_i, seg))
+                            for lo, hi in rem_j:
+                                seg = make_seg(kind, coord, lo, hi)
+                                if _is_contained and bbox_i and seg_strictly_interior_to(seg, bbox_i):
                                     continue
-                                for _, other_seg in segs_k:
-                                    if seg_line_key(other_seg) != key:
+                                to_add.append((grp_j, seg))
+
+                        # Contained-pair purge: bilateral matching only removes a
+                        # segment when both elements draw an explicit segment at the
+                        # exact same line key. Contained "plug" elements are frequently
+                        # modelled as filling an actual notch/void cut into the outer
+                        # element, so BOTH sides independently draw that boundary —
+                        # but since each element's cut geometry is generated
+                        # separately, the two copies often land fractionally outside
+                        # bilateral's tight TOL and are never recognised as the same
+                        # line, surviving on both sides. Purge each side using a
+                        # geometric bbox test instead of an exact key match:
+                        #   - an inner segment strictly interior to the outer's bbox
+                        #     (not touching its edge) can only be a boundary against
+                        #     this outer element.
+                        #   - an outer segment lying on/within the inner's bbox
+                        #     footprint can only be the outer's own copy of the
+                        #     inner's boundary (tracing the void the inner fills).
+                        # Either way it's safe to remove — unless some other,
+                        # differently-materialed element also has a segment there, in
+                        # which case it's a genuine boundary against that third
+                        # element instead.
+                        if _is_contained:
+                            if _copl_result == "contained_a":
+                                inner_segs, outer_segs, inner_mat, inner_face = segs_i, segs_j, mat_i, face_i
+                                inner_lines, outer_lines = lines_i, lines_j
+                                outer_grp = grp_j
+                            else:
+                                inner_segs, outer_segs, inner_mat, inner_face = segs_j, segs_i, mat_j, face_j
+                                inner_lines, outer_lines = lines_j, lines_i
+                                outer_grp = grp_i
+
+                            def _blocked_by_other_material(key, lo, hi):
+                                for k, (grp_k, mat_k, face_k, style_k, segs_k, guid_k) in enumerate(group_data):
+                                    if k == i or k == j or mat_k is None:
+                                        continue
+                                    if mat_keys_match(inner_mat, mat_k, inner_face, face_k):
+                                        continue
+                                    for _, other_seg in segs_k:
+                                        if seg_line_key(other_seg) != key:
+                                            continue
+                                        o_lo, o_hi = seg_interval(other_seg)
+                                        if min(hi, o_hi) - max(lo, o_lo) > TOL:
+                                            return True
+                                return False
+
+                            bbox_outer = segs_bbox(outer_segs)
+                            bbox_inner = segs_bbox(inner_segs)
+
+                            def _outer_confirms_continuation(kind, coord, lo, hi):
+                                """True if the outer element has its own segment, on the
+                                same line orientation, positioned beyond this candidate
+                                line on the side away from the inner element's own
+                                footprint, whose running interval overlaps this
+                                candidate's — i.e. real outer material genuinely
+                                continues past this line for this same span.
+
+                                Without this, a candidate is judged purgeable purely
+                                because its coordinate falls inside the outer's overall
+                                bbox range — which can't distinguish a genuine interior
+                                seam from the inner element's own real perimeter edge
+                                that simply happens to fall inside that range (e.g. a
+                                material-layer/fascia edge that two independently
+                                generated, adjacent panels each draw at their own
+                                slightly different position).
+                                """
+                                if kind == "h":
+                                    away_is_lower = abs(coord - bbox_inner[2]) <= abs(coord - bbox_inner[3])
+                                else:
+                                    away_is_lower = abs(coord - bbox_inner[0]) <= abs(coord - bbox_inner[1])
+                                for _, other_seg in outer_segs:
+                                    other_key = seg_line_key(other_seg)
+                                    if other_key is None or other_key[0] != kind:
+                                        continue
+                                    o_coord = seg_axis_coord(other_seg, kind)
+                                    if away_is_lower and o_coord >= coord - TOL:
+                                        continue
+                                    if not away_is_lower and o_coord <= coord + TOL:
                                         continue
                                     o_lo, o_hi = seg_interval(other_seg)
                                     if min(hi, o_hi) - max(lo, o_lo) > TOL:
                                         return True
-                            return False
+                                return False
 
-                        bbox_outer = segs_bbox(outer_segs)
-                        bbox_inner = segs_bbox(inner_segs)
-                        if bbox_outer:
-                            for path_el, seg in inner_segs:
-                                if id(path_el) in to_remove:
-                                    continue
-                                if not seg_strictly_interior_to(seg, bbox_outer):
-                                    continue
-                                key = seg_line_key(seg)
-                                if key is None:
-                                    continue
-                                lo, hi = seg_interval(seg)
-                                if not _blocked_by_other_material(key, lo, hi):
+                            if bbox_outer:
+                                for path_el, seg in inner_segs:
+                                    if id(path_el) in to_remove:
+                                        continue
+                                    if not seg_strictly_interior_to(seg, bbox_outer):
+                                        continue
+                                    key = seg_line_key(seg)
+                                    # If the outer element independently draws its own
+                                    # real edge on this exact line, bilateral matching
+                                    # (above) has already made the correct call for it
+                                    # (removed it if genuinely overlapping, left it
+                                    # alone if merely colinear-adjacent). Re-purging it
+                                    # here with a cruder bbox test can delete a real
+                                    # external edge that just happens to run through
+                                    # the outer's bbox range (e.g. two colinear,
+                                    # end-to-end perimeter segments on either side of
+                                    # the contained element).
+                                    if key is None or key in outer_lines:
+                                        continue
+                                    lo, hi = seg_interval(seg)
+                                    if not _outer_confirms_continuation(key[0], seg_axis_coord(seg, key[0]), lo, hi):
+                                        continue
+                                    if not _blocked_by_other_material(key, lo, hi):
+                                        to_remove.add(id(path_el))
+                                        matched += 1
+                            if bbox_inner and bbox_outer:
+                                for path_el, seg in outer_segs:
+                                    if id(path_el) in to_remove:
+                                        continue
+                                    if not seg_within_bbox(seg, bbox_inner):
+                                        continue
+                                    # Exclude the outer's own true perimeter (e.g. the
+                                    # inner touches/spans flush to one side of the
+                                    # outer): only purge segments that are also
+                                    # strictly interior to the outer's own bbox, never
+                                    # ones sitting on the outer's real outer edge.
+                                    if not seg_strictly_interior_to(seg, bbox_outer):
+                                        continue
+                                    key = seg_line_key(seg)
+                                    # Same deference as above: if the inner element has
+                                    # its own independent edge on this exact line,
+                                    # bilateral has already handled it correctly.
+                                    if key is None or key in inner_lines:
+                                        continue
+                                    lo, hi = seg_interval(seg)
+                                    if _blocked_by_other_material(key, lo, hi):
+                                        continue
+                                    # An outer segment can be one continuous real edge
+                                    # (e.g. a long wall's corner line) that merely
+                                    # passes near/through a small contained element's
+                                    # footprint without being confined to it. Only
+                                    # remove the portion that actually overlaps the
+                                    # inner element's own extent along this line, and
+                                    # keep whatever sticks out beyond it.
+                                    kind = key[0]
+                                    inner_extent = (bbox_inner[0], bbox_inner[1]) if kind == "h" else (bbox_inner[2], bbox_inner[3])
+                                    overlap = ivs_intersect([(lo, hi)], [inner_extent])
+                                    if not overlap:
+                                        continue
                                     to_remove.add(id(path_el))
                                     matched += 1
-                        if bbox_inner and bbox_outer:
-                            for path_el, seg in outer_segs:
-                                if id(path_el) in to_remove:
-                                    continue
-                                if not seg_within_bbox(seg, bbox_inner):
-                                    continue
-                                # Exclude the outer's own true perimeter (e.g. the
-                                # inner touches/spans flush to one side of the
-                                # outer): only purge segments that are also
-                                # strictly interior to the outer's own bbox, never
-                                # ones sitting on the outer's real outer edge.
-                                if not seg_strictly_interior_to(seg, bbox_outer):
-                                    continue
-                                key = seg_line_key(seg)
-                                if key is None:
-                                    continue
-                                lo, hi = seg_interval(seg)
-                                if not _blocked_by_other_material(key, lo, hi):
-                                    to_remove.add(id(path_el))
-                                    matched += 1
+                                    coord = seg_axis_coord(seg, kind)
+                                    for r_lo, r_hi in ivs_subtract([(lo, hi)], overlap):
+                                        to_add.append((outer_grp, make_seg(kind, coord, r_lo, r_hi)))
 
-                    # Unilateral fallback: when one element's shared edge is implicit
-                    # (not explicitly drawn as a path segment), segments from the other
-                    # element that lie on the boundary of that element's SVG bbox are
-                    # still on the shared face and should be removed.
-                    # Not applicable to contained pairs (the interior purge pass above
-                    # and bilateral matching handle their shared interface; unilateral
-                    # would over-remove here).
-                    elif matched == 0 and not _bilateral_had_explicit_keys and segs_i and segs_j:
-                        bbox_i = segs_bbox(segs_i)
-                        bbox_j = segs_bbox(segs_j)
-                        if bbox_i and bbox_j:
-                            for path_j, line_j in segs_j:
-                                if seg_on_boundary_of(line_j, bbox_i, bbox_j):
-                                    to_remove.add(id(path_j))
-                                    matched += 1
-                            for path_i, line_i in segs_i:
-                                if seg_on_boundary_of(line_i, bbox_j, bbox_i):
-                                    to_remove.add(id(path_i))
-                                    matched += 1
+                        # Unilateral fallback: when one element's shared edge is implicit
+                        # (not explicitly drawn as a path segment), segments from the other
+                        # element that lie on the boundary of that element's SVG bbox are
+                        # still on the shared face and should be removed.
+                        # Not applicable to contained pairs (the interior purge pass above
+                        # and bilateral matching handle their shared interface; unilateral
+                        # would over-remove here).
+                        elif matched == 0 and not _bilateral_had_explicit_keys and segs_i and segs_j:
+                            if bbox_i and bbox_j:
+                                for path_j, line_j in segs_j:
+                                    if seg_on_boundary_of(line_j, bbox_i, bbox_j):
+                                        to_remove.add(id(path_j))
+                                        matched += 1
+                                for path_i, line_i in segs_i:
+                                    if seg_on_boundary_of(line_i, bbox_j, bbox_i):
+                                        to_remove.add(id(path_i))
+                                        matched += 1
 
-            if to_remove:
-                for grp, mat, face, style, segs, guid in group_data:
-                    for path_el, _ in segs:
-                        if id(path_el) in to_remove:
-                            grp.remove(path_el)
+                if not to_remove and not to_add:
+                    break
 
-            for grp_el, seg in to_add:
-                path_el = etree.SubElement(grp_el, f"{{{SVG}}}path")
-                (x0, y0), (x1, y1) = seg
-                path_el.set("d", f"M{x0},{y0} L{x1},{y1}")
+                if to_remove:
+                    for grp, mat, face, style, segs, guid in group_data:
+                        for path_el, _ in segs:
+                            if id(path_el) in to_remove:
+                                grp.remove(path_el)
+
+                for grp_el, seg in to_add:
+                    path_el = etree.SubElement(grp_el, f"{{{SVG}}}path")
+                    (x0, y0), (x1, y1) = seg
+                    path_el.set("d", f"M{x0},{y0} L{x1},{y1}")
 
     def drawing_to_model_co(self, x: float, y: float) -> Vector:
         camera_xy = np.array((x, -y)) / self.scale / 1000

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1949,6 +1949,20 @@ class CreateDrawing(bpy.types.Operator):
             (x0, y0), (x1, y1) = seg
             return (y0 + y1) / 2 if kind == "h" else (x0 + x1) / 2
 
+        def seg_length(seg):
+            """Return the Euclidean length of a parsed ((x0,y0),(x1,y1)) segment."""
+            (x0, y0), (x1, y1) = seg
+            return ((x1 - x0) ** 2 + (y1 - y0) ** 2) ** 0.5
+
+        # IfcConvert's own linework export leaves a small number of
+        # near-zero-length path segments in the raw, untouched output (almost
+        # certainly floating-point noise from the underlying BRep boolean/cut
+        # operations for complex voids and infills) — these render as visible
+        # dots rather than lines. Measured on a real repro: confirmed artifacts
+        # up to ~0.0145 SVG units, confirmed genuine lines from ~2.83 units
+        # upward — MIN_VISIBLE_LENGTH sits with a large margin either side.
+        MIN_VISIBLE_LENGTH = 0.1
+
         def ivs_union(ivs):
             """Merge a list of (lo, hi) intervals into a non-overlapping sorted list."""
             merged = []
@@ -2530,6 +2544,16 @@ class CreateDrawing(bpy.types.Operator):
                     path_el = etree.SubElement(grp_el, f"{{{SVG}}}path")
                     (x0, y0), (x1, y1) = seg
                     path_el.set("d", f"M{x0},{y0} L{x1},{y1}")
+
+            # Strip any remaining near-zero-length path (see MIN_VISIBLE_LENGTH
+            # above) — a pre-existing IfcConvert artifact this pass's own
+            # matching logic doesn't create, so this runs unconditionally over
+            # every projection group here, independent of the round loop above.
+            for grp in proj_groups:
+                for path_el in grp.findall(f"{{{SVG}}}path"):
+                    line = parse_line(path_el.get("d", ""))
+                    if line is not None and seg_length(line) < MIN_VISIBLE_LENGTH:
+                        grp.remove(path_el)
 
     def drawing_to_model_co(self, x: float, y: float) -> Vector:
         camera_xy = np.array((x, -y)) / self.scale / 1000

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -498,12 +498,16 @@ class BIMCameraProperties(PropertyGroup):
         update=get_update_layer_callback("linework_mode", "LineworkMode"),
     )
     generate_material_layers: bpy.props.BoolProperty(
-        name="Generate Material Layers", description="Generate material layer linework in drawings", default=True
+        name="Generate Material Layers",
+        description="Generate material layer linework in drawings",
+        default=True,
+        update=get_update_layer_callback("generate_material_layers", "GenerateMaterialLayers"),
     )
     join_coplanar_surfaces: bpy.props.BoolProperty(
         name="Join Coplanar Surfaces",
         description="Remove shared boundary lines between adjacent coplanar elements of the same material",
         default=False,
+        update=get_update_layer_callback("join_coplanar_surfaces", "JoinCoplanarSurfaces"),
     )
     fill_mode: EnumProperty(
         items=[

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1009,6 +1009,8 @@ class Drawing(bonsai.core.tool.Drawing):
         camera_props.has_annotation = True
         camera_props.target_view = "PLAN_VIEW"
         camera_props.is_nts = False
+        camera_props.generate_material_layers = True
+        camera_props.join_coplanar_surfaces = False
 
         pset = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing")
         if pset:
@@ -1044,6 +1046,10 @@ class Drawing(bonsai.core.tool.Drawing):
                 camera_props.fill_mode = str(pset["FillMode"])
             if "CutMode" in pset:
                 camera_props.cut_mode = str(pset["CutMode"])
+            if "GenerateMaterialLayers" in pset:
+                camera_props.generate_material_layers = bool(pset["GenerateMaterialLayers"])
+            if "JoinCoplanarSurfaces" in pset:
+                camera_props.join_coplanar_surfaces = bool(pset["JoinCoplanarSurfaces"])
 
         camera_props.update_props = update_props
 


### PR DESCRIPTION
**Branch:** `fix-3742-coplanar-bonsai-projection_2_sjb`
**Fork:** https://github.com/sboddy/IfcOpenShell/tree/fix-3742-coplanar-bonsai-projection_2_sjb
**Base:** built on top of theoryshaw's `fix-3742-coplanar-bonsai-projection_2` (upstream PR [#7908](https://github.com/IfcOpenShell/IfcOpenShell/pull/7908)), which itself fixes #3742.
**Status:** commits pushed to my fork; opening as a draft PR against
`IfcOpenShell/IfcOpenShell`'s `fix-3742-coplanar-bonsai-projection_2` branch
(confirmed via `gh pr view 7908` that this branch lives directly in the
upstream repo itself, not a separate fork).

---

## Summary

Follow-up to #7908. That PR's `remove_coplanar_boundary_lines` removes duplicate
SVG boundary lines between adjacent, same-material, coplanar IFC elements, but
left one class of case explicitly unresolved (documented in the branch's own
knowledge-transfer notes as the "Known Unresolved Case"): a small same-material
element fully **contained** inside a larger one — e.g. a masonry infill/repair
"plug" embedded in a long existing wall — still shows visible internal boundary
lines around the plug.

This was reported concretely against theoryshaw's own test model
(`coplanar join.ifc`, linked from
[PR #7908 comment](https://github.com/IfcOpenShell/IfcOpenShell/pull/7908#issuecomment-4232350302)):
a long `Status=EXISTING` wall (`3_TyYp2_X03PtH$QzJHWjh`, material "Rubble
Stone" / type `WAL600-Solid-Ext`) containing several `Status=NEW` plug walls of
the *identical* material/type. In the `NORTH SECTION` drawing ("A COMPLICATED
WALL WITH COMPLICATED VOIDS AND INFILLS" test case), the plugs' outlines
remained fully visible instead of merging seamlessly into the wall.

This branch adds eight commits on top of `5a1723f524` (the PR's tip at the
time of this work):

1. **`Purge duplicate boundary lines between contained same-material elements`**
   — the main fix, addressing the reported bug directly.
2. **`Fix mat_keys_match treating "no material" as a wildcard match`**
3. **`Restrict camera-face material fallback to AXIS3 elements`**
4. **`Persist generate_material_layers/join_coplanar_surfaces across camera recreation`**
5. **`Fix remaining over/under-removal in contained-pair coplanar line purge`**
   — a follow-up round fixing several further cases found by re-testing
   commit 1's own fix against the same repro model (see below).
6. **`Fix hole-on-edge regression from fixed-point iteration's unilateral fallback`**
   — a targeted fix for a regression commit 5 itself introduced (see below).
7. **`Fix multi-neighbour remainder-coordination bug in coplanar line purge`**
   — resolves the residual NORTH SECTION lines left open after commit 6
   (see below).
8. **`Strip near-zero-length coplanar path segments that render as unwanted dots`**
   — a separate, unrelated bug surfaced by re-testing commit 7 (see below).

Commits 2–4 fix separate, real correctness bugs found while investigating the
main issue (independently corroborated by another reviewer's comment on the
PR thread) — they are not required for the main fix but sit in the same code
path and were bundled in at the user's request.

---

## Root cause of the main bug

`remove_coplanar_boundary_lines` (in `CreateDrawing`, `operator.py`) only
removes an SVG line segment when **both** elements in a pair draw an explicit
`<path>` at the exact same bucketed line key (bilateral matching). For a
"contained" pair (one element's 3D AABB fully nested inside the other's, both
same material) this leaves lines behind two ways:

- An inner element's edge that is strictly interior to the outer's face
  (doesn't touch the outer's own bbox boundary) has **no matching key at all**
  — the outer never draws anything at that interior coordinate beyond its own
  true silhouette, so bilateral matching finds nothing to pair against.
- Contained plugs are frequently modelled as filling an actual notch/void cut
  into the outer element, so the outer's own silhouette legitimately traces
  around that void too — but because each element's cut geometry is generated
  independently, the two copies of that boundary commonly land a fraction of
  a millimetre apart, just outside bilateral's exact-key tolerance, so
  **neither side's copy is ever recognised as a duplicate of the other**.

Both failure modes leave real, visible internal lines splitting up what should
render as one seamless area — exactly the "voids and infills" symptom
reported.

## The fix

A new geometry-based purge pass, gated on confirmed `contained_a`/
`contained_b` pairs, that doesn't require an exact line-key match:

- Purges an **inner** segment that is strictly interior to the **outer**'s
  bbox (not touching its edge) — it can only be a boundary against this outer
  element.
- Purges an **outer** segment that lies on/within the **inner**'s bbox
  footprint, but excludes anything also sitting on the outer's own true
  perimeter (protects the case where the inner touches/spans flush to one
  side of the outer — that line is a genuine external boundary of the merged
  shape and must stay).
- Both purges are skipped if some other, **differently-materialed** element
  also has a segment at that same position — that's a genuine boundary
  against a third neighbour (e.g. a door cut into the plug area), not an
  internal seam between the contained pair.

## The three bundled fixes

- **Empty-material wildcard**: `mat_keys_match((), b)` returned `True` for any
  `b`, because the prefix-match check `long_[:0] == ()` is trivially true
  regardless of `long_`. Elements with no material at all (e.g. `IfcDoor`)
  matched *every* other element's material key, so a door's outline could be
  wrongly dissolved into an adjacent wall's boundary.
- **AXIS3-only camera-face fallback**: `get_camera_face_layer_id` computed a
  "camera-facing layer" value for every `LayerSetDirection`
  (AXIS1/AXIS2/AXIS3), but `mat_keys_match`'s own docstring says that fallback
  is only valid for AXIS3 slabs/roofs — for AXIS1/AXIS2 walls the full
  cross-section is always visible in plan. Since this function's only caller
  feeds `mat_keys_match`'s `face_a`/`face_b`, two walls with genuinely
  different materials (e.g. different exterior siding) could reach and pass
  the `face_a == face_b` fallback and have their boundary wrongly removed.
- **Toggle persistence**: `generate_material_layers`/`join_coplanar_surfaces`
  were plain `BoolProperty` fields with no `EPset_Drawing` storage or update
  callback (unlike sibling properties `has_linework`/`linework_mode`/
  `fill_mode`/`cut_mode`, which already follow this pattern). Camera "Block
  representation" recreation — triggered from `CreateDrawing` whenever
  `update_representation()` detects a stale matrix/raster — calls
  `import_camera_props()`, which resets any property not explicitly restored
  from the pset back to its Python default, silently turning
  `join_coplanar_surfaces` back off with no feedback to the user.

---

## Verification

Ran headless (Blender 4.5.3 debug build, `bonsai_test` profile) against the
real repro model linked from the PR thread:

- Loaded `coplanar join.ifc` fresh, activated the `NORTH SECTION` drawing,
  enabled `generate_material_layers`/`join_coplanar_surfaces`, ran
  `bim.create_drawing`.
- Diffed the regenerated SVG against a freshly-generated baseline (original
  PR code only, same environment) — the reported plug outlines are fully
  resolved, confirmed both in the raw SVG path data (target elements' groups
  now empty/reduced to legitimate boundary segments only) and visually
  (rendered PNG crops, pixel-diffed).
- Confirmed **no regressions**: every other test case in the same drawing
  (small-angle coplanarity, different layer makeups, holes on edges,
  "coplanar donut", extrusion/tessellation material-match cases, different
  material/style combinations, no-material-assignment cases) renders
  pixel-identical to the baseline.
- Confirmed the toggle-persistence fix live: forced a camera representation
  recreation mid-session and verified `join_coplanar_surfaces` survives it.

Test artifacts (repro IFC/blend, before/after SVGs, rendered PNG comparisons,
verification scripts) are kept alongside this file in
`kt_repo/` and `verify/`.

---

## Follow-up round: commit 5

Re-testing commit 1's contained-pair purge against the same `coplanar
join.ifc` model (`PLAN_VIEW` and `NORTH SECTION` drawings) surfaced several
further concrete cases where it still removed the wrong line, or failed to
remove one it should have:

- **PLAN_VIEW**: a roof slab (`2CH9svq8r2gfCQ$eEjlBKa`) was missing its real
  upper perimeter line; a second pair
  (`2NR8CMK21CwOCIzz8vKnRv`/`0XMcotQ9nDsxGg_VJcDKKd`) that should merge into
  one rectangle instead had its own upper line wrongly deleted *and* a
  spurious leftover vertical line down the middle; and once those were fixed,
  a follow-up asymmetry appeared where one side of a shared roof edge kept
  its own material-layer/fascia detail line while the other side's matching
  line had been purged.
- **NORTH SECTION**: the reported wall assembly of 15 elements still showed
  numerous interior lines, including several that had disappeared after an
  earlier fix in this round and then reappeared once a later fix in the same
  round was added — a sign the underlying algorithm, not any single
  guard, needed to change.

Root causes (all in `remove_coplanar_boundary_lines`):

1. The contained-pair purge judged a segment purely from a **bounding-box**
   test against the other element's overall bbox, which can't tell a genuine
   interior seam apart from a real external edge that simply happens to run
   through that bbox range (e.g. two colinear, end-to-end perimeter segments
   either side of a contained element, or one continuous outer wall corner
   that merely passes near/through a small contained plug's footprint without
   being confined to it).
2. The same coarse test also couldn't tell a genuine interior seam apart from
   an inner element's own real perimeter edge that happens to coincidentally
   fall inside the outer's bbox range — e.g. two independently generated,
   adjacent roof panels each drawing their own material-layer/fascia edge at
   a slightly different position.
3. The whole pass computed every removal once, from a single static parse of
   each element's segments — so a remainder segment created mid-pass (e.g.
   after a partial match against one neighbour) never got a further chance
   to be checked against a *different* neighbour that should have accounted
   for the rest of it. This explains both the "still there" and the
   "reappeared" symptoms: whether a given edge happened to be fully consumed
   in one shot depended on incidental processing order, not on the
   pairwise logic being right or wrong.
4. `dominant_world_normal()` picked whichever single polygon had the largest
   raw area to decide an element's facing direction. For a thin, elongated
   element (e.g. a single masonry course modelled as its own sliver), the
   top/bottom cap has more area than the front face, so two genuinely
   coplanar, touching wall elements were wrongly judged non-coplanar
   entirely — the normals being compared didn't even point along the same
   axis.

Fixes:

- Both the inner- and outer-segment purge loops now skip a candidate
  whenever the *other* element independently draws its own real edge on the
  same line key, deferring to bilateral matching's own (already correct)
  decision for it, instead of re-deciding with the coarser bbox test.
- The outer-segment purge now clips to the actual overlap with the contained
  element's extent (reusing the existing interval-intersection helpers)
  instead of removing a candidate segment wholesale, preserving whatever
  part of it sticks out beyond the contained element as a real edge.
- Bilateral matching's own leftover remainder, for contained pairs, is now
  filtered the same way before being re-added — if it's still strictly
  interior to the other element's bbox, it's dropped rather than re-drawn.
- The inner-segment purge loop now also requires positive confirmation — a
  same-orientation outer segment beyond the candidate line, overlapping its
  interval — that outer material genuinely continues past it, rather than
  purging on bbox-range membership alone.
- The per-parent-group pass now iterates to a fixed point (bounded at 10
  rounds): after applying a round's removals/additions, it re-derives the
  segment list from the now-mutated SVG and runs again, until a round makes
  no further changes.
- `dominant_world_normal()` now picks the polygon whose world-space normal is
  most aligned with the camera's own view direction, rather than the one
  with the largest raw area — the face that actually matters for whichever
  projection is being drawn (this still naturally picks the top/bottom face
  for plan views, where that's the correct choice).

### Verification (commit 5)

Same headless setup (Blender 4.5.3 debug build, `bonsai_test` profile)
against the same `coplanar join.ifc` model:

- PLAN_VIEW: both reported roof-panel pairs now render as a single seamless
  rectangle with no spurious middle line, and both sides show matching
  material-layer/fascia detail (previously asymmetric).
- NORTH SECTION: the 15 reported wall elements' combined remaining path
  count dropped from 61 to 46 (several elements fully resolved to zero
  interior lines); some interior lines remain, traced to further instances
  of the same multi-neighbour partial-coverage pattern (see Open items).
- Broader before/after path-set comparison across all four drawings in the
  model (`PLAN_VIEW`, `NORTH SECTION`, `SOUTH SECTION`,
  `REFLECTED_PLAN_VIEW`) shows only small, legitimate-looking corrections of
  the same kind elsewhere, no unexplained regressions.

---

## Follow-up round: commit 6

Commit 5's fixed-point iteration (re-deriving segments and reprocessing each
parent group across multiple rounds) fixed several NORTH SECTION wall cases,
but introduced a regression of its own, reported against the model's "HOLE
ON EDGE" test case: `1eW6OACmXD1hWJLDeB6erW` (a wall with a hole cut all the
way through to its right edge) and `2x0$XNlFH6FxlvS7eYJttx` (the adjacent
wall sharing that edge, with no hole). The entire left edge of `2x0$` — the
*only* remaining copy of that hole's right-hand boundary, since `1eW6` has no
material left on its own side to draw it — had been deleted, leaving that
side of the hole unlined.

Root cause: in round 0, bilateral matching correctly matches the overlapping
portions of this pair's shared edge and leaves the non-overlapping remainder
in place (the hole's exposed edge) — this fully drains `1eW6`'s presence at
that line key (nothing left on its side at all). In round 1, the segment
list is re-derived from the mutated SVG; since `1eW6` now has zero segments
at that key, bilateral has nothing to compare this round, so the cruder
unilateral fallback fires instead — and its bbox-boundary heuristic, blind
to the fact that `1eW6`'s side was already deliberately and fully drained,
wrongly treats the remainder as an unmatched implicit edge and deletes it.
This failure mode only exists because the pass now runs more than once —
with a single pass, round 1 (and this re-examination) never happened.

Fix: track every `(guid, line_key)` whose entire presence at that line was
consumed to nothing by a bilateral match in an earlier round. The unilateral
fallback now skips a removal whenever the bbox reference it would rely on
belongs to a guid+key that was already fully drained — that match already
gave its final, precise answer for this line; a later round must not
re-litigate it with a cruder heuristic. An initial attempt blocked
unilateral for an entire *pair* once they'd shown any bilateral relationship
at all, which fixed the hole case but was too broad — it also blocked a
legitimate wall-panel cleanup elsewhere in NORTH SECTION that genuinely
needed a later round's unilateral pass. Tracking drained *keys* instead of
related *pairs* is narrower and correct: it only suppresses unilateral for
the specific line that was actually resolved, leaving every other key and
pair (including the wall-panel case) unaffected.

### Verification (commit 6)

Same headless setup against the same `coplanar join.ifc` model:

- `2x0$`'s hole edge is restored in both `NORTH SECTION` and `SOUTH SECTION`,
  matching the pre-regression baseline exactly.
- Commit 5's NORTH SECTION wall-panel fix is preserved: the 15-GUID
  remaining path count is 48 (versus 47 with the regression still present) —
  one small residual segment remains on a different element
  (`0gbhn0X9z7BBLNF58AuXfq`), part of the same disclosed multi-neighbour
  partial-coverage tail from commit 5, not a new issue.
- Broader before/after comparison across all four drawings shows only this
  restoration plus the same class of sub-micron coordinate noise seen in
  every previous round.

---

## Follow-up round: commit 7

Commit 6's own "Open items" note named the next issue precisely: NORTH
SECTION's wall assembly still showed a small number of residual interior
lines (e.g. one segment on `0gbhn0X9z7BBLNF58AuXfq`), and had already
identified the root cause without yet fixing it.

Root cause: bilateral matching computed each pair's remainder ("this
element's line minus what this one partner matched") immediately and
independently, inside the per-pair loop. When an element shares the same
line key with **more than one** same-material neighbour in the same round —
`0gbhn` shares its bottom edge with both `0ZA0gbiYP4yeaGvSMlNATl` (matching
the left portion) and `2gKm6D45r4xgNcZthbYpFn` (matching the middle
portion) — each pair's remainder calculation was blind to what the *other*
pair contributed against that same element+line: `0gbhn`'s remainder from
the `0ZA0g` match still included the portion `2gKm6` was about to claim, and
vice versa. Both partial remainders got added back as separate paths, and
the next round's `group_by_line`/`ivs_union` merged them back into something
that looked like almost the entire original, untouched edge — even though
the two neighbours together had already fully accounted for it. Neither the
round-based iteration (commit 5) nor the drained-keys guard (commit 6) fixes
this, since it isn't about a segment failing to find a *second-round* match
or being wrongly re-examined — it's that the *first-round* remainder itself
was computed wrong whenever two partners split the same line.

Fix: `group_by_line` is now computed once per round (`lines_by_guid`),
shared across every pair instead of recomputed per pair. For non-contained
matches (`same_surface` / plain adjacent), a pair no longer computes and
re-adds its own remainder immediately — it accumulates its matched interval
into a per-`(guid, line_key)` union across every partner this round. After
the full `(i, j)` double loop finishes, a finalisation pass computes each
affected element's true remainder once — its original extent minus the
*combined* union of every partner's match — and adds back only that (or
marks the key drained if nothing is left). Contained-pair remainder handling
is completely untouched; multi-neighbour splits only occur on the
non-contained path.

### Verification (commit 7)

Same headless setup against the same `coplanar join.ifc` model:

- NORTH SECTION's 15-GUID remaining path count drops from 48 to 43. `0gbhn`'s
  residual is gone, and `0MmPs4lGP0zgpUVE$tStUb` (sharing the same underlying
  pattern) resolves fully as a side effect — neither appears in an
  overall-bbox interior-line scan any more.
- The "hole on edge" pair (`1eW6OACmXD1hWJLDeB6erW` / `2x0$XNlFH6FxlvS7eYJttx`)
  and PLAN_VIEW's contained-pair fixes are unaffected (identical segment
  counts before and after).
- Broader before/after path-set comparison across all four drawings shows
  only this fix's intended removals plus the same class of sub-micron
  coordinate noise seen in every previous round.

---

## Follow-up round: commit 8

Re-testing commit 7 against NORTH SECTION's wall assembly turned up two
distinct problems, reported precisely by GlobalId plus line start-coordinate.
Only one of the two is fixed here.

### Fixed: degenerate near-zero-length paths render as unwanted dots

IfcConvert's own linework export leaves a small number of near-zero-length
path segments in the raw, untouched output for elements with complex voids
and infills (confirmed present in `3_TyYp2`'s very first raw dump, long
before any of this branch's changes) — almost certainly floating-point noise
from the underlying BRep boolean/cut operations. These render as visible
dots rather than lines. Measured on `3_TyYp2`: 9 segments at length < 0.0001
(true points), 5 more at length ≈0.0135–0.0145; the smallest confirmed
genuine line on the same element is length ≈2.83 — a 100x+ margin either
side. Fix: strip any remaining path below a `MIN_VISIBLE_LENGTH = 0.1`
threshold, applied to every projection group this function already
processes, after the existing round-based matching converges.

Verified by comparing **total line coverage** (the union of every real-length
segment) before/after, rather than just path counts or path-string diffs —
identical in every one of the four drawings in the model, confirming nothing
with genuine length is ever removed. This methodology was itself checked for
soundness: re-running identical, unmodified code twice (to measure Blender's
own run-to-run floating-point noise) also produces identical total coverage,
so the technique reliably distinguishes "real content changed" from
"harmless coordinate jitter."

### Found, not fixed: contained-pair multi-neighbour bug causes real data loss

The other reported issue — several NORTH SECTION lines following the exact
same "two different neighbours independently compute their own remainder"
pattern commit 7 fixed, but occurring in the **contained**-pair code path
(which commit 7 deliberately left untouched, reasoned to be "usually 1:1").
`3_TyYp2` is the counter-example: it's the `contained_b` outer for four
different inner plugs, and the identical blind-spot bug exists in two
contained-pair mechanisms that each compute an "outer" remainder per-pair,
independently (the bilateral match's own remainder, and the interior-purge
pass's outer-segment clip-to-overlap). Traced precisely: `1$k4ji92` and
`3taVdKrmD45ehPoNLdDmdt` together account for the entirety of one of
`3_TyYp2`'s vertical lines, but each pair's independent remainder
computation left an incomplete piece behind, exactly reproducing two of the
reported unwanted lines.

Extending commit 7's same accumulate-then-finalise pattern to the outer side
of contained-pair interactions did resolve those two specific lines — but
checking **total wall-edge coverage** in REFLECTED_PLAN_VIEW (where
`3_TyYp2` is visible from a different camera angle, overlapping a different
combination of contained plugs) exposed real data loss: a continuous
360.44-unit wall-top edge shrank to 246.5 units, an 80+ unit gap. Diagnosed as
the finalisation pass running every round and recomputing "original extent"
from the current round's segment state — which, in a later round, is already
the *shrunk remainder* from an earlier round, not the true pristine original
— so a further match against that already-reduced piece keeps eroding it,
compounding across up to 10 rounds.

A follow-up attempt replaced the per-round remainder computation with a
persisted-across-rounds pristine original (captured once, at round 0, before
any pair processing) and a persisted, ever-growing accumulator of every
partner's matched interval, so the remainder is always computed against the
same true original rather than a prior round's already-shrunk one. This
correctly fixed the round-erosion arithmetic: reverifying with the same
coverage check, the two originally-targeted NORTH SECTION lines
(`418.17856 205.35803` and `418.17856 196.76428` on `3_TyYp2`) now resolve to
exactly zero remainder, as expected.

However, the *same* coverage check caught a second, deeper problem in
REFLECTED_PLAN_VIEW that this arithmetic fix doesn't and can't address:
bilateral matching's core assumption — that any line drawn by both sides of a
same-material pair is necessarily a duplicate internal seam, safe to remove
from both — is wrong whenever that shared line actually coincides with the
combined shape's true **external** perimeter. Traced precisely: contained
plug `3taVdKrmD45ehPoNLdDmdt` reaches flush to containing wall
`3_TyYp2_X03PtH$QzJHWjh`'s own exterior top face; both independently draw a
copy of that same real, visible exterior edge at line key `('h', 2714)` in
REFLECTED_PLAN_VIEW (a plan/roof-facing camera where this edge is genuinely
part of the silhouette, not an interior seam at all). Bilateral matching
removes both copies as if deduplicating an interior seam, deleting 113.9
units of real, visible boundary rather than reducing two copies to one.
Distinguishing this case from a genuine interior seam using only 2D SVG
line-key/interval data isn't possible — both look identical at that level;
it needs 3D reasoning about whether the material genuinely continues past
the shared line (in the same sense already used for the inner-segment
purge's `_outer_confirms_continuation` guard) applied to bilateral matching
itself. This is a pre-existing gap in bilateral matching's own core
assumption, predating this branch entirely (present in the original #7908
design) — it was previously masked here only by chance, because the old,
buggy round-accumulation logic happened to leave an accidental redundant
copy in that exact spot instead of cleanly deleting both.

Given the depth of the fix this now needs, the round-erosion redesign was
reverted rather than committed (confirmed via `git checkout --` back to
commit 8's tip, re-verified against the test profile). No new commit is
added for this round; the contained-pair multi-neighbour bug remains open,
now with a materially clearer, precisely-located root cause.

A third, distinct edge case was also found while investigating the above:
colinear-but-**adjacent** (non-overlapping) segments between a contained
inner and its outer, which represent a shared void/notch boundary split
between the two — bilateral correctly leaves both alone (matching its
existing, deliberate handling of offset-wall corners), but the interior-purge
pass's line-key-deference guard (from an earlier round) then *also* defers to
that decision, so neither side is ever merged. Distinguishing "genuine
offset-wall corner, must stay split" from "split void boundary, should merge"
using only line-key/interval data is nontrivial and needs its own dedicated
design.

One reported line (`310.06823 199.15698` on `3_TyYp2`) was confirmed to be an
original, untouched raw segment with no matching partner in *any* pair — not
caused by either bug above; likely needs a same-surface/adjacent partner
elsewhere not yet identified.

---

## Open items / not addressed here

- The bundled fixes are real but were surfaced as a side effect of this
  investigation, not exhaustively tested beyond the repro model above.
- `fill_mode == "SVGFILL"` changes noted elsewhere on the PR thread as
  ungated/pre-existing-crash are untouched by this branch.
- NORTH SECTION's wall assembly still shows residual interior lines. Three
  distinct causes have been identified and precisely characterised (see
  "Follow-up round: commit 8" above) but not yet fixed:
  1. The contained-pair analogue of commit 7's multi-neighbour bug. A
     redesign (persisted pristine-original + ever-growing accumulator,
     rather than each round's own restated "original") correctly fixed the
     round-erosion arithmetic — verified against the two originally-targeted
     NORTH SECTION lines — but exposed a deeper, pre-existing gap: bilateral
     matching assumes any line both sides of a same-material pair draw is a
     safe-to-remove duplicate internal seam, which is wrong when that line
     is actually the combined shape's true external perimeter (confirmed
     concretely: `3taVdKrmD45ehPoNLdDmdt` flush with `3_TyYp2`'s exterior
     face, 113.9 units of real boundary deleted at REFLECTED_PLAN_VIEW line
     key `('h', 2714)`). This predates the whole branch (present in the
     original #7908 design) and needs 3D material-continuity reasoning, not
     just 2D SVG line-key/interval data, to resolve safely. The redesign was
     reverted rather than committed.
  2. Colinear-but-adjacent split void/notch boundaries between a contained
     inner and outer, currently left unmerged by design (correctly
     protecting a different, legitimate case — offset-wall corners) with no
     way yet to distinguish the two.
  3. At least one original raw segment with no matching partner in any pair
     at all (`310.06823 199.15698` on `3_TyYp2`), needing its own
     investigation.
