### PR TITLE
Bonsai: keep auto-generated drawing reference annotations within camera bounds

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/helper.py
+++ b/src/bonsai/bonsai/bim/module/drawing/helper.py
@@ -494,15 +494,17 @@ def parse_diagram_scale(camera: bpy.types.Camera) -> float:
     return float(numerator) / float(denominator)
 
 
-def ortho_view_frame(
-    camera: bpy.types.Camera, margin: float = 0.015
-) -> tuple[float, float, float, float, float, float]:
-    """Calculates 2d bounding box of camera view area.
+def ortho_view_frame(camera: bpy.types.Camera, margin: float = 20.0) -> tuple[float, float, float, float, float, float]:
+    """Calculates 2d bounding box of camera view area, inset to leave room for
+    auto-generated reference annotations (section/elevation/grid tags, storey
+    level marks) drawn at its edges.
 
     Similar to `bpy.types.Camera.view_frame`
 
     :param camera: camera of drawing
-    :param margin: margins, in scene units
+    :param margin: margin to reserve on the printed drawing, in mm, converted
+        to world space using the drawing scale (a fixed paper-space size needs
+        more world space to be left clear the smaller the drawing scale is).
     :return: (xmin, xmax, ymin, ymax, zmin, zmax) in local camera coordinates
     """
     props = tool.Drawing.get_camera_props(camera)
@@ -511,8 +513,8 @@ def ortho_view_frame(
     hwidth = size * 0.5
     hheight = size * 0.5 * aspect
     scale = parse_diagram_scale(camera)
-    xmarg = margin * scale
-    ymarg = margin * scale * aspect
+    xmarg = min((margin / 1000) / scale, hwidth * 0.4)
+    ymarg = min(xmarg * aspect, hheight * 0.4)
     return (-hwidth + xmarg, hwidth - xmarg, -hheight + ymarg, hheight - ymarg, -camera.clip_start, -camera.clip_end)
 
 

--- a/src/bonsai/test/bim/module/drawing/test_helper.py
+++ b/src/bonsai/test/bim/module/drawing/test_helper.py
@@ -1,0 +1,70 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell
+import mathutils
+import pytest
+
+import bonsai.bim.module.drawing.helper as helper
+import bonsai.tool as tool
+from bonsai.tool.drawing import Drawing as subject
+from test.bim.bootstrap import NewFile
+
+
+class TestOrthoViewFrame(NewFile):
+    def make_camera(self, ortho_scale: float, diagram_scale: str = "1:100|1/100"):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        camera = subject.create_camera("Camera", mathutils.Matrix(), 0, "PLAN_VIEW")
+        camera.data.ortho_scale = ortho_scale
+        tool.Drawing.get_camera_props(camera.data).diagram_scale = diagram_scale
+        return camera
+
+    def test_it_reserves_a_fixed_paper_space_margin_regardless_of_drawing_scale(self):
+        camera = self.make_camera(ortho_scale=50.0, diagram_scale="1:100|1/100")
+
+        xmin, xmax, ymin, ymax = helper.ortho_view_frame(camera.data)[:4]
+
+        scale = helper.parse_diagram_scale(camera.data)
+        half_width = camera.data.ortho_scale / 2
+        margin_mm_on_paper = (half_width - xmax) * scale * 1000
+        assert margin_mm_on_paper == pytest.approx(20.0)
+        assert xmin == pytest.approx(-xmax)
+        assert ymin == pytest.approx(-ymax)
+
+    def test_the_paper_space_margin_is_the_same_at_a_smaller_drawing_scale(self):
+        # A fixed physical symbol size on paper needs more world space to be
+        # left clear the smaller the drawing scale is (e.g. 1:200 vs 1:100).
+        camera = self.make_camera(ortho_scale=100.0, diagram_scale="1:200|1/200")
+
+        xmin, xmax, ymin, ymax = helper.ortho_view_frame(camera.data)[:4]
+
+        scale = helper.parse_diagram_scale(camera.data)
+        half_width = camera.data.ortho_scale / 2
+        margin_mm_on_paper = (half_width - xmax) * scale * 1000
+        assert margin_mm_on_paper == pytest.approx(20.0)
+
+    def test_it_does_not_invert_the_bounds_for_a_camera_smaller_than_the_margin(self):
+        camera = self.make_camera(ortho_scale=0.001, diagram_scale="1:100|1/100")
+
+        xmin, xmax, ymin, ymax = helper.ortho_view_frame(camera.data)[:4]
+
+        assert xmin < xmax
+        assert ymin < ymax


### PR DESCRIPTION
Fixes #7497

Section/elevation reference markers and storey level tags that Bonsai auto-generates when syncing a drawing's references were placed with almost no margin from the camera's view bounds, so the fixed-size symbols drawn at their endpoints stuck out past the printable frame and were clipped in the rendered drawing, as reported by @manuvarkey. @maxfb87's workaround of manually grabbing and resizing the annotation still worked, but the goal here is for the default placement to already fit.

Root cause: `ortho_view_frame`'s margin was computed as `margin * scale`, which shrinks the world-space margin as the drawing scale gets smaller (larger denominator), the opposite of what's needed. A fixed physical symbol size on paper needs more world space reserved at smaller scales, not less. At a typical 1:100 scale this worked out to a fraction of a millimeter of clearance, effectively none.

The margin is now expressed in millimeters of the printed drawing (default 20mm) and converted to world space by dividing by the scale, with a clamp so it can never invert the bounds for a camera view smaller than the margin itself.

Verified live in headless Blender: for a default project (1:100 scale, 50m camera ortho_scale), the auto-generated storey level annotation's endpoint sat at 24.9998 world units from the camera center (0.0015mm of clearance from the 25.0 unit camera edge) before the fix, and at 23.0 world units (20mm of clearance) after.

## AI disclosure

This PR was generated with the assistance of an AI coding tool, as noted in the commit messages.