### PR TITLE
Bonsai: add discoverable 3D-viewport align icons for slabs

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/__init__.py
+++ b/src/bonsai/bonsai/bim/module/model/__init__.py
@@ -112,6 +112,7 @@ classes = (
     wall.GizmoWallFilletReedit,
     wall.GizmoWallFilletToggleOpenings,
     wall.GizmoPairDisconnect,
+    wall.GizmoSlabAlign,
     wall.GizmoSlabEdition,
     wall.GizmoSlabUnjoinWalls,
     wall.GizmoWallJoinIntersection,

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -4298,6 +4298,105 @@ class GizmoSlabEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
         return tool.Parametric.is_slab(element) and any(tool.Wall.iter_slab_wall_connections(element))
 
 
+class GizmoSlabAlign(bpy.types.GizmoGroup, gizmo.BillboardingGizmoGroupMixin):
+    """Exterior / Centreline / Interior align icons for a selected IfcSlab.
+
+    Unlike ``GizmoWallEdition``'s "baseline" triplet (which cycles a single
+    wall's own material-layer offset via ``bim.cycle_wall_offset`` and only
+    ever needs one selected object), the Exterior/Centreline/Interior tool
+    referenced in #6211 is the two-object "match edges" action already bound
+    to Shift+X/C/V and surfaced as text buttons in the N-panel's Align row
+    (``EditObjectUI.draw_align`` in workspace.py). For a LAYER2 wall that
+    dispatches to ``core.align_walls`` (true layer alignment); for anything
+    else, including IfcSlab, it falls through to ``core.align_objects`` — a
+    generic bounding-box alignment of the selected objects to the active one
+    along whichever world axis needs the least travel (``tool.Model.align_objects``).
+
+    That fallback already works for slabs from the keyboard/N-panel; what was
+    missing was a 3D-viewport affordance a user editing a slab would actually
+    see. This group adds exactly that, dispatching through the same
+    ``bim.hotkey`` operator (hotkeys S_X / S_C / S_V) the N-panel buttons use,
+    so the alignment math itself is not duplicated anywhere."""
+
+    bl_idname = "OBJECT_GGT_bim_slab_align"
+    bl_label = "Slab Align Gizmo"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "WINDOW"
+    bl_options = {"3D", "PERSISTENT"}
+
+    ICON_SCALE: ClassVar[float] = 0.35
+    ICON_SPACING_X: ClassVar[float] = 0.4
+    ICON_Z_OFFSET: ClassVar[float] = 0.5
+
+    @classmethod
+    def poll(cls, context: bpy.types.Context) -> bool:
+        # Shared gate (viewport gizmos enabled, no preview active, no array
+        # child in the selection) — same one the other 2-object wall topology
+        # gizmos (extend / join / fillet) use, since this group shares their
+        # shape: a multi-object action gated on the WHOLE selection, not just
+        # the active object.
+        if not _wall_topology_gizmo_poll_gate(context):
+            return False
+        if len(tool.Blender.get_selected_objects()) < 2:
+            return False
+        obj = tool.Blender.get_active_object(is_selected=True)
+        if obj is None:
+            return False
+        element = tool.Ifc.get_entity(obj)
+        if element is None or not element.is_a("IfcSlab"):
+            return False
+        return True
+
+    def setup(self, context: bpy.types.Context) -> None:
+        default_color, highlight_color = self.get_decoration_colors()
+
+        self.exterior_icon = self.setup_icon_gizmo(
+            "VIEW3D_GT_offset_exterior", default_color, highlight_color, "bim.hotkey"
+        )
+        self.exterior_op = self.exterior_icon.target_set_operator("bim.hotkey")
+        self.exterior_op.hotkey = "S_X"
+        self.exterior_op.description = "Align Exterior: match the selected slabs' edge to the active slab's edge"
+
+        self.centerline_icon = self.setup_icon_gizmo(
+            "VIEW3D_GT_offset_center", default_color, highlight_color, "bim.hotkey"
+        )
+        self.centerline_op = self.centerline_icon.target_set_operator("bim.hotkey")
+        self.centerline_op.hotkey = "S_C"
+        self.centerline_op.description = (
+            "Align Centreline: match the selected slabs' centre to the active slab's centre"
+        )
+
+        self.interior_icon = self.setup_icon_gizmo(
+            "VIEW3D_GT_offset_interior", default_color, highlight_color, "bim.hotkey"
+        )
+        self.interior_op = self.interior_icon.target_set_operator("bim.hotkey")
+        self.interior_op.hotkey = "S_V"
+        self.interior_op.description = (
+            "Align Interior: match the selected slabs' opposite edge to the active slab's edge"
+        )
+
+    def position_gizmos(self, context: bpy.types.Context) -> None:
+        obj = tool.Blender.get_active_object(is_selected=True)
+        if obj is None:
+            return
+        bbox_world = [obj.matrix_world @ Vector(corner) for corner in obj.bound_box]
+        anchor = Vector(
+            (
+                sum(v.x for v in bbox_world) / 8,
+                sum(v.y for v in bbox_world) / 8,
+                max(v.z for v in bbox_world),
+            )
+        )
+        billboard_rot = gizmo.get_billboard_rotation(context)
+        screen_up = gizmo.get_screen_up(billboard_rot)
+        anchor += screen_up * self.ICON_Z_OFFSET
+        anchor += gizmo.top_down_clearance(context, billboard_rot)
+        offset_x = billboard_rot @ Vector((self.ICON_SPACING_X, 0.0, 0.0))
+        self.exterior_icon.matrix_basis = gizmo.billboarded_at(anchor - offset_x, billboard_rot, scale=self.ICON_SCALE)
+        self.centerline_icon.matrix_basis = gizmo.billboarded_at(anchor, billboard_rot, scale=self.ICON_SCALE)
+        self.interior_icon.matrix_basis = gizmo.billboarded_at(anchor + offset_x, billboard_rot, scale=self.ICON_SCALE)
+
+
 class GizmoPairDisconnect(bpy.types.GizmoGroup, gizmo.BillboardingGizmoGroupMixin):
     """Surfaces a disconnect icon when exactly 2 IFC elements are selected
     and they share a supported rel — currently the wall + slab pair joined

--- a/src/bonsai/test/bim/module/model/test_slab_align_gizmo.py
+++ b/src/bonsai/test/bim/module/model/test_slab_align_gizmo.py
@@ -1,0 +1,129 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Unit tests for ``GizmoSlabAlign`` (#6211): the 3D-viewport Exterior /
+Centreline / Interior align icons for a selected IfcSlab.
+
+Only ``poll()`` is exercised here — ``setup()`` / ``position_gizmos()``
+create real ``bpy.types.Gizmo`` instances via ``self.gizmos.new(...)``,
+which requires the gizmo group to be instantiated by Blender's own gizmo
+manager (not directly constructible in a test), matching the existing
+convention across this test directory (no sibling gizmo test calls
+``setup()`` directly either)."""
+
+from unittest.mock import patch
+
+import bpy
+import pytest
+
+from bonsai.bim.module.model.wall import GizmoSlabAlign
+from test.bim.module.model.conftest import make_element, make_obj
+
+pytestmark = pytest.mark.model
+
+
+class TestGizmoSlabAlignPoll:
+    def test_true_with_two_selected_and_active_slab(self, patched_tool):
+        obj_a, obj_b = make_obj(), make_obj()
+        slab = make_element(ifc_class="IfcSlab")
+        with patched_tool(
+            viewport_gizmos=True,
+            selected=[obj_a, obj_b],
+            entity=lambda o: slab,
+            modifier_predicates={"any_selected_is_array_child": False},
+        ):
+            with patch("bonsai.tool.Blender.get_active_object", return_value=obj_a):
+                assert GizmoSlabAlign.poll(bpy.context) is True
+
+    def test_false_with_only_one_selected(self, patched_tool):
+        obj_a = make_obj()
+        with patched_tool(
+            viewport_gizmos=True,
+            selected=[obj_a],
+            modifier_predicates={"any_selected_is_array_child": False},
+        ):
+            assert GizmoSlabAlign.poll(bpy.context) is False
+
+    def test_false_when_active_is_not_a_slab(self, patched_tool):
+        obj_a, obj_b = make_obj(), make_obj()
+        wall = make_element(ifc_class="IfcWall")
+        with patched_tool(
+            viewport_gizmos=True,
+            selected=[obj_a, obj_b],
+            entity=lambda o: wall,
+            modifier_predicates={"any_selected_is_array_child": False},
+        ):
+            with patch("bonsai.tool.Blender.get_active_object", return_value=obj_a):
+                assert GizmoSlabAlign.poll(bpy.context) is False
+
+    def test_false_when_active_has_no_ifc_entity(self, patched_tool):
+        obj_a, obj_b = make_obj(), make_obj()
+        with patched_tool(
+            viewport_gizmos=True,
+            selected=[obj_a, obj_b],
+            entity=None,
+            modifier_predicates={"any_selected_is_array_child": False},
+        ):
+            with patch("bonsai.tool.Blender.get_active_object", return_value=obj_a):
+                assert GizmoSlabAlign.poll(bpy.context) is False
+
+    def test_false_when_viewport_gizmos_disabled(self, patched_tool):
+        obj_a, obj_b = make_obj(), make_obj()
+        with patched_tool(viewport_gizmos=False, selected=[obj_a, obj_b]):
+            assert GizmoSlabAlign.poll(bpy.context) is False
+
+    def test_false_when_active_slab_is_an_array_child(self, patched_tool):
+        obj_a, obj_b = make_obj(), make_obj()
+        slab = make_element(ifc_class="IfcSlab")
+        with patched_tool(
+            viewport_gizmos=True,
+            selected=[obj_a, obj_b],
+            entity=lambda o: slab,
+            modifier_predicates={"any_selected_is_array_child": True},
+        ):
+            with patch("bonsai.tool.Blender.get_active_object", return_value=obj_a):
+                assert GizmoSlabAlign.poll(bpy.context) is False
+
+    def test_false_when_no_active_object(self, patched_tool):
+        obj_a, obj_b = make_obj(), make_obj()
+        with patched_tool(
+            viewport_gizmos=True,
+            selected=[obj_a, obj_b],
+            modifier_predicates={"any_selected_is_array_child": False},
+        ):
+            with patch("bonsai.tool.Blender.get_active_object", return_value=None):
+                assert GizmoSlabAlign.poll(bpy.context) is False
+
+
+class TestGizmoSlabAlignDispatchesExistingAlignOperator:
+    """The icons dispatch through ``bim.hotkey`` with the same S_X / S_C / S_V
+    hotkeys the N-panel Align row already uses (``EditObjectUI.draw_align`` in
+    workspace.py) — pin that the setup wiring references those exact hotkeys
+    so the alignment math (``core.align_objects`` / ``core.align_walls``)
+    stays defined in exactly one place."""
+
+    def test_setup_source_wires_the_same_hotkeys_as_the_npanel_align_row(self):
+        import inspect
+
+        src = inspect.getsource(GizmoSlabAlign.setup)
+        assert '"bim.hotkey"' in src
+        assert 'hotkey = "S_X"' in src
+        assert 'hotkey = "S_C"' in src
+        assert 'hotkey = "S_V"' in src


### PR DESCRIPTION
Fixes #6211.

The Exterior/Centreline/Interior align action already works for slabs from the keyboard (Shift+X/C/V) and the N-panel's Align row: for a LAYER2 wall it dispatches to `core.align_walls` (true layer alignment); for anything else, including `IfcSlab`, it falls through to `core.align_objects`, a generic bounding-box alignment of the selected objects to the active one. That fallback was never discoverable while editing a slab directly in the 3D viewport.

Adds `GizmoSlabAlign`: three viewport icons (reusing the existing offset-baseline icon shapes) shown when 2+ objects are selected and the active one is an `IfcSlab`, dispatching through the same `bim.hotkey` operator (S_X/S_C/S_V) the N-panel buttons already use. No alignment math is duplicated; `core.align_objects` remains the single source of truth.

**Design note for maintainer review:** `IfcSlab` has no wall-style material-layer "reference line", so Exterior/Centreline/Interior map to the existing generic bounding-box alignment (align to the negative/center/positive bound along whichever axis needs least travel) rather than a true layer alignment. This mirrors exactly what the N-panel already does for slabs today. Opened as a draft in case a different semantic is preferred for slabs specifically.

Thanks @theoryshaw for flagging this.

## Test plan
- [x] Live-verified in headless Blender: `poll()` gating and the underlying `bim.hotkey(S_X/S_C/S_V)` dispatch work correctly for two `IfcSlab` objects.
- [x] New unit tests (8) covering `poll()` gates; full `test/bim/module/model` suite passes (536/538; the 2 pre-existing failures are unrelated environment issues, reproduced on the unmodified base).
- [x] black + ruff clean.

Generated with the assistance of an AI coding tool.
