### PR TITLE
ifcopenshell.stream: fix streaming parse of files whose line endings differ from os.linesep

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/stream.py
+++ b/src/ifcopenshell-python/ifcopenshell/stream.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 try:
-    import os
     import re
     from typing import Any, NoReturn, Optional, Union
 
@@ -154,17 +153,22 @@ try:
 
             exclude = set()
 
-            offset = 0
-            newline_character = len(os.linesep)
-            for line in self.file:
-                line = line.strip()
+            # Offsets come from `tell()`, not an accumulated `len(line)` guess, so line
+            # endings that differ from the running OS (e.g. CRLF files on Linux) don't drift.
+            offset = self.file.tell()
+            while True:
+                raw_line = self.file.readline()
+                if not raw_line:
+                    break
+                next_offset = self.file.tell()
+                line = raw_line.strip()
                 if line.startswith("#"):
                     step_id, ifc_class = line.split("(")[0].split("=")
                     step_id = int(step_id.strip()[1:])
                     ifc_class = ifc_class.strip()
 
                     if ifc_class in exclude:
-                        offset += len(line) + newline_character
+                        offset = next_offset
                         continue
 
                     for reference_id in self.reference_pattern.findall(line[1:]):
@@ -179,7 +183,7 @@ try:
                     for ifc_class in exclude_classes:
                         declaration = self.ifc_schema.declaration_by_name(ifc_class)
                         exclude.update([st.name().upper() for st in ifcopenshell.util.schema.get_subtypes(declaration)])
-                offset += len(line) + newline_character
+                offset = next_offset
 
             self.preprocess_schema()
 

--- a/src/ifcopenshell-python/test/test_stream.py
+++ b/src/ifcopenshell-python/test/test_stream.py
@@ -23,6 +23,55 @@ import ifcopenshell
 TEST_FILE = Path(__file__).parent / "files" / "basic.ifc"
 
 
+def build_ifc_with_many_points(num_points: int = 600) -> tuple[bytes, int, tuple[float, float, float]]:
+    """Return LF-terminated IFC bytes with extra IfcCartesianPoints appended near the end.
+
+    Also returns the step id and expected coordinates of the last appended point, which
+    is used to detect any accumulated per-line byte offset drift.
+    """
+    lines = TEST_FILE.read_text().split("\n")
+    endsec_index = lines.index("ENDSEC;")
+    next_id = 1000
+    last_id = None
+    last_coords = None
+    extra_lines = []
+    for i in range(num_points):
+        step_id = next_id + i
+        coords = (float(i), float(i) * 2, float(i) * 3)
+        extra_lines.append(f"#{step_id}=IFCCARTESIANPOINT(({coords[0]},{coords[1]},{coords[2]}));")
+        last_id = step_id
+        last_coords = coords
+    lines[endsec_index:endsec_index] = extra_lines
+    return "\n".join(lines).encode("ascii"), last_id, last_coords
+
+
+class TestStreamLineEndings:
+    def test_stream_handles_lf_and_crlf_line_endings(self, tmp_path: Path) -> None:
+        lf_content, late_id, expected_coords = build_ifc_with_many_points()
+        crlf_content = lf_content.replace(b"\n", b"\r\n")
+
+        lf_path = tmp_path / "many_points_lf.ifc"
+        crlf_path = tmp_path / "many_points_crlf.ifc"
+        lf_path.write_bytes(lf_content)
+        crlf_path.write_bytes(crlf_content)
+
+        for path in (lf_path, crlf_path):
+            stream_file: ifcopenshell.stream
+            stream_file = ifcopenshell.open(path, should_stream=True)
+            assert (element := stream_file.by_id(late_id))
+            assert element.Coordinates == expected_coords
+
+    def test_stream_handles_crlf_on_original_test_file(self, tmp_path: Path) -> None:
+        crlf_content = TEST_FILE.read_bytes().replace(b"\n", b"\r\n")
+        crlf_path = tmp_path / "basic_crlf.ifc"
+        crlf_path.write_bytes(crlf_content)
+
+        stream_file: ifcopenshell.stream
+        stream_file = ifcopenshell.open(crlf_path, should_stream=True)
+        assert (element := stream_file.by_id(1))
+        assert element.Name == "My Project"
+
+
 class TestFile:
     def test_run(self):
         stream_file: ifcopenshell.stream


### PR DESCRIPTION
## Summary
- Fixes a streaming-parser bug where `ifcopenshell.open(path, should_stream=True)` raised `lark.exceptions.UnexpectedToken` / `UnexpectedCharacters` on a valid IFC file whose line endings differ from the running interpreter's `os.linesep` (e.g. a CRLF file streamed on Linux/macOS, which is the reporter's Windows-authored case).
- The line-offset index in `ifcopenshell/stream.py` assumed every line ends with `os.linesep`; it now derives offsets from the text-mode file's own `tell()`, which correctly handles LF, CRLF, bare-CR, and mixed line endings within one file. The byte-offset drift previously caused later `seek()` calls to land mid-token.

## Test plan
- [x] Added `TestStreamLineEndings` regression tests in `test/test_stream.py`: a late-entity (~600 entities in) streaming test with both LF and CRLF copies of the same file, plus a CRLF copy of the existing `basic.ifc` fixture.
- [x] Verified the new tests reproduce the exact reported exception against the pre-fix code, and pass against the fix.
- [x] Existing `test_stream.py` tests still pass (no regression).
- [x] black + ruff clean.

Fixes #4448

Generated with the assistance of an AI coding tool. This entire PR (fix and tests) was AI-generated.
