### PR TITLE
ifcopenshell.util, Bonsai: expose a document's superseded revision history

### DIFF
--- a/src/bonsai/bonsai/bim/data/templates/titleblocks/README.md
+++ b/src/bonsai/bonsai/bim/data/templates/titleblocks/README.md
@@ -1,1 +1,18 @@
 SVG [mustache](https://mustache.github.io/) templates that will be used for sheets and fill be filled with infromation from the sheet's IfcDocumentInformation attributes (e.g. Identification, Name, Revision, etc).
+
+A `Revisions` list is also available for templates that want to render a
+revision history table. It is populated from any older revisions attached to
+the sheet via `IfcDocumentInformationRelationship` (see
+`ifcopenshell.api.document.add_information`'s `parent` argument and
+`ifcopenshell.util.document.get_revision_history`), ordered from the most
+recent superseded revision to the oldest. Each item is the superseded
+document's raw attribute dictionary (e.g. `Revision`, `Description`,
+`CreationTime`), so a template can do:
+
+```xml
+{{#Revisions}}<tspan>{{Revision}} - {{Description}}</tspan>{{/Revisions}}
+```
+
+None of the stock A1/A2/A3 titleblocks currently draw a revision table (that
+is a titleblock artwork/layout decision left to project-specific templates);
+they only show the sheet's own current `{{Revision}}`.

--- a/src/bonsai/bonsai/bim/module/drawing/sheeter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/sheeter.py
@@ -26,6 +26,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from xml.dom import minidom
 
+import ifcopenshell.util.document
 import ifcopenshell.util.geolocation
 import pystache
 from mathutils import Vector
@@ -319,7 +320,9 @@ class SheetBuilder:
     def build_titleblock(self, root: ET.Element, sheet: ifcopenshell.entity_instance) -> None:
         titleblock = root.findall(f'{SVG}g[@data-type="titleblock"]')[0]
         image = titleblock.findall(f"{SVG}image")[0]
-        g = self.parse_embedded_svg(image, sheet.get_info())
+        data = sheet.get_info()
+        data["Revisions"] = [r.get_info() for r in ifcopenshell.util.document.get_revision_history(sheet)]
+        g = self.parse_embedded_svg(image, data)
         grid_north = ifcopenshell.util.geolocation.get_grid_north(tool.Ifc.get()) * -1
         true_north = ifcopenshell.util.geolocation.get_true_north(tool.Ifc.get()) * -1
         for north in g.iterfind(f'.//{SVG}g[@data-type="grid-north"]'):

--- a/src/ifcopenshell-python/ifcopenshell/util/document.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/document.py
@@ -1,0 +1,62 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from typing import Optional
+
+import ifcopenshell
+
+
+def get_revision_history(
+    document: ifcopenshell.entity_instance, _visited: Optional[set[int]] = None
+) -> list[ifcopenshell.entity_instance]:
+    """Gets the superseded revisions of a document, oldest edits last
+
+    A document (typically an IfcDocumentInformation, such as a drawing
+    sheet) may have older revisions attached to it as subdocuments via
+    IfcDocumentInformationRelationship, where ``document`` is considered the
+    latest version and its related documents are progressively older
+    revisions. See ``ifcopenshell.api.document.add_information`` for how
+    such a chain is created.
+
+    :param document: The IfcDocumentInformation to get the revision history
+        of. This is typically the current/latest revision.
+    :return: A flattened list of older IfcDocumentInformation revisions,
+        ordered from the most recent to the oldest. ``document`` itself is
+        not included.
+
+    Example:
+
+    .. code:: python
+
+        history = ifcopenshell.util.document.get_revision_history(sheet)
+        for revision in history:
+            print(revision.Revision, revision.Description)
+    """
+    if _visited is None:
+        _visited = set()
+    results: list[ifcopenshell.entity_instance] = []
+    for rel in document.IsPointer or []:
+        for child in rel.RelatedDocuments or []:
+            if child.id() in _visited:
+                continue
+            _visited.add(child.id())
+            results.append(child)
+            results.extend(get_revision_history(child, _visited))
+    return results

--- a/src/ifcopenshell-python/test/util/test_document.py
+++ b/src/ifcopenshell-python/test/util/test_document.py
@@ -1,0 +1,60 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.api.document
+import ifcopenshell.util.document as subject
+import test.bootstrap
+
+
+class TestGetRevisionHistory(test.bootstrap.IFC4):
+    def test_a_document_with_no_history(self):
+        self.file.createIfcProject()
+        document = ifcopenshell.api.document.add_information(self.file, parent=None)
+        assert subject.get_revision_history(document) == []
+
+    def test_a_linear_chain_of_revisions(self):
+        self.file.createIfcProject()
+        latest = ifcopenshell.api.document.add_information(self.file, parent=None)
+        rev_b = ifcopenshell.api.document.add_information(self.file, parent=latest)
+        rev_a = ifcopenshell.api.document.add_information(self.file, parent=rev_b)
+        assert subject.get_revision_history(latest) == [rev_b, rev_a]
+        # An older revision only sees its own, even older, history.
+        assert subject.get_revision_history(rev_b) == [rev_a]
+        assert subject.get_revision_history(rev_a) == []
+
+    def test_branching_history_is_flattened(self):
+        self.file.createIfcProject()
+        latest = ifcopenshell.api.document.add_information(self.file, parent=None)
+        rev_b1 = ifcopenshell.api.document.add_information(self.file, parent=latest)
+        rev_b2 = ifcopenshell.api.document.add_information(self.file, parent=latest)
+        rev_a = ifcopenshell.api.document.add_information(self.file, parent=rev_b1)
+        results = subject.get_revision_history(latest)
+        assert set(results) == {rev_b1, rev_b2, rev_a}
+        assert results.index(rev_b1) < results.index(rev_a)
+
+    def test_a_cyclic_relationship_does_not_infinitely_recurse(self):
+        self.file.createIfcProject()
+        latest = ifcopenshell.api.document.add_information(self.file, parent=None)
+        child = ifcopenshell.api.document.add_information(self.file, parent=latest)
+        self.file.createIfcDocumentInformationRelationship(RelatingDocument=child, RelatedDocuments=[latest])
+        results = subject.get_revision_history(latest)
+        assert set(results) == {child, latest}
+
+
+class TestGetRevisionHistoryIFC2X3(test.bootstrap.IFC2X3, TestGetRevisionHistory):
+    pass


### PR DESCRIPTION
Fixes part of #2956.

`ifcopenshell.api.document.add_information(parent=...)` already lets you attach older document revisions to a sheet via `IfcDocumentInformationRelationship` ("parent is the latest version, children are older revisions"), but nothing read that chain back out or fed it to the titleblock renderer. This adds `ifcopenshell.util.document.get_revision_history()` (walks the chain, newest-first, cycle-safe) and wires it into `SheetBuilder.build_titleblock` as a `Revisions` list, so a titleblock SVG template can render a revision-history table with `{{#Revisions}}...{{/Revisions}}`.

Non-breaking: templates that don't reference `Revisions` render identically (verified byte-identical before/after on a stock-shaped template).

**Open question for a maintainer:** the stock A1/A2/A3 titleblocks don't draw a revision table today (only the current `{{Revision}}`). Adding one is a titleblock artwork/layout decision I didn't want to guess at blindly. Should the stock templates get a fixed-row revision table now that the data is available, or is this left to project-specific templates (as the README note says)? Also open: does the broader question aothms raised (IFC-monolith vs. external/ICDD storage for drawing metadata) block or coexist with this?

## Test plan
- [x] `ifcopenshell/util/document.py::get_revision_history` — 4 tests x IFC4/IFC2X3 = 8 cases (empty, linear chain, branching flattened, cycle-safe), all pass.
- [x] `build_titleblock` end-to-end render with a synthetic 3-revision chain; stock-template render byte-identical before/after.
- [x] black + ruff clean.

This contribution was produced with the assistance of an AI coding tool.
