### PR TITLE
Bonsai: batch geometry iterator setup when reimporting many representations

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2436,13 +2436,11 @@ class ActivateModel(bpy.types.Operator):
             return refined_elements
 
         refined_elements = refine_elements(elements)
-        for _, (model, obj) in refined_elements.items():
-            bonsai.core.geometry.switch_representation(
-                tool.Ifc,
-                tool.Geometry,
-                obj=obj,
-                representation=model,
-            )
+        bonsai.core.geometry.switch_representations(
+            tool.Ifc,
+            tool.Geometry,
+            items=[(obj, model, True) for _, (model, obj) in refined_elements.items()],
+        )
 
         tool.Blender.reset_object_visibility()
         tool.Drawing.hide_all_drawing_collections()

--- a/src/bonsai/bonsai/core/geometry.py
+++ b/src/bonsai/bonsai/core/geometry.py
@@ -129,6 +129,28 @@ def switch_representation(
     geometry.reimport_element_representations(obj, representation, apply_openings=apply_openings)
 
 
+def switch_representations(
+    ifc: type[tool.Ifc],
+    geometry: type[tool.Geometry],
+    items: list[tuple[bpy.types.Object, ifcopenshell.entity_instance, bool]],
+) -> None:
+    """Switch representations for multiple objects in a single batched geometry pass.
+
+    Equivalent to calling switch_representation for each (obj, representation, apply_openings)
+    item, but the underlying reimport is batched so representations that share a context and
+    apply_openings setting only pay for one geometry iterator between them. See #5696.
+    """
+    pending: list[tuple[bpy.types.Object, ifcopenshell.entity_instance, bool]] = []
+    for obj, representation, apply_openings in items:
+        if not geometry.get_object_data(obj) and geometry.is_text_literal(representation):
+            continue
+        element = ifc.get_entity(obj)
+        assert element
+        geometry.clear_cache(element)
+        pending.append((obj, representation, apply_openings))
+    geometry.reimport_element_representations_batch(pending)
+
+
 def get_representation_ifc_parameters(geometry: type[tool.Geometry], obj: bpy.types.Object) -> None:
     geometry.import_representation_parameters(geometry.get_object_data(obj))
 

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -477,12 +477,14 @@ class Geometry:
     def is_box_representation(cls, representation): pass
     def is_data_supported_for_adding_representation(cls, data): pass
     def is_mapped_representation(cls, representation): pass
+    def is_text_literal(cls, representation): pass
     def is_type_product(cls, element): pass
     def link(cls, element, obj): pass
     def record_object_materials(cls, obj): pass
     def record_object_position(cls, obj): pass
     def recreate_object_with_data(cls, obj, data): pass
     def reimport_element_representations(cls, obj, representation, apply_openings=True): pass
+    def reimport_element_representations_batch(cls, items): pass
     def remove_connection(cls, connection): pass
     def rename_object(cls, obj, name): pass
     def replace_object_data_globally(cls, old_data, new_data): pass

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2598,7 +2598,10 @@ class Drawing(bonsai.core.tool.Drawing):
         target_view = cls.get_drawing_target_view(drawing)
         subcontexts = cls.get_drawing_subcontexts(target_view)
 
-        # Switch representations
+        # Switch representations. Collected and applied in one batched call so
+        # elements sharing a context only pay for one geometry iterator between
+        # them, instead of one iterator per element. See #5696.
+        switch_items: list[tuple[bpy.types.Object, ifcopenshell.entity_instance, bool]] = []
         for element in filtered_elements:
             obj = tool.Ifc.get_object(element)
             if not obj:
@@ -2616,13 +2619,10 @@ class Drawing(bonsai.core.tool.Drawing):
                     break
                 priority_representation = ifcopenshell.util.representation.get_representation(element, *subcontext)
                 if priority_representation:
-                    bonsai.core.geometry.switch_representation(
-                        tool.Ifc,
-                        tool.Geometry,
-                        obj=obj,
-                        representation=priority_representation,
-                    )
+                    switch_items.append((obj, priority_representation, True))
                     break
+
+        bonsai.core.geometry.switch_representations(tool.Ifc, tool.Geometry, items=switch_items)
 
         linked_handles: set[bpy.types.Object] = set()
         for link in tool.Project.get_project_props().get_loaded_links_for_drawings():

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1074,21 +1074,24 @@ class Geometry(bonsai.core.tool.Geometry):
     def reimport_element_representations(
         cls, obj: bpy.types.Object, representation: ifcopenshell.entity_instance, apply_openings: bool = True
     ) -> None:
-        element = tool.Ifc.get_entity(obj)
-        assert element
+        cls.reimport_element_representations_batch([(obj, representation, apply_openings)])
+
+    @classmethod
+    def reimport_element_representations_batch(
+        cls, items: list[tuple[bpy.types.Object, ifcopenshell.entity_instance, bool]]
+    ) -> None:
+        """Reimport geometry for multiple (obj, representation, apply_openings) requests at once.
+
+        Behaves like calling reimport_element_representations for each item, except that
+        items sharing the same context and apply_openings end up on a single geometry
+        iterator instead of one iterator each. Iterator setup is a large fixed cost paid
+        per call regardless of how much it covers, so batching turns N iterators into one
+        per distinct (context, apply_openings) pair. See #5696.
+        """
+        if not items:
+            return
 
         ifc_file = tool.Ifc.get()
-        elements: set[ifcopenshell.entity_instance] = set()
-        element_types: set[ifcopenshell.entity_instance] = set()
-        representation = ifcopenshell.util.representation.resolve_representation(representation)
-        context = representation.ContextOfItems
-        for mapped_element in ifcopenshell.util.element.get_elements_by_representation(tool.Ifc.get(), representation):
-            if mapped_element.is_a("IfcTypeProduct"):
-                element_types.add(mapped_element)
-            else:
-                elements.add(mapped_element)
-                if element_type := ifcopenshell.util.element.get_type(mapped_element):
-                    element_types.add(element_type)
 
         def change_data(obj: bpy.types.Object, element: ifcopenshell.entity_instance, data: bpy.types.ID) -> None:
             old_data = obj.data
@@ -1102,149 +1105,193 @@ class Geometry(bonsai.core.tool.Geometry):
             cls.clear_modifiers(obj)
             cls.clear_cache(element)
 
-        # Import swept disk solids as Blender curves if possible.
-        elements_without_openings = {e for e in elements if not getattr(e, "HasOpenings", False)}
-        curve, curve_thickness = None, None
-        for element_ in elements_without_openings | element_types:
-            if not tool.Loader.is_native_swept_disk_solid(element, representation):
+        groups: dict[tuple[int, bool], dict[str, Any]] = {}
+
+        for obj, representation, apply_openings in items:
+            element = tool.Ifc.get_entity(obj)
+            assert element
+
+            elements: set[ifcopenshell.entity_instance] = set()
+            element_types: set[ifcopenshell.entity_instance] = set()
+            representation = ifcopenshell.util.representation.resolve_representation(representation)
+            context = representation.ContextOfItems
+            for mapped_element in ifcopenshell.util.element.get_elements_by_representation(ifc_file, representation):
+                if mapped_element.is_a("IfcTypeProduct"):
+                    element_types.add(mapped_element)
+                else:
+                    elements.add(mapped_element)
+                    if element_type := ifcopenshell.util.element.get_type(mapped_element):
+                        element_types.add(element_type)
+
+            # Import swept disk solids as Blender curves if possible. This does not use
+            # the geometry iterator, so it is handled per item rather than batched.
+            elements_without_openings = {e for e in elements if not getattr(e, "HasOpenings", False)}
+            curve, curve_thickness = None, None
+            for element_ in elements_without_openings | element_types:
+                if not tool.Loader.is_native_swept_disk_solid(element, representation):
+                    continue
+                if curve is None:
+                    mesh_name = tool.Loader.get_mesh_name(representation)
+                    native_data = {
+                        "representation": representation,
+                        # TODO: calculate mapped item matrix.
+                        "matrix": np.eye(4),
+                    }
+                    curve, curve_thickness = tool.Loader.create_native_swept_disk_solid(element, mesh_name, native_data)
+                    tool.Ifc.link(representation, curve)
+                curve_obj = tool.Ifc.get_object(element)
+                change_data(curve_obj, element, curve)
+                tool.Loader.setup_native_swept_disk_solid_thickness(curve_obj, curve_thickness)
+                elements.discard(element_)
+                element_types.discard(element_)
+
+            if not elements and not element_types:
                 continue
-            if curve is None:
-                mesh_name = tool.Loader.get_mesh_name(representation)
-                native_data = {
-                    "representation": representation,
-                    # TODO: calculate mapped item matrix.
-                    "matrix": np.eye(4),
+
+            # Fallback to custom methods as IOS doesn't process points, see #5218.
+            representation_type = representation.RepresentationType
+            if representation_type in ("PointCloud", "Point", "Vertex"):
+                if representation_type == "Vertex":
+                    mesh = tool.Loader.create_structural_point_connection_mesh(representation)
+                else:
+                    mesh = tool.Loader.create_point_cloud_mesh(representation)
+
+                if mesh is None:
+                    raise Exception(f"Failed to process representation with custom method: {representation}.")
+
+                tool.Ifc.link(representation, mesh)
+                for point_element in elements | element_types:
+                    point_obj = tool.Ifc.get_object(point_element)
+                    change_data(point_obj, point_element, mesh)
+                continue
+
+            key = (context.id(), apply_openings)
+            group = groups.get(key)
+            if group is None:
+                group = groups[key] = {
+                    "context": context,
+                    "elements": set(),
+                    "element_types": set(),
+                    "targets": {},
                 }
-                curve, curve_thickness = tool.Loader.create_native_swept_disk_solid(element, mesh_name, native_data)
-                tool.Ifc.link(representation, curve)
-            obj = tool.Ifc.get_object(element)
-            change_data(obj, element, curve)
-            tool.Loader.setup_native_swept_disk_solid_thickness(obj, curve_thickness)
-            elements.discard(element_)
-            element_types.discard(element_)
+            group["elements"] |= elements
+            group["element_types"] |= element_types
+            for element_ in elements:
+                group["targets"][element_] = representation
 
-        if not elements and not element_types:
-            return
-
-        # Fallback to custom methods as IOS doesn't process points, see #5218.
-        representation_type = representation.RepresentationType
-        if representation_type in ("PointCloud", "Point", "Vertex"):
-            if representation_type == "Vertex":
-                mesh = tool.Loader.create_structural_point_connection_mesh(representation)
-            else:
-                mesh = tool.Loader.create_point_cloud_mesh(representation)
-
-            if mesh is None:
-                raise Exception(f"Failed to process representation with custom method: {representation}.")
-
-            tool.Ifc.link(representation, mesh)
-            for element in elements | element_types:
-                obj = tool.Ifc.get_object(element)
-                change_data(obj, element, mesh)
+        if not groups:
             return
 
         logger = logging.getLogger("ImportIFC")
         ifc_import_settings = bonsai.bim.import_ifc.IfcImportSettings.factory(bpy.context, None, logger)
-        settings = ifcopenshell.geom.settings()
-        settings.set("weld-vertices", True)
-        settings.set("apply-default-materials", False)
-        settings.set("layerset-first", True)
-        settings.set("keep-bounding-boxes", True)
-        settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
-        settings.set("mesher-linear-deflection", ifc_import_settings.deflection_tolerance)
-        settings.set("mesher-angular-deflection", ifc_import_settings.angular_tolerance)
         geometry_library = ifc_import_settings.geometry_library
-
         ifc_importer = bonsai.bim.import_ifc.IfcImporter(ifc_import_settings)
-        ifc_importer.file = tool.Ifc.get()
+        ifc_importer.file = ifc_file
 
-        settings.set("context-ids", [context.id()])
-        if not apply_openings:
-            settings.set("disable-opening-subtractions", True)
+        for (context_id, apply_openings), group in groups.items():
+            context = group["context"]
+            elements = group["elements"]
+            element_types = group["element_types"]
+            targets = group["targets"]
 
-        shape = None
-        if elements:
-            iterator = ifcopenshell.geom.iterator(
-                settings,
-                tool.Ifc.get(),
-                multiprocessing.cpu_count(),
-                include=elements,
-                geometry_library=geometry_library,
-            )
-        else:
-            iterator = None  # For example, when switching representation of a type with no occurrences
-        meshes = {}
-        base_representation = representation
-        if iterator and iterator.initialize():
-            while True:
-                shape = iterator.get()
-                assert isinstance(shape, W.TriangulationElement)
-                element = tool.Ifc.get().by_id(shape.id)
-                if obj := tool.Ifc.get_object(element):
-                    # It's possible that there will be multiple shapes for the same context,
-                    # Unfortunately, iterator still processes them all and
-                    # we need to ensure we pick the one that was requested for reimport.
-                    representation_id = tool.Loader.get_representation_id_from_shape(shape.geometry)
-                    representation = ifc_file.by_id(representation_id)
-                    resolved_representation = ifcopenshell.util.representation.resolve_representation(representation)
-                    if resolved_representation != base_representation:
-                        if not iterator.next():
-                            break
-                        continue
+            settings = ifcopenshell.geom.settings()
+            settings.set("weld-vertices", True)
+            settings.set("apply-default-materials", False)
+            settings.set("layerset-first", True)
+            settings.set("keep-bounding-boxes", True)
+            settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
+            settings.set("mesher-linear-deflection", ifc_import_settings.deflection_tolerance)
+            settings.set("mesher-angular-deflection", ifc_import_settings.angular_tolerance)
+            settings.set("context-ids", [context_id])
+            if not apply_openings:
+                settings.set("disable-opening-subtractions", True)
 
-                    mesh_name = tool.Loader.get_mesh_name_from_shape(shape.geometry)
-                    mesh = meshes.get(mesh_name)
-                    if mesh is None:
-                        if element.is_a("IfcAnnotation") and element.ObjectType == "DRAWING":
-                            mesh = tool.Loader.create_camera(element, representation, shape)
-                        elif element.is_a("IfcAnnotation") and ifc_importer.is_curve_annotation(element):
-                            mesh = ifc_importer.create_curve(element, shape)
-                        elif shape:
-                            cartesian_point_offset = cls.get_cartesian_point_offset(obj)
-                            if cartesian_point_offset is None:
-                                cartesian_point_offset = False
-                            mesh = ifc_importer.create_mesh(
-                                element, shape, cartesian_point_offset=cartesian_point_offset
-                            )
-                            ifc_importer.material_creator.load_existing_materials()
-                            shape_has_openings = cls.does_shape_has_openings(shape)
-                            ifc_importer.material_creator.create(element, obj, mesh, shape_has_openings)
-                            mprops = tool.Geometry.get_mesh_props(mesh)
-                            mprops.has_openings_applied = apply_openings
-                            if not shape_has_openings:
-                                tool.Loader.load_indexed_colour_map(representation, mesh)
-                        tool.Loader.link_mesh(shape, mesh)
-                        meshes[mesh_name] = mesh
+            if elements:
+                iterator = ifcopenshell.geom.iterator(
+                    settings,
+                    ifc_file,
+                    multiprocessing.cpu_count(),
+                    include=elements,
+                    geometry_library=geometry_library,
+                )
+            else:
+                iterator = None  # For example, when switching representation of a type with no occurrences
+            meshes: dict[str, Any] = {}
+            if iterator and iterator.initialize():
+                while True:
+                    shape = iterator.get()
+                    assert isinstance(shape, W.TriangulationElement)
+                    element = ifc_file.by_id(shape.id)
+                    if obj := tool.Ifc.get_object(element):
+                        # It's possible that there will be multiple shapes for the same context,
+                        # Unfortunately, iterator still processes them all and
+                        # we need to ensure we pick the one that was requested for reimport.
+                        representation_id = tool.Loader.get_representation_id_from_shape(shape.geometry)
+                        shape_representation = ifc_file.by_id(representation_id)
+                        resolved_representation = ifcopenshell.util.representation.resolve_representation(
+                            shape_representation
+                        )
+                        base_representation = targets.get(element)
+                        if base_representation is None or resolved_representation != base_representation:
+                            if not iterator.next():
+                                break
+                            continue
 
-                    change_data(obj, element, mesh)
+                        mesh_name = tool.Loader.get_mesh_name_from_shape(shape.geometry)
+                        mesh = meshes.get(mesh_name)
+                        if mesh is None:
+                            if element.is_a("IfcAnnotation") and element.ObjectType == "DRAWING":
+                                mesh = tool.Loader.create_camera(element, shape_representation, shape)
+                            elif element.is_a("IfcAnnotation") and ifc_importer.is_curve_annotation(element):
+                                mesh = ifc_importer.create_curve(element, shape)
+                            elif shape:
+                                cartesian_point_offset = cls.get_cartesian_point_offset(obj)
+                                if cartesian_point_offset is None:
+                                    cartesian_point_offset = False
+                                mesh = ifc_importer.create_mesh(
+                                    element, shape, cartesian_point_offset=cartesian_point_offset
+                                )
+                                ifc_importer.material_creator.load_existing_materials()
+                                shape_has_openings = cls.does_shape_has_openings(shape)
+                                ifc_importer.material_creator.create(element, obj, mesh, shape_has_openings)
+                                mprops = tool.Geometry.get_mesh_props(mesh)
+                                mprops.has_openings_applied = apply_openings
+                                if not shape_has_openings:
+                                    tool.Loader.load_indexed_colour_map(shape_representation, mesh)
+                            tool.Loader.link_mesh(shape, mesh)
+                            meshes[mesh_name] = mesh
 
-                if not iterator.next():
-                    break
+                        change_data(obj, element, mesh)
 
-        for element in element_types:
-            if obj := tool.Ifc.get_object(element):
-                if representation := ifcopenshell.util.representation.get_representation(element, context):
-                    geometry = ifcopenshell.geom.create_shape(
-                        settings, representation, geometry_library=geometry_library
-                    )
-                    mesh_name = tool.Loader.get_mesh_name_from_shape(geometry)
-                    mesh = meshes.get(mesh_name)
-                    if mesh is None:
-                        # Duplicate code
-                        representation = tool.Ifc.get().by_id(int(geometry.id.split("-")[0]))
-                        if geometry:
-                            mesh = ifc_importer.create_mesh(element, geometry)
-                            tool.Loader.link_mesh(geometry, mesh)
-                            ifc_importer.material_creator.load_existing_materials()
-                            shape_has_openings = False
-                            ifc_importer.material_creator.create(element, obj, mesh, shape_has_openings)
-                            mprops = tool.Geometry.get_mesh_props(mesh)
-                            mprops.has_openings_applied = apply_openings
-                            if not shape_has_openings:
-                                tool.Loader.load_indexed_colour_map(representation, mesh)
-                        meshes[mesh_name] = mesh
+                    if not iterator.next():
+                        break
 
-                    change_data(obj, element, mesh)
+            for type_element in element_types:
+                if obj := tool.Ifc.get_object(type_element):
+                    if type_representation := ifcopenshell.util.representation.get_representation(
+                        type_element, context
+                    ):
+                        geometry = ifcopenshell.geom.create_shape(
+                            settings, type_representation, geometry_library=geometry_library
+                        )
+                        mesh_name = tool.Loader.get_mesh_name_from_shape(geometry)
+                        mesh = meshes.get(mesh_name)
+                        if mesh is None:
+                            # Duplicate code
+                            type_representation = ifc_file.by_id(int(geometry.id.split("-")[0]))
+                            if geometry:
+                                mesh = ifc_importer.create_mesh(type_element, geometry)
+                                tool.Loader.link_mesh(geometry, mesh)
+                                ifc_importer.material_creator.load_existing_materials()
+                                shape_has_openings = False
+                                ifc_importer.material_creator.create(type_element, obj, mesh, shape_has_openings)
+                                mprops = tool.Geometry.get_mesh_props(mesh)
+                                mprops.has_openings_applied = apply_openings
+                                if not shape_has_openings:
+                                    tool.Loader.load_indexed_colour_map(type_representation, mesh)
+                            meshes[mesh_name] = mesh
+
+                        change_data(obj, type_element, mesh)
 
     @classmethod
     def does_shape_has_openings(

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1487,6 +1487,14 @@ class Geometry(bonsai.core.tool.Geometry):
 
     @classmethod
     def record_object_materials(cls, obj: bpy.types.Object) -> None:
+        # During reimport, material_creator.create() calls this before
+        # change_data() assigns the new mesh, so obj.data is still the object's
+        # prior data — which is None when switching a representation onto an
+        # object that is currently an empty. Nothing to checksum yet; the mesh
+        # is assigned immediately after. (Same ordering in the non-batch
+        # reimport_element_representations path.)
+        if obj.data is None:
+            return
         props = tool.Geometry.get_mesh_props(obj.data)
         props.material_checksum = cls.get_material_checksum(obj)
 

--- a/src/bonsai/test/core/test_geometry.py
+++ b/src/bonsai/test/core/test_geometry.py
@@ -208,6 +208,41 @@ class TestSwitchRepresentation:
         )
 
 
+class TestSwitchRepresentations:
+    def test_batches_all_items_into_a_single_reimport_call(self, ifc, geometry):
+        # get_object_data returns truthy, so is_text_literal is short-circuited away,
+        # same as switch_representation's own guard.
+        geometry.get_object_data("obj1").should_be_called().will_return("data1")
+        ifc.get_entity("obj1").should_be_called().will_return("element1")
+        geometry.clear_cache("element1").should_be_called()
+
+        geometry.get_object_data("obj2").should_be_called().will_return("data2")
+        ifc.get_entity("obj2").should_be_called().will_return("element2")
+        geometry.clear_cache("element2").should_be_called()
+
+        geometry.reimport_element_representations_batch(
+            [("obj1", "rep1", True), ("obj2", "rep2", False)]
+        ).should_be_called()
+
+        subject.switch_representations(
+            ifc,
+            geometry,
+            items=[("obj1", "rep1", True), ("obj2", "rep2", False)],
+        )
+
+    def test_skips_text_literals_without_object_data(self, ifc, geometry):
+        geometry.get_object_data("obj1").should_be_called().will_return(None)
+        geometry.is_text_literal("rep1").should_be_called().will_return(True)
+
+        geometry.reimport_element_representations_batch([]).should_be_called()
+
+        subject.switch_representations(
+            ifc,
+            geometry,
+            items=[("obj1", "rep1", True)],
+        )
+
+
 class TestGetRepresentationIfcParameters:
     def test_run(self, geometry):
         geometry.get_object_data("obj").should_be_called().will_return("data")


### PR DESCRIPTION
Fixes #5696

## Problem

`ActivateModel.execute` (switching back to the model view) calls `switch_representation` once for every representation that needs reimporting, and `tool.Geometry.reimport_element_representations` builds a fresh `ifcopenshell.geom.iterator` on every call. `iterator.initialize()` pays a large fixed setup cost over the whole file regardless of how many elements it actually covers, so N representations paid that setup cost N times.

@sboddy's profiling on Highland Haven pinned this precisely: 87 iterator constructions accounted for 26.1 of the model's 38 second reimport, and a quick hack that limited iterator calls got roughly a 10x speedup. @theoryshaw reported the issue and supplied both benchmark models.

## Fix

Added `reimport_element_representations_batch`, which groups the requested representations by `(context, apply_openings)` (elements needing different settings genuinely can't share an iterator) and runs one geometry iterator per group instead of one per representation. Shapes are dispatched back to the representation that requested them the same way the existing single-representation code already tolerates shapes it didn't ask for, just generalized from one target representation to a mapping.

`reimport_element_representations` (the single-item entry point used by `parametric_lifecycle.py`, `misc/operator.py`, `type/operator.py`, `drawing/workspace.py`, and elsewhere) now just calls the batch function with a list of one, so those callers are unaffected. Only `ActivateModel.execute`, the loop that was actually constructing many iterators back to back, is switched to the new batched entry point via `switch_representations`.

Related to #4481 per @Moult's note that the two share code (drawing switch speed). This PR only touches the iterator-per-representation path; it does not touch the visibility/hide_view_set work discussed there.

## Measurements

Instrumented `ifcopenshell.geom.iterator` construction and `initialize()` calls directly (not through the full `bim.activate_model` operator, which needs an elaborate drawing setup to time meaningfully). Reimported 80 body representations picked from each model.

Highland Haven (32MB, IFC4, 11028 IfcProducts):
| | iterators | total initialize() |
|---|---|---|
| before | 80 | 15.8s |
| after | 1 | 0.18s |

Verona 3 Season Porch (15MB):
| | iterators | total initialize() |
|---|---|---|
| before | 80 | 3.2s |
| after | 1 | 0.04s |

Separately, measured through the actual operator on Highland Haven: `bim.activate_model` 9.35s to 1.58s, iterator construction 37 to 1, `initialize()` 8.03s to 0.24s.

## Correctness

For both models, captured per-object mesh vertex counts and bounding boxes for all 80 reimported objects, comparing the unpatched code against the batched code. All 80/80 objects matched bit-for-bit on both models (zero mismatches).

## Tests

`pytest -p no:pytest-blender test/core`: 390 passing before, 392 passing after (added `TestSwitchRepresentations` covering the new batched core function; also filled in a pre-existing gap where `is_text_literal` was implemented but missing from the `Geometry` core interface declaration, needed for the mock to work).

## Drawing activation (added)

@theoryshaw tested this PR against his own report and saw no improvement, because activating a drawing goes through `Drawing.activate_drawing`, a separate operator this PR did not originally touch: it also called `switch_representation` once per element.

Extended the same batching to that path. Measured on Highland Haven, activating drawing "FLOOR PLAN - 1ST - 4 UNITS": iterator count 17 to 10, `initialize()` 0.43s to 0.24s. Correctness verified: 7514/7514 objects identical on vertex count, bounding box and active representation id versus the unbatched code.

Honest framing: this is a real but small fix, on the order of 2% of the roughly 9-10 second wall clock for that action in this environment. Profiling showed the actual bottleneck for drawing activation is `ifcopenshell.util.selector.filter_elements` and `ifcopenshell.util.element.get_psets` evaluating the drawing's Include/Exclude psets, which this PR does not touch. That is addressed separately.

## AI disclosure

This PR was generated with the assistance of an AI coding tool, per AGENTS.md. See the commit message for the same note.
