### PR TITLE
Bonsai: don't apply a false origin the model does not sit under

### DIFF
--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -923,7 +923,9 @@ class Loader(bonsai.core.tool.Loader):
         return camera
 
     @classmethod
-    def get_offset_point(cls, ifc_file: ifcopenshell.file) -> Union[npt.NDArray[np.float64], None]:
+    def get_geometry_point(cls, ifc_file: ifcopenshell.file) -> Union[npt.NDArray[np.float64], None]:
+        """Absolute location in meters of the first vertex of the first element
+        that has geometry, or None when the file has no geometry at all."""
         # Check walls first, as they're usually cheap
         elements = ifc_file.by_type("IfcWall")
         elements += ifc_file.by_type("IfcElement")
@@ -946,12 +948,28 @@ class Loader(bonsai.core.tool.Loader):
                 continue
             mat = ifcopenshell.util.shape.get_shape_matrix(shape)
             verts = ifcopenshell.util.shape.get_vertices(shape.geometry)
-            point = (mat @ np_to_4d(verts[0]))[:3]
-            if cls.is_point_far_away(point, is_meters=True):
-                # Arbitrary origins should be to the nearest millimeter.
-                # Anything more precise is just ridiculous from a practical surveying perspective.
-                return np.array([round(float(p), 3) / cls.unit_scale for p in point])
-            break
+            return (mat @ np_to_4d(verts[0]))[:3]
+        return None
+
+    @classmethod
+    def get_offset_point(cls, ifc_file: ifcopenshell.file) -> Union[npt.NDArray[np.float64], None]:
+        point = cls.get_geometry_point(ifc_file)
+        if point is None or not cls.is_point_far_away(point, is_meters=True):
+            return None
+        # Arbitrary origins should be to the nearest millimeter.
+        # Anything more precise is just ridiculous from a practical surveying perspective.
+        return np.array([round(float(p), 3) / cls.unit_scale for p in point])
+
+    @classmethod
+    def moves_geometry_towards_origin(cls, ifc_file: ifcopenshell.file, element: ifcopenshell.entity_instance) -> bool:
+        """True when subtracting ``element``'s placement would bring the model's
+        geometry closer to the Blender origin than it already is."""
+        point = cls.get_geometry_point(ifc_file)
+        if point is None:
+            return True
+        placement = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement)
+        offset = placement[:3, 3] * cls.unit_scale
+        return bool(np.linalg.norm(point - offset) < np.linalg.norm(point))
 
     @classmethod
     def guess_false_origin_from_elements(cls, ifc_file: ifcopenshell.file) -> None:
@@ -976,10 +994,10 @@ class Loader(bonsai.core.tool.Loader):
         else:
             project = ifc_file.by_type("IfcContext")[0]
         site = cls.find_decomposed_ifc_class(project, "IfcSite")
-        if site and cls.is_element_far_away(site):
+        if site and cls.is_element_far_away(site) and cls.moves_geometry_towards_origin(ifc_file, site):
             return cls.guess_false_origin_and_project_north(ifc_file, site)
         building = cls.find_decomposed_ifc_class(project, "IfcBuilding")
-        if building and cls.is_element_far_away(building):
+        if building and cls.is_element_far_away(building) and cls.moves_geometry_towards_origin(ifc_file, building):
             return cls.guess_false_origin_and_project_north(ifc_file, building)
         return cls.guess_false_origin_from_elements(ifc_file)
 

--- a/src/bonsai/test/bim/test_false_origin_guard.py
+++ b/src/bonsai/test/bim/test_false_origin_guard.py
@@ -1,0 +1,159 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Which placement is allowed to become the false origin.
+
+Exporters exist that put map coordinates on the IfcSite while leaving the
+building tree hanging off the world origin. Subtracting that placement moves
+geometry that already sits at the origin hundreds of kilometres away, where
+single precision viewport maths quantises vertices and doors flicker, render
+chunky or disappear. Measured on ifc-georeferencer-AC20-FZK-Haus 1 wall.ifc:
+site at 433832, 477738; wall geometry at 11.7, 9.7; the offset took the wall
+from 15.2 m off the Blender origin to 645309.5 m.
+
+A false origin the model's geometry does sit under stays accepted, measured on
+the same corpus: BWFI_X_3_ELT 38211.9 m to 0.6 m, QTO-Test_extracted
+7087311.5 m to 1225.8 m, Rampe_V6_251028_v3 5665787.1 m to 2832889.8 m."""
+
+import ifcopenshell
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.georeference
+
+
+def _placement(ifc, translation):
+    return ifc.create_entity(
+        "IfcLocalPlacement",
+        RelativePlacement=ifc.create_entity(
+            "IfcAxis2Placement3D",
+            Location=ifc.create_entity("IfcCartesianPoint", Coordinates=tuple(float(c) for c in translation)),
+        ),
+    )
+
+
+def _project_with_site(site_translation):
+    ifc = ifcopenshell.file(schema="IFC4")
+    project = ifc.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new())
+    site = ifc.create_entity(
+        "IfcSite",
+        GlobalId=ifcopenshell.guid.new(),
+        ObjectPlacement=_placement(ifc, site_translation),
+    )
+    ifc.create_entity(
+        "IfcRelAggregates",
+        GlobalId=ifcopenshell.guid.new(),
+        RelatingObject=project,
+        RelatedObjects=[site],
+    )
+    return ifc, site
+
+
+class _Route:
+    """Records which false origin branch ``guess_false_origin`` took."""
+
+    def __init__(self, monkeypatch, geometry_point):
+        from bonsai.tool.loader import Loader
+
+        self.taken = None
+        monkeypatch.setattr(Loader, "unit_scale", 1.0, raising=False)
+        monkeypatch.setattr(Loader, "get_geometry_point", classmethod(lambda cls, f: geometry_point))
+        monkeypatch.setattr(
+            Loader,
+            "guess_false_origin_and_project_north",
+            classmethod(lambda cls, f, element: self._record("placement")),
+        )
+        monkeypatch.setattr(
+            Loader,
+            "guess_false_origin_from_elements",
+            classmethod(lambda cls, f: self._record("elements")),
+        )
+
+    def _record(self, name):
+        self.taken = name
+
+
+def _limit_settings(monkeypatch, limit=1000.0):
+    from bonsai.tool.loader import Loader
+
+    class Settings:
+        distance_limit = limit
+
+    monkeypatch.setattr(Loader, "settings", Settings(), raising=False)
+
+
+def test_site_placement_the_geometry_sits_under_is_a_false_origin(monkeypatch):
+    from bonsai.tool.loader import Loader
+
+    _limit_settings(monkeypatch)
+    ifc, _site = _project_with_site((433832.0, 477738.0, 0.0))
+    route = _Route(monkeypatch, np.array([433840.0, 477745.0, 0.0]))
+    Loader.guess_false_origin(ifc)
+    assert route.taken == "placement"
+
+
+def test_site_placement_the_geometry_does_not_sit_under_is_not_a_false_origin(monkeypatch):
+    from bonsai.tool.loader import Loader
+
+    _limit_settings(monkeypatch)
+    ifc, _site = _project_with_site((433832.0, 477738.0, 0.0))
+    route = _Route(monkeypatch, np.array([11.7, 9.7, 0.0]))
+    Loader.guess_false_origin(ifc)
+    assert route.taken == "elements"
+
+
+def test_a_file_without_geometry_keeps_the_placement_false_origin(monkeypatch):
+    from bonsai.tool.loader import Loader
+
+    _limit_settings(monkeypatch)
+    ifc, _site = _project_with_site((433832.0, 477738.0, 0.0))
+    route = _Route(monkeypatch, None)
+    Loader.guess_false_origin(ifc)
+    assert route.taken == "placement"
+
+
+def test_moves_geometry_towards_origin_measures_both_distances(monkeypatch):
+    from bonsai.tool.loader import Loader
+
+    _limit_settings(monkeypatch)
+    monkeypatch.setattr(Loader, "unit_scale", 1.0, raising=False)
+    ifc, site = _project_with_site((433832.0, 477738.0, 0.0))
+
+    monkeypatch.setattr(Loader, "get_geometry_point", classmethod(lambda cls, f: np.array([11.7, 9.7, 0.0])))
+    assert Loader.moves_geometry_towards_origin(ifc, site) is False
+
+    monkeypatch.setattr(Loader, "get_geometry_point", classmethod(lambda cls, f: np.array([433840.0, 477745.0, 0.0])))
+    assert Loader.moves_geometry_towards_origin(ifc, site) is True
+
+
+def test_offset_point_only_reports_geometry_that_is_far_away(monkeypatch):
+    from bonsai.tool.loader import Loader
+
+    _limit_settings(monkeypatch)
+    monkeypatch.setattr(Loader, "unit_scale", 1.0, raising=False)
+    ifc = ifcopenshell.file(schema="IFC4")
+
+    monkeypatch.setattr(Loader, "get_geometry_point", classmethod(lambda cls, f: np.array([11.7, 9.7, 0.0])))
+    assert Loader.get_offset_point(ifc) is None
+
+    monkeypatch.setattr(
+        Loader, "get_geometry_point", classmethod(lambda cls, f: np.array([4581141.2384, 5407691.0, 339.2027]))
+    )
+    np.testing.assert_allclose(Loader.get_offset_point(ifc), [4581141.238, 5407691.0, 339.203])


### PR DESCRIPTION
Bonsai applies a false origin so georeferenced models load near the Blender origin, otherwise single precision float error makes geometry flicker, render blocky, or disappear.

`Loader` picked that origin by asking only **where the IfcSite is**, never whether the model's geometry is there too:

```python
site = cls.find_decomposed_ifc_class(project, "IfcSite")
if site and cls.is_element_far_away(site):
    return cls.guess_false_origin_and_project_north(ifc_file, site)
```

Some files put the map coordinates on the site while the building sits at the local origin with no `PlacementRelTo` linking them. Subtracting the site's placement then throws near-origin geometry far away instead of bringing it closer.

Measured on a georeferenced test file: the wall's absolute placement is `12, 10, 0`, the site carries `433832, 477738, 0`, and applying it put the wall at **223270.84, 605453.50** in Blender, about 645 km out, where a float32 step is 0.06 m. Nothing raises. The IFC written back is correct, but the viewport geometry is unusable and a door placed there is invisible.

## Fix

A placement is accepted as a false origin only if subtracting it brings the model's geometry **closer** to the origin, reusing the same geometry point `get_offset_point` already reads.

Corpus check over every model whose site or building placement is far away:

```
BWFI_X_3_ELT_FM          38211.9 m -> 0.6 m         accepted
BWFI_X_3_RLT_FM          38211.9 m -> 0.6 m         accepted
QTO-Test_extracted     7087311.5 m -> 1225.8 m      accepted
Rampe_V6_251028_v3     5665787.1 m -> 2832889.8 m   accepted
ifc-georeferencer 1 wall     15.2 m -> 645309.5 m   REJECTED
```

Only the pathological case changes. After the fix the Blender and IFC coordinate spaces agree to the last digit, and the geometry survives save and reload.

Verified by hand in Blender on the reporting model, and on non georeferenced controls which are unaffected.

Generated with the assistance of an AI coding tool.
