### PR TITLE
selector, Bonsai: include classification system name in search and UI

### DIFF
--- a/src/bonsai/bonsai/bim/module/classification/operator.py
+++ b/src/bonsai/bonsai/bim/module/classification/operator.py
@@ -259,7 +259,8 @@ class EnableEditingClassificationReference(bpy.types.Operator):
         props.reference_attributes.clear()
         ifc_reference = tool.Ifc.get().by_id(self.reference)
         bonsai.bim.helper.import_attributes(ifc_reference, props.reference_attributes)
-        props.classification_system_name = ifc_reference.ReferencedSource.Name or ""
+        classification = ifcopenshell.util.classification.get_classification(ifc_reference)
+        props.classification_system_name = (classification.Name if classification else None) or ""
         props.active_reference_id = self.reference
         return {"FINISHED"}
 
@@ -327,9 +328,6 @@ class EditClassificationReference(bpy.types.Operator, tool.Ifc.Operator):
         attributes = bonsai.bim.helper.export_attributes(props.reference_attributes)
         ifc_file = tool.Ifc.get()
         reference_entity = ifc_file.by_id(props.active_reference_id)
-        referenced_source = reference_entity.ReferencedSource
-        if props.classification_system_name:
-            referenced_source.Name = props.classification_system_name
         ifcopenshell.api.classification.edit_reference(
             ifc_file,
             reference=reference_entity,

--- a/src/bonsai/bonsai/bim/module/classification/ui.py
+++ b/src/bonsai/bonsai/bim/module/classification/ui.py
@@ -157,6 +157,11 @@ class ReferenceUI:
         if not self.data.data["references"]:
             row = self.layout.row(align=True)
             row.label(text="No References")
+        else:
+            row = self.layout.row(align=True)
+            row.label(text="Classification")
+            row.label(text="Identification")
+            row.label(text="Name")
 
         def get_classification_name(reference):
             classification_entity = ifcopenshell.util.classification.get_classification(
@@ -263,6 +268,7 @@ class ReferenceUI:
         row.operator("bim.edit_classification_reference", text="Save changes", icon="CHECKMARK")
         row.operator("bim.disable_editing_classification_reference", text="", icon="CANCEL")
         row = self.layout.row()
+        row.enabled = False
         row.prop(self.props, "classification_system_name", text="Classification System Name")
 
         bonsai.bim.helper.draw_attributes(self.props.reference_attributes, self.layout)

--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -1080,6 +1080,11 @@ class FacetTransformer(lark.Transformer):
                     getattr(reference, "Identification", getattr(reference, "ItemReference", None)), comparison, value
                 ):
                     result = True
+                classification = ifcopenshell.util.classification.get_classification(reference)
+                if classification is not None and self.compare(
+                    getattr(classification, "Name", None), comparison, value
+                ):
+                    result = True
             if result is not None:
                 return result if comparison == "=" else not result
             return self.compare(None, comparison, value)

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -29,6 +29,7 @@ import ifcopenshell.api.root
 import ifcopenshell.api.spatial
 import ifcopenshell.api.type
 import ifcopenshell.api.unit
+import ifcopenshell.guid
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
 import ifcopenshell.util.selector as subject
@@ -348,6 +349,37 @@ class TestFilterElements(test.bootstrap.IFC4):
         assert subject.filter_elements(self.file, "IfcWall, classification=X") == {element}
         assert subject.filter_elements(self.file, "IfcWall, classification=Foobar") == {element}
         assert subject.filter_elements(self.file, "IfcWall, classification!=X") == {element2}
+
+    def test_selecting_by_classification_system(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        uniclass = ifcopenshell.api.classification.add_classification(self.file, classification="Uniclass 2015")
+        cci = ifcopenshell.api.classification.add_classification(self.file, classification="CCI")
+        # Both systems share the same identification, so only the system name can disambiguate.
+        # Built directly (rather than via the add_reference API) since that API deduplicates
+        # references purely by identification, which would collapse these two into one.
+        reference1 = self.file.createIfcClassificationReference(
+            Identification="03 31 19", Name="Cast in situ concrete", ReferencedSource=uniclass
+        )
+        reference2 = self.file.createIfcClassificationReference(
+            Identification="03 31 19", Name="Cast in situ concrete", ReferencedSource=cci
+        )
+        self.file.createIfcRelAssociatesClassification(
+            GlobalId=ifcopenshell.guid.new(), RelatedObjects=[element], RelatingClassification=reference1
+        )
+        self.file.createIfcRelAssociatesClassification(
+            GlobalId=ifcopenshell.guid.new(), RelatedObjects=[element2], RelatingClassification=reference2
+        )
+        # System name is part of the classification search scope.
+        assert subject.filter_elements(self.file, "IfcWall, classification=CCI") == {element2}
+        assert subject.filter_elements(self.file, 'IfcWall, classification="Uniclass 2015"') == {element}
+        # Identification and reference name still match as before, without the system name.
+        assert subject.filter_elements(self.file, 'IfcWall, classification="03 31 19"') == {element, element2}
+        assert subject.filter_elements(self.file, 'IfcWall, classification="Cast in situ concrete"') == {
+            element,
+            element2,
+        }
 
     def test_selecting_by_location(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")


### PR DESCRIPTION
Fixes #4732.

`Classification.Identification` codes can collide across different classification systems (e.g. `03 31 19` exists in both Uniclass 2015 and CCI), so results from the Classification search facet and the Classification References panel could be misleading without knowing which system a reference belongs to.

- **ifcopenshell.util.selector**: the `classification` facet now also matches the root `IfcClassification.Name` (reached via `ReferencedSource`, using the existing `ifcopenshell.util.classification.get_classification` helper), in addition to the existing Identification/Name matching. So `classification=CCI` now selects only elements classified under the CCI system.
- **Bonsai Classification References panel**: added column headers above the Classification / Identification / Name columns. The classification-system-name column and attribute field already existed from earlier work; this makes the attribute field **read-only**, because it was previously an editable text field whose edits were written back onto the reference's `ReferencedSource` — which is usually shared by many other references (and isn't always the root `IfcClassification` in a hierarchy), so editing it from one element could silently rename the classification system everywhere.

Opened as a draft to get maintainer sign-off on that read-only change (it alters previously-shipped editable behavior, even though the old behavior was a latent data-corruption risk).

@ppaawweeuu could you confirm this matches what you had in mind?

## Test plan
- [x] `test/util/test_selector.py::test_selecting_by_classification_system` (new): two systems (Uniclass 2015, CCI) sharing Identification `03 31 19`; asserts the system name disambiguates while Identification/Name queries still match both. Existing `test_selecting_by_classification` unchanged and passing.
- [x] Live-verified in headless Blender: selector `classification=CCI`/`classification='Uniclass 2015'` resolve correctly, panel renders the column headers and read-only system-name field.
- [x] black + ruff clean.

Generated with the assistance of an AI coding tool.
