### PR TITLE
ifcopenshell.api.sequence: honour the calendar's declared work hours

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/edit_task_time.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/edit_task_time.py
@@ -75,13 +75,14 @@ class Usecase:
             del attributes["ScheduleFinish"]
 
         duration_type = attributes.get("DurationType", self.task_time.DurationType)
+        start_time, finish_time = ifcopenshell.util.sequence.get_calendar_work_hours(self.calendar)
         finish = attributes.get("ScheduleFinish", None)
         if finish:
             if isinstance(finish, str):
                 finish = datetime.datetime.fromisoformat(finish)
             attributes["ScheduleFinish"] = datetime.datetime.combine(
                 ifcopenshell.util.sequence.get_soonest_working_day(finish, duration_type, self.calendar),
-                datetime.time(17),
+                finish_time,
             )
         start = attributes.get("ScheduleStart", None)
         if start:
@@ -89,7 +90,7 @@ class Usecase:
                 start = datetime.datetime.fromisoformat(start)
             attributes["ScheduleStart"] = datetime.datetime.combine(
                 ifcopenshell.util.sequence.get_soonest_working_day(start, duration_type, self.calendar),
-                datetime.time(9),
+                start_time,
             )
 
         for name, value in attributes.items():

--- a/src/ifcopenshell-python/ifcopenshell/util/sequence.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/sequence.py
@@ -108,6 +108,41 @@ def count_working_days(start, finish, calendar: ifcopenshell.entity_instance) ->
     return result
 
 
+def get_calendar_work_hours(
+    calendar: Union[ifcopenshell.entity_instance, None],
+) -> tuple[datetime.time, datetime.time]:
+    """Get the start and finish time of day declared by a calendar's working times.
+
+    An IfcWorkCalendar's IfcWorkTime may declare the actual hours worked in a
+    day using the RecurrencePattern's TimePeriods (see
+    IfcTimePeriod.StartTime / EndTime). This looks at all of a calendar's
+    WorkingTimes and returns the earliest declared start and latest declared
+    finish. If no calendar is given, or it declares no time periods, the
+    conventional 9am to 5pm working day is assumed.
+
+    :param calendar: The IfcWorkCalendar to check, if any.
+    :return: A tuple of (start_time, finish_time) as datetime.time objects.
+    """
+    default_start = datetime.time(9)
+    default_finish = datetime.time(17)
+    start_time = None
+    finish_time = None
+    for work_time in (calendar and calendar.WorkingTimes) or []:
+        recurrence = work_time.RecurrencePattern
+        if not recurrence or not recurrence.TimePeriods:
+            continue
+        for period in recurrence.TimePeriods:
+            if period.StartTime:
+                time = ifcopenshell.util.date.ifc2datetime(period.StartTime)
+                if start_time is None or time < start_time:
+                    start_time = time
+            if period.EndTime:
+                time = ifcopenshell.util.date.ifc2datetime(period.EndTime)
+                if finish_time is None or time > finish_time:
+                    finish_time = time
+    return start_time or default_start, finish_time or default_finish
+
+
 def get_start_or_finish_date(
     start,
     duration,
@@ -127,9 +162,10 @@ def get_start_or_finish_date(
     if date_type == "START":
         duration = -duration
     result = offset_date(start, duration, duration_type, calendar)
+    start_time, finish_time = get_calendar_work_hours(calendar)
     if date_type == "START":
-        return datetime.datetime.combine(result, datetime.time(9))
-    return datetime.datetime.combine(result, datetime.time(17))
+        return datetime.datetime.combine(result, start_time)
+    return datetime.datetime.combine(result, finish_time)
 
 
 def offset_date(start, duration, duration_type: DURATION_TYPE, calendar: ifcopenshell.entity_instance):

--- a/src/ifcopenshell-python/test/api/sequence/test_edit_task_time.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_edit_task_time.py
@@ -234,3 +234,68 @@ class TestEditTaskTime(test.bootstrap.IFC4):
         assert task_time.ScheduleStart == "2020-01-01T09:00:00"
         assert task_time.ScheduleFinish == "2020-01-09T17:00:00"
         assert task_time.ScheduleDuration == "P7D"
+
+    def test_schedule_start_and_finish_honour_the_calendars_declared_work_hours(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        calendar = ifcopenshell.api.sequence.add_work_calendar(self.file)
+        task = self.file.createIfcTask()
+        ifcopenshell.api.control.assign_control(self.file, relating_control=calendar, related_objects=[task])
+        task_time = ifcopenshell.api.sequence.add_task_time(self.file, task=task)
+
+        work_time = ifcopenshell.api.sequence.add_work_time(self.file, work_calendar=calendar, time_type="WorkingTimes")
+        pattern = ifcopenshell.api.sequence.assign_recurrence_pattern(
+            self.file, parent=work_time, recurrence_type="WEEKLY"
+        )
+        ifcopenshell.api.sequence.edit_recurrence_pattern(
+            self.file,
+            recurrence_pattern=pattern,
+            attributes={"WeekdayComponent": [1, 2, 3, 4, 5]},
+        )
+        # The calendar declares an 8am to 4pm working day, not the default 9 to 5.
+        ifcopenshell.api.sequence.add_time_period(
+            self.file, recurrence_pattern=pattern, start_time="08:00", end_time="16:00"
+        )
+
+        ifcopenshell.api.sequence.edit_task_time(
+            self.file,
+            task_time=task_time,
+            attributes={
+                "DurationType": "WORKTIME",
+                "ScheduleDuration": "P1D",
+                "ScheduleStart": datetime.datetime(2020, 1, 1),
+            },
+        )
+        assert task_time.ScheduleStart == "2020-01-01T08:00:00"
+        assert task_time.ScheduleFinish == "2020-01-01T16:00:00"
+        assert task_time.ScheduleDuration == "P1D"
+
+    def test_schedule_start_and_finish_fall_back_to_9_to_5_when_no_hours_are_declared(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        calendar = ifcopenshell.api.sequence.add_work_calendar(self.file)
+        task = self.file.createIfcTask()
+        ifcopenshell.api.control.assign_control(self.file, relating_control=calendar, related_objects=[task])
+        task_time = ifcopenshell.api.sequence.add_task_time(self.file, task=task)
+
+        # A calendar exists and declares working weekdays, but no explicit time periods.
+        work_time = ifcopenshell.api.sequence.add_work_time(self.file, work_calendar=calendar, time_type="WorkingTimes")
+        pattern = ifcopenshell.api.sequence.assign_recurrence_pattern(
+            self.file, parent=work_time, recurrence_type="WEEKLY"
+        )
+        ifcopenshell.api.sequence.edit_recurrence_pattern(
+            self.file,
+            recurrence_pattern=pattern,
+            attributes={"WeekdayComponent": [1, 2, 3, 4, 5]},
+        )
+
+        ifcopenshell.api.sequence.edit_task_time(
+            self.file,
+            task_time=task_time,
+            attributes={
+                "DurationType": "WORKTIME",
+                "ScheduleDuration": "P1D",
+                "ScheduleStart": datetime.datetime(2020, 1, 1),
+            },
+        )
+        assert task_time.ScheduleStart == "2020-01-01T09:00:00"
+        assert task_time.ScheduleFinish == "2020-01-01T17:00:00"
+        assert task_time.ScheduleDuration == "P1D"


### PR DESCRIPTION
## Summary
- `edit_task_time` hardcoded ScheduleStart/ScheduleFinish at 09:00/17:00 regardless of what the task's IfcWorkCalendar actually declares as working hours, ignoring `IfcWorkTime.RecurrencePattern.TimePeriods`.
- Adds `ifcopenshell.util.sequence.get_calendar_work_hours()` to derive the declared start/finish time of day from the calendar (falling back to 09:00/17:00 when nothing is declared), and wires it into `edit_task_time` and `get_start_or_finish_date` (the latter is called by `edit_task_time`'s own `calculate_finish`, so both had to change to stay consistent).
- Scope is intentionally limited to the time-of-day stamp. The day-scale scheduling engine (`offset_date`/`cascade_schedule`/`recalculate_schedule`) is unchanged, per @Moult's 2024-05-08 comment that full hours-awareness there is a larger piece of work.

Fixes #4442

## Test plan
- [x] `pytest test/api/sequence/` (68 passed) including two new tests reproducing the reporter's scenario (calendar declaring 08:00 to 16:00 lands ScheduleStart/Finish at those hours) and the no-declared-hours fallback (still 09:00/17:00)
- [x] `pytest test/util/test_date.py`, `test/api/resource`, `test/api/control`, `test/api/cost` (regression check, all passed)
- [x] black + ruff clean

Generated with the assistance of an AI coding tool.
