### PR TITLE
Bonsai: default profile for cable carrier / cable segment tools

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -126,6 +126,12 @@ class AddDefaultType(bpy.types.Operator, tool.Ifc.Operator):
         elif self.ifc_element_type == "IfcPipeSegmentType":
             props.ifc_predefined_type = "RIGIDSEGMENT"
             props.representation_template = "FLOW_SEGMENT_CIRCULAR"
+        elif self.ifc_element_type == "IfcCableCarrierSegmentType":
+            props.ifc_predefined_type = "CABLETRAYSEGMENT"
+            props.representation_template = "FLOW_SEGMENT_U_SHAPE"
+        elif self.ifc_element_type == "IfcCableSegmentType":
+            props.ifc_predefined_type = "CABLESEGMENT"
+            props.representation_template = "FLOW_SEGMENT_CIRCULAR"
 
         elif self.ifc_element_type == "IfcStairFlightType":
             props.ifc_predefined_type = "STRAIGHT"

--- a/src/bonsai/test/bim/module/model/test_add_default_type_flow_segments.py
+++ b/src/bonsai/test/bim/module/model/test_add_default_type_flow_segments.py
@@ -1,0 +1,83 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression test for https://github.com/IfcOpenShell/IfcOpenShell/issues/5374
+
+``bim.add_default_type`` gives duct and pipe segment types a sensible default
+profile (rectangular / circular) when created without a preloaded type.
+Cable carrier and cable segment types had no matching branch in
+``AddDefaultType._execute`` (bonsai/bim/module/model/product.py), so they fell
+through with a stale or empty ``representation_template`` and ended up with
+no distinguishing default profile.
+
+This pins that all four "Segment" tool defaults get their own predefined
+type and profile shape, and that the fix does not disturb the pre-existing
+duct/pipe defaults."""
+
+import bpy
+import ifcopenshell.util.element
+import pytest
+
+import bonsai.tool as tool
+from test.bim.bootstrap import NewIfc
+
+pytestmark = pytest.mark.model
+
+
+class TestAddDefaultTypeFlowSegments(NewIfc):
+    @pytest.mark.parametrize(
+        "ifc_class,expected_predefined_type,expected_profile_class",
+        [
+            ("IfcDuctSegmentType", "RIGIDSEGMENT", "IfcRectangleProfileDef"),
+            ("IfcPipeSegmentType", "RIGIDSEGMENT", "IfcCircleProfileDef"),
+            ("IfcCableCarrierSegmentType", "CABLETRAYSEGMENT", "IfcUShapeProfileDef"),
+            ("IfcCableSegmentType", "CABLESEGMENT", "IfcCircleProfileDef"),
+        ],
+    )
+    def test_default_type_gets_a_shaped_profile(self, ifc_class, expected_predefined_type, expected_profile_class):
+        bpy.ops.bim.add_default_type(ifc_element_type=ifc_class)
+        obj = bpy.context.active_object
+        element = tool.Ifc.get_entity(obj)
+
+        assert element.is_a(ifc_class)
+        assert element.PredefinedType == expected_predefined_type
+
+        profile_set = ifcopenshell.util.element.get_material(element)
+        assert profile_set is not None and profile_set.is_a("IfcMaterialProfileSet")
+        profile = profile_set.MaterialProfiles[0].Profile
+        assert profile.is_a(expected_profile_class)
+
+    def test_cable_carrier_and_cable_do_not_reuse_a_cube_or_stale_profile(self):
+        """Before the fix, creating a duct/pipe type first would leave
+        ``representation_template`` set to a duct/pipe value, so a
+        subsequently-created cable carrier or cable type silently inherited
+        the wrong (or no) profile shape instead of its own default."""
+        bpy.ops.bim.add_default_type(ifc_element_type="IfcDuctSegmentType")
+        bpy.ops.bim.add_default_type(ifc_element_type="IfcPipeSegmentType")
+
+        bpy.ops.bim.add_default_type(ifc_element_type="IfcCableCarrierSegmentType")
+        carrier = tool.Ifc.get_entity(bpy.context.active_object)
+        carrier_profile = ifcopenshell.util.element.get_material(carrier).MaterialProfiles[0].Profile
+        assert carrier_profile.is_a("IfcUShapeProfileDef")
+
+        bpy.ops.bim.add_default_type(ifc_element_type="IfcCableSegmentType")
+        cable = tool.Ifc.get_entity(bpy.context.active_object)
+        cable_profile = ifcopenshell.util.element.get_material(cable).MaterialProfiles[0].Profile
+        assert cable_profile.is_a("IfcCircleProfileDef")


### PR DESCRIPTION
Fixes #5374.

Cable carrier and cable segment tools now get a proper default profile when created without a preloaded type, instead of falling back to a cube or reusing whatever profile a duct/pipe type creation last left behind. `AddDefaultType._execute` had explicit branches for `IfcDuctSegmentType` and `IfcPipeSegmentType` but none for `IfcCableCarrierSegmentType`/`IfcCableSegmentType`, so those fell through and inherited stale `representation_template` state.

Added two branches, reusing the existing template mechanism:
- `IfcCableCarrierSegmentType` -> `CABLETRAYSEGMENT` + `FLOW_SEGMENT_U_SHAPE` (an open U-channel tray; `root/data.py` already special-cases the cable carrier for U-shape in the manual "Add Representation" dropdown, it just wasn't wired into the auto-default path).
- `IfcCableSegmentType` -> `CABLESEGMENT` + `FLOW_SEGMENT_CIRCULAR` (a round conductor, mirroring pipe).

Both predefined-type literals are valid in IFC4 / IFC4X3 / IFC4X3_ADD2, so no schema guard is needed (consistent with the unguarded duct/pipe branches).

## Test plan
- [x] Live headless Blender: cable carrier -> `IfcUShapeProfileDef`, cable -> `IfcCircleProfileDef`; duct/pipe unchanged (no regression). Confirmed the pre-fix stale-reuse symptom (cable carrier inheriting the pipe's circle) and that it's gone.
- [x] `test_add_default_type_flow_segments.py` (5 cases incl. a no-stale-reuse regression) added; fails 3/5 pre-fix, passes 5/5 with the fix.
- [x] black + ruff clean.

Thanks @Plae-Blue-Dot for the repro screenshot and demo IFC with the reference profiles.

Generated with the assistance of an AI coding tool.
