### PR TITLE
geometry.edit_object_placement: move openings that are not placed relative to their host (#7997)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/edit_object_placement.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/edit_object_placement.py
@@ -57,6 +57,11 @@ def edit_object_placement(
         and you want all children to follow. If False (default), child elements
         keep their current world positions; their local placements are rewritten
         to compensate for the parent move.
+
+        Openings are the exception and always follow their host, regardless of
+        this setting. This holds even for openings that some authoring tools
+        place outside the host's placement tree, which are moved explicitly
+        from their ``IfcRelVoidsElement`` relationship.
     :return: The new or updated IfcLocalPlacement entity
     """
     usecase = Usecase()
@@ -83,9 +88,13 @@ class Usecase:
         if not self.settings["is_si"]:
             self.convert_matrix_to_si(self.settings["matrix"])
 
+        should_transform_children = self.settings["should_transform_children"]
+
         children_settings = []
-        if not self.settings["should_transform_children"]:
+        if not should_transform_children:
             children_settings = self.get_children_settings(self.settings["product"].ObjectPlacement)
+
+        detached_openings = self.get_detached_openings(self.settings["product"].ObjectPlacement)
 
         placement_rel_to = self.get_placement_rel_to()
         relative_placement = self.get_relative_placement(placement_rel_to)
@@ -111,6 +120,17 @@ class Usecase:
         for settings in children_settings:
             self.settings = settings
             self.execute()
+
+        if detached_openings:
+            new_matrix = ifcopenshell.util.placement.get_local_placement(new_placement)
+            for opening, relative_matrix in detached_openings:
+                self.settings = {
+                    "product": opening,
+                    "matrix": new_matrix @ relative_matrix,
+                    "is_si": False,
+                    "should_transform_children": should_transform_children,
+                }
+                self.execute()
 
         return new_placement
 
@@ -143,6 +163,43 @@ class Usecase:
 
         if relating_object:
             return getattr(relating_object, "ObjectPlacement", None)
+
+    def get_detached_openings(
+        self, placement: Union[ifcopenshell.entity_instance, None]
+    ) -> list[tuple[ifcopenshell.entity_instance, NPArrayOfFloats]]:
+        """Openings that void the product but are not placed relative to it.
+
+        Openings placed relative to the product follow it through the placement
+        rewrite in ``execute``. Openings that are semantically bound via
+        ``IfcRelVoidsElement`` but placed elsewhere in the placement tree are
+        invisible to that rewrite and must be moved explicitly. Each is returned
+        with its matrix expressed in the product's local coordinate system.
+        """
+        if placement is None:
+            return []
+        openings = []
+        for rel in getattr(self.settings["product"], "HasOpenings", None) or ():
+            opening = rel.RelatedOpeningElement
+            opening_placement = opening.ObjectPlacement
+            if opening_placement is None or self.is_placed_relative_to(opening_placement, placement):
+                continue
+            openings.append((opening, opening_placement))
+        if not openings:
+            return []
+        inverted_matrix = np.linalg.inv(ifcopenshell.util.placement.get_local_placement(placement))
+        return [
+            (opening, inverted_matrix @ ifcopenshell.util.placement.get_local_placement(opening_placement))
+            for opening, opening_placement in openings
+        ]
+
+    @staticmethod
+    def is_placed_relative_to(placement: ifcopenshell.entity_instance, ancestor: ifcopenshell.entity_instance) -> bool:
+        parent = getattr(placement, "PlacementRelTo", None)
+        while parent is not None:
+            if parent == ancestor:
+                return True
+            parent = getattr(parent, "PlacementRelTo", None)
+        return False
 
     def get_children_settings(self, placement: Union[ifcopenshell.entity_instance, None]) -> list[dict]:
         if not placement:

--- a/src/ifcopenshell-python/test/api/geometry/test_edit_object_placement.py
+++ b/src/ifcopenshell-python/test/api/geometry/test_edit_object_placement.py
@@ -596,6 +596,115 @@ class TestEditObjectPlacement(test.bootstrap.IFC4):
         with pytest.raises(RuntimeError):
             self.file.by_id(previous_placement_id)
 
+    def test_moving_a_host_moves_an_opening_placed_outside_the_host_placement_tree(self):
+        site, wall, opening = self.setup_detached_opening()
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file, product=wall, matrix=self.np_translation((4, 5, 6)), is_si=False
+        )
+        assert numpy.allclose(
+            ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement),
+            self.np_translation((4, 6, 8)),
+        )
+        assert opening.ObjectPlacement.PlacementRelTo == wall.ObjectPlacement
+
+    def test_moving_a_host_moves_an_opening_placed_outside_the_host_placement_tree_exactly_once(self):
+        site, wall, opening = self.setup_detached_opening()
+        for translation in ((2, 2, 2), (3, 3, 3)):
+            ifcopenshell.api.geometry.edit_object_placement(
+                self.file, product=wall, matrix=self.np_translation(translation), is_si=False
+            )
+        assert numpy.allclose(
+            ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement),
+            self.np_translation((3, 4, 5)),
+        )
+
+    def test_moving_a_host_moves_a_nested_opening_exactly_once(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        opening = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcOpeningElement")
+        ifcopenshell.api.spatial.assign_container(self.file, products=[wall], relating_structure=site)
+        ifcopenshell.api.feature.add_feature(self.file, feature=opening, element=wall)
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=site, matrix=numpy.eye(4), is_si=False)
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file, product=wall, matrix=self.np_translation((1, 1, 1)), is_si=False
+        )
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file, product=opening, matrix=self.np_translation((1, 2, 3)), is_si=False
+        )
+        assert opening.ObjectPlacement.PlacementRelTo == wall.ObjectPlacement
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file, product=wall, matrix=self.np_translation((4, 5, 6)), is_si=False
+        )
+        assert numpy.allclose(
+            ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement),
+            self.np_translation((4, 6, 8)),
+        )
+
+    def test_moving_a_host_moves_the_filling_of_an_opening_placed_outside_the_host_placement_tree(self):
+        site, wall, opening = self.setup_detached_opening()
+        door = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcDoor")
+        ifcopenshell.api.feature.add_filling(self.file, opening=opening, element=door)
+        door.ObjectPlacement = self.file.createIfcLocalPlacement(
+            PlacementRelTo=opening.ObjectPlacement,
+            RelativePlacement=self.file.createIfcAxis2Placement3D(self.file.createIfcCartesianPoint((0.0, 0.0, 0.0))),
+        )
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file,
+            product=wall,
+            matrix=self.np_translation((4, 5, 6)),
+            is_si=False,
+            should_transform_children=True,
+        )
+        assert numpy.allclose(
+            ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement),
+            self.np_translation((4, 6, 8)),
+        )
+        assert numpy.allclose(
+            ifcopenshell.util.placement.get_local_placement(door.ObjectPlacement),
+            self.np_translation((4, 6, 8)),
+        )
+
+    def test_moving_a_host_keeps_the_filling_of_a_detached_opening_in_place_by_default(self):
+        site, wall, opening = self.setup_detached_opening()
+        door = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcDoor")
+        ifcopenshell.api.feature.add_filling(self.file, opening=opening, element=door)
+        door.ObjectPlacement = self.file.createIfcLocalPlacement(
+            PlacementRelTo=opening.ObjectPlacement,
+            RelativePlacement=self.file.createIfcAxis2Placement3D(self.file.createIfcCartesianPoint((0.0, 0.0, 0.0))),
+        )
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file, product=wall, matrix=self.np_translation((4, 5, 6)), is_si=False
+        )
+        assert numpy.allclose(
+            ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement),
+            self.np_translation((4, 6, 8)),
+        )
+        assert numpy.allclose(
+            ifcopenshell.util.placement.get_local_placement(door.ObjectPlacement),
+            self.np_translation((1, 2, 3)),
+        )
+
+    def test_moving_an_element_without_openings_is_unaffected(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.spatial.assign_container(self.file, products=[wall], relating_structure=site)
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=site, matrix=numpy.eye(4), is_si=False)
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file, product=wall, matrix=self.np_translation((1, 1, 1)), is_si=False
+        )
+        entity_count = len(list(self.file))
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file, product=wall, matrix=self.np_translation((4, 5, 6)), is_si=False
+        )
+        assert numpy.allclose(
+            ifcopenshell.util.placement.get_local_placement(wall.ObjectPlacement), self.np_translation((4, 5, 6))
+        )
+        assert len(list(self.file)) == entity_count
+
     def test_changing_placements_without_affecting_children_doesnt_affect_subchildren(self):
         def np_matrix_translation(translation):
             (m := numpy.eye(4))[:3, 3] = translation
@@ -635,6 +744,31 @@ class TestEditObjectPlacement(test.bootstrap.IFC4):
         # subchildren are unaffected, exception is not raised
         self.file.by_id(wall_placement_id)
         assert numpy.array_equal(ifcopenshell.util.placement.get_local_placement(wall.ObjectPlacement), matrix)
+
+    @staticmethod
+    def np_translation(translation) -> numpy.ndarray:
+        (matrix := numpy.eye(4))[:3, 3] = translation
+        return matrix
+
+    def setup_detached_opening(self):
+        """A wall at (1,1,1) voided by an opening at (1,2,3) placed relative to the site, not the wall."""
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        opening = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcOpeningElement")
+        ifcopenshell.api.spatial.assign_container(self.file, products=[wall], relating_structure=site)
+        ifcopenshell.api.feature.add_feature(self.file, feature=opening, element=wall)
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=site, matrix=numpy.eye(4), is_si=False)
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file, product=wall, matrix=self.np_translation((1, 1, 1)), is_si=False
+        )
+        opening.ObjectPlacement = self.file.createIfcLocalPlacement(
+            PlacementRelTo=site.ObjectPlacement,
+            RelativePlacement=self.file.createIfcAxis2Placement3D(self.file.createIfcCartesianPoint((1.0, 2.0, 3.0))),
+        )
+        assert opening.ObjectPlacement.PlacementRelTo == site.ObjectPlacement
+        return site, wall, opening
 
 
 class TestEditObjectPlacementIFC2X3(test.bootstrap.IFC2X3, TestEditObjectPlacement):


### PR DESCRIPTION
Fixes #7997.

Thank you @PahlawanJoey. You came back with the reproducing model three months after reporting, and none of this was findable without it. Your openings were never being deleted, and the file is fine.

## What actually happens

Move objects, save, reload, and the openings on one facade are gone. Nothing is lost:

```
IfcOpeningElement:   295 before -> 295 after save
IfcRelVoidsElement:  295 before -> 295 after save
```

The openings simply stop following their host wall:

```
Wall #411 moved by       (1000, 500, 0) mm
Opening #421 moved by    (0, 0, 0) mm          <- voids wall #411
Resulting drift          1118 mm, against a 200 mm thick wall
=> boolean subtraction finds no overlap, no cut
Wall #411 body:          32 verts (cut) -> 24 verts (plain box)
Control wall #175:       16 -> 16 verts, unaffected
```

## Root cause

`geometry.edit_object_placement` has kept openings attached to their host since 0eae3de6a2 ("Openings now move with the host by default"), but it does so purely through the placement graph. `execute()` builds a new `IfcLocalPlacement` for the host and reparents everything that referenced the old instance:

```python
for inverse in self.file.get_inverse(old_placement):
    if inverse.is_a("IfcLocalPlacement"):
        ifcopenshell.util.element.replace_attribute(inverse, old_placement, new_placement)
```

An opening whose placement chains up through the host's placement is carried along for free. An opening that is bound to the host only by `IfcRelVoidsElement`, and placed elsewhere in the placement tree, is invisible to `get_inverse` and silently stays put.

That second shape is what the attached model contains. It is ODA authored, and on 12 walls (one per storey, one vertical facade run, all the same wall type) the opening's placement is a **sibling** of the wall's, sharing the same storey parent instead of nesting under the wall:

```
Wall    #411 placement chain: #391 -> #42 -> #30 -> #99
Opening #421 placement chain: #420 -> #42 -> #30 -> #99      detached, shares parent #42

Slab    #175 placement chain: #154 -> #42 -> #30 -> #99
Opening #186 placement chain: #185 -> #154 -> #42 -> #30 -> #99   nested, follows correctly
```

Across the file: **228 of 295 voids nested (77%, work fine), 67 detached (23%, broken), on 12 hosts.** Every wall is one kind or the other, never mixed.

## The fix

`get_placement_rel_to()` already consults `VoidsElements` and `FillsVoids` when computing an *opening's own* placement, so the codebase already treats "an opening is semantically bound to its host" as true. It just never used that in reverse, when the host moves. This uses it in both directions: walk `HasOpenings`, keep the openings whose placement chain does **not** pass through the host's placement, and move those explicitly after the host's new placement is installed.

## Blast radius, and what to scrutinise

`edit_object_placement` is the lowest level placement mutation in the codebase. Every wall, door, window, furniture and MEP move in Bonsai reaches it (`bonsai.core.geometry.edit_object_placement` -> `ifc.run("geometry.edit_object_placement", ...)`), as does any external script. So, precisely:

**What I changed**
- Added `get_detached_openings()`, which walks `product.HasOpenings` and returns openings whose placement chain does not reach the host's placement, each with its matrix expressed in the host's local frame.
- After the existing children loop, those openings are moved by a recursive `execute()` with the host's new matrix applied to that local matrix.

**How double moving is prevented.** The chain walk (`is_placed_relative_to`) is the exact complement of what the reparenting loop covers. An opening moves by the placement rewrite **or** by the new route, never both. The walk starts at `PlacementRelTo`, not at the opening's own placement, so an opening sharing the host's placement instance is correctly treated as detached rather than assumed to follow. Correctly nested openings never enter the new code path at all.

**What I deliberately did not change**
- Nested openings. Their behaviour and their output bytes are untouched (evidence below).
- `should_transform_children` semantics. The recursion inherits the caller's value, so a filling of a detached opening behaves exactly as a filling of a nested one: it follows when `True`, and keeps its world position when `False` (the #5954 behaviour). Regression tests pin both.
- **Aggregates and nests.** They have the same structural exposure, an `IfcRelAggregates` or `IfcRelNests` child placed outside the parent's placement tree will not follow. But it only bites when `should_transform_children=True`; at the default of `False` a detached child keeps its world position, which is what that mode asks for anyway. Out of scope here on purpose, one defect per PR. Happy to file it separately if you want it tracked.

**Worth a reviewer's attention.** The recursion reparents the detached opening under its host (via the existing `get_placement_rel_to`), so the file self heals on first move and later moves take the cheap nested path. That is a small structural change to files that come in this shape. I think it is right, since it converges on what `get_placement_rel_to` already declares an opening's parent should be, but it is the one behaviour here you might want to weigh in on.

## Why this layer

The alternative was to repair sibling placements on import. I argue against it, but this is a proposal, redirect me if you disagree:

1. The API function is the one making the promise that openings follow their host. It should honour that from the relationship it already trusts, rather than depending on the file having been authored in the shape it prefers.
2. Import repair would rewrite 67 placements in a file the user only opened, producing a large diff on save and breaking round tripping for anyone using Bonsai to view or lightly edit externally authored models.
3. Import repair would not help anyone calling `ifcopenshell.api.geometry.edit_object_placement` from a script.

## Verification on the reported model

`2024125_CONSTRUCTIE_DO_GEBOUW B_RV25_290825.ifc`, IFC2X3, 46 MB, 985k entities, ODA authored. Single wall move, save, reload:

```
                          BEFORE FIX                    AFTER FIX
host    #411    4653.10, 13504.39 -> 5653.10, 14004.39   same
opening #421    4653.10, 13504.39 -> 4653.10, 13504.39   -> 5653.10, 14004.39
drift host vs opening          1118.033989 mm            0.0 mm
host body verts                     32 -> 24             32 -> 32
control #175 (nested)               16 -> 16             16 -> 16, coordinates identical
worst relative-offset change over all 295 voids
                              1118.033989 mm             0.000000 mm
```

Moving **all 71 voided hosts at once** by (1000, 500, 250) mm:

```
                                              BEFORE FIX   AFTER FIX
openings with a changed offset to their host    67 / 295     0 / 295
hosts whose body volume changed                 12 / 71      0 / 71
worst body volume error vs original            +0.130 m3    1.9e-15 relative
IfcOpeningElement / IfcRelVoidsElement         295 / 295    295 / 295
```

The 12 hosts that lost their cut before the fix are exactly the 12 with detached openings:

```
   #411      32 ->  24 verts        #7540     88 ->  70
   #1897     96 ->  70              #9260     88 ->  70
   #3143     88 ->  70              #9848     80 ->  70
   #3724     88 ->  70              #623804   80 ->  70
   #4289     88 ->  70              #624282   88 ->  70
   #4854     96 ->  70              #5419     80 ->  70
```

Body volume is the honest measure here, and it is preserved exactly (max relative deviation 1.9e-15). Triangle counts wobble by a few verts on some hosts, but that is the OCCT boolean retriangulating at different absolute coordinates: an unpatched zero-delta placement rewrite already perturbs 5 hosts the same way, and the opening-to-host matrices in the output are bit identical to the original (max abs difference 0.000000000 across all 12).

**The 77% that already worked are untouched.** Moving all 59 hosts that have only nested openings, before and after the fix, produces output that differs only in `IfcOwnerHistory` wall clock timestamps:

```
$ diff ctrl_unpatched.ifc ctrl_patched.ifc | grep -v IFCOWNERHISTORY
(nothing but line numbers)
openings on nested hosts:  once=228  twice=0  zero=0  other=0     (both runs)
total entities in output:  985286                                 (both runs)
```

Performance is unchanged (773 elements without openings: 1.058s before, 1.086s after; 71 voided hosts: 0.099s before, 0.109s after, and the second figure now includes 67 extra opening moves that previously did not happen).

## Tests

Six new tests in `test_edit_object_placement.py`, run against both IFC4 and IFC2X3:

- detached opening follows its host
- detached opening follows exactly once over two consecutive moves
- **nested** opening follows exactly once (guards against the double move regression)
- filling of a detached opening follows when `should_transform_children=True`
- filling of a detached opening keeps its world position by default
- element with no openings is unaffected, including entity count

```
before the fix:  8 failed, 43 passed   (test_edit_object_placement.py)
after the fix:   0 failed, 51 passed
```

Whole `test/api` plus `test/util`:

```
before:  9 failed, 1818 passed
after:   1 failed, 1826 passed
```

The single remaining failure is `test/util/scripts/test_validate_stub.py::TestValidateStub::test_run`, which fails identically before and after and is an artefact of my local environment pairing the repo's `.pyi` with a prebuilt wrapper. **Pre-existing and not from this change** (it is also the subject of #8946).

`black` and `ruff` clean, run from the repo so `pyproject.toml` is picked up.

## AI disclosure

Per AGENTS.md: this contribution, the code change, the tests, this description, and the commit message, was written with the assistance of an AI coding tool. The root cause analysis and every number above were verified against @PahlawanJoey's model. No new files were added.

@Moult over to you.
