### PR TITLE
geometry.regenerate_wall_representation: create the Body context when missing

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/regenerate_wall_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/regenerate_wall_representation.py
@@ -110,6 +110,13 @@ class Regenerator:
         self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(file)
         self.is_angled = False
 
+        if not self.body:
+            if not (model := ifcopenshell.util.representation.get_context(file, "Model")):
+                model = ifcopenshell.api.context.add_context(file, context_type="Model")
+            self.body = ifcopenshell.api.context.add_context(
+                file, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=model
+            )
+
         if not self.axis:
             if not (plan := ifcopenshell.util.representation.get_context(file, "Plan")):
                 plan = ifcopenshell.api.context.add_context(file, context_type="Plan")


### PR DESCRIPTION
`regenerate_wall_representation` fetches two contexts. The Axis context is get or created:

```python
self.axis = ifcopenshell.util.representation.get_context(file, "Plan", "Axis", "GRAPH_VIEW")
if not self.axis:
    if not (plan := ifcopenshell.util.representation.get_context(file, "Plan")):
        plan = ifcopenshell.api.context.add_context(file, context_type="Plan")
    self.axis = ifcopenshell.api.context.add_context(...)
```

but the Body context was only fetched, never created. In a file that has no `Model/Body/MODEL_VIEW` subcontext, `self.body` is `None` and the regenerated wall body has nowhere to go, so the wall is destroyed.

Files exported by some authoring tools carry every representation on a single `IfcGeometricRepresentationContext` with no subcontexts at all, so this is reachable in practice rather than theoretical.

This mirrors the existing Axis handling exactly: create the parent `Model` context if it is missing, then create the `Body` subcontext under it.

## Testing

Verified idempotent, so repeated regeneration does not accumulate duplicate contexts.

Generated with the assistance of an AI coding tool.
