### PR TITLE
Bonsai: preserve world position when classifying a mesh object as IfcElement

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -340,6 +340,8 @@ class AssignClass(bpy.types.Operator, tool.Ifc.Operator):
                     predefined_type=predefined_type,
                     should_add_representation=False,
                 )
+                # Write obj.matrix_world into the new element's IfcLocalPlacement.
+                bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
                 ifcopenshell.api.geometry.assign_representation(tool.Ifc.get(), element, representation)
                 bonsai.core.geometry.switch_representation(
                     tool.Ifc, tool.Geometry, obj=obj, representation=representation

--- a/src/bonsai/test/bim/bootstrap.py
+++ b/src/bonsai/test/bim/bootstrap.py
@@ -24,6 +24,7 @@ import webbrowser
 import bpy
 import ifcopenshell
 import ifcopenshell.util.element
+import ifcopenshell.util.placement
 import ifcopenshell.util.representation
 import pytest
 from mathutils import Vector
@@ -354,6 +355,16 @@ def the_object_name_is_at_location(name, location):
     ).length < 0.1, f"Object is at {obj_location}"
 
 
+def the_object_name_has_an_ifc_location_of_value(name, location):
+    ifc = an_ifc_file_exists()
+    element = ifc.by_id(tool.Blender.get_ifc_definition_id(the_object_name_exists(name)))
+    matrix = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement)
+    ifc_location = Vector(matrix[:3, 3])
+    assert (
+        ifc_location - Vector([float(co) for co in location.split(",")])
+    ).length < 0.1, f"IFC placement is at {ifc_location}"
+
+
 def the_variable_key_is_value(key, value):
     variables[key] = eval(value)
 
@@ -399,6 +410,7 @@ definitions = {
     'the object "(.*)" should display as "(.*)"': the_object_name_should_display_as_mode,
     'the object "(.*)" has "([0-9]+)" vertices': the_object_name_has_number_vertices,
     'the object "(.*)" is at "(.*)"': the_object_name_is_at_location,
+    'the object "(.*)" has an ifc location of "(.*)"': the_object_name_has_an_ifc_location_of_value,
     "nothing interesting happens": lambda: None,
     'the void "(.*)" is filled by "(.*)"': the_void_name_is_filled_by_filling,
     'the void "(.*)" is not filled by "(.*)"': the_void_name_is_not_filled_by_filling,

--- a/src/bonsai/test/bim/feature/root.feature
+++ b/src/bonsai/test/bim/feature/root.feature
@@ -111,6 +111,16 @@ Scenario: Assign a class to a cube
     And the object "IfcWall/Cube" is in the collection "IfcBuildingStorey/My Storey"
     And the object "IfcWall/Cube" has a "Tessellation" representation of "Model/Body/MODEL_VIEW"
 
+Scenario: Assign a class to an offset cube preserves its world position
+    Given an empty IFC project
+    And I add a cube of size "2" at "5,3,1"
+    When the object "Cube" is selected
+    And I set "scene.BIMRootProperties.ifc_product" to "IfcElement"
+    And I set "scene.BIMRootProperties.ifc_class" to "IfcFurniture"
+    And I press "bim.assign_class"
+    Then the object "IfcFurniture/Cube" is an "IfcFurniture"
+    And the object "IfcFurniture/Cube" has an ifc location of "5,3,1"
+
 Scenario: Assign a type class to a cube
     Given an empty IFC project
     And I add a cube


### PR DESCRIPTION
Fixes #8848.

`bim.assign_class` has a special path for mesh objects with polygons: it exports the mesh as a tessellation and creates the element with `should_add_representation=False`, then assigns the representation by hand. That bypasses `add_representation`, which is what normally writes the object's world transform into the new element's `IfcLocalPlacement`. The element ends up with no placement at all, so the object does not move visibly in the current session but resets to the IFC origin on reload.

Fix: write the object's `matrix_world` into the placement in that branch too, the same way the other branch already does.

Verified live in headless Blender against @Plae-Blue-Dot's own fixture from the issue: all 220 furniture objects in that file reset to the origin on reopen before this fix, and keep their position after it. Added a regression scenario that checks the actual IFC ObjectPlacement (not just Blender's transform, which the bug does not affect).

Generated with the assistance of an AI coding tool.
