### PR TITLE
Bonsai: report bad external style data instead of raising

### DIFF
--- a/src/bonsai/bonsai/bim/module/style/operator.py
+++ b/src/bonsai/bonsai/bim/module/style/operator.py
@@ -439,6 +439,19 @@ class ActivateExternalStyle(bpy.types.Operator):
             location = external_style.Location
             identification = external_style.Identification
 
+        if not location:
+            self.report({"ERROR"}, f'Error loading external style for "{material.name}" - Location is not set')
+            return {"CANCELLED"}
+
+        if not identification or identification.count("/") != 1:
+            self.report(
+                {"ERROR"},
+                f'Error loading external style for "{material.name}"'
+                ' - Identification must be in the form "DataBlockType/DataBlockName"'
+                f", got: {identification!r}",
+            )
+            return {"CANCELLED"}
+
         data_block_type, data_block = identification.split("/")
         style_path = Path(tool.Ifc.resolve_uri(location))
 


### PR DESCRIPTION
`bim.activate_external_style` did this before validating anything:

```python
data_block_type, data_block = identification.split("/")
style_path = Path(tool.Ifc.resolve_uri(location))
```

Both `Location` and `Identification` are optional on `IfcExternallyDefinedSurfaceStyle` (confirmed against the IFC4 schema: `#1=IfcExternallyDefinedSurfaceStyle($,'Foo/Bar',$)` is valid), and `Identification` is only meaningful in the form `DataBlockType/DataBlockName`. So ordinary input reached the user as a traceback rather than a message:

| Input | Result before |
|---|---|
| `Identification=None` | `AttributeError: 'NoneType' object has no attribute 'split'` |
| `Identification='TestMat'` | `ValueError: not enough values to unpack (expected 2, got 1)` |
| `Identification='a/b/c'` | `ValueError: too many values to unpack (expected 2)` |
| `Location=None` | `TypeError: expected str, bytes or os.PathLike object` |

The lines immediately after already validate the resolved path and report a friendly operator error for a non `.blend` suffix and for a missing file. So these two unguarded lines were inconsistent with the surrounding intent, not a deliberate fast path. The fix reports in the same style and returns `CANCELLED`.

Verified each failure mode and confirmed the guard blocks exactly those four inputs while `materials/Foo` still passes through unchanged.

Found while investigating #5900, where a test file with an `IfcExternallyDefinedSurfaceStyle` whose `Identification` had no `/` crashed here. That issue is a separate and much larger question about the linked-project cache and is not addressed by this PR.

This PR was generated with the assistance of an AI coding tool.