### PR TITLE
Bonsai: sync Representation Items list selection with the 3D viewport

### DIFF
--- a/src/bonsai/bonsai/bim/handler.py
+++ b/src/bonsai/bonsai/bim/handler.py
@@ -122,6 +122,7 @@ def active_object_callback():
     refresh_ui_data()
     update_bim_tool_props()
     tool.Geometry.sync_item_positions()
+    tool.Geometry.sync_active_item_index()
 
 
 def update_bim_tool_props():

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2160,6 +2160,31 @@ class Geometry(bonsai.core.tool.Geometry):
             tool.Root.reload_item_decorator()
 
     @classmethod
+    def sync_active_item_index(cls) -> None:
+        """Highlight the newly active representation item in the "Representation
+        Items" UI list to match the object just selected in the 3D viewport.
+
+        Only relevant in Item Mode (``representation_obj`` is set), so this is a
+        no-op for regular element selection.
+        """
+        props = tool.Geometry.get_geometry_props()
+        rep_obj = props.representation_obj
+        if not rep_obj:
+            return
+        obj = tool.Blender.get_active_object()
+        if not obj or obj == rep_obj or not cls.has_mesh_properties(obj.data):
+            return
+        ifc_definition_id = cls.get_mesh_props(obj.data).ifc_definition_id
+        if not ifc_definition_id:
+            return
+        obj_props = cls.get_object_geometry_props(rep_obj)
+        for i, item in enumerate(obj_props.items):
+            if item.ifc_definition_id == ifc_definition_id:
+                if obj_props.active_item_index != i:
+                    obj_props.active_item_index = i
+                return
+
+    @classmethod
     def import_item_attributes(cls, obj: bpy.types.Object) -> None:
         props = tool.Geometry.get_mesh_props(obj.data)
         props.item_attributes.clear()

--- a/src/bonsai/test/tool/test_geometry.py
+++ b/src/bonsai/test/tool/test_geometry.py
@@ -758,3 +758,74 @@ class TestApplyItemIdsAsVertexGroups(NewFile):
                 vert = verts[vi]
                 groups = [g.group for g in vert.groups]
                 assert groups == [ios_item_ids_unique[i]]
+
+
+class TestSyncActiveItemIndex(NewFile):
+    """https://github.com/IfcOpenShell/IfcOpenShell/issues/6239
+
+    Selecting a representation item object in the 3D viewport should
+    highlight the matching row in the "Representation Items" UI list.
+    """
+
+    def setup_item_mode(self, item_ifc_ids: list[int]) -> tuple[bpy.types.Object, list[bpy.types.Object]]:
+        rep_obj = bpy.data.objects.new("RepObj", bpy.data.meshes.new("RepObj"))
+        bpy.context.collection.objects.link(rep_obj)
+
+        gprops = tool.Geometry.get_geometry_props()
+        gprops.representation_obj = rep_obj
+
+        obj_props = tool.Geometry.get_object_geometry_props(rep_obj)
+        for ifc_id in item_ifc_ids:
+            row = obj_props.items.add()
+            row.name = "IfcPolygonalFaceSet"
+            row.ifc_definition_id = ifc_id
+
+        item_objs = []
+        for i, ifc_id in enumerate(item_ifc_ids):
+            item_obj = bpy.data.objects.new(f"Item.{i}", bpy.data.meshes.new(f"Item.{i}"))
+            bpy.context.collection.objects.link(item_obj)
+            tool.Geometry.get_mesh_props(item_obj.data).ifc_definition_id = ifc_id
+            item_objs.append(item_obj)
+        return rep_obj, item_objs
+
+    def test_selecting_an_item_object_syncs_the_active_row(self):
+        rep_obj, item_objs = self.setup_item_mode([101, 202])
+        obj_props = tool.Geometry.get_object_geometry_props(rep_obj)
+
+        bpy.context.view_layer.objects.active = item_objs[1]
+        subject.sync_active_item_index()
+        assert obj_props.active_item_index == 1
+
+        bpy.context.view_layer.objects.active = item_objs[0]
+        subject.sync_active_item_index()
+        assert obj_props.active_item_index == 0
+
+    def test_does_nothing_outside_item_mode(self):
+        rep_obj, item_objs = self.setup_item_mode([101, 202])
+        obj_props = tool.Geometry.get_object_geometry_props(rep_obj)
+        tool.Geometry.get_geometry_props().representation_obj = None
+
+        bpy.context.view_layer.objects.active = item_objs[1]
+        subject.sync_active_item_index()
+        assert obj_props.active_item_index == 0  # unchanged default
+
+    def test_does_nothing_for_unrelated_object(self):
+        rep_obj, item_objs = self.setup_item_mode([101, 202])
+        obj_props = tool.Geometry.get_object_geometry_props(rep_obj)
+        obj_props.active_item_index = 1
+
+        unrelated = bpy.data.objects.new("Unrelated", bpy.data.meshes.new("Unrelated"))
+        bpy.context.collection.objects.link(unrelated)
+        bpy.context.view_layer.objects.active = unrelated
+
+        subject.sync_active_item_index()  # must not raise
+        assert obj_props.active_item_index == 1  # unchanged
+
+    def test_does_nothing_when_representation_obj_itself_is_active(self):
+        rep_obj, item_objs = self.setup_item_mode([101, 202])
+        obj_props = tool.Geometry.get_object_geometry_props(rep_obj)
+        obj_props.active_item_index = 1
+
+        bpy.context.view_layer.objects.active = rep_obj
+        subject.sync_active_item_index()  # must not raise
+        assert obj_props.active_item_index == 1  # unchanged


### PR DESCRIPTION
Fixes #6239.

Selecting a representation item object in the 3D viewport now highlights the matching row in the "Representation Items" list, instead of leaving it on whatever row was last active. `Geometry.sync_active_item_index()` reads the newly active object's `ifc_definition_id` and updates `active_item_index` to the matching row; it reuses the existing active-object msgbus hook that already drives BIM-tool-props sync, so no new selection handler was added. It no-ops immediately outside Item Mode, for the representation host, or for unrelated objects, so it only ever scans one element's items.

Thanks for reporting this, @theoryshaw.

## Test plan
- [x] Live-verified through the real Bonsai geometry pipeline: selecting each item object updates the list index both ways; unrelated/host objects are a safe no-op. The identical script fails on the unfixed source.
- [x] `TestSyncActiveItemIndex` (4 cases) added; full `test_geometry.py` suite 68/68 pass.
- [x] black + ruff clean.

Generated with the assistance of an AI coding tool.
