### PR TITLE
Bonsai: orient a filling from the clicked face when the host has no reference line

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/decorator.py
+++ b/src/bonsai/bonsai/bim/module/model/decorator.py
@@ -1549,21 +1549,29 @@ class ProductDecorator(tool.Blender.ViewportDecorator):
         rot_mat = Matrix()
         if relating_type.is_a() in ["IfcDoorType", "IfcWindowType"] and snap_element and snap_element.is_a("IfcWall"):
             layers = tool.Model.get_material_layer_parameters(snap_element)
-            axes = tool.Model.get_wall_axis(snap_obj, layers=layers)
-            axis_base = axes["base"]
-            axis_side = axes["side"]
-            point_on_base_axis = tool.Cad.point_on_edge(mouse_point, axis_base)
-            point_on_side_axis = tool.Cad.point_on_edge(mouse_point, axis_side)
-            if (point_on_base_axis - mouse_point).length_squared <= (point_on_side_axis - mouse_point).length_squared:
-                # mouse is snapped to the base axis, the preview looks exactly like the placed door / window
-                rot_mat = snap_obj.matrix_world
+            face_frame = None
+            if not tool.Model.has_layer2_reference_line(snap_element):
+                face_frame = tool.Model.get_wall_face_frame(snap_obj, mouse_point)
+            if face_frame is not None:
+                rot_mat = tool.Model.get_filling_rotation(face_frame[0])
             else:
-                # mouse is snapped to the side axis, the preview is inverted, rotate it now and correct x position later
-                rot_mat = (
-                    (snap_obj.matrix_world.to_quaternion() @ Quaternion(Vector((0, 0, 1)), radians(180)))
-                    .to_matrix()
-                    .to_4x4()
-                )
+                axes = tool.Model.get_wall_axis(snap_obj, layers=layers)
+                axis_base = axes["base"]
+                axis_side = axes["side"]
+                point_on_base_axis = tool.Cad.point_on_edge(mouse_point, axis_base)
+                point_on_side_axis = tool.Cad.point_on_edge(mouse_point, axis_side)
+                if (point_on_base_axis - mouse_point).length_squared <= (
+                    point_on_side_axis - mouse_point
+                ).length_squared:
+                    # mouse is snapped to the base axis, the preview looks exactly like the placed door / window
+                    rot_mat = snap_obj.matrix_world
+                else:
+                    # mouse is snapped to the side axis, the preview is inverted, rotate it now and correct x position later
+                    rot_mat = (
+                        (snap_obj.matrix_world.to_quaternion() @ Quaternion(Vector((0, 0, 1)), radians(180)))
+                        .to_matrix()
+                        .to_4x4()
+                    )
 
             mouse_point.z = snap_obj.matrix_world.translation.z
 

--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -297,19 +297,28 @@ class FilledOpeningGenerator:
             layers = tool.Model.get_material_layer_parameters(element)
             if layers["layer_set_direction"] == "AXIS2":
                 opening_thickness_si = layers["thickness"] * 2
-                axes = tool.Model.get_wall_axis(voided_obj, layers=layers)
-                axis_base = axes["base"]
-                axis_side = axes["side"]
-                new_matrix = voided_obj.matrix_world.copy()
-                point_on_base_axis = tool.Cad.point_on_edge(target, axis_base)
-                point_on_side_axis = tool.Cad.point_on_edge(target, axis_side)
-                if (point_on_base_axis - target).length <= (point_on_side_axis - target).length:
-                    new_matrix.translation.x = point_on_base_axis.x
-                    new_matrix.translation.y = point_on_base_axis.y
+                face_frame = None
+                if not tool.Model.has_layer2_reference_line(element):
+                    face_frame = tool.Model.get_wall_face_frame(voided_obj, target)
+                if face_frame is not None:
+                    inward, face_point = face_frame
+                    new_matrix = tool.Model.get_filling_rotation(inward)
+                    new_matrix.translation.x = face_point.x
+                    new_matrix.translation.y = face_point.y
                 else:
-                    new_matrix.translation.x = point_on_side_axis.x
-                    new_matrix.translation.y = point_on_side_axis.y
-                    new_matrix = new_matrix @ Matrix.Rotation(radians(180.0), 4, "Z")
+                    axes = tool.Model.get_wall_axis(voided_obj, layers=layers)
+                    axis_base = axes["base"]
+                    axis_side = axes["side"]
+                    new_matrix = voided_obj.matrix_world.copy()
+                    point_on_base_axis = tool.Cad.point_on_edge(target, axis_base)
+                    point_on_side_axis = tool.Cad.point_on_edge(target, axis_side)
+                    if (point_on_base_axis - target).length <= (point_on_side_axis - target).length:
+                        new_matrix.translation.x = point_on_base_axis.x
+                        new_matrix.translation.y = point_on_base_axis.y
+                    else:
+                        new_matrix.translation.x = point_on_side_axis.x
+                        new_matrix.translation.y = point_on_side_axis.y
+                        new_matrix = new_matrix @ Matrix.Rotation(radians(180.0), 4, "Z")
 
                 if should_set_z_level:
                     if filling.is_a("IfcDoor"):

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -1114,6 +1114,96 @@ class Model(bonsai.core.tool.Model):
         return axes
 
     @classmethod
+    def has_layer2_reference_line(cls, element: ifcopenshell.entity_instance) -> bool:
+        """True when the element's local X is the wall reference line.
+
+        Only an ``IfcMaterialLayerSetUsage`` with ``AXIS2`` and a non-zero
+        layer set establishes that; ``get_wall_axis`` and every caller that
+        offsets from ``bound_box`` min_x/max_x are only meaningful then."""
+        material = ifcopenshell.util.element.get_material(element)
+        if material is None or not material.is_a("IfcMaterialLayerSetUsage"):
+            return False
+        if material.LayerSetDirection != "AXIS2":
+            return False
+        layer_set = material.ForLayerSet
+        if layer_set is None:
+            return False
+        return sum(layer.LayerThickness for layer in layer_set.MaterialLayers or ()) > 0
+
+    @classmethod
+    def get_run_axis(cls, obj: bpy.types.Object) -> Union[Vector, None]:
+        """World-space direction of the object's greatest horizontal extent.
+
+        Read off the mesh rather than the placement, so it stays right for
+        imported walls whose local X is not the wall run."""
+        mesh = obj.data
+        if not isinstance(mesh, bpy.types.Mesh) or len(mesh.vertices) < 2:
+            return None
+        matrix = obj.matrix_world
+        co = np.array([(matrix @ v.co)[:2] for v in mesh.vertices])
+        co -= co.mean(axis=0)
+        if not np.isfinite(co).all():
+            return None
+        try:
+            _, _, vt = np.linalg.svd(co, full_matrices=False)
+        except np.linalg.LinAlgError:
+            return None
+        axis = Vector((float(vt[0][0]), float(vt[0][1]), 0.0))
+        if axis.length < 1e-9:
+            return None
+        axis = axis.normalized()
+        across = Vector((-axis.y, axis.x, 0.0))
+        along_extent = np.ptp(co @ np.array([axis.x, axis.y]))
+        across_extent = np.ptp(co @ np.array([across.x, across.y]))
+        # A host that is as deep as it is long has no run direction to read off;
+        # the principal axis is then numerically arbitrary and would flip
+        # between neighbouring hosts.
+        if along_extent < 1.2 * across_extent:
+            return None
+        return axis
+
+    @classmethod
+    def get_wall_face_frame(cls, obj: bpy.types.Object, point: Vector) -> Union[tuple[Vector, Vector], None]:
+        """``(into-the-wall horizontal normal, point on the face)`` at ``point``.
+
+        Both in world space, and the normal is snapped square to the run axis
+        so a filling ends up parallel to the wall even on a faceted face.
+        ``None`` when the object has no faces, when nothing lies near
+        ``point``, or when the nearest face is an end cap or a top rather than
+        a face a filling can sit in."""
+        mesh = obj.data
+        if not isinstance(mesh, bpy.types.Mesh) or not len(mesh.polygons):
+            return None
+        run = cls.get_run_axis(obj)
+        if run is None:
+            return None
+        matrix = obj.matrix_world
+        try:
+            hit, location, normal, _ = obj.closest_point_on_mesh(matrix.inverted() @ point)
+        except RuntimeError:
+            return None
+        if not hit:
+            return None
+        world_normal = (matrix.to_3x3().inverted().transposed() @ normal).normalized()
+        horizontal = Vector((world_normal.x, world_normal.y, 0.0))
+        if horizontal.length < 0.5:
+            return None
+        inward = -horizontal.normalized()
+        across = Vector((-run.y, run.x, 0.0))
+        alignment = across.dot(inward)
+        if abs(alignment) < 0.5:
+            return None
+        return (across if alignment > 0 else -across), matrix @ location
+
+    @classmethod
+    def get_filling_rotation(cls, inward: Vector) -> Matrix:
+        """Rotation putting a filling's local +Y along ``inward`` and +Z up."""
+        y = inward.normalized()
+        z = Vector((0.0, 0.0, 1.0))
+        x = y.cross(z)
+        return Matrix((x, y, z)).transposed().to_4x4()
+
+    @classmethod
     def get_connected_walls(cls, walls: list[bpy.types.Object]) -> list[bpy.types.Object]:
         """
         Loop through walls by retrieving the next connected wall using the connection path.

--- a/src/bonsai/test/tool/test_model_filling_placement.py
+++ b/src/bonsai/test/tool/test_model_filling_placement.py
@@ -1,0 +1,150 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Where a door or window lands when it is dropped into an imported wall.
+
+``get_wall_axis`` reads the wall run off ``bound_box`` min_x/max_x, so every
+caller that positions a filling from it assumes the wall's placement X is the
+wall reference line. Only an IfcMaterialLayerSetUsage makes that true. Across
+a corpus of real models, hosts carrying a plain IfcMaterial, an
+IfcMaterialConstituentSet or a bare IfcMaterialLayerSet produced doors rotated
+by exactly the angle between the placement X and the wall run: 89.11, 84.74,
+43.87, 21.44, 14.32 degrees. ``has_layer2_reference_line`` is the gate that
+sends those hosts down the geometry-derived path instead."""
+
+import ifcopenshell
+import pytest
+
+pytestmark = pytest.mark.model
+
+
+def _wall_with_material(schema, material_builder):
+    ifc = ifcopenshell.file(schema=schema)
+    wall = ifc.create_entity("IfcWall", GlobalId=ifcopenshell.guid.new())
+    material = material_builder(ifc)
+    if material is not None:
+        ifc.create_entity(
+            "IfcRelAssociatesMaterial",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedObjects=[wall],
+            RelatingMaterial=material,
+        )
+    return ifc, wall
+
+
+def _layer_set(ifc, thickness):
+    material = ifc.create_entity("IfcMaterial", Name="Concrete")
+    layer = ifc.create_entity("IfcMaterialLayer", Material=material, LayerThickness=thickness)
+    return ifc.create_entity("IfcMaterialLayerSet", MaterialLayers=[layer], LayerSetName="Wall")
+
+
+def test_layer_set_usage_keeps_the_reference_line_path():
+    from bonsai import tool
+
+    def build(ifc):
+        return ifc.create_entity(
+            "IfcMaterialLayerSetUsage",
+            ForLayerSet=_layer_set(ifc, 0.2),
+            LayerSetDirection="AXIS2",
+            DirectionSense="POSITIVE",
+            OffsetFromReferenceLine=0.0,
+        )
+
+    _ifc, wall = _wall_with_material("IFC4", build)
+    assert tool.Model.has_layer2_reference_line(wall) is True
+
+
+def test_plain_material_has_no_reference_line():
+    from bonsai import tool
+
+    _ifc, wall = _wall_with_material("IFC4", lambda ifc: ifc.create_entity("IfcMaterial", Name="Concrete"))
+    assert tool.Model.has_layer2_reference_line(wall) is False
+
+
+def test_layer_set_without_usage_has_no_reference_line():
+    from bonsai import tool
+
+    _ifc, wall = _wall_with_material("IFC4", lambda ifc: _layer_set(ifc, 0.2))
+    assert tool.Model.has_layer2_reference_line(wall) is False
+
+
+def test_no_material_has_no_reference_line():
+    from bonsai import tool
+
+    _ifc, wall = _wall_with_material("IFC4", lambda ifc: None)
+    assert tool.Model.has_layer2_reference_line(wall) is False
+
+
+def test_axis3_usage_is_not_a_wall_reference_line():
+    from bonsai import tool
+
+    def build(ifc):
+        return ifc.create_entity(
+            "IfcMaterialLayerSetUsage",
+            ForLayerSet=_layer_set(ifc, 0.2),
+            LayerSetDirection="AXIS3",
+            DirectionSense="POSITIVE",
+            OffsetFromReferenceLine=0.0,
+        )
+
+    _ifc, wall = _wall_with_material("IFC4", build)
+    assert tool.Model.has_layer2_reference_line(wall) is False
+
+
+def test_zero_thickness_layer_set_has_no_usable_reference_line():
+    from bonsai import tool
+
+    def build(ifc):
+        return ifc.create_entity(
+            "IfcMaterialLayerSetUsage",
+            ForLayerSet=_layer_set(ifc, 0.0),
+            LayerSetDirection="AXIS2",
+            DirectionSense="POSITIVE",
+            OffsetFromReferenceLine=0.0,
+        )
+
+    _ifc, wall = _wall_with_material("IFC4", build)
+    assert tool.Model.has_layer2_reference_line(wall) is False
+
+
+def test_filling_rotation_puts_local_y_into_the_wall_and_z_up():
+    from mathutils import Vector
+
+    from bonsai import tool
+
+    inward = Vector((0.0, 1.0, 0.0))
+    matrix = tool.Model.get_filling_rotation(inward)
+    assert (matrix.to_3x3() @ Vector((0.0, 1.0, 0.0)) - inward).length < 1e-6
+    assert (matrix.to_3x3() @ Vector((0.0, 0.0, 1.0)) - Vector((0.0, 0.0, 1.0))).length < 1e-6
+    assert matrix.to_3x3().determinant() == pytest.approx(1.0)
+
+
+def test_filling_rotation_follows_a_skewed_wall_face():
+    import math
+
+    from mathutils import Vector
+
+    from bonsai import tool
+
+    inward = Vector((math.cos(math.radians(37.0)), math.sin(math.radians(37.0)), 0.0))
+    matrix = tool.Model.get_filling_rotation(inward)
+    local_x = matrix.to_3x3() @ Vector((1.0, 0.0, 0.0))
+    assert abs(local_x.dot(inward)) < 1e-6
+    assert abs(local_x.z) < 1e-6


### PR DESCRIPTION
`Model.get_wall_axis` derives a wall's run from its bounding box on the host's **local X**:

```python
x_values = [v[0] for v in obj.bound_box]
min_x = min(x_values)
max_x = max(x_values)
```

That is only the reference line when an `IfcMaterialLayerSetUsage` says so. Many imported hosts have no layer set usage at all, and for those the local X axis is not the wall run, so the filling comes out rotated by exactly that mismatch.

Measured across an 81 model corpus: in **every** misoriented case the door's angle against the wall equalled the wall's own local X mismatch to two decimal places, and **every one** was a host without a layer set usage.

```
89.11 deg   Stevens_St, Verona_3_Season_Porch
84.74 deg   220133_FR01
43.87 deg   Untitled101
14.32 deg   Untitled101
21.44 deg   BWFI
 6.15 deg   BWFI
```

The same assumption also placed a door **4.08 m away** from the click on one file.

## Fix

Fillings on hosts without a reference line are placed from the clicked wall face instead. The preview decorator uses the same two helpers, so the hover ghost and the final placement stay identical.

Hosts that do have a layer set usage are unaffected, and an earlier unguarded version of this change was rejected because it regressed 4 placements on another model; the guarded version fixes 2 and regresses 0.

## Note for reviewers

Touches `opening.py` and `tool/model.py`, shared with two sibling PRs from the same investigation. Independent defects, any merge order, small rebase for whichever lands later.

Generated with the assistance of an AI coding tool.
