### PR TITLE
Build: install OpenCASCADE headers into the IfcOpenShell install tree (#3164)

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -97,6 +97,11 @@ option(
 option(SCHEMA_VERSIONS "Explicitly specify schemas to build." "")
 
 option(WITH_OPENCASCADE "Enable geometry interpretation using Open CASCADE" ON)
+option(
+    INSTALL_DEPENDENCY_HEADERS
+    "Also install Open CASCADE headers into the IfcOpenShell install tree, so the install directory is self-sufficient for C++ consumers (#3164)."
+    ON
+)
 option(WITH_CGAL "Enable geometry interpretation using CGAL" ON)
 option(COLLADA_SUPPORT "Build IfcConvert with COLLADA support (requires OpenCOLLADA)." ON)
 option(GLTF_SUPPORT "Build IfcConvert with glTF support (requires json.hpp)." OFF)
@@ -220,6 +225,14 @@ if(BUILD_IFCGEOM AND WITH_OPENCASCADE)
     add_definitions(-DIFOPSH_WITH_OPENCASCADE)
     set(SWIG_DEFINES ${SWIG_DEFINES} -DIFOPSH_WITH_OPENCASCADE)
     list(APPEND GEOMETRY_KERNELS opencascade)
+
+    # Make the install tree self-sufficient for C++ consumers, see #3164.
+    if(INSTALL_DEPENDENCY_HEADERS AND OpenCASCADE_INCLUDE_DIR)
+        install(
+            DIRECTORY "${OpenCASCADE_INCLUDE_DIR}/"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/external/occt-${OpenCASCADE_VERSION}"
+        )
+    endif()
 endif()
 
 set(GLTF_LIBRARIES "")


### PR DESCRIPTION
Addresses #3164.

IfcOpenShell's own installed headers (e.g. the opencascade geometry kernel under src/ifcgeom/kernels/opencascade) include OCCT headers such as gp_GTrsf.hxx directly, so a C++ project consuming an IfcOpenShell install tree currently has to separately locate a matching OCCT install to compile.

This adds an opt-out INSTALL_DEPENDENCY_HEADERS CMake option (default ON) that copies OpenCASCADE's resolved include directory into the IfcOpenShell install prefix under include/external/occt-VERSION, following the versioned dependency directory naming @aothms proposed in the issue thread (occt-x.y.z, similar to what the nix build script already produces under _build/.../install/occt-x.y.z).

This is purely additive. It does not move, rename, or otherwise touch the existing dependency build/install directories used by the nix or Windows build scripts (_deps, _deps-vs2022-x64-installed, nix _build), so no existing build environment is disrupted. Boost stays excluded, per @aothms's note that Boost is the exception.

Opening as a draft. I could not do a full local build with real OCCT to verify this end to end (our local toolchain is Boost-drift-blocked), so this needs @aothms's review of the OpenCASCADE_INCLUDE_DIR / OpenCASCADE_VERSION variable names against the actual vendored OCCT CMake config, plus CI's compile verification. What I did verify locally: a full CMake configure of the edited file completes without syntax errors, and an isolated reproduction of the new install() rule with dummy headers produces the exact expected layout (install/include/external/occt-7.8.1/*.hxx), with the option OFF producing no change from current behaviour.

I looked at your original occt-x.y.z proposal, @aothms; the thread trails off with Saiel walking back his follow-up, so the Windows batch-script directory reorg was never actually confirmed and I can't test those scripts from my environment anyway. So I went for the smaller, testable version of the same idea. Happy to adjust the approach if you'd prefer the fuller reorg.

Generated with the assistance of an AI coding tool.
