### PR TITLE
project.append_asset: propagate assume_asset_uniqueness_by_name to nested type append

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -428,6 +428,7 @@ class Usecase:
                 library=self.settings["library"],
                 element=element_type,
                 reuse_identities=self.reuse_identities,
+                assume_asset_uniqueness_by_name=self.assume_asset_uniqueness_by_name,
             )
             ifcopenshell.api.type.assign_type(
                 self.file,

--- a/src/ifcopenshell-python/test/api/project/test_append_asset.py
+++ b/src/ifcopenshell-python/test/api/project/test_append_asset.py
@@ -800,6 +800,25 @@ class TestAppendAssetIFC4(test.bootstrap.IFC4, TestAppendAssetIFC2X3):
         styles = self.file.by_type("IfcSurfaceStyle")
         assert len(styles) == 2 and all(s.Name == "TestStyle" for s in styles)
 
+    def test_a_products_type_is_appended_without_assuming_asset_uniqueness_by_name(self):
+        # The type is appended through a recursive `append_asset()` call, which must
+        # forward `assume_asset_uniqueness_by_name` instead of silently defaulting to True.
+        library = ifcopenshell.api.project.create_file(version=self.file.schema)
+        ifcopenshell.api.root.create_entity(library, ifc_class="IfcProject")
+        element = ifcopenshell.api.root.create_entity(library, ifc_class="IfcWall")
+        element_type = ifcopenshell.api.root.create_entity(library, ifc_class="IfcWallType")
+        ifcopenshell.api.type.assign_type(library, related_objects=[element], relating_type=element_type)
+        library_material = ifcopenshell.api.material.add_material(library, name="TestMaterial")
+        ifcopenshell.api.material.assign_material(library, products=[element_type], material=library_material)
+
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.material.add_material(self.file, name="TestMaterial")
+        ifcopenshell.api.project.append_asset(
+            self.file, library=library, element=element, assume_asset_uniqueness_by_name=False
+        )
+        materials = self.file.by_type("IfcMaterial")
+        assert len(materials) == 2 and all(m.Name == "TestMaterial" for m in materials)
+
     def test_not_duplicate_material_sets_based_on_name(self):
         # Setup library.
         library = ifcopenshell.api.project.create_file(version=self.file.schema)


### PR DESCRIPTION
## Correctness bug

`project.append_asset`'s `append_product()` appends a product's type through a
recursive call to `ifcopenshell.api.project.append_asset()`, but that call did
not forward `assume_asset_uniqueness_by_name`. Any caller that explicitly asks
for identity-based copying (`assume_asset_uniqueness_by_name=False`), such as
ifcpatch's `ExtractElements` recipe, had that setting silently ignored for the
type: the nested call always fell back to the default, `True`. So materials,
profiles and styles assigned to the type could get matched and reused by name
instead of duplicated, contradicting what the caller explicitly asked for.

The fix is one line: forward `assume_asset_uniqueness_by_name=self.assume_asset_uniqueness_by_name`
on that recursive call.

Added a regression test, `test_a_products_type_is_appended_without_assuming_asset_uniqueness_by_name`,
that appends a product whose type carries a named material, with
`assume_asset_uniqueness_by_name=False` and a same-named material already
present in the target file:

- On the unfixed code, the test fails: `AssertionError: assert (1 == 2)`, the
  type's material got matched by name and reused instead of duplicated.
- After the fix, it passes: the material is duplicated as requested.

## Performance

With the setting effectively forced `True`, every type append also paid for
`get_existing_element`'s name-based existence scans across the target file,
plus the `SafeRemovalContext` batch-removal cleanup that `True` enables, work
the caller had explicitly opted out of.

Measured on the reporter's 495 MB IFC2X3 model from #8945, extracting the same
2,004 walls the issue reports (`IfcWall, Description=Baksteen`) through
ifcpatch's `ExtractElements` recipe (`assume_asset_uniqueness_by_name=False`).
Both runs in the same session, sequentially, back to back, nothing else
running on the machine:

| | execute | write | total | ms/wall |
|---|---|---|---|---|
| before | 732.65s | 1.61s | 734.26s | 365.6 |
| after | 616.29s | 1.22s | 617.50s | 307.5 |

15.9% faster end to end. Consistent at smaller N too (loop-only, same
session): N=250 was 378.8ms/wall before vs 323.0ms/wall after (14.7% faster),
N=500 was 370.1ms/wall vs 317.7ms/wall (14.2%), N=1000 was 370.4ms/wall vs
317.9ms/wall (14.2%). Flat before and after, no complexity-class change, just
a fixed per-type-append constant that this removes.

## Audit for siblings

Checked every other internal/recursive `append_asset()` call and every
`SafeRemovalContext` construction in `append_asset.py`. The type-append above
is the only recursive `append_asset()` call in the file. Both
`SafeRemovalContext` sites (the object-placement edit in `append_product`, and
`reuse_existing_contexts`) already forward `self.assume_asset_uniqueness_by_name`
correctly. No other sites needed fixing.

## Testing

- `test/api/project/test_append_asset.py`: 78 passed (77 existing + the new
  regression test).
- `test/api/type/test_assign_type.py`: 45 passed.
- `src/ifcpatch/test/test_ExtractElements.py`: 11 passed, 1 skipped (pre-existing skip, unrelated).
- `black` and `ruff` clean on both changed files.
- Output check on the real model at N=250: with `assume_asset_uniqueness_by_name=False`,
  the 250 appended walls and their 10 wall types are byte-identical (same
  GlobalIds) before and after. The two outputs are not otherwise identical,
  which is expected now that the fix changes observed behaviour: before this
  fix, several of each type's satellite entities (organizations, persons,
  addresses, styles) were incorrectly reused by name across types; after the
  fix they are correctly duplicated per the caller's setting, same as product-level
  appends already do today. Both outputs were checked for structural validity
  (every attribute on every entity resolves); neither has broken references.

## Scope note

This is independent of #8953 (the Bonsai debug-log listener fix, also
referencing #8945). That PR removes listener/logging overhead sitting outside
`append_asset` itself; this PR fixes a bug inside `append_asset`'s own
type-append path. They address different parts of the same issue and do not
overlap.

Related to #8945, does not resolve it.

<!-- Generated with the assistance of an AI coding tool. -->
