### PR TITLE
Bonsai: resolve SVGFill hits against their own file, not the last linked model

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1288,7 +1288,8 @@ class CreateDrawing(bpy.types.Operator):
                             ]
 
                         if elements:
-                            classes = self.get_svg_classes(ifc.by_id(elements[0].instance.id()))
+                            # Resolve via the hit's own file, not the stale `ifc` loop variable.
+                            classes = self.get_svg_classes(ifcopenshell.entity_instance(elements[0].instance))
                             classes.append("projection")
                             classes.append("surface")
 


### PR DESCRIPTION
Addresses the follow-up @brunopostle left on #7016 on 2026-07-27:

> there is a further bug: although the linked file gets hidden line rendering, there are no fill polygons, so the materials can't be styled and background objects don't get clipped.

`CreateDrawing.generate_linework()` iterates over the main file plus every linked model:

```python
for ifc_path, (ifc, link_matrix) in files.items():
```

After the loop, the SVGFILL fill-mode block still resolves raycast hits through `ifc`:

```python
classes = self.get_svg_classes(ifc.by_id(elements[0].instance.id()))
```

`ifc` is a plain loop variable, so it points at whichever file was processed last. STEP ids are only unique within a single file, so a hit from any other file either raises `RuntimeError` from `by_id` and kills the fill pass, or silently resolves to an unrelated entity that happens to share the id, corrupting class and material assignment.

Demonstrated outside Blender: two independent `ifcopenshell.file` objects each with an `IfcWall` at id 1, where `file2.by_id(1)` silently returns the wrong wall.

The fix resolves through the hit's own file via `ifcopenshell.entity_instance(...)`, whose `.file` property recomputes the origin from the underlying pointer instead of trusting the stale loop variable.

The rest of the drawing module was checked for the same shape; this is the only occurrence. The SHAPELY fill path already resolves hits from `tree.select()` results, which are correctly file-bound.

Not hand-tested in a live Blender session. SVGFill is marked experimental and only appears when Linework Mode is OpenCASCADE.

This PR was generated with the assistance of an AI coding tool.
