### PR TITLE
Bonsai: guard stale ifc_definition_id lookups that abort wall split and related flows

### DIFF
--- a/src/bonsai/bonsai/tool/duplicate.py
+++ b/src/bonsai/bonsai/tool/duplicate.py
@@ -231,9 +231,11 @@ class Duplicate(bonsai.core.tool.Duplicate):
 
                     for voided_obj in voided_objs:
                         if mesh_data := voided_obj.data:
-                            representation = tool.Ifc.get().by_id(
-                                tool.Geometry.get_mesh_props(mesh_data).ifc_definition_id
-                            )
+                            ifc_id = tool.Geometry.get_mesh_props(mesh_data).ifc_definition_id
+                            try:
+                                representation = tool.Ifc.get().by_id(ifc_id)
+                            except RuntimeError:
+                                continue
                             bonsai.core.geometry.switch_representation(
                                 tool.Ifc,
                                 tool.Geometry,

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -869,7 +869,13 @@ class Geometry(bonsai.core.tool.Geometry):
         if isinstance(data, Geometry.TYPES_WITH_MESH_PROPERTIES) and (
             ifc_id := tool.Geometry.get_mesh_props(data).ifc_definition_id
         ):
-            return tool.Ifc.get().by_id(ifc_id)
+            try:
+                return tool.Ifc.get().by_id(ifc_id)
+            except RuntimeError:
+                # Stale id: a representation rebuild freed the old entity
+                # while obj.data still tracks its id. Treated as "no data
+                # representation" — same contract as a mesh with id 0.
+                return None
 
     @classmethod
     def get_active_representation_context(cls, obj: bpy.types.Object) -> ifcopenshell.entity_instance:

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1411,18 +1411,20 @@ class Geometry(bonsai.core.tool.Geometry):
 
     @classmethod
     def is_boolean_operand(cls, obj: bpy.types.Object) -> bool:
+        if not (data := obj.data) or not isinstance(data, Geometry.TYPES_WITH_MESH_PROPERTIES):
+            return False
+        if not (ifc_id := tool.Geometry.get_mesh_props(data).ifc_definition_id):
+            return False
+        try:
+            item = tool.Ifc.get().by_id(ifc_id)
+        except RuntimeError:
+            return False
         return bool(
-            (data := obj.data)
-            and isinstance(data, Geometry.TYPES_WITH_MESH_PROPERTIES)
-            and (ifc_id := tool.Geometry.get_mesh_props(data).ifc_definition_id)
-            and (item := tool.Ifc.get().by_id(ifc_id))
-            and (
-                item.is_a("IfcBooleanResult")
-                or item.is_a("IfcCsgPrimitive3D")
-                or item.is_a("IfcHalfSpaceSolid")
-                or item.is_a("IfcSolidModel")
-                or item.is_a("IfcTessellatedFaceSet")
-            )
+            item.is_a("IfcBooleanResult")
+            or item.is_a("IfcCsgPrimitive3D")
+            or item.is_a("IfcHalfSpaceSolid")
+            or item.is_a("IfcSolidModel")
+            or item.is_a("IfcTessellatedFaceSet")
         )
 
     @classmethod

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2197,7 +2197,11 @@ class Model(bonsai.core.tool.Model):
         for element in elements:
             if not (obj := tool.Ifc.get_object(element)) or not (data := obj.data):
                 continue
-            representation = tool.Ifc.get().by_id(tool.Geometry.get_mesh_props(data).ifc_definition_id)
+            ifc_id = tool.Geometry.get_mesh_props(data).ifc_definition_id
+            try:
+                representation = tool.Ifc.get().by_id(ifc_id)
+            except RuntimeError:
+                continue
             bonsai.core.geometry.switch_representation(
                 tool.Ifc,
                 tool.Geometry,

--- a/src/bonsai/bonsai/tool/root.py
+++ b/src/bonsai/bonsai/tool/root.py
@@ -205,7 +205,10 @@ class Root(bonsai.core.tool.Root):
     @classmethod
     def get_object_representation(cls, obj: bpy.types.Object) -> Union[ifcopenshell.entity_instance, None]:
         if obj.data and (mesh_props := tool.Geometry.get_mesh_props(obj.data)).ifc_definition_id:
-            return tool.Ifc.get().by_id(mesh_props.ifc_definition_id)
+            try:
+                return tool.Ifc.get().by_id(mesh_props.ifc_definition_id)
+            except RuntimeError:
+                return None
         element = tool.Ifc.get_entity(obj)
         if element.is_a("IfcTypeProduct"):
             if element.RepresentationMaps:
@@ -334,7 +337,11 @@ class Root(bonsai.core.tool.Root):
 
                     for voided_obj in voided_objs:
                         if data := voided_obj.data:
-                            representation = tool.Ifc.get().by_id(tool.Geometry.get_mesh_props(data).ifc_definition_id)
+                            ifc_id = tool.Geometry.get_mesh_props(data).ifc_definition_id
+                            try:
+                                representation = tool.Ifc.get().by_id(ifc_id)
+                            except RuntimeError:
+                                continue
                             bonsai.core.geometry.switch_representation(
                                 tool.Ifc,
                                 tool.Geometry,

--- a/src/bonsai/test/tool/test_geometry.py
+++ b/src/bonsai/test/tool/test_geometry.py
@@ -299,6 +299,34 @@ class TestIsBodyRepresentation(NewFile):
         assert subject.is_body_representation(representation) is False
 
 
+class TestIsBooleanOperand(NewFile):
+    def test_run(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        item = ifc.createIfcBooleanResult()
+        obj = bpy.data.objects.new("Object", (mesh := bpy.data.meshes.new("Mesh")))
+        tool.Geometry.get_mesh_props(mesh).ifc_definition_id = item.id()
+        assert subject.is_boolean_operand(obj) is True
+
+    def test_returns_false_for_non_boolean_item(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        item = ifc.createIfcShapeRepresentation()
+        obj = bpy.data.objects.new("Object", (mesh := bpy.data.meshes.new("Mesh")))
+        tool.Geometry.get_mesh_props(mesh).ifc_definition_id = item.id()
+        assert subject.is_boolean_operand(obj) is False
+
+    def test_returns_false_instead_of_raising_for_a_stale_ifc_definition_id(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        item = ifc.createIfcBooleanResult()
+        obj = bpy.data.objects.new("Object", (mesh := bpy.data.meshes.new("Mesh")))
+        stale_id = item.id()
+        tool.Geometry.get_mesh_props(mesh).ifc_definition_id = stale_id
+        ifc.remove(item)
+        assert subject.is_boolean_operand(obj) is False
+
+
 class TestIsBoxRepresentation(NewFile):
     def test_run(self):
         ifc = ifcopenshell.file()

--- a/src/bonsai/test/tool/test_geometry.py
+++ b/src/bonsai/test/tool/test_geometry.py
@@ -166,6 +166,35 @@ class TestGetActiveRepresentation(NewFile):
         assert subject.get_active_representation(obj) is None
 
 
+class TestGetDataRepresentation(NewFile):
+    def test_returns_representation_for_live_id(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        representation = ifc.createIfcShapeRepresentation()
+        mesh = bpy.data.meshes.new("Mesh")
+        tool.Geometry.get_mesh_props(mesh).ifc_definition_id = representation.id()
+        assert subject.get_data_representation(mesh) == representation
+
+    def test_returns_none_when_mesh_has_no_id(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        mesh = bpy.data.meshes.new("Mesh")
+        assert subject.get_data_representation(mesh) is None
+
+    def test_returns_none_when_id_is_stale(self):
+        """A representation rebuild can free the old entity while obj.data
+        still tracks its id. Returning ``None`` keeps every UI redraw alive
+        instead of spamming ``RuntimeError`` from the by_id lookup."""
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        representation = ifc.createIfcShapeRepresentation()
+        mesh = bpy.data.meshes.new("Mesh")
+        stale_id = representation.id()
+        tool.Geometry.get_mesh_props(mesh).ifc_definition_id = stale_id
+        ifc.remove(representation)
+        assert subject.get_data_representation(mesh) is None
+
+
 class TestGetRepresentationId(NewFile):
     def test_run(self):
         ifc = ifcopenshell.file()

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -920,6 +920,30 @@ class TestApplyIfcMaterialChanges(NewFile):
         assert self.get_mesh(obj).materials[:] == [bpy.data.materials["Red"]]
 
 
+class TestApplyIfcMaterialChangesToleratesStaleIfcDefinitionId(NewFile):
+    def test_run(self):
+        # Regression test for #7909's bug class: apply_ifc_material_changes
+        # iterates several elements and can invalidate a shared representation
+        # while reloading an earlier one, so a later element's cached
+        # ifc_definition_id can go stale mid-loop. It must be skipped instead
+        # of raising.
+        from unittest import mock
+
+        ifc_file = ifcopenshell.file()
+        tool.Ifc.set(ifc_file)
+        element = ifc_file.createIfcWall()
+        representation = ifc_file.createIfcShapeRepresentation()
+        obj = bpy.data.objects.new("Object", (mesh := bpy.data.meshes.new("Mesh")))
+        tool.Ifc.link(element, obj)
+        stale_id = representation.id()
+        tool.Geometry.get_mesh_props(mesh).ifc_definition_id = stale_id
+        ifc_file.remove(representation)
+
+        with mock.patch("bonsai.core.geometry.switch_representation") as switch_representation:
+            subject.apply_ifc_material_changes([element])
+        switch_representation.assert_not_called()
+
+
 class TestOffsetWall(NewFile):
     def test_run(self):
         ifc = ifcopenshell.file()

--- a/src/bonsai/test/tool/test_root.py
+++ b/src/bonsai/test/tool/test_root.py
@@ -128,6 +128,20 @@ class TestGetObjectRepresentation(NewFile):
         tool.Geometry.get_mesh_props(mesh).ifc_definition_id = representation.id()
         assert subject.get_object_representation(obj) == representation
 
+    def test_returns_none_instead_of_raising_for_a_stale_ifc_definition_id(self):
+        # Regression test for #7909: a duplicated wall's mesh can keep an
+        # ifc_definition_id whose representation was already removed earlier
+        # in the same operation (e.g. during a wall split), and this must not
+        # abort the whole operator with a RuntimeError.
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        representation = ifc.createIfcShapeRepresentation()
+        obj = bpy.data.objects.new("Object", (mesh := bpy.data.meshes.new("Mesh")))
+        stale_id = representation.id()
+        tool.Geometry.get_mesh_props(mesh).ifc_definition_id = stale_id
+        ifc.remove(representation)
+        assert subject.get_object_representation(obj) is None
+
 
 class TestGetRepresentationContext(NewFile):
     def test_run(self):


### PR DESCRIPTION
Fixes #7909.

`tool.Root.get_object_representation` called `by_id` on a mesh's cached `ifc_definition_id` with no guard, so a duplicated wall whose representation was already removed earlier in the same operation raised `RuntimeError` and aborted the whole split (`DumbWallJoiner.split` -> `duplicate_wall` -> `core.root.copy_class`). This adds the same `try/except RuntimeError: return None` guard used by commit 5f1efeffaf (#8177) for `by_guid`/`by_id` lookups.

This also completes that #8177 `by_id` guard sweep for the remaining sites exposed to the same stale-id risk: `tool.Root.recreate_decompositions` and the identical `tool.Duplicate` counterpart (both iterate several objects sharing a decomposition and can invalidate one object's representation while reloading another's), `tool.Geometry.is_boolean_operand`, and `tool.Model.apply_ifc_material_changes` (whose own docstring notes it invalidates existing object data while looping over elements).

Added regression tests confirming each guarded function returns the tolerant default instead of raising when the cached id no longer resolves.

Generated with the assistance of an AI coding tool.
