### PR TITLE
Bonsai: keep authored voids on reference view hosts, and stop prompting to recut them

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -206,7 +206,15 @@ class IfcImporter:
     """Either provided by user as an attribute or will be loaded from ``input_file`` during ``execute()``."""
 
     elements: set[ifcopenshell.entity_instance]
-    """Set of IfcElements to import. Excluding ``gross_elements`` and ```native_elements``."""
+    """Set of IfcElements to import. Excluding ``gross_elements``, ``baked_void_elements`` and ```native_elements``."""
+
+    gross_elements: set[ifcopenshell.entity_instance]
+    """Elements whose opening cuts were skipped because there were too many of
+    them. The user is offered a manual recut for these."""
+
+    baked_void_elements: set[ifcopenshell.entity_instance]
+    """Elements loaded without opening cuts because their body already includes
+    them. Nothing was skipped, so these are not offered for recut."""
 
     def __init__(self, ifc_import_settings: IfcImportSettings):
         self.ifc_import_settings = ifc_import_settings
@@ -219,6 +227,7 @@ class IfcImporter:
         self.elements: set[ifcopenshell.entity_instance] = set()
         self.annotations: set[ifcopenshell.entity_instance] = set()
         self.gross_elements: set[ifcopenshell.entity_instance] = set()
+        self.baked_void_elements: set[ifcopenshell.entity_instance] = set()
         self.broken_arrays: set[ifcopenshell.entity_instance] = set()
         self.element_types: set[ifcopenshell.entity_instance] = set()
         self.spatial_elements: set[ifcopenshell.entity_instance] = set()
@@ -369,11 +378,26 @@ class IfcImporter:
             else:
                 self.spatial_elements = set(self.file.by_type("IfcSpatialElement"))
 
-        # Detect excessive voids
-        self.gross_elements = set(
-            filter(lambda e: len(getattr(e, "HasOpenings", [])) > self.ifc_import_settings.void_limit, self.elements)
-        )
-        self.elements = self.elements.difference(self.gross_elements)
+        self.classify_voided_elements()
+
+    def classify_voided_elements(self) -> None:
+        """Split off the elements that must load without opening subtractions:
+        the ones with more voids than we will cut, and the ones a Reference
+        View exporter already cut into the host body."""
+        void_limit = self.ifc_import_settings.void_limit
+        reference_view = self.ifc_import_settings.is_reference_view
+        self.gross_elements = set()
+        self.baked_void_elements = set()
+        for element in self.elements:
+            openings = getattr(element, "HasOpenings", None) or ()
+            if not openings:
+                continue
+            if len(openings) > void_limit:
+                self.gross_elements.add(element)
+            elif reference_view and not self.has_subtractive_void(element):
+                self.baked_void_elements.add(element)
+        self.elements -= self.gross_elements
+        self.elements -= self.baked_void_elements
 
         if self.gross_elements:
             print("Warning! Excessive voids were found and skipped for the following elements:")
@@ -403,6 +427,20 @@ class IfcImporter:
             if self.is_native(element):
                 self.native_elements.add(element)
         self.elements -= self.native_elements
+
+    @staticmethod
+    def has_subtractive_void(element: ifcopenshell.entity_instance) -> bool:
+        """True when one of the element's openings still has to be subtracted.
+
+        A Reference View exporter writes the host body already cut and gives
+        the matching opening a Reference representation only. An opening
+        carrying a Body representation is one nothing has cut yet, which is
+        what every opening Bonsai authors looks like."""
+        for rel in getattr(element, "HasOpenings", None) or ():
+            definition = getattr(rel.RelatedOpeningElement, "Representation", None)
+            if definition and any(r.RepresentationIdentifier == "Body" for r in definition.Representations):
+                return True
+        return False
 
     def is_native(self, element: ifcopenshell.entity_instance) -> bool:
         if (
@@ -632,7 +670,7 @@ class IfcImporter:
 
     def create_elements(self) -> None:
         self.create_generic_elements(self.elements)
-        self.create_generic_elements(self.gross_elements, is_gross=True)
+        self.create_generic_elements(self.gross_elements | self.baked_void_elements, is_gross=True)
 
     def create_generic_elements(self, elements: set[ifcopenshell.entity_instance], is_gross=False) -> None:
         if isinstance(self.file, ifcopenshell.sqlite):
@@ -958,7 +996,7 @@ class IfcImporter:
         self.file = tool.Ifc.get()
         # IFC4 Reference View shall have no booleans https://github.com/BuildingSMART/IFC4-CV/issues/14
         if self.file.schema == "IFC4" and "ReferenceView" in str(self.file.header.file_description.description):
-            self.ifc_import_settings.void_limit = 0
+            self.ifc_import_settings.is_reference_view = True
 
     def calculate_unit_scale(self):
         self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(self.file)
@@ -1285,6 +1323,7 @@ class IfcImportSettings:
         self.deflection_tolerance = 0.05  # Default is 0.001, but I find this to be more practical
         self.angular_tolerance = 0.5
         self.void_limit = 30
+        self.is_reference_view = False
         self.style_limit = 300
         # Locations greater than 1km are not considered "small sites" according to the georeferencing guide
         # Users can configure this if they have to handle larger sites but beware of surveying precision

--- a/src/bonsai/test/bim/test_reference_view_voids.py
+++ b/src/bonsai/test/bim/test_reference_view_voids.py
@@ -1,0 +1,127 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Voids on IFC4 Reference View files.
+
+A Reference View exporter writes the host body already cut and gives the
+matching IfcOpeningElement a Reference representation only, so the importer
+skips the booleans. An opening Bonsai authors is different: it carries a Body
+representation and nothing has cut the host yet. Treating both the same made
+a door's hole show in the session and vanish on reload, measured on
+Perspective générique.ifc (6.527 m3 uncut, 6.200 m3 cut) and on
+DigitalHub_FM-ARC_v2.ifc."""
+
+import ifcopenshell
+import pytest
+
+pytestmark = pytest.mark.geometry
+
+
+def _host_with_opening(representation_identifier):
+    ifc = ifcopenshell.file(schema="IFC4")
+    context = ifc.create_entity(
+        "IfcGeometricRepresentationContext",
+        ContextType="Model",
+        CoordinateSpaceDimension=3,
+    )
+    wall = ifc.create_entity("IfcWall", GlobalId=ifcopenshell.guid.new())
+    opening = ifc.create_entity("IfcOpeningElement", GlobalId=ifcopenshell.guid.new())
+    if representation_identifier is not None:
+        representation = ifc.create_entity(
+            "IfcShapeRepresentation",
+            ContextOfItems=context,
+            RepresentationIdentifier=representation_identifier,
+            RepresentationType="Tessellation",
+            Items=[],
+        )
+        opening.Representation = ifc.create_entity("IfcProductDefinitionShape", Representations=[representation])
+    ifc.create_entity(
+        "IfcRelVoidsElement",
+        GlobalId=ifcopenshell.guid.new(),
+        RelatingBuildingElement=wall,
+        RelatedOpeningElement=opening,
+    )
+    return wall
+
+
+def test_body_opening_still_has_to_be_subtracted():
+    from bonsai.bim.import_ifc import IfcImporter
+
+    assert IfcImporter.has_subtractive_void(_host_with_opening("Body")) is True
+
+
+def test_reference_only_opening_was_already_baked_in():
+    from bonsai.bim.import_ifc import IfcImporter
+
+    assert IfcImporter.has_subtractive_void(_host_with_opening("Reference")) is False
+
+
+def test_opening_without_geometry_was_already_baked_in():
+    from bonsai.bim.import_ifc import IfcImporter
+
+    assert IfcImporter.has_subtractive_void(_host_with_opening(None)) is False
+
+
+def test_host_without_openings_is_not_affected():
+    from bonsai.bim.import_ifc import IfcImporter
+
+    ifc = ifcopenshell.file(schema="IFC4")
+    wall = ifc.create_entity("IfcWall", GlobalId=ifcopenshell.guid.new())
+    assert IfcImporter.has_subtractive_void(wall) is False
+
+
+def _classify(elements, *, reference_view, void_limit=30):
+    """Run ``process_element_filter``'s void classification without Blender."""
+    from bonsai.bim.import_ifc import IfcImporter
+
+    importer = IfcImporter.__new__(IfcImporter)
+    importer.elements = set(elements)
+    importer.ifc_import_settings = type(
+        "Settings", (), {"void_limit": void_limit, "is_reference_view": reference_view}
+    )()
+    IfcImporter.classify_voided_elements(importer)
+    return importer
+
+
+def test_baked_voids_are_not_offered_for_recut():
+    """The banner asks the user to apply cuts we skipped. Nothing was skipped
+    on a host whose body already includes its voids, and on Perspective
+    générique.ifc that banner named all 7 walls on every load."""
+    wall = _host_with_opening("Reference")
+    importer = _classify([wall], reference_view=True)
+    assert importer.baked_void_elements == {wall}
+    assert importer.gross_elements == set()
+    assert wall not in importer.elements
+
+
+def test_excessive_voids_are_still_offered_for_recut():
+    wall = _host_with_opening("Body")
+    importer = _classify([wall], reference_view=True, void_limit=0)
+    assert importer.gross_elements == {wall}
+    assert importer.baked_void_elements == set()
+    assert wall not in importer.elements
+
+
+def test_authored_void_on_a_reference_view_host_is_cut_normally():
+    wall = _host_with_opening("Body")
+    importer = _classify([wall], reference_view=True)
+    assert importer.elements == {wall}
+    assert importer.gross_elements == set()
+    assert importer.baked_void_elements == set()


### PR DESCRIPTION
An IFC4 Reference View exporter bakes openings into the host body, so those hosts must load with opening subtractions disabled. Bonsai handled that by adding them to `gross_elements`, the same set used for hosts whose voids were skipped because there were too many of them.

Those two things are not the same. `gross_elements` drives a user facing prompt offering to recut the openings. That prompt is correct for "we gave up cutting these" and wrong for "the exporter already cut these", where there is nothing to recut and the offer cannot help.

It also meant an opening authored by the user in Bonsai, on the Body representation, was discarded on reload. Measured on a reference view file, wall `3t$4vpz0XAB9ilEi52BT5P`: solid volume 6.527175 in the file, 6.200174 after placing a door in the session, and **6.527175 again after save and reload**, while a manual `switch_representation` on the reloaded file gives 6.200174. The hole was authored correctly and thrown away on load.

## Fix

Reference view hosts with exporter baked voids go to a separate `baked_void_elements` set. Same load settings, same geometry, same load time, no prompt. `gross_elements` keeps only the case the prompt is actually about.

Measured on the reference view file: elements offered for recut on load **7 to 0**, and after placing a door and reloading **6 to 0**. All eight wall volumes unchanged to the digit. The authored hole now survives save and reload.

Separately verified that the exporter baked openings subtract to nothing: loading them with booleans enabled gives byte identical volumes.

Note this is a net reduction in prompting overall, not only on reference view files: on one test model the count went from 58 to 0.

Verified by hand in Blender, including the save and reload round trip.

Generated with the assistance of an AI coding tool.
