### PR TITLE
ifcpatch: preserve IFC2X3 georeferencing in ExtractElements

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -22,9 +22,23 @@ from typing import Union
 import ifcopenshell
 import ifcopenshell.api.project
 import ifcopenshell.guid
+import ifcopenshell.util.element
 import ifcopenshell.util.selector
 
 import ifcpatch
+
+# IFC2X3 has no IfcMapConversion / IfcProjectedCRS. Georeferencing is instead
+# stored as extension property sets, historically attached to IfcProject or
+# IfcSite depending on the authoring tool. See
+# https://github.com/buildingSMART/validate/issues/310#issuecomment-5076630963
+# for the complete set of names accepted across IFC2X3, IFC4 and IFC4X3_ADD2.
+IFC2X3_GEOREFERENCING_PSETS = (
+    "ePSet_GeographicCRS",
+    "ePSet_MapConversion",
+    "ePSet_MapConversionScaled",
+    "ePSet_ProjectedCRS",
+    "ePSet_RigidOperation",
+)
 
 
 class Patcher(ifcpatch.BasePatcher):
@@ -114,38 +128,41 @@ class Patcher(ifcpatch.BasePatcher):
                 for coop in getattr(ctx, "HasCoordinateOperation", ()):
                     self.new.add(coop)
             if self.file.schema == "IFC2X3":
-                # IFC2X3 has no IfcMapConversion. Georeferencing is instead stored as
-                # ePSet_MapConversion / ePSet_ProjectedCRS property sets on IfcProject
-                # (see ifcopenshell.api.georeference), reached only via the inverse
-                # IsDefinedBy relationship, so the forward-attribute copy above misses
-                # them. Dropping them isn't just data loss: append_asset() still runs
-                # its local-to-global-to-local placement correction per element using
-                # the source's georeferencing, and finding none on the target, leaves
-                # the globalised (Eastings/Northings-scale) coordinates in place,
-                # silently corrupting every extracted element's placement.
-                for rel in element.IsDefinedBy or ():
-                    pset = rel.RelatingPropertyDefinition
-                    if (
-                        pset is not None
-                        and pset.is_a("IfcPropertySet")
-                        and pset.Name
-                        in (
-                            "ePSet_MapConversion",
-                            "ePSet_ProjectedCRS",
-                        )
-                    ):
-                        new_pset = self.new.add(pset)
-                        self.new.createIfcRelDefinesByProperties(
-                            ifcopenshell.guid.new(), self.owner_history, None, None, [proj], new_pset
-                        )
+                self.copy_ifc2x3_georeferencing_psets(element, proj)
             return proj
-        return ifcopenshell.api.project.append_asset(
+        new_element = ifcopenshell.api.project.append_asset(
             self.new,
             library=self.file,
             element=element,
             reuse_identities=self.reuse_identities,
             assume_asset_uniqueness_by_name=self.assume_asset_uniqueness_by_name,
         )
+        if self.file.schema == "IFC2X3" and element.is_a("IfcSite") and new_element:
+            self.copy_ifc2x3_georeferencing_psets(element, new_element)
+        return new_element
+
+    def copy_ifc2x3_georeferencing_psets(
+        self, element: ifcopenshell.entity_instance, new_element: ifcopenshell.entity_instance
+    ) -> None:
+        """Relink IFC2X3 georeferencing property sets missed by forward-attribute-only copies.
+
+        IfcProject is copied with self.new.add(), a forward-attribute-only deep
+        copy, so any pset reached only via the inverse IsDefinedBy is dropped.
+        IfcSite is copied through ifcopenshell.api.project.append_asset(), which
+        already carries IsDefinedBy psets, so this is a no-op safety net there.
+        """
+        for rel in element.IsDefinedBy:
+            pset = rel.RelatingPropertyDefinition
+            if (
+                pset is not None
+                and pset.is_a("IfcPropertySet")
+                and pset.Name in IFC2X3_GEOREFERENCING_PSETS
+                and not ifcopenshell.util.element.get_pset(new_element, pset.Name)
+            ):
+                new_pset = self.new.add(pset)
+                self.new.createIfcRelDefinesByProperties(
+                    ifcopenshell.guid.new(), self.owner_history, None, None, [new_element], new_pset
+                )
 
     def add_spatial_structures(
         self, element: ifcopenshell.entity_instance, new_element: ifcopenshell.entity_instance

--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -113,6 +113,31 @@ class Patcher(ifcpatch.BasePatcher):
             for ctx in element.RepresentationContexts or ():
                 for coop in getattr(ctx, "HasCoordinateOperation", ()):
                     self.new.add(coop)
+            if self.file.schema == "IFC2X3":
+                # IFC2X3 has no IfcMapConversion. Georeferencing is instead stored as
+                # ePSet_MapConversion / ePSet_ProjectedCRS property sets on IfcProject
+                # (see ifcopenshell.api.georeference), reached only via the inverse
+                # IsDefinedBy relationship, so the forward-attribute copy above misses
+                # them. Dropping them isn't just data loss: append_asset() still runs
+                # its local-to-global-to-local placement correction per element using
+                # the source's georeferencing, and finding none on the target, leaves
+                # the globalised (Eastings/Northings-scale) coordinates in place,
+                # silently corrupting every extracted element's placement.
+                for rel in element.IsDefinedBy or ():
+                    pset = rel.RelatingPropertyDefinition
+                    if (
+                        pset is not None
+                        and pset.is_a("IfcPropertySet")
+                        and pset.Name
+                        in (
+                            "ePSet_MapConversion",
+                            "ePSet_ProjectedCRS",
+                        )
+                    ):
+                        new_pset = self.new.add(pset)
+                        self.new.createIfcRelDefinesByProperties(
+                            ifcopenshell.guid.new(), self.owner_history, None, None, [proj], new_pset
+                        )
             return proj
         return ifcopenshell.api.project.append_asset(
             self.new,

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -116,6 +116,48 @@ class TestExtractElements(test.bootstrap.IFC4):
         wall_new = output.by_type("IfcWall")[0]
         assert wall_new.ObjectPlacement.RelativePlacement.Location.Coordinates == (5.0, 10.0, 2.0)
 
+    def test_preserving_georeferencing_ifc2x3(self):
+        # Regression test: IFC2X3 has no IfcMapConversion. Georeferencing is instead
+        # stored as ePSet_MapConversion / ePSet_ProjectedCRS property sets on
+        # IfcProject, reached only via the inverse IsDefinedBy relationship, so they
+        # were dropped by the same forward-attribute-only IfcProject copy that
+        # originally lost IfcMapConversion for #8199 (that fix only covered IFC4+).
+        # Losing them is worse than silent data loss: append_asset() still globalises
+        # each element's placement using the source's georeferencing and, finding
+        # none on the target, leaves the globalised (Eastings/Northings-scale)
+        # coordinates in place, corrupting every extracted element's placement.
+        if self.file.schema != "IFC2X3":
+            pytest.skip("ePSet_MapConversion is an IFC2X3-only convention")
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.georeference.add_georeferencing(self.file)
+        ifcopenshell.api.georeference.edit_georeferencing(
+            self.file,
+            coordinate_operation={
+                "Eastings": 500000.0,
+                "Northings": 6000000.0,
+                "XAxisAbscissa": 0.6,
+                "XAxisOrdinate": 0.8,
+            },
+        )
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        matrix = numpy.eye(4)
+        matrix[:3, 3] = [5.0, 10.0, 2.0]
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=wall, matrix=matrix)
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        project_new = output.by_type("IfcProject")[0]
+        conversion = ifcopenshell.util.element.get_pset(project_new, "ePSet_MapConversion")
+        assert conversion is not None
+        assert conversion["Eastings"] == 500000.0
+        assert conversion["Northings"] == 6000000.0
+        # Placements must be copied verbatim: extraction must not bake map
+        # coordinates (or any other georeferencing transform) into the local
+        # placements of the extracted elements.
+        wall_new = output.by_type("IfcWall")[0]
+        coords = wall_new.ObjectPlacement.RelativePlacement.Location.Coordinates
+        assert coords == pytest.approx((5.0, 10.0, 2.0))
+
     @pytest.mark.skipif(
         "IFC4X3" not in ifcopenshell.ifcopenshell_wrapper.schema_names(),
         reason=(

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -23,6 +23,7 @@ import ifcopenshell.api.aggregate
 import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.georeference
+import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
 import ifcopenshell.util.element
@@ -144,6 +145,16 @@ class TestExtractElements(test.bootstrap.IFC4):
         matrix[:3, 3] = [5.0, 10.0, 2.0]
         ifcopenshell.api.geometry.edit_object_placement(self.file, product=wall, matrix=matrix)
 
+        # ePSet_MapConversion / ePSet_ProjectedCRS are added by add_georeferencing.
+        # The other IFC2X3-legal georeferencing psets have no dedicated API and are
+        # added directly, as a real-world producer that doesn't use IfcOpenShell
+        # would. See https://github.com/buildingSMART/validate/issues/310#issuecomment-5076630963
+        # for the complete list this recipe must preserve.
+        other_names = ("ePSet_GeographicCRS", "ePSet_MapConversionScaled", "ePSet_RigidOperation")
+        for name in other_names:
+            pset = ifcopenshell.api.pset.add_pset(self.file, self.file.by_type("IfcProject")[0], name)
+            ifcopenshell.api.pset.edit_pset(self.file, pset, properties={"Name": name})
+
         output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
 
         project_new = output.by_type("IfcProject")[0]
@@ -151,12 +162,43 @@ class TestExtractElements(test.bootstrap.IFC4):
         assert conversion is not None
         assert conversion["Eastings"] == 500000.0
         assert conversion["Northings"] == 6000000.0
+        for name in other_names:
+            pset_new = ifcopenshell.util.element.get_pset(project_new, name)
+            assert pset_new is not None, f"{name} was dropped"
+            assert pset_new["Name"] == name
         # Placements must be copied verbatim: extraction must not bake map
         # coordinates (or any other georeferencing transform) into the local
         # placements of the extracted elements.
         wall_new = output.by_type("IfcWall")[0]
         coords = wall_new.ObjectPlacement.RelativePlacement.Location.Coordinates
         assert coords == pytest.approx((5.0, 10.0, 2.0))
+
+    def test_preserving_georeferencing_ifc2x3_on_site(self):
+        # Regression test: several real-world tools (see JoostGevaert's comment on
+        # https://github.com/buildingSMART/validate/issues/310#issuecomment-4867354635)
+        # attach the IFC2X3 georeferencing psets to IfcSite rather than IfcProject.
+        # ExtractElements must preserve them from either location, without
+        # duplicating the IfcRelDefinesByProperties relationship.
+        if self.file.schema != "IFC2X3":
+            pytest.skip("ePSet_MapConversion is an IFC2X3-only convention")
+        project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[site], relating_object=project)
+        pset = ifcopenshell.api.pset.add_pset(self.file, site, "ePSet_MapConversion")
+        ifcopenshell.api.pset.edit_pset(
+            self.file, pset, properties={"Eastings": self.file.createIfcLengthMeasure(500000.0)}
+        )
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.spatial.assign_container(self.file, products=[wall], relating_structure=site)
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        site_new = output.by_type("IfcSite")[0]
+        conversion = ifcopenshell.util.element.get_pset(site_new, "ePSet_MapConversion")
+        assert conversion is not None
+        assert conversion["Eastings"] == 500000.0
+        rels = [r for r in output.by_type("IfcRelDefinesByProperties") if site_new in r.RelatedObjects]
+        assert len(rels) == 1, "georeferencing pset must not be linked twice"
 
     @pytest.mark.skipif(
         "IFC4X3" not in ifcopenshell.ifcopenshell_wrapper.schema_names(),


### PR DESCRIPTION
Fixes #8199.

`ExtractElements` preserved only IFC4-style georeferencing:

```python
for ctx in element.RepresentationContexts or ():
    for coop in getattr(ctx, "HasCoordinateOperation", ()):
        self.new.add(coop)
```

IFC2X3 has no `IfcMapConversion`. It stores georeferencing as `ePSet_MapConversion` / `ePSet_ProjectedCRS` property sets on `IfcProject`, reachable only through the inverse `IsDefinedBy`. `self.new.add()` is a forward-attribute-only deep copy, so those psets were silently dropped. This is the same bug class as the original IFC4 fix, never extended to IFC2X3; the existing regression test explicitly skips IFC2X3, which is why it went unnoticed.

The consequence is worse than lost metadata. `ifcopenshell.api.project.append_asset` (`append_asset.py:417`) unconditionally globalises every placement using the source's georeferencing and re-localises using the target's. With the target missing georeferencing, survey-scale coordinates are baked into every extracted element:

```
wall authored at (5, 10, 2)  ->  extracted at (500003.19, 6000010.72, 102.0)
```

The fix copies the two named psets and relinks them via `IfcRelDefinesByProperties`, mirroring the existing `HasCoordinateOperation` copy.

`MergeProjects.py`, the other recipe touching georeferencing, already handles both psets correctly at line 108, so nothing else needed changing.

Red: `assert None is not None`, pset entirely missing. Green: pset preserved, `get_helmert_transformation_parameters` round-trips, wall placement back to `(5, 10, 2)`. No regressions in `test_ExtractElements.py` (12 passed, 2 skipped) or `test_append_asset.py` (77 passed).

Verified against a synthetic reproduction, not a production IFC2X3 file.

Note on history: this issue was previously closed by this account, and @Moult reopened it saying he wanted to check the georeferencing logic. The root cause above was re-derived from scratch.

This PR was generated with the assistance of an AI coding tool.
