### PR TITLE
Agent/fix ms project task lags

### DIFF
--- a/src/ifc4d/ifc4d/msp2ifc.py
+++ b/src/ifc4d/ifc4d/msp2ifc.py
@@ -64,9 +64,23 @@ class MSP2Ifc:
         id = 0
         if task.findall("pr:PredecessorLink", self.ns):
             for relationship in task.findall("pr:PredecessorLink", self.ns):
+                lag_format = relationship.findtext("pr:LagFormat", namespaces=self.ns)
+                link_lag = relationship.findtext("pr:LinkLag", namespaces=self.ns)
+                duration_type = (
+                    "ELAPSEDTIME"
+                    if lag_format in {"4", "6", "8", "10", "12", "36", "38", "40", "42", "44"}
+                    else "WORKTIME"
+                )
+                hours_per_day = (
+                    24 if duration_type == "ELAPSEDTIME" else int(self.project["MinutesPerDay"] or 8 * 60) / 60
+                )
                 relationships[id] = {
                     "PredecessorTask": relationship.find("pr:PredecessorUID", self.ns).text,
                     "Type": relationship.find("pr:Type", self.ns).text,
+                    "Lag": (
+                        timedelta(days=int(link_lag) / 10 / 60 / hours_per_day) if link_lag and int(link_lag) else None
+                    ),
+                    "LagDurationType": duration_type,
                 }
                 id += 1
         return relationships
@@ -371,6 +385,13 @@ class MSP2Ifc:
                         self.file,
                         rel_sequence=rel_sequence,
                         attributes={"SequenceType": self.sequence_type_map[predecessor["Type"]]},
+                    )
+                if predecessor["Lag"]:
+                    ifcopenshell.api.sequence.assign_lag_time(
+                        self.file,
+                        rel_sequence=rel_sequence,
+                        lag_value=predecessor["Lag"],
+                        duration_type=predecessor["LagDurationType"],
                     )
 
     def parse_resources_xml(self, project):

--- a/src/ifc4d/ifc4d/msp2ifc.py
+++ b/src/ifc4d/ifc4d/msp2ifc.py
@@ -27,6 +27,10 @@ import ifcopenshell.api.root
 import ifcopenshell.api.sequence
 import ifcopenshell.util.date
 
+ELAPSED_LAG_FORMATS = {"4", "6", "8", "10", "12", "20", "36", "38", "40", "42", "44", "52"}
+PERCENTAGE_LAG_FORMATS = {"19", "20", "51", "52"}
+NULL_LAG_FORMATS = {"21", "53"}
+
 
 class MSP2Ifc:
     def __init__(self, optionalColumns: list[str] = []):
@@ -65,25 +69,49 @@ class MSP2Ifc:
         if task.findall("pr:PredecessorLink", self.ns):
             for relationship in task.findall("pr:PredecessorLink", self.ns):
                 lag_format = relationship.findtext("pr:LagFormat", namespaces=self.ns)
-                link_lag = relationship.findtext("pr:LinkLag", namespaces=self.ns)
-                duration_type = (
-                    "ELAPSEDTIME"
-                    if lag_format in {"4", "6", "8", "10", "12", "36", "38", "40", "42", "44"}
-                    else "WORKTIME"
-                )
-                hours_per_day = (
-                    24 if duration_type == "ELAPSEDTIME" else int(self.project["MinutesPerDay"] or 8 * 60) / 60
-                )
+                link_lag = int(relationship.findtext("pr:LinkLag", namespaces=self.ns) or 0)
+                duration_type = "ELAPSEDTIME" if lag_format in ELAPSED_LAG_FORMATS else "WORKTIME"
+                if lag_format in PERCENTAGE_LAG_FORMATS:
+                    lag = link_lag / 100 if link_lag else None
+                elif lag_format not in NULL_LAG_FORMATS:
+                    minutes_per_day = (
+                        24 * 60 if duration_type == "ELAPSEDTIME" else int(self.project["MinutesPerDay"] or 8 * 60)
+                    )
+                    lag = self._format_link_lag(link_lag, minutes_per_day)
+                else:
+                    lag = None
                 relationships[id] = {
                     "PredecessorTask": relationship.find("pr:PredecessorUID", self.ns).text,
                     "Type": relationship.find("pr:Type", self.ns).text,
-                    "Lag": (
-                        timedelta(days=int(link_lag) / 10 / 60 / hours_per_day) if link_lag and int(link_lag) else None
-                    ),
+                    "Lag": lag,
                     "LagDurationType": duration_type,
                 }
                 id += 1
         return relationships
+
+    @staticmethod
+    def _format_link_lag(link_lag: int, minutes_per_day: int) -> str | None:
+        if not link_lag:
+            return None
+
+        # Microsoft Project stores LinkLag in tenths of a minute.
+        total_seconds = abs(link_lag) * 60 // 10
+        days, seconds = divmod(total_seconds, minutes_per_day * 60)
+        hours, seconds = divmod(seconds, 60 * 60)
+        minutes, seconds = divmod(seconds, 60)
+
+        duration = f"{'-' if link_lag < 0 else ''}P"
+        if days:
+            duration += f"{days}D"
+        if hours or minutes or seconds:
+            duration += "T"
+            if hours:
+                duration += f"{hours}H"
+            if minutes:
+                duration += f"{minutes}M"
+            if seconds:
+                duration += f"{seconds}S"
+        return duration
 
     def parse_task_xml(self, project):
         if self.project["MinutesPerDay"]:
@@ -386,7 +414,7 @@ class MSP2Ifc:
                         rel_sequence=rel_sequence,
                         attributes={"SequenceType": self.sequence_type_map[predecessor["Type"]]},
                     )
-                if predecessor["Lag"]:
+                if predecessor["Lag"] is not None:
                     ifcopenshell.api.sequence.assign_lag_time(
                         self.file,
                         rel_sequence=rel_sequence,

--- a/src/ifc4d/test/test_msp2ifc.py
+++ b/src/ifc4d/test/test_msp2ifc.py
@@ -1,9 +1,5 @@
 # This file was generated with the assistance of an AI coding tool.
 
-import datetime
-
-import ifcopenshell.util.date
-
 from ifc4d.msp2ifc import MSP2Ifc
 
 
@@ -98,6 +94,30 @@ def test_ms_project_relationship_lags_are_imported(tmp_path):
         <LagFormat>7</LagFormat>
       </PredecessorLink>
     </Task>
+    <Task>
+      <UID>6</UID>
+      <Name>Partial and percentage lags</Name>
+      <WBS>6</WBS>
+      <OutlineNumber>6</OutlineNumber>
+      <OutlineLevel>0</OutlineLevel>
+      <Start>2024-03-25T12:00:00</Start>
+      <Finish>2024-03-25T16:00:00</Finish>
+      <Duration>PT4H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <PredecessorLink>
+        <PredecessorUID>4</PredecessorUID>
+        <Type>1</Type>
+        <LinkLag>2400</LinkLag>
+        <LagFormat>5</LagFormat>
+      </PredecessorLink>
+      <PredecessorLink>
+        <PredecessorUID>5</PredecessorUID>
+        <Type>1</Type>
+        <LinkLag>50</LinkLag>
+        <LagFormat>19</LagFormat>
+      </PredecessorLink>
+    </Task>
   </Tasks>
   <Calendars />
 </Project>
@@ -116,14 +136,23 @@ def test_ms_project_relationship_lags_are_imported(tmp_path):
 
     working_lag = relationships[("1", "2")].TimeLag
     assert working_lag.DurationType == "WORKTIME"
-    assert ifcopenshell.util.date.ifc2datetime(working_lag.LagValue.wrappedValue) == datetime.timedelta(days=5)
+    assert working_lag.LagValue.wrappedValue == "P5D"
 
     elapsed_lag = relationships[("2", "3")].TimeLag
     assert elapsed_lag.DurationType == "ELAPSEDTIME"
-    assert ifcopenshell.util.date.ifc2datetime(elapsed_lag.LagValue.wrappedValue) == datetime.timedelta(days=75)
+    assert elapsed_lag.LagValue.wrappedValue == "P75D"
 
     negative_lag = relationships[("3", "4")].TimeLag
     assert negative_lag.DurationType == "WORKTIME"
-    assert ifcopenshell.util.date.ifc2datetime(negative_lag.LagValue.wrappedValue) == datetime.timedelta(days=-1)
+    assert negative_lag.LagValue.wrappedValue == "-P1D"
 
     assert relationships[("4", "5")].TimeLag is None
+
+    partial_lag = relationships[("4", "6")].TimeLag
+    assert partial_lag.DurationType == "WORKTIME"
+    assert partial_lag.LagValue.wrappedValue == "PT4H"
+
+    percentage_lag = relationships[("5", "6")].TimeLag
+    assert percentage_lag.DurationType == "WORKTIME"
+    assert percentage_lag.LagValue.is_a("IfcRatioMeasure")
+    assert percentage_lag.LagValue.wrappedValue == 0.5

--- a/src/ifc4d/test/test_msp2ifc.py
+++ b/src/ifc4d/test/test_msp2ifc.py
@@ -1,0 +1,129 @@
+# This file was generated with the assistance of an AI coding tool.
+
+import datetime
+
+import ifcopenshell.util.date
+
+from ifc4d.msp2ifc import MSP2Ifc
+
+
+def test_ms_project_relationship_lags_are_imported(tmp_path):
+    xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Relationship lag test</Name>
+  <MinutesPerDay>480</MinutesPerDay>
+  <Tasks>
+    <Task>
+      <UID>1</UID>
+      <Name>Predecessor</Name>
+      <WBS>1</WBS>
+      <OutlineNumber>1</OutlineNumber>
+      <OutlineLevel>0</OutlineLevel>
+      <Start>2024-01-01T08:00:00</Start>
+      <Finish>2024-01-01T16:00:00</Finish>
+      <Duration>PT8H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+    </Task>
+    <Task>
+      <UID>2</UID>
+      <Name>Working time lag</Name>
+      <WBS>2</WBS>
+      <OutlineNumber>2</OutlineNumber>
+      <OutlineLevel>0</OutlineLevel>
+      <Start>2024-01-08T08:00:00</Start>
+      <Finish>2024-01-08T16:00:00</Finish>
+      <Duration>PT8H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <PredecessorLink>
+        <PredecessorUID>1</PredecessorUID>
+        <Type>1</Type>
+        <LinkLag>24000</LinkLag>
+        <LagFormat>7</LagFormat>
+      </PredecessorLink>
+    </Task>
+    <Task>
+      <UID>3</UID>
+      <Name>Elapsed time lag</Name>
+      <WBS>3</WBS>
+      <OutlineNumber>3</OutlineNumber>
+      <OutlineLevel>0</OutlineLevel>
+      <Start>2024-03-23T08:00:00</Start>
+      <Finish>2024-03-23T16:00:00</Finish>
+      <Duration>PT8H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <PredecessorLink>
+        <PredecessorUID>2</PredecessorUID>
+        <Type>1</Type>
+        <LinkLag>1080000</LinkLag>
+        <LagFormat>8</LagFormat>
+      </PredecessorLink>
+    </Task>
+    <Task>
+      <UID>4</UID>
+      <Name>Negative working time lag</Name>
+      <WBS>4</WBS>
+      <OutlineNumber>4</OutlineNumber>
+      <OutlineLevel>0</OutlineLevel>
+      <Start>2024-03-22T08:00:00</Start>
+      <Finish>2024-03-22T16:00:00</Finish>
+      <Duration>PT8H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <PredecessorLink>
+        <PredecessorUID>3</PredecessorUID>
+        <Type>1</Type>
+        <LinkLag>-4800</LinkLag>
+        <LagFormat>7</LagFormat>
+      </PredecessorLink>
+    </Task>
+    <Task>
+      <UID>5</UID>
+      <Name>Zero lag</Name>
+      <WBS>5</WBS>
+      <OutlineNumber>5</OutlineNumber>
+      <OutlineLevel>0</OutlineLevel>
+      <Start>2024-03-25T08:00:00</Start>
+      <Finish>2024-03-25T16:00:00</Finish>
+      <Duration>PT8H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <PredecessorLink>
+        <PredecessorUID>4</PredecessorUID>
+        <Type>1</Type>
+        <LinkLag>0</LinkLag>
+        <LagFormat>7</LagFormat>
+      </PredecessorLink>
+    </Task>
+  </Tasks>
+  <Calendars />
+</Project>
+"""
+    xml_path = tmp_path / "relationship-lags.xml"
+    xml_path.write_text(xml)
+
+    importer = MSP2Ifc()
+    importer.xml = xml_path
+    importer.execute()
+
+    relationships = {
+        (relationship.RelatingProcess.Identification, relationship.RelatedProcess.Identification): relationship
+        for relationship in importer.file.by_type("IfcRelSequence")
+    }
+
+    working_lag = relationships[("1", "2")].TimeLag
+    assert working_lag.DurationType == "WORKTIME"
+    assert ifcopenshell.util.date.ifc2datetime(working_lag.LagValue.wrappedValue) == datetime.timedelta(days=5)
+
+    elapsed_lag = relationships[("2", "3")].TimeLag
+    assert elapsed_lag.DurationType == "ELAPSEDTIME"
+    assert ifcopenshell.util.date.ifc2datetime(elapsed_lag.LagValue.wrappedValue) == datetime.timedelta(days=75)
+
+    negative_lag = relationships[("3", "4")].TimeLag
+    assert negative_lag.DurationType == "WORKTIME"
+    assert ifcopenshell.util.date.ifc2datetime(negative_lag.LagValue.wrappedValue) == datetime.timedelta(days=-1)
+
+    assert relationships[("4", "5")].TimeLag is None

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/assign_lag_time.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/assign_lag_time.py
@@ -16,11 +16,17 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
+from typing import Union
+
 import ifcopenshell.util.date
 
 
 def assign_lag_time(
-    file: ifcopenshell.file, rel_sequence: ifcopenshell.entity_instance, lag_value: str, duration_type: str = "WORKTIME"
+    file: ifcopenshell.file,
+    rel_sequence: ifcopenshell.entity_instance,
+    lag_value: Union[str, datetime.timedelta, float],
+    duration_type: str = "WORKTIME",
 ) -> ifcopenshell.entity_instance:
     """Assign a lag time to a sequence relationship between tasks
 
@@ -34,7 +40,9 @@ def assign_lag_time(
     are allowed.
 
     :param rel_sequence: The IfcRelSequence to assign the lag time to.
-    :param lag_value: An ISO standardised duration string.
+    :param lag_value: An ISO standardised duration string or a percentage
+        ratio, where 0.5 represents 50%. A datetime timedelta is also
+        supported.
     :param duration_type: Choose from WORKTIME for the associated
         calendar-based lag times (this is the most common scenario and is
         recommended as a default), or ELAPSEDTIME to not follow the
@@ -80,8 +88,11 @@ def assign_lag_time(
         # for whatever reason.
         ifcopenshell.api.sequence.assign_lag_time(model, rel_sequence=sequence, lag_value="P1D")
     """
-    duration = file.create_entity("IfcDuration", ifcopenshell.util.date.datetime2ifc(lag_value, "IfcDuration"))
-    lag_time = file.create_entity("IfcLagTime", DurationType=duration_type, LagValue=duration)
+    if isinstance(lag_value, float):
+        lag_value = file.create_entity("IfcRatioMeasure", lag_value)
+    else:
+        lag_value = file.create_entity("IfcDuration", ifcopenshell.util.date.datetime2ifc(lag_value, "IfcDuration"))
+    lag_time = file.create_entity("IfcLagTime", DurationType=duration_type, LagValue=lag_value)
     if rel_sequence.is_a("IfcRelSequence"):
         if (current_lag_time := rel_sequence.TimeLag) and file.get_total_inverses(current_lag_time) == 1:
             file.remove(current_lag_time)

--- a/src/ifcopenshell-python/test/api/sequence/test_assign_lag_time.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_assign_lag_time.py
@@ -1,0 +1,41 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.sequence
+import test.bootstrap
+
+
+class TestAssignLagTime(test.bootstrap.IFC4):
+    def test_assigning_a_percentage_lag(self):
+        predecessor = self.file.createIfcTask()
+        successor = self.file.createIfcTask()
+        rel_sequence = ifcopenshell.api.sequence.assign_sequence(
+            self.file, relating_process=predecessor, related_process=successor
+        )
+
+        lag_time = ifcopenshell.api.sequence.assign_lag_time(self.file, rel_sequence=rel_sequence, lag_value=0.5)
+
+        assert rel_sequence.TimeLag == lag_time
+        assert lag_time.LagValue.is_a("IfcRatioMeasure")
+        assert lag_time.LagValue.wrappedValue == 0.5
+
+
+class TestAssignLagTimeIFC4X3(test.bootstrap.IFC4X3, TestAssignLagTime):
+    pass


### PR DESCRIPTION
Fixes #4185 

Problem

When importing Microsoft Project XML, msp2ifc.py created the predecessor relationships as IfcRelSequence, but ignored the LinkLag and LagFormat values inside each PredecessorLink.

As a result, the relationship type was imported correctly, but no IfcLagTime was assigned. Any delay or lead between predecessor and successor tasks therefore disappeared from the IFC schedule.

Root cause

Microsoft Project stores relationship lag in LinkLag, normally in tenths of a minute. LagFormat determines how that value should be interpreted, including:

* Working time based on the project calendar
* Elapsed time using a 24-hour day
* Percentage lag
* Estimated variants of these formats

Neither LinkLag nor LagFormat was previously processed by the importer.

Fix

parse_relationship_xml() now reads and converts both values.

For duration-based lags:

* Working-time lags use the project’s MinutesPerDay, falling back to 480 minutes.
* Elapsed-time lags use 1,440 minutes per day.
* The value is converted from tenths of a minute into an ISO duration string.
* Negative values are preserved as leads.
* Zero and null lag values do not create an IfcLagTime.

The duration is constructed directly as an ISO string instead of passing an abstract fractional-day timedelta. This is important for sub-day working-time lags. For example, with an eight-hour working day, a four-hour lag must be stored as PT4H. Converting it through timedelta(days=0.5) would incorrectly serialise it as PT12H.

The elapsed and estimated elapsed LagFormat variants are mapped to ELAPSEDTIME; other duration formats use WORKTIME.

Percentage formats are stored as IfcRatioMeasure, which is supported by IfcLagTime. For example, a 50% lag is stored as a ratio of 0.5. assign_lag_time() was extended accordingly while retaining support for ISO duration strings and datetime.timedelta.

Finally, create_rel_sequences() now calls ifcopenshell.api.sequence.assign_lag_time() whenever a parsed lag is present.

Validation

Regression coverage includes:

* Working-time lag
* Elapsed-time lag
* Negative lag or lead
* Zero lag
* Sub-day working-time lag
* Percentage lag
* IfcRatioMeasure assignment in IFC4 and IFC4X3

The original XML file from issue #4185 was also imported successfully:

* 811 tasks
* 974 predecessor relationships
* 138 non-zero lags
* 135 WORKTIME lags
* 3 ELAPSEDTIME lags
* 3 negative lags

Black and Ruff pass, the dedicated importer tests pass, and all 68 sequence API tests pass.

This change focuses on correctly preserving the relationship lag in IFC. Existing downstream scheduling functions that operate at whole-day granularity are outside the scope of this fix.

Generated with the assistance of an AI coding tool.