### PR TITLE
Bonsai: pool all projections for shapely fill cell formation

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1046,7 +1046,6 @@ class CreateDrawing(bpy.types.Operator):
         # linked models) so the SHAPELY fill pass after the loop covers all of
         # them, not just whichever file happened to be processed last.
         raycast_objs = set()
-        elements_with_faces = set()
 
         for ifc_path, (ifc, link_matrix) in files.items():
             # Don't use draw.main() just whilst we're prototyping and experimenting
@@ -1063,7 +1062,6 @@ class CreateDrawing(bpy.types.Operator):
                         continue
                     obj = tool.Ifc.get_object(element)
                     if obj and obj.type == "MESH" and len(obj.data.polygons):
-                        elements_with_faces.add(element.GlobalId)
                         raycast_objs.add(obj)
 
             # Get all representation contexts to see what we're dealing with.
@@ -1145,11 +1143,9 @@ class CreateDrawing(bpy.types.Operator):
                 ".//svg:g[contains(@class, 'projection')]", namespaces={"svg": "http://www.w3.org/2000/svg"}
             )
 
+            # Pool boundary lines from all projections, not just face elements.
             boundary_lines = []
             for projection in projections:
-                global_id = projection.attrib["{http://www.ifcopenshell.org/ns}guid"]
-                if global_id not in elements_with_faces:
-                    continue
                 for path in projection.findall("./{http://www.w3.org/2000/svg}path"):
                     start, end = [[float(o) for o in co[1:].split(",")] for co in path.attrib["d"].split()]
                     if start == end:


### PR DESCRIPTION
Fixes #4774.

Calculate Shapely Surfaces filled an object's cell correctly when it sat inside a surface, but failed to close the cell when the object was moved flush to the surface's edge. `generate_linework()`'s boundary-line pool for cell formation (`union_all`/`polygonize`) was gated by `elements_with_faces`, the same set used to restrict raycast fill classification. When the neighboring surface wasn't a face-based mesh, its edges were dropped from the pool, leaving a flush shared boundary open. This pools boundary segments from all projections for cell formation while keeping raycast classification restricted to face elements, which is non-breaking since more segments can only subdivide cells, never merge them.

## Test plan
- [x] Unit A/B on the exact cell-formation code: pre-fix the flush object yields 0 closed polygons; post-fix its cell closes (9.0 mm2); the inside-surface baseline area is byte-identical pre/post (no regression).
- [x] Live end-to-end: `bim.create_drawing(fill_mode="SHAPELY")` on two flush IfcSlabs completes with correct separate fill paths.
- [x] black + ruff clean.

This matches our own prior diagnosis on the issue thread. Note: the fix addresses the diagnosed `elements_with_faces`-gating cause and is proven safe; the reporter's exact model (hosted behind Cloudflare) could not be pulled to confirm their specific case, so if it still reproduces there we can refine.

Generated with the assistance of an AI coding tool.
