### PR TITLE
validate: fix --json crashing on messages containing a percent sign

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -97,7 +97,14 @@ class json_logger:
         self.state[key] = value
 
     def log(self, level, message, *args):
-        self.statements.append({"level": level, "message": message % args, **self.state})
+        # Mirror logging.LogRecord.getMessage(): only apply %-formatting when args
+        # are actually supplied. Several call sites pass a pre-built message (e.g.
+        # str(ValidationError), which can embed arbitrary IFC content such as a
+        # Name containing a literal "%s"). Unconditionally formatting with an
+        # empty args tuple would raise instead of logging the error.
+        if args:
+            message = message % args
+        self.statements.append({"level": level, "message": message, **self.state})
 
     def __getattr__(self, level):
         return functools.partial(self.log, level)

--- a/src/ifcopenshell-python/test/fixtures/validate/fail-json-logger-percent-in-message.ifc
+++ b/src/ifcopenshell-python/test/fixtures/validate/fail-json-logger-percent-in-message.ifc
@@ -1,0 +1,16 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPERSON($,$,$,$,$,$,$,$);
+#2=IFCORGANIZATION($,'Org',$,$,$);
+#3=IFCPERSONANDORGANIZATION(#1,#2,$);
+#4=IFCAPPLICATION(#2,'1.0','App','app');
+#5=IFCOWNERHISTORY(#3,#4,$,.ADDED.,$,$,$,0);
+#20=IFCANNOTATION('1000000000000000000009',#5,'Filled region 40%s green',$,$,$,$);
+#21=IFCANNOTATION('1000000000000000000001',#5,'Bad placement ref',$,$,#20,$);
+ENDSEC;
+END-ISO-10303-21;


### PR DESCRIPTION
Fixes #2481.

`json_logger.log` at `src/ifcopenshell-python/ifcopenshell/validate.py:99` applies `%` formatting unconditionally:

```python
self.statements.append({"level": level, "message": message % args, **self.state})
```

Several call sites pass a fully built message with no args, for example `logger.error(str(e))` at lines 570, 585 and 594. That message is `str(ValidationError)`, which embeds arbitrary content from the file being validated, including attribute values and entity names. When that content contains a literal `%` followed by a conversion character, `message % ()` raises `TypeError: not enough arguments for format string` and the whole validation run aborts, which is the traceback @cadgiru reported.

The fix mirrors `logging.LogRecord.getMessage()` and only substitutes when there are args to substitute.

Reproduced from scratch against unmodified `v0.8.0` with an `IfcAnnotation` named `Filled region 40%s green`, giving the same `TypeError` at the same line. Red on baseline with the new fixture, green after: 39 passed, including the 38 pre-existing `test_validate.py` cases. Real `%` substitution still works, confirmed with the duplicate-GlobalId message that does pass args.

Note on history: this issue was previously closed by this account with an incorrect analysis, and @Moult reopened it for a human to verify. The root cause above was re-derived from scratch rather than carried over from that comment.

This PR was generated with the assistance of an AI coding tool.
