### PR TITLE
Bonsai: fix null representation for items added via the Asset Browser

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -282,6 +282,62 @@ class AssignClass(bpy.types.Operator, tool.Ifc.Operator):
                 )
                 continue
 
+            # A collection-instance Empty (e.g. dropped in from the Asset Browser, which
+            # wraps a dragged-in collection asset in an instancing Empty) has no mesh
+            # data of its own, so it would otherwise silently end up with no IFC
+            # representation. If every object it instances is a mesh, realize them into
+            # real local mesh objects and join them into one, so the existing
+            # split-by-loose-parts tessellation path (which already handles multi-part
+            # furniture like this) can take over normally.
+            if (
+                self.should_add_representation
+                and not is_structural
+                and obj.type == "EMPTY"
+                and obj.instance_type == "COLLECTION"
+                and obj.instance_collection
+            ):
+                instanced_objects = list(obj.instance_collection.all_objects)
+                mesh_children = [o for o in instanced_objects if o.type == "MESH"]
+                if mesh_children and len(mesh_children) == len(instanced_objects):
+                    empty_name = obj.name
+                    tool.Blender.select_and_activate_single_object(context, obj)
+                    bpy.ops.object.duplicates_make_real(use_base_parent=False, use_hierarchy=False)
+                    realized = [o for o in context.selected_objects if o.type == "MESH"]
+                    if realized:
+                        # Realized parts may still point at the source library's mesh
+                        # data. object.join() (and editing in general) refuses to touch
+                        # external library data, so make each part's data local first.
+                        for r in realized:
+                            if r.data.library is not None or r.data.users > 1:
+                                r.data = r.data.copy()
+                        if len(realized) > 1:
+                            tool.Blender.set_objects_selection(context, active_object=realized[0], selected_objects=realized)
+                            bpy.ops.object.join()
+                        new_obj = realized[0]
+                        new_obj.name = empty_name
+                        bpy.data.objects.remove(obj)
+                        obj = new_obj
+                        self.report(
+                            {"INFO"},
+                            f"Object '{empty_name}' was a collection instance (e.g. from the Asset Browser) "
+                            "and has been converted to a standalone local mesh to assign it an IFC class. "
+                            "It will no longer update if the source asset/collection changes.",
+                        )
+                    else:
+                        self.report(
+                            {"WARNING"},
+                            f"Object '{empty_name}' is a collection instance and could not be "
+                            "automatically converted to a mesh; no IFC representation was created. "
+                            "Try Object > Apply > Make Instances Real manually, then assign the class again.",
+                        )
+                else:
+                    self.report(
+                        {"WARNING"},
+                        f"Object '{obj.name}' is a collection instance containing non-mesh objects, "
+                        "which isn't supported yet, so no IFC representation was created. Try Object > Apply "
+                        "> Make Instances Real manually, then assign the class again.",
+                    )
+
             if (
                 self.should_add_representation
                 and not is_structural


### PR DESCRIPTION
## Problem

Dragging a Collection asset in from Blender's Asset Browser wraps it in an Empty that instances the collection, rather than adding the mesh object(s) directly. `AssignClass` only knew how to handle plain `Mesh` objects, so these instances silently got an IFC element with a null `Representation` (`$`) — no error, no warning. The object looks fine until the `.ifc` is saved and reopened, at which point the geometry is gone.

Objects added via normal File > Append/Import don't hit this, since they're already plain mesh objects.

Closes #8947

## Fix

In `AssignClass._execute` (`bim/module/root/operator.py`), before the existing mesh-export path runs: if the object is a collection-instance Empty and every object it instances is a mesh, realize those instances into real local mesh objects (`object.duplicates_make_real`), joining multiple parts into one first. This hands off to the existing split-by-loose-parts tessellation logic, which already supports multi-part representations, so no new geometry-conversion code was needed.

Realized mesh data may still point at the source library, and `object.join()` refuses to touch external library data, so each part is localized first.

If the instance can't be converted (non-mesh children, multi-object realize failure), the operator now reports a clear `WARNING` instead of silently creating a representation-less element. On success it reports an `INFO` noting the object was detached from its source asset/collection and won't reflect future updates to it.

## Testing

- Manually reproduced the original bug in Blender 5.1 (Asset Browser drag-in of both a single-cube and a multi-part furniture asset), confirmed null representation before the fix and correct geometry surviving a save/close/reopen cycle after it.
- Re-ran the normal File > Append/Import path to confirm no regression.
