### PR TITLE
ifc5d: allow cost schedule Property column to list candidate quantity names

### DIFF
--- a/src/ifc5d/ifc5d/csv2ifc.py
+++ b/src/ifc5d/ifc5d/csv2ifc.py
@@ -451,12 +451,22 @@ class Csv2Ifc:
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
 
 
-def has_property(self, product: ifcopenshell.entity_instance, property_name: str) -> bool:
+def has_property(file: ifcopenshell.file, product: ifcopenshell.entity_instance, property_name: str) -> bool:
+    """Check if ``product`` has a quantity matching ``property_name``.
+
+    ``property_name`` may list several candidate quantity names separated by
+    a comma (the same "," OR convention used by ifcopenshell.util.selector),
+    so a single article can resolve the right quantity per element class,
+    e.g. "SOLIDWALL, COLUMN".
+    """
     if not property_name:
+        return True
+    candidates = {name.strip().lower() for name in property_name.split(",") if name.strip()}
+    if not candidates:
         return True
     qtos = ifcopenshell.util.element.get_psets(product, qtos_only=True)
     for qset, quantities in qtos.items():
-        for quantity, value in quantities.items():
-            if quantity == property_name:
+        for quantity in quantities:
+            if quantity.lower() in candidates:
                 return True
     return False

--- a/src/ifc5d/test/test_csv2ifc.py
+++ b/src/ifc5d/test/test_csv2ifc.py
@@ -22,6 +22,7 @@ import tempfile
 from pathlib import Path
 
 import ifcopenshell
+import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
 import ifcopenshell.util.cost
@@ -147,6 +148,40 @@ class TestCsv2Ifc:
             # A parent/sum item gets the sum of its direct children's Total Cost.
             parent_row = next(row for row in worksheet.iter_rows(min_row=2) if row[0].value == "DB.1")
             assert parent_row[4].value.startswith("=SUM(")
+
+    def test_property_column_accepts_comma_separated_candidate_names(self):
+        # Regression test for #6616. A single article can cover elements of
+        # different classes even when their relevant quantity is stored
+        # under a different property name per class, e.g. IfcWall.SOLIDWALL
+        # and IfcColumn.COLUMN. The Query column already supports selecting
+        # both classes with a comma (an existing ifcopenshell.util.selector
+        # OR), so only the Property column needed to gain the same "," OR
+        # convention to resolve the right name per element.
+        ifc_file = self.setup_ifc_file()
+
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Wall")
+        wall_qto = ifcopenshell.api.pset.add_qto(ifc_file, product=wall, name="Qto_WallFormwork")
+        ifcopenshell.api.pset.edit_qto(ifc_file, qto=wall_qto, properties={"SOLIDWALL": 24.0})
+
+        column = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcColumn", name="Column")
+        column_qto = ifcopenshell.api.pset.add_qto(ifc_file, product=column, name="Qto_ColumnFormwork")
+        ifcopenshell.api.pset.edit_qto(ifc_file, qto=column_qto, properties={"COLUMN": 9.5})
+
+        csv_rows = [
+            ["Id", "Index", "Name", "Unit", "Value", "Property", "Query"],
+            ["1", "1", "Formwork - all verticals", "m2", "10", "SOLIDWALL, COLUMN", "IfcWall, IfcColumn"],
+        ]
+        with tempfile.TemporaryDirectory("w") as temp_dir:
+            csv_filepath = Path(temp_dir) / "article.csv"
+            with csv_filepath.open("w", newline="", encoding="utf-8") as csv_file:
+                csv.writer(csv_file).writerows(csv_rows)
+
+            ifc5d.csv2ifc.Csv2Ifc(str(csv_filepath), ifc_file).execute()
+
+        cost_item = ifc_file.by_type("IfcCostItem")[0]
+        names = sorted(q.Name for q in cost_item.CostQuantities)
+        assert names == ["COLUMN", "SOLIDWALL"]
+        assert ifcopenshell.util.cost.get_total_quantity(cost_item) == 33.5
 
 
 class TestSerialiseCostQuantities:

--- a/src/ifcopenshell-python/ifcopenshell/api/cost/assign_cost_item_quantity.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cost/assign_cost_item_quantity.py
@@ -63,7 +63,10 @@ def assign_cost_item_quantity(
     :param products: The IfcObjects to assign parametric quantities to
     :param prop_name: The name of the quantity. If this is not specified,
         then it is assumed that there is no calculated quantity, and the
-        number of objects are counted instead.
+        number of objects are counted instead. May list several candidate
+        names separated by a comma (e.g. "SOLIDWALL, COLUMN") so that
+        products of different classes, whose relevant quantity is stored
+        under a different name, can be resolved by the same call.
     :param formula: The string that contains the formula
     :param ifc_class: The quantity class of the calculated value if the formula is
         specified. Can be ['IfcQuantityCount', 'IfcQuantityNumber',
@@ -97,6 +100,15 @@ def assign_cost_item_quantity(
         # item.
         ifcopenshell.api.cost.assign_cost_item_quantity(model,
             cost_item=item, products=[slab], prop_name="NetVolume")
+
+        # If different classes of products store the relevant quantity under
+        # different names (e.g. a wall's formwork area is under "SOLIDWALL"
+        # while a column's is under "COLUMN"), list the candidate names
+        # separated by a comma. Each product resolves to whichever of these
+        # names is actually present on it, so one cost item can cover both
+        # classes instead of being duplicated per class.
+        ifcopenshell.api.cost.assign_cost_item_quantity(model,
+            cost_item=item, products=[wall, column], prop_name="SOLIDWALL, COLUMN")
 
         # Now let's use the formula in order to calculate the quantity value.
         # For example, let's say that a IfcWall has the reinfocement volume ratio
@@ -134,6 +146,7 @@ class Usecase:
     ):
         self.cost_item = cost_item
         self.prop_name = prop_name
+        self.prop_names = {name.strip().lower() for name in prop_name.split(",") if name.strip()}
         if self.prop_name or formula:
             self.quantities = set(cost_item.CostQuantities or [])
         for product in products:
@@ -185,7 +198,7 @@ class Usecase:
                 continue
 
             if self.prop_name:
-                if cost_item.CostQuantities and cost_item.CostQuantities[0].Name.lower() != self.prop_name.lower():
+                if cost_item.CostQuantities and cost_item.CostQuantities[0].Name.lower() not in self.prop_names:
                     continue
                 self.add_quantity_from_related_object(product)
         if self.prop_name or formula:
@@ -221,7 +234,7 @@ class Usecase:
         if not qto.is_a("IfcElementQuantity"):
             return
         for prop in qto.Quantities:
-            if prop.is_a("IfcPhysicalSimpleQuantity") and prop.Name.lower() == self.prop_name.lower():
+            if prop.is_a("IfcPhysicalSimpleQuantity") and prop.Name.lower() in self.prop_names:
                 self.quantities.add(prop)
 
     def update_cost_item_count(self):


### PR DESCRIPTION
Fixes #6616.

@DimitriosThe reported that a Cost Schedule article covering formwork for all vertical elements needs quantities from differently named properties depending on class, e.g. IfcWall stores it under `SOLIDWALL` and IfcColumn under `COLUMN`. Today that forces duplicating the article once per class.

The imported CSV's `Query` column already supports selecting multiple classes with a comma (`IfcWall, IfcColumn`), an existing OR convention from `ifcopenshell.util.selector`. The `Property` column had no equivalent, so it could only ever match one literal quantity name, defeating the point of a multi-class query.

The `Property` column now accepts a comma-separated list of candidate names, e.g. `SOLIDWALL, COLUMN`. Each matched element resolves to whichever candidate is actually present in its own quantity set. This reuses the same "," OR convention already used throughout the selector grammar rather than inventing a new syntax, and `ifcopenshell.api.cost.assign_cost_item_quantity`'s `prop_name` parameter gained the same comma-separated support so the resolution happens correctly within a single call (avoiding a name-mismatch guard that would otherwise reject a second name on the same cost item).

Single-name Property values keep working exactly as before.

Verified locally with a synthetic model (an IfcWall with `SOLIDWALL=24.0` and an IfcColumn with `COLUMN=9.5`, both matched by one article with `Query=IfcWall, IfcColumn` and `Property=SOLIDWALL, COLUMN`): the resulting cost item ends up with both quantities (`COLUMN=9.5`, `SOLIDWALL=24.0`) and a correct total of `33.5`.

`src/ifc5d/test/` baseline checked before and after against this v0.8.0 branch: 20 passed / 0 failed before (with the optional `odf`/`openpyxl` dependencies installed locally), 21 passed / 0 failed after (one new regression test, `test_property_column_accepts_comma_separated_candidate_names`). Without those optional dependencies there are 2 known pre-existing skips plus 1 pre-existing `TypeError` unrelated to this change, per the CI-green campaign notes.

This PR was generated with the assistance of an AI coding tool, reviewed and tested before submission, per this repository's AGENTS.md AI disclosure policy.

cc @DimitriosThe @steverugi