### PR TITLE
Bonsai: fix "Feet - Decimal" dimension unit breaking annotation decorators (#9015)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/helper.py
+++ b/src/bonsai/bonsai/bim/module/drawing/helper.py
@@ -256,10 +256,14 @@ def format_distance(
 
         base = int(precision)
 
+        # Number of decimals for decimal imperial output (feet/inches). Honor
+        # the drawing's DecimalPlaces if set, otherwise keep the legacy default.
+        imperial_dp = decimal_places if decimal_places is not None else 3
+
         # Separate ft and inches
         # Unless Inches are the specified Length Unit or unit_fraction is False
         if unit_length == "FEET" and not unit_fraction:
-            feet = round(decInches / inPerFoot, 3)  # keep decimal
+            feet = round(decInches / inPerFoot, imperial_dp)  # keep decimal
             decInches = 0
         elif unit_length != "INCHES":
             feet = int(decInches / inPerFoot)  # remove decimal
@@ -311,10 +315,13 @@ def format_distance(
 
         # Check whether decimal or fractional
         if not unit_fraction:
-            inches = round(decInches, 3)
+            inches = round(decInches, imperial_dp)
             frac = None
         if not isArea:
             add_inches = bool(inches) or not suppress_zero_inches or (inches == 0 and frac)
+            # Decimal feet holds the entire value in `feet`; there is no separate inches part.
+            if unit_length == "FEET" and not unit_fraction:
+                add_inches = False
 
             tx_dist = ""
             if feet:
@@ -346,7 +353,7 @@ def format_distance(
                 tx_dist += str(frac) + "/" + str(base)
             if add_inches or frac:
                 # Only add inch symbol if we actually added inch content
-                if inches > 0 or frac > 0 or feet == 0:
+                if inches > 0 or frac or feet == 0:
                     tx_dist += '"'
 
             if precision == "12" and unit_system == "IMPERIAL":


### PR DESCRIPTION
Fixes #9015.

Selecting `BBIM_Dimension.CustomUnit = "Feet - Decimal"` broke Bonsai drawing dimensions in three ways. It was the only `CustomUnit` value that misbehaved. All fixes are in `format_distance()` in `src/bonsai/bonsai/bim/module/drawing/helper.py`.

## 1. All annotation decorators disappeared

The decimal-feet path forces `inches = 0` and `frac = None`, then the string composer evaluated:

```python
if inches > 0 or frac > 0 or feet == 0:
```

With `inches == 0`, Python went on to `frac > 0` = `None > 0`, raising `TypeError`. That exception propagated out of the decoration draw handler, so Blender disabled the entire decorator draw pass and *all* `IfcAnnotation` decorators vanished.

Fixed by using plain truthiness (`frac`) — `frac` is always `None` or a non-negative int, so this is equivalent for real fractions and safe for `None`. Other units never hit this: decimal inches keep `inches` non-zero (short-circuit), fractional units keep `frac` as an int, metric never reaches the branch.

## 2. Spurious trailing ` - 0`

Decimal feet keeps the whole value in `feet`, but the composer still appended a separate inches part:

```
24.574' - 0      (before)
24.574'          (after)
```

Fixed by forcing `add_inches` off in decimal-feet mode.

## 3. Honor `DecimalPlaces` for imperial decimal output (feature request in #9015)

`EPset_Drawing.DecimalPlaces` previously only affected the metric formatter; the imperial decimal count was hardcoded to 3. It's now honored in the imperial decimal path (feet and inches), falling back to 3 when unset:

- `DecimalPlaces = 1` -> `24.6'`
- `DecimalPlaces = 2` -> `24.57'`
- unset -> `24.574'` (unchanged default)

## Testing

Verified manually with `CustomUnit = "Feet - Decimal"`: decorators render again, output reads `24.574'` (no trailing ` - 0`), and `DecimalPlaces` controls rounding. Fractional and metric units are unaffected — the new guards only trigger for imperial + non-fractional.
