### PR TITLE
Bonsai: add Create Fill Area From Profile

### DIFF
--- a/src/bonsai/bonsai/bim/module/profile/__init__.py
+++ b/src/bonsai/bonsai/bim/module/profile/__init__.py
@@ -22,6 +22,7 @@ from . import data, operator, prop, ui
 
 classes = (
     operator.AddProfileDef,
+    operator.CreateFillAreaFromProfile,
     operator.DuplicateProfileDef,
     operator.DisableEditingArbitraryProfile,
     operator.DisableEditingProfile,

--- a/src/bonsai/bonsai/bim/module/profile/operator.py
+++ b/src/bonsai/bonsai/bim/module/profile/operator.py
@@ -23,6 +23,7 @@ import ifcopenshell.util.element
 
 import bonsai.bim.helper
 import bonsai.bim.module.model.profile as model_profile
+import bonsai.core.drawing as core_drawing
 import bonsai.tool as tool
 from bonsai.bim.module.geometry.helper import Helper
 from bonsai.bim.module.model.decorator import ProfileDecorator
@@ -225,6 +226,79 @@ class DuplicateProfileDef(bpy.types.Operator, tool.Ifc.Operator):
         profile = ifc_file.by_id(profile_item.ifc_definition_id)
         tool.Profile.duplicate_profile(profile)
         bpy.ops.bim.load_profiles()
+
+
+class CreateFillAreaFromProfile(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.create_fill_area_from_profile"
+    bl_label = "Create Fill Area From Profile"
+    bl_description = "Add a hatch fill area annotation to the active drawing, shaped like the active profile"
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        if not tool.Profile.get_active_profile_ui():
+            cls.poll_message_set("No profile selected.")
+            return False
+        if not context.scene.camera:
+            cls.poll_message_set("No active drawing.")
+            return False
+        return True
+
+    def _execute(self, context):
+        ifc_file = tool.Ifc.get()
+        profile_item = tool.Profile.get_active_profile_ui()
+        assert profile_item
+        profile = ifc_file.by_id(profile_item.ifc_definition_id)
+
+        # Profiles with voids or more than one boundary curve cannot be
+        # converted yet: the outer/inner curve detection they need relies on
+        # a containment check that currently mishandles closed polylines,
+        # so it never rebuilds a proper void relationship. Fail early with a
+        # clear message instead of silently producing the wrong shape.
+        if profile.is_a("IfcArbitraryProfileDefWithVoids") or (
+            profile.is_a("IfcCompositeProfileDef") and len(profile.Profiles) > 1
+        ):
+            self.report(
+                {"ERROR"},
+                "Profiles with holes or multiple boundaries are not yet supported for fill area conversion.",
+            )
+            return {"CANCELLED"}
+
+        dprops = tool.Drawing.get_document_props()
+        drawing = dprops.get_active_drawing()
+        if not drawing:
+            self.report({"WARNING"}, "No active drawing.")
+            return {"CANCELLED"}
+
+        obj = core_drawing.add_annotation(
+            tool.Ifc,
+            tool.Collector,
+            tool.Drawing,
+            drawing=drawing,
+            object_type="FILL_AREA",
+            relating_type=None,
+            enable_editing=False,
+        )
+
+        element = tool.Ifc.get_entity(obj)
+        assert element
+        representation = element.Representation.Representations[0]
+        old_item = representation.Items[0]
+
+        tool.Model.import_profile(profile, obj=obj)
+
+        new_item = tool.Model.export_annotation_fill_area(obj)
+        if not new_item:
+            self.report({"ERROR"}, "Selected profile could not be converted to a fill area.")
+            return {"CANCELLED"}
+
+        for inverse in ifc_file.get_inverse(old_item):
+            ifcopenshell.util.element.replace_attribute(inverse, old_item, new_item)
+        ifcopenshell.util.element.remove_deep2(ifc_file, old_item)
+
+        tool.Drawing.reload_representation(obj, representation)
+        tool.Blender.select_and_activate_single_object(context, obj)
+        return {"FINISHED"}
 
 
 class EnableEditingArbitraryProfile(bpy.types.Operator):

--- a/src/bonsai/bonsai/bim/module/profile/ui.py
+++ b/src/bonsai/bonsai/bim/module/profile/ui.py
@@ -116,6 +116,7 @@ class BIM_PT_profiles(Panel):
                 row.operator("bim.disable_editing_arbitrary_profile", text="", icon="CANCEL")
             else:
                 row.operator("bim.duplicate_profile_def", icon="DUPLICATE", text="")
+                row.operator("bim.create_fill_area_from_profile", icon="NODE_TEXTURE", text="")
                 row.operator("bim.select_by_profile", icon="RESTRICT_SELECT_OFF", text="")
                 if is_editable:
                     row.operator("bim.enable_editing_arbitrary_profile", text="", icon="ITALIC")


### PR DESCRIPTION
Fixes #6317

@jes-r asked for the inverse of Bonsai's existing mesh/fill-area to profile conversion: turning a named profile into a fill area annotation on the current drawing. He noted he isn't a coder and asked whether the existing conversion could simply be run in reverse.

It isn't a literal reversal (the mesh-to-profile analysis isn't invertible as a function), but Bonsai already has both halves needed to build it: `tool.Model.import_profile` converts any profile into 2D mesh geometry, and `tool.Model.export_annotation_fill_area` converts a mesh back into an `IfcAnnotationFillArea`, which is the same round trip already used when manually editing an existing fill area's mesh.

This PR adds a "Create Fill Area From Profile" button to the Profiles panel. It creates a FILL_AREA annotation in the active drawing (the "current view" from the issue title) shaped from the active profile's curves.

Scope: this only handles profiles with a single outer boundary (`IfcArbitraryClosedProfileDef`, `IfcRectangleProfileDef`, etc.), which covers the common case. Profiles with voids or more than one boundary curve are rejected up front with a clear error rather than silently producing a wrong shape. While testing, I found that converting a multi-loop profile exposes a pre-existing bug in `auto_detect_profiles`: its outer/inner containment check mishandles closed polylines built as a plain `IfcIndexedPolyCurve`, because the closing edge is lost when the curve is re-triangulated for the Shapely containment test, so it never reconstructs a proper `IfcArbitraryProfileDefWithVoids` from a multi-loop mesh. That bug reaches well beyond fill areas (it's shared by profile and curve auto-detection generally), so I've left it for a separate, dedicated fix instead of expanding this change's scope.

Verified live in headless Blender: created an IfcArbitraryClosedProfileDef, ran the new operator, confirmed the resulting IfcAnnotationFillArea's OuterBoundary matches the source profile's geometry exactly (all 6 vertices of an L-shape), confirmed it persists correctly on save/reload, and confirmed a profile with a hole is cleanly rejected with no partial state created.

This PR is AI-generated (Claude), reviewed and tested by me before submitting.