### PR TITLE
Bonsai: allow aggregating IfcAnnotation elements and moving them as a unit

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -4091,7 +4091,7 @@ class OverrideMoveSelect(bpy.types.Operator):
             if obj == props.editing_aggregate:
                 continue
             element = tool.Ifc.get_entity(obj)
-            if not element or not element.is_a("IfcElement"):
+            if not element or not (element.is_a("IfcElement") or element.is_a("IfcAnnotation")):
                 continue
 
             if parts := ifcopenshell.util.element.get_parts(element):

--- a/src/bonsai/bonsai/tool/aggregate.py
+++ b/src/bonsai/bonsai/tool/aggregate.py
@@ -57,6 +57,12 @@ class Aggregate(bonsai.core.tool.Aggregate):
             "IfcElement"
         ):
             is_compatible_class = True
+        elif (
+            relating_object.is_a("IfcElement")
+            or relating_object.is_a("IfcElementType")
+            or relating_object.is_a("IfcAnnotation")
+        ) and related_object.is_a("IfcAnnotation"):
+            is_compatible_class = True
         elif tool.Ifc.get_schema() == "IFC2X3":
             if relating_object.is_a("IfcSpatialStructureElement") and related_object.is_a("IfcSpatialStructureElement"):
                 is_compatible_class = True


### PR DESCRIPTION
## Summary

Allow `IfcAnnotation` elements (dimensions, text, symbols, etc.) to be aggregated into an assembly, and have them behave like any other aggregate part — in particular, grabbing one part moves the whole aggregate together.

Closes #9017.

## Problem

- `bpy.ops.bim.add_aggregate()` silently did nothing when the selection contained annotations. `tool.Aggregate.can_aggregate()` only accepted `IfcElement`/`IfcElementType` → `IfcElement` (or spatial → spatial). `IfcAnnotation` is a direct subtype of `IfcProduct` (not `IfcElement`), so it failed the compatible-class check, `core.assign_object` raised `IncompatibleAggregateError`, and the operator swallowed it.
- Even once aggregated, moving one annotation part did **not** move its siblings. The `G`/move override (`OverrideMoveSelect`), which auto-selects all parts of an aggregate, was gated on `element.is_a("IfcElement")`.

There is no schema reason for the restriction: `IfcRelAggregates` only requires `IfcObjectDefinition` on both sides, and `IfcAnnotation` inherits from `IfcObjectDefinition`.

## Changes

1. **`tool/aggregate.py`** — `can_aggregate()` now allows `IfcAnnotation` on the related side (under an element/assembly, or under another `IfcAnnotation`).
2. **`bim/module/geometry/operator.py`** — `OverrideMoveSelect._execute()` now treats `IfcAnnotation` like `IfcElement`, so the move override expands the selection to aggregate siblings for annotations.

## Testing

- Select multiple `IfcAnnotation` objects → **Add Aggregate** → they now aggregate (previously a silent no-op).
- Grab (`G`) one annotation part of the aggregate → the whole aggregate moves together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
