### PR TITLE
Fix ci-ifctester-org: install setuptools build dep

### DIFF
--- a/src/ifctester/Makefile
+++ b/src/ifctester/Makefile
@@ -100,7 +100,7 @@ else
 	$(SED) 's/version = "0.0.0"/version = "$(VERSION)a$(VERSION_DATE)"/' $(WEBAPP_IFCTESTER_BUILD_DIR)/pyproject.toml
 	$(SED) 's/version = "0.0.0"/version = "$(VERSION)-alpha$(VERSION_DATE)"/' $(WEBAPP_IFCTESTER_BUILD_DIR)/$(PACKAGE_NAME)/__init__.py
 endif
-	cd $(WEBAPP_IFCTESTER_BUILD_DIR) && $(PYTHON) -m venv env --system-site-packages && . env/$(VENV_ACTIVATE) && python -m pip install build && python -m build --wheel --no-isolation
+	cd $(WEBAPP_IFCTESTER_BUILD_DIR) && $(PYTHON) -m venv env --system-site-packages && . env/$(VENV_ACTIVATE) && python -m pip install build "setuptools>=61.0" && python -m build --wheel --no-isolation
 	mkdir -p $(WEBAPP_GENERATED_DIR)
 	wheel=$$(basename $(WEBAPP_IFCTESTER_BUILD_DIR)/dist/$(PACKAGE_NAME)-*.whl); \
 	cp "$(WEBAPP_IFCTESTER_BUILD_DIR)/dist/$$wheel" "$(WEBAPP_GENERATED_DIR)/$$wheel"; \


### PR DESCRIPTION
## Root cause

The `ci-ifctester-org` workflow has been red since 2026-07-24 (runs 30085027436, 30085007095, 30084856466, 30084679600, 30084568869). The `publish_website` job fails in `make webapp-build`, in the `webapp-stage-ifctester-wheel` target of `src/ifctester/Makefile`:

```
cd $(WEBAPP_IFCTESTER_BUILD_DIR) && $(PYTHON) -m venv env --system-site-packages && . env/$(VENV_ACTIVATE) && python -m pip install build && python -m build --wheel --no-isolation
```

`src/ifctester/pyproject.toml` declares `[build-system] requires = ["setuptools>=61.0"]`. The `--no-isolation` flag tells `build` not to create an isolated environment and not to fetch those declared build requirements, so they must already be present. The line only pip installs `build` itself, and the venv (`--system-site-packages`) was silently relying on the runner's system `setuptools`. That system `setuptools` no longer satisfies `>=61.0`, so the build fails with:

```
ERROR Missing dependencies:
	setuptools>=61.0
```

## Fix

Install `setuptools>=61.0` explicitly alongside `build` on that line, so the requirement is satisfied regardless of the runner's system packages:

```
python -m pip install build "setuptools>=61.0"
```

The `>=` is quoted since it is otherwise a shell redirection operator.

`wheel` is not added. I confirmed locally that modern `setuptools.build_meta` (>=61.0, tested with 80.9.0) declares an empty extra requirement set in `get_requires_for_build_wheel` and does not need the external `wheel` package to build a wheel. Only old `setuptools` (<61.0, tested with 60.10.0) declares `wheel` as an additional build requirement, so once `setuptools>=61.0` is guaranteed this is moot.

Dropping `--no-isolation` was also considered and rejected. It was likely chosen deliberately for build speed and to avoid a network fetch of the full isolated toolchain on every CI run, and changing it has broader blast radius than this fix needs. The minimal fix is to satisfy the one declared build requirement that `--no-isolation` expects to already be present.

I checked `src/common.mk`'s shared `dist` target (used by the other `src/*/Makefile` packages) and every other `src/*/Makefile` for the same `--no-isolation` plus incomplete `pip install` pattern. `src/ifctester/Makefile` line 103 is the only place in the repository using `--no-isolation`; `common.mk`'s `dist` target runs a plain `python -m build` (isolated), so it is not affected by this bug.

## Local reproduction

Reproduced by pip installing only `build` plus an old `setuptools` (60.10.0, with `wheel` also present to match the exact single-line error from the CI log) into a venv, then running `python -m build --wheel --no-isolation` against a staged copy of `src/ifctester`:

Before fix:
```
* Getting build dependencies for wheel...
running egg_info
...

ERROR Missing dependencies:
	setuptools>=61.0
```

After installing `build "setuptools>=61.0"` (same command as the fixed Makefile line) and rerunning:
```
* Getting build dependencies for wheel...
...
Successfully built ifctester-0.0.0-py3-none-any.whl
```

Also ran the actual `make webapp-stage-ifctester-wheel` target end to end with the Makefile fix applied (before the fix, `make webapp-stage-ifctester-wheel` fails at the same line; after the fix it completes and produces `webapp/public/worker/generated/ifctester-<version>-py3-none-any.whl` and `ifctester.json`).

This unblocks `ci-ifctester-org`, which has been red since at least 2026-07-24. For broader context see #8870, which tracks CI health across multiple workflows (this PR only fixes `ci-ifctester-org`, not the whole tracking issue).

## AI disclosure

This change was generated with the assistance of an AI coding tool, per AGENTS.md. It is a single-line Makefile fix with local reproduction evidence as shown above.
