### PR TITLE
util.selector: resolve mats.Category via the material set item

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -426,7 +426,7 @@ def get_element_value(element: ifcopenshell.entity_instance, query: str) -> Any:
 
 def _get_element_value(element: ifcopenshell.entity_instance, keys: list[str]) -> Any:
     value = element
-    for key in keys:
+    for i, key in enumerate(keys):
         if value is None:
             return
         if key == "type":
@@ -434,7 +434,22 @@ def _get_element_value(element: ifcopenshell.entity_instance, keys: list[str]) -
         elif key in ("material", "mat"):
             value = ifcopenshell.util.element.get_material(value, should_skip_usage=True)
         elif key in ("materials", "mats"):
-            value = ifcopenshell.util.element.get_materials(value)
+            next_key = keys[i + 1] if i + 1 < len(keys) else None
+            if next_key == "Category":
+                # Category is defined on the material set item (IfcMaterialLayer,
+                # IfcMaterialProfile, IfcMaterialConstituent), not on the IfcMaterial
+                # it references, so get_materials() alone can never resolve it.
+                material_set = ifcopenshell.util.element.get_material(value, should_skip_usage=True)
+                if material_set is not None and material_set.is_a("IfcMaterialLayerSet"):
+                    value = list(material_set.MaterialLayers)
+                elif material_set is not None and material_set.is_a("IfcMaterialProfileSet"):
+                    value = list(material_set.MaterialProfiles)
+                elif material_set is not None and material_set.is_a("IfcMaterialConstituentSet"):
+                    value = list(material_set.MaterialConstituents)
+                else:
+                    value = ifcopenshell.util.element.get_materials(value)
+            else:
+                value = ifcopenshell.util.element.get_materials(value)
         elif key == "profiles":
             value = ifcopenshell.util.shape.get_profiles(value)
         elif key == "styles":

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -162,6 +162,47 @@ class TestGetElementValue(test.bootstrap.IFC4):
         # Provide shortform for convenience
         assert subject.get_element_value(element, "mat.i.Name") == ["L1", "L2"]
 
+    def test_selecting_material_set_item_category_using_mats_shortform(self):
+        # Feature test for #7000: Category is an attribute of the material set
+        # item (IfcMaterialConstituent, IfcMaterialLayer, IfcMaterialProfile),
+        # not of the IfcMaterial it references, so "mats.Category"/"materials.Category"
+        # must resolve it via the set item rather than the flattened material list.
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        material_set = ifcopenshell.api.material.add_material_set(
+            self.file, name="FOO", set_type="IfcMaterialConstituentSet"
+        )
+        material1 = ifcopenshell.api.material.add_material(self.file, name="CON01")
+        material2 = ifcopenshell.api.material.add_material(self.file, name="CON02")
+        constituent1 = ifcopenshell.api.material.add_constituent(
+            self.file, constituent_set=material_set, material=material1
+        )
+        constituent1.Category = "Structure"
+        constituent2 = ifcopenshell.api.material.add_constituent(
+            self.file, constituent_set=material_set, material=material2
+        )
+        constituent2.Category = "Insulation"
+        ifcopenshell.api.material.assign_material(self.file, products=[element], material=material_set)
+        assert subject.get_element_value(element, "mats.Category") == ["Structure", "Insulation"]
+        assert subject.get_element_value(element, "materials.Category") == ["Structure", "Insulation"]
+        # Unaffected: mats without .Category keeps resolving to the flattened
+        # IfcMaterial list, same as before this fix.
+        assert subject.get_element_value(element, "mats.Name") == ["CON01", "CON02"]
+
+    def test_selecting_material_layer_category_using_mats_shortform(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        material = ifcopenshell.api.material.add_material(self.file, name="CON01")
+        material_set = ifcopenshell.api.material.add_material_set(self.file, name="FOO", set_type="IfcMaterialLayerSet")
+        layer = ifcopenshell.api.material.add_layer(self.file, layer_set=material_set, material=material)
+        layer.Category = "Cladding"
+        ifcopenshell.api.material.assign_material(self.file, products=[element], material=material_set)
+        assert subject.get_element_value(element, "mats.Category") == ["Cladding"]
+
+    def test_selecting_a_single_materials_category_does_not_error(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        material = ifcopenshell.api.material.add_material(self.file, name="CON01")
+        ifcopenshell.api.material.assign_material(self.file, products=[element], material=material)
+        assert subject.get_element_value(element, "mats.Category") == [None]
+
     def test_selecting_a_query_that_fails_silently(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         assert subject.get_element_value(element, "material.item.Name.0") is None


### PR DESCRIPTION
Fixes #7000.

Worth saying first: `material.item.Category` already works today on `v0.8.0`, via the existing `item`/`i` key at `selector.py:442`. @theoryshaw, that may already unblock you without waiting for this.

What was genuinely broken is `mats.Category`, which silently returned `None` instead of erroring. `get_element_value()` resolved `mats`/`materials` through `get_materials()`, which flattens layer, profile and constituent sets down to the `IfcMaterial` each item references. `Category` is declared on `IfcMaterialLayer`, `IfcMaterialProfile` and `IfcMaterialConstituent`, not on `IfcMaterial`, so the lookup could never succeed.

When the next key is `Category`, the set items are now resolved directly. Every other `mats`/`materials` query, including `mats.Name`, still goes through `get_materials()` unchanged.

`get_materials()` itself is untouched. It is public API relied on by `import_ifc`, drawing decoration, and the project and root tools for its flattened list contract, so its return type was not a safe place to change.

Red: `[None, None] == ['Structure', 'Insulation']`. Green: 43 passed in `test_selector.py`, 155 in `test_element.py`.

Two related spots are deliberately out of scope: the same `Category` flattening exists in the `material()` facet filter at `selector.py:1031`, and in the write path at `selector.py:650`.

This PR was generated with the assistance of an AI coding tool.
