### PR TITLE
Bonsai: cut and align skylights/windows on parametric roofs to the sloped face

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -240,6 +240,33 @@ def _store_batch_in_cache(cache_key: tuple[int, str], batch: "gpu.types.GPUBatch
     _batch_cache[cache_key] = (epoch, batch)
 
 
+def get_surface_aligned_rotation(voided_obj_matrix_world: Matrix, local_normal: Vector) -> Matrix:
+    """Rotation that lays a filling flush against the host's surface at the
+    raycasted point, with its "up" axis following the surface's slope.
+
+    Generalises the old flat-slab assumption (host's own rotation, twisted
+    -90 degrees around X) to any face normal, so a filling rotates to match
+    a sloped face (eg. a parametric roof) rather than always coming out
+    horizontal. Reduces to the exact old result when ``local_normal`` is the
+    host's local +Z (flat slabs, and single-slope hosts whose whole object
+    is tilted, eg. a "Horizontal Layers" roof).
+    """
+    normal_matrix = voided_obj_matrix_world.to_3x3().inverted().transposed()
+    world_normal = (normal_matrix @ local_normal).normalized()
+
+    world_up = Vector((0.0, 0.0, 1.0))
+    tangent = world_up - world_up.dot(world_normal) * world_normal
+    if tangent.length < 1e-6:
+        tangent = Vector((0.0, 1.0, 0.0))
+    tangent.normalize()
+
+    y_axis = -world_normal
+    x_axis = y_axis.cross(tangent).normalized()
+    z_axis = tangent
+
+    return Matrix((x_axis, y_axis, z_axis)).transposed().to_4x4()
+
+
 def is_filling_supported(element) -> bool:
     """True when Bonsai's opening generator can derive an opening from this
     element. IFC's schema permits any IfcElement as a filling; Bonsai
@@ -319,13 +346,26 @@ class FilledOpeningGenerator:
                 else:
                     new_matrix.translation.z = filling_obj.matrix_world.copy().translation.z
             elif layers["layer_set_direction"] == "AXIS3":
-                new_matrix = voided_obj.matrix_world.copy()
                 local_position_on_voided_obj = raycast[1]
-                # Equivalent to "side Z" for a wall axis, so that stuff like skylights appear on the top.
-                local_position_on_voided_obj.z = layers["offset"] + layers["thickness"]
-                new_matrix.translation.xyz = voided_obj.matrix_world @ local_position_on_voided_obj
-                rotation_matrix = Matrix.Rotation(radians(-90), 4, "X")
-                new_matrix @= rotation_matrix
+                if layers["offset"] or layers["thickness"]:
+                    # A real material layer set to read a "top of layers" elevation from:
+                    # keep the exact existing flat-host behaviour (host's own rotation,
+                    # twisted -90 around X; equivalent to "side Z" for a wall axis, so
+                    # that stuff like skylights appear on the top).
+                    local_position_on_voided_obj.z = layers["offset"] + layers["thickness"]
+                    new_matrix = voided_obj.matrix_world.copy()
+                    new_matrix.translation.xyz = voided_obj.matrix_world @ local_position_on_voided_obj
+                    new_matrix @= Matrix.Rotation(radians(-90), 4, "X")
+                else:
+                    # No material layer set (eg. a parametric roof, which never gets
+                    # one): there's no single flat elevation to snap to, and the host
+                    # object itself usually isn't rotated even though individual faces
+                    # are sloped, so fall back to the actual raycasted point and its
+                    # face normal instead of assuming a flat top face.
+                    new_translation = voided_obj.matrix_world @ local_position_on_voided_obj
+                    new_matrix = Matrix.Translation(new_translation) @ get_surface_aligned_rotation(
+                        voided_obj.matrix_world, raycast[2]
+                    )
             else:
                 assert False, f"Unexpected layer set direction: {layers['layer_set_direction']}"
 

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -787,7 +787,15 @@ class Model(bonsai.core.tool.Model):
     @classmethod
     def get_material_layer_parameters(cls, element: ifcopenshell.entity_instance) -> MaterialLayerParameters:
         unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
-        layer_set_direction = "AXIS2"
+        # Without an actual IfcMaterialLayerSetUsage to read LayerSetDirection
+        # from (eg. a parametric IfcRoof, which never gets one), fall back to
+        # the same class-based inference get_usage_type() uses, rather than
+        # always guessing the wall-like AXIS2. Anything not recognised keeps
+        # defaulting to AXIS2, matching prior behaviour.
+        if element.is_a() in cls.AXIS3_HOST_CLASSES:
+            layer_set_direction = "AXIS3"
+        else:
+            layer_set_direction = "AXIS2"
         offset = 0.0
         thickness = 0.0
         direction_sense = "POSITIVE"
@@ -1041,6 +1049,22 @@ class Model(bonsai.core.tool.Model):
         if material and material.is_a("IfcMaterialProfileSet") and len(material.MaterialProfiles) == 1:
             return material.MaterialProfiles[0].Profile
 
+    # Classes that behave like a horizontal (or sloped, e.g. a roof) slab when
+    # no explicit IfcMaterialLayerSetUsage tells us the layer set direction.
+    AXIS3_HOST_CLASSES = (
+        "IfcSlabType",
+        "IfcRoofType",
+        "IfcRampType",
+        "IfcPlateType",
+        "IfcSlab",
+        "IfcRoof",
+        "IfcRamp",
+        "IfcPlate",
+    )
+    # Classes that behave like a vertical wall when no explicit
+    # IfcMaterialLayerSetUsage tells us the layer set direction.
+    AXIS2_HOST_CLASSES = ("IfcWallType", "IfcWall")
+
     @classmethod
     def get_usage_type(
         cls, element: ifcopenshell.entity_instance
@@ -1052,18 +1076,9 @@ class Model(bonsai.core.tool.Model):
             elif material.is_a("IfcMaterialLayerSet"):
                 axis = ifcopenshell.util.element.get_pset(element, "EPset_Parametric", "LayerSetDirection")
                 if axis is None:
-                    if element.is_a() in (
-                        "IfcSlabType",
-                        "IfcRoofType",
-                        "IfcRampType",
-                        "IfcPlateType",
-                        "IfcSlab",
-                        "IfcRoof",
-                        "IfcRamp",
-                        "IfcPlate",
-                    ):
+                    if element.is_a() in cls.AXIS3_HOST_CLASSES:
                         axis = "AXIS3"
-                    elif element.is_a() in ("IfcWallType", "IfcWall"):
+                    elif element.is_a() in cls.AXIS2_HOST_CLASSES:
                         axis = "AXIS2"
                     else:
                         return

--- a/src/bonsai/test/bim/module/model/test_get_surface_aligned_rotation.py
+++ b/src/bonsai/test/bim/module/model/test_get_surface_aligned_rotation.py
@@ -1,0 +1,134 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Pure-math coverage for ``get_surface_aligned_rotation`` (opening.py).
+
+https://github.com/IfcOpenShell/IfcOpenShell/issues/5611 : a window/skylight
+added to a parametric IfcRoof came out vertical with no opening cut, because
+the AXIS3 branch that places slab/roof fillings assumed a flat top face
+(host's own world rotation, twisted -90 degrees around X) instead of reading
+the actual (possibly sloped, per-face) surface normal. These tests pin the
+replacement helper against that old formula so a flat or
+whole-object-tilted host keeps behaving identically, and confirm a per-face
+sloped normal (the roof case) rotates the filling to match the slope.
+"""
+
+import math
+
+import pytest
+from mathutils import Matrix, Vector
+
+from bonsai.bim.module.model.opening import get_surface_aligned_rotation
+
+pytestmark = pytest.mark.model
+
+
+def _old_flat_slab_rotation(voided_obj_matrix_world: Matrix) -> Matrix:
+    """The formula this helper generalises, kept here only so the
+    "no regression on flat / tilted-whole-object hosts" tests can pin
+    against it without re-deriving it."""
+    return voided_obj_matrix_world.to_3x3().to_4x4() @ Matrix.Rotation(math.radians(-90), 4, "X")
+
+
+def _matrices_are_close(a: Matrix, b: Matrix, tolerance: float = 1e-6) -> bool:
+    return all(abs(a[i][j] - b[i][j]) < tolerance for i in range(3) for j in range(3))
+
+
+def _is_proper_rotation(m3: Matrix, tolerance: float = 1e-6) -> bool:
+    orthonormal = (m3 @ m3.transposed() - Matrix.Identity(3)).to_3x3()
+    max_error = max(abs(orthonormal[i][j]) for i in range(3) for j in range(3))
+    return max_error < tolerance and abs(m3.determinant() - 1.0) < tolerance
+
+
+class TestFlatHost:
+    def test_matches_old_formula_when_normal_is_local_z_and_host_unrotated(self):
+        identity = Matrix.Identity(4)
+        result = get_surface_aligned_rotation(identity, Vector((0.0, 0.0, 1.0)))
+        assert _matrices_are_close(result, _old_flat_slab_rotation(identity))
+
+
+class TestTiltedWholeObjectHost:
+    """ "Horizontal Layers" roofs / lean-to slabs: a single flat local mesh
+    (local normal +Z) with the whole object rotated to the slope. The old
+    formula (host rotation, then twist -90 around X) and the new
+    normal-based one must still agree exactly, *for tilts where the old
+    formula's height axis already pointed uphill* (see
+    ``TestNegativeTiltIsUphillCorrected`` below for the other case)."""
+
+    @pytest.mark.parametrize("angle_degrees", [10, 30, 45])
+    def test_matches_old_formula_for_various_tilts(self, angle_degrees):
+        host_matrix = Matrix.Rotation(math.radians(angle_degrees), 4, "X")
+        result = get_surface_aligned_rotation(host_matrix, Vector((0.0, 0.0, 1.0)))
+        assert _matrices_are_close(result, _old_flat_slab_rotation(host_matrix))
+
+
+class TestNegativeTiltIsUphillCorrected:
+    """A slab/roof can be tilted either way via ``x_angle`` (see
+    ``obj.matrix_world = obj.matrix_world @ Matrix.Rotation(x_angle, 4, "X")``
+    in slab.py), and both signs are legitimate, real authoring input.
+
+    The old formula's height axis was whatever the host's own local Y
+    rotated to, which pointed downhill (below horizontal) for negative
+    tilts: an existing, if minor, wrong-way-round quirk. The new formula
+    always keeps the height axis pointing uphill by construction, so it
+    intentionally does NOT reproduce the old formula bit-for-bit here. This
+    only changes the filling's in-plane roll (still flush, still cut); it
+    does not reintroduce the reported bug of no rotation / no cut."""
+
+    def test_height_axis_always_points_uphill_regardless_of_tilt_sign(self):
+        world_up = Vector((0.0, 0.0, 1.0))
+        for angle_degrees in (10, 30, 45, -10, -30, -45):
+            host_matrix = Matrix.Rotation(math.radians(angle_degrees), 4, "X")
+            result = get_surface_aligned_rotation(host_matrix, Vector((0.0, 0.0, 1.0)))
+            height_axis_world = result.to_3x3() @ Vector((0.0, 0.0, 1.0))
+            assert height_axis_world.dot(world_up) >= -1e-9
+
+    def test_old_formula_pointed_downhill_for_a_negative_tilt(self):
+        """Documents the old quirk being fixed, not a property of the new code."""
+        world_up = Vector((0.0, 0.0, 1.0))
+        host_matrix = Matrix.Rotation(math.radians(-20), 4, "X")
+        old_height_axis_world = _old_flat_slab_rotation(host_matrix).to_3x3() @ Vector((0.0, 0.0, 1.0))
+        assert old_height_axis_world.dot(world_up) < 0
+
+
+class TestSlopedRoofFace:
+    """A parametric IfcRoof: the object itself isn't rotated, but individual
+    faces (read from the raycast normal) are sloped."""
+
+    def test_thickness_axis_follows_the_face_normal(self):
+        identity = Matrix.Identity(4)
+        local_normal = Vector((0.0, -0.5, math.sqrt(3) / 2))  # 30 degree slope
+        result = get_surface_aligned_rotation(identity, local_normal)
+        # Local Y (thickness) is the axis that ends up opposite the outward
+        # face normal (matches the flat case: Y -> world -Z when normal +Z).
+        thickness_axis_world = result.to_3x3() @ Vector((0.0, 1.0, 0.0))
+        assert (thickness_axis_world + local_normal.normalized()).length < 1e-6
+
+    def test_is_a_proper_rotation(self):
+        identity = Matrix.Identity(4)
+        local_normal = Vector((0.3, -0.4, 0.8))
+        assert _is_proper_rotation(get_surface_aligned_rotation(identity, local_normal).to_3x3())
+
+    def test_does_not_blow_up_on_a_downward_facing_normal(self):
+        # eg. a soffit / underside face picked up by a stray raycast.
+        identity = Matrix.Identity(4)
+        result = get_surface_aligned_rotation(identity, Vector((0.0, 0.0, -1.0)))
+        assert _is_proper_rotation(result.to_3x3())
+        assert all(math.isfinite(v) for row in result for v in row)

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -15,6 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was modified with the assistance of an AI coding tool.
 
 import json
 from typing import Any
@@ -959,6 +961,58 @@ class TestOffsetWall(NewFile):
         usage.DirectionSense = "NEGATIVE"
         subject.offset_wall(obj, "EXTERIOR")
         assert usage.OffsetFromReferenceLine == 100
+
+
+class TestGetMaterialLayerParameters(NewFile):
+    """https://github.com/IfcOpenShell/IfcOpenShell/issues/5611 : a host with
+    no material (eg. a parametric IfcRoof, which never gets an
+    IfcMaterialLayerSetUsage) used to silently default to AXIS2, the
+    wall convention, so windows/skylights added to it never rotated or cut
+    an opening. The default should follow the host's class instead, the
+    same way ``get_usage_type`` already infers AXIS3 vs AXIS2."""
+
+    def test_roof_with_no_material_defaults_to_axis3(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        roof = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcRoof")
+        assert subject.get_material_layer_parameters(roof)["layer_set_direction"] == "AXIS3"
+
+    def test_slab_with_no_material_defaults_to_axis3(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        slab = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcSlab")
+        assert subject.get_material_layer_parameters(slab)["layer_set_direction"] == "AXIS3"
+
+    def test_wall_with_no_material_defaults_to_axis2(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        assert subject.get_material_layer_parameters(wall)["layer_set_direction"] == "AXIS2"
+
+    def test_unrelated_class_with_no_material_defaults_to_axis2(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        proxy = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcBuildingElementProxy")
+        assert subject.get_material_layer_parameters(proxy)["layer_set_direction"] == "AXIS2"
+
+    def test_explicit_layer_set_usage_still_wins_over_class_default(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        # A wall-shaped element that's actually authored with an AXIS3 usage
+        # (unusual, but the explicit material must still win over the
+        # class-based fallback).
+        wall_type = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWallType", name="WAL01")
+        material_set = ifcopenshell.api.material.add_material_set(ifc, set_type="IfcMaterialLayerSet")
+        material = ifcopenshell.api.material.add_material(ifc, name="PB01", category="gypsum")
+        layer = ifcopenshell.api.material.add_layer(ifc, layer_set=material_set, material=material)
+        ifcopenshell.api.material.edit_layer(ifc, layer=layer, attributes={"LayerThickness": 100})
+        ifcopenshell.api.material.assign_material(ifc, products=[wall_type], material=material_set)
+
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(ifc, related_objects=[wall], relating_type=wall_type)
+        rel = ifcopenshell.api.material.assign_material(ifc, products=[wall], type="IfcMaterialLayerSetUsage")
+        rel.RelatingMaterial.LayerSetDirection = "AXIS3"
+        assert subject.get_material_layer_parameters(wall)["layer_set_direction"] == "AXIS3"
 
 
 class TestGetSiblingOccurrenceCount(NewFile):


### PR DESCRIPTION
Fixes #5611.

Adding a window/skylight to a parametric Roof left the filling vertical with no opening cut. `get_material_layer_parameters()` defaulted the layer set direction to `AXIS2` (wall-like, translation only) whenever no material was found, and parametric roofs never get a material layer set, so they silently fell into the wall placement branch. The `AXIS3` (slab-like) placement also assumed a single flat top face, so it wouldn't have aligned to a sloped face even with the right default.

This adds:
- a class-based fallback for the layer direction (reusing the same class list `get_usage_type()` already uses) instead of hardcoding `AXIS2` when there's no material to read `LayerSetDirection` from, and
- a `get_surface_aligned_rotation()` helper that derives the rotation from the actual raycasted face normal, used only for hosts with no material layer set to read a flat elevation from.

Hosts with a real `IfcMaterialLayerSetUsage` (flat slabs, tilted "Horizontal Layers" roofs) keep the exact previous code path, so those working cases are unaffected by construction.

## Test plan
- [x] Live-verified in headless Blender: a default hipped roof's skylight now rotates to match the sloped face exactly (rotation-dot-face-normal = 1.0, height axis z = sin(slope)) and cuts an opening; wall windows stay vertical and flat-slab skylights stay flat (both still cut correctly).
- [x] `TestGetMaterialLayerParameters` (5 cases) + `test_get_surface_aligned_rotation.py` (9 cases) added; full `test/bim/module/model` + `test/tool` suites pass (pre-existing unrelated failures confirmed on the base branch).
- [x] black + ruff clean.

Thanks @sboddy for the report.

Generated with the assistance of an AI coding tool.
