### PR TITLE
Bonsai: rotate the door hover preview with the wall on IFC2X3

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -1547,6 +1547,9 @@ class ProductDecorator(tool.Blender.ViewportDecorator):
         mouse_point = Vector((snap_prop.x, snap_prop.y, default_container_elevation))
         snap_obj = bpy.data.objects.get(snap_prop.snap_object)
         snap_element = tool.Ifc.get_entity(snap_obj)
+        if snap_element and (container := ifcopenshell.util.element.get_container(snap_element)):
+            container_obj = tool.Ifc.get_object(container)
+            mouse_point.z = container_obj.location.z
         rot_mat = Matrix()
         if (
             relating_class in ("IfcDoorType", "IfcDoorStyle", "IfcWindowType", "IfcWindowStyle")
@@ -1559,22 +1562,15 @@ class ProductDecorator(tool.Blender.ViewportDecorator):
             axis_side = axes["side"]
             point_on_base_axis = tool.Cad.point_on_edge(mouse_point, axis_base)
             point_on_side_axis = tool.Cad.point_on_edge(mouse_point, axis_side)
-            if (point_on_base_axis - mouse_point).length_squared <= (point_on_side_axis - mouse_point).length_squared:
-                # mouse is snapped to the base axis, the preview looks exactly like the placed door / window
-                rot_mat = snap_obj.matrix_world
-            else:
+            # rotation only: the ghost is positioned by translate_mouse, so
+            # carrying the wall's own translation would displace it
+            rot_quat = snap_obj.matrix_world.to_quaternion()
+            if (point_on_base_axis - mouse_point).length_squared > (point_on_side_axis - mouse_point).length_squared:
                 # mouse is snapped to the side axis, the preview is inverted, rotate it now and correct x position later
-                rot_mat = (
-                    (snap_obj.matrix_world.to_quaternion() @ Quaternion(Vector((0, 0, 1)), radians(180)))
-                    .to_matrix()
-                    .to_4x4()
-                )
+                rot_quat = rot_quat @ Quaternion(Vector((0, 0, 1)), radians(180))
+            rot_mat = rot_quat.to_matrix().to_4x4()
 
             mouse_point.z = snap_obj.matrix_world.translation.z
-
-        if snap_element and (container := ifcopenshell.util.element.get_container(snap_element)):
-            container_obj = tool.Ifc.get_object(container)
-            mouse_point.z = container_obj.location.z
 
         obj_type = tool.Ifc.get_object(relating_type)
 

--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -1533,10 +1533,11 @@ class ProductDecorator(tool.Blender.ViewportDecorator):
         if not (data := self.obj_data):
             return
         relating_type = self.relating_type
+        relating_class = relating_type.is_a()
         model_props = tool.Model.get_model_props()
-        if relating_type.is_a("IfcDoorType"):
+        if relating_class in ("IfcDoorType", "IfcDoorStyle"):
             rl = float(model_props.rl1)
-        elif relating_type.is_a("IfcWindowType"):
+        elif relating_class in ("IfcWindowType", "IfcWindowStyle"):
             rl = float(model_props.rl2)
         else:
             rl = 0
@@ -1547,7 +1548,11 @@ class ProductDecorator(tool.Blender.ViewportDecorator):
         snap_obj = bpy.data.objects.get(snap_prop.snap_object)
         snap_element = tool.Ifc.get_entity(snap_obj)
         rot_mat = Matrix()
-        if relating_type.is_a() in ["IfcDoorType", "IfcWindowType"] and snap_element and snap_element.is_a("IfcWall"):
+        if (
+            relating_class in ("IfcDoorType", "IfcDoorStyle", "IfcWindowType", "IfcWindowStyle")
+            and snap_element
+            and snap_element.is_a("IfcWall")
+        ):
             layers = tool.Model.get_material_layer_parameters(snap_element)
             axes = tool.Model.get_wall_axis(snap_obj, layers=layers)
             axis_base = axes["base"]

--- a/src/bonsai/bonsai/bim/module/model/product.py
+++ b/src/bonsai/bonsai/bim/module/model/product.py
@@ -511,7 +511,7 @@ class AddOccurrence(bpy.types.Operator, tool.Ifc.Operator):
             new_port.SystemType = port.SystemType
             ifcopenshell.api.geometry.edit_object_placement(ifc_file, product=new_port, matrix=mat, is_si=True)
 
-        if ifc_class == "IfcDoorType" and len(context.selected_objects) >= 1:
+        if ifc_class in ("IfcDoorType", "IfcDoorStyle") and len(context.selected_objects) >= 1:
             pass
         else:
             tool.Blender.select_and_activate_single_object(context, obj)

--- a/src/bonsai/test/bim/module/model/test_door_preview_orientation.py
+++ b/src/bonsai/test/bim/module/model/test_door_preview_orientation.py
@@ -1,0 +1,115 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Hover-preview orientation for door/window fillings must be schema
+independent: the preview a ProductDecorator draws while the user hovers a
+filling over a wall follows the wall's rotation on IFC4 and must do the same
+on IFC2X3, where the type classes are spelled IfcDoorStyle/IfcWindowStyle."""
+
+import bpy
+import pytest
+from mathutils import Vector
+
+import bonsai.tool as tool
+from bonsai.bim.module.geometry.decorator import ItemDecorator
+from bonsai.bim.module.model.decorator import ProductDecorator
+from bonsai.bim.module.model.wall import DumbWallGenerator
+from test.bim.bootstrap import NewFile
+
+pytestmark = pytest.mark.model
+
+
+def _xy_extents(verts) -> tuple[float, float]:
+    xs = [v[0] for v in verts]
+    ys = [v[1] for v in verts]
+    return max(xs) - min(xs), max(ys) - min(ys)
+
+
+class TestDoorPreviewFollowsWall(NewFile):
+    @pytest.mark.parametrize("schema", ["IFC2X3", "IFC4"])
+    def test_hover_preview_and_placement_follow_a_rotated_wall(self, schema):
+        pprops = tool.Project.get_project_props()
+        pprops.export_schema = schema
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        assert ifc.schema == schema
+
+        bpy.ops.bim.add_default_type(ifc_element_type="IfcWallType")
+        wall_type = ifc.by_type("IfcWallType")[-1]
+
+        # Wall drawn along +Y, so an unrotated preview reads as 90 degrees off.
+        polyline_props = tool.Model.get_polyline_props()
+        polyline_data = polyline_props.insertion_polyline.add()
+        for co in ((0.0, 0.0, 0.0), (0.0, 3.0, 0.0)):
+            point = polyline_data.polyline_points.add()
+            point.x, point.y, point.z = co
+        walls, _ = DumbWallGenerator(wall_type).generate(insertion_type="POLYLINE")
+        polyline_props.insertion_polyline.clear()
+        wall_obj = walls[0]["obj"] if isinstance(walls[0], dict) else walls[0]
+        bpy.context.view_layer.update()
+        wall = tool.Ifc.get_entity(wall_obj)
+
+        rprops = tool.Root.get_root_props()
+        rprops.ifc_product = "IfcElementType"
+        door_class = "IfcDoorStyle" if schema == "IFC2X3" else "IfcDoorType"
+        rprops.ifc_class = door_class
+        if schema != "IFC2X3":
+            rprops.ifc_predefined_type = "DOOR"
+        rprops.representation_template = "DOOR"
+        bpy.ops.bim.add_element()
+        door_type = ifc.by_type(door_class)[-1]
+        door_type_obj = tool.Ifc.get_object(door_type)
+        assert door_type.RepresentationMaps
+
+        layers = tool.Model.get_material_layer_parameters(wall)
+        axes = tool.Model.get_wall_axis(wall_obj, layers=layers)
+        mouse = tool.Cad.point_on_edge(Vector((0.0, 1.5, 0.0)), axes["base"])
+        try:
+            snap_vertex = polyline_props.snap_mouse_point[0]
+        except IndexError:
+            snap_vertex = polyline_props.snap_mouse_point.add()
+        snap_vertex.x, snap_vertex.y, snap_vertex.z = mouse
+        snap_vertex.snap_type = "EDGE"
+        snap_vertex.snap_object = wall_obj.name
+
+        handler = ProductDecorator()
+        handler.relating_type = door_type
+        handler.preview_mode = "GENERIC"
+        handler.obj_data = ItemDecorator.get_obj_data(door_type_obj)
+        handler.obj_data["raw_verts"] = [Vector(v) for v in handler.obj_data["verts"]]
+        handler.obj_matrix_i = door_type_obj.matrix_world.inverted()
+        data = handler.get_generic_preview_data()
+        assert data
+
+        # The door is ~0.9 wide and ~0.1 deep: on a +Y wall the rotated
+        # preview footprint must be longer along Y than along X.
+        x_extent, y_extent = _xy_extents(data["verts"])
+        assert y_extent > x_extent, f"preview not rotated with the wall: x={x_extent:.3f} y={y_extent:.3f}"
+
+        # Click-to-place parity: door matrix aligns with the wall and the
+        # wall stays active, on both schemas.
+        tool.Blender.select_and_activate_single_object(bpy.context, wall_obj)
+        bpy.context.scene.cursor.location = mouse
+        bpy.ops.bim.add_occurrence(relating_type_id=door_type.id())
+        door_obj = tool.Ifc.get_object(ifc.by_type("IfcDoor")[-1])
+        door_x = (door_obj.matrix_world.to_3x3() @ Vector((1, 0, 0))).normalized()
+        wall_x = (wall_obj.matrix_world.to_3x3() @ Vector((1, 0, 0))).normalized()
+        assert abs(door_x.dot(wall_x)) > 0.999
+        assert bpy.context.active_object is wall_obj

--- a/src/bonsai/test/bim/module/model/test_door_preview_orientation.py
+++ b/src/bonsai/test/bim/module/model/test_door_preview_orientation.py
@@ -18,12 +18,17 @@
 #
 # This file was generated with the assistance of an AI coding tool.
 
-"""Hover-preview orientation for door/window fillings must be schema
-independent: the preview a ProductDecorator draws while the user hovers a
-filling over a wall follows the wall's rotation on IFC4 and must do the same
-on IFC2X3, where the type classes are spelled IfcDoorStyle/IfcWindowStyle."""
+"""Hover-preview correctness for door fillings must be schema independent
+and wall-angle independent: the ghost a ProductDecorator draws while the
+user hovers a filling over a wall must land where the placed door will
+land, on IFC4 and on IFC2X3 (where the type classes are spelled
+IfcDoorStyle/IfcWindowStyle), for walls at any angle and any origin,
+including the rl1 sill offset and the wall's Z."""
+
+import math
 
 import bpy
+import numpy as np
 import pytest
 from mathutils import Vector
 
@@ -35,16 +40,23 @@ from test.bim.bootstrap import NewFile
 
 pytestmark = pytest.mark.model
 
+RL1 = 0.3
 
-def _xy_extents(verts) -> tuple[float, float]:
-    xs = [v[0] for v in verts]
-    ys = [v[1] for v in verts]
-    return max(xs) - min(xs), max(ys) - min(ys)
+
+def _principal_xy_angle_vs(dir_world: Vector, verts) -> float:
+    pts = np.array([(v[0], v[1]) for v in verts])
+    pts = pts - pts.mean(axis=0)
+    evals, evecs = np.linalg.eigh(pts.T @ pts)
+    principal = Vector((evecs[0, -1], evecs[1, -1], 0.0)).normalized()
+    d = Vector((dir_world.x, dir_world.y, 0.0)).normalized()
+    cosang = max(-1.0, min(1.0, abs(principal.dot(d))))
+    return math.degrees(math.acos(cosang))
 
 
 class TestDoorPreviewFollowsWall(NewFile):
     @pytest.mark.parametrize("schema", ["IFC2X3", "IFC4"])
-    def test_hover_preview_and_placement_follow_a_rotated_wall(self, schema):
+    @pytest.mark.parametrize("wall_angle", [0, 30, 90, 135])
+    def test_hover_preview_matches_the_placed_door(self, schema, wall_angle):
         pprops = tool.Project.get_project_props()
         pprops.export_schema = schema
         bpy.ops.bim.create_project()
@@ -53,11 +65,16 @@ class TestDoorPreviewFollowsWall(NewFile):
 
         bpy.ops.bim.add_default_type(ifc_element_type="IfcWallType")
         wall_type = ifc.by_type("IfcWallType")[-1]
+        tool.Model.get_model_props().rl1 = RL1
 
-        # Wall drawn along +Y, so an unrotated preview reads as 90 degrees off.
+        # Wall away from the world origin so a preview displaced by the
+        # wall's own translation cannot pass.
+        a = math.radians(wall_angle)
+        p0 = Vector((5.0, 3.0, 0.0))
+        p1 = p0 + Vector((math.cos(a), math.sin(a), 0.0)) * 3.0
         polyline_props = tool.Model.get_polyline_props()
         polyline_data = polyline_props.insertion_polyline.add()
-        for co in ((0.0, 0.0, 0.0), (0.0, 3.0, 0.0)):
+        for co in (p0, p1):
             point = polyline_data.polyline_points.add()
             point.x, point.y, point.z = co
         walls, _ = DumbWallGenerator(wall_type).generate(insertion_type="POLYLINE")
@@ -65,6 +82,7 @@ class TestDoorPreviewFollowsWall(NewFile):
         wall_obj = walls[0]["obj"] if isinstance(walls[0], dict) else walls[0]
         bpy.context.view_layer.update()
         wall = tool.Ifc.get_entity(wall_obj)
+        wall_x = (wall_obj.matrix_world.to_3x3() @ Vector((1, 0, 0))).normalized()
 
         rprops = tool.Root.get_root_props()
         rprops.ifc_product = "IfcElementType"
@@ -80,7 +98,8 @@ class TestDoorPreviewFollowsWall(NewFile):
 
         layers = tool.Model.get_material_layer_parameters(wall)
         axes = tool.Model.get_wall_axis(wall_obj, layers=layers)
-        mouse = tool.Cad.point_on_edge(Vector((0.0, 1.5, 0.0)), axes["base"])
+        mid = (axes["base"][0] + axes["base"][1]) / 2
+        mouse = tool.Cad.point_on_edge(Vector((mid.x, mid.y, 0.0)), axes["base"])
         try:
             snap_vertex = polyline_props.snap_mouse_point[0]
         except IndexError:
@@ -98,18 +117,27 @@ class TestDoorPreviewFollowsWall(NewFile):
         data = handler.get_generic_preview_data()
         assert data
 
-        # The door is ~0.9 wide and ~0.1 deep: on a +Y wall the rotated
-        # preview footprint must be longer along Y than along X.
-        x_extent, y_extent = _xy_extents(data["verts"])
-        assert y_extent > x_extent, f"preview not rotated with the wall: x={x_extent:.3f} y={y_extent:.3f}"
+        preview_angle = _principal_xy_angle_vs(wall_x, data["verts"])
+        assert preview_angle < 5.0, f"preview not rotated with the wall: {preview_angle:.2f} degrees off"
 
-        # Click-to-place parity: door matrix aligns with the wall and the
-        # wall stays active, on both schemas.
+        # Click-to-place, then require the ghost to sit exactly where the
+        # placed door sits (position, rotation, sill and wall Z in one).
         tool.Blender.select_and_activate_single_object(bpy.context, wall_obj)
         bpy.context.scene.cursor.location = mouse
         bpy.ops.bim.add_occurrence(relating_type_id=door_type.id())
         door_obj = tool.Ifc.get_object(ifc.by_type("IfcDoor")[-1])
         door_x = (door_obj.matrix_world.to_3x3() @ Vector((1, 0, 0))).normalized()
-        wall_x = (wall_obj.matrix_world.to_3x3() @ Vector((1, 0, 0))).normalized()
         assert abs(door_x.dot(wall_x)) > 0.999
         assert bpy.context.active_object is wall_obj
+
+        placed_centroid = Vector((0.0, 0.0, 0.0))
+        for v in door_obj.data.vertices:
+            placed_centroid += door_obj.matrix_world @ v.co
+        placed_centroid /= len(door_obj.data.vertices)
+        preview_centroid = Vector((0.0, 0.0, 0.0))
+        preview_mesh_verts = data["verts"][: len(door_obj.data.vertices)]
+        for v in preview_mesh_verts:
+            preview_centroid += Vector(v)
+        preview_centroid /= len(preview_mesh_verts)
+        gap = (preview_centroid - placed_centroid).length
+        assert gap < 0.05, f"preview does not match the placed door: {gap:.3f} m apart"


### PR DESCRIPTION
IFC2X3 spells door and window types `IfcDoorStyle` and `IfcWindowStyle`. `ProductDecorator.get_generic_preview_data` matched only the IFC4 spellings:

```python
if relating_type.is_a() in ["IfcDoorType", "IfcWindowType"] and snap_element and snap_element.is_a("IfcWall"):
```

so on IFC2X3 the wall alignment block never ran, `rot_mat` stayed the identity matrix, and the hover preview was drawn in the door's rest orientation. The visible error equalled the wall's own angle, which is why it read as 90 degrees on a wall running along Y. The same miss skipped the sill offset and the wall Z snap.

Two further defects surfaced while measuring the fix at non axis aligned angles, and both are fixed here:

1. The base axis branch used the wall's full 4x4 matrix as `rot_mat`, so its translation landed on top of the mouse translation and the ghost was displaced by the wall's distance from the origin. This affected **IFC4 as well**, and was invisible when drawing near the origin. Both branches now build a rotation only matrix.
2. The wall Z snap was immediately overwritten by the container elevation override. The override now runs first as the generic fallback so the wall branch wins.

## Measured

Preview rotation error against the wall, real decorator data path, walls away from the origin:

| wall angle | IFC2X3 before | IFC2X3 after | IFC4 before | IFC4 after |
|---|---|---|---|---|
| 0 | 0.23 | 0.23 | 0.23 | 0.23 |
| 30 | 29.77 | 0.23 | 0.23 | 0.23 |
| 45 | 44.77 | 0.23 | 0.23 | 0.23 |
| 90 | 89.77 | 0.23 | 0.23 | 0.23 |
| 135 | 45.23 | 0.23 | 0.23 | 0.23 |
| 225 | 44.77 | 0.23 | 0.23 | 0.23 |

The 0.23 residual is PCA noise from the asymmetric frame profile, identical in both schemas.

Ghost to placed door centroid distance after the fix: **0.000 m at every angle, on both wall faces, in both schemas**, across 96 placements including walls flipped with `bim.flip_wall` so the direction sense path is covered.

## Testing

New parametrized regression test over wall angles 0, 30, 90 and 135 in both schemas, asserting rotation, ghost to door distance, placement alignment and that the wall stays the active object. Red on unfixed code, all 8 cases failing. Green with the fix. 16 neighbouring preview and decorator tests still pass.

Verified by hand in Blender on IFC2X3 and IFC4, on freshly drawn walls at several angles and on an imported IFC2X3 model.

Generated with the assistance of an AI coding tool.


---

**2026-08-31 update.** Fixes #9346 (#9347 is the same report). The double-applied host translation those issues describe is exactly the `rot_mat = snap_obj.matrix_world` composition this PR replaces with rotation-only quaternions; the regression test's origin-offset cases cover the reported 10 m displacement. Credit where due: @jaliste's earlier #7659 fixes the same line by zeroing `rot_mat.translation` and additionally recalculates `obj_matrix_i` per frame; if maintainers prefer that PR, this one folds its test in on top gladly.
