### PR TITLE
ifcmcp: pin mcp below 2.0 to fix broken FastMCP import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,9 @@ jobs:
           cd ../ifcquery && make test || ERROR=1
           pip install -e ../ifcedit --no-deps
           cd ../ifcedit && make test || ERROR=1
-          pip install mcp
+          # Pinned <2: mcp 2.0.0 renamed mcp.server.fastmcp.FastMCP to
+          # mcp.server.mcpserver.MCPServer, which ifcmcp doesn't support yet.
+          pip install "mcp>=1.0,<2"
           pip install -e ../ifcmcp --no-deps
           cd ../ifcmcp && make test || ERROR=1
           pip install -e ../ifctester --no-deps

--- a/src/ifcmcp/ifcmcp/server.py
+++ b/src/ifcmcp/ifcmcp/server.py
@@ -9,7 +9,7 @@ from ifcmcp.core import IfcSession
 try:
     from mcp.server.fastmcp import FastMCP  # type: ignore
     from mcp.types import ImageContent  # type: ignore
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     FastMCP = None  # type: ignore
     ImageContent = None  # type: ignore
 

--- a/src/ifcmcp/pyproject.toml
+++ b/src/ifcmcp/pyproject.toml
@@ -18,7 +18,9 @@ classifiers = [
 dependencies = ["ifcopenshell", "ifcquery", "ifcedit"]
 
 [project.optional-dependencies]
-mcp = ["mcp"]
+# Pinned <2: mcp 2.0.0 renamed mcp.server.fastmcp.FastMCP to
+# mcp.server.mcpserver.MCPServer, which this package doesn't support yet.
+mcp = ["mcp>=1.0,<2"]
 
 [project.scripts]
 ifcmcp = "ifcmcp.__main__:main"


### PR DESCRIPTION
`mcp` 2.0.0 removed the `mcp.server.fastmcp` module, which `ifcmcp/server.py` imports. Every CI run since that release fails `ifcmcp`'s own test suite, so **every open PR in this repository currently shows a red `compile-and-test`** regardless of what it changes.

Verified in a clean venv:

- **mcp 2.0.0**: `from mcp.server.fastmcp import FastMCP` raises `ModuleNotFoundError: No module named 'mcp.server.fastmcp'`. No `FastMCP` symbol exists anywhere else in the package; the replacement is `mcp.server.mcpserver.MCPServer`, confirmed present.
- **mcp 1.29.0**, the highest release below 2.0: both `FastMCP` and `ImageContent` import cleanly.

Both declarations were unpinned. The workflow pin unbreaks CI. The `pyproject.toml` pin matters beyond CI, since `pip install ifcopenshell-mcp[mcp]` currently installs a version the code cannot use.

This also narrows the import guard from `except Exception` to `except ImportError`. The bare catch reported an upstream API removal as "FastMCP is not installed", which sent the diagnosis in the wrong direction.

Porting `ifcmcp` to the mcp 2.x API is a separate change and is not attempted here.

This PR was generated with the assistance of an AI coding tool.
