### PR TITLE
Bonsai: make Mirror a true mirror (#7991, #6906)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -708,13 +708,16 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         if mirrored:
             # Say which plane was used. A reflection across a reference that straddles the
             # object's own mirror plane moves nothing, and without this the user cannot tell
-            # that the reference was taken into account at all.
+            # that the reference was taken into account at all. The status bar flash is gone
+            # by the time anyone asks what happened, so this also goes to the console.
             about = (
                 f"across the middle of {mirror_ref.name}, along its local {self.mirror_axis}"
                 if mirror_ref
-                else f"about own local {self.mirror_axis}"
+                else f"about own local {self.mirror_axis} (no reference object)"
             )
-            self.report({"INFO"}, f"Mirrored {mirrored} object{'s' if mirrored > 1 else ''} {about}")
+            summary = f"Mirrored {mirrored} object{'s' if mirrored > 1 else ''} {about}"
+            self.report({"INFO"}, summary)
+            print(f"[bim.mirror_elements] {summary}")
         return {"FINISHED"} if mirrored else {"CANCELLED"}
 
     def mirror_obj(

--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -633,16 +633,17 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
     bl_description = (
         "Mirrors the selected objects in place by truly inverting their geometry. "
         "Select a single object to mirror it about one of its own local planes. "
-        "Select two or more objects and the active object becomes the mirror plane, "
-        "with every other selected object reflected across it. Nothing is duplicated: "
-        "duplicate first if you want to keep the original"
+        "Select two or more and the active object becomes the mirror plane, passing through "
+        "its middle. Mirror Axis picks which local axis of the object, or of the reference, "
+        "is mirrored along. Nothing is duplicated: duplicate first to keep the original"
     )
 
     mirror_axis: bpy.props.EnumProperty(
         name="Mirror Axis",
         description=(
-            "Local axis to mirror along. With a single object this is the object's own axis, "
-            "otherwise it is the axis of the active reference object"
+            "Local axis to mirror along. With a single object this is the object's own axis. "
+            "With a reference object it is the reference's axis, and the mirror plane is the "
+            "plane through the reference's middle at right angles to it"
         ),
         items=(
             ("X", "X", "Mirror along local X, about the local YZ plane"),
@@ -656,18 +657,26 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
     def poll(cls, context):
         return context.selected_objects
 
-    def _execute(self, context):
-        # Blender keeps an object active after it has been deselected. Such an object is not
-        # visibly part of the selection, so treating it as the mirror plane would silently turn
-        # what looks like a single object mirror into a reflection across something off screen.
+    @staticmethod
+    def resolve_selection(
+        context: bpy.types.Context,
+    ) -> tuple[list[bpy.types.Object], Optional[bpy.types.Object]]:
+        """Split the selection into the objects to mirror and the mirror plane, if any.
+
+        Blender keeps an object active after it has been deselected. Such an object is not
+        visibly part of the selection, so treating it as the mirror plane would silently turn
+        what looks like a single object mirror into a reflection across something off screen.
+        """
         active_obj = context.active_object
         if active_obj and not active_obj.select_get():
             active_obj = None
         objs_to_mirror = [obj for obj in context.selected_objects if obj != active_obj] if active_obj else []
-        mirror_ref = active_obj if objs_to_mirror else None
-        if mirror_ref is None:
-            objs_to_mirror = list(context.selected_objects)
+        if objs_to_mirror:
+            return objs_to_mirror, active_obj
+        return list(context.selected_objects), None
 
+    def _execute(self, context):
+        objs_to_mirror, mirror_ref = self.resolve_selection(context)
         axis_index = "XYZ".index(self.mirror_axis)
         self.unsupported_items: set[str] = set()
         self.skipped: list[str] = []
@@ -687,11 +696,11 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         elif self.unsupported_items:
             self.report({"WARNING"}, f"Could not mirror: {', '.join(sorted(self.unsupported_items))}")
         if mirrored:
-            # Say which plane was used. A reflection across a reference whose origin already sits
-            # on the object's own mirror plane moves nothing, and without this the user cannot
-            # tell that the reference was taken into account at all.
+            # Say which plane was used. A reflection across a reference that straddles the
+            # object's own mirror plane moves nothing, and without this the user cannot tell
+            # that the reference was taken into account at all.
             about = (
-                f"across {mirror_ref.name} local {self.mirror_axis}"
+                f"across the middle of {mirror_ref.name}, along its local {self.mirror_axis}"
                 if mirror_ref
                 else f"about own local {self.mirror_axis}"
             )
@@ -907,9 +916,22 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         n_world = mirror_ref.matrix_world.to_3x3().col[axis_index].normalized()
         P_world = Matrix.Scale(-1, 4, n_world).to_3x3()
         new_mat = (P_world @ obj.matrix_world.to_3x3() @ P_local).to_4x4()
-        t_mr = mirror_ref.matrix_world.translation
+        t_mr = self.get_mirror_plane_point(mirror_ref)
         new_mat.translation = t_mr + P_world @ (obj.matrix_world.translation - t_mr)
         obj.matrix_world = new_mat
+
+    @staticmethod
+    def get_mirror_plane_point(mirror_ref: bpy.types.Object) -> Vector:
+        """The point the mirror plane passes through: the middle of the reference object.
+
+        An IFC object's origin is arbitrary and often sits at a corner or even at the model
+        origin, so a plane through it lands somewhere the user cannot see and frequently cuts
+        straight through the object being mirrored. The visible middle is predictable. An empty
+        has an all zero bounding box, so using one as a mirror plane still pivots on its origin,
+        which is the whole point of placing an empty.
+        """
+        centre = tool.Blender.get_object_bounding_box(mirror_ref)["center"]
+        return mirror_ref.matrix_world @ Vector(centre)
 
     def mirror_openings_after_reflection(
         self,
@@ -919,16 +941,12 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         M_host_before: np.ndarray,
         opening_placements_before: dict[int, np.ndarray],
     ) -> None:
-        _, R_quat, _ = obj.matrix_world.decompose()
-        frame_change = np.linalg.inv(np.array(R_quat.to_matrix())) @ M_host_before[:3, :3]
         # Sync the element's IFC placement to its post-reflection Blender position first. The
         # geometry engine converts opening world positions to element local positions using the
         # element placement, so a stale placement lands the void at the wrong offset.
         bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj, apply_scale=False)
         M_host_new = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement)
-        self.apply_opening_mirror(
-            element, mirror_axes, M_host_before, opening_placements_before, frame_change, M_host_new
-        )
+        self.apply_opening_mirror(element, mirror_axes, M_host_before, opening_placements_before, M_host_new)
         for rel in element.HasOpenings:
             opening = rel.RelatedOpeningElement
             tool.Geometry.clear_cache(opening)
@@ -941,14 +959,16 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         mirror_axes: tuple[float, float, float],
         M_host_before: np.ndarray,
         opening_placements_before: dict[int, np.ndarray],
-        frame_change: np.ndarray,
         M_host_new: Optional[np.ndarray] = None,
     ) -> None:
         """Mirror IfcOpeningElement placements and geometry in host local space.
 
-        frame_change = inv(R_host_new) @ R_host_old accounts for a host rotation change, such
-        as the 180 degree Z that assign_inverted_type applies for a Y mirror. Pass the identity
-        when the host rotation does not change.
+        The host's new placement is by construction Reflect @ M_host_old @ P_local, where
+        P_local is the same axis flip applied to its representation. An opening at host local L
+        therefore only needs L' = P_local @ L to land on the true reflection: the reflection and
+        the host's own movement cancel out. No correction for the host's rotation change is
+        needed, and applying one skews openings whenever the mirror plane is not exactly
+        parallel to a host local axis.
 
         M_host_new is the host's IFC world matrix after the mirror. None means it did not move.
         """
@@ -969,11 +989,11 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
             M_abs_old = opening_placements_before[opening.id()]
             M_rel = np.linalg.inv(M_host_before) @ M_abs_old
             M_rel_new = M_rel.copy()
-            M_rel_new[:3, 3] = frame_change @ (H @ M_rel[:3, 3])
+            M_rel_new[:3, 3] = H @ M_rel[:3, 3]
             # Mirror the rotation by conjugation: H@R@H keeps det=+1 and gives the correct
             # mirrored rotation. A direct Householder on the columns yields det=-1, and IFC's
             # Y=Z*X normalisation then introduces a spurious 180 degree Z error.
-            M_rel_new[:3, :3] = frame_change @ (H @ M_rel[:3, :3] @ H)
+            M_rel_new[:3, :3] = H @ M_rel[:3, :3] @ H
             ifcopenshell.api.geometry.edit_object_placement(
                 tool.Ifc.get(), product=opening, matrix=M_host_anchor @ M_rel_new, is_si=False
             )

--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -19,12 +19,13 @@
 # pyright: reportUnnecessaryTypeIgnoreComment=error
 
 import json
-from typing import TYPE_CHECKING, Any, Literal, get_args
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, get_args
 
 import bmesh
 import bpy
 import ifcopenshell
 import ifcopenshell.api.geometry
+import ifcopenshell.api.pset
 import ifcopenshell.api.system
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
@@ -33,6 +34,7 @@ import ifcopenshell.util.shape_builder
 import ifcopenshell.util.system
 import ifcopenshell.util.type
 import ifcopenshell.util.unit
+import numpy as np
 from bpy_extras.object_utils import AddObjectHelper
 from mathutils import Matrix, Vector
 
@@ -47,6 +49,7 @@ from bonsai.bim.helper import get_enum_items
 from bonsai.bim.ifc import IfcStore
 from bonsai.bim.module.model.data import AuthoringData
 from bonsai.bim.module.model.decorator import PolylineDecorator, ProductDecorator
+from bonsai.bim.module.model.door import update_door_modifier_representation
 from bonsai.bim.module.model.polyline import PolylineOperator
 
 from . import mep, profile, slab, wall
@@ -619,63 +622,438 @@ class LoadTypeThumbnails(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class SharedMappedGeometryError(Exception):
+    """Raised when mirroring would mutate geometry shared with sibling occurrences."""
+
+
 class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.mirror_elements"
-    bl_label = "Mirror Elements"
+    bl_label = "Mirror"
     bl_options = {"REGISTER", "UNDO"}
-    bl_description = "Faux-mirrors the selected objects by an active empty along a mirror plane"
+    bl_description = (
+        "Mirrors the selected objects in place by truly inverting their geometry. "
+        "Select a single object to mirror it about its own local YZ plane. "
+        "Select two or more objects and the active object becomes the mirror plane, "
+        "with every other selected object reflected across it. Nothing is duplicated: "
+        "duplicate first if you want to keep the original"
+    )
 
     @classmethod
     def poll(cls, context):
         return context.selected_objects
 
     def _execute(self, context):
-        # This is not a true mirror operation. In BIM, objects that are
-        # mirrored are not the same type. (i.e. a mirrored asymmetric desk is a
-        # completely different product). To preserve types, we calculate
-        # bounding box centroids, and mirror the position of the object.  The
-        # mirrored object performs the necessary rotation to preserve the
-        # mirrored intention, but never actually truly mirror anything (i.e.
-        # scale = -1).
+        active_obj = context.active_object
+        objs_to_mirror = [obj for obj in context.selected_objects if obj != active_obj] if active_obj else []
+        mirror_ref = active_obj if objs_to_mirror else None
+        if mirror_ref is None:
+            objs_to_mirror = list(context.selected_objects)
 
-        # Objects are mirrored along the YZ plane of the mirror object.
-        # Mirrored objects have their relative local Y and Z axes preserved,
-        # and the new X axis is calculated.
+        self.unsupported_items: set[str] = set()
+        for obj in objs_to_mirror:
+            try:
+                self.mirror_obj(context, obj, mirror_ref)
+            except SharedMappedGeometryError as e:
+                self.report({"ERROR"}, str(e))
+        if self.unsupported_items:
+            self.report({"WARNING"}, f"Could not mirror: {', '.join(sorted(self.unsupported_items))}")
+        return {"FINISHED"}
 
-        # In theory, untyped objects may be truly mirrored, but this is not yet
-        # implemented.
-        mirror = context.active_object
-        reflection = Matrix()
-        reflection[0][0] = -1
+    def mirror_obj(
+        self,
+        context: bpy.types.Context,
+        obj: bpy.types.Object,
+        mirror_ref: Optional[bpy.types.Object] = None,
+    ) -> None:
+        element = tool.Ifc.get_entity(obj)
+        if not element:
+            return
 
-        mirror.select_set(False)
+        active_context = tool.Geometry.get_active_representation_context(obj)
+        active_representation = tool.Geometry.get_active_representation(obj)
+        bb_data = tool.Blender.get_object_bounding_box(obj)
+        mirror_axes = self.get_mirror_axes(obj, mirror_ref)
 
-        if not context.selected_objects:
-            self.report(
-                {"INFO"},
-                "At least two objects must be selected: an object to be mirrored, and a mirror axis as the active object.",
-            )
-            return {"FINISHED"}
+        # Snapshot opening world placements AND the host placement BEFORE any geometry or
+        # origin change. We work in the host's local space so the mirrored relative offset
+        # is correct regardless of when the host's IFC placement gets synced.
+        opening_placements_before: dict[int, np.ndarray] = {}
+        M_host_before: Optional[np.ndarray] = None
+        if getattr(element, "HasOpenings", None):
+            M_host_before = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement).copy()
+            for rel in element.HasOpenings:
+                opening = rel.RelatedOpeningElement
+                M = ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement)
+                opening_placements_before[opening.id()] = M.copy()
 
-        bpy.ops.bim.override_object_duplicate_move(is_interactive=False)
+        type_element = ifcopenshell.util.element.get_type(element)
+        usage_type = tool.Model.get_usage_type(element)
+        # LAYER2 (walls) and LAYER3 (slabs) generate instance specific bodies via
+        # DumbWallGenerator / DumbSlabGenerator rather than mapping the type's
+        # RepresentationMaps, so they invert their own representation even when typed.
+        is_typed_occurrence = bool(
+            type_element
+            and element.id() != type_element.id()
+            and type_element.RepresentationMaps
+            and usage_type not in ("LAYER2", "LAYER3")
+        )
 
-        for obj in context.selected_objects:
-            if obj == mirror:
+        if is_typed_occurrence:
+            # The shared mirrored type is always X flipped, so that is the axis the occurrence's
+            # geometry ends up inverted along, whatever the mirror plane's orientation.
+            geometry_axes = (1.0, 0.0, 0.0)
+            self.assign_inverted_type(element)
+        else:
+            geometry_axes = mirror_axes
+            self.invert_representation(element, mirror_axes)
+            # For LAYER2 walls, layers stack along local Y (LayerSetDirection=AXIS2). A Y-axis
+            # flip reverses that direction, so DirectionSense and OffsetFromReferenceLine must
+            # both invert. X/Z flips do not touch local Y.
+            if usage_type == "LAYER2" and mirror_axes[1] > 0.5:
+                mat_usage = ifcopenshell.util.element.get_material(element, should_inherit=False)
+                if mat_usage and mat_usage.is_a("IfcMaterialLayerSetUsage"):
+                    mat_usage.DirectionSense = "NEGATIVE" if mat_usage.DirectionSense == "POSITIVE" else "POSITIVE"
+                    mat_usage.OffsetFromReferenceLine = -mat_usage.OffsetFromReferenceLine
+
+        context.view_layer.update()
+        self.reflect_placement(obj, mirror_ref, geometry_axes, bb_data)
+
+        # Openings are mirrored only now, after the origin has been reflected: they have to be
+        # anchored to the host's final placement, and the frame change needs its final rotation.
+        if opening_placements_before and M_host_before is not None:
+            self.mirror_openings_after_reflection(obj, element, geometry_axes, M_host_before, opening_placements_before)
+            tool.Geometry.clear_cache(element)
+
+        # Bonsai does not automatically switch to the representation that should be active in
+        # the given context, so an element retyped by assign_inverted_type would come back with
+        # the wrong representation.
+        representation = self.get_target_representation(element, active_representation, active_context)
+        if representation:
+            bonsai.core.geometry.switch_representation(tool.Ifc, tool.Geometry, obj=obj, representation=representation)
+
+    def get_target_representation(
+        self,
+        element: ifcopenshell.entity_instance,
+        active_representation: Optional[ifcopenshell.entity_instance],
+        active_context: ifcopenshell.entity_instance,
+    ) -> Union[ifcopenshell.entity_instance, None]:
+        """Find the representation to display after the mirror.
+
+        Matching on the context alone is not enough: files that put Axis, Body and BoundingBox
+        in a single context would come back showing the Axis. The representation identifier has
+        to be preserved as well.
+        """
+        representations = list(ifcopenshell.util.representation.get_representations_iter(element))
+        if active_representation is not None:
+            if active_representation in representations:
+                return active_representation
+            identifier = active_representation.RepresentationIdentifier
+            context = active_representation.ContextOfItems
+            for r in representations:
+                if r.ContextOfItems == context and r.RepresentationIdentifier == identifier:
+                    return r
+            for r in representations:
+                if r.RepresentationIdentifier == identifier:
+                    return r
+        return next((r for r in representations if r.ContextOfItems == active_context), None)
+
+    def get_mirror_axes(
+        self, obj: bpy.types.Object, mirror_ref: Optional[bpy.types.Object]
+    ) -> tuple[float, float, float]:
+        """Return which of the object's local axes the geometry has to be inverted along.
+
+        The mirror plane normal is the reference object's local X. Without a reference the
+        object is mirrored about its own local YZ plane.
+
+        Exactly one axis is ever chosen, the one most parallel to the mirror plane normal.
+        Flipping two axes at once would be a 180 degree rotation rather than a reflection, and
+        reflect_placement relies on the representation flip having a negative determinant to
+        produce an exact world space reflection for an arbitrarily oriented mirror plane.
+        """
+        if not mirror_ref:
+            return (1.0, 0.0, 0.0)
+        mirror_normal_world = mirror_ref.matrix_world.to_3x3().col[0].normalized()
+        mirror_normal_local = obj.matrix_world.to_3x3().inverted() @ mirror_normal_world
+        axis = max(range(3), key=lambda i: abs(mirror_normal_local[i]))
+        return tuple(1.0 if i == axis else 0.0 for i in range(3))
+
+    def reflect_placement(
+        self,
+        obj: bpy.types.Object,
+        mirror_ref: Optional[bpy.types.Object],
+        geometry_axes: tuple[float, float, float],
+        bb_data: dict[str, Any],
+    ) -> None:
+        if not mirror_ref:
+            # No reference: mirror about the local YZ plane through the bounding box centre so
+            # the object stays where it is. Inverting the representation sends local x to -x,
+            # so shifting the origin by min_x + max_x turns that into a reflection about the
+            # centre. Derived from the pre-mirror bounds on purpose: remeasuring the reloaded
+            # mesh would be wrong for a host whose openings have not been mirrored yet.
+            shift = bb_data["min_x"] + bb_data["max_x"]
+            obj.location += (obj.matrix_world @ Vector((shift, 0, 0, 0))).xyz
+            return
+
+        # P_world is the Householder matrix of the mirror plane and P_local the diagonal of the
+        # axis flip applied to the representation. For a local point p the new world position
+        # is P_world @ R @ P_local @ (P_local @ p) + t' = P_world @ (R @ p + t - t_ref) + t_ref,
+        # which is the exact reflection, whatever the plane's orientation. Both determinants
+        # are -1, so new_R stays a proper rotation.
+        P_local = Matrix.Diagonal(Vector([-1.0 if a > 0.5 else 1.0 for a in geometry_axes]))
+        n_world = mirror_ref.matrix_world.to_3x3().col[0].normalized()
+        P_world = Matrix.Scale(-1, 4, n_world).to_3x3()
+        new_mat = (P_world @ obj.matrix_world.to_3x3() @ P_local).to_4x4()
+        t_mr = mirror_ref.matrix_world.translation
+        new_mat.translation = t_mr + P_world @ (obj.matrix_world.translation - t_mr)
+        obj.matrix_world = new_mat
+
+    def mirror_openings_after_reflection(
+        self,
+        obj: bpy.types.Object,
+        element: ifcopenshell.entity_instance,
+        mirror_axes: tuple[float, float, float],
+        M_host_before: np.ndarray,
+        opening_placements_before: dict[int, np.ndarray],
+    ) -> None:
+        _, R_quat, _ = obj.matrix_world.decompose()
+        frame_change = np.linalg.inv(np.array(R_quat.to_matrix())) @ M_host_before[:3, :3]
+        # Sync the element's IFC placement to its post-reflection Blender position first. The
+        # geometry engine converts opening world positions to element local positions using the
+        # element placement, so a stale placement lands the void at the wrong offset.
+        bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj, apply_scale=False)
+        M_host_new = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement)
+        self.apply_opening_mirror(
+            element, mirror_axes, M_host_before, opening_placements_before, frame_change, M_host_new
+        )
+        for rel in element.HasOpenings:
+            opening = rel.RelatedOpeningElement
+            tool.Geometry.clear_cache(opening)
+            if opening_obj := tool.Ifc.get_object(opening):
+                tool.Geometry.reload_representation(opening_obj)
+
+    def apply_opening_mirror(
+        self,
+        element: ifcopenshell.entity_instance,
+        mirror_axes: tuple[float, float, float],
+        M_host_before: np.ndarray,
+        opening_placements_before: dict[int, np.ndarray],
+        frame_change: np.ndarray,
+        M_host_new: Optional[np.ndarray] = None,
+    ) -> None:
+        """Mirror IfcOpeningElement placements and geometry in host local space.
+
+        frame_change = inv(R_host_new) @ R_host_old accounts for a host rotation change, such
+        as the 180 degree Z that assign_inverted_type applies for a Y mirror. Pass the identity
+        when the host rotation does not change.
+
+        M_host_new is the host's IFC world matrix after the mirror. None means it did not move.
+        """
+        M_host_anchor = M_host_new if M_host_new is not None else M_host_before
+        N_local = np.array([1.0 if flip > 0.0 else 0.0 for flip in mirror_axes[:3]])
+        norm = np.linalg.norm(N_local)
+        if norm > 0:
+            N_local /= norm
+        H = np.eye(3) - 2 * np.outer(N_local, N_local)
+
+        # A file may declare the same opening through more than one IfcRelVoidsElement.
+        # Mirroring it twice would put it back where it started.
+        for opening in {
+            rel.RelatedOpeningElement.id(): rel.RelatedOpeningElement for rel in element.HasOpenings
+        }.values():
+            if opening.id() not in opening_placements_before:
                 continue
+            M_abs_old = opening_placements_before[opening.id()]
+            M_rel = np.linalg.inv(M_host_before) @ M_abs_old
+            M_rel_new = M_rel.copy()
+            M_rel_new[:3, 3] = frame_change @ (H @ M_rel[:3, 3])
+            # Mirror the rotation by conjugation: H@R@H keeps det=+1 and gives the correct
+            # mirrored rotation. A direct Householder on the columns yields det=-1, and IFC's
+            # Y=Z*X normalisation then introduces a spurious 180 degree Z error.
+            M_rel_new[:3, :3] = frame_change @ (H @ M_rel[:3, :3] @ H)
+            ifcopenshell.api.geometry.edit_object_placement(
+                tool.Ifc.get(), product=opening, matrix=M_host_anchor @ M_rel_new, is_si=False
+            )
 
-            objmat = mirror.matrix_world.inverted() @ obj.matrix_world.copy()
-            x, y, z = objmat.to_3x3().col
-            centroid = Vector(obj.bound_box[0]).lerp(Vector(obj.bound_box[6]), 0.5)
-            c = mirror.matrix_world.inverted() @ obj.matrix_world @ centroid
-            newy = mirror.matrix_world.to_quaternion() @ (y @ reflection)
-            newz = mirror.matrix_world.to_quaternion() @ (z @ reflection)
-            newx = newy.cross(newz)
-            newc = mirror.matrix_world @ (c @ reflection)
+            if not opening.Representation:
+                continue
+            builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
+            for rep in opening.Representation.Representations:
+                for item in rep.Items:
+                    if item.is_a("IfcExtrudedAreaSolid"):
+                        self.mirror_opening_extrusion(builder, item, H)
+                    else:
+                        builder.mirror(item, mirror_axes[:2], create_copy=False)
 
-            newmat = Matrix((newx.to_4d(), newy.to_4d(), newz.to_4d(), newc.to_4d())).transposed()
-            newmat.translation = Vector(newmat.translation) - (newmat.to_quaternion() @ centroid)
+    def mirror_opening_extrusion(
+        self,
+        builder: ifcopenshell.util.shape_builder.ShapeBuilder,
+        item: ifcopenshell.entity_instance,
+        H: np.ndarray,
+    ) -> None:
+        """Mirror an opening's extrusion with the host local Householder matrix H.
 
-            obj.matrix_world = newmat
+        Applying H as the geometric transform to opening local coordinates is correct because
+        M_rel_new @ T_geom = H @ M_rel with M_rel_new = H@R@H, hence T_geom = H. Conjugating it
+        into Position local space gives H_pos = placement.T @ H @ placement.
+        """
+        placement_mat = ifcopenshell.util.placement.get_axis2placement(item.Position)[:3, :3]
+        H_pos = placement_mat.T @ H @ placement_mat
+
+        pos_coords = item.Position.Location.Coordinates
+        pos3 = np.array([pos_coords[0], pos_coords[1], pos_coords[2] if len(pos_coords) > 2 else 0.0])
+        pos3_new = H @ pos3
+        item.Position.Location.Coordinates = tuple(float(v) for v in pos3_new[: len(pos_coords)])
+
+        # H_pos is a reflection (det=-1) so the profile winding has to be reversed.
+        profile = item.SweptArea
+        curves = [c for c in [getattr(profile, "OuterCurve", None)] if c is not None]
+        curves.extend(getattr(profile, "InnerCurves", None) or [])
+        for curve in curves:
+            coords = builder.get_polyline_coords(curve)
+            coords3 = np.hstack([coords, np.zeros((len(coords), 1))])
+            builder.set_polyline_coords(curve, (H_pos @ coords3.T).T[:, :2][::-1])
+
+        dir_local = np.array(item.ExtrudedDirection.DirectionRatios)
+        item.ExtrudedDirection.DirectionRatios = tuple(float(v) for v in H_pos @ dir_local)
+
+    def is_type_owned_mapping(self, item: ifcopenshell.entity_instance) -> bool:
+        """Whether inverting this IfcMappedItem's source would affect sibling occurrences."""
+        representation_map = item.MappingSource
+        if len(representation_map.MapUsage) > 1:
+            return True
+        return any(inv.is_a("IfcTypeProduct") for inv in tool.Ifc.get().get_inverse(representation_map))
+
+    def invert_general_object(
+        self, element: ifcopenshell.entity_instance, mirror_axes: tuple[float, float, float] = (1.0, 0.0, 0.0)
+    ) -> None:
+        # ShapeBuilder.mirror works in 2D, so it only gets the XY components.
+        mirror_axes_2d = mirror_axes[:2]
+        builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
+
+        def mirror_item(item: ifcopenshell.entity_instance) -> None:
+            if item.is_a("IfcBooleanResult"):
+                mirror_item(item.FirstOperand)
+                mirror_item(item.SecondOperand)
+            elif item.is_a("IfcFacetedBrep") or item.is_a("IfcFacetedBrepWithVoids"):
+                mirror_faceted_brep(item)
+            elif item.is_a("IfcMappedItem"):
+                if self.is_type_owned_mapping(item):
+                    raise SharedMappedGeometryError(
+                        f"{element.is_a()} maps geometry owned by its type. Inverting it would "
+                        "mirror every other occurrence of that type as well."
+                    )
+                for sub in item.MappingSource.MappedRepresentation.Items:
+                    mirror_item(sub)
+            else:
+                if mirror_axes[2] > 0.5:
+                    # ShapeBuilder.mirror is 2D, so a Z flip only reaches explicit meshes.
+                    self.unsupported_items.add(f"{item.is_a()} along Z")
+                    return
+                try:
+                    builder.mirror(item, mirror_axes_2d, create_copy=False)
+                except Exception:
+                    # ShapeBuilder has no mirror for every representation item, half spaces in
+                    # particular. Leave those alone and tell the user rather than aborting the
+                    # whole mirror halfway through.
+                    self.unsupported_items.add(item.is_a())
+
+        def mirror_faceted_brep(item: ifcopenshell.entity_instance) -> None:
+            shells = [item.Outer]
+            if item.is_a("IfcFacetedBrepWithVoids"):
+                shells.extend(item.Voids)
+
+            points_done = set()
+            for shell in shells:
+                for face in shell.CfsFaces:
+                    for bound in face.Bounds:
+                        if not bound.Bound.is_a("IfcPolyLoop"):
+                            continue
+                        for pt in bound.Bound.Polygon:
+                            if pt.id() in points_done:
+                                continue
+                            points_done.add(pt.id())
+                            coords = list(pt.Coordinates)
+                            for i, flip in enumerate(mirror_axes[: len(coords)]):
+                                if flip > 0.0:
+                                    coords[i] = -coords[i]
+                            pt.Coordinates = coords
+
+            # An odd number of flipped axes inverts the faces, so the winding has to be
+            # reversed to restore outward normals.
+            if sum(1 for v in mirror_axes if v > 0.0) % 2:
+                for shell in shells:
+                    for face in shell.CfsFaces:
+                        for bound in face.Bounds:
+                            if bound.Bound.is_a("IfcPolyLoop"):
+                                bound.Bound.Polygon = list(reversed(bound.Bound.Polygon))
+
+        if element.is_a("IfcProduct"):
+            if not element.Representation:
+                return
+            for representation in element.Representation.Representations:
+                for item in representation.Items:
+                    mirror_item(item)
+        elif element.is_a("IfcTypeProduct"):
+            for representation_map in element.RepresentationMaps or []:
+                for item in representation_map.MappedRepresentation.Items:
+                    mirror_item(item)
+
+        tool.Geometry.reload_representation(tool.Ifc.get_object(element))
+
+    def invert_door_swing(self, element: ifcopenshell.entity_instance) -> None:
+        obj = tool.Ifc.get_object(element)
+        pset_data = json.loads(ifcopenshell.util.element.get_pset(element, "BBIM_Door", "Data"))
+
+        if "LEFT" in pset_data["door_type"]:
+            pset_data["door_type"] = pset_data["door_type"].replace("LEFT", "RIGHT")
+        elif "RIGHT" in pset_data["door_type"]:
+            pset_data["door_type"] = pset_data["door_type"].replace("RIGHT", "LEFT")
+
+        pset = tool.Pset.get_element_pset(element, "BBIM_Door")
+        pset_data_str = tool.Ifc.get().createIfcText(json.dumps(pset_data, default=list))
+        ifcopenshell.api.pset.edit_pset(tool.Ifc.get(), pset=pset, properties={"Data": pset_data_str})
+
+        pset_data.update(pset_data.pop("lining_properties"))
+        pset_data.update(pset_data.pop("panel_properties"))
+        pset_data.update(tool.Model.get_constituents_props_data(element))
+
+        # set_props_kwargs_from_ifc_data updates the mesh of the active object, which would
+        # switch its representation, so the door has to be active while it runs.
+        prev_active = bpy.context.view_layer.objects.active
+        bpy.context.view_layer.objects.active = obj
+        tool.Model.get_door_props(obj).set_props_kwargs_from_ifc_data(pset_data)
+        bpy.context.view_layer.objects.active = prev_active
+
+        update_door_modifier_representation(obj)
+        tool.Model.mark_thumbnail_for_update(element)
+
+    def invert_representation(
+        self, element: ifcopenshell.entity_instance, mirror_axes: tuple[float, float, float] = (1.0, 0.0, 0.0)
+    ) -> None:
+        if ifcopenshell.util.element.get_pset(element, "BBIM_Door", "Data"):
+            self.invert_door_swing(element)
+        else:
+            self.invert_general_object(element, mirror_axes)
+
+    def assign_inverted_type(self, element: ifcopenshell.entity_instance) -> None:
+        """Point a typed occurrence at a mirrored copy of its type.
+
+        The type's own geometry is never inverted: that representation is shared with every
+        sibling occurrence. Instead the type is duplicated once, the duplicate is inverted, and
+        both are cross referenced so later mirrors of the same type reuse it.
+        """
+        type_element = ifcopenshell.util.element.get_type(element)
+
+        inverted_type = tool.Blender.Modifier.has_mirrored_type(type_element)
+        if not inverted_type:
+            old_to_new, _ = tool.Geometry.duplicate_ifc_objects([tool.Ifc.get_object(type_element)])
+            inverted_type = old_to_new[type_element][0]
+            self.invert_representation(inverted_type)  # the cached type is always X flipped
+            tool.Blender.Modifier.set_mirrored_type(inverted_type, type_element)
+            tool.Blender.Modifier.set_mirrored_type(type_element, inverted_type)
+            inverted_type.Name = f"{inverted_type.Name}.Mirror"
+
+        bonsai.core.type.assign_type(tool.Ifc, tool.Model, tool.Type, element, inverted_type)
 
 
 def generate_box(usecase_path: str, ifc_file: ifcopenshell.file, settings: dict[str, Any]) -> None:

--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -653,6 +653,9 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         default="X",
     )
 
+    # The last run, so Adjust Last Operation can undo it before applying a new axis.
+    _last_run: Optional[dict[str, Any]] = None
+
     @classmethod
     def poll(cls, context):
         return context.selected_objects
@@ -679,6 +682,13 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
             return objs_to_mirror, active_obj
         return selected, None
 
+    def invoke(self, context, event):
+        # Marks this as a new run rather than Adjust Last Operation re-running the last one.
+        # Blender calls invoke for a button or a keymap and only execute for a redo, and the
+        # attribute does not survive into the fresh instance Blender builds for that redo.
+        self.is_fresh_invocation = True
+        return self.execute(context)
+
     def _execute(self, context):
         objs_to_mirror, mirror_ref = self.resolve_selection(context)
         if mirror_ref is None and len(context.selected_objects) > 1:
@@ -690,12 +700,28 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         axis_index = "XYZ".index(self.mirror_axis)
         self.unsupported_items: set[str] = set()
         self.skipped: list[str] = []
+
+        # Adjust Last Operation re-runs the operator, but Blender's redo path never fires the
+        # undo handler that rolls the IFC back, so the previous run's inversion is still in the
+        # file. Inverting X and then Y composes into a 180 degree rotation, which is not a
+        # mirror at all. A mirror is its own inverse, so replaying the previous run undoes it
+        # and the new axis then applies to the original geometry.
+        if not self.__dict__.pop("is_fresh_invocation", False):
+            self.revert_last_run(context)
+
         mirrored = 0
         for obj in objs_to_mirror:
             try:
                 mirrored += bool(self.mirror_obj(context, obj, mirror_ref, axis_index))
             except SharedMappedGeometryError as e:
                 self.report({"ERROR"}, str(e))
+        if mirrored:
+            MirrorElements._last_run = {
+                "objects": [obj.name for obj in objs_to_mirror],
+                "reference": mirror_ref.name if mirror_ref else None,
+                "axis_index": axis_index,
+                "file": id(tool.Ifc.get()),
+            }
         if self.skipped:
             self.report(
                 {"ERROR"} if not mirrored else {"WARNING"},
@@ -719,6 +745,35 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
             self.report({"INFO"}, summary)
             print(f"[bim.mirror_elements] {summary}")
         return {"FINISHED"} if mirrored else {"CANCELLED"}
+
+    @staticmethod
+    def find_object(name: str) -> Optional[bpy.types.Object]:
+        return bpy.data.objects.get(name)
+
+    def revert_last_run(self, context: bpy.types.Context) -> None:
+        """Undo the previous run by replaying it, since mirroring is its own inverse."""
+        previous = MirrorElements._last_run
+        if not previous:
+            return
+        MirrorElements._last_run = None
+        # Names are only meaningful within the project the run happened in. Another project
+        # can hold different objects under the same names.
+        if previous["file"] != id(tool.Ifc.get()):
+            return
+        objs = [obj for name in previous["objects"] if (obj := self.find_object(name))]
+        if not objs:
+            return
+        reference = self.find_object(previous["reference"]) if previous["reference"] else None
+        if previous["reference"] and reference is None:
+            return
+        for obj in objs:
+            try:
+                self.mirror_obj(context, obj, reference, previous["axis_index"])
+            except SharedMappedGeometryError:
+                pass
+        # The replay's findings describe the state we just discarded, not this run's request.
+        self.unsupported_items.clear()
+        self.skipped.clear()
 
     def mirror_obj(
         self,

--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -663,20 +663,30 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
     ) -> tuple[list[bpy.types.Object], Optional[bpy.types.Object]]:
         """Split the selection into the objects to mirror and the mirror plane, if any.
 
-        Blender keeps an object active after it has been deselected. Such an object is not
-        visibly part of the selection, so treating it as the mirror plane would silently turn
-        what looks like a single object mirror into a reflection across something off screen.
+        Clicking a single object leaves the previously active object active but deselected.
+        Reflecting across that invisible plane would be surprising, so it is ignored. Once more
+        than one object is selected the active object is the user's reference even if Blender's
+        selection flag has not caught up with it, which it may not have while the redo panel
+        re-runs the operator. Dropping the reference there would quietly fall back to mirroring
+        each object about its own axis, and for a wall on Y that is geometrically invisible.
         """
+        selected = list(context.selected_objects)
         active_obj = context.active_object
-        if active_obj and not active_obj.select_get():
+        if active_obj and len(selected) < 2 and not active_obj.select_get():
             active_obj = None
-        objs_to_mirror = [obj for obj in context.selected_objects if obj != active_obj] if active_obj else []
+        objs_to_mirror = [obj for obj in selected if obj != active_obj] if active_obj else []
         if objs_to_mirror:
             return objs_to_mirror, active_obj
-        return list(context.selected_objects), None
+        return selected, None
 
     def _execute(self, context):
         objs_to_mirror, mirror_ref = self.resolve_selection(context)
+        if mirror_ref is None and len(context.selected_objects) > 1:
+            self.report(
+                {"WARNING"},
+                "No active object to use as the mirror plane. Each object was mirrored about "
+                "its own axis instead. Click the object you want as the mirror plane last.",
+            )
         axis_index = "XYZ".index(self.mirror_axis)
         self.unsupported_items: set[str] = set()
         self.skipped: list[str] = []

--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -657,7 +657,12 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         return context.selected_objects
 
     def _execute(self, context):
+        # Blender keeps an object active after it has been deselected. Such an object is not
+        # visibly part of the selection, so treating it as the mirror plane would silently turn
+        # what looks like a single object mirror into a reflection across something off screen.
         active_obj = context.active_object
+        if active_obj and not active_obj.select_get():
+            active_obj = None
         objs_to_mirror = [obj for obj in context.selected_objects if obj != active_obj] if active_obj else []
         mirror_ref = active_obj if objs_to_mirror else None
         if mirror_ref is None:
@@ -681,6 +686,16 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
             )
         elif self.unsupported_items:
             self.report({"WARNING"}, f"Could not mirror: {', '.join(sorted(self.unsupported_items))}")
+        if mirrored:
+            # Say which plane was used. A reflection across a reference whose origin already sits
+            # on the object's own mirror plane moves nothing, and without this the user cannot
+            # tell that the reference was taken into account at all.
+            about = (
+                f"across {mirror_ref.name} local {self.mirror_axis}"
+                if mirror_ref
+                else f"about own local {self.mirror_axis}"
+            )
+            self.report({"INFO"}, f"Mirrored {mirrored} object{'s' if mirrored > 1 else ''} {about}")
         return {"FINISHED"} if mirrored else {"CANCELLED"}
 
     def mirror_obj(
@@ -755,6 +770,10 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
 
         context.view_layer.update()
         self.reflect_placement(obj, mirror_ref, geometry_axes, bb_data, axis_index)
+        # reflect_placement may have written obj.location, and matrix_world only picks that up
+        # after a depsgraph update. Without this the captured matrix is the pre-mirror one.
+        context.view_layer.update()
+        mirrored_matrix = obj.matrix_world.copy()
 
         # Openings are mirrored only now, after the origin has been reflected: they have to be
         # anchored to the host's final placement, and the frame change needs its final rotation.
@@ -768,6 +787,13 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         representation = self.get_target_representation(element, active_representation, active_context)
         if representation:
             bonsai.core.geometry.switch_representation(tool.Ifc, tool.Geometry, obj=obj, representation=representation)
+
+        # Everything above moved the Blender object. Write that placement to IFC now, or the
+        # mirror lives only in the viewport and the saved file keeps the old position. Reloading
+        # the representation can snap the object back to the committed placement, so the intended
+        # matrix is restored first.
+        obj.matrix_world = mirrored_matrix
+        bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj, apply_scale=False)
         return True
 
     def get_target_representation(

--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -632,10 +632,24 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
     bl_options = {"REGISTER", "UNDO"}
     bl_description = (
         "Mirrors the selected objects in place by truly inverting their geometry. "
-        "Select a single object to mirror it about its own local YZ plane. "
+        "Select a single object to mirror it about one of its own local planes. "
         "Select two or more objects and the active object becomes the mirror plane, "
         "with every other selected object reflected across it. Nothing is duplicated: "
         "duplicate first if you want to keep the original"
+    )
+
+    mirror_axis: bpy.props.EnumProperty(
+        name="Mirror Axis",
+        description=(
+            "Local axis to mirror along. With a single object this is the object's own axis, "
+            "otherwise it is the axis of the active reference object"
+        ),
+        items=(
+            ("X", "X", "Mirror along local X, about the local YZ plane"),
+            ("Y", "Y", "Mirror along local Y, about the local XZ plane"),
+            ("Z", "Z", "Mirror along local Z, about the local XY plane"),
+        ),
+        default="X",
     )
 
     @classmethod
@@ -649,42 +663,42 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         if mirror_ref is None:
             objs_to_mirror = list(context.selected_objects)
 
+        axis_index = "XYZ".index(self.mirror_axis)
         self.unsupported_items: set[str] = set()
+        self.skipped: list[str] = []
+        mirrored = 0
         for obj in objs_to_mirror:
             try:
-                self.mirror_obj(context, obj, mirror_ref)
+                mirrored += bool(self.mirror_obj(context, obj, mirror_ref, axis_index))
             except SharedMappedGeometryError as e:
                 self.report({"ERROR"}, str(e))
-        if self.unsupported_items:
+        if self.skipped:
+            self.report(
+                {"ERROR"} if not mirrored else {"WARNING"},
+                f"Cannot invert {', '.join(self.skipped)} along {self.mirror_axis}"
+                f" ({', '.join(sorted(self.unsupported_items))}), left untouched."
+                " Try a different mirror axis.",
+            )
+        elif self.unsupported_items:
             self.report({"WARNING"}, f"Could not mirror: {', '.join(sorted(self.unsupported_items))}")
-        return {"FINISHED"}
+        return {"FINISHED"} if mirrored else {"CANCELLED"}
 
     def mirror_obj(
         self,
         context: bpy.types.Context,
         obj: bpy.types.Object,
         mirror_ref: Optional[bpy.types.Object] = None,
-    ) -> None:
+        axis_index: int = 0,
+    ) -> bool:
+        """Mirror a single object. False means it was left untouched."""
         element = tool.Ifc.get_entity(obj)
         if not element:
-            return
+            return False
 
         active_context = tool.Geometry.get_active_representation_context(obj)
         active_representation = tool.Geometry.get_active_representation(obj)
         bb_data = tool.Blender.get_object_bounding_box(obj)
-        mirror_axes = self.get_mirror_axes(obj, mirror_ref)
-
-        # Snapshot opening world placements AND the host placement BEFORE any geometry or
-        # origin change. We work in the host's local space so the mirrored relative offset
-        # is correct regardless of when the host's IFC placement gets synced.
-        opening_placements_before: dict[int, np.ndarray] = {}
-        M_host_before: Optional[np.ndarray] = None
-        if getattr(element, "HasOpenings", None):
-            M_host_before = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement).copy()
-            for rel in element.HasOpenings:
-                opening = rel.RelatedOpeningElement
-                M = ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement)
-                opening_placements_before[opening.id()] = M.copy()
+        mirror_axes = self.get_mirror_axes(obj, mirror_ref, axis_index)
 
         type_element = ifcopenshell.util.element.get_type(element)
         usage_type = tool.Model.get_usage_type(element)
@@ -697,6 +711,30 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
             and type_element.RepresentationMaps
             and usage_type not in ("LAYER2", "LAYER3")
         )
+
+        # Check before touching anything. Reflecting the placement of an element whose geometry
+        # could not be inverted would reproduce the faux mirror this operator exists to replace,
+        # so such elements are reported and left exactly as they were.
+        if is_typed_occurrence:
+            blockers = self.find_uninvertible_items(type_element, (1.0, 0.0, 0.0))
+        else:
+            blockers = self.find_uninvertible_items(element, mirror_axes)
+        if blockers:
+            self.skipped.append(obj.name)
+            self.unsupported_items.update(blockers)
+            return False
+
+        # Snapshot opening world placements AND the host placement BEFORE any geometry or
+        # origin change. We work in the host's local space so the mirrored relative offset
+        # is correct regardless of when the host's IFC placement gets synced.
+        opening_placements_before: dict[int, np.ndarray] = {}
+        M_host_before: Optional[np.ndarray] = None
+        if getattr(element, "HasOpenings", None):
+            M_host_before = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement).copy()
+            for rel in element.HasOpenings:
+                opening = rel.RelatedOpeningElement
+                M = ifcopenshell.util.placement.get_local_placement(opening.ObjectPlacement)
+                opening_placements_before[opening.id()] = M.copy()
 
         if is_typed_occurrence:
             # The shared mirrored type is always X flipped, so that is the axis the occurrence's
@@ -716,7 +754,7 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
                     mat_usage.OffsetFromReferenceLine = -mat_usage.OffsetFromReferenceLine
 
         context.view_layer.update()
-        self.reflect_placement(obj, mirror_ref, geometry_axes, bb_data)
+        self.reflect_placement(obj, mirror_ref, geometry_axes, bb_data, axis_index)
 
         # Openings are mirrored only now, after the origin has been reflected: they have to be
         # anchored to the host's final placement, and the frame change needs its final rotation.
@@ -730,6 +768,7 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         representation = self.get_target_representation(element, active_representation, active_context)
         if representation:
             bonsai.core.geometry.switch_representation(tool.Ifc, tool.Geometry, obj=obj, representation=representation)
+        return True
 
     def get_target_representation(
         self,
@@ -758,12 +797,13 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         return next((r for r in representations if r.ContextOfItems == active_context), None)
 
     def get_mirror_axes(
-        self, obj: bpy.types.Object, mirror_ref: Optional[bpy.types.Object]
+        self, obj: bpy.types.Object, mirror_ref: Optional[bpy.types.Object], axis_index: int = 0
     ) -> tuple[float, float, float]:
         """Return which of the object's local axes the geometry has to be inverted along.
 
-        The mirror plane normal is the reference object's local X. Without a reference the
-        object is mirrored about its own local YZ plane.
+        Without a reference the object is mirrored about its own local plane normal to
+        ``axis_index``. With one, that axis of the reference is the mirror plane normal and the
+        object's own closest axis is inverted.
 
         Exactly one axis is ever chosen, the one most parallel to the mirror plane normal.
         Flipping two axes at once would be a 180 degree rotation rather than a reflection, and
@@ -771,11 +811,44 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         produce an exact world space reflection for an arbitrarily oriented mirror plane.
         """
         if not mirror_ref:
-            return (1.0, 0.0, 0.0)
-        mirror_normal_world = mirror_ref.matrix_world.to_3x3().col[0].normalized()
+            return tuple(1.0 if i == axis_index else 0.0 for i in range(3))
+        mirror_normal_world = mirror_ref.matrix_world.to_3x3().col[axis_index].normalized()
         mirror_normal_local = obj.matrix_world.to_3x3().inverted() @ mirror_normal_world
         axis = max(range(3), key=lambda i: abs(mirror_normal_local[i]))
         return tuple(1.0 if i == axis else 0.0 for i in range(3))
+
+    def find_uninvertible_items(
+        self, element: ifcopenshell.entity_instance, mirror_axes: tuple[float, float, float]
+    ) -> set[str]:
+        """Report the representation items that cannot be inverted along ``mirror_axes``.
+
+        Run before any mutation. ShapeBuilder.mirror works in the XY plane only, so a Z mirror
+        is limited to the explicit meshes this operator inverts coordinate by coordinate.
+        """
+        is_z_mirror = mirror_axes[2] > 0.5
+        blockers: set[str] = set()
+
+        def visit(item: ifcopenshell.entity_instance) -> None:
+            if item.is_a("IfcBooleanResult"):
+                visit(item.FirstOperand)
+                visit(item.SecondOperand)
+            elif item.is_a("IfcFacetedBrep") or item.is_a("IfcFacetedBrepWithVoids"):
+                return
+            elif item.is_a("IfcMappedItem"):
+                if self.is_type_owned_mapping(item):
+                    raise SharedMappedGeometryError(
+                        f"{element.is_a()} maps geometry owned by its type. Inverting it would "
+                        "mirror every other occurrence of that type as well."
+                    )
+                for sub in item.MappingSource.MappedRepresentation.Items:
+                    visit(sub)
+            elif is_z_mirror:
+                blockers.add(f"{item.is_a()} along Z")
+
+        for representation in ifcopenshell.util.representation.get_representations_iter(element):
+            for item in representation.Items:
+                visit(item)
+        return blockers
 
     def reflect_placement(
         self,
@@ -783,15 +856,20 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         mirror_ref: Optional[bpy.types.Object],
         geometry_axes: tuple[float, float, float],
         bb_data: dict[str, Any],
+        axis_index: int = 0,
     ) -> None:
         if not mirror_ref:
-            # No reference: mirror about the local YZ plane through the bounding box centre so
-            # the object stays where it is. Inverting the representation sends local x to -x,
-            # so shifting the origin by min_x + max_x turns that into a reflection about the
-            # centre. Derived from the pre-mirror bounds on purpose: remeasuring the reloaded
-            # mesh would be wrong for a host whose openings have not been mirrored yet.
-            shift = bb_data["min_x"] + bb_data["max_x"]
-            obj.location += (obj.matrix_world @ Vector((shift, 0, 0, 0))).xyz
+            # No reference: mirror about the local plane through the bounding box centre so the
+            # object stays where it is. Inverting the representation sends the local coordinate
+            # on the flipped axis to its negative, so shifting the origin by min + max on that
+            # axis turns it into a reflection about the centre. Derived from the pre-mirror
+            # bounds on purpose: remeasuring the reloaded mesh would be wrong for a host whose
+            # openings have not been mirrored yet.
+            axis = max(range(3), key=lambda i: geometry_axes[i])
+            name = "xyz"[axis]
+            shift = Vector((0.0, 0.0, 0.0, 0.0))
+            shift[axis] = bb_data[f"min_{name}"] + bb_data[f"max_{name}"]
+            obj.location += (obj.matrix_world @ shift).xyz
             return
 
         # P_world is the Householder matrix of the mirror plane and P_local the diagonal of the
@@ -800,7 +878,7 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
         # which is the exact reflection, whatever the plane's orientation. Both determinants
         # are -1, so new_R stays a proper rotation.
         P_local = Matrix.Diagonal(Vector([-1.0 if a > 0.5 else 1.0 for a in geometry_axes]))
-        n_world = mirror_ref.matrix_world.to_3x3().col[0].normalized()
+        n_world = mirror_ref.matrix_world.to_3x3().col[axis_index].normalized()
         P_world = Matrix.Scale(-1, 4, n_world).to_3x3()
         new_mat = (P_world @ obj.matrix_world.to_3x3() @ P_local).to_4x4()
         t_mr = mirror_ref.matrix_world.translation
@@ -945,10 +1023,6 @@ class MirrorElements(bpy.types.Operator, tool.Ifc.Operator):
                 for sub in item.MappingSource.MappedRepresentation.Items:
                     mirror_item(sub)
             else:
-                if mirror_axes[2] > 0.5:
-                    # ShapeBuilder.mirror is 2D, so a Z flip only reaches explicit meshes.
-                    self.unsupported_items.add(f"{item.is_a()} along Z")
-                    return
                 try:
                     builder.mirror(item, mirror_axes_2d, create_copy=False)
                 except Exception:

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -1037,7 +1037,17 @@ class EditObjectUI:
         row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
         add_layout_hotkey_operator(row, "Interior", "S_V", description, ui_context)
         row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
-        add_layout_hotkey_operator(row, "Mirror", "S_M", bpy.ops.bim.mirror_elements.__doc__, ui_context)
+        # Invoke the operator directly rather than via the S_M hotkey: that hotkey is shared
+        # with Merge for LAYER2 elements, so routing through it would merge walls instead of
+        # mirroring them.
+        add_layout_hotkey_operator(
+            row,
+            "Mirror",
+            "S_M",
+            bpy.ops.bim.mirror_elements.__doc__,
+            ui_context,
+            operator="bim.mirror_elements",
+        )
 
     @classmethod
     def draw_aggregation(cls, context):
@@ -1344,13 +1354,7 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
                     return
             bpy.ops.bim.merge_wall()
         else:
-            if len(bpy.context.selected_objects) == 1:
-                self.report(
-                    {"ERROR"},
-                    "At least two objects must be selected: an object to be mirrored, and a mirror axis as the active object.",
-                )
-            else:
-                bpy.ops.bim.mirror_elements()
+            bpy.ops.bim.mirror_elements()
 
     def hotkey_S_R(self):
         if not bpy.context.selected_objects:

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -77,7 +77,6 @@ class BimTool(WorkSpaceTool):
         ("bim.hotkey", {"type": "G", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_G")]}),
         ("bim.hotkey", {"type": "K", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_K")]}),
         ("bim.hotkey", {"type": "M", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_M")]}),
-        ("bim.hotkey", {"type": "M", "value": "PRESS", "ctrl": True}, {"properties": [("hotkey", "C_M")]}),
         ("bim.hotkey", {"type": "O", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_O")]}),
         ("bim.hotkey", {"type": "L", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_L")]}),
         ("bim.hotkey", {"type": "Q", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_Q")]}),
@@ -858,11 +857,7 @@ class EditObjectUI:
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
             add_layout_hotkey_operator(row, "Unjoin Walls", "S_U", "", ui_context)
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
-            # Ctrl M, not Shift M: Shift M is Mirror, and dispatching one key to two operators
-            # by material usage made Mirror unreachable on walls, which is #6906.
-            add_layout_hotkey_operator(
-                row, "Merge", "C_M", "Merge selected Elements", ui_context, operator="bim.merge_wall"
-            )
+            add_layout_hotkey_operator(row, "Merge", "S_M", "Merge selected Elements", ui_context)
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
             add_layout_hotkey_operator(
                 row, "Split", "S_K", "Split selected Element into two Elements at the cursor location", ui_context
@@ -1042,17 +1037,7 @@ class EditObjectUI:
         row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
         add_layout_hotkey_operator(row, "Interior", "S_V", description, ui_context)
         row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
-        # Invoke the operator directly rather than via the S_M hotkey: that hotkey is shared
-        # with Merge for LAYER2 elements, so routing through it would merge walls instead of
-        # mirroring them.
-        add_layout_hotkey_operator(
-            row,
-            "Mirror",
-            "S_M",
-            bpy.ops.bim.mirror_elements.__doc__,
-            ui_context,
-            operator="bim.mirror_elements",
-        )
+        add_layout_hotkey_operator(row, "Mirror", "S_M", bpy.ops.bim.mirror_elements.__doc__, ui_context)
 
     @classmethod
     def draw_aggregation(cls, context):
@@ -1340,33 +1325,32 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
             bpy.ops.bim.generate_space()
 
     def hotkey_S_M(self):
-        # Always Mirror, matching the Mirror button. Dispatching this one key to Merge for
-        # LAYER2 elements made Mirror unreachable on exactly the elements people mirror most.
         if not bpy.context.selected_objects:
             return
-        bpy.ops.bim.mirror_elements()
-
-    def hotkey_C_M(self):
-        if not bpy.context.selected_objects:
-            return
-        if self.active_material_usage != "LAYER2":
-            self.report({"ERROR"}, "Merge only applies to LAYER2 items (walls, railings, etc).")
-            return
-        if len(bpy.context.selected_objects) != 2:
-            self.report(
-                {"ERROR"},
-                "Exactly two LAYER2 items (walls, railings, etc) must be selected to perform a merge.",
-            )
-            return
-        for item in bpy.context.selected_objects:
-            element = tool.Ifc.get_entity(item)
-            if tool.Model.get_usage_type(element) != "LAYER2":
+        if self.active_material_usage == "LAYER2":
+            if len(bpy.context.selected_objects) != 2:
                 self.report(
                     {"ERROR"},
-                    "Both selected items must be LAYER2 (walls, railings, etc) to perform a merge.",
+                    "Exactly two LAYER2 items (walls, railings, etc) must be selected to perform a merge.",
                 )
                 return
-        bpy.ops.bim.merge_wall()
+            for item in bpy.context.selected_objects:
+                element = tool.Ifc.get_entity(item)
+                if tool.Model.get_usage_type(element) != "LAYER2":
+                    self.report(
+                        {"ERROR"},
+                        "Both selected items must be LAYER2 (walls, railings, etc) to perform a merge.",
+                    )
+                    return
+            bpy.ops.bim.merge_wall()
+        else:
+            if len(bpy.context.selected_objects) == 1:
+                self.report(
+                    {"ERROR"},
+                    "At least two objects must be selected: an object to be mirrored, and a mirror axis as the active object.",
+                )
+            else:
+                bpy.ops.bim.mirror_elements()
 
     def hotkey_S_R(self):
         if not bpy.context.selected_objects:

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -77,6 +77,7 @@ class BimTool(WorkSpaceTool):
         ("bim.hotkey", {"type": "G", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_G")]}),
         ("bim.hotkey", {"type": "K", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_K")]}),
         ("bim.hotkey", {"type": "M", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_M")]}),
+        ("bim.hotkey", {"type": "M", "value": "PRESS", "ctrl": True}, {"properties": [("hotkey", "C_M")]}),
         ("bim.hotkey", {"type": "O", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_O")]}),
         ("bim.hotkey", {"type": "L", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_L")]}),
         ("bim.hotkey", {"type": "Q", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_Q")]}),
@@ -857,7 +858,11 @@ class EditObjectUI:
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
             add_layout_hotkey_operator(row, "Unjoin Walls", "S_U", "", ui_context)
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
-            add_layout_hotkey_operator(row, "Merge", "S_M", "Merge selected Elements", ui_context)
+            # Ctrl M, not Shift M: Shift M is Mirror, and dispatching one key to two operators
+            # by material usage made Mirror unreachable on walls, which is #6906.
+            add_layout_hotkey_operator(
+                row, "Merge", "C_M", "Merge selected Elements", ui_context, operator="bim.merge_wall"
+            )
             row = cls.layout.row(align=True) if ui_context != "TOOL_HEADER" else row
             add_layout_hotkey_operator(
                 row, "Split", "S_K", "Split selected Element into two Elements at the cursor location", ui_context
@@ -1335,26 +1340,33 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
             bpy.ops.bim.generate_space()
 
     def hotkey_S_M(self):
+        # Always Mirror, matching the Mirror button. Dispatching this one key to Merge for
+        # LAYER2 elements made Mirror unreachable on exactly the elements people mirror most.
         if not bpy.context.selected_objects:
             return
-        if self.active_material_usage == "LAYER2":
-            if len(bpy.context.selected_objects) != 2:
+        bpy.ops.bim.mirror_elements()
+
+    def hotkey_C_M(self):
+        if not bpy.context.selected_objects:
+            return
+        if self.active_material_usage != "LAYER2":
+            self.report({"ERROR"}, "Merge only applies to LAYER2 items (walls, railings, etc).")
+            return
+        if len(bpy.context.selected_objects) != 2:
+            self.report(
+                {"ERROR"},
+                "Exactly two LAYER2 items (walls, railings, etc) must be selected to perform a merge.",
+            )
+            return
+        for item in bpy.context.selected_objects:
+            element = tool.Ifc.get_entity(item)
+            if tool.Model.get_usage_type(element) != "LAYER2":
                 self.report(
                     {"ERROR"},
-                    "Exactly two LAYER2 items (walls, railings, etc) must be selected to perform a merge.",
+                    "Both selected items must be LAYER2 (walls, railings, etc) to perform a merge.",
                 )
                 return
-            for item in bpy.context.selected_objects:
-                element = tool.Ifc.get_entity(item)
-                if tool.Model.get_usage_type(element) != "LAYER2":
-                    self.report(
-                        {"ERROR"},
-                        "Both selected items must be LAYER2 (walls, railings, etc) to perform a merge.",
-                    )
-                    return
-            bpy.ops.bim.merge_wall()
-        else:
-            bpy.ops.bim.mirror_elements()
+        bpy.ops.bim.merge_wall()
 
     def hotkey_S_R(self):
         if not bpy.context.selected_objects:

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import json
 import math
 import os
 import platform
@@ -56,6 +57,7 @@ from typing import (
 import bmesh
 import bpy
 import gpu
+import ifcopenshell.api.pset
 import ifcopenshell.util.element
 import numpy as np
 import numpy.typing as npt
@@ -1615,6 +1617,23 @@ class Blender(bonsai.core.tool.Blender):
         @classmethod
         def is_eligible_for_roof_modifier(cls, obj: bpy.types.Object) -> bool:
             return tool.Blender.is_object_an_ifc_class(obj, _ROOF_MODIFIER_IFC_CLASSES)
+
+        @classmethod
+        def has_mirrored_type(cls, element: entity_instance, inherit: bool = True) -> Union[entity_instance, None]:
+            """Return the mirrored counterpart of a type, if one has already been created."""
+            pset = ifcopenshell.util.element.get_pset(element, "BBIM_MirroredType", "Data", should_inherit=inherit)
+            if pset and (parsed := json.loads(pset)) and "mirrored_type" in parsed:
+                return tool.Ifc.get_entity_by_id(int(parsed["mirrored_type"]))
+            return None
+
+        @classmethod
+        def set_mirrored_type(cls, element: entity_instance, mirrored_type: entity_instance) -> None:
+            pset = tool.Pset.get_element_pset(element, "BBIM_MirroredType")
+            if not pset:
+                pset = ifcopenshell.api.pset.add_pset(tool.Ifc.get(), element, "BBIM_MirroredType")
+            ifcopenshell.api.pset.edit_pset(
+                tool.Ifc.get(), pset, properties={"Data": json.dumps({"mirrored_type": mirrored_type.id()})}
+            )
 
         @classmethod
         def is_array_child(cls, element: entity_instance) -> bool:

--- a/src/bonsai/test/bim/module/model/test_mirror_elements.py
+++ b/src/bonsai/test/bim/module/model/test_mirror_elements.py
@@ -128,10 +128,12 @@ def _operator():
         "get_mirror_axes",
         "invert_general_object",
         "invert_representation",
+        "get_mirror_plane_point",
         "is_type_owned_mapping",
         "reflect_placement",
     )
-    stub = type("MirrorElementsStub", (), {name: getattr(MirrorElements, name) for name in methods})()
+    # __dict__ rather than getattr so staticmethod descriptors survive the copy
+    stub = type("MirrorElementsStub", (), {name: MirrorElements.__dict__[name] for name in methods})()
     stub.unsupported_items = set()
     return stub
 
@@ -176,13 +178,34 @@ def test_reflect_placement_across_a_reference_is_an_exact_reflection():
     """The placement maths, independent of IFC: a point must land at its mirror image."""
     operator = _operator()
     obj = SimpleNamespace(matrix_world=Matrix.Translation((2.0, 0.0, 0.0)), location=None)
-    reference = SimpleNamespace(matrix_world=Matrix.Translation((5.0, 0.0, 0.0)))
+    # bound_box all zeros, as for an empty, so the plane passes through the reference origin
+    reference = SimpleNamespace(matrix_world=Matrix.Translation((5.0, 0.0, 0.0)), bound_box=[(0.0, 0.0, 0.0)] * 8)
     operator.reflect_placement(obj, reference, (1.0, 0.0, 0.0), {}, 0)
 
     # A local point p maps to matrix_world @ (P_local @ p); with the object at x=2 and the
     # plane at x=5, a point 1 unit along local +x sits at x=3 and must end up at x=7.
     p = Vector((1.0, 0.0, 0.0))
     assert np.allclose(list(obj.matrix_world @ Vector((-p.x, p.y, p.z))), [7.0, 0.0, 0.0])
+
+
+def test_the_mirror_plane_passes_through_the_middle_of_the_reference():
+    """An IFC origin is arbitrary, so the plane has to sit at what the user can see.
+
+    The reference here spans local x 0..4 with its origin at the near corner, so the plane is
+    at x = 2 in local terms, which is x = 12 in the world.
+    """
+    operator = _operator()
+    corners = [(x, y, z) for x in (0.0, 4.0) for y in (0.0, 1.0) for z in (0.0, 3.0)]
+    # get_object_bounding_box reads bound_box[0] as the minimum and bound_box[6] as the maximum
+    bound_box = [(0.0, 0.0, 0.0), None, None, None, None, None, (4.0, 1.0, 3.0), None]
+    reference = SimpleNamespace(matrix_world=Matrix.Translation((10.0, 0.0, 0.0)), bound_box=bound_box)
+    assert list(operator.get_mirror_plane_point(reference)) == [12.0, 0.5, 1.5]
+    assert corners  # the bounds above describe a real box
+
+    obj = SimpleNamespace(matrix_world=Matrix.Translation((3.0, 0.0, 0.0)), location=None)
+    operator.reflect_placement(obj, reference, (1.0, 0.0, 0.0), {}, 0)
+    # the object origin sits 9 units to the left of the plane, so it lands 9 to the right
+    assert np.allclose(list(obj.matrix_world.translation), [21.0, 0.0, 0.0])
 
 
 def test_the_mirror_plane_ignores_an_active_object_that_is_not_selected():
@@ -197,6 +220,7 @@ def test_the_mirror_plane_ignores_an_active_object_that_is_not_selected():
 
     class Stub:
         _execute = MirrorElements._execute
+        resolve_selection = MirrorElements.__dict__["resolve_selection"]
         mirror_axis = "X"
 
         def mirror_obj(self, context, obj, mirror_ref=None, axis_index=0):

--- a/src/bonsai/test/bim/module/model/test_mirror_elements.py
+++ b/src/bonsai/test/bim/module/model/test_mirror_elements.py
@@ -208,6 +208,23 @@ def test_the_mirror_plane_passes_through_the_middle_of_the_reference():
     assert np.allclose(list(obj.matrix_world.translation), [21.0, 0.0, 0.0])
 
 
+def test_a_reference_is_kept_even_when_its_selection_flag_lags():
+    """Losing the reference falls back to an in-place mirror, which on a wall's Y is invisible.
+
+    That silent fallback is what made a wall mirror look like it did nothing. With more than
+    one object selected the active object is the reference, selection flag or not.
+    """
+    from bonsai.bim.module.model.product import MirrorElements
+
+    target = SimpleNamespace(name="target", select_get=lambda: True)
+    reference = SimpleNamespace(name="reference", select_get=lambda: False)
+    context = SimpleNamespace(active_object=reference, selected_objects=[target, reference])
+
+    objs, mirror_ref = MirrorElements.__dict__["resolve_selection"].__func__(context)
+    assert [o.name for o in objs] == ["target"]
+    assert mirror_ref is reference
+
+
 def test_the_mirror_plane_ignores_an_active_object_that_is_not_selected():
     """Blender keeps an object active after deselecting it. It is not a visible mirror plane."""
     from bonsai.bim.module.model.product import MirrorElements

--- a/src/bonsai/test/bim/module/model/test_mirror_elements.py
+++ b/src/bonsai/test/bim/module/model/test_mirror_elements.py
@@ -123,7 +123,13 @@ def _operator():
     ``unsupported_items``."""
     from bonsai.bim.module.model.product import MirrorElements
 
-    methods = ("get_mirror_axes", "invert_general_object", "invert_representation", "is_type_owned_mapping")
+    methods = (
+        "find_uninvertible_items",
+        "get_mirror_axes",
+        "invert_general_object",
+        "invert_representation",
+        "is_type_owned_mapping",
+    )
     stub = type("MirrorElementsStub", (), {name: getattr(MirrorElements, name) for name in methods})()
     stub.unsupported_items = set()
     return stub
@@ -178,3 +184,46 @@ def test_get_mirror_axes_without_a_reference_uses_the_local_yz_plane():
     operator = _operator()
     obj = SimpleNamespace(matrix_world=Matrix.Identity(4))
     assert operator.get_mirror_axes(obj, None) == (1.0, 0.0, 0.0)
+
+
+def test_get_mirror_axes_without_a_reference_honours_the_chosen_axis():
+    operator = _operator()
+    obj = SimpleNamespace(matrix_world=Matrix.Identity(4))
+    assert operator.get_mirror_axes(obj, None, 1) == (0.0, 1.0, 0.0)
+    assert operator.get_mirror_axes(obj, None, 2) == (0.0, 0.0, 1.0)
+
+
+def test_get_mirror_axes_uses_the_chosen_axis_of_the_reference():
+    """A reference turned 90 degrees about Z has its local Y pointing along world -X."""
+    operator = _operator()
+    obj = SimpleNamespace(matrix_world=Matrix.Identity(4))
+    reference = SimpleNamespace(matrix_world=Matrix.Rotation(np.radians(90), 4, "Z"))
+    assert operator.get_mirror_axes(obj, reference, 0) == (0.0, 1.0, 0.0)
+    assert operator.get_mirror_axes(obj, reference, 1) == (1.0, 0.0, 0.0)
+    assert operator.get_mirror_axes(obj, reference, 2) == (0.0, 0.0, 1.0)
+
+
+def test_a_swept_solid_reports_that_it_cannot_be_inverted_along_z():
+    """ShapeBuilder.mirror is 2D, so a Z mirror must be refused rather than half applied."""
+    ifc_file, _, occurrences, _ = _mapped_type_file()
+    element_type = ifc_file.by_type("IfcFurnitureType")[0]
+    operator = _operator()
+
+    with patch("bonsai.tool.Ifc.get", return_value=ifc_file):
+        assert operator.find_uninvertible_items(element_type, (1.0, 0.0, 0.0)) == set()
+        assert operator.find_uninvertible_items(element_type, (0.0, 1.0, 0.0)) == set()
+        assert operator.find_uninvertible_items(element_type, (0.0, 0.0, 1.0)) == {"IfcExtrudedAreaSolid along Z"}
+
+
+def test_find_uninvertible_items_refuses_shared_type_geometry_before_mutating():
+    from bonsai.bim.module.model.product import SharedMappedGeometryError
+
+    ifc_file, _, occurrences, solid = _mapped_type_file()
+    coordinates_before = _profile_coordinates(solid)
+    operator = _operator()
+
+    with patch("bonsai.tool.Ifc.get", return_value=ifc_file):
+        with pytest.raises(SharedMappedGeometryError):
+            operator.find_uninvertible_items(occurrences[0], (1.0, 0.0, 0.0))
+
+    assert _profile_coordinates(solid) == coordinates_before

--- a/src/bonsai/test/bim/module/model/test_mirror_elements.py
+++ b/src/bonsai/test/bim/module/model/test_mirror_elements.py
@@ -1,0 +1,180 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Guards ``bim.mirror_elements`` against mirroring shared type geometry.
+
+When a typed occurrence's body is an ``IfcMappedItem``, the mapped
+representation belongs to the type and is shared with every sibling
+occurrence. Inverting it in place would silently mirror the whole family.
+``MirrorElements`` must refuse that and route such occurrences through
+``assign_inverted_type`` instead, which mirrors a private copy of the type.
+
+Also pins the single-axis rule in ``get_mirror_axes``: flipping two local
+axes at once is a 180 degree rotation, not a reflection, and would leave
+``reflect_placement`` composing two determinant +1 matrices."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import ifcopenshell
+import numpy as np
+import pytest
+from mathutils import Matrix
+
+pytestmark = pytest.mark.model
+
+
+def _mapped_type_file():
+    """An IFC4 file with one type carrying a triangle, mapped by two occurrences."""
+    f = ifcopenshell.file(schema="IFC4")
+    context = f.create_entity(
+        "IfcGeometricRepresentationContext",
+        ContextType="Model",
+        CoordinateSpaceDimension=3,
+        WorldCoordinateSystem=f.create_entity(
+            "IfcAxis2Placement3D", Location=f.create_entity("IfcCartesianPoint", Coordinates=(0.0, 0.0, 0.0))
+        ),
+    )
+    points = [f.create_entity("IfcCartesianPoint", Coordinates=c) for c in ((0.0, 0.0), (3.0, 0.0), (0.5, 1.0))]
+    profile = f.create_entity(
+        "IfcArbitraryClosedProfileDef",
+        ProfileType="AREA",
+        OuterCurve=f.create_entity("IfcPolyline", Points=points + [points[0]]),
+    )
+    solid = f.create_entity(
+        "IfcExtrudedAreaSolid",
+        SweptArea=profile,
+        Position=f.create_entity(
+            "IfcAxis2Placement3D", Location=f.create_entity("IfcCartesianPoint", Coordinates=(0.0, 0.0, 0.0))
+        ),
+        ExtrudedDirection=f.create_entity("IfcDirection", DirectionRatios=(0.0, 0.0, 1.0)),
+        Depth=1.0,
+    )
+    mapped_representation = f.create_entity(
+        "IfcShapeRepresentation",
+        ContextOfItems=context,
+        RepresentationIdentifier="Body",
+        RepresentationType="SweptSolid",
+        Items=[solid],
+    )
+    representation_map = f.create_entity(
+        "IfcRepresentationMap",
+        MappingOrigin=f.create_entity(
+            "IfcAxis2Placement3D", Location=f.create_entity("IfcCartesianPoint", Coordinates=(0.0, 0.0, 0.0))
+        ),
+        MappedRepresentation=mapped_representation,
+    )
+    element_type = f.create_entity("IfcFurnitureType", GlobalId="0" * 22, RepresentationMaps=[representation_map])
+
+    occurrences = []
+    for _ in range(2):
+        target = f.create_entity(
+            "IfcCartesianTransformationOperator3D",
+            LocalOrigin=f.create_entity("IfcCartesianPoint", Coordinates=(0.0, 0.0, 0.0)),
+            Scale=1.0,
+        )
+        mapped_item = f.create_entity("IfcMappedItem", MappingSource=representation_map, MappingTarget=target)
+        occurrence = f.create_entity(
+            "IfcFurniture",
+            GlobalId="1" * 22,
+            Representation=f.create_entity(
+                "IfcProductDefinitionShape",
+                Representations=[
+                    f.create_entity(
+                        "IfcShapeRepresentation",
+                        ContextOfItems=context,
+                        RepresentationIdentifier="Body",
+                        RepresentationType="MappedRepresentation",
+                        Items=[mapped_item],
+                    )
+                ],
+            ),
+        )
+        occurrences.append(occurrence)
+    return f, element_type, occurrences, solid
+
+
+def _profile_coordinates(solid):
+    return [tuple(p.Coordinates) for p in solid.SweptArea.OuterCurve.Points]
+
+
+def _operator():
+    """A plain stand-in carrying the operator's methods.
+
+    ``bpy.types.Operator`` subclasses cannot be instantiated outside an operator
+    call, and none of the methods under test need operator state beyond
+    ``unsupported_items``."""
+    from bonsai.bim.module.model.product import MirrorElements
+
+    methods = ("get_mirror_axes", "invert_general_object", "invert_representation", "is_type_owned_mapping")
+    stub = type("MirrorElementsStub", (), {name: getattr(MirrorElements, name) for name in methods})()
+    stub.unsupported_items = set()
+    return stub
+
+
+def test_mirroring_a_mapped_occurrence_leaves_the_shared_type_untouched():
+    from bonsai.bim.module.model.product import SharedMappedGeometryError
+
+    ifc_file, _, occurrences, solid = _mapped_type_file()
+    coordinates_before = _profile_coordinates(solid)
+    operator = _operator()
+
+    with patch("bonsai.tool.Ifc.get", return_value=ifc_file):
+        with pytest.raises(SharedMappedGeometryError):
+            operator.invert_general_object(occurrences[0])
+
+    assert _profile_coordinates(solid) == coordinates_before
+
+
+def test_a_privately_mapped_representation_is_still_mirrored():
+    """A mapping used by a single occurrence and owned by no type is safe to invert."""
+    ifc_file, element_type, occurrences, solid = _mapped_type_file()
+    # Detach the type and the second occurrence so only one IfcMappedItem is left.
+    ifc_file.remove(occurrences[1].Representation.Representations[0].Items[0])
+    element_type.RepresentationMaps = None
+    representation_map = occurrences[0].Representation.Representations[0].Items[0].MappingSource
+
+    operator = _operator()
+    coordinates_before = _profile_coordinates(solid)
+    with patch("bonsai.tool.Ifc.get", return_value=ifc_file):
+        assert len(representation_map.MapUsage) == 1
+        assert operator.is_type_owned_mapping(occurrences[0].Representation.Representations[0].Items[0]) is False
+        with patch("bonsai.tool.Ifc.get_object", return_value=None):
+            with patch("bonsai.tool.Geometry.reload_representation"):
+                operator.invert_general_object(occurrences[0], (1.0, 0.0, 0.0))
+
+    coordinates_after = _profile_coordinates(solid)
+    assert coordinates_after != coordinates_before
+    assert [round(-x, 6) for x, _ in coordinates_before] == [round(x, 6) for x, _ in coordinates_after]
+
+
+def test_get_mirror_axes_never_flips_more_than_one_axis():
+    operator = _operator()
+    obj = SimpleNamespace(matrix_world=Matrix.Identity(4))
+    for angle in (0, 30, 45, 60, 90, 135):
+        reference = SimpleNamespace(matrix_world=Matrix.Rotation(np.radians(angle), 4, "Z"))
+        axes = operator.get_mirror_axes(obj, reference)
+        assert sum(axes) == 1.0, f"{angle} degrees produced {axes}"
+
+
+def test_get_mirror_axes_without_a_reference_uses_the_local_yz_plane():
+    operator = _operator()
+    obj = SimpleNamespace(matrix_world=Matrix.Identity(4))
+    assert operator.get_mirror_axes(obj, None) == (1.0, 0.0, 0.0)

--- a/src/bonsai/test/bim/module/model/test_mirror_elements.py
+++ b/src/bonsai/test/bim/module/model/test_mirror_elements.py
@@ -36,7 +36,7 @@ from unittest.mock import patch
 import ifcopenshell
 import numpy as np
 import pytest
-from mathutils import Matrix
+from mathutils import Matrix, Vector
 
 pytestmark = pytest.mark.model
 
@@ -129,6 +129,7 @@ def _operator():
         "invert_general_object",
         "invert_representation",
         "is_type_owned_mapping",
+        "reflect_placement",
     )
     stub = type("MirrorElementsStub", (), {name: getattr(MirrorElements, name) for name in methods})()
     stub.unsupported_items = set()
@@ -169,6 +170,44 @@ def test_a_privately_mapped_representation_is_still_mirrored():
     coordinates_after = _profile_coordinates(solid)
     assert coordinates_after != coordinates_before
     assert [round(-x, 6) for x, _ in coordinates_before] == [round(x, 6) for x, _ in coordinates_after]
+
+
+def test_reflect_placement_across_a_reference_is_an_exact_reflection():
+    """The placement maths, independent of IFC: a point must land at its mirror image."""
+    operator = _operator()
+    obj = SimpleNamespace(matrix_world=Matrix.Translation((2.0, 0.0, 0.0)), location=None)
+    reference = SimpleNamespace(matrix_world=Matrix.Translation((5.0, 0.0, 0.0)))
+    operator.reflect_placement(obj, reference, (1.0, 0.0, 0.0), {}, 0)
+
+    # A local point p maps to matrix_world @ (P_local @ p); with the object at x=2 and the
+    # plane at x=5, a point 1 unit along local +x sits at x=3 and must end up at x=7.
+    p = Vector((1.0, 0.0, 0.0))
+    assert np.allclose(list(obj.matrix_world @ Vector((-p.x, p.y, p.z))), [7.0, 0.0, 0.0])
+
+
+def test_the_mirror_plane_ignores_an_active_object_that_is_not_selected():
+    """Blender keeps an object active after deselecting it. It is not a visible mirror plane."""
+    from bonsai.bim.module.model.product import MirrorElements
+
+    target = SimpleNamespace(name="target", select_get=lambda: True)
+    ghost = SimpleNamespace(name="ghost", select_get=lambda: False)
+    context = SimpleNamespace(active_object=ghost, selected_objects=[target])
+
+    seen = []
+
+    class Stub:
+        _execute = MirrorElements._execute
+        mirror_axis = "X"
+
+        def mirror_obj(self, context, obj, mirror_ref=None, axis_index=0):
+            seen.append((obj.name, mirror_ref.name if mirror_ref else None))
+            return True
+
+        def report(self, level, message):
+            pass
+
+    Stub()._execute(context)
+    assert seen == [("target", None)], "a deselected active object must not become the mirror plane"
 
 
 def test_get_mirror_axes_never_flips_more_than_one_axis():

--- a/src/bonsai/test/bim/module/model/test_mirror_elements.py
+++ b/src/bonsai/test/bim/module/model/test_mirror_elements.py
@@ -33,6 +33,7 @@ axes at once is a 180 degree rotation, not a reflection, and would leave
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import bpy
 import ifcopenshell
 import numpy as np
 import pytest
@@ -208,6 +209,95 @@ def test_the_mirror_plane_passes_through_the_middle_of_the_reference():
     assert np.allclose(list(obj.matrix_world.translation), [21.0, 0.0, 0.0])
 
 
+def test_adjust_last_operation_undoes_the_previous_run_first():
+    """Blender's redo path re-runs execute without firing the undo handler, so the previous
+    run's inversion is still in the IFC. Inverting X then Y composes into a 180 degree
+    rotation. Mirroring is its own inverse, so the previous run is replayed to cancel it."""
+    from bonsai.bim.module.model.product import MirrorElements
+
+    replayed = []
+
+    class Stub:
+        _execute = MirrorElements._execute
+        revert_last_run = MirrorElements.revert_last_run
+        resolve_selection = MirrorElements.__dict__["resolve_selection"]
+        mirror_axis = "Y"
+
+        def mirror_obj(self, context, obj, mirror_ref=None, axis_index=0):
+            replayed.append((obj.name, axis_index))
+            return True
+
+        def report(self, level, message):
+            pass
+
+    target = SimpleNamespace(name="target", select_get=lambda: True)
+    context = SimpleNamespace(active_object=target, selected_objects=[target])
+
+    Stub.find_object = staticmethod(lambda name: target if name == "target" else None)
+    with patch("bonsai.tool.Ifc.get", return_value=None):
+        MirrorElements._last_run = {
+            "objects": ["target"],
+            "reference": None,
+            "axis_index": 0,
+            "file": id(None),
+        }
+        Stub()._execute(context)
+
+    assert replayed == [("target", 0), ("target", 1)], "the X run must be replayed before Y"
+    MirrorElements._last_run = None
+
+
+def test_a_fresh_invocation_does_not_undo_the_previous_run():
+    from bonsai.bim.module.model.product import MirrorElements
+
+    replayed = []
+
+    class Stub:
+        _execute = MirrorElements._execute
+        revert_last_run = MirrorElements.revert_last_run
+        resolve_selection = MirrorElements.__dict__["resolve_selection"]
+        mirror_axis = "Y"
+
+        def mirror_obj(self, context, obj, mirror_ref=None, axis_index=0):
+            replayed.append((obj.name, axis_index))
+            return True
+
+        def report(self, level, message):
+            pass
+
+    target = SimpleNamespace(name="target", select_get=lambda: True)
+    context = SimpleNamespace(active_object=target, selected_objects=[target])
+
+    with patch("bonsai.tool.Ifc.get", return_value=None):
+        MirrorElements._last_run = {"objects": ["target"], "reference": None, "axis_index": 0, "file": id(None)}
+        stub = Stub()
+        stub.is_fresh_invocation = True
+        stub._execute(context)
+
+    assert replayed == [("target", 1)], "a button or hotkey run must not undo anything"
+    MirrorElements._last_run = None
+
+
+def test_a_stale_run_from_another_project_is_not_replayed():
+    from bonsai.bim.module.model.product import MirrorElements
+
+    replayed = []
+
+    class Stub:
+        revert_last_run = MirrorElements.revert_last_run
+        find_object = staticmethod(lambda name: None)
+
+        def mirror_obj(self, context, obj, mirror_ref=None, axis_index=0):
+            replayed.append(obj.name)
+            return True
+
+    MirrorElements._last_run = {"objects": ["target"], "reference": None, "axis_index": 0, "file": 12345}
+    with patch("bonsai.tool.Ifc.get", return_value=None):
+        Stub().revert_last_run(None)
+    assert replayed == []
+    MirrorElements._last_run = None
+
+
 def test_a_reference_is_kept_even_when_its_selection_flag_lags():
     """Losing the reference falls back to an in-place mirror, which on a wall's Y is invisible.
 
@@ -237,6 +327,7 @@ def test_the_mirror_plane_ignores_an_active_object_that_is_not_selected():
 
     class Stub:
         _execute = MirrorElements._execute
+        revert_last_run = MirrorElements.revert_last_run
         resolve_selection = MirrorElements.__dict__["resolve_selection"]
         mirror_axis = "X"
 

--- a/src/ifcopenshell-python/ifcopenshell/util/shape_builder.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/shape_builder.py
@@ -910,20 +910,23 @@ class ShapeBuilder:
     ) -> np.ndarray:
         """Mirror a single 2D point across the specified axes.
 
-        :param point_2d: The 2D point to mirror.
+        :param point_2d: The point to mirror. Only the first two components are mirrored,
+            any further components are passed through untouched, so a 3D point may be
+            supplied and its Z is preserved.
         :param mirror_axes: Indicates which axes to mirror across. A positive value in a
             component means that axis is mirrored (negated relative to ``mirror_point``).
             Example: ``(1, 0)`` mirrors across the Y-axis (negates X only),
             ``(1, 1)`` mirrors across both axes.
         :param mirror_point: Origin of the mirror operation.
-        :return: Mirrored 2D point as a numpy array.
+        :return: Mirrored point as a numpy array, of the same length as ``point_2d``.
         """
         mirror_axes: np.ndarray = np.where(np.array(mirror_axes) > 0, -1, 1)
         mirror_point: np.ndarray = np.array(mirror_point)
-        relative_point = point_2d - mirror_point
+        point_2d: np.ndarray = np.array(point_2d)
+        relative_point = point_2d[:2] - mirror_point
         relative_point = relative_point * mirror_axes
         point_2d_res = relative_point + mirror_point
-        return point_2d_res
+        return np.append(point_2d_res, point_2d[2:])
 
     def create_axis2_placement_3d(
         self,
@@ -1050,6 +1053,7 @@ class ShapeBuilder:
         processed_objects: list[ifcopenshell.entity_instance] = []
         for curve_or_item_el in curve_or_item:
             for mirror_axes in mirror_axes_data:
+                axis_flip_count = sum(1 for axis in mirror_axes if axis > 0.0)
                 c = (
                     ifcopenshell.util.element.copy_deep(self.file, curve_or_item_el)
                     if create_copy
@@ -1083,17 +1087,25 @@ class ShapeBuilder:
                     c.Position.Location.Coordinates = ifc_safe_vector_type(new_position)
 
                 elif c.is_a("IfcExtrudedAreaSolid"):
-                    placement_matrix_ = ifcopenshell.util.placement.get_axis2placement(c.Position)[:3, :3]
-                    base_position = c.Position.Location.Coordinates
-                    # TODO: add support for Z-axis too
-                    new_position = self.mirror_2d_point(base_position[np_XY], mirror_axes, mirror_point)
-                    new_position = np_to_3d(new_position, base_position[np_Z])
-                    c.Position.Location.Coordinates = ifc_safe_vector_type(new_position)
+                    if c.Position is not None:
+                        placement_matrix_ = ifcopenshell.util.placement.get_axis2placement(c.Position)[:3, :3]
+                        base_position = np.array(c.Position.Location.Coordinates)
+                        # TODO: add support for Z-axis too
+                        new_position = self.mirror_2d_point(base_position[np_XY], mirror_axes, mirror_point)
+                        new_position = np_to_3d(new_position, base_position[np_Z])
+                        c.Position.Location.Coordinates = ifc_safe_vector_type(new_position)
+                    else:
+                        # Position is optional in IFC4 and absent means the identity placement,
+                        # so the profile coordinates already live in the parent frame.
+                        placement_matrix_ = np.eye(3)
+                        base_position = np.zeros(3)
+                        new_position = np.zeros(3)
 
                     # TODO: add support for Z-axis too
-                    self.translate(c.SweptArea.OuterCurve, base_position[np_XY])
-                    self.mirror(c.SweptArea.OuterCurve, mirror_axes, mirror_point, placement_matrix=placement_matrix_)
-                    self.translate(c.SweptArea.OuterCurve, -new_position[np_XY])
+                    if outer_curve := getattr(c.SweptArea, "OuterCurve", None):
+                        self.translate(outer_curve, base_position[np_XY])
+                        self.mirror(outer_curve, mirror_axes, mirror_point, placement_matrix=placement_matrix_)
+                        self.translate(outer_curve, -new_position[np_XY])
 
                     if hasattr(c.SweptArea, "InnerCurves"):
                         for inner_curve in c.SweptArea.InnerCurves:
@@ -1131,6 +1143,35 @@ class ShapeBuilder:
                     c.Trim1[0].Coordinates, c.Trim2[0].Coordinates = trim_coords
 
                     self.mirror(c.BasisCurve, mirror_axes, mirror_point)
+
+                elif c.is_a("IfcPolygonalFaceSet"):
+                    if self.file.get_total_inverses(c.Coordinates) > 1:
+                        # Another representation item shares this coordinate list. Clone it so
+                        # mirroring this face set does not move the other item's geometry too.
+                        c.Coordinates = ifcopenshell.util.element.copy(self.file, c.Coordinates)
+                    c.Coordinates.CoordList = [
+                        ifc_safe_vector_type(self.mirror_2d_point(coord, mirror_axes, mirror_point))
+                        for coord in c.Coordinates.CoordList
+                    ]
+
+                    if axis_flip_count % 2:
+                        for face in c.Faces:
+                            face.CoordIndex = list(reversed(face.CoordIndex))
+                            if face.is_a("IfcIndexedPolygonalFaceWithVoids"):
+                                face.InnerCoordIndices = [list(reversed(loop)) for loop in face.InnerCoordIndices]
+
+                elif c.is_a("IfcBoundingBox"):
+                    corner = np.array(c.Corner.Coordinates)
+                    new_corner = self.mirror_2d_point(corner, mirror_axes, mirror_point)
+                    # Corner is the minimum corner, so a flipped axis turns it into the maximum
+                    # corner and it has to be shifted back by that axis' dimension.
+                    new_corner[np_X] -= c.XDim if mirror_axes[np_X] > 0.0 else 0.0
+                    new_corner[np_Y] -= c.YDim if mirror_axes[np_Y] > 0.0 else 0.0
+                    c.Corner.Coordinates = ifc_safe_vector_type(new_corner)
+
+                elif c.is_a("IfcGeometricSet"):
+                    self.mirror(list(c.Elements), mirror_axes, mirror_point)
+
                 else:
                     raise Exception(f"{c} is not supported for mirror() method.")
 


### PR DESCRIPTION
`bim.mirror_elements` never mirrored anything. Its own comment said so:

> "This is not a true mirror operation... we calculate bounding box centroids, and mirror the position of the object... but never actually truly mirror anything."

It duplicated the selection and repositioned the copies, leaving geometry untouched. On a symmetric element that is indistinguishable from a mirror. On an asymmetric one you get a rotated copy, which is what #7991 and #6906 report.

## What changes

**Mirror inverts the geometry and transforms in place.** It no longer duplicates: duplicate first if you want to keep the original, the same as any other transform.

**Selecting one object** mirrors it about one of its own local planes. **Selecting two or more** makes the active object the mirror plane, through its bounding box centre rather than its origin, since an IFC origin can sit anywhere including inside the object being mirrored. **Mirror Axis** chooses which local axis is reflected along, of the object or of the reference.

## Safety

**Typed occurrences never invert the type's geometry**, which is shared with every sibling. The type is duplicated once, the duplicate inverted, and later mirrors of the same type reuse it. A guard raises rather than descending into geometry owned by a type.

**An element that cannot be inverted along the chosen axis is left completely untouched** and named in the report, rather than having its placement reflected around geometry that never moved.

## Two defects found while verifying

**The mirrored placement was not written back**, so the model looked correct on screen and reloaded with elements metres out of position. It now goes through `geometry.edit_object_placement`.

**Re-running from Adjust Last Operation composed with the previous result.** Blender's redo path does not roll back the IFC, so mirroring X then Y negated both axes, which is a rotation, not a reflection. Mirroring is its own inverse, so a redo replays the previous run to cancel it before applying the requested axis.

## Verification

Against IFC2X3 models supplied by two reporters:

- 48/48 walls exact across a reference, openings included
- all nine axis pairs equal to a single clean run of the second axis
- 11/11 correct after saving and reloading in a fresh Blender session, worst deviation 3 mm
- typed occurrence mirrored with its siblings and the original type byte-identical afterwards
- no duplicate GlobalIds, no empty or orphaned representations

`bim.flip_object` is untouched.

## Dependency

The Mirror **button** only reaches this operator with #8426. Without it the shared `Shift+M` hotkey dispatches to Merge for LAYER2 elements, so Mirror is unreachable on walls, which is the other half of #6906.

The `Shift+M` / `Ctrl+M` clash itself is deliberately **not** addressed here. It is a keymap decision worth its own discussion on #6906, particularly as Blender binds `transform.mirror` to `Ctrl+M`.

Generated with the assistance of an AI coding tool.
