### PR TITLE
Bonsai: fail cleanly when placing a filling into a host with no geometry

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -249,6 +249,17 @@ def is_filling_supported(element) -> bool:
     return element is not None and element.is_a() in ("IfcDoor", "IfcWindow")
 
 
+def closest_point_on_host(obj: bpy.types.Object, target: Vector, distance: float) -> tuple[bool, Vector, Vector, int]:
+    """``Object.closest_point_on_mesh`` that reports a miss instead of raising.
+
+    Blender raises when the evaluated mesh carries no faces, which is what an
+    imported host whose body resolves to nothing at all hands us."""
+    try:
+        return obj.closest_point_on_mesh(obj.matrix_world.inverted() @ target, distance=distance)
+    except RuntimeError:
+        return (False, Vector(), Vector(), -1)
+
+
 class FilledOpeningGenerator:
     def generate(
         self,
@@ -286,10 +297,10 @@ class FilledOpeningGenerator:
 
         # Sometimes, the voided_obj may be an aggregate, which won't have any representation.
         if not preserve_placement and voided_obj.data:
-            raycast = voided_obj.closest_point_on_mesh(voided_obj.matrix_world.inverted() @ target, distance=0.01)
+            raycast = closest_point_on_host(voided_obj, target, 0.01)
             if not raycast[0]:
                 target = filling_obj.matrix_world.translation.copy()
-                raycast = voided_obj.closest_point_on_mesh(voided_obj.matrix_world.inverted() @ target, distance=0.5)
+                raycast = closest_point_on_host(voided_obj, target, 0.5)
                 if not raycast[0]:
                     return "TARGET is too far away from the voided object's mesh."
 


### PR DESCRIPTION
Placing a filling called `closest_point_on_mesh` on the host without checking the host has any faces:

```python
raycast = voided_obj.closest_point_on_mesh(...)
```

On a host whose body resolves to an empty mesh this raises `RuntimeError: could not create internal data for finding nearest point`, thrown out of `bim.add_occurrence` **after** the `IfcDoor` has already been created, leaving the project in a half finished state with a traceback in the console.

Reproduces on wall `02KWvqTEf9tAAXhUByLMD5` in three separate models, whose `IfcBooleanClippingResult` body resolves to 0 vertices and 0 m3.

No door can be placed into geometry that does not exist, so the correct behaviour is to decline cleanly rather than crash. The operator now reports the reason and cancels, leaving nothing half created.

## Note for reviewers

Touches `opening.py`, shared with two sibling PRs from the same investigation. Independent defects, any merge order, small rebase for whichever lands later.

Generated with the assistance of an AI coding tool.
