### PR TITLE
ci-ifctester-org: restrict publish trigger to v0.8.0 branch

### DIFF
--- a/.github/workflows/ci-ifctester-org.yml
+++ b/.github/workflows/ci-ifctester-org.yml
@@ -3,6 +3,8 @@ name: ci-ifctester-org
 on:
   workflow_dispatch:
   push:
+    branches:
+      - v0.8.0
     paths:
       - src/ifctester/**
 


### PR DESCRIPTION
## The problem

`ci-ifctester-org.yml` triggers on push with only a `paths:` filter, no `branches:` filter:

```yaml
on:
  workflow_dispatch:
  push:
    paths:
      - src/ifctester/**
```

That means a push to any branch that touches `src/ifctester/**` runs the job, not just pushes to the default branch. The job does not merely build the webapp. Its final steps check out the separate `IfcOpenShell/ifctester_org_static_html` repository using `secrets.IFCOPENBOT_TOKEN`, copy `src/ifctester/webapp/dist/*` into it, and commit and push:

```yaml
- name: Checkout ifctester_org_static_html
  uses: actions/checkout@v7
  with:
    repository: IfcOpenShell/ifctester_org_static_html
    token: ${{ secrets.IFCOPENBOT_TOKEN }}
    path: ifctester_org_static_html
...
- name: Commit and push
  run: |
    cp -r src/ifctester/webapp/dist/* ifctester_org_static_html/
    git -C ifctester_org_static_html add .
    git -C ifctester_org_static_html commit --allow-empty -m "$(git log --oneline -1)"
    git -C ifctester_org_static_html push
```

So a push to a feature branch that touches `src/ifctester/**` can publish that branch's webapp build to the live ifctester.org static site. This is a real production-publish risk, not just a CI nuisance.

It is currently masked because the build step fails first on `sudo apt update && sudo apt install -y nodejs` / `make webapp-build`, missing the `setuptools>=61.0` build dependency that #8943 fixes. Merging #8943 alone, without this branch filter, would turn a stream of harmless build failures into working publishes from any feature branch that happens to touch `src/ifctester/**`. This PR should land alongside #8943, ideally before or together, not after.

## The fix

Add `branches: [v0.8.0]` to the `push` trigger, matching the repo's default branch (confirmed via `gh repo view IfcOpenShell/IfcOpenShell --json defaultBranchRef`). `workflow_dispatch` is left unfiltered on purpose, it is the manual escape hatch for republishing the site on demand from any branch/ref an operator chooses, and that is a deliberate action rather than an implicit side effect of a routine push.

## Secondary benefit

The workflow has failed 19+ times in a single day, mostly from feature-branch pushes, generating failure notifications for everyone watching the repo. The branch filter also removes that noise, but that is incidental to the correctness fix above.

## Other workflows checked

I scanned every workflow under `.github/workflows/` for the same publish-on-any-branch pattern (push trigger plus a step that pushes to a repo, using a token). Findings:

- `ci-bonsai-daily.yml` and `publish-pyodide-demo-app.yml` both push on `push` events and already have a `branches: [v0.8.0]` guard. `ci-ifctester-org.yml` was the outlier missing it.
- `ci-ifcopenshell-docker.yml` pushes a Docker image but triggers on `push: tags: v0.**`, tags are created intentionally, so this is not the same risk.
- `build_pyodide.yml`, `build_osx.yml`, `build_rocky_arm.yml`, `build_rocky.yml`, `build_win.yml`, and `ci-pyodide-wasm-release.yml` all push (wheels, branches, or release artifacts) but are `workflow_dispatch` only, no `push` trigger at all, so they cannot fire from an arbitrary branch push.

No other workflow shares this gap. This PR fixes only `ci-ifctester-org.yml` to keep the change small and reviewable.

Generated with the assistance of an AI coding tool.
