### PR TITLE
Bonsai: option to hide the sheet reference on section/elevation markers

### DIFF
--- a/src/bonsai/bonsai/bim/data/pset/EPset_Drawing.ifc
+++ b/src/bonsai/bonsai/bim/data/pset/EPset_Drawing.ifc
@@ -5,7 +5,7 @@ FILE_NAME('EPset_Drawing.ifc','2020-01-01T00:00:00',$,$,'EPset_Drawing','EPset_D
 FILE_SCHEMA(('IFC4'));
 ENDSEC;
 DATA;
-#1=IFCPROPERTYSETTEMPLATE('2JhNIvqZrFnAgxfhK0XVQX',$,'EPset_Drawing','',.PSET_OCCURRENCEDRIVEN.,'IfcAnnotation/DRAWING',(#23,#22,#27,#24,#29,#30,#19,#12,#26,#9,#8,#7,#6,#4,#18,#11,#5,#20,#25,#14,#10,#17,#28,#16,#3,#21,#13,#15,#2,#31,#32,#33,#34,#35,#36,#37));
+#1=IFCPROPERTYSETTEMPLATE('2JhNIvqZrFnAgxfhK0XVQX',$,'EPset_Drawing','',.PSET_OCCURRENCEDRIVEN.,'IfcAnnotation/DRAWING',(#23,#22,#27,#24,#29,#30,#19,#12,#26,#9,#8,#7,#6,#4,#18,#11,#5,#20,#25,#14,#10,#17,#28,#16,#3,#21,#13,#15,#2,#31,#32,#33,#34,#35,#36,#37,#38));
 #2=IFCSIMPLEPROPERTYTEMPLATE('23JavTMk98ZxXhrUEnjAcf',$,'TargetView','',.P_SINGLEVALUE.,'IfcLabel',$,$,$,$,$,.READWRITE.);
 #3=IFCSIMPLEPROPERTYTEMPLATE('1yVWUt5H9DAOuu0OaMMLpe',$,'Scale','The scale of this drawing represented as a numerator and denominator, such as 1/100',.P_SINGLEVALUE.,'IfcLabel',$,$,$,$,$,.READWRITE.);
 #4=IFCSIMPLEPROPERTYTEMPLATE('3gsuPBtU93b8f0gg1pjkq6',$,'HumanScale','The scale of this drawing in human readable format, such as 1:100',.P_SINGLEVALUE.,'IfcLabel',$,$,$,$,$,.READWRITE.);
@@ -42,5 +42,6 @@ DATA;
 #35=IFCSIMPLEPROPERTYTEMPLATE('3TZwsEjkr5WRDKcgrYzSIA',$,'RidgeAngleMinDegrees','Minimum convex dihedral deviation from flat, in degrees, for a projection edge to be classified as ''sharp'' rather than ''flush''.',.P_SINGLEVALUE.,'IfcReal',$,$,$,$,$,.READWRITE.);
 #36=IFCSIMPLEPROPERTYTEMPLATE('2Jua$lO754vgZOkBoHM2gA',$,'RenderFlush','Whether to render ''flush'' edges (dihedral deviation below both ridge/valley thresholds). Only relevant when UseEdgeClassification is enabled.',.P_SINGLEVALUE.,'IfcBoolean',$,$,$,$,$,.READWRITE.);
 #37=IFCSIMPLEPROPERTYTEMPLATE('1zM9sia2L8RQDnWZxgUwlZ',$,'JoinClasses','Comma separated list of IFC classes whose cut linework will be joined together when they meet (e.g. mitred at a corner).\X2\000A\X0\Defaults to ''IfcWall,IfcSlab'' if not set. Override to also join other classes, such as ''IfcWall,IfcSlab,IfcCovering''.',.P_SINGLEVALUE.,'IfcText',$,$,$,$,$,.READWRITE.);
+#38=IFCSIMPLEPROPERTYTEMPLATE('3cq2E6EmbAFBpQKXGuLIb9',$,'ShowSheetReferences','Whether section and elevation markers show the sheet reference below the drawing number.',.P_SINGLEVALUE.,'IfcBoolean',$,$,$,$,$,.READWRITE.);
 ENDSEC;
 END-ISO-10303-21;

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -543,6 +543,12 @@ class BIMCameraProperties(PropertyGroup):
         default=True,
         update=get_update_layer_callback("has_annotation", "HasAnnotation"),
     )
+    show_sheet_references: BoolProperty(
+        name="Show Sheet References",
+        description="Show the sheet reference below the drawing number in section and elevation markers",
+        default=True,
+        update=get_update_layer_callback("show_sheet_references", "ShowSheetReferences"),
+    )
     use_edge_classification: BoolProperty(
         name="Use Edge Classification",
         description="Classify projection edges into boundary/outline/sharp/crease/flush "
@@ -630,6 +636,7 @@ class BIMCameraProperties(PropertyGroup):
         has_underlay: bool
         has_linework: bool
         has_annotation: bool
+        show_sheet_references: bool
         target_view: TargetView
 
         representation: str

--- a/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
@@ -846,22 +846,7 @@ class SvgWriter:
                 if display_data[current_marker_position]["add_circle"]:
                     self.svg.add(self.svg.use("#section-tag", insert=symbol_position_svg))
 
-                    reference_id, sheet_id = self.get_reference_and_sheet_id_from_annotation(tool.Ifc.get_entity(obj))
-                    text_position = symbol_position_svg
-                    text_style = SvgWriter.get_box_alignment_parameters("center")
-                    self.svg.add(
-                        self.svg.text(
-                            reference_id,
-                            insert=(text_position[0], text_position[1] - 2.5),
-                            class_="SECTION",
-                            **text_style,
-                        )
-                    )
-                    self.svg.add(
-                        self.svg.text(
-                            sheet_id, insert=(text_position[0], text_position[1] + 2.5), class_="SECTION", **text_style
-                        )
-                    )
+                    self.draw_marker_reference_text(tool.Ifc.get_entity(obj), symbol_position_svg, "SECTION")
 
     def draw_elevation_annotation(self, obj: bpy.types.Object) -> None:
         x_offset = self.raw_width / 2
@@ -879,17 +864,23 @@ class SvgWriter:
         self.svg.add(self.svg.use("#elevation-arrow", insert=symbol_position_svg, transform=transform))
         self.svg.add(self.svg.use("#elevation-tag", insert=symbol_position_svg))
 
-        reference_id, sheet_id = self.get_reference_and_sheet_id_from_annotation(tool.Ifc.get_entity(obj))
-        text_position = symbol_position_svg
+        self.draw_marker_reference_text(tool.Ifc.get_entity(obj), symbol_position_svg, "ELEVATION")
+
+    def draw_marker_reference_text(self, element: ifcopenshell.entity_instance, insert: Vector, class_: str) -> None:
+        """Draw the drawing number (and optionally the sheet reference) under a section/elevation tag circle."""
+        reference_id, sheet_id = self.get_reference_and_sheet_id_from_annotation(element)
         text_style = SvgWriter.get_box_alignment_parameters("center")
-        self.svg.add(
-            self.svg.text(
-                reference_id, insert=(text_position[0], text_position[1] - 2.5), class_="ELEVATION", **text_style
-            )
-        )
-        self.svg.add(
-            self.svg.text(sheet_id, insert=(text_position[0], text_position[1] + 2.5), class_="ELEVATION", **text_style)
-        )
+        if self.should_show_sheet_references():
+            self.svg.add(self.svg.text(reference_id, insert=(insert[0], insert[1] - 2.5), class_=class_, **text_style))
+            self.svg.add(self.svg.text(sheet_id, insert=(insert[0], insert[1] + 2.5), class_=class_, **text_style))
+        else:
+            self.svg.add(self.svg.text(reference_id, insert=(insert[0], insert[1]), class_=class_, **text_style))
+
+    def should_show_sheet_references(self) -> bool:
+        drawing = tool.Ifc.get_entity(self.camera)
+        if not drawing:
+            return True
+        return tool.Drawing.show_sheet_references(drawing)
 
     def get_reference_and_sheet_id_from_annotation(self, element: ifcopenshell.entity_instance) -> tuple[str, str]:
         reference_id = "-"

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -73,6 +73,8 @@ class BIM_PT_camera(Panel):
         row = col.row(align=True)
         row.prop(props, "has_annotation", icon="MOD_EDGESPLIT")
         row.prop(dprops, "should_use_annotation_cache", text="", icon="FILE_REFRESH")
+        row = col.row(align=True)
+        row.prop(props, "show_sheet_references", icon="BOOKMARKS")
 
         # Drawing linked projects.
         row = col.row(align=True)

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -1081,6 +1081,7 @@ class Drawing(bonsai.core.tool.Drawing):
         camera_props.has_underlay = False
         camera_props.has_linework = True
         camera_props.has_annotation = True
+        camera_props.show_sheet_references = True
         camera_props.target_view = "PLAN_VIEW"
         camera_props.is_nts = False
         camera_props.use_edge_classification = False
@@ -1116,6 +1117,8 @@ class Drawing(bonsai.core.tool.Drawing):
                 camera_props.has_linework = bool(pset["HasLinework"])
             if "HasAnnotation" in pset:
                 camera_props.has_annotation = bool(pset["HasAnnotation"])
+            if "ShowSheetReferences" in pset:
+                camera_props.show_sheet_references = bool(pset["ShowSheetReferences"])
             if "IsNTS" in pset:
                 camera_props.is_nts = bool(pset["IsNTS"])
             if "UseEdgeClassification" in pset:
@@ -2353,6 +2356,10 @@ class Drawing(bonsai.core.tool.Drawing):
     @classmethod
     def has_annotation(cls, drawing: ifcopenshell.entity_instance) -> bool:
         return ifcopenshell.util.element.get_psets(drawing).get("EPset_Drawing", {}).get("HasAnnotation", False)
+
+    @classmethod
+    def show_sheet_references(cls, drawing: ifcopenshell.entity_instance) -> bool:
+        return ifcopenshell.util.element.get_psets(drawing).get("EPset_Drawing", {}).get("ShowSheetReferences", True)
 
     @classmethod
     def get_drawing_elements(

--- a/src/bonsai/test/bim/module/drawing/test_svgwriter_section_markers.py
+++ b/src/bonsai/test/bim/module/drawing/test_svgwriter_section_markers.py
@@ -1,0 +1,93 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Covers issue #5872: an EPset_Drawing.ShowSheetReferences toggle lets a
+drawing hide the sheet-reference line under section/elevation tags, for
+projects where every section already lives on one sheet.
+"""
+
+import bpy
+import ifcopenshell
+import ifcopenshell.api.pset
+import pytest
+from mathutils import Vector
+
+import bonsai.tool as tool
+from bonsai.bim.module.drawing.svgwriter import SvgWriter
+from test.bim.bootstrap import NewFile
+
+pytestmark = pytest.mark.drawing
+
+
+def _make_drawing_and_marker(show_sheet_references=None):
+    ifc = ifcopenshell.file()
+    tool.Ifc.set(ifc)
+
+    drawing = ifc.create_entity("IfcAnnotation", ObjectType="DRAWING")
+    pset = ifcopenshell.api.pset.add_pset(ifc, product=drawing, name="EPset_Drawing")
+    if show_sheet_references is not None:
+        ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"ShowSheetReferences": show_sheet_references})
+
+    camera_data = bpy.data.cameras.new("TestCamera")
+    camera_obj = bpy.data.objects.new("TestCamera", camera_data)
+    bpy.context.scene.collection.objects.link(camera_obj)
+    tool.Ifc.link(drawing, camera_obj)
+
+    marker = ifc.create_entity("IfcAnnotation", ObjectType="SECTION")
+    ifc.create_entity("IfcRelAssignsToProduct", RelatedObjects=[marker], RelatingProduct=drawing)
+
+    return camera_obj, marker
+
+
+def _render_marker_text(camera_obj, marker):
+    writer = SvgWriter(camera_width=10, camera_height=10, camera=camera_obj, camera_projection=Vector((0, 0, -1)))
+    writer.create_blank_svg("/tmp/test_svgwriter_section_markers.svg")
+    writer.draw_marker_reference_text(marker, Vector((100.0, 200.0)), "SECTION")
+    return writer.svg.tostring()
+
+
+class TestShowSheetReferences(NewFile):
+    def test_defaults_to_true_when_pset_key_is_absent(self):
+        camera_obj, marker = _make_drawing_and_marker(show_sheet_references=None)
+        drawing = tool.Ifc.get_entity(camera_obj)
+        assert tool.Drawing.show_sheet_references(drawing) is True
+
+    def test_shows_reference_and_sheet_id_by_default(self):
+        camera_obj, marker = _make_drawing_and_marker(show_sheet_references=None)
+        svg = _render_marker_text(camera_obj, marker)
+        assert svg.count("<text") == 2
+        # split above and below the marker centre (y=200), unchanged legacy layout.
+        assert 'y="197.5"' in svg
+        assert 'y="202.5"' in svg
+
+    def test_hides_sheet_id_and_recenters_reference_id_when_disabled(self):
+        camera_obj, marker = _make_drawing_and_marker(show_sheet_references=False)
+        svg = _render_marker_text(camera_obj, marker)
+        assert svg.count("<text") == 1
+        assert 'y="200.0"' in svg
+
+    def test_toggle_applies_to_elevation_markers_too(self):
+        camera_obj, marker = _make_drawing_and_marker(show_sheet_references=False)
+        writer = SvgWriter(camera_width=10, camera_height=10, camera=camera_obj, camera_projection=Vector((0, 0, -1)))
+        writer.create_blank_svg("/tmp/test_svgwriter_section_markers.svg")
+        writer.draw_marker_reference_text(marker, Vector((50.0, 60.0)), "ELEVATION")
+        svg = writer.svg.tostring()
+        assert svg.count("<text") == 1
+        assert 'y="60.0"' in svg


### PR DESCRIPTION
Fixes #5872.

Section and elevation markers always drew two text lines under the tag circle: the drawing number and the sheet reference. When every section lives on a single sheet (e.g. a key plan), the sheet reference is redundant, and the two-line layout crowds the small circular tags, causing them to clash, as reported by @theoryshaw.

Adds `EPset_Drawing.ShowSheetReferences` (default true, so existing drawings are unaffected). When disabled for a drawing, section/elevation tags show only the drawing number, vertically re-centered. Exposed as a per-drawing toggle in the Active Drawing panel, following the exact pattern of the sibling `has_underlay`/`has_linework`/`has_annotation` options.

This scopes to the literal request only. The later thread discussion (fully customizable tag anchors driven by symbols.svg, per-tag-type configurable fields) is a much larger design question and is intentionally not addressed here.

## Test plan
- [x] Live headless Blender: with the toggle on, both text lines render at y∓2.5 (unchanged); with it off, only the drawing number renders re-centered at y; default (no pset key) is true, so existing files are unaffected. Applies to both section and elevation markers.
- [x] `test/bim/module/drawing/test_svgwriter_section_markers.py` (4 tests) added; full drawing suite 34/34 pass.
- [x] black + ruff clean.

Generated with the assistance of an AI coding tool.
