### PR TITLE
ifc4d: preserve MS Project task lag on import

### DIFF
--- a/src/ifc4d/ifc4d/msp2ifc.py
+++ b/src/ifc4d/ifc4d/msp2ifc.py
@@ -64,9 +64,13 @@ class MSP2Ifc:
         id = 0
         if task.findall("pr:PredecessorLink", self.ns):
             for relationship in task.findall("pr:PredecessorLink", self.ns):
+                link_lag = relationship.find("pr:LinkLag", self.ns)
+                lag_format = relationship.find("pr:LagFormat", self.ns)
                 relationships[id] = {
                     "PredecessorTask": relationship.find("pr:PredecessorUID", self.ns).text,
                     "Type": relationship.find("pr:Type", self.ns).text,
+                    "LinkLag": link_lag.text if link_lag is not None else None,
+                    "LagFormat": lag_format.text if lag_format is not None else None,
                 }
                 id += 1
         return relationships
@@ -76,6 +80,9 @@ class MSP2Ifc:
             hours_per_day = int(self.project["MinutesPerDay"]) / 60
         else:
             hours_per_day = 8
+        # Stored so create_rel_sequences can convert PredecessorLink/LinkLag with the
+        # same calendar-based hours-per-day scaling used for task durations below.
+        self.hours_per_day = hours_per_day
 
         for task in project.find("pr:Tasks", self.ns):
             task_id = task.find("pr:UID", self.ns).text
@@ -357,6 +364,11 @@ class MSP2Ifc:
             "2": "START_FINISH",
             "3": "START_START",
         }
+        # PredecessorLink/LagFormat codes used by MSPDI exports for a calendar
+        # based ("working time") lag versus an elapsed (24/7) lag. Percentage
+        # based formats (e.g. 19/20) are not a duration and are left alone.
+        worktime_lag_formats = {"3", "5", "7", "9", "11"}
+        elapsed_lag_formats = {"4", "6", "8", "10"}
         for task in self.tasks.values():
             if not task["PredecessorTasks"]:
                 continue
@@ -372,6 +384,24 @@ class MSP2Ifc:
                         rel_sequence=rel_sequence,
                         attributes={"SequenceType": self.sequence_type_map[predecessor["Type"]]},
                     )
+
+                link_lag = predecessor.get("LinkLag")
+                lag_format = predecessor.get("LagFormat")
+                if not link_lag or int(link_lag) == 0:
+                    continue
+                if lag_format not in worktime_lag_formats and lag_format not in elapsed_lag_formats:
+                    continue
+                # MSPDI stores LinkLag in tenths of a minute, regardless of LagFormat.
+                lag_hours = int(link_lag) / 10 / 60
+                if lag_format in elapsed_lag_formats:
+                    duration_type = "ELAPSEDTIME"
+                    lag_value = timedelta(hours=lag_hours)
+                else:
+                    duration_type = "WORKTIME"
+                    lag_value = timedelta(days=lag_hours / float(self.hours_per_day))
+                ifcopenshell.api.sequence.assign_lag_time(
+                    self.file, rel_sequence=rel_sequence, lag_value=lag_value, duration_type=duration_type
+                )
 
     def parse_resources_xml(self, project):
         resources_lst = project.find("pr:Resources", self.ns)

--- a/src/ifc4d/test/test_msp2ifc.py
+++ b/src/ifc4d/test/test_msp2ifc.py
@@ -1,0 +1,159 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import tempfile
+from pathlib import Path
+
+import ifcopenshell
+
+from ifc4d.msp2ifc import MSP2Ifc
+
+# Minimal MSPDI export with 4 tasks in a chain:
+#   Task 1 -> Task 2: no lag (LinkLag 0)
+#   Task 2 -> Task 3: 3 working days lag (LinkLag 14400, LagFormat 7 "Days")
+#   Task 3 -> Task 4: 2 elapsed days lag (LinkLag 28800, LagFormat 8 "Elapsed Days")
+#
+# LinkLag/LagFormat values and their tenths-of-a-minute encoding were verified
+# against a real MS Project XML export attached to
+# https://github.com/IfcOpenShell/IfcOpenShell/issues/4185, where these lags
+# were silently dropped on import.
+MSPDI_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Lag Test Project</Name>
+  <MinutesPerDay>480</MinutesPerDay>
+  <Tasks>
+    <Task>
+      <UID>1</UID>
+      <Name>Task 1</Name>
+      <OutlineLevel>0</OutlineLevel>
+      <OutlineNumber>1</OutlineNumber>
+      <WBS>1</WBS>
+      <Duration>PT8H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <Start>2024-01-01T08:00:00</Start>
+      <Finish>2024-01-01T16:00:00</Finish>
+    </Task>
+    <Task>
+      <UID>2</UID>
+      <Name>Task 2</Name>
+      <OutlineLevel>0</OutlineLevel>
+      <OutlineNumber>2</OutlineNumber>
+      <WBS>2</WBS>
+      <Duration>PT8H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <Start>2024-01-02T08:00:00</Start>
+      <Finish>2024-01-02T16:00:00</Finish>
+      <PredecessorLink>
+        <PredecessorUID>1</PredecessorUID>
+        <Type>1</Type>
+        <CrossProject>0</CrossProject>
+        <LinkLag>0</LinkLag>
+        <LagFormat>7</LagFormat>
+      </PredecessorLink>
+    </Task>
+    <Task>
+      <UID>3</UID>
+      <Name>Task 3</Name>
+      <OutlineLevel>0</OutlineLevel>
+      <OutlineNumber>3</OutlineNumber>
+      <WBS>3</WBS>
+      <Duration>PT8H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <Start>2024-01-08T08:00:00</Start>
+      <Finish>2024-01-08T16:00:00</Finish>
+      <PredecessorLink>
+        <PredecessorUID>2</PredecessorUID>
+        <Type>1</Type>
+        <CrossProject>0</CrossProject>
+        <LinkLag>14400</LinkLag>
+        <LagFormat>7</LagFormat>
+      </PredecessorLink>
+    </Task>
+    <Task>
+      <UID>4</UID>
+      <Name>Task 4</Name>
+      <OutlineLevel>0</OutlineLevel>
+      <OutlineNumber>4</OutlineNumber>
+      <WBS>4</WBS>
+      <Duration>PT8H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <Start>2024-01-11T08:00:00</Start>
+      <Finish>2024-01-11T16:00:00</Finish>
+      <PredecessorLink>
+        <PredecessorUID>3</PredecessorUID>
+        <Type>1</Type>
+        <CrossProject>0</CrossProject>
+        <LinkLag>28800</LinkLag>
+        <LagFormat>8</LagFormat>
+      </PredecessorLink>
+    </Task>
+  </Tasks>
+  <Calendars/>
+</Project>
+"""
+
+
+class TestMsp2IfcLag:
+    @staticmethod
+    def convert() -> ifcopenshell.file:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            xml_path = Path(tmp_dir) / "project.xml"
+            xml_path.write_text(MSPDI_XML)
+            converter = MSP2Ifc()
+            converter.xml = str(xml_path)
+            converter.execute()
+            return converter.file
+
+    @staticmethod
+    def get_rel_sequence(ifc_file, predecessor_identification: str, successor_identification: str):
+        for rel in ifc_file.by_type("IfcRelSequence"):
+            if (
+                rel.RelatingProcess.Identification == predecessor_identification
+                and rel.RelatedProcess.Identification == successor_identification
+            ):
+                return rel
+        assert False, f"No IfcRelSequence found for {predecessor_identification} -> {successor_identification}"
+
+    def test_zero_lag_leaves_time_lag_unset(self):
+        ifc_file = self.convert()
+        rel = self.get_rel_sequence(ifc_file, "1", "2")
+        assert rel.TimeLag is None
+
+    def test_worktime_lag_is_converted_from_tenths_of_a_minute(self):
+        # LinkLag 14400 (tenths of a minute) / 10 / 60 = 24 hours = 3 working
+        # days at the project's 8 hours (480 minutes) per day calendar.
+        ifc_file = self.convert()
+        rel = self.get_rel_sequence(ifc_file, "2", "3")
+        assert rel.TimeLag is not None
+        assert rel.TimeLag.DurationType == "WORKTIME"
+        assert rel.TimeLag.LagValue.wrappedValue == "P3D"
+
+    def test_elapsed_lag_uses_24_hour_days(self):
+        # LinkLag 28800 (tenths of a minute) / 10 / 60 = 48 hours = 2 elapsed
+        # (24/7) days, independent of the calendar's working hours per day.
+        ifc_file = self.convert()
+        rel = self.get_rel_sequence(ifc_file, "3", "4")
+        assert rel.TimeLag is not None
+        assert rel.TimeLag.DurationType == "ELAPSEDTIME"
+        assert rel.TimeLag.LagValue.wrappedValue == "P2D"


### PR DESCRIPTION
Fixes #4185.

`MSP2Ifc.parse_relationship_xml` read only the predecessor and link type:

```python
relationships[id] = {
    "PredecessorTask": relationship.find("pr:PredecessorUID", self.ns).text,
    "Type": relationship.find("pr:Type", self.ns).text,
}
```

`LinkLag` and `LagFormat` were never read, so `create_rel_sequences` never set `IfcRelSequence.TimeLag` and every lag or lead gap between linked tasks vanished on import. In the reporter's attached file, **138 of 974 `PredecessorLink` elements carry a non-zero `LinkLag`**.

The unit is tenths of a minute. That is not guessed: `ifc2msp.py` already performs the inverse conversion on export, with the comment `# Lag time is expressed in tenths of a minute. Seriously, Microsoft?`. Round-trip validated against the real file, for example `LinkLag=14400, LagFormat=7` gives exactly 20 working days at 8h/day, and `LinkLag=1080000, LagFormat=8` gives exactly 75 elapsed days.

The fix parses both fields, converts to WORKTIME days via `hours_per_day` or ELAPSEDTIME days via 24h, and calls `ifcopenshell.api.sequence.assign_lag_time`.

Percent-based `LagFormat` codes (19 and 20 in MSPDI) are deliberately left unhandled and skipped as before, since none appear in the sample and the conversion is not confidently sourced.

The other ifc4d importers were checked: `p6xer2ifc.py` and `pp2ifc.py` both delegate to the shared `ScheduleIfcGenerator.create_rel_sequences` in `common.py`, which already calls `assign_lag_time` correctly. The bug was isolated to `msp2ifc.py`.

`src/ifc4d` had no test suite; one is added here following the `src/ifc5d/test` convention. Red: 2 failed, 1 passed, both lag cases returning `None`. Green: 3 passed. Re-run against the reporter's real 10 MB file, all 138 non-zero lags now populate `TimeLag` correctly and the 836 zero-lag links are left unset.

This PR was generated with the assistance of an AI coding tool.
