### PR TITLE
Bonsai: keep loaded classification libraries selectable without reloading

### DIFF
--- a/src/bonsai/bonsai/bim/ifc.py
+++ b/src/bonsai/bonsai/bim/ifc.py
@@ -119,6 +119,10 @@ class IfcStore:
     pset_template_file: Optional[ifcopenshell.file] = None
     classification_path: str = ""
     classification_file: Optional[ifcopenshell.file] = None
+    classification_files: dict[str, ifcopenshell.file] = {}
+    """Every classification library loaded this session, keyed by filepath. Unlike ``classification_file``,
+    which is overwritten on each ``bim.load_classification_library`` call, this accumulates so a previously
+    loaded library stays selectable without reloading it from disk."""
     library_path: str = ""
     library_file: Optional[ifcopenshell.file] = None
     current_transaction = ""
@@ -140,6 +144,9 @@ class IfcStore:
         IfcStore.edited_objs = set()
         IfcStore.pset_template_path = ""
         IfcStore.pset_template_file = None
+        IfcStore.classification_path = ""
+        IfcStore.classification_file = None
+        IfcStore.classification_files = {}
         IfcStore.library_path = ""
         IfcStore.library_file = None
         IfcStore.last_transaction = ""

--- a/src/bonsai/bonsai/bim/module/classification/data.py
+++ b/src/bonsai/bonsai/bim/module/classification/data.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 from typing import Any, Literal, Union
 
 import bpy
@@ -46,10 +47,15 @@ class ClassificationsData:
         cls.data["classifications"] = cls.classifications()
         cls.data["available_classifications"] = cls.available_classifications()
         cls.data["classification_source"] = cls.classification_source()
+        cls.data["loaded_classification_libraries"] = cls.loaded_classification_libraries()
 
     @classmethod
     def has_classification_file(cls):
         return bool(IfcStore.classification_file)
+
+    @classmethod
+    def loaded_classification_libraries(cls) -> tool.Blender.BLENDER_ENUM_ITEMS:
+        return [(filepath, os.path.basename(filepath), filepath) for filepath in IfcStore.classification_files]
 
     @classmethod
     def classifications(cls):

--- a/src/bonsai/bonsai/bim/module/classification/operator.py
+++ b/src/bonsai/bonsai/bim/module/classification/operator.py
@@ -37,7 +37,9 @@ class LoadClassificationLibrary(bpy.types.Operator, tool.Ifc.Operator, ImportHel
     filter_glob: bpy.props.StringProperty(default="*.ifc;*.ifczip;*.ifcxml", options={"HIDDEN"})
 
     def _execute(self, context):
-        IfcStore.classification_file = ifcopenshell.open(self.filepath)
+        file = ifcopenshell.open(self.filepath)
+        IfcStore.classification_files[self.filepath] = file
+        IfcStore.classification_file = file
 
 
 class AddClassification(bpy.types.Operator, tool.Ifc.Operator):

--- a/src/bonsai/bonsai/bim/module/classification/prop.py
+++ b/src/bonsai/bonsai/bim/module/classification/prop.py
@@ -29,9 +29,11 @@ from bpy.props import (
 from bpy.types import PropertyGroup
 
 import bonsai.tool as tool
+from bonsai.bim.ifc import IfcStore
 from bonsai.bim.module.classification.data import (
     ClassificationsData,
     ObjectClassificationsData,
+    refresh,
 )
 from bonsai.bim.prop import Attribute
 
@@ -42,6 +44,22 @@ def get_available_classifications(
     if not ClassificationsData.is_loaded:
         ClassificationsData.load()
     return ClassificationsData.data["available_classifications"]
+
+
+def get_loaded_classification_libraries(
+    self: "BIMClassificationProperties", context: bpy.types.Context
+) -> tool.Blender.BLENDER_ENUM_ITEMS:
+    if not ClassificationsData.is_loaded:
+        ClassificationsData.load()
+    return ClassificationsData.data["loaded_classification_libraries"]
+
+
+def update_loaded_classification_library(self: "BIMClassificationProperties", context: bpy.types.Context) -> None:
+    file = IfcStore.classification_files.get(self.loaded_classification_library)
+    if file is None:
+        return
+    IfcStore.classification_file = file
+    refresh()
 
 
 def get_classifications(self, context):
@@ -75,6 +93,11 @@ class BIMClassificationProperties(PropertyGroup):
     is_adding: BoolProperty(name="Is Adding", default=False)
     classification_source: EnumProperty(items=get_classification_source, name="Classification Source")
     available_classifications: EnumProperty(items=get_available_classifications, name="Available Classifications")
+    loaded_classification_library: EnumProperty(
+        items=get_loaded_classification_libraries,
+        name="Loaded Classification Library",
+        update=update_loaded_classification_library,
+    )
     classification_attributes: CollectionProperty(name="Classification Attributes", type=Attribute)
     active_classification_id: IntProperty(name="Active Classification Id")
     available_library_references: CollectionProperty(name="Available Library References", type=ClassificationReference)
@@ -85,6 +108,7 @@ class BIMClassificationProperties(PropertyGroup):
         is_adding: bool
         classification_source: str
         available_classifications: str
+        loaded_classification_library: str
         classification_attributes: bpy.types.bpy_prop_collection_idprop[Attribute]
         active_classification_id: int
         available_library_references: bpy.types.bpy_prop_collection_idprop[ClassificationReference]

--- a/src/bonsai/bonsai/bim/module/classification/ui.py
+++ b/src/bonsai/bonsai/bim/module/classification/ui.py
@@ -96,6 +96,9 @@ class BIM_PT_classifications(Panel):
 
     def draw_add_file_ui(self, context):
         assert self.layout
+        if len(ClassificationsData.data["loaded_classification_libraries"]) > 1:
+            row = self.layout.row(align=True)
+            row.prop(self.props, "loaded_classification_library", text="")
         if ClassificationsData.data["has_classification_file"]:
             row = self.layout.row(align=True)
             row.prop(self.props, "available_classifications", text="")


### PR DESCRIPTION
Fixes #4612.

## Root cause

`IfcStore.classification_file` (`bonsai/bim/ifc.py`) is a single global that gets overwritten by every `bim.load_classification_library` call. The FILE-mode "Available Classifications" dropdown (`available_classifications` in `classification/prop.py` and `classification/data.py`) is built entirely from that one global.

So once a second classification library file is loaded, the first one's entities become unreachable, even though both classifications are already added to the project (visible in the Classifications list below the dropdown). The only way to browse the first library's hierarchy again (to add more references from it) is to re-select its file from disk, exactly as reported: "Active IfcClassification (the one I can use to add reference to objects) is the one I added most recently. Other ones can't be used unless I add them again."

## What changed

- `IfcStore.classification_files`: a new session cache, keyed by filepath, populated by `bim.load_classification_library` in addition to (not instead of) the existing `classification_file` global. Previously loaded libraries are no longer discarded.
- A new "Loaded Classification Library" dropdown (only shown once more than one library has been loaded, so the common single-library case is unchanged) lets you switch `IfcStore.classification_file` back to a previously loaded library without re-opening it from disk. Available Classifications and reference browsing update to match.
- `IfcStore.purge()` now also resets `classification_path`/`classification_file`/`classification_files` on project close, which it previously omitted.

This is scoped to not touch how `available_classifications` and reference-hierarchy browsing (`bim.change_classification_level`, `bim.add_classification_reference`) already work, since both operate on whichever file is browsed at the source-library level, and there are 12 existing `.feature` scenarios asserting that behavior.

## Design question left open

The reporter's literal ask ("all IfcClassifications in the file should be listed in the dropdown") also covers project classifications whose source library was never loaded in the current session (e.g. reopening a saved .ifc that already has classifications baked in from a previous session). That's not solved here: without the original library file, there is no reference hierarchy to browse from, only the classification's name/attributes are in the project. Solving that fully would mean either bundling common libraries by name (see #8920, which adds a built-in library picker and is a natural complement to this) or a broader change to how FILE-mode reference browsing is scoped. Opening as draft so a maintainer can weigh in on whether that's in scope for this issue or a separate one.

## Verification

Reproduced and verified live in headless Blender 4.5.8 LTS, loading Bonsai from source (not the real profile, `BLENDER_USER_RESOURCES` isolated).

Before the fix (confirmed by stashing the change and rerunning):
```
=== loading lib1 (Foobar) ===
project classifications after adding lib1's: ['Foobar']
=== loading lib2 (Uniclass 2015) ===
project classifications after adding lib2's: ['Foobar', 'Uniclass 2015']
has classification_files attr: False
current IfcStore.classification_file entities (should be lib2's only, this is the reported bug):
['Uniclass 2015']
```
Both classifications are in the project, but only the last-loaded library's entities are reachable, matching the two screenshots in the issue.

After the fix:
```
classification_files keys: ['.../classification.ifc', '.../lib2.ifc']
current IfcStore.classification_file entities (should be lib2's only, this is the reported bug):
['Uniclass 2015']
=== FIX CHECK: switching loaded_classification_library back to lib1 WITHOUT reloading from disk ===
IfcStore.classification_file entities after switching dropdown to lib1:
['Foobar']
ClassificationsData.data['available_classifications']: [('2', 'Foobar', '')]
```
Switching the new dropdown restores lib1's entities without touching disk again.

Also ran a full FILE-mode workflow regression (load library, add classification, assign an IfcWallType, browse the reference hierarchy with `bim.change_classification_level`, add/remove a classification reference on an object, remove the classification) end to end in the same environment, all passing, confirming the existing single-library flow the `.feature` scenarios cover is unaffected.

Linted with the project's black + ruff config, both clean.

Generated with the assistance of an AI coding tool.
