### PR TITLE
Bonsai: grey out Trim and Merge when the active-tool selection is invalid

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/__init__.py
+++ b/src/bonsai/bonsai/bim/module/model/__init__.py
@@ -124,6 +124,7 @@ classes = (
     wall.RotateWall90,
     wall.SplitWall,
     wall.SplitWallAtCursor,
+    wall.TrimWall,
     wall.DisconnectElements,
     wall.UnjoinWalls,
     wall.EnableWallFilletPreview,

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -696,6 +696,35 @@ class FlipWall(bpy.types.Operator, tool.Ifc.Operator):
         return {"FINISHED"}
 
 
+class TrimWall(_CommitWallDraftsFirstMixin, bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.trim_wall"
+    bl_label = "Trim Wall"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Connects and trims two non-parallel LAYER2 elements (walls, railings, etc) into a joint"
+
+    @classmethod
+    def poll(cls, context):
+        selected_objs = [
+            o
+            for o in tool.Blender.get_selected_objects()
+            if (e := tool.Ifc.get_entity(o)) and tool.Model.get_usage_type(e) == "LAYER2"
+        ]
+        if len(selected_objs) != 2:
+            cls.poll_message_set("Exactly two LAYER2 items (walls, railings, etc) must be selected to perform a trim.")
+            return False
+        if _poll_reject_array_children(cls):
+            return False
+        return True
+
+    def _perform(self, context):
+        try:
+            core.join_walls_LV(tool.Ifc, tool.Blender, tool.Geometry, DumbWallJoiner(), tool.Model)
+        except core.RequireTwoWallsError as e:
+            self.report({"ERROR"}, str(e))
+            return {"CANCELLED"}
+        return {"FINISHED"}
+
+
 class SplitWall(_CommitWallDraftsFirstMixin, bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.split_wall"
     bl_label = "Split Wall"
@@ -743,6 +772,9 @@ class MergeWall(_CommitWallDraftsFirstMixin, bpy.types.Operator, tool.Ifc.Operat
         mesh_objects = [o for o in tool.Model.get_selected_ifc_objects() if o.type == "MESH"]
         if len(mesh_objects) != 2:
             cls.poll_message_set("Please select exactly two mesh IFC objects.")
+            return False
+        if any(not (e := tool.Ifc.get_entity(o)) or tool.Model.get_usage_type(e) != "LAYER2" for o in mesh_objects):
+            cls.poll_message_set("Both selected items must be LAYER2 (walls, railings, etc) to perform a merge.")
             return False
         if _poll_reject_array_children(cls):
             return False

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -852,12 +852,19 @@ class EditObjectUI:
             )
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
             add_layout_hotkey_operator(
-                row, "Trim", "S_T", "Connects and trims two non-parallel elements into a joint", ui_context
+                row,
+                "Trim",
+                "S_T",
+                "Connects and trims two non-parallel elements into a joint",
+                ui_context,
+                operator="bim.trim_wall",
             )
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
             add_layout_hotkey_operator(row, "Unjoin Walls", "S_U", "", ui_context)
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
-            add_layout_hotkey_operator(row, "Merge", "S_M", "Merge selected Elements", ui_context)
+            add_layout_hotkey_operator(
+                row, "Merge", "S_M", "Merge selected Elements", ui_context, operator="bim.merge_wall"
+            )
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
             add_layout_hotkey_operator(
                 row, "Split", "S_K", "Split selected Element into two Elements at the cursor location", ui_context
@@ -1328,21 +1335,13 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
         if not bpy.context.selected_objects:
             return
         if self.active_material_usage == "LAYER2":
-            if len(bpy.context.selected_objects) != 2:
+            if bpy.ops.bim.merge_wall.poll():
+                bpy.ops.bim.merge_wall()
+            else:
                 self.report(
                     {"ERROR"},
                     "Exactly two LAYER2 items (walls, railings, etc) must be selected to perform a merge.",
                 )
-                return
-            for item in bpy.context.selected_objects:
-                element = tool.Ifc.get_entity(item)
-                if tool.Model.get_usage_type(element) != "LAYER2":
-                    self.report(
-                        {"ERROR"},
-                        "Both selected items must be LAYER2 (walls, railings, etc) to perform a merge.",
-                    )
-                    return
-            bpy.ops.bim.merge_wall()
         else:
             if len(bpy.context.selected_objects) == 1:
                 self.report(
@@ -1372,10 +1371,13 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
         if not bpy.context.selected_objects:
             return
         if self.active_material_usage == "LAYER2":
-            try:
-                core.join_walls_LV(tool.Ifc, tool.Blender, tool.Geometry, DumbWallJoiner(), tool.Model)
-            except core.RequireTwoWallsError as e:
-                self.report({"ERROR"}, str(e))
+            if bpy.ops.bim.trim_wall.poll():
+                bpy.ops.bim.trim_wall()
+            else:
+                self.report(
+                    {"ERROR"},
+                    "Exactly two LAYER2 items (walls, railings, etc) must be selected to perform a trim.",
+                )
         elif self.active_material_usage == "PROFILE":
             bpy.ops.bim.extend_profile(join_type="L")
 


### PR DESCRIPTION
Fixes #7151

Trim and Merge showed up enabled in the Active Tool "Operations" panel even with a single object selected. Clicking either just produced a runtime error report instead of the button being disabled with a reason on hover.

Root cause: the panel wired both buttons through the generic `bim.hotkey` operator, whose `poll()` only checks that an IFC project is loaded, so Blender never asked the real operator whether the selection was valid. `bim.merge_wall` already had a `poll()`, but it was never consulted for the button state. Trim had no dedicated operator at all, its hotkey handler called `core.join_walls_LV` directly and only reported the failure after the fact.

Changes:
- Added `bim.trim_wall`, wrapping `core.join_walls_LV`, with a `poll()` requiring exactly two LAYER2 elements selected.
- Strengthened `bim.merge_wall`'s `poll()` to also check both selected objects are LAYER2 (it previously only checked the count of selected mesh IFC objects).
- Wired both buttons to their operator via the existing `operator=` parameter on `add_layout_hotkey_operator`, so Blender greys them out with a readable poll message instead of allowing the click.
- Simplified the `S_T` and `S_M` hotkey handlers to check the operator's `poll()` and delegate, instead of duplicating the selection validation inline.

Verified live in headless Blender 5.2: with a single object selected both `bim.trim_wall.poll()` and `bim.merge_wall.poll()` return `False` (buttons greyed), and the keyboard shortcuts still report the same readable error as before. With two LAYER2 walls selected both operators poll `True` and Trim/Merge still perform correctly (confirmed `IfcRelConnectsPathElements` created on trim).

`test/bim/module/model/` : 530 passed before and after, no regressions.

@R2naizr this should resolve the request. Thanks for the report, and thanks @sboddy for narrowing the scope to a UI fix.

---
Generated with the assistance of an AI coding tool.
