### PR TITLE
Bonsai: vendor web UI third-party assets instead of loading from CDNs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,17 @@ src/bonsai/bonsai/bim/data/gantt/index.html
 src/bonsai/bonsai/bim/data/gantt/jsgantt.js
 src/bonsai/bonsai/bim/data/gantt/jsgantt.css
 src/bonsai/bonsai/bim/data/webui/static/js/jquery.min.js
+src/bonsai/bonsai/bim/data/webui/static/js/tabulator.min.js
+src/bonsai/bonsai/bim/data/webui/static/js/socket.io.min.js
+src/bonsai/bonsai/bim/data/webui/static/js/svg.min.js
+src/bonsai/bonsai/bim/data/webui/static/js/svg-pan-zoom.min.js
+src/bonsai/bonsai/bim/data/webui/static/js/bootstrap.min.js
+src/bonsai/bonsai/bim/data/webui/static/css/tabulator_site.min.css
+src/bonsai/bonsai/bim/data/webui/static/css/tabulator_site_dark.min.css
+src/bonsai/bonsai/bim/data/webui/static/css/all.min.css
+src/bonsai/bonsai/bim/data/webui/static/css/bootstrap.min.css
+src/bonsai/bonsai/bim/data/webui/static/webfonts/
+src/bonsai/bonsai/bim/data/webui/static/images/
 src/bonsai/bonsai/bim/data/webui/running_pid.json
 
 # ifcopenshell swig and compiled files

--- a/src/bonsai/Makefile
+++ b/src/bonsai/Makefile
@@ -224,6 +224,42 @@ endif
 	# jQuery is required for web UI functionality
 	cd build/bonsai/bim/data/webui/static/js/ && wget https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js
 
+	# Tabulator renders the schedule and costing tables in the web UI.
+	# Pinned to 6.5.2, the version unpkg's unversioned URL currently resolves
+	# to, so a future upstream release can't silently change table behaviour.
+	cd build/bonsai/bim/data/webui/static/js/ && wget https://unpkg.com/tabulator-tables@6.5.2/dist/js/tabulator.min.js
+	cd build/bonsai/bim/data/webui/static/css/ && wget https://unpkg.com/tabulator-tables@6.5.2/dist/css/tabulator_site.min.css
+	cd build/bonsai/bim/data/webui/static/css/ && wget https://unpkg.com/tabulator-tables@6.5.2/dist/css/tabulator_site_dark.min.css
+
+	# Socket.IO client is required for the web UI's realtime connection to Blender
+	cd build/bonsai/bim/data/webui/static/js/ && wget https://cdn.socket.io/4.0.0/socket.io.min.js
+
+	# Font Awesome provides the icons used throughout the web UI.
+	# The CSS references these webfonts by relative path, so both must ship together.
+	cd build/bonsai/bim/data/webui/static/css/ && wget https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css
+	mkdir -p build/bonsai/bim/data/webui/static/webfonts
+	cd build/bonsai/bim/data/webui/static/webfonts/ && wget https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-brands-400.ttf
+	cd build/bonsai/bim/data/webui/static/webfonts/ && wget https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-brands-400.woff2
+	cd build/bonsai/bim/data/webui/static/webfonts/ && wget https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-regular-400.ttf
+	cd build/bonsai/bim/data/webui/static/webfonts/ && wget https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-regular-400.woff2
+	cd build/bonsai/bim/data/webui/static/webfonts/ && wget https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-solid-900.ttf
+	cd build/bonsai/bim/data/webui/static/webfonts/ && wget https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-solid-900.woff2
+	cd build/bonsai/bim/data/webui/static/webfonts/ && wget https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-v4compatibility.ttf
+	cd build/bonsai/bim/data/webui/static/webfonts/ && wget https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-v4compatibility.woff2
+
+	# SVG.js and svg-pan-zoom render and pan/zoom the drawings viewer in the web UI
+	cd build/bonsai/bim/data/webui/static/js/ && wget https://cdnjs.cloudflare.com/ajax/libs/svg.js/3.1.1/svg.min.js
+	cd build/bonsai/bim/data/webui/static/js/ && wget https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.1/dist/svg-pan-zoom.min.js
+
+	# Bootstrap provides layout and the collapsible panels in the drawings viewer
+	cd build/bonsai/bim/data/webui/static/css/ && wget https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css
+	cd build/bonsai/bim/data/webui/static/js/ && wget https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js
+
+	# Bonsai's own branding images used across the web UI
+	mkdir -p build/bonsai/bim/data/webui/static/images
+	cd build/bonsai/bim/data/webui/static/images/ && wget https://bonsaibim.org/assets/images/favicon-blender.png
+	cd build/bonsai/bim/data/webui/static/images/ && wget https://bonsaibim.org/assets/images/blender/blender-logo.png
+
 	# Provides jsgantt-improved supports for web-based construction sequencing gantt charts
 	cd build/bonsai/bim/data/gantt/ && wget https://raw.githubusercontent.com/jsGanttImproved/jsgantt-improved/master/dist/jsgantt.js
 	cd build/bonsai/bim/data/gantt/ && wget https://raw.githubusercontent.com/jsGanttImproved/jsgantt-improved/master/dist/jsgantt.css

--- a/src/bonsai/bonsai/bim/data/webui/static/js/index.js
+++ b/src/bonsai/bonsai/bim/data/webui/static/js/index.js
@@ -370,16 +370,10 @@ function setTheme(theme) {
   $(":root").css("color-scheme", theme);
   var stylesheet = $("#tabulator-stylesheet");
   if (theme === "light") {
-    stylesheet.attr(
-      "href",
-      "https://unpkg.com/tabulator-tables/dist/css/tabulator_site.min.css"
-    );
+    stylesheet.attr("href", "/static/css/tabulator_site.min.css");
     $("#toggle-theme").html('<i class="fas fa-sun"></i>');
   } else if (theme === "dark") {
-    stylesheet.attr(
-      "href",
-      "https://unpkg.com/tabulator-tables/dist/css/tabulator_site_dark.min.css"
-    );
+    stylesheet.attr("href", "/static/css/tabulator_site_dark.min.css");
     $("#toggle-theme").html('<i class="fas fa-moon"></i>');
   } else if (theme === "blender") {
     $("#toggle-theme").html('<i class="fas fa-adjust"></i>');

--- a/src/bonsai/bonsai/bim/data/webui/templates/costing.html
+++ b/src/bonsai/bonsai/bim/data/webui/templates/costing.html
@@ -13,11 +13,11 @@
     <link
       rel="stylesheet"
       id="tabulator-stylesheet"
-      href="https://unpkg.com/tabulator-tables/dist/css/tabulator_site_dark.min.css"
+      href="/static/css/tabulator_site_dark.min.css?v={{v}}"
     />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+      href="/static/css/all.min.css?v={{v}}"
     />
     <script
       type="text/javascript"
@@ -25,11 +25,11 @@
     ></script>
     <script
       type="text/javascript"
-      src="https://unpkg.com/tabulator-tables/dist/js/tabulator.min.js"
+      src="/static/js/tabulator.min.js?v={{v}}"
     ></script>
     <script
       type="text/javascript"
-      src="https://cdn.socket.io/4.0.0/socket.io.min.js"
+      src="/static/js/socket.io.min.js?v={{v}}"
     ></script>
     <script>
       var SOCKET_PORT = {{port}};
@@ -39,7 +39,7 @@
   <body>
     <nav>
       <img
-        src="https://bonsaibim.org/assets/images/blender/blender-logo.png"
+        src="/static/images/blender-logo.png?v={{v}}"
         alt="Logo"
         class="logo"
       />

--- a/src/bonsai/bonsai/bim/data/webui/templates/demo.html
+++ b/src/bonsai/bonsai/bim/data/webui/templates/demo.html
@@ -8,14 +8,14 @@
     <link
       rel="icon"
       type="image/x-icon"
-      href="https://bonsaibim.org/assets/images/favicon-blender.png"
+      href="/static/images/favicon-blender.png?v={{v}}"
     />
     <!-- here we request the CSS file from the server, -->
     <!-- using registered static path in the server -->
     <link rel="stylesheet" href="/static/css/demo.css?v={{v}}" id="demo-stylesheet" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+      href="/static/css/all.min.css?v={{v}}"
     />
     <script
       type="text/javascript"
@@ -23,7 +23,7 @@
     ></script>
     <script
       type="text/javascript"
-      src="https://cdn.socket.io/4.0.0/socket.io.min.js"
+      src="/static/js/socket.io.min.js?v={{v}}"
     ></script>
     <script>
       // here we define the port that the server is listening on.
@@ -39,7 +39,7 @@
     <!-- the navigation bar at the top of the page. -->
     <nav>
       <img
-        src="https://bonsaibim.org/assets/images/blender/blender-logo.png"
+        src="/static/images/blender-logo.png?v={{v}}"
         alt="Logo"
         class="logo"
       />

--- a/src/bonsai/bonsai/bim/data/webui/templates/drawings.html
+++ b/src/bonsai/bonsai/bim/data/webui/templates/drawings.html
@@ -7,11 +7,11 @@
     <link
       rel="icon"
       type="image/x-icon"
-      href="https://bonsaibim.org/assets/images/favicon-blender.png"
+      href="/static/images/favicon-blender.png?v={{v}}"
     />
     <link
       rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+      href="/static/css/bootstrap.min.css?v={{v}}"
     />
     <link
       rel="stylesheet"
@@ -20,7 +20,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+      href="/static/css/all.min.css?v={{v}}"
     />
     <script
       type="text/javascript"
@@ -28,19 +28,19 @@
     ></script>
     <script
       type="text/javascript"
-      src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/3.1.1/svg.min.js"
+      src="/static/js/svg.min.js?v={{v}}"
     ></script>
     <script
       type="text/javascript"
-      src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.1/dist/svg-pan-zoom.min.js"
+      src="/static/js/svg-pan-zoom.min.js?v={{v}}"
     ></script>
     <script
       type="text/javascript"
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"
+      src="/static/js/bootstrap.min.js?v={{v}}"
     ></script>
     <script
       type="text/javascript"
-      src="https://cdn.socket.io/4.0.0/socket.io.min.js"
+      src="/static/js/socket.io.min.js?v={{v}}"
     ></script>
     <script>
       var SOCKET_PORT = {{port}};
@@ -50,7 +50,7 @@
   <body>
     <nav>
       <img
-        src="https://bonsaibim.org/assets/images/blender/blender-logo.png"
+        src="/static/images/blender-logo.png?v={{v}}"
         alt="Logo"
         class="logo"
       />

--- a/src/bonsai/bonsai/bim/data/webui/templates/gantt.html
+++ b/src/bonsai/bonsai/bim/data/webui/templates/gantt.html
@@ -7,13 +7,13 @@
     <link
       rel="icon"
       type="image/x-icon"
-      href="https://bonsaibim.org/assets/images/favicon-blender.png"
+      href="/static/images/favicon-blender.png?v={{v}}"
     />
     <link rel="stylesheet" type="text/css" href="/jsgantt/jsgantt.css?v={{v}}" />
     <link rel="stylesheet" href="/static/css/gantt.css?v={{v}}" id="gantt-stylesheet" />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+      href="/static/css/all.min.css?v={{v}}"
     />
     <script
       type="text/javascript"
@@ -21,7 +21,7 @@
     ></script>
     <script
       type="text/javascript"
-      src="https://cdn.socket.io/4.0.0/socket.io.min.js"
+      src="/static/js/socket.io.min.js?v={{v}}"
     ></script>
     <script type="text/javascript" src="./jsgantt/jsgantt.js?v={{v}}"></script>
     <script>
@@ -32,7 +32,7 @@
   <body>
     <nav class="no-print">
       <img
-        src="https://bonsaibim.org/assets/images/blender/blender-logo.png"
+        src="/static/images/blender-logo.png?v={{v}}"
         alt="Logo"
         class="logo"
       />

--- a/src/bonsai/bonsai/bim/data/webui/templates/index.html
+++ b/src/bonsai/bonsai/bim/data/webui/templates/index.html
@@ -7,17 +7,17 @@
     <link
       rel="icon"
       type="image/x-icon"
-      href="https://bonsaibim.org/assets/images/favicon-blender.png"
+      href="/static/images/favicon-blender.png?v={{v}}"
     />
     <link rel="stylesheet" href="/static/css/index.css?v={{v}}" id="index-stylesheet" />
     <link
       rel="stylesheet"
       id="tabulator-stylesheet"
-      href="https://unpkg.com/tabulator-tables/dist/css/tabulator_site_dark.min.css"
+      href="/static/css/tabulator_site_dark.min.css?v={{v}}"
     />
     <link
       rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+      href="/static/css/all.min.css?v={{v}}"
     />
     <script
       type="text/javascript"
@@ -25,11 +25,11 @@
     ></script>
     <script
       type="text/javascript"
-      src="https://unpkg.com/tabulator-tables/dist/js/tabulator.min.js"
+      src="/static/js/tabulator.min.js?v={{v}}"
     ></script>
     <script
       type="text/javascript"
-      src="https://cdn.socket.io/4.0.0/socket.io.min.js"
+      src="/static/js/socket.io.min.js?v={{v}}"
     ></script>
     <script>
       var SOCKET_PORT = {{port}};
@@ -39,7 +39,7 @@
   <body>
     <nav>
       <img
-        src="https://bonsaibim.org/assets/images/blender/blender-logo.png"
+        src="/static/images/blender-logo.png?v={{v}}"
         alt="Logo"
         class="logo"
       />

--- a/src/bonsai/scripts/dev_environment.py
+++ b/src/bonsai/scripts/dev_environment.py
@@ -205,10 +205,87 @@ def main() -> None:
             "https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js",
             BONSAI_DATA / "webui" / "static" / "js" / "jquery.min.js",
         ),
+        (
+            "https://unpkg.com/tabulator-tables@6.5.2/dist/js/tabulator.min.js",
+            BONSAI_DATA / "webui" / "static" / "js" / "tabulator.min.js",
+        ),
+        (
+            "https://unpkg.com/tabulator-tables@6.5.2/dist/css/tabulator_site.min.css",
+            BONSAI_DATA / "webui" / "static" / "css" / "tabulator_site.min.css",
+        ),
+        (
+            "https://unpkg.com/tabulator-tables@6.5.2/dist/css/tabulator_site_dark.min.css",
+            BONSAI_DATA / "webui" / "static" / "css" / "tabulator_site_dark.min.css",
+        ),
+        (
+            "https://cdn.socket.io/4.0.0/socket.io.min.js",
+            BONSAI_DATA / "webui" / "static" / "js" / "socket.io.min.js",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css",
+            BONSAI_DATA / "webui" / "static" / "css" / "all.min.css",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-brands-400.ttf",
+            BONSAI_DATA / "webui" / "static" / "webfonts" / "fa-brands-400.ttf",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-brands-400.woff2",
+            BONSAI_DATA / "webui" / "static" / "webfonts" / "fa-brands-400.woff2",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-regular-400.ttf",
+            BONSAI_DATA / "webui" / "static" / "webfonts" / "fa-regular-400.ttf",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-regular-400.woff2",
+            BONSAI_DATA / "webui" / "static" / "webfonts" / "fa-regular-400.woff2",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-solid-900.ttf",
+            BONSAI_DATA / "webui" / "static" / "webfonts" / "fa-solid-900.ttf",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-solid-900.woff2",
+            BONSAI_DATA / "webui" / "static" / "webfonts" / "fa-solid-900.woff2",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-v4compatibility.ttf",
+            BONSAI_DATA / "webui" / "static" / "webfonts" / "fa-v4compatibility.ttf",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/webfonts/fa-v4compatibility.woff2",
+            BONSAI_DATA / "webui" / "static" / "webfonts" / "fa-v4compatibility.woff2",
+        ),
+        (
+            "https://cdnjs.cloudflare.com/ajax/libs/svg.js/3.1.1/svg.min.js",
+            BONSAI_DATA / "webui" / "static" / "js" / "svg.min.js",
+        ),
+        (
+            "https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.1/dist/svg-pan-zoom.min.js",
+            BONSAI_DATA / "webui" / "static" / "js" / "svg-pan-zoom.min.js",
+        ),
+        (
+            "https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css",
+            BONSAI_DATA / "webui" / "static" / "css" / "bootstrap.min.css",
+        ),
+        (
+            "https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js",
+            BONSAI_DATA / "webui" / "static" / "js" / "bootstrap.min.js",
+        ),
+        (
+            "https://bonsaibim.org/assets/images/favicon-blender.png",
+            BONSAI_DATA / "webui" / "static" / "images" / "favicon-blender.png",
+        ),
+        (
+            "https://bonsaibim.org/assets/images/blender/blender-logo.png",
+            BONSAI_DATA / "webui" / "static" / "images" / "blender-logo.png",
+        ),
     )
 
     for url, filepath in downloads:
         print(f"Downloading {url} -> {filepath}")
+        filepath.parent.mkdir(parents=True, exist_ok=True)
         urllib.request.urlretrieve(url, filepath)
 
     input("Dev environment is all set!! \nPress Enter to continue...")


### PR DESCRIPTION
## Summary

Vendors the Bonsai web UI's third-party JavaScript and CSS assets instead of loading them from five different CDNs at page load, so the web UI works with no internet access.

Fixes #8965. The offline requirement was raised by @Tudjack on that issue: some corporate networks block the CDN hosts entirely, so he has been manually downloading these libraries and re-patching every daily build he installs.

## What changed

Follows the pattern already used for jQuery, jsgantt and Brick.ttl: assets are `wget`'d into `static/` by `Makefile` at build time and gitignored, not checked into the repo as binaries.

| Asset | Pinned version | Used by |
|---|---|---|
| Tabulator (js + light/dark css) | 6.5.2 (previously unpinned, unpkg resolved to this today) | index, costing |
| Socket.IO client | 4.0.0 (unchanged) | all 5 pages |
| Font Awesome css + 8 webfont files | 6.6.0 (unchanged) | all 5 pages |
| svg.js | 3.1.1 (unchanged) | drawings |
| svg-pan-zoom | 3.6.1 (unchanged) | drawings |
| Bootstrap (css + js) | 4.5.2 (unchanged) | drawings |
| favicon-blender.png, blender-logo.png | n/a (Bonsai's own branding) | all 5 pages |

Bootstrap and the two branding images were not in the original asset inventory on #8965; re-checking each template directly (`grep -n 'http[s]\?://'`) turned them up too, so they're vendored here as well for the offline case to be complete.

Font Awesome's CSS references its webfonts by relative path (`../webfonts/...`), so those 8 files ship alongside it in a new `static/webfonts/` directory. `index.js` also swapped the Tabulator stylesheet between a light and dark CDN URL on theme toggle; that now points at the local copies too.

`dev_environment.py`'s `downloads` list is updated to match, so a source checkout doesn't diverge from a packaged build.

## Licensing

All vendored files are MIT, except svg-pan-zoom (BSD-2-Clause) and Font Awesome, whose fonts are SIL OFL 1.1 and icons are CC BY 4.0. Every vendored file retains its own embedded license/attribution header (verified for each one). Font Awesome's own license notes this is sufficient: "Downloaded Font Awesome Free files already contain embedded comments with sufficient attribution, so you shouldn't need to do anything additional."

## Verification

Ran the web UI's `sioserver.py` locally and fetched all 5 pages plus every asset they reference (including the Font Awesome webfonts pulled in transitively via CSS) through a Python process where DNS resolution for all 6 former CDN hostnames (`unpkg.com`, `cdn.socket.io`, `cdnjs.cloudflare.com`, `cdn.jsdelivr.net`, `stackpath.bootstrapcdn.com`, `bonsaibim.org`) was forcibly blocked. Every page and asset returned 200. This is process-level DNS blocking, not a full OS-level network-off test (no sudo available in this environment to edit `/etc/hosts` or add firewall rules), but it does prove nothing in the served pages or their vendored JS/CSS attempts to reach those hosts.

Also checked for other runtime network dependencies: no `fetch(`, `XMLHttpRequest`, dynamic `<script>` injection, or `@import` of a remote resource anywhere in `static/js/` or `static/css/`.

## Test plan

- [ ] `make dist` (or equivalent CI build) successfully downloads all pinned assets and the web UI still renders
- [ ] Manually load each of the 5 web UI pages and confirm icons, tables, and the drawings viewer render with no network access

---
This PR contains AI-generated code (implementation, verification, and this description), written with the assistance of an AI coding tool and reviewed by me before submission.
