### PR TITLE
Bonsai: write the opening placement in IFC space, not Blender space

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -347,7 +347,7 @@ class FilledOpeningGenerator:
         ifcopenshell.api.geometry.edit_object_placement(
             tool.Ifc.get(),
             product=opening,
-            matrix=np.array(filling_obj.matrix_world),
+            matrix=tool.Surveyor.get_absolute_matrix(filling_obj),
             is_si=True,
         )
 
@@ -651,7 +651,7 @@ class RecalculateFill(bpy.types.Operator, tool.Ifc.Operator):
             for opening in openings:
                 bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
                 ifcopenshell.api.geometry.edit_object_placement(
-                    tool.Ifc.get(), product=opening, matrix=obj.matrix_world
+                    tool.Ifc.get(), product=opening, matrix=tool.Surveyor.get_absolute_matrix(obj)
                 )
 
             decomposed_building_elements = set()

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -1454,7 +1454,7 @@ class Model(bonsai.core.tool.Model):
             ifcopenshell.api.geometry.edit_object_placement(
                 ifc_file,
                 product=new_opening,
-                matrix=np.array(child_obj.matrix_world),
+                matrix=tool.Surveyor.get_absolute_matrix(child_obj),
                 is_si=True,
             )
             mapped_representation = ifcopenshell.api.geometry.map_representation(
@@ -3215,7 +3215,7 @@ class Model(bonsai.core.tool.Model):
                         continue
                     bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=filling_obj)
                     ifcopenshell.api.geometry.edit_object_placement(
-                        tool.Ifc.get(), product=opening, matrix=filling_obj.matrix_world
+                        tool.Ifc.get(), product=opening, matrix=tool.Surveyor.get_absolute_matrix(filling_obj)
                     )
 
         for element, wall in queue:


### PR DESCRIPTION
When a door or window is placed, the opening's placement was written into IFC straight from the Blender object matrix:

```python
matrix=np.array(filling_obj.matrix_world)
```

while the filling itself goes through `Surveyor.get_absolute_matrix`. On any model where Blender and IFC coordinates differ, for example a georeferenced model loaded with a false origin, the opening lands somewhere entirely different from its host.

Measured on a georeferenced file: the wall spans x 11.7 to 12.0 in IFC space, and the opening was written at **x 223268**. Nothing raises. The `IfcOpeningElement` is created, `IfcRelVoidsElement` and `IfcRelFillsElement` are both correct, every bookkeeping check passes, and the wall is simply never cut.

Four call sites wrote a placement without the conversion, two in `opening.py` and two in `tool/model.py`. All now go through `Surveyor.get_absolute_matrix`, matching how the filling itself is handled.

Measured across an 81 model corpus: this alone fixed **8 previously failing wall placements**, and no model that already worked changed.

## Note for reviewers

This touches `src/bonsai/bonsai/bim/module/model/opening.py`, which is also touched by two sibling PRs from the same investigation. They are independent defects and can be merged in any order, but whichever lands later will need a small rebase.

Generated with the assistance of an AI coding tool.
