### PR TITLE
Bonsai: fix Drawing Underlay 'Add Style' wiping previously saved shading styles

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2773,10 +2773,15 @@ class AddDrawingStyle(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.add_drawing_style"
     bl_label = "Add Drawing Style"
     bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Add a new drawing style, keeping all previously saved styles."
 
     def _execute(self, context):
         assert context.scene and (camera_obj := context.scene.camera)
         props = tool.Drawing.get_document_props()
+        # Reload from disk first so a stale/empty cache can't overwrite previously saved styles. See #4739.
+        reload_result = bpy.ops.bim.reload_drawing_styles()
+        if "CANCELLED" in reload_result:
+            return {"CANCELLED"}
         drawing_styles = props.drawing_styles
         new = drawing_styles.add()
         # drawing style is saved to ifc on rename

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
 import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -1067,6 +1068,40 @@ class TestDrawingStyles(NewFile):
         self.drawing_styles.clear()
         bpy.ops.bim.reload_drawing_styles()
         assert len(self.drawing_styles) == 3
+
+    def test_add_drawing_style_preserves_styles_saved_in_a_previous_session(self):
+        """Regression test for #4739.
+
+        Pressing "Add Drawing Style" must never wipe out styles that were saved
+        to the shared ShadingStyles JSON file in a previous session but haven't
+        yet been reloaded into the in-memory `drawing_styles` cache (e.g. right
+        after reopening the project, before the underlay/refresh has run).
+        """
+        self.setup_project_with_drawing()
+        props = tool.Drawing.get_document_props()
+        drawing = props.get_active_drawing()
+        assert drawing
+        pset = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing")
+        json_path = tool.Ifc.resolve_uri(pset["ShadingStyles"])
+
+        # Simulate a previous session having saved a custom style to disk.
+        with open(json_path) as fi:
+            styles_on_disk = json.load(fi)
+        assert len(styles_on_disk) == 3
+        styles_on_disk["My Custom Style"] = dict(next(iter(styles_on_disk.values())))
+        with open(json_path, "w") as fo:
+            json.dump(styles_on_disk, fo)
+
+        # Simulate a fresh session where the in-memory cache is still empty/stale.
+        self.drawing_styles.clear()
+        assert len(self.drawing_styles) == 0
+
+        bpy.ops.bim.add_drawing_style()
+
+        with open(json_path) as fi:
+            styles_after = json.load(fi)
+        assert set(styles_on_disk) <= set(styles_after), "previously saved styles must survive Add Drawing Style"
+        assert len(styles_after) == 5  # 3 defaults + 1 pre-existing custom + 1 newly added
 
 
 class TestAddReferenceImage(NewFile):


### PR DESCRIPTION
Fixes #4739. Thanks @SavuGust27 for the report.

The `[+]` "Add Drawing Style" button appends a new style to Bonsai's in-memory style list and immediately re-saves that whole list to the shared `shading_styles.json` file. That in-memory list is only a cache: it starts empty in a fresh Blender session and is otherwise refreshed only by pressing refresh, toggling underlay on, or activating a drawing. Pressing `[+]` before any of those happened (e.g. right after reopening the project, exactly when the panel reads "Current style is not set.") silently overwrote the JSON file with just the one newly added entry, permanently destroying every previously saved style.

`AddDrawingStyle` now reloads from disk before appending, so the button always adds on top of the real persisted set instead of risking wiping it. This matches the existing "reload-then-act" pattern already used by `update_has_underlay` and `ActivateDrawingBase` in the same module. No UI was changed or removed (the reporter suggested removing the `[+]` button, but the root cause was fixable without any UX change).

## Test plan
- [x] Added `TestDrawingStyles::test_add_drawing_style_preserves_styles_saved_in_a_previous_session` in `test/tool/test_drawing.py`, which seeds styles on disk, clears the in-memory cache to simulate a fresh session, and asserts they survive an Add. Verified it fails on the pre-fix code and passes after.
- [x] Full `test/tool/test_drawing.py` suite: 88/88 pass, no regressions.
- [x] black + ruff clean.

Generated with the assistance of an AI coding tool.
