### PR TITLE
ifcopenshell.util.selector: include IfcMappedItem transform in x/y/z coordinate queries

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/representation.py
@@ -339,6 +339,29 @@ def resolve_items(
     return results
 
 
+def get_mapped_item_matrix(element: ifcopenshell.entity_instance) -> Union[npt.NDArray[np.float64], None]:
+    """Get the transformation matrix contributed by an element's IfcMappedItem, if any.
+
+    An element positioned through an IfcMappedItem gets part of its world
+    position from the mapping (``MappingTarget`` combined with
+    ``MappingSource.MappingOrigin``), not only from ``ObjectPlacement``. This
+    resolves that mapping transform so it can be combined with the element's
+    local placement matrix (e.g. via ``ObjectPlacement matrix @ this matrix``).
+
+    :param element: An IfcProduct
+    :return: A 4x4 numpy matrix, or None if the element has no mapped item.
+    """
+    representations = list(getattr(getattr(element, "Representation", None), "Representations", None) or [])
+    # Prefer the Body representation, as it best reflects the element's actual
+    # position, but fall back to any other representation with a mapped item.
+    representations.sort(key=lambda r: getattr(r, "RepresentationIdentifier", None) != "Body")
+    for representation in representations:
+        for item in representation.Items or []:
+            if item.is_a("IfcMappedItem"):
+                return ifcopenshell.util.placement.get_mappeditem_transformation(item)
+    return None
+
+
 def resolve_base_items(
     representation: ifcopenshell.entity_instance,
 ) -> Generator[ifcopenshell.entity_instance, None, None]:

--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -34,6 +34,7 @@ import ifcopenshell.util.element
 import ifcopenshell.util.geolocation
 import ifcopenshell.util.placement
 import ifcopenshell.util.pset
+import ifcopenshell.util.representation
 import ifcopenshell.util.schema
 import ifcopenshell.util.shape
 import ifcopenshell.util.shape_builder
@@ -484,6 +485,9 @@ def _get_element_value(element: ifcopenshell.entity_instance, keys: list[str]) -
         elif key in ("x", "y", "z", "easting", "northing", "elevation") and hasattr(value, "ObjectPlacement"):
             if getattr(value, "ObjectPlacement", None):
                 matrix = ifcopenshell.util.placement.get_local_placement(value.ObjectPlacement)
+                mapping_matrix = ifcopenshell.util.representation.get_mapped_item_matrix(value)
+                if mapping_matrix is not None:
+                    matrix = matrix @ mapping_matrix
                 xyz = matrix[:, 3][:3]
                 if key in ("x", "y", "z"):
                     value = xyz["xyz".index(key)]
@@ -495,6 +499,9 @@ def _get_element_value(element: ifcopenshell.entity_instance, keys: list[str]) -
         elif key in ("rotation_x", "rotation_y", "rotation_z") and hasattr(value, "ObjectPlacement"):
             if getattr(value, "ObjectPlacement", None):
                 matrix = ifcopenshell.util.placement.get_local_placement(value.ObjectPlacement)
+                mapping_matrix = ifcopenshell.util.representation.get_mapped_item_matrix(value)
+                if mapping_matrix is not None:
+                    matrix = matrix @ mapping_matrix
                 euler = ifcopenshell.util.shape_builder.np_matrix_to_euler(matrix)
                 value = float(np.degrees(euler[("rotation_x", "rotation_y", "rotation_z").index(key)]))
             else:

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -141,6 +141,57 @@ class TestGetElementValue(test.bootstrap.IFC4):
         element_without_placement = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         assert subject.get_element_value(element_without_placement, "rotation_z") is None
 
+    def test_selecting_an_elements_position_using_a_query(self):
+        # Control: an element placed only through ObjectPlacement (no mapped
+        # item) still resolves x/y/z straight from the placement matrix.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        matrix = np.eye(4)
+        matrix[:3, 3] = [1.0, 2.0, 3.0]
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=element, matrix=matrix, is_si=False)
+        assert subject.get_element_value(element, "x") == pytest.approx(1.0)
+        assert subject.get_element_value(element, "y") == pytest.approx(2.0)
+        assert subject.get_element_value(element, "z") == pytest.approx(3.0)
+
+    def test_selecting_an_elements_position_when_represented_via_a_mapped_item(self):
+        # Feature test for #6277: an element positioned through an
+        # IfcMappedItem gets part of its world position from the mapping
+        # transform (MappingTarget combined with MappingSource.MappingOrigin),
+        # not only from ObjectPlacement. x/y/z must account for both.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        matrix = np.eye(4)
+        matrix[:3, 3] = [1.0, 2.0, 3.0]
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=element, matrix=matrix, is_si=False)
+
+        mapped_representation = self.file.createIfcShapeRepresentation(Items=[self.file.createIfcExtrudedAreaSolid()])
+        representation_map = self.file.createIfcRepresentationMap(
+            MappingOrigin=self.file.createIfcAxis2Placement3D(
+                Location=self.file.createIfcCartesianPoint((0.0, 0.0, 0.0))
+            ),
+            MappedRepresentation=mapped_representation,
+        )
+        mapped_item = self.file.createIfcMappedItem(
+            MappingSource=representation_map,
+            MappingTarget=self.file.createIfcCartesianTransformationOperator3D(
+                LocalOrigin=self.file.createIfcCartesianPoint((10.0, 20.0, 30.0))
+            ),
+        )
+        representation = self.file.createIfcShapeRepresentation(
+            RepresentationIdentifier="Body",
+            RepresentationType="MappedRepresentation",
+            Items=[mapped_item],
+        )
+        element.Representation = self.file.createIfcProductDefinitionShape(Representations=[representation])
+
+        # Without the fix, x/y/z would only reflect ObjectPlacement (1, 2, 3)
+        # and silently drop the mapping's contribution.
+        assert subject.get_element_value(element, "x") == pytest.approx(11.0)
+        assert subject.get_element_value(element, "y") == pytest.approx(22.0)
+        assert subject.get_element_value(element, "z") == pytest.approx(33.0)
+
     def test_selecting_using_a_multiple_key_query(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         material = ifcopenshell.api.material.add_material(self.file, name="CON01")


### PR DESCRIPTION
## Problem
`ifcopenshell.util.selector`'s `x`/`y`/`z` (and `easting`/`northing`/`elevation`, `rotation_x/y/z`) queries only resolved `ObjectPlacement`. For elements positioned through an `IfcMappedItem` representation, part of the world position comes from the mapping transform (`MappingTarget` combined with `MappingSource.MappingOrigin`), which was silently dropped, returning 0 or the bare placement origin.

## Fix
Added `ifcopenshell.util.representation.get_mapped_item_matrix()`, which locates an element's `IfcMappedItem` and reuses the existing `util.placement.get_mappeditem_transformation()` helper (per aothms's guidance in the issue thread, no C++ `map_shape` wrapper needed). The selector now composes this with the `ObjectPlacement` matrix (placement outer, mapping inner, matching how `util.representation.resolve_items` composes them) before extracting coordinates/rotation. Non-mapped elements are unaffected.

## Testing
Two new tests in `test/util/test_selector.py`: a control (plain placement, unaffected) and a mapped-item case asserting the combined world position. Reverting only the selector change makes the mapped-item test return the bare origin instead of the mapped coordinate, confirming it reproduces the reported bug.

Fixes #6277.

Generated with the assistance of an AI coding tool: `ifcopenshell/util/representation.py`, `ifcopenshell/util/selector.py`, and the two new tests in `test/util/test_selector.py`.
