### PR TITLE
Auto-detect space height + IFC-direct space generation

### DIFF
--- a/src/bonsai/bonsai/bim/handler.py
+++ b/src/bonsai/bonsai/bim/handler.py
@@ -59,6 +59,7 @@ from bonsai.bim.module.model.decorator import (
 )
 from bonsai.bim.module.model.wall import WallGizmoPreviewDecorator
 from bonsai.bim.module.nest.decorator import NestDecorator
+from bonsai.tool.spatial import install_geom_cache_handlers, uninstall_geom_cache_handlers
 
 cwd = os.path.dirname(os.path.realpath(__file__))
 global_subscription_owner = object()
@@ -121,7 +122,23 @@ def name_callback(obj: Union[bpy.types.Object, bpy.types.Material], data: str) -
 def active_object_callback():
     refresh_ui_data()
     update_bim_tool_props()
+    update_spatial_tool_props()
     tool.Geometry.sync_item_positions()
+
+
+def update_spatial_tool_props():
+    """Sync ``BIMSpatialDecompositionProperties.space_height`` with the
+    active object's height when it is an ``IfcSpace``, otherwise reset to
+    the 3m default. Called from the msgbus active-object callback so Scene
+    property writes happen outside ``draw()``."""
+    obj = tool.Blender.get_active_object()
+    props = tool.Spatial.get_spatial_props()
+    if obj:
+        element = tool.Ifc.get_entity(obj)
+        if element and element.is_a("IfcSpace"):
+            props.space_height = obj.dimensions.z
+            return
+    props.space_height = 3
 
 
 def update_bim_tool_props():
@@ -528,6 +545,7 @@ def _install_viewport_overlays() -> None:
     ArrayPreviewDecorator.uninstall()
     ArraySelectionHighlightDecorator.uninstall()
     uninstall_decorator_cache_handlers()
+    uninstall_geom_cache_handlers()
     try:
         if georeference_props.should_visualise:
             GeoreferenceDecorator.install(bpy.context)
@@ -570,6 +588,7 @@ def _install_viewport_overlays() -> None:
         ArrayPreviewDecorator.install(bpy.context)
     finally:
         install_decorator_cache_handlers()
+        install_geom_cache_handlers()
 
 
 @persistent

--- a/src/bonsai/bonsai/bim/module/model/__init__.py
+++ b/src/bonsai/bonsai/bim/module/model/__init__.py
@@ -178,6 +178,7 @@ classes = (
     covering.RegenSelectedCoveringObject,
     space.ToggleSpaceVisibility,
     space.ToggleHideSpaces,
+    space.ApplySpaceHeightToSelection,
     mep.FitFlowSegments,
     mep.RegenerateDistributionElement,
     prop.SnapMousePoint,

--- a/src/bonsai/bonsai/bim/module/model/space.py
+++ b/src/bonsai/bonsai/bim/module/model/space.py
@@ -18,7 +18,9 @@
 
 
 import bpy
+import ifcopenshell.util.unit
 
+import bonsai.core.geometry as core_geometry
 import bonsai.core.spatial as core
 import bonsai.tool as tool
 
@@ -115,3 +117,47 @@ class ToggleHideSpaces(bpy.types.Operator):
     def execute(self, context):
         core.toggle_hide_spaces(tool.Ifc, tool.Spatial)
         return {"FINISHED"}
+
+
+class ApplySpaceHeightToSelection(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.apply_space_height_to_selection"
+    bl_label = "Apply Space Height To Selection"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = "Apply the space height value to all selected spaces without regenerating their footprint"
+
+    @classmethod
+    def poll(cls, context):
+        selected_spaces = [
+            obj
+            for obj in context.selected_objects
+            if (element := tool.Ifc.get_entity(obj)) and element.is_a("IfcSpace")
+        ]
+        if not selected_spaces:
+            cls.poll_message_set("No spaces selected.")
+            return False
+        return True
+
+    def _execute(self, context):
+        ifc_file = tool.Ifc.get()
+        si_conversion = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
+        depth_ifc = tool.Spatial.get_spatial_props().space_height / si_conversion
+        total = 0
+        for obj in context.selected_objects:
+            element = tool.Ifc.get_entity(obj)
+            if not element or not element.is_a("IfcSpace"):
+                continue
+            body = tool.Geometry.get_body_representation(element)
+            if not body:
+                continue
+            extrusion = tool.Model.get_extrusion(body)
+            if not extrusion:
+                continue
+            extrusion.Depth = depth_ifc
+            core_geometry.switch_representation(
+                tool.Ifc,
+                tool.Geometry,
+                obj=obj,
+                representation=body,
+            )
+            total += 1
+        self.report({"INFO"}, f"Height applied to {total} spaces.")

--- a/src/bonsai/bonsai/bim/module/spatial/prop.py
+++ b/src/bonsai/bonsai/bim/module/spatial/prop.py
@@ -24,6 +24,7 @@ from bpy.props import (
     BoolProperty,
     CollectionProperty,
     EnumProperty,
+    FloatProperty,
     IntProperty,
     PointerProperty,
     StringProperty,
@@ -277,6 +278,17 @@ class BIMSpatialDecompositionProperties(PropertyGroup):
     should_include_children: BoolProperty(
         name="Should Include Children", default=True, update=update_should_include_children
     )
+    space_height: FloatProperty(
+        name="Space Height",
+        default=3,
+        subtype="DISTANCE",
+        description="Space height in meters. Auto-detected on generation unless forced. Used as fallback.",
+    )
+    force_space_height: BoolProperty(
+        name="Force Height",
+        default=False,
+        description="If enabled, uses the height value directly and skips auto-detection",
+    )
 
     if TYPE_CHECKING:
         is_locked: bool
@@ -294,6 +306,8 @@ class BIMSpatialDecompositionProperties(PropertyGroup):
         subelement_class: str
         default_container: int
         should_include_children: bool
+        space_height: float
+        force_space_height: bool
 
     @property
     def active_container(self) -> Union[BIMContainer, None]:

--- a/src/bonsai/bonsai/bim/module/spatial/workspace.py
+++ b/src/bonsai/bonsai/bim/module/spatial/workspace.py
@@ -83,8 +83,13 @@ class SpatialToolUI:
 
     @classmethod
     def draw_default_interface(cls, context):
+        spatial_props = tool.Spatial.get_spatial_props()
         row = cls.layout.row(align=True)
         row.prop(data=cls.model_props, property="rl3", text="RL")
+        row = cls.layout.row(align=True)
+        row.prop(data=spatial_props, property="space_height", text="Height")
+        row.prop(data=spatial_props, property="force_space_height", text="", icon="PINNED")
+        row.operator("bim.apply_space_height_to_selection", text="", icon="COPYDOWN")
         row = cls.layout.row(align=True)
         op_name = lambda op: op.get_rna_type().name
         if AuthoringData.data["active_class"] == "IfcWall" and context.selected_objects:

--- a/src/bonsai/bonsai/core/covering.py
+++ b/src/bonsai/bonsai/core/covering.py
@@ -46,7 +46,7 @@ def add_instance_flooring_covering_from_cursor(
     else:
         x, y, z, h, mat = spatial.get_x_y_z_h_mat_from_cursor()
 
-    space_polygon = spatial.get_space_polygon_from_context_visible_objects(x, y)
+    space_polygon, _ = spatial.get_space_polygon_from_context_visible_objects(x, y)
 
     if isinstance(space_polygon, str):
         return
@@ -81,7 +81,7 @@ def add_instance_ceiling_covering_from_cursor(
         x, y, z, h, mat = spatial.get_x_y_z_h_mat_from_cursor()
         ceiling_height = covering.get_z_from_ceiling_height()
 
-    space_polygon = spatial.get_space_polygon_from_context_visible_objects(x, y)
+    space_polygon, _ = spatial.get_space_polygon_from_context_visible_objects(x, y)
 
     if isinstance(space_polygon, str):
         return
@@ -106,7 +106,7 @@ def regen_selected_covering_object(root: type[tool.Root], spatial: type[tool.Spa
     else:
         assert False, "Object has to be active and selected."
 
-    space_polygon = spatial.get_space_polygon_from_context_visible_objects(x, y)
+    space_polygon, _ = spatial.get_space_polygon_from_context_visible_objects(x, y)
 
     if isinstance(space_polygon, str):
         return

--- a/src/bonsai/bonsai/core/spatial.py
+++ b/src/bonsai/bonsai/core/spatial.py
@@ -206,7 +206,7 @@ def generate_space(
     else:
         x, y, z, h, mat = spatial.get_x_y_z_h_mat_from_cursor()
 
-    space_polygon = spatial.get_space_polygon_from_context_visible_objects(x, y)
+    space_polygon, bounding_walls = spatial.get_space_polygon_from_context_visible_objects(x, y)
 
     if isinstance(space_polygon, str):
         if space_polygon == "NO POLYGONS FOUND":
@@ -219,6 +219,14 @@ def generate_space(
             )
         else:
             assert space_polygon
+
+    props = spatial.get_spatial_props()
+    if props.force_space_height:
+        h = props.space_height
+    else:
+        auto_h = spatial.get_auto_space_height(space_polygon, z, bounding_walls)
+        if auto_h is not None and auto_h > 0:
+            h = auto_h
 
     if element and element.is_a("IfcSpace"):
         spatial.set_space_representation_from_polygon(active_obj, element, space_polygon, h, polygon_is_si=True)
@@ -248,10 +256,24 @@ def generate_spaces_from_walls(
     z = spatial.get_active_obj_z()
     h = spatial.get_active_obj_height()
 
+    bounding_walls = [
+        element
+        for obj in spatial.get_selected_objects()
+        if (element := ifc.get_entity(obj)) and element.is_a("IfcWall")
+    ]
+
     union = spatial.get_union_shape_from_selected_objects()
 
+    props = spatial.get_spatial_props()
     for i, linear_ring in enumerate(union.interiors):
         poly = spatial.get_buffered_poly_from_linear_ring(linear_ring)
+
+        if props.force_space_height:
+            h = props.space_height
+        else:
+            auto_h = spatial.get_auto_space_height(poly, z, bounding_walls)
+            if auto_h is not None and auto_h > 0:
+                h = auto_h
 
         name = "Space" + str(i)
 

--- a/src/bonsai/bonsai/core/spatial.py
+++ b/src/bonsai/bonsai/core/spatial.py
@@ -229,6 +229,8 @@ def generate_space(
             h = auto_h
 
     if element and element.is_a("IfcSpace"):
+        assert active_obj
+        active_obj.location.z = z
         spatial.set_space_representation_from_polygon(active_obj, element, space_polygon, h, polygon_is_si=True)
     else:
         if relating_type:

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
 from collections import defaultdict
 from collections.abc import Generator, Iterable
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
@@ -34,7 +35,9 @@ import ifcopenshell.util.classification
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
 import ifcopenshell.util.representation
+import ifcopenshell.util.shape
 import ifcopenshell.util.shape_builder
+import ifcopenshell.util.space
 import ifcopenshell.util.type
 import ifcopenshell.util.unit
 import numpy as np
@@ -58,8 +61,52 @@ if TYPE_CHECKING:
         BIMSpatialDecompositionProperties,
     )
 
+_GEOM_CACHE_TOKEN = 0
+
+
+@bpy.app.handlers.persistent
+def _bump_geom_cache_token(*args) -> None:
+    global _GEOM_CACHE_TOKEN
+    if len(args) >= 2:
+        depsgraph = args[1]
+        if depsgraph is not None and hasattr(depsgraph, "updates"):
+            if not any(
+                (getattr(u, "is_updated_geometry", False) or getattr(u, "is_updated_transform", False))
+                and hasattr(u, "id")
+                and isinstance(u.id, bpy.types.Object)
+                for u in depsgraph.updates
+            ):
+                return
+    _GEOM_CACHE_TOKEN += 1
+
+
+def install_geom_cache_handlers() -> None:
+    for hook in (
+        bpy.app.handlers.depsgraph_update_post,
+        bpy.app.handlers.undo_post,
+        bpy.app.handlers.redo_post,
+        bpy.app.handlers.load_post,
+    ):
+        if _bump_geom_cache_token not in hook:
+            hook.append(_bump_geom_cache_token)
+
+
+def uninstall_geom_cache_handlers() -> None:
+    for hook in (
+        bpy.app.handlers.depsgraph_update_post,
+        bpy.app.handlers.undo_post,
+        bpy.app.handlers.redo_post,
+        bpy.app.handlers.load_post,
+    ):
+        try:
+            hook.remove(_bump_geom_cache_token)
+        except ValueError:
+            pass
+
 
 class Spatial(bonsai.core.tool.Spatial):
+    _geom_cache: dict = {}
+
     @classmethod
     def get_spatial_props(cls) -> BIMSpatialDecompositionProperties:
         return bpy.context.scene.BIMSpatialDecompositionProperties
@@ -756,28 +803,113 @@ class Spatial(bonsai.core.tool.Spatial):
     # HERE STARTS SPATIAL TOOL
 
     @classmethod
+    def get_or_build_geom_cache(cls) -> dict:
+        """Build or return a cached dict of IFC element shapes for space generation.
+
+        The cache is keyed on ``_GEOM_CACHE_TOKEN`` which is bumped by a
+        ``depsgraph_update_post`` handler when any Object geometry or transform
+        changes, and on undo/redo/load. This means the cache survives space
+        generations (which don't change Object geometry) but is correctly
+        invalidated when a user moves or edits a wall, slab, etc.
+
+        :return: ``{"shapes": {id: {"verts": ndarray, "faces": ndarray, "bottom_z": float, "top_z": float}}, "token": int}``
+        """
+        global _GEOM_CACHE_TOKEN
+        cached = cls._geom_cache.get("current")
+        if cached and cached["token"] == _GEOM_CACHE_TOKEN:
+            return cached
+
+        ifc_file = tool.Ifc.get()
+        include = []
+        for ifc_class in ifcopenshell.util.space.BOUNDING_CLASSES + ifcopenshell.util.space.HEIGHT_DETECTION_CLASSES:
+            include.extend(ifc_file.by_type(ifc_class))
+
+        settings = ifcopenshell.geom.settings()
+        settings.set("disable-opening-subtractions", True)
+        settings.set("use-world-coords", True)
+
+        shapes = {}
+        iterator = ifcopenshell.geom.iterator(settings, ifc_file, multiprocessing.cpu_count(), include=include)
+        if iterator.initialize():
+            while True:
+                shape = iterator.get()
+                verts = ifcopenshell.util.shape.get_shape_vertices(shape, shape.geometry)
+                faces = ifcopenshell.util.shape.get_faces(shape.geometry)
+                zs = verts[:, 2]
+                shapes[shape.id] = {
+                    "verts": verts,
+                    "faces": faces,
+                    "bottom_z": float(zs.min()),
+                    "top_z": float(zs.max()),
+                }
+                if not iterator.next():
+                    break
+
+        cache = {"shapes": shapes, "token": _GEOM_CACHE_TOKEN}
+        cls._geom_cache["current"] = cache
+        return cache
+
+    @classmethod
     def is_bounding_class(cls, visible_element: ifcopenshell.entity_instance) -> bool:
-        for ifc_class in ["IfcWall", "IfcColumn", "IfcMember", "IfcVirtualElement", "IfcPlate"]:
+        for ifc_class in ifcopenshell.util.space.BOUNDING_CLASSES:
             if visible_element.is_a(ifc_class):
                 return True
         return False
 
     @classmethod
-    def get_space_polygon_from_context_visible_objects(
-        cls, x: float, y: float
-    ) -> Union[shapely.Polygon, Literal["NO POLYGONS FOUND", "NO POLYGON FOR POINT"]]:
-        boundary_lines = cls.get_boundary_lines_from_context_visible_objects()
-        unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
-        closed_polygons = shapely.polygonize(unioned_boundaries.geoms)
-        if not closed_polygons:
-            return "NO POLYGONS FOUND"
-        space_polygon = None
-        for polygon in closed_polygons.geoms:
-            if shapely.contains_xy(polygon, x, y):
-                space_polygon = shapely.force_3d(polygon)
-        if space_polygon is None:
-            return "NO POLYGON FOR POINT"
-        return space_polygon
+    def get_boundary_lines_from_ifc_elements(
+        cls,
+        cut_z: float,
+    ) -> tuple[list[shapely.LineString], list[ifcopenshell.entity_instance]]:
+        """Generate boundary lines by bisecting IFC element geometry with a horizontal plane.
+
+        Uses the class-level geometry cache (parallel iterator) instead of
+        iterating Blender visible objects. Works without any Blender objects
+        being loaded.
+
+        :param cut_z: Z elevation of the cutting plane in world coordinates.
+        :return: (boundary_lines, bounding_elements)
+        """
+        cache = cls.get_or_build_geom_cache()
+        return ifcopenshell.util.space.get_boundary_lines(tool.Ifc.get(), cache["shapes"], cut_z)
+
+    @classmethod
+    def get_space_polygon_from_context_visible_objects(cls, x: float, y: float) -> tuple[
+        Union[shapely.Polygon, Literal["NO POLYGONS FOUND", "NO POLYGON FOR POINT"]],
+        list[ifcopenshell.entity_instance],
+    ]:
+        props = tool.Model.get_model_props()
+        calculation_rl = props.rl3
+        container = tool.Root.get_default_container()
+        container_obj = tool.Ifc.get_object(container)
+        cut_z = container_obj.matrix_world.translation.z + calculation_rl
+
+        boundary_lines, bounding_elements = cls.get_boundary_lines_from_ifc_elements(cut_z)
+        polygon, _ = ifcopenshell.util.space.get_space_polygon(boundary_lines, x, y)
+        if isinstance(polygon, str):
+            return polygon, []
+        return polygon, bounding_elements
+
+    @classmethod
+    def get_auto_space_height(
+        cls,
+        space_polygon: shapely.Polygon,
+        base_z: float,
+        bounding_walls: list[ifcopenshell.entity_instance],
+    ) -> Optional[float]:
+        """Auto-detect space height from elements above using IFC geometry.
+
+        Delegates to :func:`ifcopenshell.util.space.get_auto_space_height`.
+
+        :param space_polygon: The space footprint polygon in world XY.
+        :param base_z: The space's base Z in world coordinates.
+        :param bounding_walls: List of IFC wall elements bounding the space.
+        :return: Detected height in SI (meters), or None if nothing found.
+        """
+        cache = cls.get_or_build_geom_cache()
+        return ifcopenshell.util.space.get_auto_space_height(
+            tool.Ifc.get(), cache["shapes"], space_polygon, base_z, bounding_walls
+        )
 
     @classmethod
     def debug_shape(cls, foo: shapely.Polygon) -> None:
@@ -810,7 +942,9 @@ class Spatial(bonsai.core.tool.Spatial):
         bpy.context.view_layer.update()
 
     @classmethod
-    def get_boundary_lines_from_context_visible_objects(cls) -> list[shapely.LineString]:
+    def get_boundary_lines_from_context_visible_objects(
+        cls,
+    ) -> tuple[list[shapely.LineString], list[ifcopenshell.entity_instance]]:
         props = tool.Model.get_model_props()
         calculation_rl = props.rl3
         container = tool.Root.get_default_container()
@@ -818,6 +952,7 @@ class Spatial(bonsai.core.tool.Spatial):
         cut_point = container_obj.matrix_world.translation.copy() + Vector((0, 0, calculation_rl))
         cut_normal = Vector((0, 0, 1))
         boundary_lines = []
+        bounding_elements = []
 
         for obj in bpy.context.visible_objects:
             visible_element = tool.Ifc.get_entity(obj)
@@ -831,6 +966,7 @@ class Spatial(bonsai.core.tool.Spatial):
             ):
                 continue
 
+            bounding_elements.append(visible_element)
             old_mesh = obj.data
             assert isinstance(old_mesh, bpy.types.Mesh)
             if visible_element.HasOpenings:
@@ -870,7 +1006,7 @@ class Spatial(bonsai.core.tool.Spatial):
                 start, end = tool.Drawing.extend_line(start, end, 0.05)
                 boundary_lines.append(shapely.LineString([start, end]))
 
-        return boundary_lines
+        return boundary_lines, bounding_elements
 
     @classmethod
     def get_gross_mesh_from_element(cls, visible_element: ifcopenshell.entity_instance) -> bpy.types.Mesh:

--- a/src/bonsai/bonsai/tool/wall.py
+++ b/src/bonsai/bonsai/tool/wall.py
@@ -245,16 +245,9 @@ class Wall(bonsai.core.tool.Wall):
     @classmethod
     def iter_wall_slab_connections(cls, wall: ifcopenshell.entity_instance):
         """Yield ``(slab, rel)`` tuples for every ``IfcRelConnectsElements(TOP)``
-        connecting a slab to this wall — the rel kind ``extend_walls_to_underside``
-        creates. Walks ``wall.ConnectedFrom`` because the slab is the relating
-        side of the TOP rel."""
-        for rel in getattr(wall, "ConnectedFrom", []) or ():
-            if not rel.is_a("IfcRelConnectsElements") or rel.Description != "TOP":
-                continue
-            slab = rel.RelatingElement
-            if slab is None:
-                continue
-            yield slab, rel
+        connecting a slab to this wall. Delegates to
+        :func:`ifcopenshell.util.element.iter_top_connections`."""
+        yield from ifcopenshell.util.element.iter_top_connections(wall)
 
     @classmethod
     def iter_slab_wall_connections(cls, slab: ifcopenshell.entity_instance):

--- a/src/bonsai/test/core/test_covering.py
+++ b/src/bonsai/test/core/test_covering.py
@@ -1,0 +1,110 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import bonsai
+import bonsai.core.covering as subject
+import pytest
+from test.core.bootstrap import Prophecy, ifc, root, spatial
+
+# NOTE: The Prophecy mocking framework serialises call arguments as JSON,
+# which means shapely geometry objects cannot be passed through mocked
+# calls.  We use the plain integer 42 as a serialisable stand-in for the
+# polygon return value; the test verifies the unpack behaviour (that the
+# polygon-like scalar 42 reaches set_covering_representation_from_polygon
+# instead of the tuple (42, []) which old code would have passed).
+
+
+@pytest.fixture
+def covering():
+    prophet = Prophecy(bonsai.core.tool.Covering)
+    yield prophet
+    prophet.verify()
+
+
+class TestAddInstanceFlooringCoveringFromCursor:
+    def test_run(self, ifc, root, spatial):
+        root.get_default_container().should_be_called().will_return("container")
+        spatial.get_active_obj().should_be_called().will_return(None)
+        spatial.get_selected_objects().should_be_called().will_return([])
+        spatial.get_relating_type_id().should_be_called().will_return(0)
+        spatial.get_x_y_z_h_mat_from_cursor().should_be_called().will_return((0, 0, 0, 3, None))
+
+        spatial.get_space_polygon_from_context_visible_objects(0, 0).should_be_called().will_return((42, []))
+        spatial.create_object("Covering").should_be_called().will_return("mock_obj")
+        spatial.set_obj_origin_to_cursor_position_and_zero_elevation("mock_obj").should_be_called()
+        spatial.translate_obj_to_z_location("mock_obj", 0).should_be_called()
+        spatial.assign_type_to_obj("mock_obj").should_be_called()
+        spatial.set_covering_representation_from_polygon("mock_obj", 42, polygon_is_si=True).should_be_called()
+
+        subject.add_instance_flooring_covering_from_cursor(ifc, root, spatial)
+
+    def test_raises_when_no_default_container(self, ifc, root, spatial):
+        root.get_default_container().should_be_called().will_return(None)
+        with pytest.raises(subject.NoDefaultContainer):
+            subject.add_instance_flooring_covering_from_cursor(ifc, root, spatial)
+
+
+class TestAddInstanceCeilingCoveringFromCursor:
+    def test_run(self, ifc, root, covering, spatial):
+        root.get_default_container().should_be_called().will_return("container")
+        spatial.get_active_obj().should_be_called().will_return(None)
+        spatial.get_selected_objects().should_be_called().will_return([])
+        spatial.get_relating_type_id().should_be_called().will_return(0)
+        covering.get_z_from_ceiling_height().should_be_called().will_return(3.0)
+        spatial.get_x_y_z_h_mat_from_cursor().should_be_called().will_return((0, 0, 0, 3, None))
+
+        spatial.get_space_polygon_from_context_visible_objects(0, 0).should_be_called().will_return((42, []))
+        spatial.create_object("Covering").should_be_called().will_return("mock_obj")
+        spatial.set_obj_origin_to_cursor_position_and_zero_elevation("mock_obj").should_be_called()
+        spatial.translate_obj_to_z_location("mock_obj", 3.0).should_be_called()
+        spatial.assign_type_to_obj("mock_obj").should_be_called()
+        spatial.set_covering_representation_from_polygon("mock_obj", 42, polygon_is_si=True).should_be_called()
+
+        subject.add_instance_ceiling_covering_from_cursor(ifc, root, covering, spatial)
+
+    def test_raises_when_no_default_container(self, ifc, root, covering, spatial):
+        root.get_default_container().should_be_called().will_return(None)
+        with pytest.raises(subject.NoDefaultContainer):
+            subject.add_instance_ceiling_covering_from_cursor(ifc, root, covering, spatial)
+
+
+class TestRegenSelectedCoveringObject:
+    def test_run(self, root, spatial):
+        root.get_default_container().should_be_called().will_return("container")
+        spatial.get_active_obj().should_be_called().will_return("active")
+        spatial.get_selected_objects().should_be_called().will_return(["active"])
+        spatial.get_x_y_z_h_mat_from_obj("active").should_be_called().will_return((2, 3, 1, 3, None))
+
+        spatial.get_space_polygon_from_context_visible_objects(2, 3).should_be_called().will_return((42, []))
+        spatial.set_covering_representation_from_polygon("active", 42, polygon_is_si=True).should_be_called()
+
+        subject.regen_selected_covering_object(root, spatial)
+
+    def test_raises_when_no_default_container(self, root, spatial):
+        root.get_default_container().should_be_called().will_return(None)
+        with pytest.raises(subject.NoDefaultContainer):
+            subject.regen_selected_covering_object(root, spatial)
+
+    def test_raises_when_no_active_selected(self, root, spatial):
+        root.get_default_container().should_be_called().will_return("container")
+        spatial.get_active_obj().should_be_called().will_return(None)
+        spatial.get_selected_objects().should_be_called().will_return([])
+        with pytest.raises(AssertionError):
+            subject.regen_selected_covering_object(root, spatial)

--- a/src/bonsai/test/core/test_covering.py
+++ b/src/bonsai/test/core/test_covering.py
@@ -22,6 +22,7 @@ import pytest
 
 import bonsai
 import bonsai.core.covering as subject
+import bonsai.core.tool
 from test.core.bootstrap import Prophecy, ifc, root, spatial
 
 # NOTE: The Prophecy mocking framework serialises call arguments as JSON,

--- a/src/bonsai/test/core/test_covering.py
+++ b/src/bonsai/test/core/test_covering.py
@@ -18,9 +18,10 @@
 #
 # This file was generated with the assistance of an AI coding tool.
 
+import pytest
+
 import bonsai
 import bonsai.core.covering as subject
-import pytest
 from test.core.bootstrap import Prophecy, ifc, root, spatial
 
 # NOTE: The Prophecy mocking framework serialises call arguments as JSON,

--- a/src/bonsai/test/tool/test_spatial.py
+++ b/src/bonsai/test/tool/test_spatial.py
@@ -426,3 +426,63 @@ class TestGenerateSpace(NewFile):
         bpy.ops.bim.generate_space()
         new_height = space.dimensions.z
         assert new_height != original_height or new_height > 0
+
+    def test_regenerate_space_from_centered_cube_representation(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        _BlockHelper.create_wall(ifc, height=10.0)
+        scene = bpy.context.scene
+        scene.cursor.location = (0, 0, 0)
+
+        # Create a space with a unit cube PolygonalFaceSet centered at local origin.
+        ctx = ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW")
+        points = ifc.createIfcCartesianPointList3D(
+            [
+                (-0.5, -0.5, -0.5),
+                (-0.5, -0.5, 0.5),
+                (-0.5, 0.5, -0.5),
+                (-0.5, 0.5, 0.5),
+                (0.5, -0.5, -0.5),
+                (0.5, -0.5, 0.5),
+                (0.5, 0.5, -0.5),
+                (0.5, 0.5, 0.5),
+            ]
+        )
+        faces = [
+            ifc.createIfcIndexedPolygonalFace([1, 2, 4, 3]),
+            ifc.createIfcIndexedPolygonalFace([3, 4, 8, 7]),
+            ifc.createIfcIndexedPolygonalFace([7, 8, 6, 5]),
+            ifc.createIfcIndexedPolygonalFace([5, 6, 2, 1]),
+            ifc.createIfcIndexedPolygonalFace([3, 7, 5, 1]),
+            ifc.createIfcIndexedPolygonalFace([8, 4, 2, 6]),
+        ]
+        face_set = ifc.createIfcPolygonalFaceSet(points, closed=True, faces=faces)
+        shape_rep = ifc.createIfcShapeRepresentation(ctx, "Body", "Tessellation", [face_set])
+
+        space_element = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcSpace")
+        space_element.Representation = ifc.createIfcProductDefinitionShape(None, None, [shape_rep])
+
+        bpy.ops.mesh.primitive_cube_add(size=1, location=(0, 0, 5))
+        obj = bpy.data.objects["Cube"]
+        scene.collection.objects.link(obj)
+        tool.Ifc.link(space_element, obj)
+        bpy.context.view_layer.update()
+        obj.name = "MySpace"
+
+        # Check the cube's world bottom Z before regeneration.
+        bottom_z = (obj.matrix_world @ Vector(obj.bound_box[0])).z
+        assert np.isclose(bottom_z, 4.5), f"Expected bottom_z=4.5, got {bottom_z}"
+
+        # Regenerate the space.
+        bpy.context.view_layer.objects.active = obj
+        obj.select_set(True)
+        bpy.ops.bim.generate_space()
+
+        mesh = obj.data
+        assert isinstance(mesh, bpy.types.Mesh)
+        verts = [v.co.z for v in mesh.vertices]
+        min_z = min(verts)
+        max_z = max(verts)
+        assert min_z >= 0, f"Expected extrusion to start at local z>=0, got min_z={min_z}"
+        assert max_z > 0, f"Expected extrusion to have positive height, got max_z={max_z}"
+        assert np.isclose(obj.location.z, 4.5, atol=0.01), f"Expected location.z=4.5, got {obj.location.z}"

--- a/src/bonsai/test/tool/test_spatial.py
+++ b/src/bonsai/test/tool/test_spatial.py
@@ -30,7 +30,8 @@ from mathutils import Matrix
 
 import bonsai.core.tool
 import bonsai.tool as tool
-from bonsai.tool.spatial import Spatial as subject, _bump_geom_cache_token
+from bonsai.tool.spatial import Spatial as subject
+from bonsai.tool.spatial import _bump_geom_cache_token
 from test.bim.bootstrap import NewFile
 
 

--- a/src/bonsai/test/tool/test_spatial.py
+++ b/src/bonsai/test/tool/test_spatial.py
@@ -24,12 +24,13 @@ import ifcopenshell.api.feature
 import ifcopenshell.api.nest
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
+import ifcopenshell.util.representation
 import numpy as np
 from mathutils import Matrix
 
 import bonsai.core.tool
 import bonsai.tool as tool
-from bonsai.tool.spatial import Spatial as subject
+from bonsai.tool.spatial import Spatial as subject, _bump_geom_cache_token
 from test.bim.bootstrap import NewFile
 
 
@@ -258,17 +259,44 @@ class TestSelectProducts(NewFile):
         assert obj in bpy.context.selected_objects
 
 
+class _BlockHelper:
+    """Shared helpers for creating IFC walls/slabs with solid-block representations."""
+
+    @staticmethod
+    def create_wall(ifc, height=10.0):
+        """Create an IFC wall with a 10x10x{height} block representation from z=0."""
+        ctx = ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW")
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        placement_2d = ifc.createIfcAxis2Placement2D(ifc.createIfcCartesianPoint([0.0, 0.0]))
+        profile = ifc.createIfcRectangleProfileDef("AREA", None, placement_2d, 10.0, 10.0)
+        placement_3d = ifc.createIfcAxis2Placement3D(ifc.createIfcCartesianPoint([-5.0, -5.0, 0.0]))
+        extrusion = ifc.createIfcExtrudedAreaSolid(
+            profile, placement_3d, ifc.createIfcDirection([0.0, 0.0, 1.0]), height
+        )
+        shape_rep = ifc.createIfcShapeRepresentation(ctx, "Body", "SweptSolid", [extrusion])
+        wall.Representation = ifc.createIfcProductDefinitionShape(None, None, [shape_rep])
+        return wall, extrusion
+
+    @staticmethod
+    def create_slab(ifc, z=4.0):
+        """Create an IfcSlab with a 12x12x1.0 block representation at bottom_z={z}."""
+        ctx = ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW")
+        slab = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcSlab")
+        placement_2d = ifc.createIfcAxis2Placement2D(ifc.createIfcCartesianPoint([0.0, 0.0]))
+        profile = ifc.createIfcRectangleProfileDef("AREA", None, placement_2d, 12.0, 12.0)
+        placement_3d = ifc.createIfcAxis2Placement3D(ifc.createIfcCartesianPoint([-6.0, -6.0, z]))
+        extrusion = ifc.createIfcExtrudedAreaSolid(profile, placement_3d, ifc.createIfcDirection([0.0, 0.0, 1.0]), 1.0)
+        shape_rep = ifc.createIfcShapeRepresentation(ctx, "Body", "SweptSolid", [extrusion])
+        slab.Representation = ifc.createIfcProductDefinitionShape(None, None, [shape_rep])
+
+
 class TestGenerateSpace(NewFile):
     def test_generate_space_at_cursor(self):
         bpy.ops.bim.create_project()
         ifc = tool.Ifc.get()
-        scene = bpy.context.scene
-        product = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
-        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
-        obj = bpy.data.objects["Cube"]
-        scene.collection.objects.link(obj)
-        tool.Ifc.link(product, obj)
-        scene.cursor.location = (0, 0, 0)
+        # The wall block spans z=0..10, bisects to a 10x10 polygon at cut_z.
+        _BlockHelper.create_wall(ifc, height=10.0)
+        bpy.context.scene.cursor.location = (0, 0, 0)
 
         bpy.ops.bim.generate_space()
         space = bpy.data.objects["IfcSpace/Space"]
@@ -292,13 +320,8 @@ class TestGenerateSpace(NewFile):
     def test_regenerate_space_preserves_z_location(self):
         bpy.ops.bim.create_project()
         ifc = tool.Ifc.get()
-        scene = bpy.context.scene
-        product = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
-        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
-        obj = bpy.data.objects["Cube"]
-        scene.collection.objects.link(obj)
-        tool.Ifc.link(product, obj)
-        scene.cursor.location = (0, 0, 0)
+        _BlockHelper.create_wall(ifc, height=10.0)
+        bpy.context.scene.cursor.location = (0, 0, 0)
 
         bpy.ops.bim.generate_space()
         space = bpy.data.objects["IfcSpace/Space"]
@@ -307,7 +330,6 @@ class TestGenerateSpace(NewFile):
 
         bpy.context.view_layer.objects.active = space
         space.select_set(True)
-        obj.select_set(False)
 
         bpy.ops.bim.generate_space()
 
@@ -316,20 +338,10 @@ class TestGenerateSpace(NewFile):
     def test_auto_space_height_from_slab_above(self):
         bpy.ops.bim.create_project()
         ifc = tool.Ifc.get()
-        scene = bpy.context.scene
-        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
-        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
-        wall_obj = bpy.data.objects["Cube"]
-        scene.collection.objects.link(wall_obj)
-        tool.Ifc.link(wall, wall_obj)
+        _BlockHelper.create_wall(ifc, height=10.0)
+        _BlockHelper.create_slab(ifc, z=4.0)
+        bpy.context.scene.cursor.location = (0, 0, 0)
 
-        slab = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcSlab")
-        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4 + 4))
-        slab_obj = bpy.data.objects["Cube.001"]
-        scene.collection.objects.link(slab_obj)
-        tool.Ifc.link(slab, slab_obj)
-
-        scene.cursor.location = (0, 0, 0)
         bpy.ops.bim.generate_space()
         space = bpy.data.objects["IfcSpace/Space"]
         assert np.isclose(space.dimensions.z, 4, atol=0.1), f"Expected height ~4, got {space.dimensions.z}"
@@ -337,14 +349,9 @@ class TestGenerateSpace(NewFile):
     def test_forced_space_height(self):
         bpy.ops.bim.create_project()
         ifc = tool.Ifc.get()
-        scene = bpy.context.scene
-        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
-        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
-        wall_obj = bpy.data.objects["Cube"]
-        scene.collection.objects.link(wall_obj)
-        tool.Ifc.link(wall, wall_obj)
+        _BlockHelper.create_wall(ifc, height=10.0)
+        bpy.context.scene.cursor.location = (0, 0, 0)
 
-        scene.cursor.location = (0, 0, 0)
         spatial_props = tool.Spatial.get_spatial_props()
         spatial_props.force_space_height = True
         spatial_props.space_height = 5
@@ -355,14 +362,9 @@ class TestGenerateSpace(NewFile):
     def test_auto_space_height_fallback_no_slab(self):
         bpy.ops.bim.create_project()
         ifc = tool.Ifc.get()
-        scene = bpy.context.scene
-        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
-        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
-        wall_obj = bpy.data.objects["Cube"]
-        scene.collection.objects.link(wall_obj)
-        tool.Ifc.link(wall, wall_obj)
+        _BlockHelper.create_wall(ifc, height=10.0)
+        bpy.context.scene.cursor.location = (0, 0, 0)
 
-        scene.cursor.location = (0, 0, 0)
         spatial_props = tool.Spatial.get_spatial_props()
         spatial_props.force_space_height = False
         bpy.ops.bim.generate_space()
@@ -372,14 +374,9 @@ class TestGenerateSpace(NewFile):
     def test_apply_space_height_to_selection(self):
         bpy.ops.bim.create_project()
         ifc = tool.Ifc.get()
-        scene = bpy.context.scene
-        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
-        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
-        wall_obj = bpy.data.objects["Cube"]
-        scene.collection.objects.link(wall_obj)
-        tool.Ifc.link(wall, wall_obj)
+        _BlockHelper.create_wall(ifc, height=10.0)
+        bpy.context.scene.cursor.location = (0, 0, 0)
 
-        scene.cursor.location = (0, 0, 0)
         bpy.ops.bim.generate_space()
         space = bpy.data.objects["IfcSpace/Space"]
 
@@ -387,7 +384,6 @@ class TestGenerateSpace(NewFile):
         spatial_props.space_height = 6
         bpy.context.view_layer.objects.active = space
         space.select_set(True)
-        wall_obj.select_set(False)
 
         bpy.ops.bim.apply_space_height_to_selection()
         bpy.context.view_layer.update()
@@ -396,13 +392,8 @@ class TestGenerateSpace(NewFile):
     def test_cache_survives_second_generation(self):
         bpy.ops.bim.create_project()
         ifc = tool.Ifc.get()
-        scene = bpy.context.scene
-        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
-        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
-        wall_obj = bpy.data.objects["Cube"]
-        scene.collection.objects.link(wall_obj)
-        tool.Ifc.link(wall, wall_obj)
-        scene.cursor.location = (0, 0, 0)
+        _BlockHelper.create_wall(ifc, height=10.0)
+        bpy.context.scene.cursor.location = (0, 0, 0)
 
         bpy.ops.bim.generate_space()
         space1 = bpy.data.objects["IfcSpace/Space"]
@@ -417,24 +408,19 @@ class TestGenerateSpace(NewFile):
     def test_regenerate_after_wall_height_change(self):
         bpy.ops.bim.create_project()
         ifc = tool.Ifc.get()
-        scene = bpy.context.scene
-        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
-        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
-        wall_obj = bpy.data.objects["Cube"]
-        scene.collection.objects.link(wall_obj)
-        tool.Ifc.link(wall, wall_obj)
-        scene.cursor.location = (0, 0, 0)
+        wall, extrusion = _BlockHelper.create_wall(ifc, height=10.0)
+        bpy.context.scene.cursor.location = (0, 0, 0)
 
         bpy.ops.bim.generate_space()
         space = bpy.data.objects["IfcSpace/Space"]
         original_height = space.dimensions.z
 
-        wall_obj.dimensions.z = original_height + 2
-        bpy.context.view_layer.update()
+        # Modify the IFC representation to change the wall height.
+        extrusion.Depth = 15.0
+        _bump_geom_cache_token()
 
         bpy.context.view_layer.objects.active = space
         space.select_set(True)
-        wall_obj.select_set(False)
 
         bpy.ops.bim.generate_space()
         new_height = space.dimensions.z

--- a/src/bonsai/test/tool/test_spatial.py
+++ b/src/bonsai/test/tool/test_spatial.py
@@ -312,3 +312,130 @@ class TestGenerateSpace(NewFile):
         bpy.ops.bim.generate_space()
 
         assert np.isclose(space.location.z, 5), f"Expected z=5, got {space.location.z}"
+
+    def test_auto_space_height_from_slab_above(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        scene = bpy.context.scene
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
+        wall_obj = bpy.data.objects["Cube"]
+        scene.collection.objects.link(wall_obj)
+        tool.Ifc.link(wall, wall_obj)
+
+        slab = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcSlab")
+        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4 + 4))
+        slab_obj = bpy.data.objects["Cube.001"]
+        scene.collection.objects.link(slab_obj)
+        tool.Ifc.link(slab, slab_obj)
+
+        scene.cursor.location = (0, 0, 0)
+        bpy.ops.bim.generate_space()
+        space = bpy.data.objects["IfcSpace/Space"]
+        assert np.isclose(space.dimensions.z, 4, atol=0.1), f"Expected height ~4, got {space.dimensions.z}"
+
+    def test_forced_space_height(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        scene = bpy.context.scene
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
+        wall_obj = bpy.data.objects["Cube"]
+        scene.collection.objects.link(wall_obj)
+        tool.Ifc.link(wall, wall_obj)
+
+        scene.cursor.location = (0, 0, 0)
+        spatial_props = tool.Spatial.get_spatial_props()
+        spatial_props.force_space_height = True
+        spatial_props.space_height = 5
+        bpy.ops.bim.generate_space()
+        space = bpy.data.objects["IfcSpace/Space"]
+        assert np.isclose(space.dimensions.z, 5, atol=0.1), f"Expected height 5, got {space.dimensions.z}"
+
+    def test_auto_space_height_fallback_no_slab(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        scene = bpy.context.scene
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
+        wall_obj = bpy.data.objects["Cube"]
+        scene.collection.objects.link(wall_obj)
+        tool.Ifc.link(wall, wall_obj)
+
+        scene.cursor.location = (0, 0, 0)
+        spatial_props = tool.Spatial.get_spatial_props()
+        spatial_props.force_space_height = False
+        bpy.ops.bim.generate_space()
+        space = bpy.data.objects["IfcSpace/Space"]
+        assert space.dimensions.z > 0, f"Expected positive height, got {space.dimensions.z}"
+
+    def test_apply_space_height_to_selection(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        scene = bpy.context.scene
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
+        wall_obj = bpy.data.objects["Cube"]
+        scene.collection.objects.link(wall_obj)
+        tool.Ifc.link(wall, wall_obj)
+
+        scene.cursor.location = (0, 0, 0)
+        bpy.ops.bim.generate_space()
+        space = bpy.data.objects["IfcSpace/Space"]
+
+        spatial_props = tool.Spatial.get_spatial_props()
+        spatial_props.space_height = 6
+        bpy.context.view_layer.objects.active = space
+        space.select_set(True)
+        wall_obj.select_set(False)
+
+        bpy.ops.bim.apply_space_height_to_selection()
+        bpy.context.view_layer.update()
+        assert np.isclose(space.dimensions.z, 6, atol=0.1), f"Expected height 6, got {space.dimensions.z}"
+
+    def test_cache_survives_second_generation(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        scene = bpy.context.scene
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
+        wall_obj = bpy.data.objects["Cube"]
+        scene.collection.objects.link(wall_obj)
+        tool.Ifc.link(wall, wall_obj)
+        scene.cursor.location = (0, 0, 0)
+
+        bpy.ops.bim.generate_space()
+        space1 = bpy.data.objects["IfcSpace/Space"]
+        height1 = space1.dimensions.z
+
+        bpy.ops.bim.generate_space()
+        space2 = bpy.data.objects["IfcSpace/Space"]
+        height2 = space2.dimensions.z
+
+        assert np.isclose(height1, height2, atol=0.1), f"Cache changed height: {height1} vs {height2}"
+
+    def test_regenerate_after_wall_height_change(self):
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        scene = bpy.context.scene
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        bpy.ops.mesh.primitive_cube_add(size=10, location=(0, 0, 4))
+        wall_obj = bpy.data.objects["Cube"]
+        scene.collection.objects.link(wall_obj)
+        tool.Ifc.link(wall, wall_obj)
+        scene.cursor.location = (0, 0, 0)
+
+        bpy.ops.bim.generate_space()
+        space = bpy.data.objects["IfcSpace/Space"]
+        original_height = space.dimensions.z
+
+        wall_obj.dimensions.z = original_height + 2
+        bpy.context.view_layer.update()
+
+        bpy.context.view_layer.objects.active = space
+        space.select_set(True)
+        wall_obj.select_set(False)
+
+        bpy.ops.bim.generate_space()
+        new_height = space.dimensions.z
+        assert new_height != original_height or new_height > 0

--- a/src/ifcopenshell-python/ifcopenshell/util/element.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/element.py
@@ -2007,3 +2007,24 @@ def get_material_profiles(element: ifcopenshell.entity_instance) -> list[Priorit
         )
         for material_profile in material.MaterialProfiles
     ]
+
+
+def iter_top_connections(
+    element: ifcopenshell.entity_instance,
+) -> Generator[tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance], None, None]:
+    """Yield ``(connected_element, rel)`` tuples for every
+    ``IfcRelConnectsElements`` with ``Description == "TOP"`` connecting
+    to this element.
+
+    Walks ``element.ConnectedFrom`` because the connecting element (e.g. a
+    slab) is the relating side of the TOP relationship.
+
+    :param element: The IFC element (typically a wall).
+    :return: Generator of ``(connected_element, rel)`` tuples.
+    """
+    for rel in getattr(element, "ConnectedFrom", []) or ():
+        if not rel.is_a("IfcRelConnectsElements") or rel.Description != "TOP":
+            continue
+        connected = rel.RelatingElement
+        if connected is not None:
+            yield connected, rel

--- a/src/ifcopenshell-python/ifcopenshell/util/shape.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/shape.py
@@ -752,3 +752,81 @@ def get_total_edge_length(geometry: W.triangulation) -> float:
     vertices = get_vertices(geometry)
     vertices = vertices[get_edges(geometry)]
     return np.linalg.norm(vertices[:, 1] - vertices[:, 0], axis=1).sum().item()
+
+
+def _extend_line(start: np.ndarray, end: np.ndarray, distance: float) -> tuple[np.ndarray, np.ndarray]:
+    """Extend a line segment by a fixed distance on both ends.
+
+    :param start: (x, y) or (x, y, z) array.
+    :param end: (x, y) or (x, y, z) array.
+    :param distance: Distance to extend on each end.
+    :return: (new_start, new_end) arrays.
+    """
+    direction = end - start
+    norm = np.linalg.norm(direction)
+    if norm == 0:
+        return start, end
+    offset = distance * (direction / norm)
+    return start - offset, end + offset
+
+
+def bisect_mesh_plane_vf(
+    verts: npt.NDArray[np.float64],
+    faces: npt.NDArray[np.int32],
+    plane_z: float,
+    *,
+    precision: int = 3,
+    extend: float = 0.0,
+) -> list:
+    """Intersect a triangulated mesh with a horizontal Z plane.
+
+    All faces are processed at once via numpy broadcasting for performance.
+
+    :param verts: (n, 3) array of vertices in world coordinates.
+    :param faces: (m, 3) array of triangle vertex indices.
+    :param plane_z: Z elevation of the horizontal cutting plane.
+    :param precision: Decimal places to round intersection point coordinates to.
+    :param extend: Distance to extend each segment on both ends, to ensure
+        overlap with neighbouring segments for polygon closure.
+    :return: List of (start_xy, end_xy) tuples where each coordinate is (x, y).
+    """
+    if len(faces) == 0:
+        return []
+    v0 = verts[faces[:, 0]]
+    v1 = verts[faces[:, 1]]
+    v2 = verts[faces[:, 2]]
+    d0 = v0[:, 2] - plane_z
+    d1 = v1[:, 2] - plane_z
+    d2 = v2[:, 2] - plane_z
+    straddle = ~((np.minimum(np.minimum(d0, d1), d2) > 0) | (np.maximum(np.maximum(d0, d1), d2) < 0))
+    if not np.any(straddle):
+        return []
+    idx = np.where(straddle)[0]
+    d0s, d1s, d2s = d0[idx], d1[idx], d2[idx]
+    v0s, v1s, v2s = v0[idx], v1[idx], v2[idx]
+
+    def _edge_intersections(va, vb, da, db):
+        mask = da * db < 0
+        diff = da - db
+        diff = np.where(diff == 0, 1.0, diff)
+        t = np.where(mask, da / diff, 0.0)
+        pts = va + t[:, np.newaxis] * (vb - va)
+        return pts, mask
+
+    p01, m01 = _edge_intersections(v0s, v1s, d0s, d1s)
+    p12, m12 = _edge_intersections(v1s, v2s, d1s, d2s)
+    p20, m20 = _edge_intersections(v2s, v0s, d2s, d0s)
+
+    segments = []
+    for i in range(len(idx)):
+        pts_xy = []
+        for pt, mask in ((p01[i], m01[i]), (p12[i], m12[i]), (p20[i], m20[i])):
+            if mask:
+                pts_xy.append((round(float(pt[0]), precision), round(float(pt[1]), precision)))
+        if len(pts_xy) == 2 and pts_xy[0] != pts_xy[1]:
+            if extend > 0:
+                s, e = _extend_line(np.array(pts_xy[0]), np.array(pts_xy[1]), extend)
+                segments.append((s.tolist(), e.tolist()))
+            else:
+                segments.append(pts_xy)
+    return segments

--- a/src/ifcopenshell-python/ifcopenshell/util/space.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/space.py
@@ -1,0 +1,246 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Blender-independent utilities for space geometry generation.
+
+These functions operate on IFC geometry data (vertices, faces, element
+relationships) without requiring any Blender objects to be loaded. They are
+used by Bonsai's space generation pipeline but can also be used standalone
+for IFC analysis.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import ifcopenshell
+import ifcopenshell.util.element
+import ifcopenshell.util.shape
+import shapely
+
+BOUNDING_CLASSES = ("IfcWall", "IfcColumn", "IfcMember", "IfcVirtualElement", "IfcPlate")
+HEIGHT_DETECTION_CLASSES = ("IfcSlab", "IfcRoof")
+
+
+def get_boundary_lines(
+    ifc_file: ifcopenshell.file,
+    shapes: dict,
+    cut_z: float,
+    bounding_classes: tuple = BOUNDING_CLASSES,
+) -> tuple[list[shapely.LineString], list[ifcopenshell.entity_instance]]:
+    """Generate boundary lines by bisecting IFC element geometry with a horizontal plane.
+
+    :param ifc_file: The IFC file.
+    :param shapes: Dict of element shapes keyed by element id, as produced by
+        a geometry cache. Each entry must have ``verts`` (n,3 ndarray),
+        ``faces`` (m,3 ndarray), ``bottom_z`` (float), ``top_z`` (float).
+    :param cut_z: Z elevation of the cutting plane in world coordinates.
+    :param bounding_classes: IFC classes to treat as space-bounding elements.
+    :return: ``(boundary_lines, bounding_elements)`` where boundary_lines is a
+        list of shapely LineString segments and bounding_elements is a list of
+        IFC entity instances that intersect the cutting plane.
+    """
+    boundary_lines: list[shapely.LineString] = []
+    bounding_elements: list[ifcopenshell.entity_instance] = []
+
+    for element_id, shape_data in shapes.items():
+        element = ifc_file.by_id(element_id)
+        if not any(element.is_a(cls) for cls in bounding_classes):
+            continue
+        if cut_z <= shape_data["bottom_z"] or cut_z >= shape_data["top_z"]:
+            continue
+        bounding_elements.append(element)
+        segments = ifcopenshell.util.shape.bisect_mesh_plane_vf(
+            shape_data["verts"], shape_data["faces"], cut_z, precision=3, extend=0.05
+        )
+        for start, end in segments:
+            boundary_lines.append(shapely.LineString([start, end]))
+
+    return boundary_lines, bounding_elements
+
+
+def get_space_polygon(
+    boundary_lines: list[shapely.LineString],
+    x: float,
+    y: float,
+) -> tuple[Union[shapely.Polygon, str], list]:
+    """Assemble boundary lines into closed polygons and find the one containing (x, y).
+
+    :param boundary_lines: List of shapely LineString segments forming a planar graph.
+    :param x: X coordinate of the point to test.
+    :param y: Y coordinate of the point to test.
+    :return: ``(polygon, [])`` on success, or ``("NO POLYGONS FOUND", [])`` /
+        ``("NO POLYGON FOR POINT", [])`` on failure. The second element is
+        reserved for bounding elements (returned by the caller from
+        :func:`get_boundary_lines`).
+    """
+    unioned = shapely.union_all(shapely.GeometryCollection(boundary_lines))
+    closed_polygons = shapely.polygonize(unioned.geoms)
+    if not closed_polygons:
+        return "NO POLYGONS FOUND", []
+    for polygon in closed_polygons.geoms:
+        if shapely.contains_xy(polygon, x, y):
+            return shapely.force_3d(polygon), []
+    return "NO POLYGON FOR POINT", []
+
+
+def get_auto_space_height(
+    ifc_file: ifcopenshell.file,
+    shapes: dict,
+    space_polygon: shapely.Polygon,
+    base_z: float,
+    bounding_walls: list[ifcopenshell.entity_instance],
+) -> Optional[float]:
+    """Auto-detect space height from elements above using IFC geometry.
+
+    Detection priority:
+    1. ``IfcRelConnectsElements`` (TOP) connections on bounding walls
+    2. ``IfcSlab`` / ``IfcRoof`` elements above with XY overlap to the space polygon
+    3. Minimum wall top Z of bounding walls
+
+    :param ifc_file: The IFC file.
+    :param shapes: Dict of element shapes keyed by element id (see :func:`get_boundary_lines`).
+    :param space_polygon: The space footprint polygon in world XY.
+    :param base_z: The space's base Z in world coordinates.
+    :param bounding_walls: List of IFC wall elements bounding the space.
+    :return: Detected height in meters, or ``None`` if nothing found.
+    """
+    height = get_height_from_top_connections(ifc_file, shapes, bounding_walls, base_z, space_polygon)
+    if height is not None and height > 0:
+        return height
+
+    height = get_height_from_elements_above(ifc_file, shapes, space_polygon, base_z)
+    if height is not None and height > 0:
+        return height
+
+    height = get_height_from_wall_tops(shapes, bounding_walls, base_z)
+    if height is not None and height > 0:
+        return height
+
+    return None
+
+
+def get_height_from_top_connections(
+    ifc_file: ifcopenshell.file,
+    shapes: dict,
+    bounding_walls: list[ifcopenshell.entity_instance],
+    base_z: float,
+    space_polygon: shapely.Polygon,
+) -> Optional[float]:
+    """Find the lowest bottom face of elements connected to bounding walls via IfcRelConnectsElements(TOP).
+
+    :param ifc_file: The IFC file.
+    :param shapes: Dict of element shapes keyed by element id.
+    :param bounding_walls: List of IFC wall elements.
+    :param base_z: The space's base Z in world coordinates.
+    :param space_polygon: The space footprint polygon in world XY.
+    :return: Height in meters, or ``None``.
+    """
+    lowest_min_z: Optional[float] = None
+    for wall_element in bounding_walls:
+        for connected_element, _rel in ifcopenshell.util.element.iter_top_connections(wall_element):
+            if not (connected_element.is_a("IfcSlab") or connected_element.is_a("IfcRoof")):
+                continue
+            shape_data = shapes.get(connected_element.id())
+            if not shape_data:
+                continue
+            min_z = shape_data["bottom_z"]
+            if min_z <= base_z:
+                continue
+            verts = shape_data["verts"]
+            element_box = shapely.box(
+                float(verts[:, 0].min()),
+                float(verts[:, 1].min()),
+                float(verts[:, 0].max()),
+                float(verts[:, 1].max()),
+            )
+            if not element_box.intersects(space_polygon):
+                continue
+            if lowest_min_z is None or min_z < lowest_min_z:
+                lowest_min_z = min_z
+    if lowest_min_z is not None:
+        return lowest_min_z - base_z
+    return None
+
+
+def get_height_from_elements_above(
+    ifc_file: ifcopenshell.file,
+    shapes: dict,
+    space_polygon: shapely.Polygon,
+    base_z: float,
+    height_classes: tuple = HEIGHT_DETECTION_CLASSES,
+) -> Optional[float]:
+    """Find the lowest IfcSlab / IfcRoof above whose XY bbox overlaps the space polygon.
+
+    :param ifc_file: The IFC file.
+    :param shapes: Dict of element shapes keyed by element id.
+    :param space_polygon: The space footprint polygon in world XY.
+    :param base_z: The space's base Z in world coordinates.
+    :param height_classes: IFC classes to consider as ceiling elements.
+    :return: Height in meters, or ``None``.
+    """
+    lowest_min_z: Optional[float] = None
+    for ifc_class in height_classes:
+        for element in ifc_file.by_type(ifc_class):
+            shape_data = shapes.get(element.id())
+            if not shape_data:
+                continue
+            min_z = shape_data["bottom_z"]
+            if min_z <= base_z:
+                continue
+            verts = shape_data["verts"]
+            element_box = shapely.box(
+                float(verts[:, 0].min()),
+                float(verts[:, 1].min()),
+                float(verts[:, 0].max()),
+                float(verts[:, 1].max()),
+            )
+            if not element_box.intersects(space_polygon):
+                continue
+            if lowest_min_z is None or min_z < lowest_min_z:
+                lowest_min_z = min_z
+    if lowest_min_z is not None:
+        return lowest_min_z - base_z
+    return None
+
+
+def get_height_from_wall_tops(
+    shapes: dict,
+    bounding_walls: list[ifcopenshell.entity_instance],
+    base_z: float,
+) -> Optional[float]:
+    """Find the minimum wall top Z among bounding walls.
+
+    :param shapes: Dict of element shapes keyed by element id.
+    :param bounding_walls: List of IFC wall elements.
+    :param base_z: The space's base Z in world coordinates.
+    :return: Height in meters, or ``None``.
+    """
+    lowest_top_z: Optional[float] = None
+    for wall_element in bounding_walls:
+        shape_data = shapes.get(wall_element.id())
+        if not shape_data:
+            continue
+        max_z = shape_data["top_z"]
+        if max_z <= base_z:
+            continue
+        if lowest_top_z is None or max_z < lowest_top_z:
+            lowest_top_z = max_z
+    if lowest_top_z is not None:
+        return lowest_top_z - base_z
+    return None

--- a/src/ifcopenshell-python/test/util/test_element.py
+++ b/src/ifcopenshell-python/test/util/test_element.py
@@ -1392,3 +1392,47 @@ class TestCopyDeepIFC4(test.bootstrap.IFC4):
         element2 = subject.copy_deep(self.file, element)
         assert element2.Segments[0][0] == (1, 2)
         assert element2.Segments[1][0] == (3, 4)
+
+
+class TestIterTopConnections(test.bootstrap.IFC4):
+    def test_yields_top_connected_element(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        slab = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSlab")
+        rel = self.file.createIfcRelConnectsElements(
+            GlobalId=ifcopenshell.guid.new(),
+            RelatingElement=slab,
+            RelatedElement=wall,
+            Description="TOP",
+        )
+        results = list(subject.iter_top_connections(wall))
+        assert len(results) == 1
+        assert results[0][0] == slab
+        assert results[0][1] == rel
+
+    def test_returns_empty_when_no_connections(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        assert list(subject.iter_top_connections(wall)) == []
+
+    def test_filters_non_top_description(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        slab = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSlab")
+        self.file.createIfcRelConnectsElements(
+            GlobalId=ifcopenshell.guid.new(),
+            RelatingElement=slab,
+            RelatedElement=wall,
+            Description="BOTTOM",
+        )
+        assert list(subject.iter_top_connections(wall)) == []
+
+    def test_filters_non_rel_connects_elements(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        slab = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSlab")
+        self.file.createIfcRelConnectsPathElements(
+            GlobalId=ifcopenshell.guid.new(),
+            RelatingElement=slab,
+            RelatedElement=wall,
+            Description="ATPATH",
+            RelatingConnectionType="ATPATH",
+            RelatedConnectionType="ATPATH",
+        )
+        assert list(subject.iter_top_connections(wall)) == []

--- a/src/ifcopenshell-python/test/util/test_shape.py
+++ b/src/ifcopenshell-python/test/util/test_shape.py
@@ -1,0 +1,97 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+
+import ifcopenshell.util.shape as subject
+
+
+def _cube_verts_faces(size=2.0, z_offset=0.0):
+    """Build a triangulated cube as (verts, faces) numpy arrays."""
+    s = size / 2
+    verts = np.array(
+        [
+            [-s, -s, -s + z_offset],
+            [s, -s, -s + z_offset],
+            [s, s, -s + z_offset],
+            [-s, s, -s + z_offset],
+            [-s, -s, s + z_offset],
+            [s, -s, s + z_offset],
+            [s, s, s + z_offset],
+            [-s, s, s + z_offset],
+        ],
+        dtype=np.float64,
+    )
+    faces = np.array(
+        [
+            [0, 1, 2],
+            [0, 2, 3],
+            [4, 6, 5],
+            [4, 7, 6],
+            [0, 4, 5],
+            [0, 5, 1],
+            [1, 5, 6],
+            [1, 6, 2],
+            [2, 6, 7],
+            [2, 7, 3],
+            [3, 7, 4],
+            [3, 4, 0],
+        ],
+        dtype=np.int32,
+    )
+    return verts, faces
+
+
+class TestBisectMeshPlaneVf:
+    def test_bisect_at_mid_height(self):
+        verts, faces = _cube_verts_faces(size=2.0)
+        segments = subject.bisect_mesh_plane_vf(verts, faces, plane_z=0.0)
+        assert len(segments) >= 4
+        for start, end in segments:
+            assert len(start) == 2
+            assert len(end) == 2
+
+    def test_bisect_above_mesh_returns_empty(self):
+        verts, faces = _cube_verts_faces(size=2.0)
+        segments = subject.bisect_mesh_plane_vf(verts, faces, plane_z=10.0)
+        assert segments == []
+
+    def test_bisect_below_mesh_returns_empty(self):
+        verts, faces = _cube_verts_faces(size=2.0)
+        segments = subject.bisect_mesh_plane_vf(verts, faces, plane_z=-10.0)
+        assert segments == []
+
+    def test_bisect_with_extend(self):
+        verts, faces = _cube_verts_faces(size=2.0)
+        segments_no_extend = subject.bisect_mesh_plane_vf(verts, faces, plane_z=0.0, extend=0.0)
+        segments_extend = subject.bisect_mesh_plane_vf(verts, faces, plane_z=0.0, extend=0.05)
+        assert len(segments_extend) == len(segments_no_extend)
+        for (s_ext, e_ext), (s_no, e_no) in zip(segments_extend, segments_no_extend):
+            assert abs(s_ext[0] - s_no[0]) >= 0.04 or abs(s_ext[1] - s_no[1]) >= 0.04
+
+    def test_bisect_empty_faces(self):
+        verts = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float64)
+        faces = np.array([], dtype=np.int32).reshape(0, 3)
+        assert subject.bisect_mesh_plane_vf(verts, faces, plane_z=0.0) == []
+
+    def test_bisect_precision(self):
+        verts, faces = _cube_verts_faces(size=2.0)
+        segments = subject.bisect_mesh_plane_vf(verts, faces, plane_z=0.0, precision=6)
+        for start, end in segments:
+            for coord in start + end:
+                assert round(coord, 6) == coord

--- a/src/ifcopenshell-python/test/util/test_space.py
+++ b/src/ifcopenshell-python/test/util/test_space.py
@@ -1,0 +1,186 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.api.geometry
+import ifcopenshell.api.root
+import ifcopenshell.geom
+import ifcopenshell.guid
+import ifcopenshell.util.shape
+import ifcopenshell.util.space as subject
+import pytest
+import shapely
+import test.bootstrap
+
+
+def _build_shapes_dict(ifc_file, elements):
+    """Build a shapes dict as expected by ifcopenshell.util.space functions."""
+    settings = ifcopenshell.geom.settings()
+    settings.set("disable-opening-subtractions", True)
+    settings.set("use-world-coords", True)
+    shapes = {}
+    for element in elements:
+        shape = ifcopenshell.geom.create_shape(settings, element)
+        verts = ifcopenshell.util.shape.get_shape_vertices(shape, shape.geometry)
+        faces = ifcopenshell.util.shape.get_faces(shape.geometry)
+        zs = verts[:, 2]
+        shapes[element.id()] = {
+            "verts": verts,
+            "faces": faces,
+            "bottom_z": float(zs.min()),
+            "top_z": float(zs.max()),
+        }
+    return shapes
+
+
+def _add_extruded_body(ifc_file, element, coords_2d, depth, z_offset=0.0):
+    """Add a body representation (extruded polyline) to an element."""
+    if not ifc_file.by_type("IfcProject"):
+        ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject")
+    ctx = ifc_file.createIfcGeometricRepresentationContext(
+        ContextType="Model",
+        CoordinateSpaceDimension=3,
+        Precision=1e-5,
+        WorldCoordinateSystem=ifc_file.createIfcAxis2Placement3D(
+            ifc_file.createIfcCartesianPoint((0.0, 0.0, 0.0)),
+            ifc_file.createIfcDirection((0.0, 0.0, 1.0)),
+            ifc_file.createIfcDirection((1.0, 0.0, 0.0)),
+        ),
+    )
+    sub_ctx = ifc_file.createIfcGeometricRepresentationSubContext(
+        ContextIdentifier="Body",
+        ContextType="Model",
+        ParentContext=ctx,
+        TargetView="MODEL_VIEW",
+    )
+    pts = [ifc_file.createIfcCartesianPoint((float(x), float(y))) for x, y in coords_2d]
+    polyline = ifc_file.createIfcPolyline(pts)
+    profile = ifc_file.create_entity("IfcArbitraryClosedProfileDef", ProfileType="CURVE", OuterCurve=polyline)
+    placement = ifc_file.createIfcAxis2Placement3D(
+        ifc_file.createIfcCartesianPoint((0.0, 0.0, z_offset)),
+        ifc_file.createIfcDirection((0.0, 0.0, 1.0)),
+        ifc_file.createIfcDirection((1.0, 0.0, 0.0)),
+    )
+    direction = ifc_file.createIfcDirection((0.0, 0.0, 1.0))
+    solid = ifc_file.createIfcExtrudedAreaSolid(profile, placement, direction, depth)
+    rep = ifc_file.create_entity(
+        "IfcShapeRepresentation",
+        ContextOfItems=sub_ctx,
+        RepresentationIdentifier="Body",
+        RepresentationType="SweptSolid",
+        Items=[solid],
+    )
+    ifcopenshell.api.geometry.assign_representation(ifc_file, product=element, representation=rep)
+
+
+class TestGetBoundaryLines(test.bootstrap.IFC4):
+    def test_returns_segments_for_intersecting_walls(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        _add_extruded_body(self.file, wall, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+        shapes = _build_shapes_dict(self.file, [wall])
+        lines, bounding = subject.get_boundary_lines(self.file, shapes, cut_z=1.0)
+        assert len(lines) > 0
+        assert wall in bounding
+
+    def test_skips_elements_not_intersecting_plane(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        _add_extruded_body(self.file, wall, [[-1, -1], [1, -1], [1, 1], [-1, 1]], 1.0)
+        shapes = _build_shapes_dict(self.file, [wall])
+        lines, bounding = subject.get_boundary_lines(self.file, shapes, cut_z=10.0)
+        assert lines == []
+        assert bounding == []
+
+    def test_skips_non_bounding_classes(self):
+        slab = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSlab")
+        _add_extruded_body(self.file, slab, [[-1, -1], [1, -1], [1, 1], [-1, 1]], 1.0)
+        shapes = _build_shapes_dict(self.file, [slab])
+        lines, bounding = subject.get_boundary_lines(self.file, shapes, cut_z=0.5)
+        assert slab not in bounding
+
+
+class TestGetSpacePolygon(test.bootstrap.IFC4):
+    def test_finds_containing_polygon(self):
+        lines = [
+            shapely.LineString([(0, 0), (10, 0)]),
+            shapely.LineString([(10, 0), (10, 10)]),
+            shapely.LineString([(10, 10), (0, 10)]),
+            shapely.LineString([(0, 10), (0, 0)]),
+        ]
+        polygon, _ = subject.get_space_polygon(lines, 5, 5)
+        assert not isinstance(polygon, str)
+        assert polygon.area == pytest.approx(100)
+
+    def test_no_polygons_found(self):
+        polygon, _ = subject.get_space_polygon([], 0, 0)
+        assert polygon == "NO POLYGONS FOUND"
+
+    def test_no_polygon_for_point(self):
+        lines = [
+            shapely.LineString([(0, 0), (10, 0)]),
+            shapely.LineString([(10, 0), (10, 10)]),
+            shapely.LineString([(10, 10), (0, 10)]),
+            shapely.LineString([(0, 10), (0, 0)]),
+        ]
+        polygon, _ = subject.get_space_polygon(lines, 50, 50)
+        assert polygon == "NO POLYGON FOR POINT"
+
+
+class TestGetAutoSpaceHeight(test.bootstrap.IFC4):
+    def test_height_from_top_connection(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        slab = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSlab")
+        _add_extruded_body(self.file, wall, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+        _add_extruded_body(self.file, slab, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 0.3, z_offset=3.0)
+        self.file.createIfcRelConnectsElements(
+            GlobalId=ifcopenshell.guid.new(),
+            RelatingElement=slab,
+            RelatedElement=wall,
+            Description="TOP",
+        )
+        shapes = _build_shapes_dict(self.file, [wall, slab])
+        space_polygon = shapely.box(-5, -5, 5, 5)
+        height = subject.get_auto_space_height(self.file, shapes, space_polygon, 0.0, [wall])
+        assert height is not None
+        assert height == pytest.approx(3.0, abs=0.1)
+
+    def test_height_from_elements_above_without_top_connection(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        slab = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSlab")
+        _add_extruded_body(self.file, wall, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+        _add_extruded_body(self.file, slab, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 0.3, z_offset=3.0)
+        shapes = _build_shapes_dict(self.file, [wall, slab])
+        space_polygon = shapely.box(-5, -5, 5, 5)
+        height = subject.get_auto_space_height(self.file, shapes, space_polygon, 0.0, [wall])
+        assert height is not None
+        assert height == pytest.approx(3.0, abs=0.1)
+
+    def test_height_from_wall_tops_when_no_slab(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        _add_extruded_body(self.file, wall, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+        shapes = _build_shapes_dict(self.file, [wall])
+        space_polygon = shapely.box(-5, -5, 5, 5)
+        height = subject.get_auto_space_height(self.file, shapes, space_polygon, 0.0, [wall])
+        assert height is not None
+        assert height == pytest.approx(3.0, abs=0.1)
+
+    def test_returns_none_when_no_elements_above(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        _add_extruded_body(self.file, wall, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+        shapes = _build_shapes_dict(self.file, [wall])
+        space_polygon = shapely.box(-100, -100, -90, -90)
+        height = subject.get_auto_space_height(self.file, shapes, space_polygon, 0.0, [])
+        assert height is None


### PR DESCRIPTION
## Summary

This PR adds automatic space height detection from elements above (slabs, roofs) and rewrites the space generation pipeline to use IFC geometry directly instead of Blender object bounding boxes. The Blender-independent algorithms are extracted to `ifcopenshell.util` (LGPL) for reuse outside Bonsai.

The PR is split into two commits that can be reviewed independently:

- **Commit 1** (`518bd0f4b`): Auto-detect space height + UI controls + `ApplySpaceHeightToSelection` operator
- **Commit 2** (`84465de2f`): Extract algorithms to `ifcopenshell.util` + IFC-direct footprint detection with caching

**Commit 1 can be merged independently** if the extraction in commit 2 needs more review time.

## Problem

Space generation used a hardcoded height of 3m for new spaces and kept the existing height on regeneration. On real projects, the space height should match the slab above. Additionally, the footprint detection iterated `bpy.context.visible_objects` and bisected Blender meshes one at a time (single-threaded), which was slow and failed when elements above weren't loaded in Blender.

## Commit 1: Auto-detect space height

### Height detection priority

1. **Forced height** — if `force_space_height` toggle is ON, uses the `space_height` value directly
2. **TOP connections** — `IfcRelConnectsElements(TOP)` on bounding walls → lowest bottom face of connected slab/roof
3. **Elements above (geometric)** — lowest `IfcSlab`/`IfcRoof` whose XY bbox overlaps the space polygon
4. **Wall top Z** — minimum top Z of bounding walls
5. **Fallback** — `space_height` property (default 3m, or selected space's current height)

All detection uses IFC geometry via `ifcopenshell.geom.create_shape` + `ifcopenshell.util.shape.get_shape_bottom_elevation`/`get_shape_top_elevation` — no Blender objects required.

### UI additions

- **Height** field (Spatial properties) — shows the active space's height, defaults to 3m when no space selected
- **Force toggle** (PINNED icon) — skips auto-detection, uses the height value directly
- **Apply button** (COPYDOWN icon) — `ApplySpaceHeightToSelection` operator: modifies `IfcExtrudedAreaSolid.Depth` in place without regenerating the footprint

The height field is synced to the active space via `active_object_callback` (msgbus), not in `draw()` — following the same pattern as `update_bim_tool_props`.

### Files changed (commit 1)

- `spatial/prop.py` — `space_height` + `force_space_height` properties
- `spatial/workspace.py` — Height UI controls
- `bim/handler.py` — `update_spatial_tool_props()` in `active_object_callback`
- `model/space.py` — `ApplySpaceHeightToSelection` operator
- `model/__init__.py` — operator registration
- `core/spatial.py` — height detection logic in `generate_space` + `generate_spaces_from_walls`
- `tool/spatial.py` — `get_auto_space_height` + helpers (IFC geometry based)
- `test/tool/test_spatial.py` — 4 tests: auto-height from slab, forced height, fallback, apply to selection

## Commit 2: IFC-direct footprint detection + algorithm extraction

### IFC-direct footprint detection

Replaced `get_boundary_lines_from_context_visible_objects` (iterated Blender visible objects, bisected bmesh one at a time) with `get_boundary_lines_from_ifc_elements` which:

1. Builds a **class-level geometry cache** using `ifcopenshell.geom.iterator` (parallel, `multiprocessing.cpu_count()` threads) over all bounding + height-detection elements
2. Filters cached shapes by Z range intersection with the cutting plane
3. Bisects each element's triangulation using **vectorized numpy** (`bisect_mesh_plane_vf`) — all faces processed at once via broadcasting
4. Assembles boundary lines with shapely (same `union_all` + `polygonize` as before)

### Geometry cache invalidation

The cache is keyed on a `_GEOM_CACHE_TOKEN` integer, bumped by a `depsgraph_update_post` handler (same pattern as `decorator_cache.py`). The handler only bumps on Object geometry/transform changes — no IFC queries, just Blender type checks (microseconds per depsgraph tick).

- Space generation → no Object geometry change → **cache hit** (instant)
- Move/edit a wall → `is_updated_transform`/`is_updated_geometry` → **cache invalidated**, rebuilt on next generation
- Undo/redo/load → **cache invalidated**
- Animate scene → no Object transform/geometry updates → **no overhead**

### Algorithm extraction to ifcopenshell.util (LGPL)

Blender-independent algorithms moved from Bonsai (GPL) to `ifcopenshell.util` (LGPL):

- **`ifcopenshell.util.shape.bisect_mesh_plane_vf`** — vectorized numpy triangle/plane intersection
- **`ifcopenshell.util.element.iter_top_connections`** — `IfcRelConnectsElements(TOP)` relationship walker
- **`ifcopenshell.util.space`** (new module) — `get_boundary_lines`, `get_space_polygon`, `get_auto_space_height` + height detection helpers

Bonsai's `tool/spatial.py` now delegates to these via thin wrappers, keeping only Blender-specific concerns (cache management, UI property reads, depsgraph handler). `tool/wall.py` delegates `iter_wall_slab_connections` to `ifcopenshell.util.element.iter_top_connections`.

### Files changed (commit 2)

- `ifcopenshell/util/shape.py` — `bisect_mesh_plane_vf` + `_extend_line` helper
- `ifcopenshell/util/element.py` — `iter_top_connections`
- `ifcopenshell/util/space.py` — **new module** with all space generation algorithms
- `bonsai/tool/spatial.py` — thin wrappers, removed extracted algorithms
- `bonsai/tool/wall.py` — delegates to `ifcopenshell.util.element`
- `bonsai/bim/handler.py` — registers geom cache depsgraph handler
- `test/util/test_shape.py` — **new**, 6 tests for `bisect_mesh_plane_vf`
- `test/util/test_space.py` — **new**, 10 tests for space generation algorithms
- `test/util/test_element.py` — 4 tests for `iter_top_connections`
- `bonsai/test/tool/test_spatial.py` — 2 cache integration tests

## Profiling results

Profiled on a real project (`BDR-GENE-32-BIN-COO-MN-TN-TC-31002-A_ConceptionBonsai.ifc`):

- 446 walls, 46 slabs, 662 spaces, 26 storeys
- 570 total bounding + height-detection elements
- 124 elements intersect the cutting plane at a typical storey
- 990 boundary line segments from bisection

| Operation | Old (main branch) | New (this PR) | Speedup |
|-----------|-------------------|----------------|---------|
| Geometry creation (570 elements) | 3.184s (create_shape per element, single-threaded) | 0.607s (parallel iterator, 12 threads) | **5.2x** |
| 2nd space generation (cache hit) | 3.184s again (no cache) | 0.000s (cache lookup) | **instant** |
| Height detection (46 slabs/roofs) | 0.604s (create_shape per slab) | 0.000s (cache lookup) | **instant** |
| Bisection filter (524 elements) | 2.580s (create_shape per element) | 0.003s (cache dict lookup) | **860x** |
| Bisection math (124 elements, 990 segments) | bmesh (C, in Blender) | 0.028s (vectorized numpy) | — |
| **Total IFC geometry** | **~6.4s** | **~0.63s** (1st) / **~0.03s** (2nd) | **10x** / **200x** |

The old code called `ifcopenshell.geom.create_shape` three separate times for the same elements (footprint bisection, height detection from TOP connections, height detection from elements above). The new code builds the cache once and reuses it.

## Unsolved: spatial decomposition tree overhead

The remaining "multiple seconds" experienced in Blender comes from **Blender-dependent steps** that happen after the IFC geometry work:

1. **`switch_representation` → `reimport_element_representations`** — runs a second `ifcopenshell.geom.iterator` to rebuild the Blender mesh from the new IFC representation
2. **`import_spatial_decomposition`** — rebuilds the entire spatial decomposition UI tree. This is slow in general (e.g., deleting a space also takes a long time). There may be an existing issue or discussion about this.
3. **Operator transaction overhead** — Bonsai's undo system wraps every IFC operator in a transaction

These are separate from the space generation algorithm and affect all spatial operations. They should be addressed in a separate topic.

## Design choices

- **Why `ifcopenshell.util.space` instead of `ifcopenshell.api`**: `api` is for IFC-mutating CRUD operations; `util` is for read-only analysis/computation. Space generation algorithms are read-only — they analyze geometry and return results. This follows the existing convention (e.g., `ifcopenshell.util.shape` for measurement functions).

- **Why a token-based cache instead of `IfcStore.last_transaction`**: `last_transaction` changes after every IFC operator (including `GenerateSpace` itself), which would invalidate the cache after every space generation — defeating its purpose. The depsgraph token only invalidates when Object geometry/transform actually changes.

- **Why vectorized numpy bisection instead of `bmesh.ops.bisect_plane`**: The bmesh approach requires Blender objects to be loaded and is single-threaded. The numpy approach works on IFC triangulation data directly (Blender-independent) and processes all faces at once via broadcasting. The final loop only iterates over straddling faces (typically 10-50 out of thousands).

- **Why `IfcSlab` + `IfcRoof` only for height detection**: These are the structural elements that form floors/ceilings. `IfcCovering` (ceilings) could be added later but is typically thinner and non-structural.

- **Why `iter_top_connections` in `util.element` instead of `util.space`**: It's a generic IFC relationship walker (walks `ConnectedFrom` for `Description=="TOP"`), not specific to spaces. It matches `element.py`'s role as the relationship-query module.

## Review request

**@Moult** — please review especially:
1. The `ifcopenshell.util.space` module (new LGPL module)
2. The depsgraph cache invalidation pattern in `tool/spatial.py` + `bim/handler.py`
3. Whether the `ApplySpaceHeightToSelection` operator should also sync the IFC `ObjectPlacement` (currently it only modifies `Depth`)

Generated with the assistance of an AI coding tool.