### PR TITLE
Bonsai: add File menu entry to export selected elements as a new IFC

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/__init__.py
+++ b/src/bonsai/bonsai/bim/module/project/__init__.py
@@ -53,6 +53,7 @@ classes = (
     operator.EnableEditingHeader,
     operator.EnableEditingLink,
     operator.ExportIFC,
+    operator.ExportSelectedElements,
     operator.FlipClippingPlane,
     operator.HideQueriedLinkedElement,
     operator.IFCFileHandlerOperator,

--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -48,6 +48,7 @@ import ifcopenshell.util.selector
 import ifcopenshell.util.shape
 import ifcopenshell.util.shape_builder
 import ifcopenshell.util.unit
+import ifcpatch
 import numpy as np
 from bpy.app.handlers import persistent
 from bpy_extras.io_utils import ExportHelper, ImportHelper
@@ -2166,6 +2167,61 @@ class ExportIFC(bpy.types.Operator, ExportHelper):
         if properties.should_save_as:
             return "Save the IFC file under a new name, or relocate file"
         return "Save the IFC file.  Will save both .IFC/.BLEND files if synced together"
+
+
+class ExportSelectedElements(bpy.types.Operator, ExportHelper):
+    bl_idname = "bim.export_selected_elements"
+    bl_label = "Save Selected Elements As..."
+    bl_description = (
+        "Save the selected elements to a new IFC file, keeping their spatial "
+        "containment and decomposition parents. Runs the ifcpatch 'Extract "
+        "Elements' recipe (Quality Control > Patch has the same recipe with "
+        "more query options). Large models may take a while, Blender will "
+        "show a wait cursor while it works."
+    )
+    bl_options = {"REGISTER"}
+    filename_ext = ".ifc"
+    filter_glob: bpy.props.StringProperty(default="*.ifc;*.ifczip", options={"HIDDEN"})
+
+    if TYPE_CHECKING:
+        filter_glob: str
+
+    @classmethod
+    def poll(cls, context):
+        if not tool.Ifc.get():
+            cls.poll_message_set("No IFC project is loaded.")
+            return False
+        for obj in tool.Blender.get_selected_objects():
+            if tool.Ifc.get_entity(obj):
+                return True
+        cls.poll_message_set("Select one or more IFC elements first.")
+        return False
+
+    def invoke(self, context, event):
+        props = tool.Blender.get_bim_props()
+        stem = Path(props.ifc_file).stem if props.ifc_file else "selected"
+        self.filepath = f"{stem}-selected.ifc"
+        return ExportHelper.invoke(self, context, event)
+
+    def execute(self, context):
+        query = tool.Search.get_query_for_selected_elements()
+        text_name = None
+        if query.startswith("bpy.data.texts['"):
+            text_name = query.split("bpy.data.texts")[1][2:-2]
+        query = tool.Patch.post_process_patch_arguments("ExtractElements", [query])[0]
+
+        context.window.cursor_modal_set("WAIT")
+        try:
+            output = ifcpatch.execute({"file": tool.Ifc.get(), "recipe": "ExtractElements", "arguments": [query]})
+            ifcpatch.write(output, self.filepath)
+        finally:
+            context.window.cursor_modal_restore()
+            if text_name and (text_block := bpy.data.texts.get(text_name)):
+                bpy.data.texts.remove(text_block)
+
+        element_count = query.count(",") + 1 if query else 0
+        self.report({"INFO"}, f"Saved {element_count} selected element(s) to {os.path.basename(self.filepath)}")
+        return {"FINISHED"}
 
 
 class LoadAutosavedRecoveryPopup(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/project/ui.py
+++ b/src/bonsai/bonsai/bim/module/project/ui.py
@@ -140,6 +140,7 @@ def file_menu(self, context):
     op.should_save_as = False
     op = self.layout.operator("bim.save_project", text="Save IFC Project As...")
     op.should_save_as = True
+    self.layout.operator("bim.export_selected_elements", icon="EXPORT")
     self.layout.separator()
     self.layout.operator("bim.revert_project")
     self.layout.separator()


### PR DESCRIPTION
Fixes #6118

## What

Adds a **Save Selected Elements As...** entry to the File menu (next to Save IFC Project / Save IFC Project As...) that saves the currently selected elements to a new IFC file.

## Why

@OrionSehn asked for a "save only the selected elements to a new IFC" export, comparable to a `.obj` export, for slicing a portion of a large model to send to a client.

@brunopostle replied: "This exists as Quality Control > Patch > Extract Elements, but I agree this is a common task and should be more prominent (I was asked this question in a presentation last week)."

So the capability already exists (the `ExtractElements` ifcpatch recipe). The gap is discoverability. This PR does not touch or reimplement that recipe, it just adds a second, more prominent path to the same feature. The Quality Control > Patch > Extract Elements route is untouched, this adds a path, it does not move one.

## How

The new `bim.export_selected_elements` operator:
- Reuses `tool.Search.get_query_for_selected_elements()` (the same helper already used by the Patch panel's "fill query from selection" eyedropper button) to turn the current Blender selection into a GlobalId query.
- Runs that query through the existing `ExtractElements` ifcpatch recipe via `ifcpatch.execute()` / `ifcpatch.write()`, exactly like the Patch panel does.
- Cleans up the temporary text data-block the helper creates for selections over 50 elements (that block is meant to persist for the editable Patch-panel workflow, but this is a one-shot export so it's removed right after use).

`ExtractElements` is known to be slow on large models, and that performance work is already in flight elsewhere (#8945, with PRs #8953/#8956 open), so this PR does not attempt to speed it up. Since the motivating use case is large models, the operator sets a wait cursor (`context.window.cursor_modal_set("WAIT")`, matching the pattern already used in `bim/module/structural/operator.py`) for the duration of the (still blocking) call, so the UI doesn't look frozen.

## Testing

Verified live in headless Blender (`/Applications/Blender.app/Contents/MacOS/Blender -b`, isolated `BLENDER_USER_RESOURCES`, never touching the real profile):
- Built a small fixture (IfcProject > IfcSite > IfcBuilding > IfcBuildingStorey, 5 walls, 2 slabs), loaded it into Bonsai, selected 3 of the 5 walls, ran the operator. Output file contained exactly those 3 walls (matching GlobalIds), 0 slabs, and the IfcProject/spatial parent, and opened cleanly with `ifcopenshell.open()`.
- Repeated with 80 walls / 60 selected to exercise the "large selection" text-block query path, confirmed the extracted file has exactly the 60 selected GlobalIds and the temporary text data-block is cleaned up afterwards.
- Confirmed `poll()` correctly disables the operator with no IFC project loaded and with nothing selected.
- Addon registers with no traceback in all runs.

Existing coverage: there's no existing automated test file for `project/operator.py` (`bim/module/project/` only has autosave/library/opening-cuts tests), so this operator has no prior baseline to compare against; `test/core/test_project.py` (Blender-agnostic core-layer tests, untouched by this change) passes both before and after: 5 passed.

## AI disclosure

Per AGENTS.md: this PR's code and commit message were generated with the assistance of an AI coding tool.