### PR TITLE
Bonsai: Quick Create authors a real door type on IFC2X3, not an empty one

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -73,85 +73,100 @@ class AddDefaultType(bpy.types.Operator, tool.Ifc.Operator):
     bl_options = {"REGISTER", "UNDO"}
     ifc_element_type: bpy.props.StringProperty()
 
+    # IFC2X3 spells these two type classes differently and the toolbar passes the
+    # spelling of the active schema, while the defaults below are keyed by the IFC4 name.
+    TYPE_CLASS_ALIASES = {
+        "IfcDoorStyle": "IfcDoorType",
+        "IfcWindowStyle": "IfcWindowType",
+    }
+
+    def set_predefined_type(self, context: bpy.types.Context, predefined_type: str) -> None:
+        props = tool.Root.get_root_props()
+        items = get_enum_items(props, "ifc_predefined_type", context) or ()
+        if predefined_type in {i[0] for i in items if i}:
+            props.ifc_predefined_type = predefined_type
+
     def _execute(self, context):
         props = tool.Root.get_root_props()
         props.ifc_product = "IfcElementType"
         props.ifc_class = self.ifc_element_type
-        if self.ifc_element_type == "IfcWallType":
+        ifc_element_type = self.TYPE_CLASS_ALIASES.get(self.ifc_element_type, self.ifc_element_type)
+
+        if ifc_element_type == "IfcWallType":
             if tool.Ifc.get().schema == "IFC2X3":
-                props.ifc_predefined_type = "STANDARD"
+                self.set_predefined_type(context, "STANDARD")
             else:
-                props.ifc_predefined_type = "SOLIDWALL"
+                self.set_predefined_type(context, "SOLIDWALL")
             props.representation_template = "LAYERSET_AXIS2"
-        elif self.ifc_element_type == "IfcRailingType":
-            props.ifc_predefined_type = "BALUSTRADE"
+        elif ifc_element_type == "IfcRailingType":
+            self.set_predefined_type(context, "BALUSTRADE")
             props.representation_template = "RAILING"
 
-        elif self.ifc_element_type == "IfcRoofType":
-            props.ifc_predefined_type = "HIP_ROOF"
+        elif ifc_element_type == "IfcRoofType":
+            self.set_predefined_type(context, "HIP_ROOF")
             props.representation_template = "ROOF"
-        elif self.ifc_element_type == "IfcSlabType":
-            props.ifc_predefined_type = "FLOOR"
+        elif ifc_element_type == "IfcSlabType":
+            self.set_predefined_type(context, "FLOOR")
             props.representation_template = "LAYERSET_AXIS3"
 
-        elif self.ifc_element_type == "IfcDoorType":
-            props.ifc_predefined_type = "DOOR"
+        elif ifc_element_type == "IfcDoorType":
+            self.set_predefined_type(context, "DOOR")
             props.representation_template = "DOOR"
-        elif self.ifc_element_type == "IfcWindowType":
-            props.ifc_predefined_type = "WINDOW"
+        elif ifc_element_type == "IfcWindowType":
+            self.set_predefined_type(context, "WINDOW")
             props.representation_template = "WINDOW"
 
-        elif self.ifc_element_type == "IfcColumnType":
-            props.ifc_predefined_type = "COLUMN"
+        elif ifc_element_type == "IfcColumnType":
+            self.set_predefined_type(context, "COLUMN")
             props.representation_template = "PROFILESET"
-        elif self.ifc_element_type == "IfcBeamType":
-            props.ifc_predefined_type = "BEAM"
+        elif ifc_element_type == "IfcBeamType":
+            self.set_predefined_type(context, "BEAM")
             props.representation_template = "PROFILESET"
-        elif self.ifc_element_type == "IfcMemberType":
-            props.ifc_predefined_type = "CHORD"
+        elif ifc_element_type == "IfcMemberType":
+            self.set_predefined_type(context, "CHORD")
             props.representation_template = "PROFILESET"
-        elif self.ifc_element_type == "IfcPlateType":
-            props.ifc_predefined_type = "SHEET"
+        elif ifc_element_type == "IfcPlateType":
+            self.set_predefined_type(context, "SHEET")
             props.representation_template = "LAYERSET_AXIS3"
-        elif self.ifc_element_type == "IfcFootingType":
-            props.ifc_predefined_type = "FOOTING_BEAM"
+        elif ifc_element_type == "IfcFootingType":
+            self.set_predefined_type(context, "FOOTING_BEAM")
             props.representation_template = "PROFILESET"
-        elif self.ifc_element_type == "IfcPileType":
-            props.ifc_predefined_type = "COHESION"
+        elif ifc_element_type == "IfcPileType":
+            self.set_predefined_type(context, "COHESION")
             props.representation_template = "PROFILESET"
 
-        elif self.ifc_element_type == "IfcDuctSegmentType":
-            props.ifc_predefined_type = "RIGIDSEGMENT"
+        elif ifc_element_type == "IfcDuctSegmentType":
+            self.set_predefined_type(context, "RIGIDSEGMENT")
             props.representation_template = "FLOW_SEGMENT_RECTANGULAR"
-        elif self.ifc_element_type == "IfcPipeSegmentType":
-            props.ifc_predefined_type = "RIGIDSEGMENT"
+        elif ifc_element_type == "IfcPipeSegmentType":
+            self.set_predefined_type(context, "RIGIDSEGMENT")
             props.representation_template = "FLOW_SEGMENT_CIRCULAR"
 
-        elif self.ifc_element_type == "IfcStairFlightType":
-            props.ifc_predefined_type = "STRAIGHT"
+        elif ifc_element_type == "IfcStairFlightType":
+            self.set_predefined_type(context, "STRAIGHT")
             props.representation_template = "STAIR"
-        elif self.ifc_element_type == "IfcRampFlightType":
-            props.ifc_predefined_type = "STRAIGHT"
+        elif ifc_element_type == "IfcRampFlightType":
+            self.set_predefined_type(context, "STRAIGHT")
             props.representation_template = "LAYERSET_AXIS3"
 
-        elif self.ifc_element_type == "IfcFurnitureType":
-            props.ifc_predefined_type = "CHAIR"
+        elif ifc_element_type == "IfcFurnitureType":
+            self.set_predefined_type(context, "CHAIR")
             props.representation_template = "MESH"
-        elif self.ifc_element_type == "IfcSanitaryTerminalType":
-            props.ifc_predefined_type = "TOILETPAN"
+        elif ifc_element_type == "IfcSanitaryTerminalType":
+            self.set_predefined_type(context, "TOILETPAN")
             props.representation_template = "MESH"
-        elif self.ifc_element_type == "IfcLightFixtureType":
-            props.ifc_predefined_type = "DIRECTIONSOURCE"
+        elif ifc_element_type == "IfcLightFixtureType":
+            self.set_predefined_type(context, "DIRECTIONSOURCE")
             props.representation_template = "MESH"
-        elif self.ifc_element_type == "IfcElectricApplianceType":
-            props.ifc_predefined_type = "WASHINGMACHINE"
+        elif ifc_element_type == "IfcElectricApplianceType":
+            self.set_predefined_type(context, "WASHINGMACHINE")
             props.representation_template = "MESH"
-        elif self.ifc_element_type == "IfcGeographicElementType":
+        elif ifc_element_type == "IfcGeographicElementType":
             if tool.Ifc.get().schema == "IFC4":
-                props.ifc_predefined_type = "USERDEFINED"
+                self.set_predefined_type(context, "USERDEFINED")
                 props.ifc_userdefined_type = "VEGETATION"
             elif tool.Ifc.get().schema == "IFC4X3":
-                props.ifc_predefined_type = "VEGETATION"
+                self.set_predefined_type(context, "VEGETATION")
             props.representation_template = "MESH"
 
         bpy.ops.bim.add_element()

--- a/src/bonsai/test/bim/feature/model.feature
+++ b/src/bonsai/test/bim/feature/model.feature
@@ -55,6 +55,30 @@ Scenario: Add one type from the Construction Type Browser
     And I add the construction type
     Then the object "IfcColumn/Column" exists
 
+Scenario: Quick Create a door type
+    Given an empty IFC project
+    When I press "bim.add_default_type(ifc_element_type='IfcDoorType')"
+    Then the variable "representations" is "len({ifc}.by_type('IfcDoorType')[0].RepresentationMaps or ())"
+    And the variable "representations" equals "3"
+
+Scenario: Quick Create a door type on IFC2X3
+    Given an empty IFC2X3 project
+    When I press "bim.add_default_type(ifc_element_type='IfcDoorStyle')"
+    Then the variable "representations" is "len({ifc}.by_type('IfcDoorStyle')[0].RepresentationMaps or ())"
+    And the variable "representations" equals "3"
+
+Scenario: Quick Create a window type on IFC2X3
+    Given an empty IFC2X3 project
+    When I press "bim.add_default_type(ifc_element_type='IfcWindowStyle')"
+    Then the variable "representations" is "len({ifc}.by_type('IfcWindowStyle')[0].RepresentationMaps or ())"
+    And the variable "representations" equals "3"
+
+Scenario: Quick Create a furniture type on IFC2X3, which has no PredefinedType
+    Given an empty IFC2X3 project
+    When I press "bim.add_default_type(ifc_element_type='IfcFurnitureType')"
+    Then the variable "furniture_types" is "len({ifc}.by_type('IfcFurnitureType'))"
+    And the variable "furniture_types" equals "1"
+
 Scenario: Add grid
     Given an empty IFC project
     When I press "bim.add_grid"


### PR DESCRIPTION
## Problem

On an IFC2X3 project, the toolbar path "Door tool > Quick Create IfcDoorStyle" creates a door type with no geometry. The representation template comes out as "No Geometry" and the door type has no representation maps, so every occurrence placed from it is empty. Same for windows.

## Root cause

`bim.add_default_type` selects its defaults with a chain of equality tests against the IFC4 spelling of each type class:

```python
elif self.ifc_element_type == "IfcDoorType":
    props.ifc_predefined_type = "DOOR"
    props.representation_template = "DOOR"
```

The toolbar passes the spelling of the active schema. `AuthoringData.load` already remaps it for IFC2X3 (`src/bonsai/bonsai/bim/module/model/data.py:60-65`), so the Door tool sends `IfcDoorStyle` and the Window tool sends `IfcWindowStyle`. No branch fires, `representation_template` keeps whatever it had, and `bim.add_element` builds a type with nothing in it.

The `IfcWallType` branch immediately above already special-cases IFC2X3 for its predefined type, so the schema difference was known, just not applied to doors and windows.

Measured on a fresh IFC2X3 project, before this commit:

| toolbar tool | class sent | representation_template after | representation maps |
| --- | --- | --- | --- |
| Door | `IfcDoorStyle` | `EMPTY` | 0 |
| Window | `IfcWindowStyle` | `EMPTY` | 0 |

## Audit of the whole operator

Every one of the 23 classes the toolbar can send was run through the operator on IFC2X3, IFC4 and IFC4X3_ADD2, recording the resulting template, predefined type and any exception.

**Two classes have a different IFC2X3 spelling**, and only two: `IfcDoorType` becomes `IfcDoorStyle` and `IfcWindowType` becomes `IfcWindowStyle`. Both are fixed here.

The audit also found a second, distinct schema drift in the same operator, in predefined types rather than class names. IFC2X3's `IfcFurnitureType` has no `PredefinedType` attribute, so `props.ifc_predefined_type = "CHAIR"` raised

```
TypeError: bpy_struct: item.attr = val: enum "CHAIR" not found in ()
```

and aborted the operator before it reached `representation_template`, meaning Quick Create Furniture on IFC2X3 created nothing at all. `IfcDoorStyle` and `IfcWindowStyle` have no `PredefinedType` either. Predefined types are now assigned only when the active schema's class offers the value, which covers all three cases with one guard.

## Fix

Branch selection resolves the two schema aliases to the IFC4 name the defaults are keyed by. `props.ifc_class` still receives the schema's own spelling, so the entity created is a real `IfcDoorStyle`. Predefined types go through `set_predefined_type`, which checks the enum the active schema offers for that class.

After this commit, on IFC2X3:

| toolbar tool | class sent | representation_template after | representation maps |
| --- | --- | --- | --- |
| Door | `IfcDoorStyle` | `DOOR` | 3 |
| Window | `IfcWindowStyle` | `WINDOW` | 3 |
| Furniture | `IfcFurnitureType` | `MESH` | created, no exception |

Three representation maps is what Bonsai's own shipped `IFC2X3 Demo Library.ifc` door style has.

## Out of scope, found by the same audit

Reported here rather than fixed, to keep this reviewable. All verified on a fresh IFC2X3 project.

- `IfcRoofType`, `IfcPileType`, `IfcFootingType` and `IfcGeographicElementType` do not exist in IFC2X3 at all. Activating those tools raises `RuntimeError: Entity with name 'IfcRoofType' not found in schema 'IFC2X3'` from `AuthoringData.ifc_classes` (`data.py:292`), before the operator is ever reached. That is a different layer.
- Quick Create Column, Beam, Member, Duct Segment and Pipe Segment on IFC2X3 fail inside `ifcopenshell.api.material.assign_material` because `IfcMaterialProfileSet` is IFC4 and later. Quick Create Stair Flight fails in `stair.py:139` on `product.ReferencedBy`, which is also IFC4 and later.
- `IfcCableCarrierSegmentType` and `IfcCableSegmentType` have no branch in this operator in any schema, so Quick Create silently produces an empty type for those two tools. Not a schema issue, a gap. Picking their defaults is a design choice, so it is left for a maintainer.

## Verification

Headless Blender 4.5.8, isolated `BLENDER_USER_RESOURCES`, Bonsai and `ifcopenshell` loaded from this tree.

- All 23 toolbar classes re-run on IFC4 and IFC4X3_ADD2 after the change: identical template and predefined type for every one.
- New scenarios in `model.feature`. Without this commit, the three IFC2X3 ones fail (`Variable "representations" is 0, expected 3` for door and window, operator exception for furniture) and the IFC4 control passes.
- `test/tool/test_model.py test/bim -m model`: 562 passed, 1 failed, `test_create_a_mep_transition`, which fails identically on the branch point and is a float tolerance issue unrelated to this change.

## Related

The user hit this on `CLD_Blok_U_Kalkzandsteen_BGG.ifc`, an IFC2X3 export with no representation subcontexts. Getting a usable door in that file also needs #8995 and #8317, which are open. This PR is independent of both and fixes a different step of the same workflow.

Generated with the assistance of an AI coding tool.
