### PR TITLE
validate_stub: resolve property/staticmethod wrappers deterministically

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/scripts/validate_stub.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/scripts/validate_stub.py
@@ -59,8 +59,6 @@ def get_function_node_name(node: ast.FunctionDef) -> Union[SubnameType, None]:
     node_name = node.name
     is_init = node_name == "__init__"
 
-    if node_name.startswith("_") and node_name not in ("_is",) and not is_init:
-        return None
     arg_nodes = node.args.args
     defaults = [None] * (len(arg_nodes) - len(node.args.defaults)) + node.args.defaults
     args: list[str] = []
@@ -89,11 +87,51 @@ def get_function_node_name(node: ast.FunctionDef) -> Union[SubnameType, None]:
     return node_name
 
 
+def _count_params(def_string: str) -> int:
+    """Count parameters in a rendered ``def name(...): ...`` string.
+
+    Used to tell a getter (typically just ``self``) apart from a setter
+    (``self`` plus one more argument) when two same-named function
+    definitions need to be resolved.
+    """
+    start = def_string.index("(")
+    depth = 0
+    count = 0
+    has_params = False
+    for ch in def_string[start:]:
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+            if depth == 0:
+                break
+        elif depth == 1:
+            if ch == ",":
+                count += 1
+            elif ch not in " \t":
+                has_params = True
+    return count + 1 if has_params else 0
+
+
+def _is_hidden_def(entry: SubnameType) -> bool:
+    text = entry if isinstance(entry, str) else entry[-1]
+    if not text.startswith("def "):
+        return False
+    name = text[len("def ") :].split("(", 1)[0]
+    return name.startswith("_") and name not in ("_is",) and name != "__init__"
+
+
 def get_names_tree(tree: ast.Module) -> dict[str, set[SubnameType]]:
     # Get class tree.
     names_tree: dict[str, set[SubnameType]] = {}
     for node in tree.body:
         subnames: set[SubnameType] = set()
+        # Raw function definitions seen so far in this class, keyed by short
+        # name, in source order. Used to resolve which definition a
+        # `property(getter, setter)` / `staticmethod(func)` wrapper refers
+        # to without depending on `set` iteration order, which is randomized
+        # per-process and previously made this lookup nondeterministic.
+        functions_by_name: dict[str, list[str]] = {}
         node_name = None
         if isinstance(node, ast.ClassDef):
             # Skip `object_` as it's just a reference to `object`,
@@ -137,30 +175,38 @@ def get_names_tree(tree: ast.Module) -> dict[str, set[SubnameType]]:
                         len_args = len(args)
                         if len_args in (1, 2):
 
-                            def find_method_by_name(name: str) -> Union[str, None]:
-                                function_def = f"def {name}("
-                                return next(
-                                    (
-                                        func_
-                                        for func_ in subnames
-                                        if isinstance(func_, str) and func_.startswith(function_def)
-                                    ),
-                                    None,
-                                )
+                            def claim_function(name: str, prefer_min_arity: bool) -> Union[str, None]:
+                                candidates = functions_by_name.get(name)
+                                if not candidates:
+                                    return None
+                                picked = (min if prefer_min_arity else max)(candidates, key=_count_params)
+                                candidates.remove(picked)
+                                subnames.discard(picked)
+                                return picked
 
-                            # Use `set` for cases like `description = property(description, description)`.
+                            # `args` preserves declaration order: the first distinct name is the
+                            # getter (or the sole wrapped function for `staticmethod`), the
+                            # second, when present, is the setter (e.g. `description =
+                            # property(description, description)` only names one distinct
+                            # function and is claimed once, same as before). Resolving by
+                            # position, and preferring the lower-arity definition for the
+                            # getter, disambiguates getter/setter pairs that share a name,
+                            # instead of picking whichever same-named definition a
+                            # hash-ordered lookup happened to yield first.
+                            distinct_names = list(dict.fromkeys(args))
                             wrapped_function = None
-                            for arg in set(args):
-                                assert (wrapped_function := find_method_by_name(arg))
-                                subnames.remove(wrapped_function)
+                            for i, name in enumerate(distinct_names):
+                                found = claim_function(name, prefer_min_arity=(i == 0))
+                                assert found is not None, f"Could not resolve wrapped function {name!r}."
+                                wrapped_function = found
 
                             # TODO: sort it out in wrapper.py
                             # There's one annoying case in Element.product
                             # when property is overriding existing function, without using it.
                             # We should probably just exclude that function from the wrapper.
-                            overridden_name = find_method_by_name(subname_)
-                            if overridden_name:
-                                subnames.remove(overridden_name)
+                            overridden_candidates = functions_by_name.get(subname_)
+                            if overridden_candidates:
+                                subnames.discard(overridden_candidates.pop(0))
 
                             if len_args == 2:
                                 # Has both getter and setter, can be defined as a simple attribute.
@@ -189,6 +235,14 @@ def get_names_tree(tree: ast.Module) -> dict[str, set[SubnameType]]:
 
                 if subname is not None:
                     subnames.add(subname)
+                    text = subname if isinstance(subname, str) else subname[-1]
+                    if text.startswith("def "):
+                        functions_by_name.setdefault(text[len("def ") :].split("(", 1)[0], []).append(text)
+
+            # Function definitions that are still underscore-prefixed at this point
+            # were never claimed by a `property()`/`staticmethod()` wrapper above,
+            # so they're genuinely private and can be hidden from the output.
+            subnames = {s for s in subnames if not _is_hidden_def(s)}
             if not subnames:
                 node_name += " ..."
 


### PR DESCRIPTION
## Context

`validate_stub` skips any function whose name begins with an underscore, treating it as unused. When a `property()` or `staticmethod()` wrapper references such a function, the lookup can never resolve it and the check fails with a bare `AssertionError` at `validate_stub.py:154`.

Our own commit 824c1fc (2026-07-17, the #1124 owning-element fix) introduced exactly that pattern in `IfcGeomWrapper.i`, via `geometry = property(_geometry_with_backref)`. That broke `compile-and-test` on v0.8.0, and it stayed broken for about a week. @Andrej730 fixed the specific instance in 88c8bd03 on 2026-07-24 by dropping the underscore, with the commit message "ifcwrap: fix breaking validate_stub (824c1fc)". Thanks for cleaning that up, and apologies for causing it.

This PR does not re-fix that instance. It hardens `validate_stub` itself so the same class of breakage cannot recur the next time someone writes an underscore-prefixed wrapped helper.

## What changed

`get_names_tree` resolved a wrapper by matching the wrapped function's name against a `set` of candidate definitions using `next()`, then destructively removing the match. That is replaced with a `functions_by_name` index built in source order, resolving getter (position 0, lowest arity) against setter (position 1) deterministically, and preserving the `property(description, description)` dedup case. Underscore-prefixed definitions are no longer excluded before matching; they are only hidden from the final output if never claimed.

## An honest negative result

An earlier hypothesis, including in our own comments on #8870, was that this failure was intermittent and driven by `PYTHONHASHSEED` randomising set iteration order. **We could not reproduce that.** A 300 case fuzzer across 8 hash seeds, plus a scan of 9 real generated `ifcopenshell_wrapper.py`/`.pyi` pairs, found zero hash-driven flakiness: for a fixed input the outcome is deterministic, because supply and demand for a given name are consumed in fixed statement order regardless of which set member `next()` returns.

So the apparent intermittency across PRs was branch base, not randomness. Branches cut before 88c8bd03 fail; branches cut after it pass. We are not claiming this PR fixes a flaky test, because on the evidence the test was not flaky. The set-based matching is still genuinely fragile and worth removing on its own merits, which is what this PR does.

## Verification

- Constructed the underscore-prefixed failure case: 50 runs before the change, 50 assertion errors. 50 runs after, 50 clean.
- 400 case old versus new comparison: zero differing outcomes.
- All 9 real wrapper/stub pairs available locally (pip, conda, and local CMake builds spanning Python 3.11 to 3.13) produce byte-identical output before and after.
- `black` and `ruff` clean.

## Credit

#8763 diagnosed the underscore-skip cause correctly back when this first broke. We closed it earlier today partly on the reasoning that the test passes cleanly, which was not a sound basis given the failure depends on branch base. That diagnosis is carried forward here.

Context for #8870. Not marked as fixing it, since that issue tracks several workflows.

This change was made with the assistance of an AI tool.
