### PR TITLE
Fix space regen doubling Z location

### DIFF
--- a/src/bonsai/bonsai/core/spatial.py
+++ b/src/bonsai/bonsai/core/spatial.py
@@ -222,7 +222,6 @@ def generate_space(
 
     if element and element.is_a("IfcSpace"):
         spatial.set_space_representation_from_polygon(active_obj, element, space_polygon, h, polygon_is_si=True)
-        spatial.translate_obj_to_z_location(active_obj, z)
     else:
         if relating_type:
             name = model.generate_occurrence_name(relating_type, "IfcSpace")

--- a/src/bonsai/test/tool/test_spatial.py
+++ b/src/bonsai/test/tool/test_spatial.py
@@ -288,3 +288,27 @@ class TestGenerateSpace(NewFile):
             )
         )
         assert np.allclose(TEST_VERTS, sorted([tuple(v.co) for v in mesh.vertices]))
+
+    def test_regenerate_space_preserves_z_location(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        scene = bpy.context.scene
+        product = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
+        obj = bpy.data.objects["Cube"]
+        scene.collection.objects.link(obj)
+        tool.Ifc.link(product, obj)
+        scene.cursor.location = (0, 0, 0)
+
+        bpy.ops.bim.generate_space()
+        space = bpy.data.objects["IfcSpace/Space"]
+        space.location.z = 5
+        bpy.context.view_layer.update()
+
+        bpy.context.view_layer.objects.active = space
+        space.select_set(True)
+        obj.select_set(False)
+
+        bpy.ops.bim.generate_space()
+
+        assert np.isclose(space.location.z, 5), f"Expected z=5, got {space.location.z}"


### PR DESCRIPTION
## Summary

When regenerating an existing `IfcSpace` via the Spatial tool (`Shift+G`), the space was placed at double its Z elevation (e.g. 18.98m instead of 9.49m).

## Root cause

Commit `d8de62308` ("Fix space regen not saving geometry to IFC (#7055)") rewrote the space regeneration to use `ShapeBuilder` to write geometry in the object's **local** space (via `get_2d_vertices_from_polygon` which transforms world→local using `obj.matrix_world.inverted()`), then reload via `switch_representation`. This preserves `obj.matrix_world` — the object is already at the correct world position after the representation is rebuilt.

However, the old `spatial.translate_obj_to_z_location(active_obj, z)` call was left in place. This call adds `z` (the object's current world Z from `get_x_y_z_h_mat_from_obj`) on top of the already-correct `obj.location.z`, producing `2 * z`.

Under the previous bmesh-based approach, geometry was built in global coordinates at Z=0, so the translate was necessary to lift the space to the right elevation. With the local-space approach it became redundant.

## Fix

Remove the `spatial.translate_obj_to_z_location(active_obj, z)` call from the existing-`IfcSpace` regeneration branch in `bonsai/core/spatial.py`. The new-space creation branch still needs it (the object starts at Z=0).

## Test

Adds `test_regenerate_space_preserves_z_location` to `test/tool/test_spatial.py`, covering the existing-space regeneration path (previously untested). The test:
1. Creates a wall and generates a space at cursor
2. Moves the space to Z=5 and updates the view layer
3. Selects the space as active object (triggers regeneration branch)
4. Calls `bpy.ops.bim.generate_space()` again
5. Asserts `space.location.z` is still 5 (not 10)

The test uses a non-zero Z because `translate_obj_to_z_location` has a `if z != 0` guard — the bug only manifests at non-zero elevations.

Generated with the assistance of an AI coding tool.