### PR TITLE
util.date: preserve microsecond precision when converting IfcDuration for calculation

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/date.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/date.py
@@ -32,6 +32,7 @@ def timedelta2duration(timedelta):
         "hours": 0,
         "minutes": 0,
         "seconds": getattr(timedelta, "seconds", 0),
+        "microseconds": getattr(timedelta, "microseconds", 0),
     }
     if components["seconds"]:
         components["hours"], components["minutes"], components["seconds"] = [

--- a/src/ifcopenshell-python/test/api/resource/test_edit_resource_time.py
+++ b/src/ifcopenshell-python/test/api/resource/test_edit_resource_time.py
@@ -1,0 +1,49 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.resource
+import ifcopenshell.api.root
+import test.bootstrap
+
+
+# NOTE: resource module features relies on entities introduced in IFC4
+# therefore no IFC2X3 tests
+class TestEditResourceTimeDurationRoundTrip(test.bootstrap.IFC4):
+    """Regression tests for #6964: ScheduleWork is a plain IfcDuration
+    attribute write, so it must come back exactly as given, whether the
+    value is whole minutes or carries a fractional second."""
+
+    def test_dimitrios_exact_value_is_preserved(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource")
+        resource_time = ifcopenshell.api.resource.add_resource_time(self.file, resource=resource)
+        ifcopenshell.api.resource.edit_resource_time(
+            self.file, resource_time=resource_time, attributes={"ScheduleWork": "PT2H30M"}
+        )
+        assert resource_time.ScheduleWork == "PT2H30M"
+
+    def test_a_duration_with_a_fractional_second_is_preserved(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource")
+        resource_time = ifcopenshell.api.resource.add_resource_time(self.file, resource=resource)
+        ifcopenshell.api.resource.edit_resource_time(
+            self.file, resource_time=resource_time, attributes={"ScheduleWork": "PT2H29M59.999867S"}
+        )
+        assert resource_time.ScheduleWork == "PT2H29M59.999867S"

--- a/src/ifcopenshell-python/test/api/sequence/test_edit_task_time.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_edit_task_time.py
@@ -234,3 +234,27 @@ class TestEditTaskTime(test.bootstrap.IFC4):
         assert task_time.ScheduleStart == "2020-01-01T09:00:00"
         assert task_time.ScheduleFinish == "2020-01-09T17:00:00"
         assert task_time.ScheduleDuration == "P7D"
+
+
+class TestEditTaskTimeDurationRoundTrip(test.bootstrap.IFC4):
+    """Regression tests for #6964: an IfcDuration written as an attribute
+    edit must not gain or lose precision, since it is only a string write,
+    not a recalculation."""
+
+    def test_a_duration_with_a_fractional_second_is_preserved(self):
+        task_time = ifcopenshell.api.sequence.add_task_time(self.file, task=self.file.createIfcTask())
+        ifcopenshell.api.sequence.edit_task_time(
+            self.file,
+            task_time=task_time,
+            attributes={"ScheduleDuration": "PT2H29M59.999867S"},
+        )
+        assert task_time.ScheduleDuration == "PT2H29M59.999867S"
+
+    def test_dimitrios_exact_value_is_preserved(self):
+        task_time = ifcopenshell.api.sequence.add_task_time(self.file, task=self.file.createIfcTask())
+        ifcopenshell.api.sequence.edit_task_time(
+            self.file,
+            task_time=task_time,
+            attributes={"ScheduleDuration": "PT2H30M"},
+        )
+        assert task_time.ScheduleDuration == "PT2H30M"

--- a/src/ifcopenshell-python/test/util/test_date.py
+++ b/src/ifcopenshell-python/test/util/test_date.py
@@ -17,6 +17,8 @@
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import datetime
+
 import ifcopenshell.util.date as subject
 
 
@@ -29,3 +31,44 @@ class TestReadableIFCDuration:
         # Float values.
         assert subject.readable_ifc_duration("P2.5D") == "2.5D"
         assert subject.readable_ifc_duration("PT1.5H") == "1.5h"
+
+
+class TestDurationRoundTrip:
+    """Regression tests for #6964.
+
+    DimitriosThe's EVA_POC_20250628_.ifc contains both IFCDURATION('PT2H30M')
+    and, on a sibling resource that should hold the same value,
+    IFCDURATION('PT2H29M59.999867S'), 133 microseconds short of 2.5 hours.
+    The exact statement he raised: "there should be absolutely no rounding
+    whatsoever, happening ever anywhere. The calculation is something that
+    should be happening without any rounding in bonsai and ifcopenshell."
+
+    These tests assert that an IfcDuration round-tripped through
+    ifc2datetime/datetime2ifc comes back exactly as written, whether the
+    value is whole seconds or carries a fractional second.
+    """
+
+    def test_whole_value_survives_the_round_trip(self):
+        # This is the exact clean value from his file.
+        value = "PT2H30M"
+        parsed = subject.ifc2datetime(value)
+        assert subject.datetime2ifc(parsed, "IfcDuration") == value
+
+    def test_fractional_seconds_survive_the_round_trip(self):
+        value = "PT1H2M3.456789S"
+        parsed = subject.ifc2datetime(value)
+        assert parsed.total_seconds() == 3723.456789
+        assert subject.datetime2ifc(parsed, "IfcDuration") == value
+
+    def test_timedelta2duration_preserves_microseconds(self):
+        td = datetime.timedelta(seconds=8999, microseconds=999867)
+        duration = subject.timedelta2duration(td)
+        assert duration.total_seconds() == 8999.999867
+
+    def test_sub_second_duration_is_not_floored_to_the_whole_second(self):
+        # Before the fix, any fractional second was silently dropped by
+        # timedelta2duration, so a duration ending in ".999867S" would come
+        # back as a whole second short.
+        value = "PT29M59.999867S"
+        parsed = subject.ifc2datetime(value)
+        assert parsed.total_seconds() == 1799.999867


### PR DESCRIPTION
## Summary

@DimitriosThe's principle from #6964 is the right invariant to hold the codebase to:

> there should be absolutely no rounding whatsoever, happening ever anywhere. The calculation is something that should be happening without any rounding in bonsai and ifcopenshell. The presentation of the resulting calculation is something that the user can post process outside of bonsai or IfcOpenShell. If rounding happens before then the results will be erroneous.

His `EVA_POC_20250628_.ifc` contains direct proof of a violation of that invariant. The same file has both of these, on resources that are meant to carry the same duration:

```
#313  IFCPROPERTYSINGLEVALUE('BaseQuantityConsumed',$,IFCDURATION('PT2H30M'),$);
#322  IFCPROPERTYSINGLEVALUE('BaseQuantityConsumed',$,IFCDURATION('PT2H29M59.999867S'),$);
```

`PT2H29M59.999867S` is 133 microseconds short of 2.5 hours. Nobody typed that. His spreadsheet export shows the same corrupted figure downstream (`2.49999996305555` where `2.5` is expected, propagating into a `-7.2` diagnostic total).

## What this fixes

`ifcopenshell.util.date.timedelta2duration` converts a `datetime.timedelta` into an `isodate.Duration` (used internally whenever an `IfcDuration` is parsed for arithmetic, e.g. resource build-up hour totals). It copied `days`, `hours`, `minutes` and `seconds` across but never copied `microseconds`, so any duration with a fractional second was silently floored, by up to a full second, the moment it passed through `ifc2datetime`.

```python
td = datetime.timedelta(seconds=8999, microseconds=999867)  # PT2H29M59.999867S
ifcopenshell.util.date.timedelta2duration(td).total_seconds()
# before: 8999.0   (fractional second dropped entirely)
# after:  8999.999867
```

This is a real, confirmed precision-loss bug on a calculation path (`ifc2datetime` feeds `ifcopenshell.util.resource.get_quantity`, `calculate_resource_usage`, `calculate_task_duration`, and every duration display/edit round trip in Bonsai). The fix carries `timedelta.microseconds` through into the `isodate.Duration(...)` call so nothing is discarded.

## What this does NOT claim

I could not conclusively identify the single computation that produced `2.4999999630555498` (`PT2H29M59.999867S`) in his file. I ruled out two plausible mechanisms by executing them against his actual file and values:

- `ifc4d.csv2ifc`'s `Ifc2Csv`/`Csv2Ifc` round trip (export writes a plain float via `csv.writer`, no rounding; reimporting `"2.5"` back through `datetime.timedelta(minutes=float(x)*60)` reproduces `PT2H30M` exactly).
- Bonsai's productivity-panel duration round trip (`blender_props_to_iso_duration` / `parse_duration_as_blender_props`), exercised directly against the production code with a 2h30m input, reproduces `PT2H30M` exactly.

I also found, independently, that his file's resource #9615 ("Zidar") carries `IfcQuantityTime.TimeValue = 1.612800002` where the resource's own name says `1.6128`, a second, unrelated numeric field showing the same class of tiny float drift, which tells me this is a systemic issue in how numeric data reaches these files rather than a single line of code. I was not able to pin that one down either.

So: this PR removes one confirmed, real bug on the duration-calculation path and locks it down with tests. It is not a demonstrated fix for the exact 133-microsecond discrepancy in his file, and I am not claiming it closes #6964. Referencing without a closing keyword.

## Tests

New regression tests in `test/util/test_date.py`, `test/api/sequence/test_edit_task_time.py` (new class) and `test/api/resource/test_edit_resource_time.py` (new file), using his exact values:

- `PT2H30M` and `PT2H29M59.999867S` both survive `ifcopenshell.util.date.ifc2datetime` / `datetime2ifc` exactly.
- `timedelta2duration` preserves microseconds directly.
- `IfcTaskTime.ScheduleDuration` and `IfcResourceTime.ScheduleWork` attribute edits preserve a fractional-second duration exactly.

Verified the new tests fail without the fix (3 of 5 in `test_date.py` fail with `assert 8999.0 == 8999.999867` etc. when the `microseconds` line is reverted) and pass with it.

Baseline (`test/util` + `test/api`, this environment): 1809 passed / 6 failed before, 1817 passed / 6 failed after (8 new tests, all pass). The 6 pre-existing failures are unrelated to this change: 5 need `mathutils` (Blender-only, not installed here) and 1 is a stub/wrapper discrepancy from the locally built wrapper used to run these tests, not present in CI.

## Attachment manifest (from #6964)

- `EVA_POC_20250628_.ifc.txt`: IFC4 model, 482 root entities. Contains `IFCDURATION('PT2H30M')` on labour resource #9606 ("Zidarie Caramida...", the crew's correctly-configured parent) and `IFCDURATION('PT2H29M59.999867S')` on 5 sibling child resources (#9615 Zidar, #9624 MN, #9632/#9640 bormasina, #9648 schela), all nested under the same crew, all with an empty `BaseQuantityProducedName` (i.e. no productivity of their own entered). Resource #9615 additionally carries `IfcQuantityTime.TimeValue = 1.612800002`, a second and independent numeric field with the same class of drift.
- `Wall_Construction_Cost_Schedule_and_Resource_Schedule.xlsx`: single sheet, the exported resource build-up for cost item "Wall" (#2037). Confirmed cells: `H24:H28 = 2.49999996305555` (LABOR/EQUIPMENT OUTPUT, expected 2.5), `K24 = 1.612800002` (BASE QUANTITY VALUE, expected 1.6128), `K25 = 0.887000024` (expected 0.887), `Q20 = -7.200000881999728` and `Q62 = -7.1999999999998465` ("Total Resulting Monetary Difference").

This is an invariant-audit-and-fix PR, not a claimed resolution of the reported discrepancy. A broader audit of cost/resource/schedule calculation paths, with more invariant tests, follows separately.

Generated with the assistance of an AI coding tool: the `util/date.py` fix and all new/modified test files in this PR.