### PR TITLE
Bonsai: cut the opening when the host and the void sit on different contexts

### DIFF
--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1158,9 +1158,14 @@ class Geometry(bonsai.core.tool.Geometry):
         ifc_importer = bonsai.bim.import_ifc.IfcImporter(ifc_import_settings)
         ifc_importer.file = tool.Ifc.get()
 
-        settings.set("context-ids", [context.id()])
-        if not apply_openings:
+        context_ids = {context.id()}
+        if apply_openings:
+            context_ids |= ifcopenshell.util.representation.get_missing_opening_context_ids(
+                ifc_file, context_ids, elements
+            )
+        else:
             settings.set("disable-opening-subtractions", True)
+        settings.set("context-ids", sorted(context_ids))
 
         shape = None
         if elements:

--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -716,12 +716,18 @@ class Loader(bonsai.core.tool.Loader):
     @classmethod
     def create_settings(cls, is_gross=False):
         results = []
-        for context in cls.settings.contexts:
+        contexts = cls.settings.contexts
+        ifc_file = contexts[0].file if contexts else None
+        for context in contexts:
             settings = ifcopenshell.geom.settings()
             settings.set("mesher-linear-deflection", cls.settings.deflection_tolerance)
             settings.set("mesher-angular-deflection", cls.settings.angular_tolerance)
             settings.set("dimensionality", ifcopenshell.ifcopenshell_wrapper.CURVES_SURFACES_AND_SOLIDS)
-            settings.set("context-ids", [context.id()])
+            context_ids = {context.id()}
+            if not is_gross:
+                assert ifc_file
+                context_ids |= ifcopenshell.util.representation.get_missing_opening_context_ids(ifc_file, context_ids)
+            settings.set("context-ids", sorted(context_ids))
             settings.set("apply-default-materials", False)
             settings.set("keep-bounding-boxes", True)
             settings.set("layerset-first", True)

--- a/src/ifcopenshell-python/ifcopenshell/util/representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/representation.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from typing import Literal, Optional, TypedDict, Union
 
 import numpy as np
@@ -423,6 +423,60 @@ def get_prioritised_contexts(ifc_file: ifcopenshell.file) -> list[ifcopenshell.e
         return tuple(priority)
 
     return sorted(ifc_file.by_type("IfcGeometricRepresentationContext"), key=sort_context, reverse=True)
+
+
+def get_missing_opening_context_ids(
+    ifc_file: ifcopenshell.file,
+    context_ids: Iterable[int],
+    elements: Optional[Iterable[ifcopenshell.entity_instance]] = None,
+) -> set[int]:
+    """Gets the extra context ids an opening subtraction needs to resolve
+
+    The ``context-ids`` geometry setting is an allow list of the
+    representations the geometry kernel may resolve, and it is applied to the
+    openings subtracted from a host as well as to the host's own
+    representation. An allow list that leaves an opening with no representation
+    inside it makes the kernel drop that subtraction and emit an unvoided host,
+    so any ``context-ids`` filter used with opening subtractions enabled should
+    be extended by the result of this function.
+
+    Openings that already have a representation in ``context_ids`` contribute
+    nothing, so a model that keeps hosts and their openings in the same context
+    gets an empty result and an unchanged filter.
+
+    :param ifc_file: The model containing the openings
+    :param context_ids: The IfcGeometricRepresentationContext ids already allowed
+    :param elements: Only consider openings voiding these elements, including
+        openings inherited from an aggregate. Defaults to every opening in the
+        model.
+    :return: A set of IfcGeometricRepresentationContext ids to add
+    """
+    openings: set[ifcopenshell.entity_instance] = set()
+    if elements is None:
+        openings.update(ifc_file.by_type("IfcOpeningElement"))
+    else:
+        for element in elements:
+            seen: set[int] = set()
+            while element is not None and element.id() not in seen:
+                seen.add(element.id())
+                for rel in getattr(element, "HasOpenings", None) or ():
+                    openings.add(rel.RelatedOpeningElement)
+                decomposes = getattr(element, "Decomposes", None) or ()
+                element = next((r.RelatingObject for r in decomposes if r.is_a("IfcRelAggregates")), None)
+
+    allowed = set(context_ids)
+    missing: set[int] = set()
+    for opening in openings:
+        if not (definition := opening.Representation):
+            continue
+        representations = definition.Representations
+        if any(r.ContextOfItems.id() in allowed for r in representations):
+            continue
+        body = next((r for r in representations if r.RepresentationIdentifier == "Body"), None)
+        chosen = {body.ContextOfItems.id()} if body else {r.ContextOfItems.id() for r in representations}
+        allowed |= chosen
+        missing |= chosen
+    return missing
 
 
 def get_part_of_product(

--- a/src/ifcopenshell-python/test/util/test_representation.py
+++ b/src/ifcopenshell-python/test/util/test_representation.py
@@ -1,0 +1,104 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.util.representation as subject
+import test.bootstrap
+
+
+class TestGetMissingOpeningContextIds(test.bootstrap.IFC4):
+    def add_opening(self, wall, context, identifier="Body"):
+        opening = self.file.createIfcOpeningElement(
+            Representation=self.file.create_entity(
+                "IfcProductDefinitionShape",
+                Representations=[
+                    self.file.createIfcShapeRepresentation(ContextOfItems=context, RepresentationIdentifier=identifier)
+                ],
+            )
+        )
+        self.file.createIfcRelVoidsElement(RelatingBuildingElement=wall, RelatedOpeningElement=opening)
+        return opening
+
+    def test_returns_nothing_when_the_opening_shares_the_host_context(self):
+        body = self.file.createIfcGeometricRepresentationSubContext()
+        wall = self.file.createIfcWall()
+        self.add_opening(wall, body)
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()]) == set()
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()], [wall]) == set()
+
+    def test_returns_the_opening_context_when_it_is_not_allowed(self):
+        body = self.file.createIfcGeometricRepresentationSubContext()
+        other = self.file.createIfcGeometricRepresentationSubContext()
+        wall = self.file.createIfcWall()
+        self.add_opening(wall, other)
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()]) == {other.id()}
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()], [wall]) == {other.id()}
+
+    def test_prefers_the_body_representation_context(self):
+        body = self.file.createIfcGeometricRepresentationSubContext()
+        other = self.file.createIfcGeometricRepresentationSubContext()
+        box = self.file.createIfcGeometricRepresentationSubContext()
+        wall = self.file.createIfcWall()
+        opening = self.add_opening(wall, other)
+        opening.Representation.Representations = list(opening.Representation.Representations) + [
+            self.file.createIfcShapeRepresentation(ContextOfItems=box, RepresentationIdentifier="Box")
+        ]
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()]) == {other.id()}
+
+    def test_ignores_openings_of_other_elements_when_elements_are_given(self):
+        body = self.file.createIfcGeometricRepresentationSubContext()
+        other = self.file.createIfcGeometricRepresentationSubContext()
+        wall = self.file.createIfcWall()
+        unrelated = self.file.createIfcWall()
+        self.add_opening(unrelated, other)
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()], [wall]) == set()
+
+    def test_includes_openings_inherited_from_an_aggregate(self):
+        body = self.file.createIfcGeometricRepresentationSubContext()
+        other = self.file.createIfcGeometricRepresentationSubContext()
+        aggregate = self.file.createIfcElementAssembly()
+        part = self.file.createIfcWall()
+        self.file.createIfcRelAggregates(RelatingObject=aggregate, RelatedObjects=[part])
+        self.add_opening(aggregate, other)
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()], [part]) == {other.id()}
+
+    def test_ignores_openings_without_a_representation(self):
+        body = self.file.createIfcGeometricRepresentationSubContext()
+        wall = self.file.createIfcWall()
+        opening = self.file.createIfcOpeningElement()
+        self.file.createIfcRelVoidsElement(RelatingBuildingElement=wall, RelatedOpeningElement=opening)
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()]) == set()
+
+
+class TestGetMissingOpeningContextIdsIFC2X3(test.bootstrap.IFC2X3):
+    def test_returns_the_opening_context_when_it_is_not_allowed(self):
+        body = self.file.createIfcGeometricRepresentationContext()
+        other = self.file.createIfcGeometricRepresentationContext()
+        wall = self.file.createIfcWall()
+        opening = self.file.createIfcOpeningElement(
+            Representation=self.file.create_entity(
+                "IfcProductDefinitionShape",
+                Representations=[
+                    self.file.createIfcShapeRepresentation(ContextOfItems=other, RepresentationIdentifier="Body")
+                ],
+            )
+        )
+        self.file.createIfcRelVoidsElement(RelatingBuildingElement=wall, RelatedOpeningElement=opening)
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()]) == {other.id()}
+        assert subject.get_missing_opening_context_ids(self.file, [body.id()], [wall]) == {other.id()}


### PR DESCRIPTION
A door placed into an imported wall produced no hole. The IFC authoring is correct and complete: the `IfcOpeningElement` is created, `IfcRelVoidsElement` links it to the wall and `IfcRelFillsElement` links the door to the opening. The geometry pipeline silently declines to subtract it.

## Root cause

`src/ifcgeom/Converter.cpp` resolves each boolean operand through the output representation selector:

```cpp
auto repr = mapping()->representation_of(opening->as<IfcUtil::IfcBaseEntity>());
if (repr) { return std::make_pair(mapping()->map(repr), ...); }
else      { return std::make_pair(taxonomy::ptr{}, taxonomy::matrix4{}); }
```

`mapping::representation_of` builds its candidate set from the `context-ids` allow list and returns nullptr when the intersection with the opening's own representations is empty. Converter drops that operand, and once all operands are dropped it emits the host **unsubtracted, with no warning**:

```cpp
if (opening_items.empty()) { opened_shapes = shapes; }
```

Bonsai narrows `context-ids` to exactly the host representation's context, in `reimport_element_representations` and in `create_settings`. Bonsai authors openings on `Model/Body/MODEL_VIEW`, creating that subcontext on demand. In a file with no subcontexts the host stays on the original context while its new opening lands on the freshly created one. Different contexts, so the subtraction is skipped.

Isolated, same representation in every run:

```
default, no context filter   verts=18 faces=28
context-ids=[host]           verts=8  faces=12   <- same as disable-opening-subtractions
context-ids=[host, opening]  verts=18 faces=28
disable-opening-subtractions verts=8  faces=12
```

## The fix

`ifcopenshell.util.representation.get_missing_opening_context_ids` returns the extra context ids needed by an element's openings, and **only** for openings that have no representation already inside the allow list. Both Bonsai call sites extend their list with it. A model that keeps hosts and openings on one context gets exactly the filter it had before.

Widening unconditionally was tried first and rejected by measurement: it cost 60 percent on a model whose openings carry representations in two contexts, because every pass dragged in the other whole context.

## Not fixed here

The deeper defect is in C++: `mapping::representation_of` filters boolean operands by the output context list for every `context-ids` consumer, including `IfcConvert --context-ids`, and drops them silently rather than warning. That is left untouched because it could not be built and tested locally here, and shipping an unverified kernel change would be worse. Flagging it for anyone better placed to judge the right behaviour at that layer.

## Measured

Imported IFC2X3 wall, place a door: **8 verts / 12 polys to 18 verts / 28 polys**, and the hole survives save and reopen.

Non regression, all identical with and without the change:

- fresh IFC4 project, 14 contexts: 8/12 to 12/20 both ways
- `AC20-FZK-Haus.ifc`, openings across 2 contexts: 16242 verts, 30600 polys, all 9 voided hosts identical
- `project0-openings.ifc`, 13 contexts: identical, all 3 voided hosts
- `AC20-Institute-Var-2.ifc`, 287 openings: 26342 verts identical, 2.31s against a 2.26s baseline

## Testing

7 new unit tests. `test/util` goes from 369 to 376 passing with the same pre existing environment failures. Bonsai `test/core` 390 pass. In Blender geometry and loader tests, 94 pass.

Verified by hand in Blender on the reporter model where the door previously produced no opening at all.

Generated with the assistance of an AI coding tool.
