### PR TITLE
Bonsai: recut a voided host from the body it displays, not the first representation in its context

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -414,8 +414,7 @@ class FilledOpeningGenerator:
             if voided_obj.data:
                 voided_element = tool.Ifc.get_entity(voided_obj)
                 assert voided_element
-                context = tool.Geometry.get_active_representation_context(voided_obj)
-                representation = tool.Geometry.get_representation_by_context(voided_element, context)
+                representation = tool.Geometry.get_host_recut_representation(voided_obj, voided_element)
                 assert representation
 
                 tool.Geometry.recut_host(voided_obj, representation)

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -899,6 +899,43 @@ class Geometry(bonsai.core.tool.Geometry):
         return ifcopenshell.util.representation.get_representation(element, context)
 
     @classmethod
+    def get_opening_context_ids(
+        cls, elements: Iterable[ifcopenshell.entity_instance], context: ifcopenshell.entity_instance
+    ) -> list[int]:
+        """Contexts, other than ``context``, holding the geometry of the openings
+        voiding ``elements``. A ``context-ids`` filter that omits them makes the
+        kernel silently skip those subtractions."""
+        context_ids: list[int] = []
+        for element in elements:
+            for rel in getattr(element, "HasOpenings", None) or ():
+                for representation in cls.get_representations_iter(rel.RelatedOpeningElement):
+                    context_id = representation.ContextOfItems.id()
+                    if context_id != context.id() and context_id not in context_ids:
+                        context_ids.append(context_id)
+        return context_ids
+
+    @classmethod
+    def get_host_recut_representation(
+        cls, obj: bpy.types.Object, element: ifcopenshell.entity_instance
+    ) -> Union[ifcopenshell.entity_instance, None]:
+        """The representation a voided host must be re-tessellated from after its
+        openings change: the one ``obj`` currently displays, else the ``Body``
+        representation sharing that context, else the first one in it."""
+        representation = cls.get_active_representation(obj)
+        if representation is not None and representation.is_a("IfcShapeRepresentation"):
+            return representation
+        context = cls.get_active_representation_context(obj)
+        fallback = None
+        for candidate in cls.get_representations_iter(element):
+            if candidate.ContextOfItems != context:
+                continue
+            if candidate.RepresentationIdentifier == "Body":
+                return candidate
+            if fallback is None:
+                fallback = candidate
+        return fallback
+
+    @classmethod
     def get_cartesian_point_offset(cls, obj: bpy.types.Object) -> npt.NDArray[np.float64] | None:
         props = tool.Blender.get_object_bim_props(obj)
         if props.blender_offset_type == "CARTESIAN_POINT" and props.cartesian_point_offset:
@@ -1158,7 +1195,10 @@ class Geometry(bonsai.core.tool.Geometry):
         ifc_importer = bonsai.bim.import_ifc.IfcImporter(ifc_import_settings)
         ifc_importer.file = tool.Ifc.get()
 
-        settings.set("context-ids", [context.id()])
+        context_ids = [context.id()]
+        if apply_openings:
+            context_ids.extend(cls.get_opening_context_ids(elements, context))
+        settings.set("context-ids", context_ids)
         if not apply_openings:
             settings.set("disable-opening-subtractions", True)
 

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -1482,8 +1482,7 @@ class Model(bonsai.core.tool.Model):
             voided_element = tool.Ifc.get_entity(voided_obj)
             if voided_element is None:
                 continue
-            context = tool.Geometry.get_active_representation_context(voided_obj)
-            representation = tool.Geometry.get_representation_by_context(voided_element, context)
+            representation = tool.Geometry.get_host_recut_representation(voided_obj, voided_element)
             if representation is None:
                 continue
             tool.Geometry.recut_host(voided_obj, representation)

--- a/src/bonsai/test/tool/test_geometry.py
+++ b/src/bonsai/test/tool/test_geometry.py
@@ -166,6 +166,105 @@ class TestGetActiveRepresentation(NewFile):
         assert subject.get_active_representation(obj) is None
 
 
+class TestGetHostRecutRepresentation(NewFile):
+    @staticmethod
+    def create_wall_with_axis_and_body(ifc, context):
+        wall = ifc.createIfcWall()
+        axis = ifc.createIfcShapeRepresentation(ContextOfItems=context, RepresentationIdentifier="Axis")
+        body = ifc.createIfcShapeRepresentation(ContextOfItems=context, RepresentationIdentifier="Body")
+        wall.Representation = ifc.createIfcProductDefinitionShape(Representations=[axis, body])
+        return wall, axis, body
+
+    def test_prefers_the_representation_the_object_displays(self):
+        """Exports that place Axis, BoundingBox and Body in a single context made
+        the openings recut fall back to Axis and blank the host mesh."""
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        context = ifc.createIfcGeometricRepresentationContext(ContextType="Model")
+        wall, axis, body = self.create_wall_with_axis_and_body(ifc, context)
+        mesh = bpy.data.meshes.new("Mesh")
+        obj = bpy.data.objects.new("Object", mesh)
+        tool.Geometry.get_mesh_props(mesh).ifc_definition_id = body.id()
+        assert subject.get_host_recut_representation(obj, wall) == body
+
+    def test_falls_back_to_the_body_representation_in_the_active_context(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        parent = ifc.createIfcGeometricRepresentationContext(ContextType="Model")
+        context = ifc.createIfcGeometricRepresentationSubContext(
+            ContextType="Model",
+            ContextIdentifier="Body",
+            TargetView="MODEL_VIEW",
+            ParentContext=parent,
+        )
+        wall, axis, body = self.create_wall_with_axis_and_body(ifc, context)
+        obj = bpy.data.objects.new("Object", bpy.data.meshes.new("Mesh"))
+        assert subject.get_host_recut_representation(obj, wall) == body
+
+    def test_returns_none_when_the_element_has_no_representation(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        ifc.createIfcGeometricRepresentationSubContext(
+            ContextType="Model",
+            ContextIdentifier="Body",
+            TargetView="MODEL_VIEW",
+            ParentContext=ifc.createIfcGeometricRepresentationContext(ContextType="Model"),
+        )
+        wall = ifc.createIfcWall()
+        obj = bpy.data.objects.new("Object", bpy.data.meshes.new("Mesh"))
+        assert subject.get_host_recut_representation(obj, wall) is None
+
+
+class TestGetOpeningContextIds(NewFile):
+    @staticmethod
+    def void_wall(ifc, wall, context):
+        opening = ifc.createIfcOpeningElement()
+        representation = ifc.createIfcShapeRepresentation(ContextOfItems=context, RepresentationIdentifier="Body")
+        opening.Representation = ifc.createIfcProductDefinitionShape(Representations=[representation])
+        ifc.createIfcRelVoidsElement(RelatingBuildingElement=wall, RelatedOpeningElement=opening)
+        return opening
+
+    def test_reports_contexts_the_host_context_does_not_cover(self):
+        """A context-ids filter without them makes the kernel skip the
+        subtraction and the door leaves the host uncut."""
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        host_context = ifc.createIfcGeometricRepresentationContext(ContextType="Model")
+        opening_context = ifc.createIfcGeometricRepresentationSubContext(
+            ContextType="Model",
+            ContextIdentifier="Body",
+            TargetView="MODEL_VIEW",
+            ParentContext=host_context,
+        )
+        wall = ifc.createIfcWall()
+        self.void_wall(ifc, wall, opening_context)
+        assert subject.get_opening_context_ids([wall], host_context) == [opening_context.id()]
+
+    def test_ignores_openings_sharing_the_host_context(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        host_context = ifc.createIfcGeometricRepresentationContext(ContextType="Model")
+        wall = ifc.createIfcWall()
+        self.void_wall(ifc, wall, host_context)
+        assert subject.get_opening_context_ids([wall], host_context) == []
+
+    def test_deduplicates_and_skips_elements_that_cannot_be_voided(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        host_context = ifc.createIfcGeometricRepresentationContext(ContextType="Model")
+        opening_context = ifc.createIfcGeometricRepresentationSubContext(
+            ContextType="Model",
+            ContextIdentifier="Body",
+            TargetView="MODEL_VIEW",
+            ParentContext=host_context,
+        )
+        wall = ifc.createIfcWall()
+        self.void_wall(ifc, wall, opening_context)
+        self.void_wall(ifc, wall, opening_context)
+        annotation = ifc.createIfcAnnotation()
+        assert subject.get_opening_context_ids([wall, annotation], host_context) == [opening_context.id()]
+
+
 class TestGetRepresentationId(NewFile):
     def test_run(self):
         ifc = ifcopenshell.file()


### PR DESCRIPTION
## Problem

Dropping a door into a wall of an imported model blanks the wall. The wall's mesh is replaced by a 2 vertex polyline or by nothing at all, and no void appears.

Reproduced headlessly on the reported file (Revit IFC2X3, `CLD_Blok_U_Kalkzandsteen_BGG.ifc`) over 12 walls: the reported wall `0Dls0TwB12eQU5rWKoJ5uz` plus one wall from each rotation group present in the file (0, 43.8, 88, 90, 134.9, 178, 180, 223.7, 268, 270, 315 degrees). Ten of the twelve carried geometry when the file loaded, and every one of those ten lost it:

| result after inserting a door | walls |
| --- | --- |
| 0 vertices, 0 faces | 4 |
| 2 vertices, 0 faces (the Axis polyline) | 6 |
| kept a solid | 0 |

The other two imported with 0 vertices before any door was inserted. That is the separate, non-deterministic import defect #8555 addresses, and it is excluded from the counts above.

The same door insertion on a fresh Bonsai project works, so the door authoring code is not at fault.

## Root cause 1: the recut reads the wrong representation

Every wall in this export attaches its `Axis` (Curve2D), `BoundingBox` and `Body` (Brep) representations directly to the **same** `IfcGeometricRepresentationContext`, with no subcontexts:

```
49805 Axis        Curve2D      context 15
49808 BoundingBox BoundingBox  context 15
49837 Body        Brep         context 15
```

`FilledOpeningGenerator.generate` picked the host's representation with

```python
context = tool.Geometry.get_active_representation_context(voided_obj)
representation = tool.Geometry.get_representation_by_context(voided_element, context)
```

`ifcopenshell.util.representation.get_representation` documents itself as returning "the first IfcShapeRepresentation matching the criteria", and when `context` is an entity instance the `subcontext` filter is ignored entirely. On this file that is `49805`, the **Axis** curve. Instrumented run:

```
DBG-REIMPORT ctx=15 base_rep=49805 elements=[49839] apply_openings=True
DBG-SHAPE    elem=49839 geomid=49805-openings-45111-45084-54261 verts=0
DBG-CHANGE   obj=IfcWall/Basic Wall:21_Kalkzandsteenwand... mesh=15/49805 verts=0
```

`switch_representation` then swapped the wall mesh for the empty Axis shape. `tool.Model.resync_opening_hosts` had the same two lines.

The object already records which representation it displays, and both `Geometry.batch_host_recut` (`tool/geometry.py`) and the plain `bim.add_opening` path (`bim/module/void/operator.py`) read it back with `get_active_representation`. Only the filling path disagreed, which is why the multi-drop operator masked the bug while a single drag and drop did not.

`Geometry.get_host_recut_representation` makes the filling path agree, falling back to the `Body` representation sharing the active context, then to the first one in it.

## Root cause 2: the opening is filtered out of the boolean

Fixing the representation alone leaves the door cutting nothing. `reimport_element_representations` restricts the iterator to the host's context:

```python
settings.set("context-ids", [context.id()])
```

The opening Bonsai authors goes into `Model/Body/MODEL_VIEW`, which on such a file is a **different** context from the one holding the wall body. The kernel resolves no geometry for that opening in the allowed contexts and silently skips the subtraction. Measured directly against the kernel on the saved file:

| `context-ids` | wall body |
| --- | --- |
| `[15]` | 8 verts, uncut |
| `[15, 54211]` | 16 verts, cut |
| opening representations moved into context 15, `[15]` | 16 verts, cut |

`Geometry.get_opening_context_ids` adds the contexts of the host's openings to the filter. It returns nothing for a well formed model, where host and openings share the `Body` subcontext, so the setting is unchanged there.

## Verification

Live, headless Blender 5.1.2, Bonsai loaded from this branch, on the reporter's file.

**Reported file, one door per wall, the same 12 walls, 3 repeated runs.** After: 11 of 12 keep a real solid with the void in it, identical across all three runs. The remaining wall (`2pgbLLOrPCLfNrg8GnJvO_`) imports with 0 vertices before the door is inserted, both with and without this change; that is #8555's defect, not this path.

Target wall `0Dls0TwB12eQU5rWKoJ5uz`:

| | vertices / faces |
| --- | --- |
| before the door | 8 / 12 |
| after, on `v0.8.0` | 0 / 0 |
| after, on this branch | 16 / 28 |

16 / 28 is the same signature a fresh project wall produces for a door that does not reach the wall base.

Note on the commit message: it says "11 of 11 lost their solid, 4 to 0 vertices and 7 to the 2 vertex axis". The correct split is 10 of 10 walls that had geometry, 4 to 0 vertices and 6 to the 2 vertex axis; the two remaining walls in that run were already empty on import. The tables in this description are the accurate ones.

**No regression on authored models.** Fresh project, default wall type, default door type, door dropped in: 8 / 12 to 12 / 20 in IFC4 and in IFC2X3, the same counts before and after this change.

**Tests.** 6 new cases in `test/tool/test_geometry.py`. `test/tool/test_geometry.py` and `test/tool/test_model.py` pass (103), `test/core` passes (390).

## Relation to other open PRs

- #8555 fixes the same one-context-per-product export blanking walls on **import**. Different code path, no file overlap, merges clean.
- #8995 creates the `Model/Body` context these files lack, which is what lets a door be authored on them at all. It does not touch the recut, and root cause 2 exists precisely because the opening ends up in that newly created context. Merges clean.
- #8971 rewrites `reimport_element_representations` into a batched form and conflicts textually in `src/bonsai/bonsai/tool/geometry.py`. The resolution is mechanical: in the batched version the same two lines go around `settings.set("context-ids", [context_id])` inside the per-group loop.

Generated with the assistance of an AI coding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
