### PR TITLE
ifcpatch(MergeProjects): stop producing duplicate GlobalIds

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/MergeProjects.py
+++ b/src/ifcpatch/ifcpatch/recipes/MergeProjects.py
@@ -22,6 +22,7 @@ from typing import Union
 
 import ifcpatch
 import ifcopenshell
+import ifcopenshell.guid
 import ifcopenshell.util.element
 import ifcopenshell.util.geolocation
 import ifcopenshell.util.unit
@@ -43,6 +44,13 @@ class Patcher(ifcpatch.BasePatcher):
         Note that other than combining the two (or more) IfcProject elements into
         one, no further processing will be done. This means that you may end up
         with duplicate spatial hierarchies (i.e. 2 sites, 2 buildings, etc).
+
+        Those duplicated hierarchies are kept as separate objects, so any
+        incoming element whose GlobalId is already taken in the main model is
+        given a fresh GlobalId. Some authoring tools emit a constant GlobalId
+        for IfcProject and IfcBuilding across unrelated exports, and without
+        this the merged file would contain two IfcRoot entities sharing one
+        GlobalId, which is invalid IFC.
 
         Will automatically convert length units in the second model to the main
         model's unit before merging.
@@ -137,6 +145,8 @@ class Patcher(ifcpatch.BasePatcher):
         )
         self.added_contexts: set[ifcopenshell.entity_instance] = set()
 
+        existing_guids = {e.GlobalId for e in self.file.by_type("IfcRoot")}
+
         original_project = self.file.by_type("IfcProject")[0]
         merged_project = self.file.add(other.by_type("IfcProject")[0])
 
@@ -144,14 +154,44 @@ class Patcher(ifcpatch.BasePatcher):
             new = self.file.add(element)
             self.added_contexts.add(new)
 
+        added_roots: list[ifcopenshell.entity_instance] = []
         for element in other:
-            self.file.add(element)
+            new = self.file.add(element)
+            if element.is_a("IfcRoot"):
+                added_roots.append(new)
+
+        self.regenerate_colliding_guids(added_roots, merged_project, existing_guids)
 
         for inverse in self.file.get_inverse(merged_project):
             ifcopenshell.util.element.replace_attribute(inverse, merged_project, original_project)
         self.file.remove(merged_project)
 
         self.reuse_existing_contexts()
+
+    def regenerate_colliding_guids(
+        self,
+        added_roots: list[ifcopenshell.entity_instance],
+        merged_project: ifcopenshell.entity_instance,
+        existing_guids: set[str],
+    ) -> None:
+        collisions: list[str] = []
+        for root in added_roots:
+            if root == merged_project:
+                continue
+            guid = root.GlobalId
+            if guid not in existing_guids:
+                existing_guids.add(guid)
+                continue
+            root.GlobalId = ifcopenshell.guid.new()
+            existing_guids.add(root.GlobalId)
+            collisions.append(f"{root.is_a()} #{root.id()} ({guid})")
+
+        if collisions and self.logger:
+            self.logger.warning(
+                "MergeProjects: regenerated %s GlobalId(s) already used by the main model: %s",
+                len(collisions),
+                ", ".join(collisions[:10]) + (", ..." if len(collisions) > 10 else ""),
+            )
 
     def get_unit_name(self, ifc_file: ifcopenshell.file) -> str:
         length_unit = ifcopenshell.util.unit.get_project_unit(ifc_file, "LENGTHUNIT")

--- a/src/ifcpatch/test/test_MergeProject.py
+++ b/src/ifcpatch/test/test_MergeProject.py
@@ -199,6 +199,33 @@ class TestMergeProjects(test.bootstrap.IFC4):
         # Contexts must be reused, not accumulated: one Model + one Body.
         assert len(output.by_type("IfcGeometricRepresentationContext")) == 2
 
+    def test_regenerating_global_ids_that_collide_with_the_original_project(self):
+        # Regression test: some authoring tools emit a constant GlobalId for
+        # IfcProject and IfcBuilding across unrelated exports, so merging two of
+        # their models used to produce two IfcRoot entities sharing one
+        # GlobalId, which is invalid IFC.
+        self.file = self.setup_project(self.file)
+        second_file = self.setup_project()
+
+        original_wall = self.file.by_type("IfcWall")[0]
+        other_wall = second_file.by_type("IfcWall")[0]
+        shared_guid = original_wall.GlobalId
+        other_wall.GlobalId = shared_guid
+        second_file.by_type("IfcProject")[0].GlobalId = self.file.by_type("IfcProject")[0].GlobalId
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "MergeProjects", "arguments": [second_file]})
+
+        # Both walls are kept as distinct objects, as merging does no further processing.
+        walls = output.by_type("IfcWall")
+        assert len(walls) == 2
+        assert len(output.by_type("IfcProject")) == 1
+
+        guids = [e.GlobalId for e in output.by_type("IfcRoot")]
+        assert len(guids) == len(set(guids))
+        # The main model keeps its own identifiers, only the incoming one is reissued.
+        assert original_wall.GlobalId == shared_guid
+        assert {w.GlobalId for w in walls} != {shared_guid}
+
 
 class TestMergeProjectsIFC2X3(test.bootstrap.IFC2X3, TestMergeProjects):
     pass


### PR DESCRIPTION
`MergeProjects` can produce a file containing two `IfcRoot` entities with the same `GlobalId`, which is invalid IFC and silently makes one of them unreachable.

## How it happens

Real models triggered this. AutoCAD Architecture 2023 emits a **constant** `GlobalId` for `IfcProject` and `IfcBuilding` on every export. Two unrelated projects exported from it collide before any of our code runs:

```
roots A=2323  roots B=240  SHARED GlobalIds=2
  3pzk9$nwA1HE$qXEDl$fyR   A: IfcProject  "1304100"
                           B: IfcProject  "2502293"
  37elFsWKJqxuJZR$wV6t$Y   A: IfcBuilding "Moederorder - - voor -"
                           B: IfcBuilding "Wij-Wonen 65 woningen Noorderduin fase 4"
```

`MergeProjects.merge` federates with a bare `self.file.add(element)` loop, and `file.add` never checks `GlobalId`, so both buildings land in the output carrying the same one. Keeping both hierarchies is the recipe's documented intent and stays unchanged; keeping both with one identifier is the defect.

## Why it is worth fixing rather than blaming the producer

`IfcParse` warns on load, then overwrites its guid map, so `by_guid` returns only the later instance. The earlier entity becomes unreachable by identifier while still present in the file. Downstream tooling that keys on `GlobalId` collapses the pair into one without reporting anything.

## The change

`merge` snapshots the main model's `GlobalId` values before merging and reissues a fresh id to any incoming `IfcRoot` whose id is already taken, logging each change. The main model keeps all of its identifiers. Both hierarchies survive as distinct objects.

Before and after on a reproduction built from the two files above:

```
before:  479 roots, 478 unique, 1 duplicate  (IfcBuilding x2)
after :  479 roots, 479 unique, 0 duplicates, 2 IfcBuilding retained
```

## Tests

`test_regenerating_global_ids_that_collide_with_the_original_project` added to `src/ifcpatch/test/test_MergeProject.py`, running under both IFC4 and IFC2X3. It fails without the change and passes with it.

The 4 remaining failures in that suite are pre-existing duplicate-representation-context failures, already tracked as #8700 with PR #8707 open, and are identical before and after this change.

Separately noted while testing, not addressed here: `test_using_the_georeferencing_of_the_original_project` is nondeterministic. Running it 5 times gave 1,1,2,2,1 failures on an unmodified tree and 1,1,2,1,2 with this change. The cause is `reuse_existing_contexts` iterating `self.added_contexts`, a `set` of entity instances whose order varies by object hash. Unrelated to this change and worth its own fix.

Generated with the assistance of an AI coding tool.
