### PR TITLE
Bonsai: restore the Add From Perimeter and Add From Closed Loop buttons

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/data.py
+++ b/src/bonsai/bonsai/bim/module/model/data.py
@@ -189,6 +189,7 @@ class AuthoringData:
             "description": element.Description or "No Description",
             "predefined_type": predefined_type,
             "icon_id": cls.type_thumbnails.get(element.id(), 0),
+            "usage": tool.Model.get_usage_type(element),
         }
         return data
 

--- a/src/bonsai/test/bim/module/model/test_authoring_data_type_usage.py
+++ b/src/bonsai/test/bim/module/model/test_authoring_data_type_usage.py
@@ -1,0 +1,83 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression test for #6967 ("Generate walls from slab perimeter
+button/icon/feature missing").
+
+``EditObjectUI.draw_operations`` in ``bim/module/model/workspace.py`` draws
+the "Add From Perimeter" button (slab selected, a LAYER2 wall type picked)
+and the "Add From Closed Loop" button (walls selected, a LAYER3 slab type
+picked) by reading ``AuthoringData.data["relating_type_data"].get("usage")``.
+
+Commit b49cc6c5e9 ("AuthoringData.data['relating_type_data']") collapsed
+several separate ``AuthoringData`` fields -- including
+``relating_type_material_usage`` -- into that one dict, built by
+``get_type_data()``, but never carried the usage value across. The two
+``.get("usage")`` reads in workspace.py were left unchanged, so they always
+read ``None`` and both buttons silently disappeared, even though the
+underlying operators (``bim.draw_walls_from_slab`` / ``bim.draw_slab_from_wall``)
+still work fine via the Shift+A hotkey. The feature was never removed, only
+its icon."""
+
+import ifcopenshell
+import ifcopenshell.api.material
+import ifcopenshell.api.root
+import pytest
+
+pytestmark = pytest.mark.model
+
+
+def _make_layered_type(f: ifcopenshell.file, ifc_class: str, name: str) -> ifcopenshell.entity_instance:
+    element_type = ifcopenshell.api.root.create_entity(f, ifc_class=ifc_class, name=name)
+    material = ifcopenshell.api.material.add_material(f, name="Concrete")
+    material_set = ifcopenshell.api.material.add_material_set(f, set_type="IfcMaterialLayerSet")
+    ifcopenshell.api.material.add_layer(f, layer_set=material_set, material=material)
+    ifcopenshell.api.material.assign_material(
+        f, products=[element_type], type="IfcMaterialLayerSet", material=material_set
+    )
+    return element_type
+
+
+def test_get_type_data_reports_usage_for_wall_type():
+    from bonsai.bim.module.model.data import AuthoringData
+
+    f = ifcopenshell.file(schema="IFC4")
+    wall_type = _make_layered_type(f, "IfcWallType", "TestWallType")
+
+    data = AuthoringData.get_type_data(wall_type)
+
+    assert data.get("usage") == "LAYER2", (
+        "relating_type_data must carry 'usage', or the Add From Perimeter "
+        "button in workspace.py's LAYER3 branch never draws"
+    )
+
+
+def test_get_type_data_reports_usage_for_slab_type():
+    from bonsai.bim.module.model.data import AuthoringData
+
+    f = ifcopenshell.file(schema="IFC4")
+    slab_type = _make_layered_type(f, "IfcSlabType", "TestSlabType")
+
+    data = AuthoringData.get_type_data(slab_type)
+
+    assert data.get("usage") == "LAYER3", (
+        "relating_type_data must carry 'usage', or the Add From Closed Loop "
+        "button in workspace.py's LAYER2 branch never draws"
+    )


### PR DESCRIPTION
Fixes #6967.

Both "Add From Perimeter" and "Add From Closed Loop" are gated on a key that is never produced. `bim/module/model/workspace.py:867,881`:

```python
if AuthoringData.data["relating_type_data"].get("usage") == "LAYER3":
```

`AuthoringData.get_type_data()` (`bim/module/model/data.py:181-193`) returns only `id`, `ifc_class`, `name`, `description`, `predefined_type` and `icon_id`. There is no `usage` key, so `.get()` returns `None` and neither button ever draws.

Commit `eab527e7a2` (Jan 2025) added the buttons reading `AuthoringData.data["relating_type_material_usage"]`. Commit `b49cc6c5e9` (Feb 2025, "Simplify lots of data keys to just one dictionary relating_type_data") collapsed that field into `relating_type_data.get("usage")` but never carried the value into `get_type_data()`. The `.get()` swallowed it silently, so both buttons have been invisible for about 17 months while the underlying operators `bim.draw_walls_from_slab` and `bim.draw_slab_from_wall` kept working via Shift+A. The two screenshots on the issue, 0.8.2 with the button and a current build without it in the same panel, match this exactly.

The fix sets `"usage": tool.Model.get_usage_type(element)` in `get_type_data()`.

Verified in headless Blender driving the production path (`bim.load_project`, select object, set `relating_type_id`, `AuthoringData.load()`) and reading the exact condition `workspace.py` evaluates. Red: no `usage` key, button would not draw. Green: `usage` is `LAYER2` and the button would draw; the reverse case with a wall selected and a slab type active gives `LAYER3` and the other button. A regression test on `get_type_data()` is included.

Not clicked through in an interactive session.

This PR was generated with the assistance of an AI coding tool.
