### PR TITLE
Bonsai: add a Circle Center snap point for round n-gon end caps

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -832,6 +832,13 @@ class PolylineDecorator(tool.Blender.ViewportDecorator):
         elif snap_prop.snap_type == "Face":
             draw_circle_2d(coords, decorator_color_object_active, padding)
             return
+        elif snap_prop.snap_type == "Circle Center":
+            p1 = (coords[0] - padding, coords[1])
+            p2 = (coords[0] + padding, coords[1])
+            p3 = (coords[0], coords[1] - padding)
+            p4 = (coords[0], coords[1] + padding)
+            verts = [p1, p2, p3, p4]
+            edges = [[0, 1], [2, 3]]
         else:
             return
 

--- a/src/bonsai/bonsai/bim/prop.py
+++ b/src/bonsai/bonsai/bim/prop.py
@@ -834,6 +834,7 @@ class BIMSnapProperties(PropertyGroup):
     edge_center: BoolProperty(name="Edge Center", default=True)
     edge_intersection: BoolProperty(name="Edge Intersection", default=True)
     face: BoolProperty(name="Face", default=True)
+    circle_center: BoolProperty(name="Circle Center", default=True)
 
     if TYPE_CHECKING:
         vertex: bool
@@ -841,3 +842,4 @@ class BIMSnapProperties(PropertyGroup):
         edge_center: bool
         edge_intersection: bool
         face: bool
+        circle_center: bool

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -2064,6 +2064,7 @@ class BIM_PT_snappping(Panel):
         col.prop(prop, "edge_center", toggle=True, icon="SNAP_MIDPOINT")
         col.prop(prop, "edge_intersection", toggle=True, icon="SNAP_GRID")
         col.prop(prop, "face", toggle=True, icon="SNAP_FACE")
+        col.prop(prop, "circle_center", toggle=True, icon="MESH_CIRCLE")
         groups = tool.Snap.get_snap_groups()
         row = layout.row(align=True)
         row.label(text="Bonsai Target Selection")

--- a/src/bonsai/bonsai/tool/raycast.py
+++ b/src/bonsai/bonsai/tool/raycast.py
@@ -435,6 +435,21 @@ class Raycast(bonsai.core.tool.Raycast):
                 }
                 points.append(snap_point)
 
+        # Check round n-gon face centres (e.g. pipe/cable ends) for proximity to mouse position.
+        for center in snap_obj.circle_centers:
+            v2d = view3d_utils.location_3d_to_region_2d(region, rv3d, center)
+            if v2d is None:
+                continue
+            distance = (Vector(mouse_pos) - v2d).length
+            if distance <= snap_threshold:
+                snap_point = {
+                    "object": snap_obj.obj,
+                    "type": "Circle Center",
+                    "point": center.copy(),
+                    "distance": distance / 10,
+                }
+                points.append(snap_point)
+
         count = 0
         selected_edges = {}
         for e in edges:
@@ -1021,6 +1036,28 @@ class SnapObj:
         self._bvh_built = False
         self.verts_3d = [obj.matrix_world @ v.co for v in obj.data.vertices]
         self.snap_points = []
+        self.circle_centers = self._find_circle_centers()
+
+    def _find_circle_centers(self) -> list[Vector]:
+        """Find the centre of round n-gon faces, to offer as a derived snap point."""
+        centers = []
+        min_vertices = 8
+        tolerance = 0.02
+        for polygon in self.obj.data.polygons:
+            verts = polygon.vertices
+            n = len(verts)
+            if n < min_vertices:
+                continue
+            coords = [self.verts_3d[i] for i in verts]
+            centroid = sum(coords, Vector()) / n
+            radii = [(co - centroid).length for co in coords]
+            mean_radius = sum(radii) / n
+            if mean_radius < 1e-6:
+                continue
+            max_deviation = max(abs(r - mean_radius) for r in radii)
+            if max_deviation / mean_radius <= tolerance:
+                centers.append(centroid)
+        return centers
 
     def _ensure_bvh(self):
         if self._bvh_built:

--- a/src/bonsai/bonsai/tool/snap.py
+++ b/src/bonsai/bonsai/tool/snap.py
@@ -574,6 +574,8 @@ class Snap(bonsai.core.tool.Snap):
                 zoom_factor = rv3d.view_distance
                 if snap["type"] == "Vertex":
                     snap["distance"] *= zoom_factor / 10
+                if snap["type"] == "Circle Center":
+                    snap["distance"] *= zoom_factor / 10
                 if snap["type"] == "Edge Center":
                     snap["distance"] *= zoom_factor / 8
                 if snap["type"] == "Edge Intersection":

--- a/src/bonsai/test/tool/test_raycast.py
+++ b/src/bonsai/test/tool/test_raycast.py
@@ -1,0 +1,85 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import math
+
+import bpy
+
+from bonsai.tool.raycast import SnapObj
+from test.bim.bootstrap import NewFile
+
+
+def make_disk_object(name: str, n: int, radius: float, center=(0.0, 0.0, 0.0)) -> bpy.types.Object:
+    """Build a mesh with a single n-gon face, like a tessellated circular end cap."""
+    cx, cy, cz = center
+    verts = [
+        (cx + radius * math.cos(2 * math.pi * i / n), cy + radius * math.sin(2 * math.pi * i / n), cz) for i in range(n)
+    ]
+    mesh = bpy.data.meshes.new(name)
+    mesh.from_pydata(verts, [], [tuple(range(n))])
+    mesh.update()
+    return bpy.data.objects.new(name, mesh)
+
+
+class TestFindCircleCenters(NewFile):
+    def test_finds_the_centre_of_a_round_ngon_cap(self):
+        obj = make_disk_object("Cap", n=16, radius=0.5, center=(1.0, 2.0, 3.0))
+        snap_obj = SnapObj(obj)
+        assert len(snap_obj.circle_centers) == 1
+        center = snap_obj.circle_centers[0]
+        assert abs(center.x - 1.0) < 1e-6
+        assert abs(center.y - 2.0) < 1e-6
+        assert abs(center.z - 3.0) < 1e-6
+
+    def test_ignores_triangles_and_quads(self):
+        # Small n-gons (n < 8) are never round profile caps in practice, so they
+        # should not be treated as circle centres, avoiding false positives on
+        # every ordinary triangle/quad face in a mesh.
+        obj = make_disk_object("Quad", n=4, radius=0.5)
+        snap_obj = SnapObj(obj)
+        assert snap_obj.circle_centers == []
+
+    def test_ignores_irregular_non_round_ngon(self):
+        mesh = bpy.data.meshes.new("Irregular")
+        verts = [
+            (0.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0),
+            (1.0, 1.0, 0.0),
+            (0.6, 3.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (-2.0, 0.5, 0.0),
+            (-0.5, -1.0, 0.0),
+            (0.2, -0.3, 0.0),
+        ]
+        mesh.from_pydata(verts, [], [tuple(range(len(verts)))])
+        mesh.update()
+        obj = bpy.data.objects.new("Irregular", mesh)
+        snap_obj = SnapObj(obj)
+        assert snap_obj.circle_centers == []
+
+    def test_finds_the_centre_of_a_regular_polygon_cap(self):
+        # A regular polygon (e.g. an IfcRegularPolygonProfileDef end cap) is also
+        # equidistant from its centroid, so it is expected to qualify too.
+        obj = make_disk_object("Octagon", n=8, radius=1.0)
+        snap_obj = SnapObj(obj)
+        assert len(snap_obj.circle_centers) == 1
+        center = snap_obj.circle_centers[0]
+        assert abs(center.x) < 1e-6
+        assert abs(center.y) < 1e-6


### PR DESCRIPTION
Fixes #6707

## Problem

@Walpa reported that meshes with circular ends, such as those from the cable and tube tools, have no vertex at the centre of the circle. Snapping to the centre means hunting for the right point on the perimeter, which is especially painful at small diameters.

## Root cause

Swept circular profiles (pipes, cables, round columns, piles, etc.) are tessellated as a single flat n-gon face at each end. This was confirmed live against a real `IfcPipeSegment` with a circular profile, tessellated through `ifcopenshell.geom`: the resulting cap is a 26-vertex n-gon with no centre vertex, matching the reported behaviour exactly.

## Why not add a vertex to the mesh

The mesh Bonsai authors for a circular profile element is the same mesh that drives quantities and IFC export, not a display-only proxy. Adding a real vertex to split the n-gon into a triangle fan would change the exported geometry's vertex/face counts for every existing circular-profile element, which is a bigger and riskier change than the problem calls for.

## Fix

Bonsai already has a typed snap point system (`tool/raycast.py`, `SnapObj`) with types like `Vertex`, `Edge Center`, `Edge Intersection`. This adds a new `Circle Center` type:

- `SnapObj` now scans an object's n-gon faces once (cached the same way as its existing vertex list) and flags faces whose vertices are all equidistant from their centroid, which covers both circular and regular-polygon caps.
- `ray_cast_by_proximity_2d` offers each detected centre as a snap point when the mouse is near it, using the same distance-weighting priority as `Vertex`.
- A `Circle Center` toggle was added next to the other snap type toggles in the Bonsai Snap Target panel, and a small crosshair indicator was added to the snap decorator so the centre snap is visually distinct from a face/vertex snap.

No IFC-derived geometry is touched. This is purely an additive UI affordance.

## Testing

- Live-verified in headless Blender: built a real `IfcPipeSegment` with an `IfcCircleProfileDef`, tessellated it through `ifcopenshell.geom.create_shape` (the same pipeline Bonsai's import uses), and confirmed the new detection finds the true centre of both caps precisely.
- Added `test/tool/test_raycast.py` covering: a round n-gon cap is detected precisely, small n-gons (triangles/quads) are ignored, an irregular non-round n-gon is ignored, and a regular polygon cap is also detected (expected, since it is equidistant from its centroid too).
- `test/tool` baseline before this change: 830 passed, 5 failed, 1 skipped. After this change: 834 passed (4 new), same 5 pre-existing failures, 1 skipped. The 5 failures are unrelated to this change (`test_project.py`, `test_qto.py`) and are reproducible on an unmodified checkout in this environment.
- `black` and `ruff` clean on all touched files.

This file was generated with the assistance of an AI coding tool.
