### PR TITLE
Bonsai: correct OuterSurfaceArea to exclude top and bottom

### DIFF
--- a/src/bonsai/bonsai/bim/module/qto/calculator.py
+++ b/src/bonsai/bonsai/bim/module/qto/calculator.py
@@ -25,6 +25,7 @@ import ifc5d.qto
 import ifcopenshell
 import ifcopenshell.geom
 import ifcopenshell.util.element
+import ifcopenshell.util.shape
 import mathutils
 from mathutils import Matrix, Vector
 from mathutils.bvhtree import BVHTree
@@ -830,8 +831,14 @@ def get_net_side_area(obj: bpy.types.Object) -> float:
 
 
 def get_outer_surface_area(obj: bpy.types.Object) -> float:
-    outer_surface_area = get_lateral_area(obj, exclude_end_areas=True, angle_z1=0, angle_z2=360)
-    return outer_surface_area
+    """Area of all sides except the top and bottom, which are the faces at the
+    minimum and maximum local Z.
+
+    Matches ``ifcopenshell.util.shape.get_outer_surface_area``.
+    """
+    assert isinstance(obj.data, bpy.types.Mesh)
+    tol = ifcopenshell.util.shape.tol
+    return sum(p.area for p in obj.data.polygons if abs(p.normal.z) < tol)
 
 
 def get_end_area(obj: bpy.types.Object) -> float:


### PR DESCRIPTION
Fixes #7470. Reported by @DimitriosThe with a reproducer script.

@Moult confirmed the intended definition on the issue:

> `util.shape.get_outer_surface_area` is correct. Extrusion axis should be local Z, and the top/bottom should be excluded.

Bonsai's `qto/calculator.py` did not implement that. Two defects combined:

1. **The top/bottom filter was dead code.** `get_outer_surface_area` called `get_lateral_area(obj, exclude_end_areas=True, angle_z1=0, angle_z2=360)`. Inside, the guard is `if angle_to_top_axis < angle_z1 or angle_to_top_axis > angle_z2: continue`, and `polygon.normal.rotation_difference(...).angle` is a quaternion angle always in `[0, pi]`, so in degrees it is always within `[0, 360]`. The condition could never be true, so top and bottom faces were always counted.
2. **The remaining exclusion used a guessed axis.** `exclude_end_areas` keys off `get_object_main_axis`, which picks the largest bounding box dimension, not local Z.

The two implementations therefore only agreed when the element happened to be longest along Z, which is why this survived.

Measured on axis aligned boxes, comparing the old routing against `util.shape`:

| Shape | util.shape | old Bonsai | |
|---|---|---|---|
| Beam along Z (1x1x10) | 40.00 | 40.00 | agree |
| Beam along X (10x1x1) | 22.00 | 40.00 | 82% too high |
| Slab (10x10x0.2) | 8.00 | 204.00 | over 25x too high |

The slab case is the worst because its guessed main axis is horizontal, so both large faces were counted as sides.

`get_outer_surface_area` now computes the quantity directly with the same rule and the same `tol` value as `util.shape`, imported from it so the two cannot drift apart. It no longer routes through `get_lateral_area`, whose other callers (`get_gross_side_area`, `get_net_side_area`, `get_end_area`) rely on the existing axis-guessing behaviour and are deliberately untouched.

**This changes reported quantities.** Anyone relying on the old `OuterSurfaceArea` for non Z-aligned elements will see different, correct numbers.

Note there is a separate latent problem I did **not** change: in `get_lateral_area`, `subtract_openings` does the opposite of its name in both branches (`total_opening_area = 0 if subtract_openings else get_opening_area(...)`, then `return area + total_opening_area`), and `get_gross_side_area` passes `subtract_openings=False` specifically to exploit that. It cannot be corrected in isolation and is out of scope here.

This PR was generated with the assistance of an AI coding tool.