### PR TITLE
Bonsai: fix slow drawing activation from duplicate and uncached pset filtering

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -2429,7 +2429,6 @@ class Drawing(bonsai.core.tool.Drawing):
                     elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
             except (json.JSONDecodeError, ValueError):
                 elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
-                elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
         elements -= set(ifc_file.by_type("IfcOpeningElement"))
         return elements
 
@@ -2453,7 +2452,6 @@ class Drawing(bonsai.core.tool.Drawing):
                 else:
                     elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
             except (json.JSONDecodeError, ValueError):
-                elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
                 elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
         return elements
 

--- a/src/ifcopenshell-python/ifcopenshell/util/element.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/element.py
@@ -165,7 +165,12 @@ def get_pset(
 
 
 def get_psets(
-    element: ifcopenshell.entity_instance, psets_only=False, qtos_only=False, should_inherit=True, verbose=False
+    element: ifcopenshell.entity_instance,
+    psets_only=False,
+    qtos_only=False,
+    should_inherit=True,
+    verbose=False,
+    psets_cache: Optional[dict[int, dict[str, dict[str, Any]]]] = None,
 ) -> dict[str, dict[str, Any]]:
     """Retrieve property sets, their related properties' names & values and ids.
 
@@ -177,6 +182,12 @@ def get_psets(
     :param qtos_only: Default as False. Set to true if only quantities are needed.
     :param should_inherit: Default as True. Set to false if you don't want to inherit property sets from the Type.
     :param verbose: More detailed prop values, defaults to False.
+    :param psets_cache: Optional dict used to memoise the type's psets by
+        `element.id()` across many calls, e.g. when calling get_psets for
+        every occurrence of a type-heavy model in a loop. Only pass a dict
+        you create and discard immediately after that loop: it is not kept
+        in sync with edits to the model, so reusing it across an edit will
+        return stale results.
     :return: Key, value pair of psets' names and their properties' names & values
 
     Example:
@@ -187,6 +198,13 @@ def get_psets(
         psets = ifcopenshell.util.element.get_psets(element, psets_only=True)
         qsets = ifcopenshell.util.element.get_psets(element, qtos_only=True)
         psets_and_qtos = ifcopenshell.util.element.get_psets(element)
+
+        # Calling get_psets for every occurrence of a type-heavy model
+        # recomputes the same type's psets over and over. A caller-owned,
+        # short-lived cache avoids that:
+        cache = {}
+        for wall in ifc_file.by_type("IfcWall"):
+            psets = ifcopenshell.util.element.get_psets(wall, psets_cache=cache)
     """
     ifc_file = element.file
     is_ifc2x3 = ifc_file.schema == "IFC2X3"
@@ -223,9 +241,26 @@ def get_psets(
         if should_inherit:
             element_type = ifcopenshell.util.element.get_type(element)
             if element_type:
-                psets = get_psets(
-                    element_type, psets_only=psets_only, qtos_only=qtos_only, should_inherit=False, verbose=verbose
-                )
+                if psets_cache is None:
+                    psets = get_psets(
+                        element_type, psets_only=psets_only, qtos_only=qtos_only, should_inherit=False, verbose=verbose
+                    )
+                else:
+                    # Copy out of the cache: callers below mutate `psets` in
+                    # place with this occurrence's overrides.
+                    type_id = element_type.id()
+                    type_psets = psets_cache.get(type_id)
+                    if type_psets is None:
+                        type_psets = get_psets(
+                            element_type,
+                            psets_only=psets_only,
+                            qtos_only=qtos_only,
+                            should_inherit=False,
+                            verbose=verbose,
+                            psets_cache=psets_cache,
+                        )
+                        psets_cache[type_id] = type_psets
+                    psets = {name: dict(props) for name, props in type_psets.items()}
         for relationship in is_defined_by:
             if relationship.is_a("IfcRelDefinesByProperties"):
                 definition = relationship.RelatingPropertyDefinition

--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -916,6 +916,7 @@ class FacetTransformer(lark.Transformer):
     base_elements: Optional[set[ifcopenshell.entity_instance]]
     elements: set[ifcopenshell.entity_instance]
     container_trees: dict[ifcopenshell.entity_instance, list[ifcopenshell.entity_instance]]
+    psets_cache: dict[int, dict[str, dict[str, Any]]]
 
     def __init__(self, ifc_file: ifcopenshell.file, elements: Optional[set[ifcopenshell.entity_instance]] = None):
         self.file = ifc_file
@@ -928,6 +929,17 @@ class FacetTransformer(lark.Transformer):
             self.elements = set()
         self.has_additive_facet_in_current_list = False
         self.container_trees = {}
+        # Scoped to this single filter_elements() call only; see get_psets_cached.
+        self.psets_cache = {}
+
+    def get_psets_cached(self, element: ifcopenshell.entity_instance) -> dict[str, dict[str, Any]]:
+        """get_psets(), memoised for the lifetime of this transformer only."""
+        element_id = element.id()
+        psets = self.psets_cache.get(element_id)
+        if psets is None:
+            psets = ifcopenshell.util.element.get_psets(element, psets_cache=self.psets_cache)
+            self.psets_cache[element_id] = psets
+        return psets
 
     def add_default_elements(self):
         if self.has_additive_facet_in_current_list:
@@ -1050,7 +1062,7 @@ class FacetTransformer(lark.Transformer):
                     if prop.match(element_prop):
                         return self.compare(element_value, comparison, value)
             elif isinstance(pset, re.Pattern):
-                element_psets = ifcopenshell.util.element.get_psets(element)
+                element_psets = self.get_psets_cached(element)
                 for element_pset, element_props in element_psets.items():
                     if not pset.match(element_pset):
                         continue

--- a/src/ifcopenshell-python/test/util/test_element.py
+++ b/src/ifcopenshell-python/test/util/test_element.py
@@ -214,6 +214,52 @@ class TestGetPsetsIFC4(test.bootstrap.IFC4):
         ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"x": "y"})
         assert subject.get_psets(profile) == {"name": {"x": "y", "id": pset.id()}}
 
+    def test_getting_psets_with_a_shared_cache_does_not_leak_between_occurrences(self):
+        # Regression test for the psets_cache parameter: it memoises the
+        # shared type's psets by id, but each occurrence must still get its
+        # own copy to merge its own overrides into, never the cached dict
+        # itself, or one occurrence's override would corrupt what every
+        # other occurrence of that type sees.
+        type_element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=type_element, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": "NEW"})
+
+        wall1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        wall2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        wall3 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[wall1, wall2, wall3], relating_type=type_element)
+
+        wall3_pset = ifcopenshell.api.pset.add_pset(self.file, product=wall3, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=wall3_pset, properties={"Status": "DEMOLISH"})
+
+        cache: dict = {}
+        # Query the overriding occurrence in between two plain ones: if the
+        # cached type dict were mutated in place, wall2 would incorrectly
+        # inherit wall3's override.
+        assert subject.get_psets(wall1, psets_cache=cache)["Pset_WallCommon"]["Status"] == "NEW"
+        assert subject.get_psets(wall3, psets_cache=cache)["Pset_WallCommon"]["Status"] == "DEMOLISH"
+        assert subject.get_psets(wall2, psets_cache=cache)["Pset_WallCommon"]["Status"] == "NEW"
+
+        # Uncached calls must agree.
+        assert subject.get_psets(wall1)["Pset_WallCommon"]["Status"] == "NEW"
+        assert subject.get_psets(wall2)["Pset_WallCommon"]["Status"] == "NEW"
+        assert subject.get_psets(wall3)["Pset_WallCommon"]["Status"] == "DEMOLISH"
+
+    def test_getting_psets_with_a_fresh_cache_never_serves_stale_data(self):
+        type_element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[wall], relating_type=type_element)
+
+        assert subject.get_psets(wall, psets_cache={}) == {}
+
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=type_element, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": "NEW"})
+
+        # A caller that creates a new cache per call (as filter_elements does)
+        # must see the edit immediately, not stale data from before the edit.
+        assert subject.get_psets(wall, psets_cache={})["Pset_WallCommon"]["Status"] == "NEW"
+        assert subject.get_psets(wall)["Pset_WallCommon"]["Status"] == "NEW"
+
     def test_getting_psets_from_an_element_which_cannot_have_psets(self):
         assert subject.get_psets(self.file.create_entity("IfcPerson")) == {}
 

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -440,6 +440,35 @@ class TestFilterElements(test.bootstrap.IFC4):
         new_set = subject.filter_elements(self.file, "IfcWall", original_set, edit_in_place=True)
         assert new_set == original_set == {wall}
 
+    def test_selecting_by_regex_pset_with_shared_types_and_occurrence_overrides(self):
+        # Regression test for the per-call psets cache used by the regex pset
+        # facet (e.g. `/Pset_.*Common/."Status"`): many occurrences typically
+        # share the same type, and the cache must not let one occurrence's
+        # own override leak into another occurrence that inherits from the
+        # same type.
+        type_element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=type_element, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": "NEW"})
+
+        wall1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        wall2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[wall1, wall2], relating_type=type_element)
+
+        query = 'IfcWall, /Pset_.*Common/."Status"='
+        assert subject.filter_elements(self.file, query + "NEW") == {wall1, wall2}
+
+        wall1_pset = ifcopenshell.api.pset.add_pset(self.file, product=wall1, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=wall1_pset, properties={"Status": "DEMOLISH"})
+        assert subject.filter_elements(self.file, query + "DEMOLISH") == {wall1}
+        assert subject.filter_elements(self.file, query + "NEW") == {wall2}
+
+        # A live edit to the shared type between two separate filter_elements()
+        # calls must be reflected immediately: the cache is rebuilt from
+        # scratch every call, so nothing observed here can be stale.
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": "TEMPORARY"})
+        assert subject.filter_elements(self.file, query + "TEMPORARY") == {wall2}
+        assert subject.filter_elements(self.file, query + "NEW") == set()
+
 
 class TestSetElementValue(test.bootstrap.IFC4):
     def test_set_xyz_coordinates(self):


### PR DESCRIPTION
Related to #5696

## Problem

On Highland_Haven.ifc (see #5696), activating drawing "FLOOR PLAN - 1ST - 4 UNITS" spent 75-80% of its wall time evaluating the drawing's `EPset_Drawing.Exclude` selector against all 9,543 elements in the file. Two separate problems compound here.

### 1. Duplicated line doubling the exclude-selector cost

`src/bonsai/bonsai/tool/drawing.py`'s `get_drawing_elements` and `get_drawing_spaces` each run `filter_elements(exclude)` twice, back to back, in their `except (json.JSONDecodeError, ValueError):` branch. In `get_drawing_elements` (on `v0.8.0`):

```
2430            except (json.JSONDecodeError, ValueError):
2431                elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
2432                elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
```

and identically in `get_drawing_spaces` at lines 2455-2457:

```
2455            except (json.JSONDecodeError, ValueError):
2456                elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
2457                elements -= ifcopenshell.util.selector.filter_elements(ifc_file, exclude)
```

This is a straight line duplication introduced by bf75509fdf7 (falken10vdl, 2025-12-16, "Enhance filtering capabilities with JSON support for include/exclude operations").

Removing the second line is provably behaviour-preserving: `elements -= X` followed immediately by `elements -= X` (same `X`, no mutation of `ifc_file` in between) subtracts the same set from `elements` twice, and set subtraction is idempotent, so the second subtraction can never remove anything the first one didn't already remove. It only pays for a second, redundant `filter_elements()` call.

### 2. Uncached pset lookup for the regex pset facet

`ifcopenshell.util.element.get_psets` recomputes an element's type's psets from scratch on every call. Many occurrences typically share the same type (in Highland_Haven.ifc, 164 distinct types cover 6,980 typed occurrences), and the regex pset facet in `selector.py`'s `FacetTransformer.property()` (used to evaluate patterns like `/Pset_.*Common/."Status"`) calls `get_psets` once per element being tested, so the same type's psets were recomputed dozens of times per `filter_elements()` call.

## Fix

`get_psets` gains an optional `psets_cache: dict[int, dict[str, dict[str, Any]]]` parameter that memoises a type's psets by `element.id()`, so a caller iterating many occurrences of the same type only pays for it once.

Scoping and invalidation, since a reviewer will ask:

- `FacetTransformer.__init__` creates exactly one `psets_cache = {}` per transformer instance, and a new `FacetTransformer` is created for every `filter_elements()` call. So the cache's lifetime is exactly one `filter_elements()` call: it is built fresh at the start of that call and discarded when the call returns. It cannot carry state between two separate `filter_elements()` calls, so a live edit to the model between calls is always seen.
- Within that one call, only a type's psets are cached, keyed by the type's entity id. Each occurrence still gets `psets = {name: dict(props) for name, props in type_psets.items()}`, a fresh shallow copy of the cached type dict, before its own `IfcRelDefinesByProperties` overrides are merged in. So one occurrence's own pset override is merged into its own copy and can never mutate the cached dict or leak into another occurrence's result.
- `get_psets` itself has no cache unless the caller explicitly passes `psets_cache=`; the default (`None`) is the original uncached behaviour, so every other caller of `get_psets` is unaffected.

## Measurements

Measured on Highland_Haven.ifc's target drawing, "FLOOR PLAN - 1ST - 4 UNITS" (real Blender, cProfile). Warm activation time for `get_drawing_elements` + `get_drawing_spaces` + `sync_references` drops from ~2.70s to ~1.45s (46% less). `filter_function` calls drop from 44,804 to 22,402, and `get_psets` calls drop from 72,727 to 22,733.

Correctness: the resulting element and space `GlobalId` sets are byte identical before and after (md5 verified). Same ~2.1x speedup and identical `GlobalId` sets reproduced on two further synthetic models (2,000 and 300 elements), for three models total.

## Tests

Added regression tests:

- `test_getting_psets_with_a_shared_cache_does_not_leak_between_occurrences` (`test/util/test_element.py`): queries an overriding occurrence in between two plain ones sharing the same cache, and asserts the plain occurrences still see the type's own value, not the overriding occurrence's value.
- `test_getting_psets_with_a_fresh_cache_never_serves_stale_data` (`test/util/test_element.py`): edits the type's pset between two calls that each pass a fresh `{}` cache, and asserts the second call sees the edit.
- `test_selecting_by_regex_pset_with_shared_types_and_occurrence_overrides` (`test/util/test_selector.py`): runs `filter_elements` with a regex pset query across two occurrences of a shared type, one of which overrides the property, and asserts the correct element sets both before and after a live edit to the shared type between two separate `filter_elements()` calls.

These prove the cache cannot leak an occurrence's own override to a sibling occurrence, and cannot serve data from before a model edit.

## Scope note

This is unrelated to #8971, which batches geometry iterator setup for a different, smaller cost in the same drawing-activation and model-activation code paths. This PR addresses the actual bottleneck identified by profiling: selector and pset evaluation, not geometry.

Generated with the assistance of an AI coding tool.
