### PR TITLE
Bonsai: exclude IfcSpace from the default linked-model query

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1398,7 +1398,8 @@ class LinkIfc(bpy.types.Operator, ImportHelper, tool.Ifc.Operator):
         name="Query",
         description=(
             "Custom selector query to use to load element from a linked model. E.g. 'IfcElement'.\n\n"
-            "Default query - IfcElement, but excluding IfcProxy, IfcSpatialStructureElement, IfcSpatialElement, IfcFeatureElement."
+            "Default query - IfcElement plus IfcProxy and spatial elements, "
+            "excluding IfcFeatureElement and IfcSpace (spaces cannot be hidden in a linked model)."
         ),
     )
 
@@ -1708,7 +1709,8 @@ class ReloadLink(bpy.types.Operator):
         name="Query",
         description=(
             "Custom selector query to use to load element from a linked model. E.g. 'IfcElement'.\n\n"
-            "Default query - IfcElement, but excluding IfcProxy, IfcSpatialStructureElement, IfcSpatialElement, IfcFeatureElement."
+            "Default query - IfcElement plus IfcProxy and spatial elements, "
+            "excluding IfcFeatureElement and IfcSpace (spaces cannot be hidden in a linked model)."
         ),
     )
 
@@ -2352,6 +2354,7 @@ class LoadLinkedProject(bpy.types.Operator, ImportHelper):
             else:
                 self.elements |= set(self.file.by_type("IfcSpatialElement"))
             self.elements -= set(self.file.by_type("IfcFeatureElement"))
+            self.elements -= set(self.file.by_type("IfcSpace"))
 
         if tool.Loader.settings.false_origin_mode == "MANUAL" and tool.Loader.settings.false_origin:
             tool.Loader.set_manual_blender_offset(self.file)

--- a/src/bonsai/test/bim/feature/project.feature
+++ b/src/bonsai/test/bim/feature/project.feature
@@ -685,6 +685,12 @@ Scenario: Link IFC - from an empty IFC project
     And the object "Chunk" exists
     And the object "Chunk" is placed in the collection "IfcProject/basic.ifc"
 
+Scenario: Link IFC - default query excludes IfcSpace so linked spaces are not shown
+    Given an empty IFC project
+    When I press "bim.link_ifc(filepath='{cwd}/test/files/decomposition.ifc', use_cache=False)"
+    Then the object "Chunk" exists
+    And "blend_data.objects['Chunk']['guids']" is "['1KiE3gs9z1sfj9c0spBIGv']"
+
 Scenario: Link IFC - from an empty IFC project - automatic false origin mode (0,0,0 will be the false origin)
     Given an empty IFC project
     # Not currently possible via UI


### PR DESCRIPTION
Fixes #8849

### Problem
Linking an IFC that contains `IfcSpace` entities with Body geometry (common in Revit-derived exports) shows the spaces as solid, occluding room volumes in the host file, with no way to hide them.

### Root cause
The default element query for `bim.link_ifc` / `bim.reload_link` intentionally includes `IfcSpatialElement`, which on IFC4+ also matches `IfcSpace`. Unlike host-opened projects, where each space is its own Blender object hideable via the existing space-visibility toggle (`tool.Spatial.set_space_visibility` / `toggle_hide_spaces`, both driven by `tool.Ifc.get_object()`), linked-model geometry is merged into shared "Chunk" objects that are never registered with `tool.Ifc`'s object map, so there is no way to single out and hide space geometry once it is loaded into a link.

### Fix
Exclude `IfcSpace` from the default link query. Users who want space geometry in a link can still opt in with a custom query (e.g. `IfcElement, IfcSpace`). Also corrects two stale Query tooltips on Link IFC / Reload Link.

### Verification
Live headless test with the reporter's attached file: before, 28 spaces load and none are hideable; after, zero spaces load, and a non-space link still loads normally. Added a feature scenario using `test/files/decomposition.ifc` verifying the default query excludes `IfcSpace` while still including a real element.

Generated with the assistance of an AI coding tool.
