### PR TITLE
Bonsai: add 'IFC Elements Only' preference for Freestyle linework

### DIFF
--- a/src/bonsai/bonsai/bim/data/pset/EPset_Drawing.ifc
+++ b/src/bonsai/bonsai/bim/data/pset/EPset_Drawing.ifc
@@ -5,7 +5,7 @@ FILE_NAME('EPset_Drawing.ifc','2020-01-01T00:00:00',$,$,'EPset_Drawing','EPset_D
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
-#1=IFCPROPERTYSETTEMPLATE('2JhNIvqZrFnAgxfhK0XVQX',$,'EPset_Drawing','',.PSET_OCCURRENCEDRIVEN.,'IfcAnnotation/DRAWING',(#23,#22,#27,#24,#29,#30,#19,#12,#26,#9,#8,#7,#6,#4,#18,#11,#5,#20,#25,#14,#10,#17,#28,#16,#3,#21,#13,#15,#2,#31,#32,#33,#34,#35,#36,#37));
+#1=IFCPROPERTYSETTEMPLATE('2JhNIvqZrFnAgxfhK0XVQX',$,'EPset_Drawing','',.PSET_OCCURRENCEDRIVEN.,'IfcAnnotation/DRAWING',(#23,#22,#27,#24,#29,#30,#19,#12,#26,#9,#8,#7,#6,#4,#18,#11,#5,#20,#25,#14,#10,#17,#28,#16,#3,#21,#13,#15,#2,#31,#32,#33,#34,#35,#36,#37,#38));
 #2=IFCSIMPLEPROPERTYTEMPLATE('23JavTMk98ZxXhrUEnjAcf',$,'TargetView','',.P_SINGLEVALUE.,'IfcLabel',$,$,$,$,$,.READWRITE.);
 #3=IFCSIMPLEPROPERTYTEMPLATE('1yVWUt5H9DAOuu0OaMMLpe',$,'Scale','The scale of this drawing represented as a numerator and denominator, such as 1/100',.P_SINGLEVALUE.,'IfcLabel',$,$,$,$,$,.READWRITE.);
 #4=IFCSIMPLEPROPERTYTEMPLATE('3gsuPBtU93b8f0gg1pjkq6',$,'HumanScale','The scale of this drawing in human readable format, such as 1:100',.P_SINGLEVALUE.,'IfcLabel',$,$,$,$,$,.READWRITE.);
@@ -42,5 +42,6 @@ DATA;
 #35=IFCSIMPLEPROPERTYTEMPLATE('3TZwsEjkr5WRDKcgrYzSIA',$,'RidgeAngleMinDegrees','Minimum convex dihedral deviation from flat, in degrees, for a projection edge to be classified as ''sharp'' rather than ''flush''.',.P_SINGLEVALUE.,'IfcReal',$,$,$,$,$,.READWRITE.);
 #36=IFCSIMPLEPROPERTYTEMPLATE('2Jua$lO754vgZOkBoHM2gA',$,'RenderFlush','Whether to render ''flush'' edges (dihedral deviation below both ridge/valley thresholds). Only relevant when UseEdgeClassification is enabled.',.P_SINGLEVALUE.,'IfcBoolean',$,$,$,$,$,.READWRITE.);
 #37=IFCSIMPLEPROPERTYTEMPLATE('1zM9sia2L8RQDnWZxgUwlZ',$,'JoinClasses','Comma separated list of IFC classes whose cut linework will be joined together when they meet (e.g. mitred at a corner).\X2\000A\X0\Defaults to ''IfcWall,IfcSlab'' if not set. Override to also join other classes, such as ''IfcWall,IfcSlab,IfcCovering''.',.P_SINGLEVALUE.,'IfcText',$,$,$,$,$,.READWRITE.);
+#38=IFCSIMPLEPROPERTYTEMPLATE('2Cmr6RknT54OvbZ7SNWZSc',$,'FreestyleIfcOnly','Restrict Freestyle linework to IFC elements, ignoring plain Blender objects (e.g. entourage). Only relevant when LineworkMode is ''FREESTYLE''.',.P_SINGLEVALUE.,'IfcBoolean',$,$,$,$,$,.READWRITE.);
 ENDSEC;
 END-ISO-10303-21;

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -898,9 +898,12 @@ class CreateDrawing(bpy.types.Operator):
         context.scene.collection.objects.link(edge_obj)
         edge_bm = bmesh.new()
 
+        ifc_only = self.cprops.freestyle_ifc_only
         visible_object_names = {obj.name for obj in bpy.context.visible_objects}
         for obj in bpy.context.view_layer.objects:
             is_visible = obj.name in visible_object_names
+            if is_visible and ifc_only and obj is not edge_obj and tool.Ifc.get_entity(obj) is None:
+                is_visible = False
             obj.hide_render = not is_visible
             if (
                 is_visible
@@ -917,6 +920,10 @@ class CreateDrawing(bpy.types.Operator):
                 finally:
                     if tmp_mesh:
                         bpy.data.meshes.remove(tmp_mesh)
+
+        # The merged-edge helper object is internal render scaffolding, not user content,
+        # so it must always render regardless of the IFC-only filter above.
+        edge_obj.hide_render = False
 
         ret = bmesh.ops.extrude_edge_only(edge_bm, edges=edge_bm.edges)
         verts_extruded = [e for e in ret["geom"] if isinstance(e, bmesh.types.BMVert)]

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -526,6 +526,13 @@ class BIMCameraProperties(PropertyGroup):
         name="Cut Mode",
         update=get_update_layer_callback("cut_mode", "CutMode"),
     )
+    freestyle_ifc_only: BoolProperty(
+        name="IFC Elements Only",
+        description="Restrict Freestyle linework to IFC elements, ignoring plain Blender "
+        "objects (e.g. entourage) so that high poly non-IFC geometry doesn't slow down the render",
+        default=False,
+        update=get_update_layer_callback("freestyle_ifc_only", "FreestyleIfcOnly"),
+    )
 
     # EPset_Drawing.
     has_underlay: BoolProperty(

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -113,6 +113,9 @@ class BIM_PT_camera(Panel):
             row.prop(props, "fill_mode")
             row = self.layout.row()
             row.prop(props, "cut_mode")
+        elif props.linework_mode == "FREESTYLE":
+            row = self.layout.row()
+            row.prop(props, "freestyle_ifc_only")
 
         row = self.layout.row()
         row.prop(props, "use_edge_classification")

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1089,6 +1089,7 @@ class Drawing(bonsai.core.tool.Drawing):
         camera_props.render_sharp = True
         camera_props.ridge_angle_min_degrees = 45.0
         camera_props.render_flush = False
+        camera_props.freestyle_ifc_only = False
         camera.shift_x = 0.0
         camera.shift_y = 0.0
 
@@ -1138,6 +1139,8 @@ class Drawing(bonsai.core.tool.Drawing):
                 camera_props.fill_mode = str(pset["FillMode"])
             if "CutMode" in pset:
                 camera_props.cut_mode = str(pset["CutMode"])
+            if "FreestyleIfcOnly" in pset:
+                camera_props.freestyle_ifc_only = bool(pset["FreestyleIfcOnly"])
             if camera.type == "PERSP":
                 shifts = cls.get_perspective_camera_shifts(drawing)
                 camera.shift_x = shifts["shift_x"]

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -127,6 +127,20 @@ class TestImportCameraProps(NewFile):
         assert props.render_sharp is True
         assert props.ridge_angle_min_degrees == pytest.approx(45.0)
         assert props.render_flush is False
+        assert props.freestyle_ifc_only is False
+
+    def test_imports_freestyle_ifc_only_from_drawing_pset(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        drawing = ifc.createIfcAnnotation(ObjectType="DRAWING")
+        pset = ifcopenshell.api.pset.add_pset(ifc, product=drawing, name="EPset_Drawing")
+        ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"FreestyleIfcOnly": True})
+        camera = bpy.data.cameras.new("Camera")
+
+        subject.import_camera_props(drawing, camera)
+
+        props = subject.get_camera_props(camera)
+        assert props.freestyle_ifc_only is True
 
     def test_imports_edge_classification_props_from_drawing_pset(self):
         ifc = ifcopenshell.file()


### PR DESCRIPTION
Fixes #5729.

Adds a per-drawing "IFC Elements Only" preference for Freestyle linework, so plain Blender objects (entourage like plants, or other high-facet decoration) don't get pulled into the Freestyle render pass and inflate render time. `generate_freestyle_linework` previously built its object set purely from `bpy.context.visible_objects` with no IFC-vs-plain distinction.

- New per-drawing boolean `freestyle_ifc_only` (`EPset_Drawing.FreestyleIfcOnly`), following the exact pattern of sibling drawing options (`has_linework`, `use_edge_classification`), round-tripped through `import_camera_props`.
- Shown in the Active Drawing panel only when Linework Mode is Freestyle. **Off by default**, so existing drawings are unaffected.
- When enabled, objects with no IFC entity are excluded from the Freestyle set (the internal "Temp Merged Edges" scaffolding object is explicitly kept, so the edge-only-mesh/suggestive-contour feature isn't broken by the toggle).

Re the secondary point in the thread ("Freestyle shouldn't run when only Underlay is checked"): that's already handled. `generate_freestyle_linework` returns early when `EPset_Drawing.HasLinework` is false (guard added in commit 1d62f6f7367, 2024-08-31), so unchecking "Linework" already prevents Freestyle from running regardless of Underlay. No rework needed there.

## Test plan
- [x] Live headless Blender: scene with an IFC wall + a non-IFC high-poly entourage object. Toggle OFF -> both included; toggle ON -> only the IFC wall included. Default is False; value persists to the pset and round-trips on reload.
- [x] `test/tool/test_drawing.py` extended (default-false + round-trip of `freestyle_ifc_only`).
- [x] black + ruff clean.

Thanks @theoryshaw for the report.

Generated with the assistance of an AI coding tool.
