### PR TITLE
Bonsai: stop routing non-profile types into the polyline profile tool (#9006)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -59,11 +59,10 @@ class DumbProfileGenerator:
         self.insertion_type = insertion_type
         self.file = tool.Ifc.get()
         self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
-        material = ifcopenshell.util.element.get_material(self.relating_type)
-        if material and material.is_a("IfcMaterialProfileSet"):
-            self.profile_set = material
-        else:
+        profile_set = tool.Model.get_material_profile_set(self.relating_type)
+        if not profile_set:
             return
+        self.profile_set = profile_set
 
         self.body_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
         self.axis_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Axis", "GRAPH_VIEW")
@@ -1151,7 +1150,11 @@ class DrawPolylineProfile(bpy.types.Operator, PolylineOperator, tool.Ifc.Operato
 
         model_props = tool.Model.get_model_props()
 
-        profiles, is_polyline_closed = DumbProfileGenerator(self.relating_type).generate("POLYLINE")
+        result = DumbProfileGenerator(self.relating_type).generate("POLYLINE")
+        if result is None:
+            self.report({"WARNING"}, "The selected type has no profile to draw with.")
+            return {"CANCELLED"}
+        profiles, is_polyline_closed = result
         if profiles:
             if is_polyline_closed:
                 for profile1, profile2 in zip(profiles, profiles[1:] + [profiles[0]]):

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -1184,9 +1184,10 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
             return bpy.ops.bim.draw_polyline_wall("INVOKE_DEFAULT")
         elif tool.Model.get_usage_type(relating_type) == "LAYER3":
             return bpy.ops.bim.draw_polyline_slab("INVOKE_DEFAULT")
-        elif tool.Model.get_usage_type(relating_type) == "PROFILE" and relating_type_class not in (
-            "IfcColumnType",
-            "IfcPileType",
+        elif (
+            tool.Model.get_usage_type(relating_type) == "PROFILE"
+            and relating_type_class not in ("IfcColumnType", "IfcPileType")
+            and tool.Model.get_material_profile_set(relating_type)
         ):
             return bpy.ops.bim.draw_polyline_profile("INVOKE_DEFAULT")
         return bpy.ops.bim.draw_occurrence("INVOKE_DEFAULT")

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -699,6 +699,7 @@ class Model:
     def has_underside_connection(cls, element): pass
     def get_manual_booleans(cls, element): pass
     def get_material_layer_parameters(cls, element): pass
+    def get_material_profile_set(cls, element): pass
     def get_slab_clipping_bmesh(cls, obj): pass
     def get_usage_type(cls, element): pass
     def get_wall_axis(cls, obj, layers=None): pass

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -1042,6 +1042,23 @@ class Model(bonsai.core.tool.Model):
             return material.MaterialProfiles[0].Profile
 
     @classmethod
+    def get_material_profile_set(
+        cls, element: ifcopenshell.entity_instance
+    ) -> Union[ifcopenshell.entity_instance, None]:
+        """The material an element (or type) needs for ``DumbProfileGenerator`` to draw it.
+
+        Unlike :func:`get_usage_type`, this only accepts a genuine
+        ``IfcMaterialProfileSet``. An ``IfcMaterialProfileSetUsage`` also makes
+        ``get_usage_type`` report ``"PROFILE"``, but ``DumbProfileGenerator``
+        can't draw from a usage, so callers routing into the polyline profile
+        tool must check this, not just the usage type.
+        """
+        material = ifcopenshell.util.element.get_material(element)
+        if material and material.is_a("IfcMaterialProfileSet"):
+            return material
+        return None
+
+    @classmethod
     def get_usage_type(
         cls, element: ifcopenshell.entity_instance
     ) -> Optional[Literal["LAYER1", "LAYER2", "LAYER3", "PROFILE"]]:

--- a/src/bonsai/test/bim/module/model/test_draw_polyline_profile_none_generate.py
+++ b/src/bonsai/test/bim/module/model/test_draw_polyline_profile_none_generate.py
@@ -1,0 +1,168 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression test for #9006: the Door Tool's "Add" button crashed when the
+selected relating type reached ``bim.draw_polyline_profile`` without a real
+``IfcMaterialProfileSet``.
+
+``DumbProfileGenerator.generate()`` already documents ``None`` as a valid
+return in its own type annotation, and hits it whenever the relating type
+has no ``IfcMaterialProfileSet`` (e.g. a plain ``IfcDoorType``, or a type
+carrying an ``IfcMaterialProfileSetUsage`` instead of the raw Set -
+``get_usage_type()`` treats both as ``"PROFILE"``, but only the raw Set is
+drawable). ``create_profiles_from_polyline`` used to unpack that ``None``
+unconditionally, raising ``TypeError: cannot unpack non-iterable NoneType
+object`` - exactly the crash reported in #9006.
+
+The fix has two layers, both covered here:
+1. ``tool.Model.get_material_profile_set`` is the single source of truth for
+   "can DumbProfileGenerator actually draw this", now shared by both the
+   generator and the routing decision in ``hotkey_S_A``
+   (``bonsai/bim/module/model/workspace.py``) that picks
+   ``bim.draw_polyline_profile`` vs. ``bim.draw_occurrence``.
+2. ``create_profiles_from_polyline`` no longer unpacks a ``None`` result -
+   it reports a warning and cancels instead of crashing, so any other path
+   that reaches this operator degrades gracefully too."""
+
+from unittest.mock import Mock, patch
+
+import ifcopenshell
+import pytest
+
+pytestmark = pytest.mark.model
+
+
+def _make_file():
+    return ifcopenshell.file(schema="IFC4")
+
+
+def _make_door_type(ifc_file):
+    return ifc_file.create_entity(
+        "IfcDoorType",
+        GlobalId=ifcopenshell.guid.new(),
+        PredefinedType="DOOR",
+    )
+
+
+def _assign_profile_set_usage(ifc_file, element):
+    """Mirrors what a real IfcMaterialProfileSetUsage association looks
+    like: get_usage_type() reports "PROFILE" for it, but it is not a
+    genuine IfcMaterialProfileSet."""
+    profile = ifc_file.create_entity(
+        "IfcRectangleProfileDef", ProfileName="Test Profile", ProfileType="AREA", XDim=0.1, YDim=0.1
+    )
+    material = ifc_file.create_entity("IfcMaterial", Name="Test Material")
+    material_profile = ifc_file.create_entity("IfcMaterialProfile", Material=material, Profile=profile)
+    profile_set = ifc_file.create_entity("IfcMaterialProfileSet", MaterialProfiles=[material_profile])
+    usage = ifc_file.create_entity("IfcMaterialProfileSetUsage", ForProfileSet=profile_set, CardinalPoint=5)
+    ifc_file.create_entity(
+        "IfcRelAssociatesMaterial",
+        GlobalId=ifcopenshell.guid.new(),
+        RelatedObjects=[element],
+        RelatingMaterial=usage,
+    )
+    return profile_set
+
+
+def _assign_profile_set(ifc_file, element):
+    profile = ifc_file.create_entity(
+        "IfcRectangleProfileDef", ProfileName="Test Profile", ProfileType="AREA", XDim=0.1, YDim=0.1
+    )
+    material = ifc_file.create_entity("IfcMaterial", Name="Test Material")
+    material_profile = ifc_file.create_entity("IfcMaterialProfile", Material=material, Profile=profile)
+    profile_set = ifc_file.create_entity("IfcMaterialProfileSet", MaterialProfiles=[material_profile])
+    ifc_file.create_entity(
+        "IfcRelAssociatesMaterial",
+        GlobalId=ifcopenshell.guid.new(),
+        RelatedObjects=[element],
+        RelatingMaterial=profile_set,
+    )
+    return profile_set
+
+
+def test_get_material_profile_set_rejects_type_with_no_material():
+    from bonsai import tool
+
+    ifc_file = _make_file()
+    door_type = _make_door_type(ifc_file)
+
+    assert tool.Model.get_material_profile_set(door_type) is None
+
+
+def test_get_material_profile_set_rejects_profile_set_usage():
+    """get_usage_type() reports "PROFILE" for an IfcMaterialProfileSetUsage,
+    but DumbProfileGenerator can't draw from a usage - get_material_profile_set
+    must reject it too, or the two functions disagree again."""
+    from bonsai import tool
+
+    ifc_file = _make_file()
+    door_type = _make_door_type(ifc_file)
+    _assign_profile_set_usage(ifc_file, door_type)
+
+    assert tool.Model.get_usage_type(door_type) == "PROFILE"
+    assert tool.Model.get_material_profile_set(door_type) is None
+
+
+def test_get_material_profile_set_accepts_genuine_profile_set():
+    from bonsai import tool
+
+    ifc_file = _make_file()
+    door_type = _make_door_type(ifc_file)
+    profile_set = _assign_profile_set(ifc_file, door_type)
+
+    assert tool.Model.get_material_profile_set(door_type) == profile_set
+
+
+def test_generate_polyline_returns_none_instead_of_raising_for_ineligible_type():
+    """The exact call at the #9006 crash site: DumbProfileGenerator(relating_type)
+    .generate("POLYLINE") must return None (not raise) when relating_type has
+    no drawable profile set, matching its own documented return type."""
+    from bonsai import tool
+    from bonsai.bim.module.model.profile import DumbProfileGenerator
+
+    ifc_file = _make_file()
+    door_type = _make_door_type(ifc_file)
+    _assign_profile_set_usage(ifc_file, door_type)
+
+    with patch.object(tool.Ifc, "get", return_value=ifc_file):
+        result = DumbProfileGenerator(door_type).generate("POLYLINE")
+
+    assert result is None
+
+
+def test_create_profiles_from_polyline_reports_and_cancels_instead_of_crashing():
+    """Regression test for the reported TypeError: unbound-call
+    create_profiles_from_polyline with a duck-typed operator ``self`` so the
+    exact #9006 crash site is exercised without a full modal operator."""
+    from bonsai.bim.module.model.profile import DrawPolylineProfile
+
+    ifc_file = _make_file()
+    door_type = _make_door_type(ifc_file)
+    _assign_profile_set_usage(ifc_file, door_type)
+
+    fake_self = Mock()
+    fake_self.relating_type = door_type
+
+    with patch("bonsai.bim.module.model.profile.tool.Ifc.get", return_value=ifc_file):
+        result = DrawPolylineProfile.create_profiles_from_polyline(fake_self, context=Mock())
+
+    assert result == {"CANCELLED"}
+    fake_self.report.assert_called_once()
+    assert fake_self.report.call_args.args[0] == {"WARNING"}


### PR DESCRIPTION
Fixes #9006.

Reported by @PahlawanJoey: activate the Door Tool, click Add to create a new Door Type, keep it selected, then draw the placement line. The operation fails and no door is created.

```
File ".../bim/module/model/profile.py", in create_profiles_from_polyline
    profiles, is_polyline_closed = DumbProfileGenerator(self.relating_type).generate("POLYLINE")
TypeError: cannot unpack non-iterable NoneType object
```

`DumbProfileGenerator.generate` returns `None` when the relating type has no genuine `IfcMaterialProfileSet`, and its own type annotation already declares `None` as a valid return. The caller unpacked it into two variables regardless.

The routing is the deeper problem. `Model.get_usage_type` reports `"PROFILE"` for both `IfcMaterialProfileSet` and `IfcMaterialProfileSetUsage`, but `DumbProfileGenerator` only accepts the former, so a type can pass the routing check and then crash. Guarding the unpack alone would stop the traceback but leave the user drawing a line that silently does nothing, which is close to what was reported.

## Fix, at two layers

- `Model.get_material_profile_set` becomes the single source of truth for whether the polyline profile tool can draw a given type, used by both the generator and the hotkey routing. An ineligible type now routes to `bim.draw_occurrence`, the correct door placement flow, instead of a dead end.
- `create_profiles_from_polyline` reports and cancels instead of unpacking blindly, as defence in depth.

Regression test included, proven to reproduce the reported traceback with the caller fix reverted.

Not a recent regression: the bare `return` dates from 2021 and the unguarded unpack from January 2025.

The second traceback in the report, from `slab.py` `disable_editing_extrusion_profile`, is independent rather than a cascade. It comes from a viewport draw handler installed by the unrelated edit extrusion profile feature, which fires on any redraw with no active object.

Generated with the assistance of an AI coding tool.
