### PR TITLE
Bonsai: add Property Set editing to the Systems UI

### DIFF
--- a/src/bonsai/bonsai/bim/module/pset/__init__.py
+++ b/src/bonsai/bonsai/bim/module/pset/__init__.py
@@ -57,6 +57,7 @@ classes = (
     ui.BIM_PT_profile_psets,
     ui.BIM_PT_work_schedule_psets,
     ui.BIM_PT_zone_psets,
+    ui.BIM_PT_system_psets,
     ui.BIM_PT_bulk_property_editor,
     ui.BIM_PT_rename_parameters,
     ui.BIM_PT_add_edit_custom_properties,
@@ -74,6 +75,7 @@ def register():
     bpy.types.Scene.ProfilePsetProperties = bpy.props.PointerProperty(type=prop.PsetProperties)
     bpy.types.Scene.WorkSchedulePsetProperties = bpy.props.PointerProperty(type=prop.PsetProperties)
     bpy.types.Scene.ZonePsetProperties = bpy.props.PointerProperty(type=prop.PsetProperties)
+    bpy.types.Scene.SystemPsetProperties = bpy.props.PointerProperty(type=prop.PsetProperties)
     bpy.types.Scene.GlobalPsetProperties = bpy.props.PointerProperty(type=prop.GlobalPsetProperties)
 
 
@@ -87,4 +89,5 @@ def unregister():
     del bpy.types.Scene.ProfilePsetProperties
     del bpy.types.Scene.WorkSchedulePsetProperties
     del bpy.types.Scene.ZonePsetProperties
+    del bpy.types.Scene.SystemPsetProperties
     del bpy.types.Scene.GlobalPsetProperties

--- a/src/bonsai/bonsai/bim/module/pset/data.py
+++ b/src/bonsai/bonsai/bim/module/pset/data.py
@@ -44,6 +44,7 @@ def refresh():
     ProfilePsetsData.is_loaded = False
     WorkSchedulePsetsData.is_loaded = False
     ZonePsetsData.is_loaded = False
+    SystemPsetsData.is_loaded = False
     AddEditCustomPropertiesData.is_loaded = False
     PsetsGeneralData.is_loaded = False
 
@@ -331,6 +332,21 @@ class ZonePsetsData(Data):
         props = tool.System.get_zone_props()
         assert (active_zone := props.active_zone)
         ifc_definition_id = active_zone.ifc_definition_id
+        cls.data = {
+            "psets": (cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id), psets_only=True)),
+        }
+        cls.is_loaded = True
+
+
+class SystemPsetsData(Data):
+    data = {}
+    is_loaded = False
+
+    @classmethod
+    def load(cls):
+        props = tool.System.get_system_props()
+        assert (active_system := props.active_system_ui_item)
+        ifc_definition_id = active_system.ifc_definition_id
         cls.data = {
             "psets": (cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id), psets_only=True)),
         }

--- a/src/bonsai/bonsai/bim/module/pset/prop.py
+++ b/src/bonsai/bonsai/bim/module/pset/prop.py
@@ -88,6 +88,8 @@ def get_pset_name(self: "PsetProperties", context: bpy.types.Context) -> tool.Bl
         results = get_work_schedule_pset_names(self, context)
     elif prop_type == "ZonePsetProperties":
         results = get_zone_pset_names(self, context)
+    elif prop_type == "SystemPsetProperties":
+        results = get_system_pset_names(self, context)
 
     if not PsetsGeneralData.is_loaded:
         PsetsGeneralData.load()
@@ -215,6 +217,17 @@ def get_work_schedule_pset_names(self: "PsetProperties", context: object) -> too
 def get_zone_pset_names(self: "PsetProperties", context: object) -> tool.Blender.BLENDER_ENUM_ITEMS:
     global psetnames
     ifc_class = "IfcZone"
+    if ifc_class not in psetnames:
+        psets = bonsai.bim.schema.ifc.psetqto.get_applicable(ifc_class, pset_only=True, schema=tool.Ifc.get_schema())
+        psetnames[ifc_class] = blender_formatted_enum_from_psets(psets)
+    return psetnames[ifc_class]
+
+
+def get_system_pset_names(self: "PsetProperties", context: object) -> tool.Blender.BLENDER_ENUM_ITEMS:
+    global psetnames
+    sprops = tool.System.get_system_props()
+    assert (active_system := sprops.active_system_ui_item)
+    ifc_class = active_system.ifc_class
     if ifc_class not in psetnames:
         psets = bonsai.bim.schema.ifc.psetqto.get_applicable(ifc_class, pset_only=True, schema=tool.Ifc.get_schema())
         psetnames[ifc_class] = blender_formatted_enum_from_psets(psets)

--- a/src/bonsai/bonsai/bim/module/pset/ui.py
+++ b/src/bonsai/bonsai/bim/module/pset/ui.py
@@ -36,6 +36,7 @@ from bonsai.bim.module.pset.data import (
     ProfilePsetsData,
     ResourcePsetsData,
     ResourceQtosData,
+    SystemPsetsData,
     TaskQtosData,
     WorkSchedulePsetsData,
     ZonePsetsData,
@@ -827,6 +828,40 @@ class BIM_PT_zone_psets(Panel):
             draw_psetqto_ui(context, 0, {}, props, self.layout, self.obj_type)
 
         for pset in ZonePsetsData.data["psets"]:
+            draw_psetqto_ui(context, pset["id"], pset, props, self.layout, self.obj_type)
+
+
+class BIM_PT_system_psets(Panel):
+    bl_label = "System Property Sets"
+    bl_idname = "BIM_PT_system_psets"
+    bl_options = {"DEFAULT_CLOSED"}
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "scene"
+    bl_parent_id = "BIM_PT_systems"
+
+    obj_type: Literal["System"] = "System"
+
+    @classmethod
+    def poll(cls, context):
+        props = tool.System.get_system_props()
+        return bool(props.active_system_ui_item)
+
+    def draw(self, context):
+        if not SystemPsetsData.is_loaded:
+            SystemPsetsData.load()
+
+        assert self.layout
+        props = tool.Pset.get_pset_props("", self.obj_type)
+        row = self.layout.row(align=True)
+        prop_with_search(row, props, "pset_name", text="")
+        op = row.operator("bim.add_pset", icon="ADD", text="")
+        op.obj_type = self.obj_type
+
+        if not props.active_pset_id and props.active_pset_name and props.active_pset_type == "PSET":
+            draw_psetqto_ui(context, 0, {}, props, self.layout, self.obj_type)
+
+        for pset in SystemPsetsData.data["psets"]:
             draw_psetqto_ui(context, pset["id"], pset, props, self.layout, self.obj_type)
 
 

--- a/src/bonsai/bonsai/bim/module/system/prop.py
+++ b/src/bonsai/bonsai/bim/module/system/prop.py
@@ -83,6 +83,12 @@ class Zone(PropertyGroup):
         ifc_definition_id: int
 
 
+def update_active_group_index(self: "BIMSystemProperties", context: bpy.types.Context) -> None:
+    from bonsai.bim.module.pset.data import SystemPsetsData
+
+    SystemPsetsData.is_loaded = False
+
+
 def toggle_decorations(self: "BIMSystemProperties", context: bpy.types.Context) -> None:
     toggle = self.should_draw_decorations
     if toggle:
@@ -121,7 +127,7 @@ class BIMSystemProperties(PropertyGroup):
     expanded_groups_json: StringProperty(name="Expanded Systems JSON", default="[]")
     """See `expanded_groups_json`. We name it "groups" for compatibility with Group UI code."""
     # Named not as `active_system_index` to match `BIMGroupProperties`.
-    active_group_index: IntProperty(name="Active System Index")
+    active_group_index: IntProperty(name="Active System Index", update=update_active_group_index)
     active_system_id: IntProperty(name="Active System Id")
     edited_system_id: IntProperty(name="Edited System Id")
     system_class: EnumProperty(items=get_system_class, name="Class")

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -328,6 +328,10 @@ class Blender(bonsai.core.tool.Blender):
             props = tool.System.get_zone_props()
             assert (active_zone := props.active_zone)
             return active_zone.ifc_definition_id
+        elif obj_type == "System":
+            props = tool.System.get_system_props()
+            assert (active_system := props.active_system_ui_item)
+            return active_system.ifc_definition_id
         assert_never(obj_type)
 
     @classmethod

--- a/src/bonsai/bonsai/tool/ifc.py
+++ b/src/bonsai/bonsai/tool/ifc.py
@@ -51,6 +51,7 @@ class Ifc(bonsai.core.tool.Ifc):
         "WorkSchedule",
         "Group",
         "Zone",
+        "System",
     ]
 
     @classmethod

--- a/src/bonsai/bonsai/tool/pset.py
+++ b/src/bonsai/bonsai/tool/pset.py
@@ -124,6 +124,8 @@ class Pset(bonsai.core.tool.Pset):
             return bpy.context.scene.GroupPsetProperties
         elif obj_type == "Zone":
             return bpy.context.scene.ZonePsetProperties
+        elif obj_type == "System":
+            return bpy.context.scene.SystemPsetProperties
         elif obj_type == "Cost":
             # No psets for cost items currently.
             assert False, obj_type

--- a/src/bonsai/test/tool/test_system.py
+++ b/src/bonsai/test/tool/test_system.py
@@ -434,6 +434,30 @@ class TestSetActiveSystem(NewFile):
         assert props.edited_system_id == system.id()
 
 
+class TestActiveSystemPsetScoping(NewFile):
+    """The Systems UI's "System Property Sets" panel (#4931) reuses the generic
+    Pset editor scoped by obj_type="System" to whichever system row is selected
+    in the Systems UIList. Verify that scoping resolves to the right IfcSystem."""
+
+    def test_run(self):
+        import bonsai.tool.blender
+        import bonsai.tool.pset
+
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        system = ifcopenshell.api.system.add_system(ifc, ifc_class="IfcDistributionSystem")
+
+        props = tool.System.get_system_props()
+        item = props.systems.add()
+        item.ifc_definition_id = system.id()
+        item.ifc_class = system.is_a()
+        props.active_group_index = 0
+
+        assert props.active_system_ui_item.ifc_definition_id == system.id()
+        assert bonsai.tool.blender.Blender.get_obj_ifc_definition_id("", "System") == system.id()
+        assert bonsai.tool.pset.Pset.get_pset_props("", "System") == bpy.context.scene.SystemPsetProperties
+
+
 class TestFlowElementAndControls(NewFile):
     def test_run(self):
         ifc = ifcopenshell.file()


### PR DESCRIPTION
Fixes #4931.

The Systems panel had no way to view or edit property sets on an `IfcSystem` (only name/class editing and assign/unassign). This adds a "System Property Sets" panel under Systems, reusing the existing generic Pset editor (the same one Groups and Zones use) scoped to whichever system is selected in the "Systems Found in Project" list. No pset logic is reimplemented; it follows the established Group/Zone/Resource/Profile pattern.

Thanks for flagging this gap, @abdelmalek-hrg.

## Test plan
- [x] Live-verified in headless Blender: added an `IfcDistributionSystem`, selected it, and confirmed via `ifcopenshell.util.element.get_psets` that a pset/property is genuinely written onto the `IfcSystem` entity through the new panel's operator chain.
- [x] `TestActiveSystemPsetScoping` added; `test/tool/test_system.py` 24/24, `test/bim -m "system or pset"` 42/42 pass. black + ruff clean.

Generated with the assistance of an AI coding tool.
