### PR TITLE
Bonsai: use consistent Length/Width stair terminology

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/prop.py
+++ b/src/bonsai/bonsai/bim/module/model/prop.py
@@ -556,12 +556,12 @@ class BIMStairProperties(PropertyGroup):
         name="Number of Treads", default=6, soft_min=1, min=0, update=update_number_of_treads
     )
     total_length_target: bpy.props.FloatProperty(
-        name="Total Length Target",
+        name="Total Length",
         default=3.0,
         min=0.01,
         subtype="DISTANCE",
         update=update_total_length_target,
-        description="Total Length Target, might not be exactly respected depending on the parameters",
+        description="Total Length target, might not be exactly respected depending on the parameters",
     )
     total_length_lock: bpy.props.BoolProperty(
         default=False,
@@ -572,7 +572,7 @@ class BIMStairProperties(PropertyGroup):
         name="Tread Depth", default=0.25, min=0.01, subtype="DISTANCE", update=update_stair
     )
     tread_run: bpy.props.FloatProperty(
-        name="Tread Run", default=0.3, min=0.01, subtype="DISTANCE", update=update_tread_run
+        name="Tread Length", default=0.3, min=0.01, subtype="DISTANCE", update=update_tread_run
     )
     base_slab_depth: bpy.props.FloatProperty(
         name="Base Slab Depth", default=0.25, min=0, subtype="DISTANCE", update=update_stair
@@ -588,14 +588,14 @@ class BIMStairProperties(PropertyGroup):
         update=validate_nosing_value,
     )
     custom_tread_lock: bpy.props.BoolProperty(
-        name="Lock First/Last Treads to Tread Run",
-        description="When enabled, first and last treads automatically use the Tread Run value",
+        name="Lock First/Last Treads to Tread Length",
+        description="When enabled, first and last treads automatically use the Tread Length value",
         default=True,
         update=update_custom_tread_lock,
     )
     custom_first_last_tread_run: bpy.props.FloatVectorProperty(
-        name="Custom First / Last Treads Widths",
-        description='Specify custom first / last treads widths, different from the general "Tread Run". Leave 0 to disable.',
+        name="Custom First / Last Tread Lengths",
+        description='Specify custom first / last tread lengths, different from the general "Tread Length". Leave 0 to disable.',
         default=(0, 0),
         min=0,
         unit="LENGTH",

--- a/src/bonsai/bonsai/bim/module/model/stair.py
+++ b/src/bonsai/bonsai/bim/module/model/stair.py
@@ -558,6 +558,7 @@ class GizmoStairEdition(bpy.types.GizmoGroup, gizmo.BaseParametricGizmoGroup):
         DimensionGizmoConfig(
             attr_name="tread_run",
             axis=(1, 0, 0),
+            prop_name="Tread Length",
             min_value=0.01,
             visibility_condition=lambda p: p.has_tread_run_gizmo(),
             matrix_position=lambda p: V_(


### PR DESCRIPTION
Fixes #7493

@SumDum reported that the stair panel uses Length, Run and Width for the same along-axis dimension (the direction along which one walks), while Width also means the perpendicular dimension. He researched ISO 6707-1:2020 sections 3.3.5.22-3.3.5.32 and proposed a consistent convention: Length for anything along the axis of travel, Width for the perpendicular dimension. This PR applies that convention.

Changes (all pure UI display strings, `bpy.props` `name=`/`description=` and one gizmo `prop_name` override):
- "Total Length Target" -> "Total Length" (now matches its own gizmo label, which already said "Total Length")
- "Tread Run" -> "Tread Length" (and its gizmo tooltip, which previously had no explicit override and auto-derived the stale "Tread Run" from the attribute name)
- "Lock First/Last Treads to Tread Run" -> "Lock First/Last Treads to Tread Length"
- "Custom First / Last Treads Widths" -> "Custom First / Last Tread Lengths" (this was the clearest bug: "Width" was used for an along-travel dimension, directly contradicting Width's use elsewhere for the perpendicular dimension)

"Width" and "Height" were already correct and are untouched.

Scope check: only display strings changed. The underlying Python attribute identifiers (`total_length_target`, `tread_run`, `custom_first_last_tread_run`, `custom_tread_lock`) are untouched, since those are the keys serialized into the `BBIM_Stair` custom property set's JSON blob in saved IFC files. Verified live in headless Blender: created a stair, saved to IFC, and confirmed the raw `BBIM_Stair` pset JSON keys are unchanged before and after this change. No IFC attribute, schema, or stored data is affected, only what's displayed in the UI.

This PR is AI-generated (Claude), reviewed and tested by me before submitting.