### PR TITLE
Bonsai: preserve quads/n-gons in the viewport after assigning an IFC class

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -344,6 +344,8 @@ class AssignClass(bpy.types.Operator, tool.Ifc.Operator):
                 bonsai.core.geometry.switch_representation(
                     tool.Ifc, tool.Geometry, obj=obj, representation=representation
                 )
+                # Restore the original quads/n-gons the reimport triangulated.
+                tool.Geometry.dissolve_triangulated_edges(obj)
             else:
 
                 def is_representation_supported() -> bool:


### PR DESCRIPTION
Fixes #6724

## Problem

Assigning an IFC class to an existing mesh (e.g. the default cube) triangulates every face in the Blender viewport, including planar quads and n-gons.

## Root cause

`bim.assign_class` builds the representation directly from the object's own mesh (preserving quads/n-gons as an `IfcPolygonalFaceSet`), then reimports that representation through the geometry kernel to refresh the Blender mesh. That kernel reimport always returns a triangulated shape, so the object's mesh gets rebuilt as triangles even though the IFC data it was just written from is untouched and still preserves the original faces.

## Fix

Bonsai already has `Geometry.dissolve_triangulated_edges`, which undoes exactly this kind of forced triangulation using the kernel's own true-edge markers (used elsewhere when entering representation item edit mode). This PR calls it after the reimport in `bim.assign_class`, so the object keeps its original topology. Genuinely non-planar faces, which the kernel must split into triangles for correct rendering, are left triangulated, since the dissolve only removes edges the kernel itself flagged as triangulation artifacts, not real face boundaries. The IFC representation itself is unaffected either way.

## Credit

Reported by @Mi-Pe. Their follow-up comments and screen capture corrected our initial diagnosis, which had looked at the representation writer (`should_triangulate_face`) instead of the actual cause, the viewport mesh rebuild after class assignment.

## Verification

Reproduced live in headless Blender before and after the fix:

Before:
```
BEFORE assign_class, Blender mesh polygons: {4: 6}
AFTER assign_class, Blender mesh polygons: {3: 12}
IFC IfcPolygonalFaceSet face vertex-count histogram: {4: 6}
Blender mesh preserves quads: False
IFC representation preserves quads: True
```

After:
```
BEFORE assign_class, Blender mesh polygons: {4: 6}
AFTER assign_class, Blender mesh polygons: {4: 6}
IFC IfcPolygonalFaceSet face vertex-count histogram: {4: 6}
Blender mesh preserves quads: True
IFC representation preserves quads: True
```

Also checked:
- A mesh with a pentagon n-gon plus quads keeps its exact original polygon counts after assignment.
- Entering representation item edit mode (`bim.import_representation_items`, the flow #5460 depends on) still works with no crash after assignment.
- A genuinely non-planar quad is still split into 2 triangles, both in the IFC representation and in the Blender mesh, since that split reflects real geometry and the kernel marks the diagonal as a true edge rather than a triangulation artifact.

## AI disclosure

This PR was written with the assistance of an AI coding tool (investigation, fix, and verification).