### PR TITLE
Bonsai: keep shape aspect names in sync when renaming a material constituent

### DIFF
--- a/src/bonsai/bonsai/bim/module/material/operator.py
+++ b/src/bonsai/bonsai/bim/module/material/operator.py
@@ -818,12 +818,15 @@ class EditMaterialSetItem(bpy.types.Operator, tool.Ifc.Operator):
         attributes = bonsai.bim.helper.export_attributes(props.material_set_item_attributes)
 
         if material.is_a("IfcMaterialConstituentSet"):
+            constituent = self.file.by_id(self.material_set_item)
+            old_name = constituent.Name
             ifcopenshell.api.material.edit_constituent(
                 self.file,
-                constituent=self.file.by_id(self.material_set_item),
+                constituent=constituent,
                 attributes=attributes,
                 material=self.file.by_id(int(props.material_set_item_material)),
             )
+            tool.Geometry.sync_shape_aspects_with_constituent_rename(constituent, old_name)
         elif material.is_a("IfcMaterialLayerSet"):
             layer = self.file.by_id(self.material_set_item)
             ifcopenshell.api.material.edit_layer(

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2003,6 +2003,29 @@ class Geometry(bonsai.core.tool.Geometry):
         return styles
 
     @classmethod
+    def sync_shape_aspects_with_constituent_rename(
+        cls, constituent: ifcopenshell.entity_instance, old_name: Union[str, None]
+    ) -> None:
+        """Renames shape aspects paired with `constituent` through get_shape_aspect_styles.
+
+        get_shape_aspect_styles pairs an IfcShapeAspect to an
+        IfcMaterialConstituent purely by matching Name, so renaming the
+        constituent without also renaming its paired shape aspects silently
+        breaks that pairing and the per-item style is lost. Only shape
+        aspects of elements actually using the constituent's material set are
+        touched, so unrelated shape aspects that happen to share the old name
+        are left alone.
+        """
+        new_name = constituent.Name
+        if not old_name or old_name == new_name:
+            return
+        for material_set in constituent.ToMaterialConstituentSet:
+            for element in ifcopenshell.util.element.get_elements_by_material(tool.Ifc.get(), material_set):
+                for shape_aspect in ifcopenshell.util.element.get_shape_aspects(element, should_inherit=False):
+                    if shape_aspect.Name == old_name:
+                        shape_aspect.Name = new_name
+
+    @classmethod
     def delete_opening_object_placement(cls, placement: ifcopenshell.entity_instance) -> None:
         model = tool.Ifc.get()
         ifcopenshell.util.element.remove_deep2(model, placement)

--- a/src/bonsai/test/tool/test_geometry.py
+++ b/src/bonsai/test/tool/test_geometry.py
@@ -22,6 +22,7 @@ from typing import Union
 import bpy
 import ifcopenshell
 import ifcopenshell.api.geometry
+import ifcopenshell.api.material
 import ifcopenshell.api.root
 import ifcopenshell.api.type
 import numpy as np
@@ -726,6 +727,68 @@ class TestRemoveRepresentationItemFromShapeAspect(NewFile):
         subject.remove_representation_items_from_shape_aspect([items[1]], shape_aspect1)
         representation = shape_aspect1.ShapeRepresentations[0]
         assert set(representation.Items) == {items[0]}
+
+
+class TestSyncShapeAspectsWithConstituentRename(NewFile):
+    def make_walled_constituent(self, ifc, context, constituent_set_name):
+        element = ifc.createIfcWall()
+        item = ifc.createIfcExtrudedAreaSolid()
+        representation = ifc.createIfcShapeRepresentation(Items=[item], ContextOfItems=context)
+        ifcopenshell.api.geometry.assign_representation(ifc, product=element, representation=representation)
+
+        material = ifc.createIfcMaterial(Name="Concrete")
+        constituent_set = ifcopenshell.api.material.add_material_set(
+            ifc, name=constituent_set_name, set_type="IfcMaterialConstituentSet"
+        )
+        constituent = ifcopenshell.api.material.add_constituent(ifc, constituent_set=constituent_set, material=material)
+        constituent.Name = "Concrete Constituent"
+        ifcopenshell.api.material.assign_material(
+            ifc, products=[element], type="IfcMaterialConstituentSet", material=constituent_set
+        )
+
+        shape_aspect = subject.create_shape_aspect(element.Representation, representation, [item], None)
+        shape_aspect.Name = "Concrete Constituent"
+        return constituent, shape_aspect
+
+    def test_renames_the_paired_shape_aspect(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        context = ifc.createIfcGeometricRepresentationContext()
+
+        constituent, shape_aspect = self.make_walled_constituent(ifc, context, "Set")
+
+        constituent.Name = "Renamed Constituent"
+        subject.sync_shape_aspects_with_constituent_rename(constituent, "Concrete Constituent")
+
+        assert shape_aspect.Name == "Renamed Constituent"
+
+    def test_does_not_touch_shape_aspects_of_unrelated_material_sets(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        context = ifc.createIfcGeometricRepresentationContext()
+
+        constituent, shape_aspect = self.make_walled_constituent(ifc, context, "Set")
+        other_constituent, other_shape_aspect = self.make_walled_constituent(ifc, context, "Other Set")
+
+        constituent.Name = "Renamed Constituent"
+        subject.sync_shape_aspects_with_constituent_rename(constituent, "Concrete Constituent")
+
+        assert shape_aspect.Name == "Renamed Constituent"
+        # Same coincidental name, but on a different material set: must be left alone.
+        assert other_shape_aspect.Name == "Concrete Constituent"
+
+    def test_noop_when_name_is_unchanged_or_absent(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        context = ifc.createIfcGeometricRepresentationContext()
+
+        constituent, shape_aspect = self.make_walled_constituent(ifc, context, "Set")
+
+        subject.sync_shape_aspects_with_constituent_rename(constituent, "Concrete Constituent")
+        assert shape_aspect.Name == "Concrete Constituent"
+
+        subject.sync_shape_aspects_with_constituent_rename(constituent, None)
+        assert shape_aspect.Name == "Concrete Constituent"
 
 
 class TestApplyItemIdsAsVertexGroups(NewFile):


### PR DESCRIPTION
Fixes #6301

## Problem

@theoryshaw reported that renaming an `IfcMaterialConstituent` does not update the name of the associated `IfcShapeAspect`, so the two names drift apart and the per-item style tied to that shape aspect is silently lost.

## Root cause

`tool.Geometry.get_shape_aspect_styles` (`src/bonsai/bonsai/tool/geometry.py`) pairs an `IfcShapeAspect` to an `IfcMaterialConstituent` purely by matching `Name` (`c.Name == shape_aspect.Name`). This is how Bonsai links a representation item's per-item style back to the material it represents. Renaming the constituent through the Object Materials UI (`EditMaterialSetItem` -> `ifcopenshell.api.material.edit_constituent`) only changed the constituent's `Name`, never the paired shape aspect's `Name`, breaking that pairing.

Reproduced live in headless Blender before the fix: after renaming a constituent from "Concrete Constituent" to "testing name change", the constituent's `Name` changed but the shape aspect kept the old name, so `shape_aspect.Name == constituent.Name` went from `True` to `False` and the style lookup stopped resolving.

## Fix

The rename is fixed at the point it happens (the `EditMaterialSetItem` operator, the authoring action behind the UI), not with a downstream repair pass. After the constituent is renamed, `tool.Geometry.sync_shape_aspects_with_constituent_rename` renames the shape aspects paired with it, scoped to elements that actually use that constituent's material set, so shape aspects belonging to unrelated elements that coincidentally share the old name are left alone.

## Testing

* Reproduced and verified live in headless Blender through the real `bpy.ops.bim.edit_material_set_item` operator path, before and after the fix (names diverge before, stay in sync after), inspecting the IFC entities directly via ifcopenshell.
* Added `TestSyncShapeAspectsWithConstituentRename` in `src/bonsai/test/tool/test_geometry.py` (rename propagates, unrelated shape aspects untouched, no-op when name is unchanged/absent).
* `test/tool/test_geometry.py`: 64 passed before -> 67 passed after (3 new tests, no regressions).
* `test/core/test_material.py` + `test/tool/test_material.py` + `test/tool/test_geometry.py` combined: 96 passed before -> 99 passed after (no regressions).
* black + ruff clean on all touched files.

---
AI-generated, human-reviewed, in accordance with AGENTS.md.