### PR TITLE
Bonsai: add a printed-sheet gap between leader lines and their text

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
@@ -200,6 +200,9 @@ class SvgWriter:
     metadata: list[str]
     resource_paths: dict[tool.Drawing.ResourceType, Union[str, None]]
 
+    # Gap between a leader line's end and its text, in mm on the printed sheet.
+    LEADER_TEXT_GAP_MM = 1.5
+
     def __init__(
         self,
         *,
@@ -805,9 +808,23 @@ class SvgWriter:
         spline_points = spline.bezier_points if spline.bezier_points else spline.points
         if spline_points:
             position = obj.matrix_world @ spline_points[0].co.xyz
+            if len(spline_points) > 1:
+                position += self.get_leader_text_gap_offset(obj, spline_points)
         else:
             position = Vector((0, 0, 0))
         self.draw_text_annotation(obj, position)
+
+    def get_leader_text_gap_offset(self, obj: bpy.types.Object, spline_points) -> Vector:
+        """World-space offset pushing the leader text away from the line end by
+        `LEADER_TEXT_GAP_MM`, converted from sheet mm using the drawing scale.
+        """
+        p0 = obj.matrix_world @ spline_points[0].co.xyz
+        p1 = obj.matrix_world @ spline_points[1].co.xyz
+        direction = p0 - p1
+        if direction.length_squared == 0:
+            return Vector((0, 0, 0))
+        gap_world = (self.LEADER_TEXT_GAP_MM / 1000) / self.scale
+        return direction.normalized() * gap_world
 
     def draw_section_annotation(self, obj: bpy.types.Object) -> None:
         x_offset = self.raw_width / 2


### PR DESCRIPTION
Fixes #8984

@Plae-Blue-Dot reported that a leader annotation's text sits flush against the end of its leader line, with no visual break between them. His workaround, covering the joint with a white fill area, only hides it on a white background and breaks on anything else; padding the text with a leading space didn't reliably clear the arrowhead either. This PR replaces both workarounds with an actual gap.

Root cause: `SvgWriter.draw_leader_annotation` (`src/bonsai/bonsai/bim/module/drawing/svgwriter.py`) anchored the text at exactly `spline_points[0]`, the leader line's own start point, so the two always touched.

The text anchor is now offset away from the line, along the line's own direction reversed from its second point, by a gap expressed in millimeters of the printed sheet and converted to world space using the drawing scale (`mm / 1000 / scale`). This is the same mm-of-sheet / scale conversion PR #8972 used for `ortho_view_frame`'s margin: a fixed gap on paper needs more world space at smaller scales, not less, so a plain world-space offset would only look right at one scale.

The gap is a document-wide constant (`SvgWriter.LEADER_TEXT_GAP_MM`, 1.5mm) rather than a per-annotation property. The request was for a visual break that always applies rather than something to tune per object, and 1.5mm reads clearly next to the default 2.5mm annotation text without pushing the text noticeably away from its target. The offset is guarded against a single-point spline and coincident points so neither crashes or divides by zero.

## Verification

Rendered a TEXT_LEADER annotation in headless Blender and inspected the produced SVG:

- At 1:100, before the fix the line end and text were both at sheet x=250.0mm (touching). After the fix, the line end stayed at 250.0mm and the text moved to 251.5mm, a 1.5mm gap.
- At 1:50, the line end and text were at 500.0mm and 501.5mm, the same 1.5mm gap, confirming the gap holds regardless of drawing scale rather than scaling with it.
- Checked left, right and center text alignment (`text-anchor` start/end/middle) and confirmed the gap direction is correct for all three.
- Checked a single-point spline and a spline with coincident first two points: both render without error and without moving the text (no direction to offset along).

Ran `test/core/test_drawing.py` (41 passed) and `test/bim/module/drawing/` (30 passed) before and after this change, no regressions. Neither suite has existing coverage for `svgwriter.py`.

## AI disclosure

This PR was generated with the assistance of an AI coding tool, as noted in the commit message.