### PR TITLE
Bonsai: warn instead of silently dropping geometry for collection instances

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -352,6 +352,11 @@ class AssignClass(bpy.types.Operator, tool.Ifc.Operator):
                     if is_structural:
                         return False
                     data = obj.data
+                    # obj.data is None for empties, including collection instances
+                    # (e.g. objects dragged in from the Asset Browser), which have no
+                    # convertible geometry of their own.
+                    if not tool.Geometry.is_data_supported_for_adding_representation(data):
+                        return False
                     # Is empty mesh.
                     if isinstance(data, bpy.types.Mesh) and not data.vertices:
                         return False
@@ -359,6 +364,10 @@ class AssignClass(bpy.types.Operator, tool.Ifc.Operator):
                     if isinstance(data, bpy.types.Curve) and not data.splines:
                         return False
                     return True
+
+                is_unresolved_collection_instance = (
+                    obj.data is None and obj.type == "EMPTY" and obj.instance_type == "COLLECTION"
+                )
 
                 element = core.assign_class(
                     tool.Ifc,
@@ -376,6 +385,13 @@ class AssignClass(bpy.types.Operator, tool.Ifc.Operator):
                     tool.Geometry.reload_representation(obj)
                 elif obj.data is not None:
                     new_obj = tool.Geometry.recreate_object_with_data(obj, None)
+                elif is_unresolved_collection_instance:
+                    self.report(
+                        {"WARNING"},
+                        f"Object '{obj.name}' is a collection instance (e.g. dragged in from the Asset Browser) "
+                        "with no mesh data of its own, so no IFC representation was created. "
+                        "Use Object > Apply > Make Instances Real, or append the object directly, then assign the class again.",
+                    )
 
             # Accomodate existing importers to Blender from other formats that set custom props
             if self.props_to_pset:

--- a/src/bonsai/test/bim/feature/root.feature
+++ b/src/bonsai/test/bim/feature/root.feature
@@ -145,6 +145,16 @@ Scenario: Assign a spatial class to a cube already in a collection
     And the object "IfcSpace/Cube" is in the collection "IfcSpace"
     And the object "IfcSpace/Cube" has a "Tessellation" representation of "Model/Body/MODEL_VIEW"
 
+Scenario: Assign a class to a collection instance
+    Given an empty IFC project
+    And I add a collection instance of a cube
+    When the object "CubeAsset" is selected
+    And I set "scene.BIMRootProperties.ifc_product" to "IfcElement"
+    And I set "scene.BIMRootProperties.ifc_class" to "IfcFurniture"
+    And I press "bim.assign_class"
+    Then the object "IfcFurniture/CubeAsset" is an "IfcFurniture"
+    And the object "IfcFurniture/CubeAsset" has no data
+
 Scenario: Assign a class to a cube in a collection
     Given an empty IFC project
     And I add a cube

--- a/src/bonsai/test/bim/test_feature.py
+++ b/src/bonsai/test/bim/test_feature.py
@@ -804,6 +804,23 @@ def i_add_a_cube():
     bpy.ops.mesh.primitive_cube_add()
 
 
+@given("I add a collection instance of a cube")
+@when("I add a collection instance of a cube")
+def i_add_a_collection_instance_of_a_cube():
+    # Mimics what Blender's Asset Browser creates when an asset is dragged
+    # into the scene: an empty of instance_type COLLECTION with no data of
+    # its own, instancing a collection that holds the actual mesh object.
+    bpy.ops.mesh.primitive_cube_add()
+    cube = bpy.context.active_object
+    collection = bpy.data.collections.new("CubeAsset")
+    collection.objects.link(cube)
+    for coll in list(cube.users_collection):
+        if coll is not collection:
+            coll.objects.unlink(cube)
+    bpy.ops.object.collection_instance_add(collection=collection.name)
+    bpy.context.active_object.name = "CubeAsset"
+
+
 @given("I add an empty")
 @when("I add an empty")
 def i_add_an_empty():


### PR DESCRIPTION
## Root cause

`AssignClass.is_representation_supported()` in `src/bonsai/bonsai/bim/module/root/operator.py` (around line 349) only checked for empty `Mesh`/`Curve` data. An object whose `obj.data` is `None` fell through both checks and returned `True`.

That is exactly the state Blender leaves an object in when a mesh asset is dragged in from the Asset Browser: it becomes an `EMPTY` with `instance_type == 'COLLECTION'`, and the real mesh lives on a separate object inside the instanced collection. I confirmed this against the reporter's screenshot: `CubeAsset` in the outliner uses the same icon as the spatial-structure empties (`IfcSite`, `IfcBuilding`, `IfcProject`), has no disclosure arrow to mesh data, and its selection gizmo sits at the world origin while the actual visible cube is a separate, unselected object.

Because `is_representation_supported()` wrongly returned `True`, `core.assign_class` (`bonsai/core/root.py`) requested a representation anyway, and `add_representation` in `bonsai/core/geometry.py` (line 73) silently `return`ed `None` since `Geometry.is_data_supported_for_adding_representation(None)` is `False`. Nothing was reported to the user. The resulting IFC product got a class, a placement and a name, but a permanently null `Representation`, only discovered after saving and reopening the file.

## Fix

`is_representation_supported()` now defers to the existing `Geometry.is_data_supported_for_adding_representation()` check, so it correctly declines any object with no representable data instead of only catching empty `Mesh`/`Curve`. This is the general, root-cause condition, not an Asset-Browser special case (it also applies if a user manually adds a Collection Instance).

Since a collection instance genuinely has no mesh of its own to convert (the real geometry lives on a different object inside the instanced collection), the operator now reports a clear warning telling the user to apply "Object > Apply > Make Instances Real" (or append the object directly) before assigning the class, instead of silently producing a null-representation product.

## Evidence

Reproduced the reporter's exact datablock state programmatically in headless Blender (`EMPTY`, `instance_type == 'COLLECTION'`, `obj.data is None`) and ran `bim.assign_class`.

Before (unpatched), no warning at all is reported:
```
#63=IfcFurniture('09Qbe2lbTAzfNugaHtYoWv',$,'CubeAsset',$,$,#74,$,$,$)
```

After the fix, the entity is unchanged (still correctly has no representation, since there is genuinely nothing to convert), but the operator now reports:
```
Warning: Object 'IfcFurniture/CubeAsset' is a collection instance (e.g. dragged in from the Asset Browser) with no mesh data of its own, so no IFC representation was created. Use Object > Apply > Make Instances Real, or append the object directly, then assign the class again.
```

All 16 scenarios in `test/bim/feature/root.feature` pass, including a new one added here that covers this exact case.

Fixes #8947.

Thank you @iorhanV for an unusually precise report, isolating this cleanly to the Asset Browser origin with a side-by-side IFC excerpt made this straightforward to trace.

## AI disclosure

Generated with the assistance of an AI coding tool, per AGENTS.md.