### PR TITLE
Bonsai: warn when a multi-profile material set has no Composite Profile

### DIFF
--- a/src/bonsai/bonsai/bim/module/material/data.py
+++ b/src/bonsai/bonsai/bim/module/material/data.py
@@ -207,6 +207,7 @@ class ObjectMaterialData:
                 "id": mset.id(),
                 "name": getattr(mset, "LayerSetName", getattr(mset, "Name", None)) or "Unnamed",
                 "description": getattr(mset, "Description", None),
+                "has_composite_profile": bool(getattr(mset, "CompositeProfile", None)),
             }
 
     @classmethod

--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -358,12 +358,18 @@ class AddProfile(bpy.types.Operator, tool.Ifc.Operator):
         self.file = tool.Ifc.get()
         props = tool.Material.get_material_props()
         omprops = tool.Material.get_object_material_props(obj)
+        profile_set = self.file.by_id(self.profile_set)
         ifcopenshell.api.material.add_profile(
             self.file,
-            profile_set=self.file.by_id(self.profile_set),
+            profile_set=profile_set,
             material=self.file.by_id(int(omprops.material)),
             profile=self.file.by_id(int(props.profiles)),
         )
+        if len(profile_set.MaterialProfiles) > 1 and not profile_set.CompositeProfile:
+            self.report(
+                {"WARNING"},
+                "Multiple profiles require a Composite Profile to be rendered. Only the first profile will be shown in the 3D view.",
+            )
 
 
 class RemoveProfile(bpy.types.Operator, tool.Ifc.Operator):

--- a/src/bonsai/bonsai/bim/module/material/ui.py
+++ b/src/bonsai/bonsai/bim/module/material/ui.py
@@ -257,6 +257,16 @@ class BIM_PT_object_material(Panel):
 
         total_items = len(ObjectMaterialData.data["set_items"])
 
+        if (
+            set_item_name == "profile"
+            and total_items > 1
+            and not ObjectMaterialData.data["set"].get("has_composite_profile")
+        ):
+            warning_row = self.layout.row()
+            warning_row.label(
+                text="Only the first profile is used for geometry without a Composite Profile", icon="ERROR"
+            )
+
         row = self.layout.row(align=True)
         box = row.box()
 


### PR DESCRIPTION
Fixes #7053

## What was happening

Thanks to @sboddy for the report and the trivial test file. A beam's `IfcMaterialProfileSetUsage` can reference several `IfcMaterialProfile` entries, but per the IFC spec the relative positioning of those profiles is only defined through an `IfcCompositeProfileDef` assigned to `IfcMaterialProfileSet.CompositeProfile`. Without that composite profile, there is no other spec-defined data (offset, cardinal point, etc.) that says how the extra profiles relate to each other geometrically.

Bonsai's profile authoring code (`bim/module/model/profile.py`, `recreate_profile`) already reflects this: it uses `material.CompositeProfile or material.MaterialProfiles[0].Profile`. That fallback to the first profile is correct given the missing data, but it happens silently. The "Add Profile" operator and the material panel gave no indication that a second (or third...) profile would never show up in the 3D view, so users have no way to know their data isn't being represented.

This is not a rendering bug in the geometry kernel: the beam's `Body` representation in the reporter's file is a single `IfcExtrudedAreaSolid` built from the first profile only, because that's what Bonsai wrote to the file at authoring time. Any viewer, including IfcOpenShell's own geometry pipeline, only draws what's in the file.

## What this changes

- `ObjectMaterialData.set()` now exposes a `has_composite_profile` flag.
- The material panel shows a warning label when a profile set has more than one profile and no Composite Profile.
- The `AddProfile` operator reports a warning when adding a profile creates this state.

This does not attempt to auto-compose multiple profiles into one swept solid. That would require inventing per-profile offset/positioning data the file (and the spec) does not provide, which is a real design decision for a future change, not something to guess at here.

## Verification

Loaded the reporter's actual test file in headless Blender (isolated `BLENDER_USER_RESOURCES`, Bonsai loaded from source):

- The beam's `ForProfileSet` has 2 `MaterialProfiles` (I-shape `DEMO-I`, C-shape `DEMO-C`) and `CompositeProfile` is `None`.
- The resulting Blender mesh has a bounding box of `[-0.05, -0.1, 0]` to `[0.05, 0.1, 11]` with 60 vertices, matching only the I-shape profile (0.1 x 0.2 cross-section) extruded 11m. The C-shape is absent from the geometry, confirming the reported symptom against the reporter's own data.
- With the fix, `ObjectMaterialData.data["set"]["has_composite_profile"]` is `False` and the panel's warning condition evaluates to `True` for this file.

Tests: `test/core/test_material.py` (13/13) and the full `test/core` suite (390/390) pass before and after this change; the change is in `bim/module/material` (UI/operator layer) which isn't exercised by `test/core`, so this confirms no regressions rather than direct coverage.

---
Generated with the assistance of an AI coding tool.