### PR TITLE
Bonsai: create the Model/Body context when authoring a door into an imported IFC

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/door.py
+++ b/src/bonsai/bonsai/bim/module/model/door.py
@@ -83,6 +83,8 @@ def update_door_modifier_representation(obj: bpy.types.Object) -> None:
         },
     }
 
+    body = tool.Model.get_body_context()
+
     active_context = tool.Geometry.get_active_representation_context(obj)
 
     # ELEVATION_VIEW representation
@@ -94,7 +96,6 @@ def update_door_modifier_representation(obj: bpy.types.Object) -> None:
 
     # MODEL_VIEW representation
     # (Model/Body defined only BEFORE Plan/Body to prevent #2744)
-    body = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
     representation_data["context"] = body
     representation_data["part_of_product"] = ifcopenshell.util.representation.get_part_of_product(element, body)
     model_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)

--- a/src/bonsai/bonsai/bim/module/model/door.py
+++ b/src/bonsai/bonsai/bim/module/model/door.py
@@ -120,32 +120,28 @@ def update_door_modifier_representation(obj: bpy.types.Object) -> None:
             ifcopenshell.api.material.remove_material_set(ifc_file, material=material)
 
     # Body/PLAN_VIEW representation
-    plan_body = ifcopenshell.util.representation.get_context(ifc_file, "Plan", "Body", "PLAN_VIEW")
-    if plan_body:
-        representation_data["context"] = plan_body
-        plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
-        tool.Model.replace_object_ifc_representation(plan_body, obj, plan_representation)
+    plan_body = tool.Model.get_or_create_context("Plan", "Body", "PLAN_VIEW")
+    representation_data["context"] = plan_body
+    plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
+    tool.Model.replace_object_ifc_representation(plan_body, obj, plan_representation)
 
     # Annotation/PLAN_VIEW representation
-    plan_annotation = ifcopenshell.util.representation.get_context(ifc_file, "Plan", "Annotation", "PLAN_VIEW")
-    if plan_annotation:
-        if not sliding_door:
-            # only sliding doors have Annotation/PLAN_VIEW
-            # for other types we just check for old representation and remove it if it's there
-            old_representation = ifcopenshell.util.representation.get_representation(
-                element, "Plan", "Annotation", "PLAN_VIEW"
-            )
-            if old_representation:
-                core.remove_representation(
-                    tool.Ifc,
-                    tool.Geometry,
-                    obj=obj,
-                    representation=old_representation,
-                )
-        else:
-            representation_data["context"] = plan_annotation
-            plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
-            tool.Model.replace_object_ifc_representation(plan_annotation, obj, plan_representation)
+    # only sliding doors have Annotation/PLAN_VIEW
+    # for other types we just check for old representation and remove it if it's there
+    if sliding_door:
+        plan_annotation = tool.Model.get_or_create_context("Plan", "Annotation", "PLAN_VIEW")
+        representation_data["context"] = plan_annotation
+        plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
+        tool.Model.replace_object_ifc_representation(plan_annotation, obj, plan_representation)
+    elif old_representation := ifcopenshell.util.representation.get_representation(
+        element, "Plan", "Annotation", "PLAN_VIEW"
+    ):
+        core.remove_representation(
+            tool.Ifc,
+            tool.Geometry,
+            obj=obj,
+            representation=old_representation,
+        )
 
     core.switch_representation(
         tool.Ifc,

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -39,6 +39,7 @@ from typing import (
 import bmesh
 import bpy
 import ifcopenshell
+import ifcopenshell.api.context
 import ifcopenshell.api.feature
 import ifcopenshell.api.geometry
 import ifcopenshell.api.grid
@@ -2244,6 +2245,27 @@ class Model(bonsai.core.tool.Model):
         body = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
         assert body
         cls.add_representation(obj, body)
+
+    @classmethod
+    def get_body_context(cls) -> ifcopenshell.entity_instance:
+        """Get the Model/Body/MODEL_VIEW subcontext, creating it if the file has none.
+
+        Externally authored IFCs often ship without it, and 3D body geometry
+        cannot be authored until it exists.
+        """
+        ifc_file = tool.Ifc.get()
+        if body := ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW"):
+            return body
+        model = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+        if not model:
+            model = ifcopenshell.api.context.add_context(ifc_file, context_type="Model")
+        return ifcopenshell.api.context.add_context(
+            ifc_file,
+            context_type="Model",
+            context_identifier="Body",
+            target_view="MODEL_VIEW",
+            parent=model,
+        )
 
     @classmethod
     def auto_detect_annotation_fill_area(cls, obj: bpy.types.Object, mesh: bpy.types.Mesh) -> dict | None:

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2247,25 +2247,37 @@ class Model(bonsai.core.tool.Model):
         cls.add_representation(obj, body)
 
     @classmethod
-    def get_body_context(cls) -> ifcopenshell.entity_instance:
-        """Get the Model/Body/MODEL_VIEW subcontext, creating it if the file has none.
+    def get_or_create_context(
+        cls,
+        context_type: ifcopenshell.util.representation.CONTEXT_TYPE,
+        context_identifier: ifcopenshell.util.representation.REPRESENTATION_IDENTIFIER,
+        target_view: ifcopenshell.util.representation.TARGET_VIEW,
+    ) -> ifcopenshell.entity_instance:
+        """Get a subcontext to author into, creating it if the file has none.
 
-        Externally authored IFCs often ship without it, and 3D body geometry
-        cannot be authored until it exists.
+        Externally authored IFCs often ship without the subcontexts Bonsai
+        authors into, and a representation cannot be created until they exist.
+        The parent context is created too if it is also missing.
         """
         ifc_file = tool.Ifc.get()
-        if body := ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW"):
-            return body
-        model = ifcopenshell.util.representation.get_context(ifc_file, "Model")
-        if not model:
-            model = ifcopenshell.api.context.add_context(ifc_file, context_type="Model")
+        if context := ifcopenshell.util.representation.get_context(
+            ifc_file, context_type, context_identifier, target_view
+        ):
+            return context
+        parent = ifcopenshell.util.representation.get_context(ifc_file, context_type)
+        if not parent:
+            parent = ifcopenshell.api.context.add_context(ifc_file, context_type=context_type)
         return ifcopenshell.api.context.add_context(
             ifc_file,
-            context_type="Model",
-            context_identifier="Body",
-            target_view="MODEL_VIEW",
-            parent=model,
+            context_type=context_type,
+            context_identifier=context_identifier,
+            target_view=target_view,
+            parent=parent,
         )
+
+    @classmethod
+    def get_body_context(cls) -> ifcopenshell.entity_instance:
+        return cls.get_or_create_context("Model", "Body", "MODEL_VIEW")
 
     @classmethod
     def auto_detect_annotation_fill_area(cls, obj: bpy.types.Object, mesh: bpy.types.Mesh) -> dict | None:

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -1003,6 +1003,35 @@ class TestGetBodyContext(NewFile):
         assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
 
 
+class TestGetOrCreateContext(NewFile):
+    def create_imported_file(self) -> ifcopenshell.file:
+        """An IFC as exported by other authoring tools: a Model context, no subcontexts."""
+        ifc = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="Project")
+        context = ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        context.ContextIdentifier = "Plan"
+        tool.Ifc.set(ifc)
+        return ifc
+
+    def test_creating_the_plan_body_subcontext_and_its_parent_context(self):
+        ifc = self.create_imported_file()
+        assert ifcopenshell.util.representation.get_context(ifc, "Plan") is None
+        plan_body = subject.get_or_create_context("Plan", "Body", "PLAN_VIEW")
+        assert plan_body.ContextType == "Plan"
+        assert plan_body.ContextIdentifier == "Body"
+        assert plan_body.TargetView == "PLAN_VIEW"
+        assert plan_body.ParentContext == ifcopenshell.util.representation.get_context(ifc, "Plan")
+        assert plan_body.ParentContext in ifc.by_type("IfcProject")[0].RepresentationContexts
+
+    def test_not_creating_duplicate_contexts_on_repeated_calls(self):
+        ifc = self.create_imported_file()
+        assert subject.get_or_create_context("Plan", "Body", "PLAN_VIEW") == subject.get_or_create_context(
+            "Plan", "Body", "PLAN_VIEW"
+        )
+        assert len(ifc.by_type("IfcGeometricRepresentationContext", include_subtypes=False)) == 2
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
+
+
 class TestGetSiblingOccurrenceCount(NewFile):
     """The pen-icon dispatcher's pre-edit warning depends on this count: zero
     means the edit is safe (unique geometry), non-zero means the edit will

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import bpy
 import ifcopenshell
+import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.material
 import ifcopenshell.api.pset
@@ -959,6 +960,47 @@ class TestOffsetWall(NewFile):
         usage.DirectionSense = "NEGATIVE"
         subject.offset_wall(obj, "EXTERIOR")
         assert usage.OffsetFromReferenceLine == 100
+
+
+class TestGetBodyContext(NewFile):
+    def create_imported_file(self) -> ifcopenshell.file:
+        """An IFC as exported by other authoring tools: a Model context, no subcontexts."""
+        ifc = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="Project")
+        context = ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        context.ContextIdentifier = "Plan"
+        tool.Ifc.set(ifc)
+        return ifc
+
+    def test_returning_the_existing_body_subcontext(self):
+        ifc = self.create_imported_file()
+        parent = ifcopenshell.util.representation.get_context(ifc, "Model")
+        body = ifcopenshell.api.context.add_context(
+            ifc, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=parent
+        )
+        assert subject.get_body_context() == body
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
+
+    def test_creating_the_body_subcontext_if_the_file_has_none(self):
+        ifc = self.create_imported_file()
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+        body = subject.get_body_context()
+        assert body.ContextType == "Model"
+        assert body.ContextIdentifier == "Body"
+        assert body.TargetView == "MODEL_VIEW"
+        assert body.ParentContext == ifcopenshell.util.representation.get_context(ifc, "Model")
+
+    def test_creating_the_model_context_if_the_file_has_none(self):
+        ifc = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="Project")
+        tool.Ifc.set(ifc)
+        body = subject.get_body_context()
+        assert body.ParentContext == ifcopenshell.util.representation.get_context(ifc, "Model")
+
+    def test_not_creating_duplicates_on_repeated_calls(self):
+        ifc = self.create_imported_file()
+        assert subject.get_body_context() == subject.get_body_context()
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
 
 
 class TestGetSiblingOccurrenceCount(NewFile):


### PR DESCRIPTION
## Problem

Quick-creating a door type in a model that has no `Model/Body/MODEL_VIEW` subcontext crashes and leaves a door with no geometry:

```
File ".../bonsai/bim/module/model/door.py", line 100, in update_door_modifier_representation
    model_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
File ".../ifcopenshell/api/geometry/add_door_representation.py", line 299, in execute
    if self.settings["context"].TargetView == "ELEVATION_VIEW":
AttributeError: 'NoneType' object has no attribute 'TargetView'
```

`ifcopenshell.util.representation.get_context` is a lookup only. `door.py` passed its `None` straight into `add_door_representation` as the representation context.

Stopping the crash is not enough. `update_door_modifier_representation` looks up four contexts, and on a file with no subcontexts the other three also come back `None` and their representations are silently skipped. A door that gets only its 3D body draws as nothing in a plan drawing.

## Root cause is imported versus authored, not the schema

A project created by Bonsai always gets the full set of subcontexts from `bonsai.core.project.create_project`, so this never shows up on a Bonsai-native model. An IFC exported by another tool may carry only a plain `Model` context, and then there is nowhere to put geometry.

Measured on the reported file (IFC2X3, originating system "Wandplan IFC-Export"):

| | fresh Bonsai project | reported file |
| --- | --- | --- |
| `IfcGeometricRepresentationContext` | 2 (`Model`, `Plan`) | 2, both `ContextIdentifier='Plan'`, `ContextType='Model'` |
| `IfcGeometricRepresentationSubContext` | 12 | 0 |
| `get_context(f, "Model", "Body", "MODEL_VIEW")` | the Body subcontext | `None` |

A synthetic **IFC4** file with the same shape reproduces the identical `AttributeError`, so the schema is not the variable.

## What a complete door type looks like

Bonsai's own shipped library is the reference. `src/bonsai/bonsai/bim/data/libraries/IFC2X3 Demo Library.ifc` contains `IfcDoorStyle` `DT01` with **two** representation maps:

| representation | context |
| --- | --- |
| `Body`, `Brep`, 2 items | `Model/Body/MODEL_VIEW` |
| `Body`, `Annotation2D`, 1 item | `Plan/Body/PLAN_VIEW` |

## Fix

`tool.Model.get_or_create_context(context_type, context_identifier, target_view)` returns a subcontext, creating it, and its parent context if that is missing too, when the file has none. `tool.Model.get_body_context()` is a one-line wrapper over it for `Model/Body/MODEL_VIEW`. `door.py` uses it for `Model/Body/MODEL_VIEW` and for `Plan/Body/PLAN_VIEW`.

This is the get-or-create pattern @theoryshaw proposed for `tool.Drawing.get_body_context` in #7868, and the one `tool.Drawing.create_annotation_context` already uses in tree, applied to the modelling path rather than reinvented. Our own #8343 duplicates @theoryshaw's #7868 for the drawing context and should be closed in favour of his.

### Exactly what gets written to the user's file, and why

Creating a context is a real edit to someone's model, so only what a correct door needs is created, and only when it is missing. On the reported file, one door adds:

| entity | why |
| --- | --- |
| `IfcGeometricRepresentationSubContext` `Model/Body/MODEL_VIEW` | the 3D body has nowhere to go without it, this is the crash |
| `IfcGeometricRepresentationContext` `Plan` (2D), with its `IfcAxis2Placement2D`, `IfcCartesianPoint`, `IfcDirection` | parent for the plan subcontext, appended to `IfcProject.RepresentationContexts` |
| `IfcGeometricRepresentationSubContext` `Plan/Body/PLAN_VIEW` | the plan symbol, the representation `DT01` has and ours was missing |

Two contexts are deliberately left as lookups:

- **`Model/Profile/ELEVATION_VIEW`** is optional. `DT01` does not have it, and its only consumer, `generate_opening_from_filling`, already falls back to a rectangle built from `OverallWidth` and `OverallHeight` when the representation is absent. For the rectangular doors this modifier authors that is the same opening.
- **`Plan/Annotation/PLAN_VIEW`** holds the sliding arrow symbol and nothing else (`add_door_representation` returns `None` for it on any non-sliding door). It is created only when the door type is a sliding one, so swinging doors add nothing.

The helper is idempotent. A file that already has the subcontexts is untouched, and creating a second door creates no further contexts.

The `Model/Body` lookup is also hoisted above `get_active_representation_context`, which falls back to the same lookup and otherwise returned `None` into `core.switch_representation` on the very same code path.

## Depends on #8317

On a file that also lacks `Model/Profile/ELEVATION_VIEW`, the `get_part_of_product` crash fixed by #8317 fires one line earlier. Verified A/B on the reported file:

- this branch alone: `TypeError: 'NoneType' object is not iterable` at `get_part_of_product`, door still empty
- #8317 alone: `AttributeError: 'NoneType' object has no attribute 'TargetView'`, door still empty
- both: door created with geometry

They are distinct defects in different files with different root causes, but the user-visible symptom needs both.

## Verification

Headless Blender 5.2, isolated `BLENDER_USER_RESOURCES`, Bonsai and `ifcopenshell` loaded from this tree, with #8317 applied.

Reported file `CLD_Blok_U_Kalkzandsteen_BGG.ifc` (IFC2X3, 2 contexts, 0 subcontexts), GUI path "Create New IfcDoorStyle" with the Door representation template:

| | branch before this commit | with this commit |
| --- | --- | --- |
| door type representations | 1: `Body`/`SweptSolid` in `Model/Body/MODEL_VIEW` | 2: `Body`/`SweptSolid` in `Model/Body/MODEL_VIEW` and `Body`/`Curve2D` in `Plan/Body/PLAN_VIEW` |
| matches `DT01`'s identifiers and contexts | no | yes |
| mesh | 104 verts, 176 polygons | 104 verts, 176 polygons |
| contexts created | 1 subcontext | 1 context, 2 subcontexts |

- **Save and reload**: the saved file reloads with both representations and the same 104 verts / 176 polygons, as a `MESH`.
- **Second door in the same session**: no new contexts, still 5 total, and the second door type has the same two representations.
- **Fresh Bonsai IFC2X3 project (control)**: 14 contexts before and after, no duplicates, door has its usual three representations (`Model/Body/MODEL_VIEW`, `Model/Profile/ELEVATION_VIEW`, `Plan/Body/PLAN_VIEW`) and 104 verts / 176 polygons. Unchanged by this PR.
- **Sliding door on the reported file**: switching the door to `SLIDING_TO_LEFT` creates `Plan/Annotation/PLAN_VIEW` on demand and writes the arrow symbol (`Annotation`/`Curve2D`, 2 items).

Tests: `test/tool/test_model.py` 39 passed, `test_geometry.py` + `test_root.py` + `test_drawing.py` + `test_type.py` 196 passed, `test/bim -m model` 556 passed with 1 failure, `test_create_a_mep_transition`, which fails identically on the branch point and is a float tolerance issue unrelated to this change.

`TestGetBodyContext` and `TestGetOrCreateContext` cover the existing-subcontext, missing-subcontext, missing-parent-context, plan-parent-creation and idempotency cases.

## Not in scope

The same unchecked lookup is passed on to a representation builder elsewhere. Two verified examples:

- `window.py:99` is an exact mirror of this defect. The `Model/Body/MODEL_VIEW` lookup is unguarded and the `Plan/Body/PLAN_VIEW` one at line 122 is a lookup only, so a window authored into the same file crashes and then comes out without its plan representation.
- `ifcopenshell/api/geometry/regenerate_wall_representation.py:108` sets `self.body` by lookup and never creates it, while `self.axis` four lines below is get-or-created. Duplicating a wall in the reported file crashes at `shape_builder.py:1283` with `AttributeError: 'NoneType' object has no attribute 'ContextIdentifier'`, which is plain `Shift+D`, no doors involved.

Both are deliberately left out to keep this PR reviewable, and the second belongs in `ifcopenshell-python` rather than here.

Generated with the assistance of an AI coding tool.
