### PR TITLE
IfcConvert: fix --unicode=escape referencing a removed enumerator

### DIFF
--- a/src/ifcconvert/IfcConvert.cpp
+++ b/src/ifcconvert/IfcConvert.cpp
@@ -529,7 +529,7 @@ int main(int argc, char** argv) {
         if (unicode_mode == "utf8") {
             IfcParse::IfcCharacterDecoder::mode = IfcParse::IfcCharacterDecoder::UTF8;
         } else if (unicode_mode == "escape") {
-            IfcParse::IfcCharacterDecoder::mode = IfcParse::IfcCharacterDecoder::JSON;
+            IfcParse::IfcCharacterDecoder::mode = IfcParse::IfcCharacterDecoder::ESCAPE;
         } else {
             cerr_ << "[Error] Invalid value for --unicode" << std::endl;
             print_options(serializer_options);


### PR DESCRIPTION
`IfcConvert.cpp` sets the decoder mode for `--unicode=escape` to `IfcParse::IfcCharacterDecoder::JSON`:

```cpp
} else if (unicode_mode == "escape") {
    IfcParse::IfcCharacterDecoder::mode = IfcParse::IfcCharacterDecoder::JSON;
```

`JSON` does not exist. `IfcCharacterDecoder.h` declares only `SUBSTITUTE`, `UTF8` and `ESCAPE`.

How it survived: the flag was added in `fa76aa9bb0` (2017) when the enumerator was still called `JSON`. `0b2bd5d0e8` ("Eliminate ICU dependency", 2019) renamed it to `ESCAPE` but missed this call site, because the site sits inside `#ifdef HAVE_ICU` and that same commit stopped defining `HAVE_ICU`. No CI workflow defines it either, so the branch has not been compiled in about six years and no build has flagged it.

The consequence is small but real: anyone re-enabling ICU support gets a compile error on a flag `--unicode=utf8|escape` that the help text still advertises. `ESCAPE` is unambiguously the intended value given the branch condition is `unicode_mode == "escape"`.

One character of behaviour change, no runtime effect on any current build.

Found while investigating #7305, which is a separate and much larger encoding question that I am not addressing here.

This PR was generated with the assistance of an AI coding tool.