### PR TITLE
Bonsai: break down Single measurement against the active object's local axes

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -448,6 +448,55 @@ class PolylineDecorator(tool.Blender.ViewportDecorator):
 
         return (x_axis, y_axis, z_axis), (x_middle, y_middle, z_middle)
 
+    def calculate_measurement_local_x_y_and_z(
+        self, context: bpy.types.Context
+    ) -> tuple[tuple[tuple[Vector, Vector], ...], tuple[Vector, ...], Vector] | tuple[None, None, None]:
+        """Like `calculate_measurement_x_y_and_z`, but decomposed against the active
+        object's own orientation instead of the global axes. The active object acts
+        as the reference frame, so no extra "pick a reference" UI is needed. Returns
+        `None` when there is no active object or its rotation matches the global axes
+        (nothing extra to show)."""
+        if len(self.polyline_points) == 0 or len(self.polyline_points) > 2:
+            return None, None, None
+
+        obj = context.active_object
+        if obj is None:
+            return None, None, None
+
+        rotation = obj.matrix_world.to_3x3().normalized()
+        if rotation.to_quaternion().angle < 1e-6:
+            # Active object isn't rotated, so its local axes match the global ones.
+            return None, None, None
+
+        start = self.polyline_points[0]
+        if len(self.polyline_points) == 1:
+            end = tool.Model.get_polyline_props().snap_mouse_point[0]
+        else:
+            end = self.polyline_points[1]
+
+        start_co = Vector((start.x, start.y, start.z))
+        end_co = Vector((end.x, end.y, end.z))
+        delta = end_co - start_co
+        local_delta = rotation.inverted() @ delta
+
+        local_x_dir = rotation @ Vector((1, 0, 0))
+        local_y_dir = rotation @ Vector((0, 1, 0))
+        local_z_dir = rotation @ Vector((0, 0, 1))
+
+        p0 = start_co
+        p1 = p0 + local_x_dir * local_delta.x
+        p2 = p1 + local_y_dir * local_delta.y
+        p3 = p2 + local_z_dir * local_delta.z
+
+        x_axis = (p0, p1)
+        y_axis = (p1, p2)
+        z_axis = (p2, p3)
+        x_middle = (x_axis[1] + x_axis[0]) / 2
+        y_middle = (y_axis[1] + y_axis[0]) / 2
+        z_middle = (z_axis[1] + z_axis[0]) / 2
+
+        return (x_axis, y_axis, z_axis), (x_middle, y_middle, z_middle), local_delta
+
     @classmethod
     def calculate_polygon(cls, points: list[Vector]) -> dict[str, Any]:
         bm = bmesh.new()
@@ -605,6 +654,17 @@ class PolylineDecorator(tool.Blender.ViewportDecorator):
                     text = f"{prefix}: {formatted_value}"
                     screen_coords[f"xyz_{i}"] = (Vector(dim_text_coords), text)
 
+            local_axis_line, local_axis_line_center, local_delta = self.calculate_measurement_local_x_y_and_z(context)
+            if local_axis_line:
+                for i, dim_text_pos in enumerate(local_axis_line_center):
+                    dim_text_coords = view3d_utils.location_3d_to_region_2d(region, rv3d, dim_text_pos)
+                    if dim_text_coords:
+                        value = round(local_delta[i], 4)
+                        prefix = "xyz"[i]
+                        formatted_value = tool.Polyline.format_input_ui_units(value)
+                        text = f"local {prefix}: {formatted_value}"
+                        screen_coords[f"local_xyz_{i}"] = (Vector(dim_text_coords), text)
+
         # Area and Length text
         polyline_verts = [Vector((p.x, p.y, p.z)) for p in self.polyline_points]
 
@@ -730,6 +790,15 @@ class PolylineDecorator(tool.Blender.ViewportDecorator):
             self.draw_batch("LINES", [*x_axis], self.decorator_color_x_axis, [(0, 1)])
             self.draw_batch("LINES", [*y_axis], self.decorator_color_y_axis, [(0, 1)])
             self.draw_batch("LINES", [*z_axis], self.decorator_color_z_axis, [(0, 1)])
+
+            local_axis, _, _ = self.calculate_measurement_local_x_y_and_z(context)
+            if local_axis:
+                local_x_axis, local_y_axis, local_z_axis = local_axis
+                # Highlighted colours distinguish the local breakdown from the global one.
+                self.line_shader.uniform_float("lineWidth", 1.5)
+                self.draw_batch("LINES", [*local_x_axis], highlight_color(self.decorator_color_x_axis), [(0, 1)])
+                self.draw_batch("LINES", [*local_y_axis], highlight_color(self.decorator_color_y_axis), [(0, 1)])
+                self.draw_batch("LINES", [*local_z_axis], highlight_color(self.decorator_color_z_axis), [(0, 1)])
 
         # Area highlight
         if self.polyline_data:

--- a/src/bonsai/test/bim/module/model/test_measurement_local_axes.py
+++ b/src/bonsai/test/bim/module/model/test_measurement_local_axes.py
@@ -1,0 +1,116 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Contract tests for PolylineDecorator.calculate_measurement_local_x_y_and_z:
+the "Single" measure tool's breakdown of a two-point delta against the active
+object's own orientation (issue #4391), on top of the existing global-axis
+breakdown (calculate_measurement_x_y_and_z)."""
+
+import math
+from types import SimpleNamespace
+
+import bpy
+import pytest
+from mathutils import Euler, Vector
+
+from test.bim.bootstrap import NewFile
+
+pytestmark = pytest.mark.model
+
+
+def _decorator_with_points(start: Vector, end: Vector):
+    from bonsai.bim.module.model.decorator import PolylineDecorator
+
+    decorator = PolylineDecorator.__new__(PolylineDecorator)
+    decorator.polyline_points = [
+        SimpleNamespace(x=start.x, y=start.y, z=start.z),
+        SimpleNamespace(x=end.x, y=end.y, z=end.z),
+    ]
+    return decorator
+
+
+def _make_active_object_rotated_about_z(degrees: float):
+    bpy.ops.object.add(type="EMPTY")
+    obj = bpy.context.active_object
+    obj.rotation_euler = Euler((0, 0, math.radians(degrees)), "XYZ")
+    bpy.context.view_layer.update()
+    return obj
+
+
+class TestCalculateMeasurementLocalXYAndZ(NewFile):
+    def test_no_active_object_returns_none(self):
+        bpy.context.view_layer.objects.active = None
+        decorator = _decorator_with_points(Vector((0, 0, 0)), Vector((1, 2, 3)))
+        axis, center, delta = decorator.calculate_measurement_local_x_y_and_z(bpy.context)
+        assert axis is None
+        assert center is None
+        assert delta is None
+
+    def test_unrotated_active_object_matches_global_so_returns_none(self):
+        _make_active_object_rotated_about_z(0)
+        decorator = _decorator_with_points(Vector((0, 0, 0)), Vector((1, 2, 3)))
+        axis, center, delta = decorator.calculate_measurement_local_x_y_and_z(bpy.context)
+        assert axis is None
+
+    def test_90_degree_z_rotation_swaps_x_and_y_components(self):
+        # A +90 deg rotation about Z maps local +X -> global +Y and local +Y -> global -X,
+        # so the local breakdown of a global (3, 4, 5) delta is (4, -3, 5).
+        _make_active_object_rotated_about_z(90)
+        start = Vector((0, 0, 0))
+        end = Vector((3, 4, 5))
+        decorator = _decorator_with_points(start, end)
+        axis, center, delta = decorator.calculate_measurement_local_x_y_and_z(bpy.context)
+
+        assert axis is not None and center is not None and delta is not None
+        assert delta.x == pytest.approx(4)
+        assert delta.y == pytest.approx(-3)
+        assert delta.z == pytest.approx(5)
+
+        x_axis, y_axis, z_axis = axis
+        assert tuple(x_axis[0]) == pytest.approx(tuple(start))
+        # Stairstep segments must land exactly on the measured end point.
+        assert tuple(z_axis[1]) == pytest.approx(tuple(end))
+        assert (x_axis[1] - x_axis[0]).length == pytest.approx(abs(delta.x))
+        assert (y_axis[1] - y_axis[0]).length == pytest.approx(abs(delta.y))
+        assert (z_axis[1] - z_axis[0]).length == pytest.approx(abs(delta.z))
+
+    def test_arbitrary_rotation_round_trips_back_to_global_delta(self):
+        # Re-projecting the local components back onto world space (via the
+        # object's rotation) must reconstruct the original global delta,
+        # regardless of the rotation chosen.
+        obj = _make_active_object_rotated_about_z(0)
+        obj.rotation_euler = Euler((math.radians(20), math.radians(35), math.radians(50)), "XYZ")
+        bpy.context.view_layer.update()
+
+        start = Vector((1, -2, 0.5))
+        end = Vector((4, 1, 3.5))
+        decorator = _decorator_with_points(start, end)
+        axis, center, delta = decorator.calculate_measurement_local_x_y_and_z(bpy.context)
+
+        assert delta is not None
+        rotation = obj.matrix_world.to_3x3().normalized()
+        reconstructed = start + rotation @ delta
+        assert tuple(reconstructed) == pytest.approx(tuple(end))
+
+        # Length is preserved (rotation only, no scale), matching what a
+        # BIMVision-style local readout should report.
+        global_length = (end - start).length
+        local_length = math.sqrt(delta.x**2 + delta.y**2 + delta.z**2)
+        assert local_length == pytest.approx(global_length)


### PR DESCRIPTION
## Bonsai: break down Single measurement against the active object's local axes

Closes part of #4391. The Single measure mode already showed a global X/Y/Z breakdown of a two-point measurement (`calculate_measurement_x_y_and_z`, matching the BIMVision-style readout in the issue's screenshot). This adds the residual ask from the thread: the same breakdown expressed in a selected object's own coordinate system.

The **active object** in the scene is used as the reference frame (no extra "pick a reference" UI needed, which was the open UX question in the thread). When an object is active and rotated relative to global axes, its local X/Y/Z components of the same measured delta are now also shown, drawn as a lightened variant of the same axis colours (reusing the existing `highlight_color()` convention already used for the plane-snapping guides) and labelled `local x/y/z`. With no active object, or an unrotated one, behaviour is unchanged (no regression).

Opened as a draft to invite direction on the UX choice (active-object-as-reference) before finalizing.

Out of scope (separate follow-ups raised by theoryshaw in the thread): feet/inches display preference, and locking Z to view for non-orthogonal point pairs.

## Test plan
- [x] 4 unit tests for the local-axis decomposition (no active object -> none; unrotated -> none; 90 deg Z swap; arbitrary rotation round-trips to the global delta).
- [x] Live-verified in headless Blender: hand-computed local delta matches tool output to 6 decimals on a cube rotated (20, 35, 50) deg; global unchanged.
- [x] Full `test/bim/module/model` + `test_polyline.py` suite (536 tests) pass, no regressions.
- [x] black + ruff clean.

This PR's changes were written with the assistance of an AI coding tool.
