### PR TITLE
ifcpatch: correct the AGS2IFC docstring example

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/AGS2IFC.py
+++ b/src/ifcpatch/ifcpatch/recipes/AGS2IFC.py
@@ -47,6 +47,10 @@ class Patcher:
 
         This is for AGS version 3.
 
+        The input file is not read. A new IFC4X3 model is built from the AGS
+        data, containing one IfcBorehole per location with its strata nested
+        inside as IfcGeotechnicalStratum.
+
         :param ags_file: The AGS file to convert.
         :filter_glob ags_file: *.ags
         :param docs_dir: The directory URI where documents are stored
@@ -55,8 +59,8 @@ class Patcher:
 
         .. code:: python
 
-            result = ifcpatch.execute({"input": fn, "file": model, "recipe": "ExtractPropertiesToSQLite"})
-            ifcpatch.write(result, "output.sqlite")
+            result = ifcpatch.execute({"file": model, "recipe": "AGS2IFC", "arguments": ["data.ags", "docs"]})
+            ifcpatch.write(result, "boreholes.ifc")
         """
         self.file = file
         self.logger = logger


### PR DESCRIPTION
The `AGS2IFC` recipe's docstring example was copy pasted verbatim from `ExtractPropertiesToSQLite`:

```python
result = ifcpatch.execute({"input": fn, "file": model, "recipe": "ExtractPropertiesToSQLite"})
ifcpatch.write(result, "output.sqlite")
```

It names the wrong recipe and writes a `.sqlite` file, on a recipe that converts AGS geotechnical data into an IFC model. ifcpatch surfaces these docstrings as CLI and UI help, so this is user facing rather than an internal comment.

The replacement uses the real recipe name and arguments, and writes a `.ifc` file. It also states that the input file is not read: `patch()` calls `ifcopenshell.api.project.create_file(version="IFC4X3")` and builds a new model, so the file passed in is ignored. That is not obvious from the signature.

Verified against the recipe body: `IfcBorehole` is created per `HOLE_ID` (line 210) and strata as `IfcGeotechnicalStratum` (line 250), which is what the updated text describes.

Context: this recipe came up on #8091, where @Moult recalled "there is a patch recipe for converting bore hole data (I forget the format standard) into IFC" but could not name it. It is this one, contributed by David Bayliss at Transport for NSW. Making its documented example correct seemed worthwhile given it is hard to find in the first place.

No behaviour change, documentation only.

This PR was generated with the assistance of an AI coding tool.