### PR TITLE
Bonsai: save pending style edits before switching editing sub-tab

### DIFF
--- a/src/bonsai/bonsai/bim/module/style/operator.py
+++ b/src/bonsai/bonsai/bim/module/style/operator.py
@@ -182,6 +182,9 @@ class EnableEditingStyle(bpy.types.Operator):
     style: bpy.props.IntProperty(default=0)
 
     def execute(self, context):
+        props = tool.Style.get_style_props()
+        if props.is_editing_style:
+            bpy.ops.bim.edit_surface_style()
         core.enable_editing_style(tool.Style, tool.Ifc.get().by_id(self.style))
         return {"FINISHED"}
 
@@ -936,6 +939,8 @@ class EnableEditingSurfaceStyle(bpy.types.Operator):
 
     def execute(self, context):
         props = tool.Style.get_style_props()
+        if props.is_editing_style:
+            bpy.ops.bim.edit_surface_style()
         style = tool.Ifc.get().by_id(self.style)
         style_elements = tool.Style.get_style_elements(style)
 


### PR DESCRIPTION
Fixes #7105

## Problem

After duplicating a style, clicking "Enable Editing Style" to rename it, then switching to the "Shade" (or Render/Texture/etc) sub-tab to edit its colour, the pending name edit is silently discarded. @Moult's workaround (double-click to rename in the list) avoids the loss but does not address the underlying reversion.

## Root cause

`bim.enable_editing_style` (the pencil icon, edits the base `IfcSurfaceStyle` attributes like Name) and `bim.enable_editing_surface_style` (the Shade/Render/Texture/Lighting/Refract/External buttons, edits the corresponding style element's own attributes) both write into the same shared UI state: `BIMStylesProperties.is_editing_style` / `is_editing_class` / `attributes`. Clicking one while the other has an uncommitted edit open just overwrites that shared state to start the new edit, without ever committing the edit that was in progress. Nothing else in the sequence saves it, so it's simply lost.

## Fix

Both operators now check for a pending edit on entry and, if one exists, commit it first by invoking the existing `bim.edit_surface_style` (the same operator already wired to the "Save" button, which already handles both the base `IfcSurfaceStyle` case and every style-element case) before switching to the newly requested tab. Explicitly clicking "Disable Editing Style" (Cancel) is untouched and still discards pending edits as it always has, since that's an intentional cancel rather than an implicit switch.

## Verification

Reproduced live in headless Blender before and after the fix, reading back the actual IFC attribute values (not just the UI):

Before (duplicate -> rename via Enable Editing Style -> switch to Shade):
```
IFC style.Name before switching tabs: 'OriginalStyle_copy'
switched to Shade tab, is_editing_class='IfcSurfaceStyleShading'
IFC style.Name AFTER switching tabs: 'OriginalStyle_copy'
Name edit persisted to IFC: False
```

After:
```
IFC style.Name before switching tabs: 'OriginalStyle_copy'
switched to Shade tab, is_editing_class='IfcSurfaceStyleShading'
IFC style.Name AFTER switching tabs: 'RenamedStyle'
Name edit persisted to IFC: True
```

Also checked the reverse direction (edit Shade colour, switch to the base attributes tab without saving: colour persists) and switching between two different styles mid-edit (the first style's pending edit is committed before the second opens, no crash).

## AI disclosure

This PR was written with the assistance of an AI coding tool (investigation, fix, and verification).