### PR TITLE
ifcdiff: fix Property-check export crash (SetOrdered not JSON serializable)

### DIFF
--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -36,7 +36,7 @@ import ifcopenshell.util.representation
 import ifcopenshell.util.selector
 import numpy as np
 from deepdiff import DeepDiff
-from orderly_set import OrderedSet
+from orderly_set import StableSet
 
 __version__ = version = "0.0.0"
 
@@ -257,7 +257,7 @@ class IfcDiff:
 
     def json_dump_default(self, obj):
         # result of DeepDiff may contain ordered sets
-        if isinstance(obj, (OrderedSet, set)):
+        if isinstance(obj, (StableSet, set)):
             return list(obj)
         return json.JSONEncoder.default(None, obj)
 

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -16,9 +16,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
+import os
+import tempfile
+
 import ifcopenshell
 import ifcopenshell.api.context
 import ifcopenshell.api.geometry
+import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
 import ifcopenshell.util.representation
@@ -93,6 +98,29 @@ class TestIfcDiff:
         assert ifc_diff.added_elements == set()
         assert ifc_diff.deleted_elements == set()
         assert ifc_diff.change_register == {wall.GlobalId: {"attributes_changed": True}}
+
+    def test_property_diff_exports_to_json(self):
+        # Regression test for #8905: comparing "property" relationships makes
+        # DeepDiff report a dictionary_item_added as a SetOrdered, which
+        # json.dump couldn't serialise, crashing export() with no results.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        pset = ifcopenshell.api.pset.add_pset(new_file, product=wall_new, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(new_file, pset=pset, properties={"FireRating": "2HR"})
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["property"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register[wall.GlobalId]["properties_changed"]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output = os.path.join(tmp_dir, "diff.json")
+            ifc_diff.export(output)
+            with open(output) as f:
+                results = json.load(f)
+            assert "Pset_WallCommon" in str(results["changed"][wall.GlobalId]["properties_changed"])
 
     def test_changed_geometry(self):
         ifc_file = setup_project()


### PR DESCRIPTION
## Summary
- `IfcDiff.json_dump_default` checked for `orderly_set.OrderedSet`, but DeepDiff's property-diff results (`dictionary_item_added`, etc.) are `deepdiff.helper.SetOrdered`, a sibling class (both extend `orderly_set.StableSet`, neither extends the other). The isinstance check silently missed it, so enabling the "Property" relationship check in Bonsai's IfcDiff always crashed `export()` with `TypeError: Object of type SetOrdered is not JSON serializable` and no results were written.
- Fixed by checking against `StableSet`, the common base class for every `orderly_set` set flavour, so the fix isn't tied to one specific concrete subclass.
- Added a regression test that reproduces a property diff producing a `SetOrdered` and asserts `export()` succeeds with the expected pset name in the output.

Reproduced with the reporter's exact sample files: pre-fix throws the reported traceback, post-fix exports valid JSON containing the real diff (`dictionary_item_added: root['Pset_WallCommon']`). No regression on the attributes-only diff path. All 6 ifcdiff tests pass; black + ruff clean.

Fixes #8905. Thanks @semhustej for the clear repro files.

Generated with the assistance of an AI coding tool.
