### PR TITLE
ifcopenshell.api.type: instantiate occurrence parts from a typed decomposition

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/type/assign_type.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/type/assign_type.py
@@ -19,8 +19,11 @@
 from typing import Union
 
 import ifcopenshell
+import ifcopenshell.api.aggregate
+import ifcopenshell.api.geometry
 import ifcopenshell.api.material
 import ifcopenshell.api.owner
+import ifcopenshell.api.root
 import ifcopenshell.api.type
 import ifcopenshell.guid
 import ifcopenshell.util.element
@@ -256,8 +259,13 @@ class Usecase:
                 objects_with_types.append(obj)
 
         objects_to_change = objects_without_types + objects_with_types
-        # nothing to change
+        # nothing to change in the type assignment itself, though an
+        # already-typed occurrence authored before this repair existed may
+        # still be missing its aggregated type parts, so check for those.
         if not objects_to_change:
+            if should_map_representations and (part_types := self.get_typed_decomposition(relating_type)):
+                for related_object in related_objects_set:
+                    self.instantiate_aggregated_type_parts(related_object, part_types)
             return types
 
         # unassign from previous types
@@ -293,6 +301,15 @@ class Usecase:
                         related_object=related_object,
                         relating_type=relating_type,
                     )
+            elif part_types := self.get_typed_decomposition(relating_type):
+                # The type itself carries no geometry, but is decomposed
+                # (IfcRelAggregates) into other types that do, e.g. an
+                # IfcSolarDeviceType built from front/back IfcPlateType
+                # parts. Reflect that decomposition at the occurrence level
+                # too, since IFC requires an occurrence's geometry to come
+                # from itself, its type, or its parts (see #2052, #5505).
+                for related_object in objects_to_change:
+                    self.instantiate_aggregated_type_parts(related_object, part_types)
             self.map_material_usages(objects_to_change, relating_type)
 
         # Remove PredefinedType  / ObjectType if existing to forbid double typing(See #7006)
@@ -317,3 +334,51 @@ class Usecase:
                 products=related_objects,
                 type=f"{ifc_class}Usage",
             )
+
+    def get_typed_decomposition(
+        self, relating_type: ifcopenshell.entity_instance
+    ) -> list[ifcopenshell.entity_instance]:
+        is_decomposed_by = next((r for r in relating_type.IsDecomposedBy if r.is_a("IfcRelAggregates")), None)
+        if not is_decomposed_by:
+            return []
+        part_types = [o for o in is_decomposed_by.RelatedObjects if o.is_a("IfcTypeProduct")]
+        if not any(getattr(part_type, "RepresentationMaps", None) for part_type in part_types):
+            return []
+        return part_types
+
+    def instantiate_aggregated_type_parts(
+        self, related_object: ifcopenshell.entity_instance, part_types: list[ifcopenshell.entity_instance]
+    ) -> None:
+        schema = ifcopenshell.schema_by_name(self.file.schema)
+        existing_part_types = {
+            existing_type
+            for part in ifcopenshell.util.element.get_parts(related_object)
+            if (existing_type := ifcopenshell.util.element.get_type(part)) is not None
+        }
+        for part_type in part_types:
+            if part_type in existing_part_types or not getattr(part_type, "RepresentationMaps", None):
+                continue
+            occurrence_class = self.get_occurrence_class(part_type, schema)
+            if occurrence_class is None:
+                continue
+            part = ifcopenshell.api.root.create_entity(self.file, ifc_class=occurrence_class, name=part_type.Name)
+            ifcopenshell.api.geometry.edit_object_placement(self.file, product=part)
+            ifcopenshell.api.aggregate.assign_object(self.file, products=[part], relating_object=related_object)
+            ifcopenshell.api.type.assign_type(self.file, related_objects=[part], relating_type=part_type)
+
+    def get_occurrence_class(self, type_entity: ifcopenshell.entity_instance, schema) -> Union[str, None]:
+        if applicable_occurrence := getattr(type_entity, "ApplicableOccurrence", None):
+            occurrence_class = applicable_occurrence.split("/", 1)[0]
+            try:
+                schema.declaration_by_name(occurrence_class)
+                return occurrence_class
+            except RuntimeError:
+                pass
+        if (type_class := type_entity.is_a()).endswith("Type"):
+            occurrence_class = type_class[: -len("Type")]
+            try:
+                schema.declaration_by_name(occurrence_class)
+                return occurrence_class
+            except RuntimeError:
+                pass
+        return None

--- a/src/ifcopenshell-python/test/api/type/test_assign_type.py
+++ b/src/ifcopenshell-python/test/api/type/test_assign_type.py
@@ -18,6 +18,7 @@
 
 import pytest
 
+import ifcopenshell.api.aggregate
 import ifcopenshell.api.geometry
 import ifcopenshell.api.material
 import ifcopenshell.api.root
@@ -28,6 +29,12 @@ import test.bootstrap
 
 
 class TestAssignType(test.bootstrap.IFC4):
+    def _create_typed_part(self, context, name):
+        part_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcPlateType", name=name)
+        rep = self.file.createIfcShapeRepresentation(ContextOfItems=context)
+        ifcopenshell.api.geometry.assign_representation(self.file, product=part_type, representation=rep)
+        return part_type
+
     def test_assigning_a_type(self):
         element1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
@@ -215,6 +222,84 @@ class TestAssignType(test.bootstrap.IFC4):
         any_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
         with pytest.raises(TypeError):
             ifcopenshell.api.type.assign_type(self.file, related_objects=[opening], relating_type=any_type)
+
+    def test_instantiating_parts_from_a_typed_decomposition(self):
+        """A type with no representation of its own but decomposed (IfcRelAggregates)
+        into other types that do have geometry must reflect that decomposition at
+        the occurrence level too, e.g. an assembly type built from front/back plate
+        types (see #2052, #5505)."""
+        context = self.file.createIfcGeometricRepresentationContext()
+        front = self._create_typed_part(context, "Front")
+        back = self._create_typed_part(context, "Back")
+        assembly_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[front, back], relating_object=assembly_type)
+
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=assembly_type)
+
+        assert element.Representation is None
+        parts = ifcopenshell.util.element.get_parts(element)
+        assert {ifcopenshell.util.element.get_type(p) for p in parts} == {front, back}
+        for part in parts:
+            assert part.is_a("IfcPlate")
+            assert ifcopenshell.util.representation.get_representation(part, context=context) is not None
+
+    def test_instantiating_parts_from_a_typed_decomposition_is_idempotent(self):
+        context = self.file.createIfcGeometricRepresentationContext()
+        front = self._create_typed_part(context, "Front")
+        assembly_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[front], relating_object=assembly_type)
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=assembly_type)
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=assembly_type)
+
+        assert len(ifcopenshell.util.element.get_parts(element)) == 1
+
+    def test_instantiating_parts_repairs_an_already_typed_occurrence(self):
+        """A file authored before this repair existed may already have the type
+        assignment but be missing its aggregated parts. Re-running assign_type
+        with the same type must still synthesize the missing parts."""
+        context = self.file.createIfcGeometricRepresentationContext()
+        front = self._create_typed_part(context, "Front")
+        assembly_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=assembly_type)
+        assert ifcopenshell.util.element.get_parts(element) == []
+
+        # The decomposition is only added to the type after the occurrence was
+        # already typed, mirroring a file authored before this repair existed.
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[front], relating_object=assembly_type)
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=assembly_type)
+
+        parts = ifcopenshell.util.element.get_parts(element)
+        assert len(parts) == 1
+        assert ifcopenshell.util.element.get_type(parts[0]) == front
+
+    def test_not_instantiating_parts_when_no_part_type_has_a_representation(self):
+        part_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcPlateType", name="Front")
+        assembly_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[part_type], relating_object=assembly_type)
+
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=assembly_type)
+
+        assert ifcopenshell.util.element.get_parts(element) == []
+
+    def test_not_instantiating_parts_when_the_type_has_its_own_representation(self):
+        context = self.file.createIfcGeometricRepresentationContext()
+        front = self._create_typed_part(context, "Front")
+        assembly_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[front], relating_object=assembly_type)
+        rep = self.file.createIfcShapeRepresentation(ContextOfItems=context)
+        ifcopenshell.api.geometry.assign_representation(self.file, product=assembly_type, representation=rep)
+
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[element], relating_type=assembly_type)
+
+        assert element.Representation is not None
+        assert ifcopenshell.util.element.get_parts(element) == []
 
 
 class TestAssignTypeIFC2X3(test.bootstrap.IFC2X3, TestAssignType):


### PR DESCRIPTION
## Problem

A type may carry no representation of its own but still be decomposed (IfcRelAggregates) into other types that do, e.g. an IfcSolarDeviceType built from front and back IfcPlateType parts (#5505). Occurrences typed by such a type ended up with Representation=None and no occurrence-level reflection of the decomposition, so create_shape() failed with "Representation is NULL" even though real geometry existed one level down on the type's parts.

## Fix

When a type has no representation but is decomposed into typed parts that do, ifcopenshell.api.type.assign_type now instantiates one occurrence per part type, aggregates it under the newly typed occurrence, and recurses assign_type so each part gets its own type's mapped representation. This also repairs occurrences typed before this fix existed: re-running assign_type with the same type checks for and fills in missing aggregated parts even when the type assignment itself is a no-op.

Placement is left at identity relative to the parent. A part type's RepresentationMap.MappingOrigin already gets applied to its own mapped geometry by the existing map_type_representations mechanism, and no other transform data exists in a type-level decomposition to say how parts should be offset from each other. Where a file's part types genuinely carry no relative offset (as in #5505's sample file, where front and back plate are authored as coincident duplicates), the parts render at that authored position rather than a fabricated one.

## Scope

This addresses the aggregation half of #2052 (instantiating occurrences from aggregated types), as raised by @Moult and @brunopostle. It is a different mechanism from #8648 (IfcMaterialProfileSet multi-profile items), which stays untouched.

Opened as a draft to invite a maintainer view on whether assign_type is the right layer for this behavior (it now creates part occurrences as a side effect of type assignment).

Known follow-up gap (not fixed here): newly-synthesized part entities exist correctly in the .ifc immediately, but Bonsai's Blender-side sync (bonsai.core.type.assign_type) only updates the Blender object for the originally selected occurrence, so a project reload is currently needed for new parts to appear in the viewport. A live sync is a separate, scoped follow-up.

## Testing

6 new test methods across IFC2X3/IFC4/IFC4X3 (instantiation, idempotency, repair of an already-typed occurrence, no-op when no part has geometry, no-op when the type has its own representation). Live-verified in headless Blender/Bonsai against kurb70's actual #5505 file: before the fix, SolarDevice renders nothing; after running the real bim.assign_type operator and reloading, both plates render as correctly-positioned mesh objects matching the file's authored geometry exactly. Full test/api suite: no new failures.

Fixes #5505. Addresses the aggregation half of #2052.

Generated with the assistance of an AI coding tool.
