### PR TITLE
Bonsai: tell the user how to recover missing dependencies (#8031)

### DIFF
--- a/src/bonsai/bonsai/__init__.py
+++ b/src/bonsai/bonsai/__init__.py
@@ -389,6 +389,15 @@ if IN_BLENDER:
                         box.label(text="installation from Blender extensions platform")
                         box.label(text="is not supported and you need to download")
                         box.label(text="and install Bonsai from the link below.")
+                elif "No module named 'ifcopenshell'" in (last_error or ""):
+                    box.separator()
+                    # Blender extracts bundled wheels into a site-packages folder shared by every
+                    # extension and only re-syncs it when an extension is enabled or disabled.
+                    box.label(text="Bonsai's Python dependencies are missing.")
+                    box.label(text="Blender only reinstalls them when an")
+                    box.label(text="extension is enabled or disabled.")
+                    box.label(text="To restore them, DISABLE Bonsai in")
+                    box.label(text="Preferences > Add-ons, then ENABLE it again.")
 
                 layout.operator("bim.copy_debug_information", text="Copy Error Message To Clipboard")
                 op = layout.operator("bim.open_uri", text="How Can I Fix This?")

--- a/src/bonsai/docs/guides/troubleshooting.rst
+++ b/src/bonsai/docs/guides/troubleshooting.rst
@@ -91,6 +91,34 @@ can `report a bug <https://github.com/ifcopenshell/ifcopenshell/issues>`_ or
    from `Github Releases <https://github.com/IfcOpenShell/IfcOpenShell/releases>`__ 
    or from Blender extensions platform.
 
+5. **I get an error saying "ModuleNotFoundError: No module named 'ifcopenshell'"**
+
+   Bonsai bundles ``ifcopenshell`` and its other Python dependencies as wheels.
+   Blender extracts those wheels into a single folder shared by every
+   installed extension (``extensions/.local/lib/pythonX.XX/site-packages/``),
+   and it only refreshes that folder when an extension is enabled, disabled,
+   installed or uninstalled. It never refreshes it on startup.
+
+   If that refresh does not complete, for example because an update was
+   interrupted, or because a file was still locked by a running Blender, the
+   Bonsai extension is left in place while its dependencies are gone. Restarting
+   Blender does not fix it, because startup does not trigger a refresh.
+
+   Two situations commonly cause this:
+
+   - An update of Bonsai was interrupted or could not replace files that were
+     still in use.
+   - You had two extensions installed that both bundle the same dependencies,
+     such as **Bonsai** and **BonsaiPR**, and you disabled or removed one of
+     them. Both share the same folder, so removing one can take the shared
+     dependencies away from the other.
+
+   To fix it, go to :menuselection:`Edit --> Preferences --> Add-ons`, find
+   Bonsai, **disable** it, then **enable** it again. Blender will re-extract the
+   bundled wheels. Restart Blender afterwards.
+
+   To avoid the second situation, only enable one Bonsai extension at a time.
+
 Saving and loading blend files
 ------------------------------
 

--- a/src/bonsai/docs/guides/troubleshooting.rst
+++ b/src/bonsai/docs/guides/troubleshooting.rst
@@ -108,16 +108,14 @@ can `report a bug <https://github.com/ifcopenshell/ifcopenshell/issues>`_ or
 
    - An update of Bonsai was interrupted or could not replace files that were
      still in use.
-   - You had two extensions installed that both bundle the same dependencies,
-     such as **Bonsai** and **BonsaiPR**, and you disabled or removed one of
-     them. Both share the same folder, so removing one can take the shared
-     dependencies away from the other.
+   - You have more than one extension installed that bundles the same
+     dependencies, such as **Bonsai** and **BonsaiPR**. They share one folder,
+     so enabling or disabling either of them rewrites it, and a rewrite that
+     cannot complete leaves both without dependencies.
 
    To fix it, go to :menuselection:`Edit --> Preferences --> Add-ons`, find
    Bonsai, **disable** it, then **enable** it again. Blender will re-extract the
    bundled wheels. Restart Blender afterwards.
-
-   To avoid the second situation, only enable one Bonsai extension at a time.
 
 Saving and loading blend files
 ------------------------------


### PR DESCRIPTION
## Problem

Bonsai fails to start with `ModuleNotFoundError: No module named 'ifcopenshell'` and `binary_error: Couldn't find ifcopenshell wrapper binary.`, and the fatal error panel only says "Bonsai could not load." The "How Can I Fix This?" link points at a troubleshooting page with no entry for this failure, so the user has nowhere to go.

## Root cause (not ours to fix, but ours to explain)

Blender extracts every extension's bundled wheels into a single shared folder, `extensions/.local/lib/pythonX.XX/site-packages`, and re-syncs it only on install, uninstall, enable or disable. Startup never triggers a sync (`addon_utils._initialize_extensions_compat_data`, `_bpy_internal.extensions.wheel_manager.apply_action`).

If that sync does not complete, the extension folder stays in place while its dependencies are gone. Repairing the install belongs to Blender, so this PR does not touch install state. It only names the condition and states the recovery step.

## Verification (Blender 5.1.2, isolated `BLENDER_USER_RESOURCES` profile)

- With `ifcopenshell` deleted from the shared site-packages, the extension is still listed as enabled and the import still fails on three consecutive restarts. The broken state is permanent from the user's point of view.
- Disabling then re-enabling the extension restores the wheels (`['ifcopenshell', 'ifcopenshell-0.8.6.dist-info']`). That is the recovery step the panel and the docs now give.
- With two extensions bundling the same wheel, the shared folder is rewritten on every enable and disable (`B enabled -> 0.8.7`, `B disabled -> []`, `A enabled -> 0.8.6`), which is why an incomplete rewrite strands whatever is left enabled.
- The new panel text renders in exactly the reported state, immediately below the existing System Information box and above "Copy Error Message To Clipboard".

## Change

- `src/bonsai/bonsai/__init__.py`: one extra branch in `BIM_PT_fatal_error.draw`, next to the existing wrong-Python-version advice, shown only when the traceback is `No module named 'ifcopenshell'`. No behaviour change, no install state is read or written.
- `src/bonsai/docs/guides/troubleshooting.rst`: a matching "Installation issues" entry.

Fixes #8031.

Generated with the assistance of an AI coding tool.
