### PR TITLE
Audit cost/resource/schedule calculation paths for precision loss; fix float32-truncated Bonsai properties

### DIFF
--- a/src/bonsai/bonsai/bim/module/cost/prop.py
+++ b/src/bonsai/bonsai/bim/module/cost/prop.py
@@ -211,6 +211,14 @@ class ScheduleColumn(PropertyGroup):
         schedule_id: int
 
 
+def get_fixed_cost_value(self: "BIMCostProperties") -> float:
+    return float(self.get("fixed_cost_value", 0.0))
+
+
+def set_fixed_cost_value(self: "BIMCostProperties", value: float) -> None:
+    self["fixed_cost_value"] = value
+
+
 class BIMCostProperties(PropertyGroup):
     cost_schedule_predefined_types: EnumProperty(
         items=get_schedule_predefined_types, name="Predefined Type", default=None
@@ -240,7 +248,7 @@ class BIMCostProperties(PropertyGroup):
         name="Cost Types",
     )
     cost_category: StringProperty(name="Cost Category")
-    fixed_cost_value: FloatProperty(name="Fixed Cost Value")
+    fixed_cost_value: FloatProperty(name="Fixed Cost Value", get=get_fixed_cost_value, set=set_fixed_cost_value)
     active_cost_value_id: IntProperty(name="Active Cost Item Value Id")
     cost_value_editing_type: StringProperty(name="Cost Value Editing Type")
     cost_value_attributes: CollectionProperty(name="Cost Value Attributes", type=Attribute)

--- a/src/bonsai/bonsai/bim/module/resource/prop.py
+++ b/src/bonsai/bonsai/bim/module/resource/prop.py
@@ -94,10 +94,23 @@ def updateResourceUsage(self: "Resource", context: object) -> None:
     bonsai.bim.module.pset.data.refresh()
 
 
+def get_resource_schedule_usage(self: "Resource") -> float:
+    return float(self.get("schedule_usage", 0.0))
+
+
+def set_resource_schedule_usage(self: "Resource", value: float) -> None:
+    self["schedule_usage"] = value
+
+
 class Resource(PropertyGroup):
     name: StringProperty(name="Name", update=updateResourceName)
     ifc_definition_id: IntProperty(name="IFC Definition ID")
-    schedule_usage: FloatProperty(name="Schedule Usage", update=updateResourceUsage)
+    schedule_usage: FloatProperty(
+        name="Schedule Usage",
+        update=updateResourceUsage,
+        get=get_resource_schedule_usage,
+        set=set_resource_schedule_usage,
+    )
     has_children: BoolProperty(name="Has Children")
     is_expanded: BoolProperty(name="Is Expanded")
     level_index: IntProperty(name="Level Index")
@@ -197,10 +210,18 @@ class BIMResourceProperties(PropertyGroup):
         return tool.Blender.get_active_uilist_element(self.tree.resources, self.active_resource_index)
 
 
+def get_quantity_produced(self: "BIMResourceProductivity") -> float:
+    return float(self.get("quantity_produced", 0.0))
+
+
+def set_quantity_produced(self: "BIMResourceProductivity", value: float) -> None:
+    self["quantity_produced"] = value
+
+
 class BIMResourceProductivity(PropertyGroup):
     ifc_definition_id: IntProperty(name="IFC Definition ID")
     quantity_consumed: CollectionProperty(name="Duration", type=ISODuration)
-    quantity_produced: FloatProperty(name="Quantity Produced")
+    quantity_produced: FloatProperty(name="Quantity Produced", get=get_quantity_produced, set=set_quantity_produced)
     quantity_produced_name: StringProperty(name="Quantity Produced Name")
 
     if TYPE_CHECKING:

--- a/src/bonsai/bonsai/bim/module/sequence/prop.py
+++ b/src/bonsai/bonsai/bim/module/sequence/prop.py
@@ -327,6 +327,14 @@ def updateAssignedResourceUsage(self: "TaskResource", context: object) -> None:
     bonsai.bim.module.pset.data.refresh()
 
 
+def get_task_resource_schedule_usage(self: "TaskResource") -> float:
+    return float(self.get("schedule_usage", 0.0))
+
+
+def set_task_resource_schedule_usage(self: "TaskResource", value: float) -> None:
+    self["schedule_usage"] = value
+
+
 def update_task_bar_list(self: "Task", context: bpy.types.Context) -> None:
     props = tool.Sequence.get_work_schedule_props()
     if not props.is_task_update_enabled:
@@ -390,7 +398,12 @@ class WorkPlan(PropertyGroup):
 class TaskResource(PropertyGroup):
     name: StringProperty(name="Name", update=updateAssignedResourceName)
     ifc_definition_id: IntProperty(name="IFC Definition ID")
-    schedule_usage: FloatProperty(name="Schedule Usage", update=updateAssignedResourceUsage)
+    schedule_usage: FloatProperty(
+        name="Schedule Usage",
+        update=updateAssignedResourceUsage,
+        get=get_task_resource_schedule_usage,
+        set=set_task_resource_schedule_usage,
+    )
 
     if TYPE_CHECKING:
         name: str

--- a/src/ifcopenshell-python/ifcopenshell/util/date.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/date.py
@@ -32,6 +32,7 @@ def timedelta2duration(timedelta):
         "hours": 0,
         "minutes": 0,
         "seconds": getattr(timedelta, "seconds", 0),
+        "microseconds": getattr(timedelta, "microseconds", 0),
     }
     if components["seconds"]:
         components["hours"], components["minutes"], components["seconds"] = [

--- a/src/ifcopenshell-python/test/util/test_cost.py
+++ b/src/ifcopenshell-python/test/util/test_cost.py
@@ -49,3 +49,34 @@ class TestGetCostItemForProduct(test.bootstrap.IFC4):
         cost_schedule = ifcopenshell.api.cost.add_cost_schedule(model)
         item1 = ifcopenshell.api.cost.add_cost_item(model, cost_schedule=cost_schedule)
         assert list(subject.get_cost_items_for_product(element)) == []
+
+
+class TestCalculateAppliedValuePrecision(test.bootstrap.IFC4):
+    """Regression tests for #6964: DimitriosThe's invariant is that "there
+    should be absolutely no rounding whatsoever, happening ever anywhere"
+    in a cost calculation. These assert a cost item total made of several
+    many-significant-digit components comes back bit-identical to the
+    Python sum, not truncated."""
+
+    def test_a_single_component_is_not_rounded(self):
+        model = self.file
+        cost_schedule = ifcopenshell.api.cost.add_cost_schedule(model)
+        item = ifcopenshell.api.cost.add_cost_item(model, cost_schedule=cost_schedule)
+        value = ifcopenshell.api.cost.add_cost_value(model, parent=item)
+        applied_value = 150.79197255123456
+        ifcopenshell.api.cost.edit_cost_value(model, cost_value=value, attributes={"AppliedValue": applied_value})
+        assert subject.calculate_applied_value(item, value) == applied_value
+
+    def test_a_sum_of_many_significant_digit_components_is_not_rounded(self):
+        model = self.file
+        cost_schedule = ifcopenshell.api.cost.add_cost_schedule(model)
+        item = ifcopenshell.api.cost.add_cost_item(model, cost_schedule=cost_schedule)
+        sum_value = ifcopenshell.api.cost.add_cost_value(model, parent=item)
+        components = [10.481575000123, 9.9278884001, 0.887000024, 1.612800002]
+        for component_value in components:
+            component = ifcopenshell.api.cost.add_cost_value(model, parent=sum_value)
+            ifcopenshell.api.cost.edit_cost_value(
+                model, cost_value=component, attributes={"AppliedValue": component_value}
+            )
+        sum_value.ArithmeticOperator = "ADD"
+        assert subject.calculate_applied_value(item, sum_value) == sum(components)

--- a/src/ifcopenshell-python/test/util/test_resource.py
+++ b/src/ifcopenshell-python/test/util/test_resource.py
@@ -1,0 +1,105 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.control
+import ifcopenshell.api.cost
+import ifcopenshell.api.resource
+import ifcopenshell.api.root
+import test.bootstrap
+
+import ifcopenshell.util.cost
+import ifcopenshell.util.resource as subject
+
+
+# NOTE: resource module features relies on entities introduced in IFC4
+# therefore no IFC2X3 tests
+class TestResourceBuildUpPrecision(test.bootstrap.IFC4):
+    """Regression tests for #6964: DimitriosThe's invariant is that a
+    resource build-up total must carry no rounding whatsoever. These assert
+    that a many-significant-digit value put into a resource cost or
+    quantity comes back bit-identical, not truncated, through the same
+    functions Bonsai's cost/resource panels call."""
+
+    def test_get_cost_preserves_a_many_significant_digit_applied_value(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource")
+        value = ifcopenshell.api.cost.add_cost_value(self.file, parent=resource)
+        applied_value = 150.79197255123456
+        ifcopenshell.api.cost.edit_cost_value(self.file, cost_value=value, attributes={"AppliedValue": applied_value})
+        cost, unit = subject.get_cost(resource)
+        assert cost == applied_value
+
+    def test_get_cost_sums_nested_resources_without_rounding(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        crew = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcCrewResource")
+        labour = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource", parent_resource=crew)
+        equipment = ifcopenshell.api.resource.add_resource(
+            self.file, ifc_class="IfcConstructionEquipmentResource", parent_resource=crew
+        )
+        labour_value = 38.707200048
+        equipment_value = 0.03000000119
+        for resource, value in ((labour, labour_value), (equipment, equipment_value)):
+            cost_value = ifcopenshell.api.cost.add_cost_value(self.file, parent=resource)
+            ifcopenshell.api.cost.edit_cost_value(self.file, cost_value=cost_value, attributes={"AppliedValue": value})
+
+        crew_cost_value = ifcopenshell.api.cost.add_cost_value(self.file, parent=crew)
+        crew_cost_value.Category = "*"
+        total, unit = subject.get_cost(crew)
+        assert total == labour_value + equipment_value
+
+    def test_get_quantity_preserves_a_duration_with_a_fractional_second(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource")
+        resource_time = ifcopenshell.api.resource.add_resource_time(self.file, resource=resource)
+        ifcopenshell.api.resource.edit_resource_time(
+            self.file, resource_time=resource_time, attributes={"ScheduleWork": "PT2H29M59.999867S"}
+        )
+        assert subject.get_quantity(resource) == 8999.999867 / 3600
+
+
+class TestCalculateCostItemResourceValuePrecision(test.bootstrap.IFC4):
+    """The cost item's calculated value is a formula of resource cost times
+    resource quantity, not a stored rounded number. It must reproduce the
+    exact product on every read."""
+
+    def test_run(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        schedule = ifcopenshell.api.cost.add_cost_schedule(self.file)
+        item = ifcopenshell.api.cost.add_cost_item(self.file, cost_schedule=schedule)
+
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcConstructionMaterialResource")
+        ifcopenshell.api.control.assign_control(self.file, relating_control=item, related_objects=[resource])
+
+        unit_cost = 42.123456789012
+        cost_value = ifcopenshell.api.cost.add_cost_value(self.file, parent=resource)
+        ifcopenshell.api.cost.edit_cost_value(self.file, cost_value=cost_value, attributes={"AppliedValue": unit_cost})
+
+        quantity = ifcopenshell.api.resource.add_resource_quantity(
+            self.file, resource=resource, ifc_class="IfcQuantityVolume"
+        )
+        volume = 200.987654321
+        ifcopenshell.api.resource.edit_resource_quantity(
+            self.file, physical_quantity=quantity, attributes={"VolumeValue": volume}
+        )
+
+        ifcopenshell.api.cost.calculate_cost_item_resource_value(self.file, cost_item=item)
+
+        total = ifcopenshell.util.cost.calculate_applied_value(item, item.CostValues[0])
+        assert total == unit_cost * volume


### PR DESCRIPTION
## Why

@DimitriosThe (#6964) raised an engineering invariant worth holding the codebase to independent of his specific reported discrepancy:

> there should be absolutely no rounding whatsoever, happening ever anywhere. The calculation is something that should be happening without any rounding in bonsai and ifcopenshell. The presentation of the resulting calculation is something that the user can post process outside of bonsai or IfcOpenShell. If rounding happens before then the results will be erroneous.

This PR is that audit: every numeric calculation path in cost, resource, sequence, ifc4d and ifc5d, classified and tested. It is **not** a claimed fix for the specific 0.1/133-microsecond discrepancies discussed on #6964; the duration precision bug found along the way (`ifcopenshell.util.date.timedelta2duration` dropping microseconds) is fixed separately in #8985, referencing the same issue. This PR is the wider sweep the two of us agreed was still worth doing regardless of what that fix does or doesn't explain.

## Findings table

DISPLAY_ONLY = formats a value for a label, never written back. CALCULATION = arithmetic on the way to a stored or compared value. PERSISTED = a display-layer truncation whose result can reach an IFC attribute.

| Site | What it does | Verdict |
|---|---|---|
| `ifcopenshell/util/cost.py: calculate_applied_value`, `sum_child_root_elements`, `get_cost_items_for_product` etc | Cost item / resource build-up arithmetic, full double precision throughout | CALCULATION, clean (no rounding found) |
| `ifcopenshell/util/cost.py:279 get_cost_values` `"{0:.2f}".format(...)` | UI label for a cost value row; `applied_value` returned unrounded alongside it | DISPLAY_ONLY |
| `ifcopenshell/util/resource.py: get_cost, get_quantity, get_parent_cost` | Resource cost/quantity aggregation, full precision | CALCULATION, clean |
| `ifcopenshell/util/resource.py: get_resource_required_work` `f"PT{required_work/3600}H"` | Builds an IfcDuration string from a raw float via Python's round-trip-safe repr | CALCULATION, clean in isolation (whatever imprecision the input float already carries is preserved, not amplified or truncated) |
| `ifcopenshell/util/date.py: timedelta2duration` | Converts a parsed duration timedelta into an isodate.Duration for arithmetic | **CALCULATION, bug: dropped `.microseconds` entirely.** Fixed in #8985 |
| `ifcopenshell/api/cost/calculate_cost_item_resource_value.py` | Builds `cost * quantity` as an unevaluated formula (`ArithmeticOperator: MULTIPLY`), not a stored product | CALCULATION, clean by design: nothing is pre-computed and rounded, the multiplication happens fresh on every read |
| `ifcopenshell/api/sequence/calculate_task_duration.py: calculate_duration_in_days` `math.ceil(...)` | Rounds a task's derived duration UP to a whole day | CALCULATION, intentional and test-covered (`test_calculate_task_duration.py`: `P3.5D` work in, `P4D` task duration out), a deliberate whole-day scheduling convention, not a precision bug. Flagged for awareness, not changed. |
| `ifc4d/csv2ifc.py: Ifc2Csv.get_row`, `Csv2Ifc` | CSV export/import of cost and resource durations | CALCULATION, clean: export via plain `csv.writer` (no formatting), import via `datetime.timedelta(minutes=float(x)*60)`. Verified directly against DimitriosThe's exact file and values. |
| `ifc5d/ifc5Dspreadsheet.py` | XLSX/ODS export, totals as spreadsheet formulas (`=SUM(...)`, `=A*B`) | CALCULATION, clean: the workbook computes totals itself at full precision, nothing is pre-rounded by us |
| `bonsai/bim/module/cost/data.py: _load_cost_values` (`TotalAppliedValue`, `TotalCost`) | The cost item panel's headline total | CALCULATION, clean |
| `bonsai/bim/module/cost/data.py:318 cost_quantities` `"{0:.2f}".format(...)` | Read-only quantity label (`row.label`, not editable) | DISPLAY_ONLY |
| `bonsai/bim/module/resource/data.py:108, 134` | `DerivedScheduleWork` / cost value labels | DISPLAY_ONLY (pre-confirmed before this audit) |
| `bonsai/bim/module/resource/prop.py: Resource.schedule_usage` | Editable "Schedule Usage" column in the resource list, written straight to `Usage.ScheduleUsage` | **PERSISTED, bug: bare `FloatProperty` (float32).** Fixed |
| `bonsai/bim/module/sequence/prop.py: TaskResource.schedule_usage` | Same field, in the task's assigned-resources list | **PERSISTED, bug: bare `FloatProperty` (float32).** Fixed |
| `bonsai/bim/module/cost/prop.py: BIMCostProperties.fixed_cost_value` | Editable fixed cost value, written to `IfcCostValue.AppliedValue`, which feeds every cost total above | **PERSISTED, bug: bare `FloatProperty` (float32).** Fixed |
| `bonsai/bim/module/resource/prop.py: BIMResourceProductivity.quantity_produced` | Editable productivity value, written to `EPset_Productivity.BaseQuantityProducedValue`, which feeds `get_resource_required_work`'s productivity ratio | **PERSISTED, bug: bare `FloatProperty` (float32).** Fixed |
| `bonsai/bim/module/cost/prop.py: CostItemQuantity.total_quantity/total_cost_quantity` | Bare `FloatProperty`, but only ever drawn via `row.label`, never `row.prop` | DISPLAY_ONLY (bare float32 storage, but nothing writes it back, so no precision reaches IFC) |
| `bonsai/bim/prop.py: ISODuration` (years/months/days/hours/minutes/seconds) | Duration-editing UI fields | Not a bug: all `IntProperty`, no float32 involved. Sub-second durations cannot be edited through this UI at all (integers only), which is a UI limitation, not a precision-loss bug, flagged for awareness. |
| `bonsai/bim/module/sequence/helper.py: blender_props_to_iso_duration`, `parse_duration_as_blender_props` | Round-trips a duration through the ISODuration int fields | CALCULATION, clean: verified directly against the production code with a 2h30m input, comes back exact |
| `bonsai/tool/sequence.py: create_bars`, `add_product_frame` `round(...)` | Blender animation frame numbers | Out of scope: Blender scene frames must be integers, never reaches IFC |

## What was fixed and why

Four Bonsai `PropertyGroup` fields declared numeric IFC data as a bare `bpy.props.FloatProperty`. Blender's `FloatProperty` stores as **float32** unless given a custom `get`/`set` pair that routes through the ID-property store (which holds doubles), exactly the pattern the codebase already uses for the generic `Attribute.float_value` (`get=lambda self: float(self.get("float_value", 0.0))`, `set=set_float_value`). These four did not use that pattern, so a value typed or written into them was silently truncated to about 7 significant digits before being persisted into an IFC double attribute:

- `resource/prop.py: Resource.schedule_usage` writes to `IfcResourceTime.ScheduleUsage`
- `sequence/prop.py: TaskResource.schedule_usage` writes to `IfcResourceTime.ScheduleUsage`
- `cost/prop.py: BIMCostProperties.fixed_cost_value` writes to `IfcCostValue.AppliedValue`
- `resource/prop.py: BIMResourceProductivity.quantity_produced` writes to `EPset_Productivity.BaseQuantityProducedValue`

All four are fixed with the same get/set-through-ID-property pattern. No display formatting was touched.

## Tests

New regression tests, all asserting exact (`==`) results, not epsilon-tolerant ones:

- `test/util/test_resource.py` (new): a resource's cost survives a many-significant-digit `AppliedValue` exactly; a crew's cost is the exact sum of its nested labour and equipment resources; `get_quantity` preserves a `ScheduleWork` duration with a fractional second exactly.
- `test/util/test_cost.py`: a cost item's calculated value from a single many-significant-digit component, and from an ADD of four such components, matches the Python sum exactly, not a rounded approximation.
- `test/util/test_resource.py::TestCalculateCostItemResourceValuePrecision`: the full `calculate_cost_item_resource_value` pipeline (resource cost times resource quantity, as a live formula) reproduces the exact product.

The duration-precision tests in this PR share the `timedelta2duration` fix and its own test coverage with #8985; see that PR for the fractional-second round-trip tests and the fail-without-fix proof.

## Verification

Baseline before any change (this environment, `test/util` + `test/api`, `networkx` installed to unblock `recalculate_schedule`): **1809 passed, 6 failed**. After this PR: **1815 passed, 6 failed** (6 new tests, all pass). The 6 pre-existing failures are unrelated to cost/resource/sequence/date: 5 need `mathutils` (Blender-only, not installed in this shell) and 1 is a stub/wrapper discrepancy specific to the locally rebuilt wrapper used to run these tests outside Blender, not present in CI. `ifc5d`'s own suite: 18 passed, 2 failed on missing `odf`/`openpyxl` (both pre-existing, matches what's already known about that suite).

Ran CI-exact `black`/`ruff` from `~/.cache/ifcos-lint-venv` on every touched file: clean.

## Attachment manifest (from #6964)

Cross-referenced for this audit, full detail in #8985:

- `EVA_POC_20250628_.ifc.txt`: the model behind the confirmed `PT2H30M` / `PT2H29M59.999867S` duration discrepancy that #8985 fixes one cause of.
- `Wall_Construction_Cost_Schedule_and_Resource_Schedule.xlsx`: the exported resource build-up showing the same discrepancy propagate into `LABOR OUTPUT`/`EQUIPMENT OUTPUT` columns and a `-7.2` diagnostic total.

Neither attachment shows evidence of the four `FloatProperty` bugs fixed here; those were found by auditing the Bonsai UI layer directly, per the task brief's instruction to check for bare `FloatProperty` on IFC numeric data.

Generated with the assistance of an AI coding tool: all four `prop.py` fixes and all new/modified test files in this PR.
