### PR TITLE
Bonsai: add redo panel toggle to invert wall join/extend trim side

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -477,6 +477,12 @@ class ExtendWallsToWall(_CommitWallDraftsFirstMixin, bpy.types.Operator, tool.If
     bl_description = "Extend and trim selected walls to another wall"
     bl_options = {"REGISTER", "UNDO"}
 
+    invert: bpy.props.BoolProperty(
+        name="Invert Trim Side",
+        description="Trim the other side of the extended wall instead of the guessed default",
+        default=False,
+    )
+
     @classmethod
     def poll(cls, context):
         if _poll_reject_array_children(cls):
@@ -509,7 +515,7 @@ class ExtendWallsToWall(_CommitWallDraftsFirstMixin, bpy.types.Operator, tool.If
                     bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
                 element = tool.Ifc.get_entity(obj)
                 ifcopenshell.api.geometry.connect_wall(
-                    tool.Ifc.get(), wall1=element, wall2=target_element, is_atpath=True
+                    tool.Ifc.get(), wall1=element, wall2=target_element, is_atpath=True, invert=self.invert
                 )
                 tool.Model.recreate_wall(element, obj)
             tool.Model.recreate_wall(target_element, target_obj)
@@ -1846,14 +1852,14 @@ class DumbWallJoiner:
         self.set_axis(element1, p1, p2)
         tool.Model.recreate_wall(element1, wall1)
 
-    def connect(self, obj1: bpy.types.Object, obj2: bpy.types.Object) -> None:
+    def connect(self, obj1: bpy.types.Object, obj2: bpy.types.Object, invert: bool = False) -> None:
         wall1 = tool.Ifc.get_entity(obj1)
         wall2 = tool.Ifc.get_entity(obj2)
         if tool.Ifc.is_moved(obj1):
             bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj1)
         if tool.Ifc.is_moved(obj2):
             bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj2)
-        ifcopenshell.api.geometry.connect_wall(tool.Ifc.get(), wall1=wall1, wall2=wall2)
+        ifcopenshell.api.geometry.connect_wall(tool.Ifc.get(), wall1=wall1, wall2=wall2, invert=invert)
         tool.Model.recreate_wall(wall1, obj1)
         tool.Model.recreate_wall(wall2, obj2)
 
@@ -4756,6 +4762,12 @@ class JoinWallsIntersection(_CommitWallDraftsFirstMixin, bpy.types.Operator, too
     bl_description = "Join two walls at their corner"
     bl_options = {"REGISTER", "UNDO"}
 
+    invert: bpy.props.BoolProperty(
+        name="Invert Trim Side",
+        description="Trim the other side of the non-active wall instead of the guessed default",
+        default=False,
+    )
+
     @classmethod
     def poll(cls, context):
         if not tool.Model.has_selected_ifc_objects():
@@ -4767,7 +4779,7 @@ class JoinWallsIntersection(_CommitWallDraftsFirstMixin, bpy.types.Operator, too
 
     def _perform(self, context: bpy.types.Context) -> set[str]:
         try:
-            core.join_walls_LV(tool.Ifc, tool.Blender, tool.Geometry, DumbWallJoiner(), tool.Model)
+            core.join_walls_LV(tool.Ifc, tool.Blender, tool.Geometry, DumbWallJoiner(), tool.Model, invert=self.invert)
         except core.RequireTwoWallsError as e:
             self.report({"ERROR"}, str(e))
             return {"CANCELLED"}

--- a/src/bonsai/bonsai/core/model.py
+++ b/src/bonsai/bonsai/core/model.py
@@ -93,6 +93,7 @@ def join_walls_LV(
     joiner: DumbWallJoiner,
     model: type[tool.Model],
     join_type: Literal["L", "V"] = "L",
+    invert: bool = False,
 ) -> None:
     selected_objs = [
         o for o in blender.get_selected_objects() if (e := ifc.get_entity(o)) and model.get_usage_type(e) == "LAYER2"
@@ -108,7 +109,7 @@ def join_walls_LV(
     for obj in selected_objs:
         geometry.clear_scale(obj)
 
-    joiner.connect(another_selected_object, active_obj)
+    joiner.connect(another_selected_object, active_obj, invert=invert)
 
 
 def offset_walls(ifc: type[tool.Ifc], blender: type[tool.Blender], model: type[tool.Model], offset_type: OffsetType):

--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/connect_wall.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/connect_wall.py
@@ -32,6 +32,7 @@ def connect_wall(
     wall1: ifcopenshell.entity_instance,
     wall2: ifcopenshell.entity_instance,
     is_atpath: bool = False,
+    invert: bool = False,
 ) -> Optional[ifcopenshell.entity_instance]:
     matrix1i = np.linalg.inv(ifcopenshell.util.placement.get_local_placement(wall1.ObjectPlacement))
     matrix2 = ifcopenshell.util.placement.get_local_placement(wall2.ObjectPlacement)
@@ -48,6 +49,9 @@ def connect_wall(
         return
 
     wall1_end = "ATEND" if x > midx else "ATSTART"
+    if invert:
+        # Flips which portion of wall1 is kept vs trimmed.
+        wall1_end = "ATSTART" if wall1_end == "ATEND" else "ATEND"
     if is_atpath:
         wall2_end = "ATPATH"
     elif abs(y - starty) < abs(y - endy):

--- a/src/ifcopenshell-python/test/api/geometry/test_connect_wall.py
+++ b/src/ifcopenshell-python/test/api/geometry/test_connect_wall.py
@@ -1,0 +1,109 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+# This file was generated with the assistance of an AI coding tool.
+
+import numpy as np
+
+import ifcopenshell.api.context
+import ifcopenshell.api.geometry
+import ifcopenshell.api.root
+import test.bootstrap
+
+
+class TestConnectWall(test.bootstrap.IFC4):
+    def setup_axis_context(self):
+        model = ifcopenshell.api.context.add_context(self.file, context_type="Plan")
+        return ifcopenshell.api.context.add_context(
+            self.file,
+            context_type="Plan",
+            context_identifier="Axis",
+            target_view="GRAPH_VIEW",
+            parent=model,
+        )
+
+    def make_wall(self, axis_context, matrix, p1, p2):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=wall, matrix=matrix)
+        poly = self.file.create_entity(
+            "IfcPolyline",
+            Points=[
+                self.file.create_entity("IfcCartesianPoint", Coordinates=p1),
+                self.file.create_entity("IfcCartesianPoint", Coordinates=p2),
+            ],
+        )
+        rep = self.file.create_entity(
+            "IfcShapeRepresentation",
+            ContextOfItems=axis_context,
+            RepresentationIdentifier="Axis",
+            RepresentationType="Curve2D",
+            Items=[poly],
+        )
+        wall.Representation = self.file.create_entity("IfcProductDefinitionShape", Representations=[rep])
+        return wall
+
+    def make_crossing_walls(self, axis_context):
+        # wall1's own axis runs (0, 0) to (10, 0). wall2 crosses it near
+        # wall1's far end (world x=8, past wall1's own midpoint of 5), so the
+        # default heuristic keeps wall1's longer (start-side) portion.
+        wall1 = self.make_wall(axis_context, np.eye(4), (0.0, 0.0), (10.0, 0.0))
+        theta = np.pi / 2
+        rotation = np.array(
+            [
+                [np.cos(theta), -np.sin(theta), 0, 0],
+                [np.sin(theta), np.cos(theta), 0, 0],
+                [0, 0, 1, 0],
+                [0, 0, 0, 1],
+            ]
+        )
+        translation = np.eye(4)
+        translation[0, 3] = 8.0
+        translation[1, 3] = -5.0
+        wall2 = self.make_wall(axis_context, translation @ rotation, (-5.0, 0.0), (5.0, 0.0))
+        return wall1, wall2
+
+    def test_default_keeps_the_longer_portion_of_wall1(self):
+        axis_context = self.setup_axis_context()
+        wall1, wall2 = self.make_crossing_walls(axis_context)
+        rel = ifcopenshell.api.geometry.connect_wall(self.file, wall1=wall1, wall2=wall2)
+        assert rel.RelatingConnectionType == "ATEND"
+
+    def test_invert_swaps_which_portion_of_wall1_is_kept(self):
+        axis_context = self.setup_axis_context()
+        wall1, wall2 = self.make_crossing_walls(axis_context)
+        rel = ifcopenshell.api.geometry.connect_wall(self.file, wall1=wall1, wall2=wall2, invert=True)
+        assert rel.RelatingConnectionType == "ATSTART"
+
+    def test_invert_does_not_affect_wall2s_own_connection_end(self):
+        axis_context = self.setup_axis_context()
+        wall1, wall2 = self.make_crossing_walls(axis_context)
+        default_rel = ifcopenshell.api.geometry.connect_wall(self.file, wall1=wall1, wall2=wall2)
+        default_related = default_rel.RelatedConnectionType
+        self.file.remove(default_rel)
+        inverted_rel = ifcopenshell.api.geometry.connect_wall(self.file, wall1=wall1, wall2=wall2, invert=True)
+        assert inverted_rel.RelatedConnectionType == default_related
+
+    def test_is_atpath_takes_precedence_over_wall2_end_regardless_of_invert(self):
+        axis_context = self.setup_axis_context()
+        wall1, wall2 = self.make_crossing_walls(axis_context)
+        rel = ifcopenshell.api.geometry.connect_wall(self.file, wall1=wall1, wall2=wall2, is_atpath=True, invert=True)
+        assert rel.RelatedConnectionType == "ATPATH"
+        assert rel.RelatingConnectionType == "ATSTART"
+
+
+class TestConnectWallIFC2X3(test.bootstrap.IFC2X3, TestConnectWall):
+    pass


### PR DESCRIPTION
Addresses #3206.

The wall Join and Extend operators pick which end of a wall to trim based only on comparing the corner position to the wall's own axis midpoint, never on anything the user clicked. When the guess is wrong, users have been repeatedly shortening a wall until the guess happens to flip.

Adds an Invert Trim Side toggle to bim.extend_walls_to_wall and bim.join_walls_intersection. Both are REGISTER and UNDO operators, so the toggle shows up in the F9 redo panel per @Gorgious56's suggestion in the issue thread: default behaviour is unchanged, and if the guess goes the wrong way, F9 then flip the checkbox instead of fighting the tool.

@theoryshaw's suggestion of driving this from where the user actually clicked (using brunoperdigao's raycasting/snapping) is a real, larger follow up. The Join and Extend gizmos already know their click position, and DumbWallJoiner.extend already resolves a similar decision from a 3D point, so it is a natural next step rather than something this PR reaches for.

Also noted in the issue thread: @Gorgious56's report of Ctrl-Z after Extend occasionally sending a wall limit flying. Not reproduced or fixed here; likely lead is a desync between Blender's undo stack and IfcStore's own undo callback leaving a wall's axis reference points mismatched after undo. Left for a follow up.

Test plan:
- Added test/api/geometry/test_connect_wall.py: default keeps the longer portion, invert swaps it, invert leaves wall2's own end alone, is_atpath still wins over invert.
- Verified live in isolated headless Blender: default matches existing behaviour exactly for both operators; invert=True genuinely swaps which wall/side is trimmed in both.

Generated with the assistance of an AI coding tool.
