### PR TITLE
Bonsai: fix bSDD class search crashing on classes without a referenceCode

### DIFF
--- a/src/bonsai/bonsai/tool/bsdd.py
+++ b/src/bonsai/bonsai/tool/bsdd.py
@@ -232,11 +232,19 @@ class Bsdd(bonsai.core.tool.Bsdd):
                 )
                 dictionary_name = response.get("name", "")
                 dictionary_namespace_uri = response.get("uri", "")
-                for _class in sorted(response.get("classes", []), key=lambda c: c["referenceCode"]):
+                # `referenceCode`, `name` and `uri` are all optional in the bSDD API
+                # response (see bsdd.ClassListItemContractV1), so classes missing them
+                # must not crash the search. Sort classes with a reference code first,
+                # keeping those without one at the end in their original order.
+                classes = sorted(
+                    response.get("classes", []),
+                    key=lambda c: (c.get("referenceCode") is None, c.get("referenceCode") or ""),
+                )
+                for _class in classes:
                     prop = bprops.classifications.add()
-                    prop.name = _class["name"]
-                    prop.reference_code = _class["referenceCode"]
-                    prop.uri = _class["uri"]
+                    prop.name = _class.get("name", "")
+                    prop.reference_code = _class.get("referenceCode", "")
+                    prop.uri = _class.get("uri", "")
                     prop.dictionary_name = dictionary_name
                     prop.dictionary_namespace_uri = dictionary_namespace_uri
 

--- a/src/bonsai/test/tool/test_bsdd.py
+++ b/src/bonsai/test/tool/test_bsdd.py
@@ -1,0 +1,63 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import bonsai.tool as tool
+from bonsai.tool.bsdd import Bsdd as subject
+from test.bim.bootstrap import NewFile
+
+
+class TestSearchClass(NewFile):
+    def test_classes_missing_reference_code_do_not_crash_the_search(self):
+        # Regression test for #9034: the bSDD API marks `referenceCode` (and
+        # `name`, `uri`) as optional on a class, so a bare subscript on any
+        # of them raised KeyError for dictionaries (e.g. NL-SfB) that return
+        # such a class.
+        class FakeClient:
+            def get_classes(self, **kwargs):
+                return {
+                    "name": "NL-SfB",
+                    "uri": "https://example.org/dictionary/nl-sfb",
+                    "classes": [
+                        {"name": "No Reference Code", "uri": "https://example.org/class/1"},
+                        {"name": "Kolom", "referenceCode": "17", "uri": "https://example.org/class/2"},
+                        {"name": "Fundering", "referenceCode": "16", "uri": "https://example.org/class/3"},
+                    ],
+                }
+
+        original_client = subject.client
+        original_get_classification_props = tool.Classification.get_classification_props
+
+        class FakeClassificationProps:
+            classification_source = "https://example.org/dictionary/nl-sfb"
+
+        subject.client = FakeClient()
+        tool.Classification.get_classification_props = classmethod(lambda cls: FakeClassificationProps())
+        try:
+            total = subject.search_class("keyword", None)
+        finally:
+            subject.client = original_client
+            tool.Classification.get_classification_props = original_get_classification_props
+
+        props = subject.get_bsdd_props()
+        assert total == 3
+        # Classes with a reference code sort first (by code), the class
+        # missing one is kept, sorted last, instead of being dropped.
+        assert [c.name for c in props.classifications] == ["Fundering", "Kolom", "No Reference Code"]
+        assert [c.reference_code for c in props.classifications] == ["16", "17", ""]


### PR DESCRIPTION
Fixes #9034.

`search_class` in `src/bonsai/bonsai/tool/bsdd.py` subscripted `referenceCode`, `name` and `uri` directly. In the `bsdd` client's own type contract (0.8.5) all three are optional:

```python
class ClassListItemContractV1(TypedDict):
    uri: NotRequired[str]
    name: NotRequired[str]
    referenceCode: NotRequired[str]
```

NL-SfB returns at least one class with no `referenceCode`, so the sort key raised `KeyError: 'referenceCode'` and the search failed entirely.

Classes with a reference code now sort first by that code, and classes without one go to the end rather than being dropped, since dropping would silently hide real search results. The three optional fields are read with `.get()`.

The dictionary sort at line 106 is deliberately left alone: `DictionaryContractV1.name` is genuinely required there, so it is not affected.

Verified in headless Blender with a stubbed response and no network. Red reproduces `KeyError: 'referenceCode'` at the reported line; green returns all classes including the one with no code.

@c-mellueh's #7986 touches this file but only `get_class_properties`, so the two do not overlap.

This PR was generated with the assistance of an AI coding tool.
