### PR TITLE
Bonsai: keep per-occurrence mapped transforms when duplicating (#7996)

### DIFF
--- a/src/bonsai/bonsai/core/root.py
+++ b/src/bonsai/bonsai/core/root.py
@@ -45,7 +45,13 @@ def copy_class(
     new = ifc.run("root.copy_class", product=element)
     ifc.link(new, obj)
     relating_type = root.get_element_type(new)
-    if relating_type and root.does_type_have_representations(relating_type):
+    # Re-mapping the type only reproduces occurrences that are identity instances of it.
+    # An occurrence that transforms what it maps must be copied instead (issue #7996).
+    if (
+        relating_type
+        and root.does_type_have_representations(relating_type)
+        and not root.has_transformed_mapped_representation(element)
+    ):
         ifc.run("type.map_type_representations", related_object=new, relating_type=relating_type)
         root.link_object_data(ifc.get_object(relating_type), obj)
     elif representation:
@@ -55,8 +61,9 @@ def copy_class(
             geometry.copy_data_links(data, copied_entities)
             geometry.change_object_data(obj, data, is_global=True)
             geometry.rename_object(data, geometry.get_representation_name(ifc.get_entity(data)))
-        # Only assign styles if element doesn't get them from material
-        if not root.has_material_styles(new):
+        # Only assign styles if element doesn't get them from material, and never
+        # through a mapped representation, whose items belong to the type.
+        if not root.has_material_styles(new) and not root.has_mapped_representation(new):
             root.assign_body_styles(new, obj)
     collector.assign(obj)
     return new

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -903,7 +903,9 @@ class Root:
     def get_object_name(cls, obj): pass
     def get_object_representation(cls, obj): pass
     def get_representation_context(cls, representation): pass
+    def has_mapped_representation(cls, element): pass
     def has_material_styles(cls, element): pass
+    def has_transformed_mapped_representation(cls, element): pass
     def is_containable(cls, element): pass
     def is_drawing_annotation(cls, element): pass
     def is_element_a(cls, element, ifc_class): pass

--- a/src/bonsai/bonsai/tool/root.py
+++ b/src/bonsai/bonsai/tool/root.py
@@ -29,6 +29,7 @@ import ifcopenshell.api.style
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
 import ifcopenshell.util.representation
+import numpy as np
 
 import bonsai.core.aggregate
 import bonsai.core.geometry
@@ -98,7 +99,8 @@ class Root(bonsai.core.tool.Root):
             dest.Representation = ifcopenshell.util.element.copy_deep(
                 tool.Ifc.get(),
                 source.Representation,
-                exclude=["IfcGeometricRepresentationContext"],
+                # An occurrence never owns the IfcRepresentationMap it maps, its type does.
+                exclude=["IfcGeometricRepresentationContext", "IfcRepresentationMap"],
                 exclude_callback=exclude_callback,
                 copied_entities=copied_entities,
             )
@@ -120,6 +122,53 @@ class Root(bonsai.core.tool.Root):
     @classmethod
     def does_type_have_representations(cls, element: ifcopenshell.entity_instance) -> bool:
         return bool(element.RepresentationMaps)
+
+    @classmethod
+    def get_mapped_items(cls, element: ifcopenshell.entity_instance) -> list[ifcopenshell.entity_instance]:
+        """All ``IfcMappedItem``\\ s used by an occurrence's representations."""
+        items = []
+        representation = getattr(element, "Representation", None)
+        if not representation:
+            return items
+        for rep in representation.Representations:
+            items.extend(i for i in rep.Items if i.is_a("IfcMappedItem"))
+        return items
+
+    @classmethod
+    def has_mapped_representation(cls, element: ifcopenshell.entity_instance) -> bool:
+        """``True`` if any of the element's representations maps geometry that
+        it shares with its type. Such geometry is owned by the type's
+        ``IfcRepresentationMap`` and must never be styled or edited through the
+        occurrence, or every sibling occurrence changes with it."""
+        return bool(cls.get_mapped_items(element))
+
+    @classmethod
+    def has_transformed_mapped_representation(cls, element: ifcopenshell.entity_instance) -> bool:
+        """``True`` if the element applies its own transform to the geometry it
+        maps from its type, so it is not an identity instance of that type.
+
+        Exporters such as AutoCAD Architecture map one unit-sized shape and
+        give each occurrence an ``IfcCartesianTransformationOperator3DnonUniform``
+        that scales it to length. Re-mapping the type instead of copying such
+        an occurrence discards that transform (issue #7996)."""
+        return any(not cls.is_identity_mapping_target(i.MappingTarget) for i in cls.get_mapped_items(element))
+
+    @classmethod
+    def is_identity_mapping_target(cls, target: ifcopenshell.entity_instance) -> bool:
+        """``True`` if an ``IfcMappedItem``'s ``MappingTarget`` leaves the
+        mapped geometry untouched."""
+        if target.is_a("IfcCartesianTransformationOperator3D"):
+            matrix = ifcopenshell.util.placement.get_cartesiantransformationoperator3d(target)
+            return bool(np.allclose(matrix, np.eye(4)))
+        # 2D operators, conservatively treated as transformed unless plainly identity.
+        if any(coordinate != 0.0 for coordinate in target.LocalOrigin.Coordinates):
+            return False
+        scales = [target.Scale]
+        if target.is_a("IfcCartesianTransformationOperator2DnonUniform"):
+            scales.append(target.Scale2)
+        if any(scale is not None and scale != 1.0 for scale in scales):
+            return False
+        return target.Axis1 is None and target.Axis2 is None
 
     @classmethod
     def get_decomposition_relationships(

--- a/src/bonsai/test/core/test_root.py
+++ b/src/bonsai/test/core/test_root.py
@@ -34,9 +34,34 @@ class TestCopyClass:
         ifc.link("element", "obj").should_be_called()
         root.get_element_type("element").should_be_called().will_return("type")
         root.does_type_have_representations("type").should_be_called().will_return(True)
+        root.has_transformed_mapped_representation("original_element").should_be_called().will_return(False)
         ifc.run("type.map_type_representations", related_object="element", relating_type="type").should_be_called()
         ifc.get_object("type").should_be_called().will_return("type_obj")
         root.link_object_data("type_obj", "obj").should_be_called()
+        collector.assign("obj").should_be_called()
+        subject.copy_class(ifc, collector, geometry, root, obj="obj")
+
+    def test_copy_keeps_the_transform_an_occurrence_applies_to_its_type_geometry(self, ifc, collector, geometry, root):
+        # Occurrences that scale, rotate or offset what they map are not identity
+        # instances of their type, so re-mapping the type would drop that transform
+        # and collapse the copy (issue #7996).
+        ifc.get_entity("obj").should_be_called().will_return("original_element")
+        root.is_element_a("original_element", "IfcRelSpaceBoundary").should_be_called().will_return(False)
+        root.get_object_representation("obj").should_be_called().will_return("representation")
+        ifc.run("root.copy_class", product="original_element").should_be_called().will_return("element")
+        ifc.link("element", "obj").should_be_called()
+        root.get_element_type("element").should_be_called().will_return("type")
+        root.does_type_have_representations("type").should_be_called().will_return(True)
+        root.has_transformed_mapped_representation("original_element").should_be_called().will_return(True)
+        root.copy_representation("original_element", "element").should_be_called().will_return("copied_entities")
+        geometry.duplicate_object_data("obj").should_be_called().will_return("data")
+        geometry.copy_data_links("data", "copied_entities").should_be_called()
+        geometry.change_object_data("obj", "data", is_global=True).should_be_called()
+        ifc.get_entity("data").should_be_called().will_return("new_representation")
+        geometry.get_representation_name("new_representation").should_be_called().will_return("name")
+        geometry.rename_object("data", "name").should_be_called()
+        root.has_material_styles("element").should_be_called().will_return(False)
+        root.has_mapped_representation("element").should_be_called().will_return(True)
         collector.assign("obj").should_be_called()
         subject.copy_class(ifc, collector, geometry, root, obj="obj")
 
@@ -56,6 +81,7 @@ class TestCopyClass:
         geometry.get_representation_name("new_representation").should_be_called().will_return("name")
         geometry.rename_object("data", "name").should_be_called()
         root.has_material_styles("element").should_be_called().will_return(False)
+        root.has_mapped_representation("element").should_be_called().will_return(False)
         root.assign_body_styles("element", "obj").should_be_called()
         collector.assign("obj").should_be_called()
         subject.copy_class(ifc, collector, geometry, root, obj="obj")

--- a/src/bonsai/test/tool/test_root.py
+++ b/src/bonsai/test/tool/test_root.py
@@ -60,6 +60,38 @@ class TestCopyRepresentation(NewFile):
         subject.copy_representation(source, dest)
         assert dest.RepresentationMaps[0].is_a("IfcRepresentationMap")
 
+    def test_copying_a_type_product_does_not_share_its_representation_maps(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        representation_map = ifc.createIfcRepresentationMap()
+        source = ifc.createIfcWallType(RepresentationMaps=[representation_map])
+        dest = ifc.createIfcWallType()
+        subject.copy_representation(source, dest)
+        assert dest.RepresentationMaps[0] != representation_map
+
+    def test_copying_a_product_shares_the_representation_map_it_maps(self):
+        # The map is owned by the type, not by the occurrence. Copying it forks the
+        # type's geometry and leaves the copy pointing at an orphan (issue #7996).
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        representation_map = ifc.createIfcRepresentationMap()
+        item = ifc.createIfcMappedItem(
+            representation_map, ifc.createIfcCartesianTransformationOperator3DnonUniform(Scale=200.0)
+        )
+        source = ifc.createIfcWall(
+            Representation=ifc.createIfcProductDefinitionShape(
+                Representations=[ifc.createIfcShapeRepresentation(Items=[item])]
+            )
+        )
+        dest = ifc.createIfcWall()
+        subject.copy_representation(source, dest)
+        new_item = dest.Representation.Representations[0].Items[0]
+        assert new_item != item
+        assert new_item.MappingSource == representation_map
+        assert new_item.MappingTarget != item.MappingTarget
+        assert new_item.MappingTarget.Scale == 200.0
+        assert len(ifc.by_type("IfcRepresentationMap")) == 1
+
 
 class TestDoesTypeHaveRepresentations(NewFile):
     def test_run(self):
@@ -68,6 +100,83 @@ class TestDoesTypeHaveRepresentations(NewFile):
         assert subject.does_type_have_representations(element) is False
         element.RepresentationMaps = [ifc.createIfcRepresentationMap()]
         assert subject.does_type_have_representations(element) is True
+
+
+class TestMappedRepresentations(NewFile):
+    def create_occurrence(self, ifc, mapping_target):
+        item = ifc.createIfcMappedItem(ifc.createIfcRepresentationMap(), mapping_target)
+        return ifc.createIfcWall(
+            Representation=ifc.createIfcProductDefinitionShape(
+                Representations=[ifc.createIfcShapeRepresentation(Items=[item])]
+            )
+        )
+
+    def identity_target(self, ifc):
+        return ifc.createIfcCartesianTransformationOperator3D(LocalOrigin=ifc.createIfcCartesianPoint((0.0, 0.0, 0.0)))
+
+    def test_an_element_without_a_representation_maps_nothing(self):
+        ifc = ifcopenshell.file()
+        element = ifc.createIfcWall()
+        assert subject.has_mapped_representation(element) is False
+        assert subject.has_transformed_mapped_representation(element) is False
+
+    def test_authored_geometry_is_not_mapped(self):
+        ifc = ifcopenshell.file()
+        element = ifc.createIfcWall(
+            Representation=ifc.createIfcProductDefinitionShape(
+                Representations=[ifc.createIfcShapeRepresentation(Items=[ifc.createIfcFacetedBrep()])]
+            )
+        )
+        assert subject.has_mapped_representation(element) is False
+        assert subject.has_transformed_mapped_representation(element) is False
+
+    def test_an_identity_instance_of_a_type_is_not_transformed(self):
+        ifc = ifcopenshell.file()
+        element = self.create_occurrence(ifc, self.identity_target(ifc))
+        assert subject.has_mapped_representation(element) is True
+        assert subject.has_transformed_mapped_representation(element) is False
+
+    def test_a_non_uniformly_scaled_instance_is_transformed(self):
+        # The AutoCAD Architecture pattern from issue #7996: one unit-sized shape
+        # on the type, scaled to length per occurrence.
+        ifc = ifcopenshell.file()
+        target = ifc.createIfcCartesianTransformationOperator3DnonUniform(
+            LocalOrigin=ifc.createIfcCartesianPoint((0.0, 0.0, 0.0)), Scale=200.0, Scale2=1.0, Scale3=1.0
+        )
+        element = self.create_occurrence(ifc, target)
+        assert subject.has_transformed_mapped_representation(element) is True
+
+    def test_a_uniformly_scaled_instance_is_transformed(self):
+        ifc = ifcopenshell.file()
+        target = self.identity_target(ifc)
+        target.Scale = 2.0
+        element = self.create_occurrence(ifc, target)
+        assert subject.has_transformed_mapped_representation(element) is True
+
+    def test_an_offset_instance_is_transformed(self):
+        ifc = ifcopenshell.file()
+        target = self.identity_target(ifc)
+        target.LocalOrigin = ifc.createIfcCartesianPoint((1.0, 0.0, 0.0))
+        element = self.create_occurrence(ifc, target)
+        assert subject.has_transformed_mapped_representation(element) is True
+
+    def test_a_rotated_instance_is_transformed(self):
+        ifc = ifcopenshell.file()
+        target = self.identity_target(ifc)
+        target.Axis1 = ifc.createIfcDirection((0.0, 1.0, 0.0))
+        target.Axis2 = ifc.createIfcDirection((-1.0, 0.0, 0.0))
+        element = self.create_occurrence(ifc, target)
+        assert subject.has_transformed_mapped_representation(element) is True
+
+    def test_explicit_identity_axes_are_not_a_transform(self):
+        ifc = ifcopenshell.file()
+        target = self.identity_target(ifc)
+        target.Axis1 = ifc.createIfcDirection((1.0, 0.0, 0.0))
+        target.Axis2 = ifc.createIfcDirection((0.0, 1.0, 0.0))
+        target.Axis3 = ifc.createIfcDirection((0.0, 0.0, 1.0))
+        target.Scale = 1.0
+        element = self.create_occurrence(ifc, target)
+        assert subject.has_transformed_mapped_representation(element) is False
 
 
 class TestGetDecompositionRelationships(NewFile):


### PR DESCRIPTION
Fixes the second, larger half of #7996. Complementary to #8385, not a replacement for it. The two are independent and compose (verified below).

## The defect

@PahlawanJoey duplicates slabs together with steel beams via **IFC Duplicate Objects** and the beams appear to vanish. In `Debug_Duplicated.ifc`, 36 of the 72 beams carry a per-occurrence transform on their mapped representation:

```
IFCCARTESIANTRANSFORMATIONOPERATOR3DNONUNIFORM(#670304,#670306,#670302,200.,#670308,1.,1.)
```

The `200.` is the Scale. The producer maps a single 1 mm stub on the type and scales it per occurrence to the real length, so the same `IfcRepresentationMap` legitimately serves occurrences of different sizes. The second model the reporter attached, `2502293-235-1TC-ISO.ifc`, is a raw AutoCAD Architecture 2023 export that Bonsai has never written, and it carries the same pattern, so this is producer data rather than anything Bonsai created.

`bonsai.core.root.copy_class` takes the type-remap path for every occurrence whose type has representation maps. `type.map_type_representations` rebuilds the occurrence's representation from the type, and `geometry.map_representation` mints a fresh identity `IfcCartesianTransformationOperator3D` with `Scale` 1. The 200 is discarded, so a 200 mm lifting anchor duplicates as a 1 mm one, which is invisible at model scale. Bonsai then linked the duplicate's mesh to the type's Blender object, which is only correct for identity instances.

The reporter's own file already shows this: its last 20 beams are the duplicates he made, and every one of them has a plain `Scale` 1 operator and measures 0.001 m along X.

## The fix

Route occurrences that transform what they map down the copy path that already exists in `copy_class`. The duplicate then carries its own copy of the mapping target and keeps its own mesh, which is exactly what the importer already gives such an occurrence on load, so duplication now agrees with import. Identity instances are unaffected and still share their type's mesh.

Two supporting changes make that path correct for mapped geometry:

- `tool.Root.copy_representation` no longer deep copies `IfcRepresentationMap` when the destination is an occurrence. The map belongs to the type, so copying it forked the type's geometry and left the copy pointing at an orphan.
- body styles are no longer assigned through a mapped representation. `assign_representation_styles` traverses into the mapped representation, which is the type's own geometry, so writing styles there would repaint every sibling occurrence.

## Verification

Headless Blender 5.2, both models the reporter supplied, duplicating every `IfcBeam` through `OverrideDuplicateMove.execute_ifc_duplicate_operator`, then measuring the saved and reloaded file with `ifcopenshell.geom`.

`Debug_Duplicated.ifc`, all 36 affected beams, local bounding box in metres:

```
  source      map              source dims         duplicate BEFORE          duplicate AFTER
  670216   670232        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  670371   670232        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  670430   670446   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  670526   670446   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  671331   670446   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  671390   670446   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  672195   672211       (0.45, 0.1, 0.015)      (0.001, 0.1, 0.015)       (0.45, 0.1, 0.015)
  672488   670232        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  672547   670232        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  672606   670446   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  672665   670446   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  673474   670446   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  673533   670446   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  674342   672211       (0.45, 0.1, 0.015)      (0.001, 0.1, 0.015)       (0.45, 0.1, 0.015)
  684130   670446   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  693763   670446   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  705854   705845   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  705879   705845   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  706351   705845   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  706379   705845   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  708601   705845   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  723536   723527       (0.06, 0.06, 0.01)      (0.001, 0.06, 0.01)       (0.06, 0.06, 0.01)
  726767   726758       (0.45, 0.1, 0.012)      (0.001, 0.1, 0.012)       (0.45, 0.1, 0.012)
  729110   729101        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  729121   729101        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  729137   705845   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  729151   705845   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  729580   705845   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  729592   705845   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  730016   726758       (0.45, 0.1, 0.012)      (0.001, 0.1, 0.012)       (0.45, 0.1, 0.012)
  730173   729101        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  730199   729101        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  730210   705845   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  730228   705845   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
  730656   705845   (0.112, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.112, 0.012, 0.0119)
  730668   705845   (0.022, 0.012, 0.0119)   (0.001, 0.012, 0.0119)   (0.022, 0.012, 0.0119)
```

`2502293-235-1TC-ISO.ifc`, all 4 affected beams:

```
  100392   100408        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  100555   100408        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  100782   100408        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
  100849   100408        (0.2, 0.15, 0.15)      (0.001, 0.15, 0.15)        (0.2, 0.15, 0.15)
```

**Sharing is preserved.** Every duplicate references the same `IfcRepresentationMap` id as its source (the `map` column above is identical for source and duplicate). `IfcRepresentationMap` count is unchanged: 16 before and after on `Debug_Duplicated.ifc`, 2 before and after on `2502293-235-1TC-ISO.ifc`, with zero orphans and zero maps unowned by a type.

**No regressions on unrelated models.** Duplicating every `IfcElement` and comparing per element against the same run on `v0.8.0`:

| model | elements | regressed | improved |
| --- | --- | --- | --- |
| AC20-FZK-Haus.ifc | 82 | 0 | 11 |
| Debug_Duplicated.ifc | 132 | 0 | 36 |
| 2502293-235-1TC-ISO.ifc | 24 | 0 | 4 |

**Identity instances still share meshes.** On a minimal fixture with one identity occurrence and one scaled occurrence of the same type, the identity duplicate still points at the type object's mesh, the scaled duplicate keeps its own, and the map count stays at 1.

## Composition with #8385

Merged locally with `fix-7487-type-mapped-duplicate` (one trivial conflict in the `copy_class` condition, the two predicates simply `and` together). Result on `Debug_Duplicated.ifc`: **72 of 72 beams** duplicate at their source size, including #8385's 16 authored `IfcFacetedBrep` beams which keep their own geometry. `2502293-235-1TC-ISO.ifc`: 6 of 6.

The `copy_representation` change here also resolves the orphan-map regression currently in #8385. On AC20-FZK-Haus, #8385 alone takes the `IfcRepresentationMap` count from 145 to 217 with 72 maps orphaned from any type. With this branch merged in, it goes to 161 with 16, which is what plain `v0.8.0` already produces.

## Tests

Regression tests that fail without the fix (9 in `test/tool/test_root.py`, 3 in `test/core/test_root.py`) and pass with it.

| suite | before | after |
| --- | --- | --- |
| `test/core` | 390 passed | 391 passed |
| `test/tool` | 831 passed, 4 failed | 841 passed, 4 failed |
| `test/bim` | 1374 passed, 51 failed | 1374 passed, 51 failed |

The `test/tool` and `test/bim` failures are pre-existing and unrelated (bSDD network fixtures, linked-element geometry slices, `BIMObjectMaterialProperties` in this local Blender 5.2). Identical before and after.

Thanks to @PahlawanJoey, who supplied both models and retested on a current build. Without the second model the scale mechanism would not have been separable from the geometry-substitution one.

@Moult for review, this one is about how a type-mapped occurrence is reproduced.

---

This PR was generated with the assistance of an AI coding tool. All of the code, tests and commit messages in it are AI-generated.
