### PR TITLE
ifc4d: match resources by GUID on CSV reimport instead of duplicating

### DIFF
--- a/src/ifc4d/ifc4d/csv2ifc.py
+++ b/src/ifc4d/ifc4d/csv2ifc.py
@@ -25,6 +25,7 @@ from typing import Any, Literal, NamedTuple, Optional, Union, cast, get_args
 
 import ifcopenshell
 import ifcopenshell.api.cost
+import ifcopenshell.api.nest
 import ifcopenshell.api.pset
 import ifcopenshell.api.resource
 import ifcopenshell.api.root
@@ -73,6 +74,10 @@ class Csv2Ifc:
     - empty rows are skipped.
     - 'HIERARCHY' must be the first column.
     - See SUPPORTED_COLUMN above for the list of supported columns.
+    - If a row has a 'GUID' matching an existing IfcConstructionResource in
+      the model, that resource is updated in place instead of creating a
+      new one. Rows with no 'GUID', an empty 'GUID', or a 'GUID' not found
+      in the model create a new resource, as before.
 
     Example:
 
@@ -164,6 +169,10 @@ class Csv2Ifc:
                 "class": quantity_class,
             }
 
+        guid = None
+        if (header_index := self.headers.get("GUID", None)) is not None:
+            guid = row[header_index] or None
+
         return {
             "Name": str(name).strip() if name else None,
             "Description": row[self.headers["DESCRIPTION"]],
@@ -173,6 +182,7 @@ class Csv2Ifc:
             "children": [],
             "usage": row[self.headers["USAGE"]],
             "quantity_data": quantity_data,
+            "GUID": guid,
         }
 
     def create_ifc(self) -> None:
@@ -186,9 +196,35 @@ class Csv2Ifc:
         for resource in resources:
             self.create_resource(resource, parent)
 
+    def get_existing_resource(self, guid: Union[str, None]) -> Union[ifcopenshell.entity_instance, None]:
+        if not guid:
+            return None
+        try:
+            element = self.file.by_guid(guid)
+        except RuntimeError:
+            return None
+        if not element.is_a("IfcConstructionResource"):
+            print(
+                f"WARNING. GUID '{guid}' from the CSV belongs to a '{element.is_a()}', not a resource. A new resource will be created instead of updating it."
+            )
+            return None
+        return element
+
     def create_resource(self, resource: dict[str, Any], parent: Union[ifcopenshell.entity_instance, None]) -> None:
         assert self.file
-        if parent is None:
+        existing_resource = self.get_existing_resource(resource.get("GUID"))
+        if existing_resource is not None:
+            resource["ifc"] = existing_resource
+            if existing_resource.is_a() != resource["class"]:
+                print(
+                    f"WARNING. GUID '{resource['GUID']}' is a '{existing_resource.is_a()}' in the model "
+                    f"but the CSV row TYPE resolves to '{resource['class']}'. Keeping the existing class."
+                )
+            if parent is not None:
+                ifcopenshell.api.nest.assign_object(
+                    self.file, related_objects=[existing_resource], relating_object=parent
+                )
+        elif parent is None:
             resource["ifc"] = ifcopenshell.api.resource.add_resource(self.file, ifc_class=resource["class"])
         else:
             resource["ifc"] = ifcopenshell.api.resource.add_resource(
@@ -205,10 +241,15 @@ class Csv2Ifc:
                 properties=resource["Productivity"],
             )
         if resource["BaseCostValue"]:
-            cost_value = ifcopenshell.api.cost.add_cost_value(self.file, parent=resource["ifc"])
+            existing_cost_values = resource["ifc"].BaseCosts
+            cost_value = existing_cost_values[0] if existing_cost_values else None
+            if cost_value is None:
+                cost_value = ifcopenshell.api.cost.add_cost_value(self.file, parent=resource["ifc"])
             cost_value.AppliedValue = self.file.createIfcMonetaryMeasure(resource["BaseCostValue"])
         if usage_value := resource["usage"]:
-            usage = ifcopenshell.api.resource.add_resource_time(self.file, resource=resource["ifc"])
+            usage = resource["ifc"].Usage
+            if usage is None:
+                usage = ifcopenshell.api.resource.add_resource_time(self.file, resource=resource["ifc"])
             ifcopenshell.api.resource.edit_resource_time(self.file, usage, {"ScheduleUsage": float(usage_value)})
 
         if quantity_data := resource["quantity_data"]:


### PR DESCRIPTION
Fixes #5760

@DimitriosThe reported that reimporting a resource CSV to update an existing schedule duplicates every resource instead of updating it. @steverugi confirmed the round trip requirement should use GUID matching. @Andrej730 wrote the export side (GUID column) in a prior PR, but nothing ever read it back on import.

`Ifc2Csv.get_row` writes a `GUID` column with `resource.GlobalId`, but `Csv2Ifc.get_row_resource_data` never parsed it and `Csv2Ifc.create_resource` always called `add_resource`, so reimporting an unmodified export doubled the resource count every time, with the reimported copies getting new GlobalIds.

## What changed

A CSV row whose `GUID` matches an existing `IfcConstructionResource` in the model now updates that resource in place (Name, Description, productivity pset, cost value, usage, base quantity) instead of creating a duplicate. The cost value and resource time entities are reused across reimports rather than appended to, so repeated reimports do not stack up extra `IfcCostValue`/`IfcResourceTime` entities.

Edge cases handled:
- A row with no `GUID`, an empty `GUID`, or a `GUID` not present in the model still creates a new resource, same as before. Hand-authored CSVs with no `GUID` column, and new rows appended to an exported CSV, are unaffected.
- A `GUID` that resolves to something that is not an `IfcConstructionResource` (e.g. it happens to collide with an `IfcProject`) is rejected with a printed warning, and a new resource is created instead, rather than blindly overwriting unrelated model data.
- Nesting/parenting is reapplied through `ifcopenshell.api.nest.assign_object`, which is a no-op if the child resource is already correctly nested under the same parent, and correctly re-parents (without orphaning or duplicating nest relationships) if the CSV hierarchy intentionally moves a resource under a different parent.

## Out of scope

- The task/work schedule side of `ifc4d` (`csv4d2ifc.py`) has the same unconditional-create pattern and, worse, has no `GUID` column in its CSV format or an export operator to produce one at all. That is a separate defect and not addressed here.
- Exporting task-to-resource allocation, requested by @steverugi in the issue, is a distinct feature (no task/process column exists in `HEADER`/`SUPPORTED_COLUMN`) and is not part of this fix.

## Verification

Manually reproduced and verified with a headless script against `ifcopenshell` + the modified `ifc4d.csv2ifc` module (no existing pytest test module exists for `ifc4d` to extend, unlike `ifc5d` which has `test/test_csv2ifc.py`):

- Before the fix: exporting one `IfcCrewResource` + nested `IfcLaborResource` and reimporting the unmodified CSV into the same model went from 2 resources to 4, with new GlobalIds on the reimported copies.
- After the fix: reimporting the unmodified CSV leaves the resource count at 2, with the original GlobalIds preserved.
- Editing a resource's Name and Cost in the CSV and reimporting lands the edit on the same resource entity (verified by GlobalId and by reading back `ifcopenshell.util.resource.get_cost`), still 2 resources total.
- A CSV row with an empty `GUID` still creates a new resource (3 resources after import, `Brand New Crew` added).
- A `GUID` pointing at an `IfcProject` prints a warning, creates a new resource instead of touching the `IfcProject`, and leaves `IfcProject.Name` untouched.
- A 5-resource, 2-level hierarchy (two crews with nested labor/equipment) round trips with all GlobalIds, classes, names and parent relationships intact, and a targeted CSV edit that intentionally moves a resource to a different parent re-parents it correctly with no orphaned entities and no duplicate nest relationships.

Ran black + ruff from the CI lint config against the touched file; both pass clean.

Generated with the assistance of an AI coding tool. The commit implementing this fix was written by an AI coding tool under human review.