### PR TITLE
Bonsai: fix crash toggling hide on spaces not loaded into the scene

### DIFF
--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -1265,18 +1265,20 @@ class Spatial(bonsai.core.tool.Spatial):
 
     @classmethod
     def toggle_hide_spaces(cls, spaces: list[ifcopenshell.entity_instance]) -> None:
-        first_obj = tool.Ifc.get_object(spaces[0])
-        assert isinstance(first_obj, bpy.types.Object)
-        obj: bpy.types.Object
-        if first_obj.hide_get() == False:
-            for space in spaces:
-                obj = tool.Ifc.get_object(space)
+        objs: list[bpy.types.Object] = []
+        for space in spaces:
+            obj = tool.Ifc.get_object(space)
+            if obj and obj.name in bpy.context.view_layer.objects:
+                objs.append(obj)
+        if not objs:
+            return
+        if objs[0].hide_get() == False:
+            for obj in objs:
                 obj.hide_set(True)
             return
 
-        elif first_obj.hide_get() == True:
-            for space in spaces:
-                obj = tool.Ifc.get_object(space)
+        elif objs[0].hide_get() == True:
+            for obj in objs:
                 obj.hide_set(False)
 
     @classmethod


### PR DESCRIPTION
Fixes #7889.

## Problem

The issue title says "Can't generate spaces" but the screenshot in the report shows spaces were generated fine. The actual crash is pressing H (Toggle Hide Spaces), which raises:

```
AttributeError: 'NoneType' object has no attribute 'hide_set'
```

## Root cause

`tool.Spatial.toggle_hide_spaces` (in `src/bonsai/bonsai/tool/spatial.py`) assumed every `IfcSpace` handed to it by `core.spatial.toggle_hide_spaces` had a corresponding Blender object, and derived the toggle direction from `spaces[0]` with an `assert isinstance(first_obj, bpy.types.Object)`. Bonsai supports loading a subset of a model into the scene, so an `IfcSpace` can legitimately have no Blender object. If a later space in the list had no object, this crashed with `AttributeError` on `obj.hide_set`. If the first space in file order had no object, it crashed earlier with `AssertionError`. A third related failure exists too: `hide_set` also raises if an object exists but isn't linked into the current view layer.

## Fix

Filter to spaces that actually have a Blender object linked into the current view layer before touching them, and derive the toggle direction from that filtered list instead of an arbitrary `spaces[0]`. This also covers the view-layer-linkage requirement of `hide_set`. If nothing is loaded, the operator now does nothing instead of crashing. The filtering is done in the tool layer (`bonsai/tool/spatial.py`) rather than core, since only the tool layer deals with Blender object/view-layer state.

## Testing

Reproduced live in headless Blender (bonsai loaded from source) with a hand-authored IFC4X3 file containing 4 `IfcSpace` entities, covering: a middle space missing its object (the reported `AttributeError`), the first space in file order missing its object (`AssertionError`), an object present but not linked into the view layer (`RuntimeError` from `hide_set`), and no space loaded at all. All four crashed before the fix and completed cleanly after it, with hide state correctly applied to every loaded, view-layer-linked object.

This PR contains AI-generated code (diagnosis, fix, and live Blender verification), disclosed per this repo's AGENTS.md.