### PR TITLE
Bonsai: parse sheet CSS with a comment and string aware scanner

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/css_scope.py
+++ b/src/bonsai/bonsai/bim/module/drawing/css_scope.py
@@ -1,0 +1,146 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2020, 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""Scope raw CSS text from an embedded drawing SVG to a per drawing prefix.
+
+Deliberately dependency free (no bpy, no bonsai imports) so it stays unit
+testable without Blender. Handles comments, quoted strings and at-rule
+preludes correctly, unlike a plain character scan, so it does not need to
+assume the CSS has no braces outside of rule blocks.
+"""
+
+import re
+
+__all__ = ["replace_css_urls", "scope_css_rules"]
+
+
+def replace_css_urls(text: str, prefix: str) -> str:
+    """Rewrite `url(#marker)` references to `url(#prefix-marker)`.
+
+    `url(#marker.prefix)` does not work, so the prefix is joined with a dash.
+    """
+    return re.sub(r"url\(#([^)]+)\)", rf"url(#{prefix}-\1)", text)
+
+
+def _split_top_level(selector_list: str, separator: str) -> list[str]:
+    """Split on `separator`, ignoring occurrences nested inside parentheses,
+    brackets or quotes.
+
+    Needed for selectors like `:is(.a, .b)` where the comma is part of the
+    functional pseudo-class argument list, and for `[data-x='a,b']` where the
+    comma is part of an attribute value, neither being a selector separator.
+    """
+    parts = []
+    buffer = ""
+    depth = 0
+    quote = None
+    for char in selector_list:
+        if quote is not None:
+            buffer += char
+            if char == quote:
+                quote = None
+            continue
+        if char in "\"'":
+            quote = char
+            buffer += char
+            continue
+        if char in "([":
+            depth += 1
+        elif char in ")]":
+            depth = max(depth - 1, 0)
+        if char == separator and depth == 0:
+            parts.append(buffer)
+            buffer = ""
+        else:
+            buffer += char
+    parts.append(buffer)
+    return parts
+
+
+def scope_css_rules(style_data: str, prefix: str) -> str:
+    """Append `.prefix` to every selector of every top level CSS rule.
+
+    Comments and quoted strings are copied through untouched, so a brace
+    inside `content: "{"` or inside `/* like this { */` no longer desyncs
+    the brace counter and silently drops the scoping of the rules that
+    follow. At-rule preludes (`@media (...)`, `@font-face`, ...) are left
+    alone rather than being corrupted into `@media (...).prefix`, since they
+    are not selectors. Nested rules inside an at-rule block (e.g. inside
+    `@media`) are still not individually scoped, matching prior behaviour.
+    """
+    text = ""
+    depth = 0
+    i = 0
+    n = len(style_data)
+
+    while i < n:
+        char = style_data[i]
+
+        if style_data.startswith("/*", i):
+            end = style_data.find("*/", i + 2)
+            end = n if end == -1 else end + 2
+            text += style_data[i:end]
+            i = end
+            continue
+
+        if char in "\"'":
+            quote = char
+            j = i + 1
+            while j < n:
+                if style_data[j] == "\\":
+                    j += 2
+                    continue
+                if style_data[j] == quote:
+                    j += 1
+                    break
+                j += 1
+            text += style_data[i:j]
+            i = j
+            continue
+
+        if char == "{":
+            if depth == 0:
+                last_close = text.rfind("}")
+                head = text[: last_close + 1] if last_close != -1 else ""
+                prelude = text[last_close + 1 :] if last_close != -1 else text
+                if prelude.strip().startswith("@"):
+                    text = head + prelude
+                else:
+                    selectors = []
+                    for selector in _split_top_level(prelude, ","):
+                        selector = selector.strip()
+                        if selector:
+                            selectors.append(f"{selector}.{prefix}")
+                    text = head + ", ".join(selectors) + " "
+            depth += 1
+            text += char
+            i += 1
+            continue
+
+        if char == "}":
+            depth = max(depth - 1, 0)
+            text += char
+            i += 1
+            continue
+
+        text += char
+        i += 1
+
+    return replace_css_urls(text, prefix)

--- a/src/bonsai/bonsai/bim/module/drawing/sheeter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/sheeter.py
@@ -18,7 +18,6 @@
 
 import ntpath
 import os
-import re
 import shutil
 import urllib.parse
 import uuid
@@ -31,6 +30,7 @@ import pystache
 from mathutils import Vector
 
 import bonsai.tool as tool
+from bonsai.bim.module.drawing import css_scope
 
 VIEW_TITLE_OFFSET_Y = 5
 DRAWING_PADDING = 10
@@ -340,44 +340,7 @@ class SheetBuilder:
         assert style is not None
         style_data = style.text
         assert style_data is not None
-        text = ""
-        brackets_level = 0
-        selector_buffer = ""  # Buffer to accumulate selectors across lines
-
-        for l in style_data:
-            if l == "{":
-                if brackets_level == 0:
-                    # Get all accumulated selector text (may span multiple lines)
-                    # Find where the last rule ended (after last }) or start of text
-                    last_close = text.rfind("}")
-                    if last_close == -1:
-                        selector_text = text
-                        text = ""
-                    else:
-                        selector_text = text[last_close + 1 :]
-                        text = text[: last_close + 1]
-
-                    # Process all selectors (split by comma)
-                    css_selectors = []
-                    for css_selector in selector_text.split(","):
-                        css_selector = css_selector.strip()
-                        if css_selector:  # Only process non-empty selectors
-                            css_selector = f"{css_selector}.{prefix}"
-                            css_selectors.append(css_selector)
-
-                    text += ", ".join(css_selectors) + " "
-                brackets_level += 1
-            elif l == "}":
-                brackets_level -= 1
-            text += l
-
-        def replace_urls(text: str) -> str:
-            """replace urls `url(#marker)` with `url(#prefix-marker)`
-            since `url(#marker.prefix)` doesn't seem to work
-            """
-            return re.sub(r"url\(#([^\)]+)\)", rf"url(#{prefix}-\1)", text)
-
-        style.text = replace_urls(text)
+        style.text = css_scope.scope_css_rules(style_data, prefix)
 
         for svg_element in svg.findall(f".//*"):
             if svg_element.tag in (f"{SVG}style", f"{SVG}svg"):
@@ -391,9 +354,9 @@ class SheetBuilder:
                 attrib["class"] += f" {prefix}"
             if "filter" in attrib:
                 # example use "#fill-background" filter
-                attrib["filter"] = replace_urls(attrib["filter"])
+                attrib["filter"] = css_scope.replace_css_urls(attrib["filter"], prefix)
             if "style" in attrib:
-                attrib["style"] = replace_urls(attrib["style"])
+                attrib["style"] = css_scope.replace_css_urls(attrib["style"], prefix)
             if svg_element.tag == f"{SVG}use":
                 href_attrib = f"{XLINK}href"
                 if href_attrib in attrib:


### PR DESCRIPTION
Fixes #7312.

@sl-x75 reported that generating a sheet with third party pattern CSS (his example: a hatch pattern library) produced broken output, and proposed a fix to `ensure_drawing_unique_styles`. @Moult's reply was the actual ask:

> We need something along these lines, but is there a safer way to do it than assumptions in parsing CSS this way?

He is right to be suspicious. `ensure_drawing_unique_styles` scopes every CSS rule to its drawing by counting `{`/`}` characters one at a time over the raw CSS text. That breaks on:

- A brace inside a comment or a quoted string, e.g. `content: "{"`. The counter desyncs and every rule after it silently loses its scoping prefix, so it leaks unscoped across the whole sheet. Concretely, before this PR:
  ```
  IN : '.foo::before { content: "{"; }\n.bar { fill: blue; }'
  OUT: '.foo::before.d42 { content: "{"; }\n.bar { fill: blue; }'
  ```
  Note `.bar` never gets `.d42`.
- An `@media (...)` prelude gets a bogus `.prefix` suffix appended to it:
  ```
  IN : '@media (min-width: 600px) { .foo { fill: red; } }'
  OUT: '@media (min-width: 600px).d42 { .foo { fill: red; } }'
  ```
- A comma inside a functional pseudo-class splits the selector in the wrong place:
  ```
  IN : ':is(.a, .b) { fill: red; }'
  OUT: ':is(.a.d42, .b).d42 { fill: red; }'
  ```

This replaces the character-by-character brace counter with a small state machine (`src/bonsai/bonsai/bim/module/drawing/css_scope.py`) that treats `/* ... */` comments and quoted strings as opaque so braces inside them do not desync anything, leaves at-rule preludes alone instead of corrupting them, and only splits selector lists on commas that are outside of `()`/`[]`/quotes. After this change the three cases above become:
```
'.foo::before.d42 { content: "{"; }.bar.d42 { fill: blue; }'
'@media (min-width: 600px) { .foo { fill: red; } }'
':is(.a, .b).d42 { fill: red; }'
```
(Nested rules inside an `@media` block are still not individually scoped, matching the previous behaviour; this is not a new regression.)

For every currently working input I checked (multi-selector rules, multi-line rules, `nth-of-type`/attribute selectors, `url()` rewriting, and sl-x75's own sample CSS from the issue), the new output is byte for byte identical to the old output.

**On the dependency question**: I looked at using `tinycss2` (a real, small, pure-Python CSS parser, BSD-3-Clause, already a transitive dependency of `cssselect2`/`CairoSVG` elsewhere in the Python ecosystem but not currently something Bonsai bundles). It would fully close the remaining gap (scoping rules nested inside `@media`/`@supports`, full spec-correct tokenizing). I did not add it, since adding a dependency to Bonsai's bundled wheels (`src/bonsai/Makefile`) is a maintainer call. The comment/string/at-rule/paren-aware scanner above gets full correctness for the concrete cases reported and checked, without a new dependency, which seemed like the better default. @Moult, if you would rather depend on `tinycss2` for full spec coverage (including the `@media`-nesting gap), say so and I will swap this out for it.

The CSS-scoping logic is kept out of `sheeter.py` on purpose so it has no `bpy`/`bonsai` imports and can be exercised directly with plain `python3` without a Blender environment, which is how I verified the before/after outputs above.

Credit to @sl-x75 for identifying the real problem (styling from custom pattern SVGs colliding across a sheet) and proposing the first fix.

Generated with the assistance of an AI coding tool. The whole diff (`src/bonsai/bonsai/bim/module/drawing/css_scope.py` and the corresponding change to `sheeter.py`) is AI-generated.
