### PR TITLE
Bonsai: add a way to hide the web export calculation row per column

### DIFF
--- a/src/bonsai/bonsai/bim/data/webui/static/js/index.js
+++ b/src/bonsai/bonsai/bim/data/webui/static/js/index.js
@@ -216,7 +216,7 @@ function addTableElement(blenderId, csvData, filename) {
     // update column defination on clicking an item
     // specifically the topCalc and pass calc type to the topCalcFormatter function
     // uisng the topCalcFormatterParams field
-    return calculations.map((calc) => ({
+    const menu = calculations.map((calc) => ({
       label: `Show ${
         calc.charAt(0).toUpperCase() + calc.slice(1)
       } for ${field}`,
@@ -225,6 +225,18 @@ function addTableElement(blenderId, csvData, filename) {
           .getColumn()
           .updateDefinition({ topCalc: calc, topCalcFormatterParams: calc }),
     }));
+
+    // topCalc defaults to "sum" for every column (see columnDefaults below)
+    // with no way to turn it off. Add an explicit option to hide it.
+    menu.push({
+      label: `Hide calculation for ${field}`,
+      action: (e, cell) =>
+        cell
+          .getColumn()
+          .updateDefinition({ topCalc: false, topCalcFormatterParams: false }),
+    });
+
+    return menu;
   }
 
   function calcFormatter(cell, formatterParams, onRendered) {


### PR DESCRIPTION
Fixes #7118.

The web export table hardcoded `columnDefaults.topCalc` to `"sum"` for every column. The right-click column menu offered Sum, Avg, Max and Min but no way to turn the calculation row off, which is the "No visible option to disable this feature" in the report.

This adds a "Hide calculation for &lt;field&gt;" entry that clears `topCalc` through Tabulator's `updateDefinition`, per column, with no global setting.

Verified with a Node harness that loads the real `index.js` into a stubbed browser environment and exercises the actual `createColumnContextMenu()` and `addTableElement()` code paths: red before the fix with no such entry in the menu, green after with the entry present and clicking it setting `topCalc: false`. The harness is not committed.

This PR was generated with the assistance of an AI coding tool.
