### PR TITLE
Bonsai: fix AXIS1 material layer offset applied to wrong axis in drawings

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -1931,7 +1931,7 @@ class CutDecorator:
             no = tool.Drawing.get_extrusion_vector(element).normalized()
             no = Vector([0.0, 0.0, 1.0])
         elif usage.LayerSetDirection == "AXIS1":
-            co = Vector((0.0, 0.0, offset))
+            co = Vector((offset, 0.0, 0.0))
             no = tool.Drawing.get_extrusion_vector(element).normalized()
             no = Vector([1.0, 0.0, 0.0])
         else:

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -821,7 +821,7 @@ class CreateDrawing(bpy.types.Operator):
                 no = tool.Drawing.get_extrusion_vector(element).normalized()
                 no = Vector([0.0, 0.0, 1.0])
             elif usage.LayerSetDirection == "AXIS1":
-                co = Vector((0.0, 0.0, offset))
+                co = Vector((offset, 0.0, 0.0))
                 no = tool.Drawing.get_extrusion_vector(element).normalized()
                 no = Vector([1.0, 0.0, 0.0])
             else:

--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -1097,7 +1097,7 @@ class Loader(bonsai.core.tool.Loader):
             no = cls.get_extrusion_vector(element).normalized()
             no = Vector([0.0, 0.0, 1.0])
         elif layer_set_direction == "AXIS1":
-            co = Vector((0.0, 0.0, offset))
+            co = Vector((offset, 0.0, 0.0))
             no = cls.get_extrusion_vector(element).normalized()
             no = Vector([1.0, 0.0, 0.0])
         else:


### PR DESCRIPTION
## Summary

`generate_material_layers` (drawing/operator.py), CutDecorator's viewport
fill (drawing/decoration.py), and slice_layerset_mesh (tool/loader.py) each
walk the material layer set along local X when LayerSetDirection is AXIS1,
but started that walk at Vector((0.0, 0.0, offset)), placing
OffsetFromReferenceLine on Z instead of X. Since the bisect plane's normal
is (1, 0, 0), the Z component has no effect on where the cut lands, so the
offset was silently dropped and every layer boundary on an AXIS1 element
was drawn as if the offset were 0.0.

AXIS2 and AXIS3 already start the walk on the same axis they walk along;
this brings AXIS1 in line with them.

Fixes #9001.

## Root cause

Each of the three files had:

```python
elif usage.LayerSetDirection == "AXIS1":
    co = Vector((0.0, 0.0, offset))   # offset on Z
    no = tool.Drawing.get_extrusion_vector(element).normalized()
    no = Vector([1.0, 0.0, 0.0])      # walk along X
```

Fixed to `co = Vector((offset, 0.0, 0.0))` in all three call sites.

## Test plan

- [x] Reproduced live in headless Blender using the repro file attached to
      #9001 (four layered walls, two AXIS2, two AXIS1, each with a real
      OffsetFromReferenceLine).
- [x] Instrumented `bmesh.ops.bisect_plane` to record the actual bisect
      plane coordinates `generate_material_layers` computes for each wall.
- [x] Before the fix: AXIS1 walls' first layer-bisect landed at the wrong
      coordinate (offset dropped); AXIS2 walls were already correct.
- [x] After the fix: all four walls land on the expected coordinate.
- [x] Ran the real `bpy.ops.bim.create_drawing()` operator end-to-end;
      completes without error.
- [x] black + ruff clean on all three changed files.

Generated with the assistance of an AI coding tool.