### PR TITLE
ifcpatch: fix invalid selector syntax in ExtractElements docstring

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -75,7 +75,7 @@ class Patcher(ifcpatch.BasePatcher):
             ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ExtractElements", "arguments": ["IfcProduct, ! IfcSlab"]})
 
             # Extract walls whose Name is not "Foo"
-            ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ExtractElements", "arguments": ["IfcWall, attribute.Name != \"Foo\""]})
+            ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ExtractElements", "arguments": ["IfcWall, Name != \"Foo\""]})
         """
         super().__init__(file, logger)
         self.query = query


### PR DESCRIPTION
## The bug

The `ExtractElements` recipe's own docstring documents this example:

```python
ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ExtractElements", "arguments": ["IfcWall, attribute.Name != \"Foo\""]})
```

`attribute.Name` is not valid `filter_elements` syntax. From the grammar in `ifcopenshell/util/selector.py`:

```
facet: instance | entity | attribute | type | material | query | classification | location | property | group | parent
attribute: attribute_name comparison value
attribute_name: /[A-Z]\w+/
property: pset "." prop comparison value
```

There is no `attribute.` keyword. `attribute.Name` instead parses as a `property` facet (`pset "." prop`), i.e. it looks for a property named `Name` inside a pset literally called `attribute`, which never exists.

## Empirical confirmation

Built a small in-memory model (two `IfcWall`s, named `Foo` and `Bar`) and ran both forms through `ifcopenshell.util.selector.filter_elements`:

```
IfcWall, attribute.Name != "Foo"  ->  2 matches: ['Foo', 'Bar']   (matches everything, including "Foo")
IfcWall, Name != "Foo"            ->  1 match:  ['Bar']            (correct)
```

The reason it's 2 and not 0: with a missing property, `compare()` computes `element_value == value` as `None == "Foo"` which is `False`, and then the leading `!` in `!=` negates that to `True`. So every element passes the `!=` check regardless of its actual `Name`, silently, and the recipe extracts unfiltered elements while the docstring claims it filters. (For completeness, the `=` form of the same typo does the opposite and matches 0.) Either way, the example silently does not do what it says.

This was found while investigating #8945 (unrelated performance issue), where an agent followed this exact docstring and got a wrong "successful" run.

## The fix

Dropped the invalid `attribute.` prefix so the example is a plain attribute facet: `"IfcWall, Name != \"Foo\""`, which filters as documented.

Checked the rest of the docstring, the rest of `ifcpatch/recipes/`, and `docs/` for the same `attribute.` mistake; this was the only genuine hit (other `attribute.` occurrences elsewhere in the codebase are ordinary Python attribute access on variables, not query strings).

Documentation only, no behavioural change.

AI-generated with Claude Code, reviewed by a human.