### PR TITLE
ifcopenshell.util: add a standalone orthogonal path calculator for MEP routing

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/mep.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/mep.py
@@ -1,0 +1,113 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""Geometry helpers for routing distribution elements (ducts, pipes, cables).
+
+This is deliberately standalone (no IFC reads, no authoring side effects) so
+it is easy to unit test and reuse from either a Bonsai operator or a script,
+per https://github.com/IfcOpenShell/IfcOpenShell/issues/6100.
+"""
+
+Point = tuple[float, float, float]
+
+_EPSILON = 1e-6
+_AXIS_NAMES = ("X", "Y", "Z")
+
+
+def _axis_and_sign(direction: Point) -> tuple[int, int]:
+    """Resolve a direction vector to a single axis index and its sign.
+
+    Only axis-aligned directions are supported, matching orthogonal routing
+    where a connection point only faces along +/-X, +/-Y or +/-Z.
+    """
+    nonzero = [i for i, v in enumerate(direction) if abs(v) > _EPSILON]
+    if len(nonzero) != 1:
+        raise ValueError(f"direction {direction!r} is not axis-aligned (expected exactly one non-zero component)")
+    axis = nonzero[0]
+    return axis, (1 if direction[axis] > 0 else -1)
+
+
+def calculate_orthogonal_path(
+    start: Point,
+    end: Point,
+    start_direction: Point | None = None,
+    end_direction: Point | None = None,
+) -> list[Point]:
+    """Calculate an axis-aligned (Manhattan) path between two points.
+
+    `start_direction` and `end_direction` are optional axis-aligned vectors
+    constraining which way the path must leave `start` and which way it must
+    be travelling when it arrives at `end`, e.g. the outward flow direction
+    of a duct or pipe connection port. When omitted, axes are traversed in
+    a fixed X, then Y, then Z order.
+
+    Returns the ordered list of waypoints, including `start` and `end`. Two
+    consecutive waypoints always share two of their three coordinates, so
+    consecutive segments are always axis-aligned. A coincident start and end
+    returns a single point. A `ValueError` is raised if a direction
+    constraint cannot be satisfied by a direct orthogonal path (for example,
+    it requires travel along an axis the two points already share, or
+    against the only available direction on that axis), since resolving that
+    needs a minimum run length that this function does not have.
+    """
+    delta = (end[0] - start[0], end[1] - start[1], end[2] - start[2])
+    active_axes = [i for i in range(3) if abs(delta[i]) > _EPSILON]
+
+    if not active_axes:
+        return [tuple(start)]
+
+    def _require_axis(direction: Point, role: str) -> int:
+        axis, sign = _axis_and_sign(direction)
+        if axis not in active_axes:
+            raise ValueError(
+                f"{role} direction is along {_AXIS_NAMES[axis]}, but start and end "
+                f"already share that coordinate, so it cannot be honoured without a detour"
+            )
+        if sign != (1 if delta[axis] > 0 else -1):
+            raise ValueError(
+                f"{role} direction points away from the target along {_AXIS_NAMES[axis]}, "
+                f"so it cannot be honoured without a detour"
+            )
+        return axis
+
+    first_axis = _require_axis(start_direction, "start") if start_direction is not None else None
+    last_axis = _require_axis(end_direction, "end") if end_direction is not None else None
+
+    if first_axis is not None and last_axis is not None and first_axis == last_axis and len(active_axes) > 1:
+        raise ValueError("start and end directions both resolve to the same axis, which is contradictory here")
+
+    order = [axis for axis in active_axes if axis not in (first_axis, last_axis)]
+    order.sort()
+    if last_axis is not None:
+        order = ([first_axis] if first_axis is not None else []) + order + [last_axis]
+    elif first_axis is not None:
+        order = [first_axis] + order
+    else:
+        order = list(active_axes)
+
+    path = [tuple(start)]
+    point = list(start)
+    for axis in order:
+        point[axis] = end[axis]
+        path.append(tuple(point))
+    # the last waypoint is `end` by construction, but rebuild it explicitly
+    # in case of floating point drift across the intermediate assignments.
+    path[-1] = tuple(end)
+    return path

--- a/src/ifcopenshell-python/test/util/test_mep.py
+++ b/src/ifcopenshell-python/test/util/test_mep.py
@@ -1,0 +1,114 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import pytest
+
+from ifcopenshell.util.mep import calculate_orthogonal_path
+
+
+def _segments_are_axis_aligned(path: list[tuple[float, float, float]]) -> bool:
+    for (x0, y0, z0), (x1, y1, z1) in zip(path, path[1:]):
+        differing = sum(1 for a, b in zip((x0, y0, z0), (x1, y1, z1)) if abs(a - b) > 1e-9)
+        if differing > 1:
+            return False
+    return True
+
+
+class TestCalculateOrthogonalPath:
+    def test_coincident_points_return_a_single_waypoint(self):
+        path = calculate_orthogonal_path((1.0, 2.0, 3.0), (1.0, 2.0, 3.0))
+        assert path == [(1.0, 2.0, 3.0)]
+
+    def test_same_axis_offset_is_a_direct_run_with_no_bends(self):
+        path = calculate_orthogonal_path((0.0, 0.0, 0.0), (5.0, 0.0, 0.0))
+        assert path == [(0.0, 0.0, 0.0), (5.0, 0.0, 0.0)]
+        assert _segments_are_axis_aligned(path)
+
+    def test_offset_on_two_axes_needs_exactly_one_bend(self):
+        path = calculate_orthogonal_path((0.0, 0.0, 0.0), (5.0, 3.0, 0.0))
+        assert len(path) == 3
+        assert path[0] == (0.0, 0.0, 0.0)
+        assert path[-1] == (5.0, 3.0, 0.0)
+        assert _segments_are_axis_aligned(path)
+
+    def test_offset_on_three_axes_needs_exactly_two_bends(self):
+        path = calculate_orthogonal_path((0.0, 0.0, 0.0), (5.0, 3.0, 2.0))
+        assert len(path) == 4
+        assert path[0] == (0.0, 0.0, 0.0)
+        assert path[-1] == (5.0, 3.0, 2.0)
+        assert _segments_are_axis_aligned(path)
+        # every coordinate is fixed to its final value one axis at a time
+        axes_fixed_at = set()
+        point = path[0]
+        for next_point in path[1:]:
+            changed = [i for i in range(3) if abs(point[i] - next_point[i]) > 1e-9]
+            assert len(changed) == 1
+            axes_fixed_at.add(changed[0])
+            point = next_point
+        assert axes_fixed_at == {0, 1, 2}
+
+    def test_start_direction_picks_which_axis_is_travelled_first(self):
+        # forcing the first leg along +Y instead of the default +X first.
+        path = calculate_orthogonal_path((0.0, 0.0, 0.0), (5.0, 3.0, 0.0), start_direction=(0.0, 1.0, 0.0))
+        assert path[1] == (0.0, 3.0, 0.0)
+        assert path[-1] == (5.0, 3.0, 0.0)
+
+    def test_end_direction_picks_which_axis_is_travelled_last(self):
+        path = calculate_orthogonal_path((0.0, 0.0, 0.0), (5.0, 3.0, 0.0), end_direction=(1.0, 0.0, 0.0))
+        assert path[1] == (0.0, 3.0, 0.0)
+        assert path[-1] == (5.0, 3.0, 0.0)
+
+    def test_start_and_end_direction_together_fix_the_whole_order(self):
+        path = calculate_orthogonal_path(
+            (0.0, 0.0, 0.0),
+            (5.0, 3.0, 2.0),
+            start_direction=(0.0, 0.0, 1.0),
+            end_direction=(1.0, 0.0, 0.0),
+        )
+        assert path[1] == (0.0, 0.0, 2.0)
+        assert path[2] == (0.0, 3.0, 2.0)
+        assert path[-1] == (5.0, 3.0, 2.0)
+
+    def test_negative_direction_matching_the_delta_sign_is_honoured(self):
+        path = calculate_orthogonal_path((5.0, 0.0, 0.0), (0.0, 3.0, 0.0), start_direction=(-1.0, 0.0, 0.0))
+        assert path[1] == (0.0, 0.0, 0.0)
+
+    def test_direction_along_a_shared_axis_is_rejected(self):
+        # start and end already agree on Z, so a Z-facing start direction
+        # cannot be honoured by a direct orthogonal path.
+        with pytest.raises(ValueError):
+            calculate_orthogonal_path((0.0, 0.0, 0.0), (5.0, 3.0, 0.0), start_direction=(0.0, 0.0, 1.0))
+
+    def test_direction_pointing_away_from_the_target_is_rejected(self):
+        with pytest.raises(ValueError):
+            calculate_orthogonal_path((0.0, 0.0, 0.0), (5.0, 3.0, 0.0), start_direction=(-1.0, 0.0, 0.0))
+
+    def test_non_axis_aligned_direction_is_rejected(self):
+        with pytest.raises(ValueError):
+            calculate_orthogonal_path((0.0, 0.0, 0.0), (5.0, 3.0, 0.0), start_direction=(1.0, 1.0, 0.0))
+
+    def test_contradictory_start_and_end_direction_on_the_same_axis_is_rejected(self):
+        with pytest.raises(ValueError):
+            calculate_orthogonal_path(
+                (0.0, 0.0, 0.0),
+                (5.0, 3.0, 2.0),
+                start_direction=(1.0, 0.0, 0.0),
+                end_direction=(1.0, 0.0, 0.0),
+            )


### PR DESCRIPTION
Fixes #6100.

@Isaina asked for automatic 3D orthogonal path generation between connection points for ducts and pipes. @Moult initially closed this as a duplicate of #2181, then reopened it with explicit scope:

> For now I'd say add a separate testing-only function to calculate the path, but not expend the effort to integrate it into the authoring tool just yet. But in the future it can be.

This PR is exactly that and nothing more: a standalone path calculation function with tests. It does not touch the MEP authoring tool, adds no UI, and is not wired into `bonsai/bim/module/model/mep.py`.

**What it does**: `calculate_orthogonal_path(start, end, start_direction=None, end_direction=None)` in `src/ifcopenshell-python/ifcopenshell/util/mep.py`. Given two 3D points, it returns the ordered waypoints of an axis-aligned (Manhattan) path between them:
- same axis: a direct 2-point run, 0 bends
- offset on two axes: one bend, 3 points
- offset on three axes: two bends, 4 points
- coincident points: a single point

`start_direction`/`end_direction` are optional axis-aligned vectors: the direction the path must leave `start` along, and the direction it must be travelling when it arrives at `end`. That is how a connection point's flow direction constrains the routing, which is the "read direction of the plane in connection point" case @Isaina raised. When a direction cannot be honoured by a direct orthogonal path (wrong axis relative to the two points, or the wrong sign), it raises `ValueError` rather than silently producing an invalid route; resolving that properly needs a minimum run length / stub distance, which is out of scope for this basic version.

**Placement**: `ifcopenshell.util` rather than a Bonsai tool module, because the function has no IFC reads, no `bpy` dependency and no authoring side effects; it is pure geometry. That keeps it reusable later from either a script or a future Bonsai operator, and it is unit testable on its own exactly like the rest of `ifcopenshell.util` (`test_shape_builder.py`, `test_placement.py`, etc.), which is what "separate testing-only function" calls for.

**Tests** (`src/ifcopenshell-python/test/util/test_mep.py`, 12 cases): same axis, offset requiring one bend, offset requiring two bends, coincident points, direction constraints picking the traversal order (start-only, end-only, both together), a negative-direction case, and the degenerate/rejection cases (direction along a shared axis, direction pointing away from the target, a non-axis-aligned direction, contradictory start/end directions on the same axis). All 12 pass:
```
test_mep.py::TestCalculateOrthogonalPath::test_coincident_points_return_a_single_waypoint PASSED
test_mep.py::TestCalculateOrthogonalPath::test_same_axis_offset_is_a_direct_run_with_no_bends PASSED
test_mep.py::TestCalculateOrthogonalPath::test_offset_on_two_axes_needs_exactly_one_bend PASSED
test_mep.py::TestCalculateOrthogonalPath::test_offset_on_three_axes_needs_exactly_two_bends PASSED
test_mep.py::TestCalculateOrthogonalPath::test_start_direction_picks_which_axis_is_travelled_first PASSED
test_mep.py::TestCalculateOrthogonalPath::test_end_direction_picks_which_axis_is_travelled_last PASSED
test_mep.py::TestCalculateOrthogonalPath::test_start_and_end_direction_together_fix_the_whole_order PASSED
test_mep.py::TestCalculateOrthogonalPath::test_negative_direction_matching_the_delta_sign_is_honoured PASSED
test_mep.py::TestCalculateOrthogonalPath::test_direction_along_a_shared_axis_is_rejected PASSED
test_mep.py::TestCalculateOrthogonalPath::test_direction_pointing_away_from_the_target_is_rejected PASSED
test_mep.py::TestCalculateOrthogonalPath::test_non_axis_aligned_direction_is_rejected PASSED
test_mep.py::TestCalculateOrthogonalPath::test_contradictory_start_and_end_direction_on_the_same_axis_is_rejected PASSED

12 passed in 2.50s
```

No authoring tool integration is included, per @Moult's scoping above; that is intentionally left for later.

Generated with the assistance of an AI coding tool. The whole diff is AI-generated.
