### PR TITLE
Bonsai: expose thickness when creating a layered element type

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -668,8 +668,7 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
             )
             layer_set = rel.RelatingMaterial
             layer = ifcopenshell.api.material.add_layer(tool.Ifc.get(), layer_set=layer_set, material=material)
-            thickness = 0.1  # Arbitrary metric thickness for now
-            layer.LayerThickness = thickness / unit_scale
+            layer.LayerThickness = props.thickness / unit_scale
             pset = ifcopenshell.api.pset.add_pset(tool.Ifc.get(), product=element, name="EPset_Parametric")
             if representation_template == "LAYERSET_AXIS2":
                 axis = "AXIS2"
@@ -869,5 +868,8 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
         elif props.representation_template == "PROFILESET":
             row = self.layout.row()
             prop_with_search(self.layout, props, "profile", text="Profile", should_click_ok=True)
+        elif props.representation_template in ("LAYERSET_AXIS2", "LAYERSET_AXIS3"):
+            row = self.layout.row()
+            row.prop(props, "thickness")
         if props.representation_template != "EMPTY":
             prop_with_search(self.layout, props, "contexts", should_click_ok=True)

--- a/src/bonsai/bonsai/bim/module/root/prop.py
+++ b/src/bonsai/bonsai/bim/module/root/prop.py
@@ -178,6 +178,7 @@ class BIMRootProperties(PropertyGroup):
         description="The representation will be a tessellation of the selected object",
     )
     profile: EnumProperty(name="Profile for profile type object", items=get_profile)
+    thickness: bpy.props.FloatProperty(name="Thickness", default=0.1, subtype="DISTANCE")
     relating_class_object: PointerProperty(
         type=bpy.types.Object,
         name="Copy Class",
@@ -202,4 +203,5 @@ class BIMRootProperties(PropertyGroup):
         representation_template: str
         representation_obj: Union[bpy.types.Object, None]
         profile: str
+        thickness: float
         relating_class_object: Union[bpy.types.Object, None]

--- a/src/bonsai/test/bim/feature/root.feature
+++ b/src/bonsai/test/bim/feature/root.feature
@@ -14,6 +14,19 @@ Scenario: Add element - a type with no geometry
     Then the object "IfcFurnitureType/Foo" exists
     And the object "IfcFurnitureType/Foo" has no data
 
+Scenario: Add element - a layered type with a custom thickness
+    Given an empty IFC project
+    And I trigger "Add Element"
+    And I set the "Name" property to "Foo"
+    And I set the "Definition" property to "IfcElementType"
+    And I set the "Class" property to "IfcWallType"
+    And I set the "Representation" property to "Vertical Layers"
+    And I set the "Thickness" property to "0.35"
+    When I click "OK"
+    Then the object "IfcWallType/Foo" exists
+    And the variable "layer_thickness" is "ifcopenshell.util.unit.calculate_unit_scale({ifc}) * {ifc}.by_type('IfcMaterialLayerSet')[0].MaterialLayers[0].LayerThickness"
+    And the variable "layer_thickness" equals "0.35"
+
 Scenario: Add element - an element with no geometry
     Given an empty IFC project
     And I trigger "Add Element"


### PR DESCRIPTION
Fixes #4738.

The "Add Element" popup hardcoded a 0.1m layer thickness whenever creating a layered type (Wall/Slab/etc. via the Vertical Layers / Horizontal Layers representation templates), so every new type needed a follow-up edit just to set thickness. This exposes a Thickness field directly in the popup for the `LAYERSET_AXIS2`/`LAYERSET_AXIS3` templates (mirroring the existing `PROFILESET` enum-conditional field) and wires it into the created `IfcMaterialLayerSet` layer. All other representation templates are unchanged.

Material selection in the popup is left as a follow-up (would need its own cached material-enum data source); this PR is thickness-only, matching the primary ask.

## Test plan
- [x] Live headless Blender: `bim.add_element` with `thickness=0.25` -> resulting `IfcMaterialLayerSet` layer thickness = 0.25 (was always 0.1); default 0.1 still gives 0.1; non-layerset templates (EXTRUSION) unaffected. Popup shows the Thickness field for LAYERSET_AXIS2/AXIS3 and hides it for EXTRUSION.
- [x] New BDD scenario in `test/bim/feature/root.feature`; black + ruff clean.

Thanks @SavuGust27 for the write-up and mockups.

Generated with the assistance of an AI coding tool.
