### PR TITLE
Bonsai: built-in classification library picker

### DIFF
--- a/src/bonsai/bonsai/bim/module/classification/data.py
+++ b/src/bonsai/bonsai/bim/module/classification/data.py
@@ -46,10 +46,24 @@ class ClassificationsData:
         cls.data["classifications"] = cls.classifications()
         cls.data["available_classifications"] = cls.available_classifications()
         cls.data["classification_source"] = cls.classification_source()
+        cls.data["builtin_classification_libraries"] = cls.builtin_classification_libraries()
 
     @classmethod
     def has_classification_file(cls):
         return bool(IfcStore.classification_file)
+
+    @classmethod
+    def builtin_classification_libraries(cls) -> tool.Blender.BLENDER_ENUM_ITEMS:
+        """Enumerate classification libraries bundled with Bonsai (and any user-provided ones),
+        so a built-in library can be picked directly without browsing for a file.
+
+        See how ``bonsai.bim.module.project.data.ProjectData.library_file`` does the same
+        for the project's built-in libraries.
+        """
+        results: tool.Blender.BLENDER_ENUM_ITEMS = [("0", "Custom File", "")]
+        for filepath in sorted(tool.Blender.get_data_dir_paths("classifications", "*.ifc*"), key=lambda p: p.stem):
+            results.append((filepath.name, filepath.stem, "Built-in Classification Library"))
+        return results
 
     @classmethod
     def classifications(cls):

--- a/src/bonsai/bonsai/bim/module/classification/prop.py
+++ b/src/bonsai/bonsai/bim/module/classification/prop.py
@@ -58,6 +58,25 @@ def get_classification_source(
     return ClassificationsData.data["classification_source"]
 
 
+def get_builtin_classification_libraries(
+    self: "BIMClassificationProperties", context: bpy.types.Context
+) -> tool.Blender.BLENDER_ENUM_ITEMS:
+    if not ClassificationsData.is_loaded:
+        ClassificationsData.load()
+    return ClassificationsData.data["builtin_classification_libraries"]
+
+
+def update_builtin_classification_library(self: "BIMClassificationProperties", context: bpy.types.Context) -> None:
+    if self.builtin_classification_library == "0":
+        return
+    filepath = next(
+        p
+        for p in tool.Blender.get_data_dir_paths("classifications", "*.ifc*")
+        if p.name == self.builtin_classification_library
+    )
+    bpy.ops.bim.load_classification_library(filepath=str(filepath))
+
+
 class ClassificationReference(PropertyGroup):
     identification: StringProperty(name="Identification")
     ifc_definition_id: IntProperty(name="IFC Definition ID")
@@ -75,6 +94,11 @@ class BIMClassificationProperties(PropertyGroup):
     is_adding: BoolProperty(name="Is Adding", default=False)
     classification_source: EnumProperty(items=get_classification_source, name="Classification Source")
     available_classifications: EnumProperty(items=get_available_classifications, name="Available Classifications")
+    builtin_classification_library: EnumProperty(
+        items=get_builtin_classification_libraries,
+        name="Built-in Classification Library",
+        update=update_builtin_classification_library,
+    )
     classification_attributes: CollectionProperty(name="Classification Attributes", type=Attribute)
     active_classification_id: IntProperty(name="Active Classification Id")
     available_library_references: CollectionProperty(name="Available Library References", type=ClassificationReference)
@@ -85,6 +109,7 @@ class BIMClassificationProperties(PropertyGroup):
         is_adding: bool
         classification_source: str
         available_classifications: str
+        builtin_classification_library: str
         classification_attributes: bpy.types.bpy_prop_collection_idprop[Attribute]
         active_classification_id: int
         available_library_references: bpy.types.bpy_prop_collection_idprop[ClassificationReference]

--- a/src/bonsai/bonsai/bim/module/classification/ui.py
+++ b/src/bonsai/bonsai/bim/module/classification/ui.py
@@ -96,15 +96,18 @@ class BIM_PT_classifications(Panel):
 
     def draw_add_file_ui(self, context):
         assert self.layout
+        row = self.layout.row(align=True)
+        row.prop(self.props, "builtin_classification_library", text="")
+        if self.props.builtin_classification_library == "0":
+            row.operator("bim.load_classification_library", text="", icon="IMPORT")
+
         if ClassificationsData.data["has_classification_file"]:
             row = self.layout.row(align=True)
             row.prop(self.props, "available_classifications", text="")
-            row.operator("bim.load_classification_library", text="", icon="IMPORT")
             row.operator("bim.add_classification", text="", icon="ADD")
         else:
             row = self.layout.row(align=True)
             row.label(text="No Active Classification Library")
-            row.operator("bim.load_classification_library", text="", icon="IMPORT")
 
     def draw_editable_ui(self) -> None:
         assert self.layout


### PR DESCRIPTION
## Prototype: built-in classification library picker

Addresses the discussion in #4613. @ppaawweeuu asked for the "Load Classification Library" file browser to default to Bonsai's bundled schema folder. @Moult replied that he'd prefer built-in libraries with no file browsing required, similar to how project libraries already work.

This is a draft concept implementing Moult's preferred direction: a dropdown that lists the classification schemas already bundled under `bonsai/bim/data/classifications` (Uniclass, Omniclass, MasterFormat, RICS NRM, NBS, etc., 38 files) and loads the picked one directly, no file dialog.

It mirrors the existing built-in project-library pattern (`ProjectData.library_file` / `update_library_file` / `bim.select_library_file`) as closely as possible: an enum populated from `tool.Blender.get_data_dir_paths`, with a "Custom File" entry that reveals the existing file-browser button for anything not bundled. The file-browser path (`bim.load_classification_library`) is unchanged and still available for custom files.

Verified headless: the dropdown enumerates all 38 bundled schemas, picking one loads it via `IfcStore.classification_file` with no dialog, and `Add Classification` then adds it into the live IFC model.

Scope: only the main Classifications panel got the dropdown; the per-object/material/cost/zone "Add Reference" panels still use the file browser (flagged as a follow-up).

@Moult, does this match what you had in mind, or would you rather the picker live somewhere else / work differently (e.g. a separate always-visible dropdown instead of a "Custom File" enum entry)? Opening as a draft to get your steer before polishing further.

Generated with the assistance of an AI coding tool.
