### PR TITLE
Bonsai: defer debug-log listener serialisation to report time

### DIFF
--- a/src/bonsai/bonsai/__init__.py
+++ b/src/bonsai/bonsai/__init__.py
@@ -169,11 +169,13 @@ def get_debug_info(*, bonsai_failed_to_load: bool = False) -> dict[str, Any]:
 
 
 def format_debug_info(info: dict[str, Any]) -> str:
+    import ifcopenshell.api
+
     last_actions = ""
     for action in info["last_actions"]:
         last_actions += f"\n# {action['type']}: {action['name']}"
         if settings := action.get("settings"):
-            last_actions += f"\n>>> {settings}"
+            last_actions += f"\n>>> {ifcopenshell.api.serialise_settings(settings)}"
     info["last_actions"] = last_actions
     text = "\n".join(f"{k}: {v}" for k, v in info.items())
     return text.strip()
@@ -278,11 +280,12 @@ if IN_BLENDER:
         import ifcopenshell.api
 
         def log_api(usecase_path, ifc_file, settings):
+            # Defer serialise_settings() to format_debug_info() (#8945).
             last_actions.append(
                 {
                     "type": "ifcopenshell.api",
                     "name": usecase_path,
-                    "settings": ifcopenshell.api.serialise_settings(settings),
+                    "settings": dict(settings),
                 }
             )
 


### PR DESCRIPTION
## Result

Measured on a real 495MB IFC2X3 model, full run, not extrapolated, extracting 2,004 walls with `ifcpatch`'s `ExtractElements` recipe:

- Before this fix: 1341.16s
- After this fix: 728.63s
- No-listener baseline (recipe with the listener unregistered entirely): 738.87s

The fixed run lands within noise of the no-listener baseline (728.63s vs 738.87s, about 1.4 percent, ordinary run-to-run variance). The listener overhead is fully eliminated, not just reduced.

## Mechanism

Bonsai registers a wildcard pre-listener on every `ifcopenshell.api` call, in `bonsai/__init__.py`:

```python
ifcopenshell.api.add_pre_listener("*", "action_logger", log_api)
```

`log_api` called `ifcopenshell.api.serialise_settings(settings)` eagerly, on every single API call. `serialise_settings()` falls back to `str(value)` for any argument type it does not special-case (it only special-cases `entity_instance`, `numpy.ndarray`, and a list of `entity_instance`), and `str()` on a dict calls `repr()` on every value. `entity_instance.__repr__` goes through the C++ STEP-line serialiser, not a cheap pointer print.

During a large `ExtractElements` run, one of the arguments threaded through `ifcopenshell.api.project.append_asset` is `reuse_identities`, a dict that grows to roughly 180,000 entries over the extraction. So every one of the roughly 10,152 calls paid the cost of stringifying the current, growing state of that dict.

The result of all that work was stored in `last_actions`, which is `deque(maxlen=20)`, and is read in exactly one place: `format_debug_info()`, which only runs when a debug or crash report is actually generated. So the serialisation ran about 10,152 times and all but the most recent 20 results were discarded unused.

## Fix

`log_api` now stores a shallow copy of the raw settings dict (`dict(settings)`) instead of the serialised string. `format_debug_info()` now calls `serialise_settings()` at display time, the one place the result is ever consumed.

## Known trade-off, disclosed rather than buried

Serialising lazily means the debug report now shows a mutable argument's state at report-generation time, not at the moment of the logged call. For `reuse_identities` specifically, I checked `ifcopenshell.api.project.append_asset`'s handling of it and it is append-only, entries are added via `reuse_identities[identity] = new` and I found no code path that removes entries. So a stale report shows a superset of what existed at call time, not wrong or dangling data, for this particular argument.

I shallow-copy the settings dict at log time (`dict(settings)`). This freezes the settings dict's own key set against later rebinding, and is essentially free since these dicts are a handful of keys. It does not protect against a referenced mutable value (like `reuse_identities`) continuing to change, since the copy holds the same object reference for that value.

I did not audit every `ifcopenshell.api` usecase for other mutable-value settings that could go stale in a way that is actively misleading rather than merely different (for example an entity later removed from the file such that a later `repr()` could behave unexpectedly). That is a real gap in this verification, not a proven-safe claim, and I want to be upfront about it rather than have it discovered in review.

## Scope, please read before assuming this closes the issue

This removes about 10.2 minutes of pure waste from a job whose own base cost is about 12.3 minutes at the reporter's scale. It does **not** explain the reporter's reported 12+ hour hang with no result and no error message in #8945. Investigation on that issue found:

- Not a regression: the 2026-07-24 daily build and a build from roughly a week earlier perform identically on the reporter's model and selection.
- Not quadratic in the core recipe: `ExtractElements` itself is linear, about 365ms/wall, flat from a 25-wall sample all the way to the reporter's full 2,004-wall selection.
- This listener defect, now fixed here, accounted for about 10 minutes of the gap at the reporter's scale.
- A large gap remains between the best measured time (about 12 minutes after this fix) and the reporter's 12+ hours. That gap is still unexplained and under investigation on #8945. This PR does not claim to resolve it.

## Wider benefit, plausible but not measured

`reuse_identities` is not specific to `ifcpatch`. Bonsai's own project-library-append and linked-model-append features (`bim/module/project/operator.py`, `tool/project.py`) drive the same `ifcopenshell.api.project.append_asset` with a persisted `reuse_identities` dict across a batch of appends. This fix likely speeds up those existing Bonsai workflows too, for the same reason. I have not measured that separately, so treat it as a plausible additional benefit, not a demonstrated one.

## Testing

- `src/ifcopenshell-python/test/api/project/test_append_asset.py` (77 tests), `test/api/type/test_assign_type.py` plus `test/util/test_selector.py` (85 tests), `src/ifcpatch/test/test_ExtractElements.py` (11 tests, 1 skipped) all pass unchanged.
- Verified old-versus-new `log_api` output is byte-identical for settings that are not mutated after logging, in an isolated script, before touching the real model.
- Before/after verified on the reporter's real model at N=250 and again at the full N=2004, both with the listener registered end to end (not extrapolated from a smaller sample).
- `black` and `ruff` clean.

Related to #8945. Not resolving it, see Scope above.

<!-- Generated with the assistance of an AI coding tool. -->
