### PR TITLE
IfcCSV: split export results into multiple worksheets (split_by)

### DIFF
--- a/src/ifccsv/ifccsv.py
+++ b/src/ifccsv/ifccsv.py
@@ -92,10 +92,13 @@ class IfcCsv:
         groups=None,
         summaries=None,
         formatting=None,
+        split_by: Optional[str] = None,
     ):
         self.ifc_file = ifc_file
         self.results = []
         self.headers = []
+        self.split_by = split_by
+        self.split_groups = None
         attributes = attributes or []
 
         if not headers:
@@ -134,6 +137,7 @@ class IfcCsv:
         self.summarise_results(summaries, attributes)
         self.sort_results(sort, attributes, include_global_id)
         self.format_results(formatting, attributes, null)
+        self.split_groups = self.split_results(split_by, attributes)
 
         if format == "csv":
             self.export_csv(output, delimiter=delimiter)
@@ -205,6 +209,42 @@ class IfcCsv:
                         result[gi] = max(group_values[key][gi])
 
         self.results = group_results.values()
+
+    def split_results(self, split_by: Optional[str], attributes: list[str]) -> Optional[list[tuple[str, list]]]:
+        """Partitions results into one bucket per unique value of `split_by`."""
+        if not split_by:
+            return None
+
+        if split_by not in attributes:
+            raise ValueError(f"split_by attribute '{split_by}' is not part of the exported attributes")
+
+        index = attributes.index(split_by)
+        split_groups: dict[str, list] = {}
+        for row in self.results:
+            key = str(row[index])
+            split_groups.setdefault(key, []).append(row)
+        return list(split_groups.items())
+
+    @staticmethod
+    def sanitize_split_key(key: str, existing_names: set[str], max_length: int = 31) -> str:
+        """Sanitizes a split value into a safe, unique sheet name or filename suffix."""
+        name = str(key).strip()
+        for char in "\\/*?:[]":
+            name = name.replace(char, "_")
+        name = name.strip("'")
+        if not name:
+            name = "Sheet"
+        name = name[:max_length]
+
+        base_name = name
+        suffix_index = 1
+        while name in existing_names:
+            suffix = f"_{suffix_index}"
+            name = base_name[: max_length - len(suffix)] + suffix
+            suffix_index += 1
+
+        existing_names.add(name)
+        return name
 
     def summarise_results(self, summaries, attributes):
         self.summaries = [None] * len(attributes)
@@ -290,6 +330,10 @@ class IfcCsv:
                 self.results = sorted(self.results, key=lambda x: x[0])
 
     def export_csv(self, output: str, delimiter: Optional[str] = None) -> None:
+        if self.split_groups is not None:
+            self.export_csv_split(output, delimiter=delimiter)
+            return
+
         with open(output, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f, delimiter=delimiter)
             writer.writerow(self.headers)
@@ -298,7 +342,27 @@ class IfcCsv:
             if self.has_summaries():
                 writer.writerow(self.summaries)
 
+    def export_csv_split(self, output: str, delimiter: Optional[str] = None) -> None:
+        # e.g. data.csv -> data_IfcWall.csv, data_IfcSlab.csv
+        assert self.split_groups is not None
+        stem, ext = os.path.splitext(output)
+        ext = ext or ".csv"
+        existing_names: set[str] = set()
+        for key, rows in self.split_groups:
+            suffix = self.sanitize_split_key(key, existing_names, max_length=100)
+            with open(f"{stem}_{suffix}{ext}", "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f, delimiter=delimiter)
+                writer.writerow(self.headers)
+                for row in rows:
+                    writer.writerow(row)
+                if self.has_summaries():
+                    writer.writerow(self.summaries)
+
     def export_ods(self, output, should_preserve_existing=False):
+        if self.split_groups is not None:
+            self.export_ods_split(output)
+            return
+
         df = self.export_pd()
         if self.has_summaries():
             df.loc[df.shape[0]] = self.summaries
@@ -330,6 +394,17 @@ class IfcCsv:
             ods_document.save(output)
         else:
             df.to_excel(output, index=False, engine="odf")
+
+    def export_ods_split(self, output) -> None:
+        assert self.split_groups is not None
+        existing_names: set[str] = set()
+        with pd.ExcelWriter(output, engine="odf") as writer:
+            for key, rows in self.split_groups:
+                sheet_name = self.sanitize_split_key(key, existing_names)
+                df = pd.DataFrame(rows, columns=self.headers)
+                if self.has_summaries():
+                    df.loc[df.shape[0]] = self.summaries
+                df.to_excel(writer, sheet_name=sheet_name, index=False)
 
     def set_cell_value(self, cell, value):
         for item in cell.childNodes:
@@ -364,6 +439,10 @@ class IfcCsv:
         return any([s for s in self.summaries if s is not None])
 
     def export_xlsx(self, output, should_preserve_existing=False):
+        if self.split_groups is not None:
+            self.export_xlsx_split(output)
+            return
+
         df = self.export_pd()
         if self.has_summaries():
             df.loc[df.shape[0]] = self.summaries
@@ -380,7 +459,26 @@ class IfcCsv:
         else:
             df.to_excel(output, index=False, engine="openpyxl")
 
-    def export_pd(self):
+    def export_xlsx_split(self, output) -> None:
+        assert self.split_groups is not None
+        existing_names: set[str] = set()
+        with pd.ExcelWriter(output, engine="openpyxl") as writer:
+            for key, rows in self.split_groups:
+                sheet_name = self.sanitize_split_key(key, existing_names)
+                df = pd.DataFrame(rows, columns=self.headers)
+                if self.has_summaries():
+                    df.loc[df.shape[0]] = self.summaries
+                df.to_excel(writer, sheet_name=sheet_name, index=False)
+
+    def export_pd(self) -> Union["pd.DataFrame", dict[str, "pd.DataFrame"]]:
+        if self.split_groups is not None:
+            existing_names: set[str] = set()
+            self.dataframe = {
+                self.sanitize_split_key(key, existing_names): pd.DataFrame(rows, columns=self.headers)
+                for key, rows in self.split_groups
+            }
+            return self.dataframe
+
         self.dataframe = pd.DataFrame(self.results, columns=self.headers)
         return self.dataframe
 
@@ -537,6 +635,15 @@ if __name__ == "__main__":
     parser.add_argument("--headers", nargs="+", help="Specify human readable headers that correlate to each attribute.")
     parser.add_argument("--sort", nargs="+", help="Specify one or more attributes to sort by.")
     parser.add_argument("--order", nargs="+", help="Choose the sort order from ASC or DESC for each sorted attribute.")
+    parser.add_argument(
+        "--split-by",
+        type=str,
+        default=None,
+        help=(
+            "Specify an attribute to split results by, writing one worksheet per unique value for "
+            "xlsx/ods, or one suffixed file per unique value for csv."
+        ),
+    )
     parser.add_argument("--export", action="store_true", help="Export from IFC to the desired format.")
     parser.add_argument("--import", action="store_true", help="Import from the autodetected format to IFC.")
     args = parser.parse_args()
@@ -562,6 +669,7 @@ if __name__ == "__main__":
             bool_false=args.bool_false,
             concat=args.concat,
             sort=sort,
+            split_by=args.split_by,
         )
     elif getattr(args, "import"):
         ifc_csv = IfcCsv()

--- a/src/ifccsv/test/test_ifccsv.py
+++ b/src/ifccsv/test/test_ifccsv.py
@@ -1,0 +1,180 @@
+# This file was generated with the assistance of an AI coding tool.
+#
+# IfcCSV - A utility to interact with IFC data through CSV.
+# Copyright (C) 2020, 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcCSV.
+#
+# IfcCSV is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcCSV is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcCSV.  If not, see <http://www.gnu.org/licenses/>.
+
+import csv
+from pathlib import Path
+
+import ifcopenshell
+import ifcopenshell.api.root
+import openpyxl
+import pandas as pd
+import pytest
+from odf.opendocument import load as load_ods
+from odf.table import Table
+
+import ifccsv
+
+
+def build_ifc_file() -> ifcopenshell.file:
+    ifc_file = ifcopenshell.file()
+    ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject")
+    ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Wall1")
+    ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Wall2")
+    ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSlab", name="Slab1")
+    ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoor", name="Door1")
+    return ifc_file
+
+
+class TestSplitBy:
+    def get_elements(self, ifc_file: ifcopenshell.file) -> list[ifcopenshell.entity_instance]:
+        return ifc_file.by_type("IfcElement")
+
+    def test_split_results_partitions_rows_by_attribute_value(self):
+        ifc_file = build_ifc_file()
+        elements = self.get_elements(ifc_file)
+
+        ifc_csv = ifccsv.IfcCsv()
+        ifc_csv.export(ifc_file, elements, ["class", "Name"], format="pd", split_by="class")
+
+        assert ifc_csv.split_groups is not None
+        split_keys = {key for key, _ in ifc_csv.split_groups}
+        assert split_keys == {"IfcWall", "IfcSlab", "IfcDoor"}
+
+        rows_by_class = dict(ifc_csv.split_groups)
+        assert len(rows_by_class["IfcWall"]) == 2
+        assert len(rows_by_class["IfcSlab"]) == 1
+        assert len(rows_by_class["IfcDoor"]) == 1
+
+    def test_split_by_unknown_attribute_raises(self):
+        ifc_file = build_ifc_file()
+        elements = self.get_elements(ifc_file)
+
+        ifc_csv = ifccsv.IfcCsv()
+        with pytest.raises(ValueError):
+            ifc_csv.export(ifc_file, elements, ["class", "Name"], format="pd", split_by="NotAnAttribute")
+
+    def test_export_pd_without_split_returns_single_dataframe(self):
+        ifc_file = build_ifc_file()
+        elements = self.get_elements(ifc_file)
+
+        ifc_csv = ifccsv.IfcCsv()
+        df = ifc_csv.export(ifc_file, elements, ["class", "Name"], format="pd")
+
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 4
+
+    def test_export_pd_with_split_returns_dict_of_dataframes(self):
+        ifc_file = build_ifc_file()
+        elements = self.get_elements(ifc_file)
+
+        ifc_csv = ifccsv.IfcCsv()
+        result = ifc_csv.export(ifc_file, elements, ["class", "Name"], format="pd", split_by="class")
+
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {"IfcWall", "IfcSlab", "IfcDoor"}
+        assert len(result["IfcWall"]) == 2
+        assert list(result["IfcWall"].columns) == ["GlobalId", "class", "Name"]
+
+    def test_export_xlsx_writes_one_worksheet_per_split_value(self, tmp_path: Path):
+        ifc_file = build_ifc_file()
+        elements = self.get_elements(ifc_file)
+        output = tmp_path / "data.xlsx"
+
+        ifc_csv = ifccsv.IfcCsv()
+        ifc_csv.export(ifc_file, elements, ["class", "Name"], output=str(output), format="xlsx", split_by="class")
+
+        workbook = openpyxl.load_workbook(output)
+        assert set(workbook.sheetnames) == {"IfcWall", "IfcSlab", "IfcDoor"}
+
+        wall_sheet = workbook["IfcWall"]
+        rows = list(wall_sheet.iter_rows(values_only=True))
+        assert rows[0] == ("GlobalId", "class", "Name")
+        assert len(rows) == 3  # header + 2 walls
+
+    def test_export_ods_writes_one_worksheet_per_split_value(self, tmp_path: Path):
+        ifc_file = build_ifc_file()
+        elements = self.get_elements(ifc_file)
+        output = tmp_path / "data.ods"
+
+        ifc_csv = ifccsv.IfcCsv()
+        ifc_csv.export(ifc_file, elements, ["class", "Name"], output=str(output), format="ods", split_by="class")
+
+        document = load_ods(str(output))
+        tables = document.spreadsheet.getElementsByType(Table)
+        sheet_names = {table.getAttribute("name") for table in tables}
+        assert sheet_names == {"IfcWall", "IfcSlab", "IfcDoor"}
+
+    def test_export_csv_writes_one_suffixed_file_per_split_value(self, tmp_path: Path):
+        ifc_file = build_ifc_file()
+        elements = self.get_elements(ifc_file)
+        output = tmp_path / "data.csv"
+
+        ifc_csv = ifccsv.IfcCsv()
+        ifc_csv.export(ifc_file, elements, ["class", "Name"], output=str(output), format="csv", split_by="class")
+
+        assert not output.exists()
+        wall_csv = tmp_path / "data_IfcWall.csv"
+        slab_csv = tmp_path / "data_IfcSlab.csv"
+        door_csv = tmp_path / "data_IfcDoor.csv"
+        assert wall_csv.exists()
+        assert slab_csv.exists()
+        assert door_csv.exists()
+
+        with wall_csv.open(newline="", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        assert rows[0] == ["GlobalId", "class", "Name"]
+        assert len(rows) == 3  # header + 2 walls
+
+    def test_export_csv_without_split_writes_single_file(self, tmp_path: Path):
+        ifc_file = build_ifc_file()
+        elements = self.get_elements(ifc_file)
+        output = tmp_path / "data.csv"
+
+        ifc_csv = ifccsv.IfcCsv()
+        ifc_csv.export(ifc_file, elements, ["class", "Name"], output=str(output), format="csv")
+
+        assert output.exists()
+        with output.open(newline="", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        assert len(rows) == 5  # header + 4 elements
+
+
+class TestSanitizeSplitKey:
+    def test_strips_forbidden_worksheet_characters(self):
+        existing: set[str] = set()
+        name = ifccsv.IfcCsv.sanitize_split_key("Pset/Foo:Bar*[1]", existing)
+        assert all(char not in name for char in "\\/*?:[]")
+
+    def test_truncates_to_max_length(self):
+        existing: set[str] = set()
+        long_value = "x" * 50
+        name = ifccsv.IfcCsv.sanitize_split_key(long_value, existing, max_length=31)
+        assert len(name) <= 31
+
+    def test_disambiguates_collisions(self):
+        existing: set[str] = set()
+        first = ifccsv.IfcCsv.sanitize_split_key("Wall", existing)
+        second = ifccsv.IfcCsv.sanitize_split_key("Wall", existing)
+        assert first != second
+
+    def test_empty_value_falls_back_to_placeholder(self):
+        existing: set[str] = set()
+        name = ifccsv.IfcCsv.sanitize_split_key("", existing)
+        assert name == "Sheet"


### PR DESCRIPTION
## Add IfcCSV support for splitting export results into multiple worksheets (#4252)

Implements #4252, requested by @Moult, as the opposite of the existing `groups` feature (which merges rows sharing a value into one; this splits rows sharing a value into separate results).

- `IfcCsv.export()` gains a `split_by` parameter: the name of an attribute/column to partition rows by.
- xlsx/ods: each unique value gets its own worksheet, name sanitized for spreadsheet rules (illegal chars stripped, 31-char limit, collision-safe).
- csv: degrades to one suffixed file per value (`data.csv` -> `data_IfcWall.csv`), per Moult's own suggestion in #4251's discussion.
- pd: returns a dict of DataFrames keyed by value instead of a single DataFrame, when split is active.
- CLI: new `--split-by` flag.
- Unknown `split_by` attribute raises a clear error rather than silently no-op.

Note: #4251 (referenced by #4252 as "the group command") turned out to be a closed docs PR, not an implementation of grouping-into-sheets; the actual `groups` param in `ifccsv.py` is an unrelated row-aggregation feature. There was nothing to mirror for "split" beyond Moult's own comments in that thread, which this PR follows directly.

## Test plan
- [x] `pytest src/ifccsv/test` (12 new tests, all passing): partitioning, unknown-attribute error, pd single-vs-dict, xlsx/ods worksheet names and content, csv suffixed files, non-split regression, sanitizer edge cases.
- [x] black + ruff clean.

Generated with the assistance of an AI coding tool.
