### PR TITLE
ifc5d: make the cost schedule CSV delimiter configurable

### DIFF
--- a/src/ifc5d/ifc5d/csv2ifc.py
+++ b/src/ifc5d/ifc5d/csv2ifc.py
@@ -113,6 +113,7 @@ class Csv2Ifc:
     file: Union[ifcopenshell.file, None] = None
     cost_schedule: Union[ifcopenshell.entity_instance, None] = None
     is_schedule_of_rates: bool = False
+    delimiter: str
 
     # Output.
     cost_items: list[CostItem]
@@ -132,12 +133,15 @@ class Csv2Ifc:
         cost_schedule: Union[ifcopenshell.entity_instance, None] = None,
         *,
         is_schedule_of_rates: bool = False,
+        delimiter: str = ",",
     ):
         """
         :param csv: CSV filepath to import.
         :param ifc_file: IFC file to import to. If not provided, boilerplate file will be created.
         :param cost_schedule: Cost schedule to load cost items to. If not provided, new one will be created.
         :param is_schedule_of_rates: Whether imported schedule is a schedule of rates.
+        :param delimiter: Field delimiter used by the CSV file. Locales that use a comma as the
+            decimal separator conventionally use a semicolon here.
         """
         # TODO: Arguments added only at 25.04.14
         # `csv` argument is actually not optional, it's only optional for backwards compatibility.
@@ -148,6 +152,7 @@ class Csv2Ifc:
         self.file = ifc_file
         self.cost_schedule = cost_schedule
         self.is_schedule_of_rates = is_schedule_of_rates
+        self.delimiter = delimiter
         self.units = {}
 
     def execute(self) -> None:
@@ -171,7 +176,7 @@ class Csv2Ifc:
         min_index = None
 
         with open(self.csv, "r", encoding="utf-8") as csv_file:
-            reader = csv.reader(csv_file)
+            reader = csv.reader(csv_file, delimiter=self.delimiter)
             for row in reader:
                 if not row[0]:
                     continue

--- a/src/ifc5d/ifc5d/ifc5Dspreadsheet.py
+++ b/src/ifc5d/ifc5d/ifc5Dspreadsheet.py
@@ -468,6 +468,9 @@ class Ifc5Dwriter:
 
 
 class Ifc5DCsvWriter(Ifc5Dwriter):
+    # Locales that use a comma as the decimal separator conventionally use a semicolon here.
+    delimiter: str = ","
+
     def write(self) -> None:
         import csv
 
@@ -477,7 +480,7 @@ class Ifc5DCsvWriter(Ifc5Dwriter):
             with open(
                 os.path.join(self.output, "{}.csv".format(data["Name"])), "w", newline="", encoding="utf-8"
             ) as file:
-                writer = csv.writer(file)
+                writer = csv.writer(file, delimiter=self.delimiter)
                 writer.writerow(data["headers"])
                 row = []
                 for cost_item_data in data["cost_items"]:

--- a/src/ifc5d/test/test_csv2ifc.py
+++ b/src/ifc5d/test/test_csv2ifc.py
@@ -41,9 +41,9 @@ class TestCsv2Ifc:
         return ifc_file
 
     @staticmethod
-    def get_items_rows_from_csv(csv_filepath: Path) -> list[list[str]]:
+    def get_items_rows_from_csv(csv_filepath: Path, delimiter: str = ",") -> list[list[str]]:
         with csv_filepath.open("r", encoding="utf-8") as csv_file:
-            reader = csv.reader(csv_file)
+            reader = csv.reader(csv_file, delimiter=delimiter)
             rows = list(reader)
         rows = rows[1:]  # Skip header.
         rows = filter(lambda l: l[0], rows)  # Skip empty rows.
@@ -76,6 +76,49 @@ class TestCsv2Ifc:
         csv2ifc.execute()
 
         self.validate_ifc_file_against_csv(ifc_file, csv_filepath)
+
+    def test_import_semicolon_delimited(self):
+        # Regression test for #7048. Locales that use a comma as the decimal separator
+        # use a semicolon as the field delimiter, which was previously unreadable.
+        csv_filepath = Path(__file__).parent.parent / "sample_cost_schedule_house_FR.csv"
+        rows = self.get_items_rows_from_csv(csv_filepath)
+
+        with csv_filepath.open("r", encoding="utf-8") as csv_file:
+            all_rows = list(csv.reader(csv_file))
+
+        with tempfile.TemporaryDirectory("w") as temp_dir:
+            semicolon_filepath = Path(temp_dir) / "semicolon.csv"
+            with semicolon_filepath.open("w", newline="", encoding="utf-8") as csv_file:
+                csv.writer(csv_file, delimiter=";").writerows(all_rows)
+
+            # The comma reader must not silently treat the whole line as one column.
+            assert len(self.get_items_rows_from_csv(semicolon_filepath, delimiter=";")) == len(rows)
+
+            ifc_file = self.setup_ifc_file()
+            csv2ifc = ifc5d.csv2ifc.Csv2Ifc(str(semicolon_filepath), ifc_file, delimiter=";")
+            csv2ifc.execute()
+
+            assert len(ifc_file.by_type("IfcCostSchedule")) == 1
+            assert len(ifc_file.by_type("IfcCostItem")) == len(rows)
+
+    def test_export_semicolon_delimited(self):
+        ifc_file = self.setup_ifc_file()
+        csv_filepath = Path(__file__).parent.parent / "sample_cost_schedule_house_FR.csv"
+        ifc5d.csv2ifc.Csv2Ifc(str(csv_filepath), ifc_file).execute()
+
+        with tempfile.TemporaryDirectory("w") as temp_csv_dir:
+            writer = ifc5d.ifc5Dspreadsheet.Ifc5DCsvWriter(ifc_file, temp_csv_dir)
+            writer.delimiter = ";"
+            writer.write()
+
+            exported = next(Path(temp_csv_dir).glob("*.csv"))
+            n_rows = len(self.get_items_rows_from_csv(csv_filepath))
+            assert len(self.get_items_rows_from_csv(exported, delimiter=";")) == n_rows
+
+            # Round trip it back through the semicolon reader.
+            new_ifc_file = self.setup_ifc_file()
+            ifc5d.csv2ifc.Csv2Ifc(str(exported), new_ifc_file, delimiter=";").execute()
+            assert len(new_ifc_file.by_type("IfcCostItem")) == n_rows
 
     def test_export_import_test(self):
         ifc_file = self.setup_ifc_file()


### PR DESCRIPTION
Fixes #7048.

`Csv2Ifc.parse_csv` called `csv.reader(csv_file)` with no delimiter, hardcoding a comma. In locales where the comma is the decimal separator (German, French, Italian and others) the field delimiter is conventionally a semicolon, so every row parsed as a single column and cost schedule import was unusable.

@epeter- reported this and had already found the fix himself, editing `csv2ifc.py` by hand to pass `delimiter=';'` and noting "not clean, but working". This makes it an option instead of a local patch.

`Ifc5DCsvWriter` hardcoded a comma on the way out as well, so exporting a schedule for the same user produced a file they could not open cleanly. Both directions are now configurable via a `delimiter` argument (reader) and attribute (writer). Both default to `","`, so existing behaviour and all existing callers are unchanged.

Two regression tests added:

- `test_import_semicolon_delimited` rewrites the FR sample schedule with semicolons and asserts the cost items import, guarding against the whole-line-as-one-column failure.
- `test_export_semicolon_delimited` exports with a semicolon and round trips it back through the reader.

Test baseline checked before and after against a pristine `v0.8.0` worktree: **3 failed / 15 passed** before, **3 failed / 17 passed** after. The three failures are pre-existing and unrelated (two are missing optional dependencies, `odf` and `openpyxl`, and one is a pre-existing `TypeError` in `test_import_sample_files[csv_filepath10]`). No new failures, plus the two new tests.

This PR was generated with the assistance of an AI coding tool.