### PR TITLE
Bonsai: add bim.select_assigned_annotations, the inverse of select_assigned_product

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/__init__.py
+++ b/src/bonsai/bonsai/bim/module/drawing/__init__.py
@@ -105,6 +105,7 @@ classes = (
     operator.SaveDrawingStylesData,
     operator.SelectAllDrawings,
     operator.SelectAllSheets,
+    operator.SelectAssignedAnnotations,
     operator.SelectAssignedProduct,
     operator.SelectSimilarTextLiteralValue,
     operator.ToggleTargetView,
@@ -183,6 +184,8 @@ def menu_func(self, context):
         element = tool.Ifc.get_entity(active_obj)
         if element and element.is_a("IfcAnnotation") and element.ObjectType in ["SECTION", "ELEVATION"]:
             self.layout.operator("bim.activate_drawing_by_annotation", text="Go to Drawing")
+        elif element and not element.is_a("IfcAnnotation") and tool.Drawing.get_assigned_annotations(element):
+            self.layout.operator("bim.select_assigned_annotations", text="Select Assigned Annotations")
 
 
 def register():

--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -47,8 +47,24 @@ class ProductAssignmentsData:
 
     @classmethod
     def load(cls):
-        cls.data = {"relating_product": cls.relating_product()}
+        cls.data = {
+            "relating_product": cls.relating_product(),
+            "assigned_annotations": cls.assigned_annotations(),
+        }
         cls.is_loaded = True
+
+    @classmethod
+    def assigned_annotations(cls):
+        """List of (annotation_id, annotation_name) assigned to the active product.
+
+        The inverse of relating_product, so it's only populated for non-annotation elements.
+        """
+        element = tool.Ifc.get_entity(bpy.context.active_object)
+        if not element or element.is_a("IfcAnnotation"):
+            return []
+        return [
+            (a.id(), a.Name or a.ObjectType or "Unnamed") for a in tool.Drawing.get_assigned_annotations(element)
+        ]
 
     @classmethod
     def relating_product(cls):

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3951,6 +3951,46 @@ class SelectAssignedProduct(bpy.types.Operator, tool.Ifc.Operator):
         core.select_assigned_product(tool.Drawing, context)
 
 
+class SelectAssignedAnnotations(bpy.types.Operator):
+    bl_idname = "bim.select_assigned_annotations"
+    bl_label = "Select Assigned Annotations"
+    bl_description = (
+        "Select the annotations assigned to the selected elements.\n\n"
+        "Annotations belonging to drawings that aren't loaded can't be selected"
+    )
+
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        if not tool.Ifc.get():
+            cls.poll_message_set("No IFC project loaded")
+            return False
+        objs = list(context.selected_objects)
+        if (active_obj := context.active_object) and active_obj not in objs:
+            objs.append(active_obj)
+        for obj in objs:
+            element = tool.Ifc.get_entity(obj)
+            if element and not element.is_a("IfcAnnotation"):
+                return True
+        cls.poll_message_set("No IFC elements selected")
+        return False
+
+    def execute(self, context):
+        total, selected = core.select_assigned_annotations(tool.Drawing, context)
+        if not total:
+            self.report({"INFO"}, "No annotations are assigned to the selected elements.")
+        elif selected < total:
+            self.report(
+                {"INFO"},
+                f"Selected {selected} of {total} assigned annotations, "
+                f"{total - selected} are in drawings that aren't loaded.",
+            )
+        else:
+            self.report({"INFO"}, f"Selected {selected} assigned annotation(s).")
+        return {"FINISHED"}
+
+
 class EnableEditingElementFilter(bpy.types.Operator, tool.Ifc.Operator):
     bl_idname = "bim.enable_editing_element_filter"
     bl_label = "Element Filter Mode"

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -547,7 +547,10 @@ class BIM_PT_product_assignments(Panel):
         element = tool.Ifc.get_entity(context.active_object)
         if not element:
             return False
-        return element.is_a("IfcAnnotation")
+        if element.is_a("IfcAnnotation"):
+            return True
+        # Products show the other side of the relationship: the annotations assigned to them.
+        return bool(tool.Drawing.get_assigned_annotations(element))
 
     def draw(self, context):
         if not ProductAssignmentsData.is_loaded:
@@ -555,6 +558,19 @@ class BIM_PT_product_assignments(Panel):
 
         assert self.layout
         assert (obj := context.active_object)
+
+        element = tool.Ifc.get_entity(obj)
+        if element and not element.is_a("IfcAnnotation"):
+            annotations = ProductAssignmentsData.data["assigned_annotations"]
+            row = self.layout.row(align=True)
+            row.label(text=f"{len(annotations)} Assigned Annotations", icon="OBJECT_DATA")
+            row.operator("bim.select_assigned_annotations", icon="RESTRICT_SELECT_OFF", text="")
+            for _, name in annotations[:10]:
+                self.layout.label(text=name, icon="GREASEPENCIL")
+            if len(annotations) > 10:
+                self.layout.label(text=f"...and {len(annotations) - 10} more")
+            return
+
         props = tool.Drawing.get_object_assigned_product_props(obj)
 
         if props.is_editing_product:

--- a/src/bonsai/bonsai/core/drawing.py
+++ b/src/bonsai/bonsai/core/drawing.py
@@ -624,6 +624,10 @@ def select_assigned_product(drawing: type[tool.Drawing], context: bpy.types.Cont
     drawing.select_assigned_product(context)
 
 
+def select_assigned_annotations(drawing: type[tool.Drawing], context: bpy.types.Context) -> tuple[int, int]:
+    return drawing.select_assigned_annotations(context)
+
+
 def activate_drawing_view(
     ifc: type[tool.Ifc],
     blender: type[tool.Blender],

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -370,6 +370,7 @@ class Drawing:
     def get_annotation_context(cls, target_view, object_type=None): pass
     def get_annotation_drawing(cls, element): pass
     def get_annotation_representation(cls, element_type): pass
+    def get_assigned_annotations(cls, element): pass
     def get_assigned_product(cls, element): pass
     def get_assigned_product_workaround(cls, element): pass
     def get_body_context(cls): pass
@@ -417,6 +418,7 @@ class Drawing:
     def run_drawing_activate_model(cls): pass
     def run_root_assign_class(cls, obj=None, ifc_class=None, predefined_type=None, should_add_representation=True, context=None, ifc_representation_class=None): pass
     def run_type_assign_type(cls, element=None, relating_type=None): pass
+    def select_assigned_annotations(cls, context): pass
     def select_assigned_product(cls, drawing): pass
     def set_camera_name(cls, drawing, name): pass
     def set_drawing_collection_name(cls, drawing, collection): pass

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -969,6 +969,30 @@ class Drawing(bonsai.core.tool.Drawing):
                 return product
 
     @classmethod
+    def get_assigned_annotations(cls, element: ifcopenshell.entity_instance) -> list[ifcopenshell.entity_instance]:
+        """Get all annotations assigned to a product. The inverse of ``get_assigned_product``."""
+        rels: list[ifcopenshell.entity_instance] = []
+        if element.is_a("IfcGridAxis"):
+            # Axes aren't products, they're identified by name on the grid's assignment.
+            grid = next(
+                (g for a in ("PartOfU", "PartOfV", "PartOfW") for g in getattr(element, a, None) or []),
+                None,
+            )
+            if grid:
+                rels = [r for r in grid.ReferencedBy or [] if r.Name == element.AxisTag]
+        elif element.is_a("IfcProduct"):
+            rels = element.ReferencedBy or []
+
+        annotations: list[ifcopenshell.entity_instance] = []
+        for rel in rels:
+            if not rel.is_a("IfcRelAssignsToProduct"):
+                continue
+            for related_object in rel.RelatedObjects:
+                if related_object.is_a("IfcAnnotation") and related_object not in annotations:
+                    annotations.append(related_object)
+        return annotations
+
+    @classmethod
     def get_assigned_product_workaround(
         cls, element: ifcopenshell.entity_instance
     ) -> list[ifcopenshell.entity_instance]:
@@ -2485,6 +2509,40 @@ class Drawing(bonsai.core.tool.Drawing):
             product_obj = tool.Ifc.get_object(product)
             product_obj.select_set(True)
             context.view_layer.objects.active = product_obj
+
+    @classmethod
+    def select_assigned_annotations(cls, context: bpy.types.Context) -> tuple[int, int]:
+        """Select the annotations assigned to the selected products.
+
+        The inverse of ``select_assigned_product``. Returns how many annotations were found
+        and how many of them could actually be selected - annotations belonging to drawings
+        that aren't loaded in the view layer are counted but left alone.
+        """
+        objs = list(context.selected_objects)
+        # The panel button acts on the active object, which isn't necessarily selected.
+        if (active_obj := context.active_object) and active_obj not in objs:
+            objs.append(active_obj)
+
+        annotations: list[ifcopenshell.entity_instance] = []
+        for obj in objs:
+            element = tool.Ifc.get_entity(obj)
+            if not element or element.is_a("IfcAnnotation"):
+                continue
+            for annotation in cls.get_assigned_annotations(element):
+                if annotation not in annotations:
+                    annotations.append(annotation)
+
+        selected_objs: list[bpy.types.Object] = []
+        for annotation in annotations:
+            annotation_obj = tool.Ifc.get_object(annotation)
+            if annotation_obj is None or annotation_obj.name not in context.view_layer.objects:
+                continue
+            tool.Blender.select_object(annotation_obj)
+            selected_objs.append(annotation_obj)
+
+        if selected_objs:
+            tool.Blender.set_active_object(selected_objs[-1])
+        return len(annotations), len(selected_objs)
 
     @classmethod
     def is_drawing_active(cls) -> bool:

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -697,6 +697,30 @@ class TestGetAssignedProduct(NewFile):
         assert subject.get_assigned_product(label) == wall
 
 
+class TestGetAssignedAnnotations(NewFile):
+    def test_run(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        wall = ifc.createIfcWall()
+        other_wall = ifc.createIfcWall()
+        label = ifc.createIfcAnnotation()
+        dimension = ifc.createIfcAnnotation()
+        ifcopenshell.api.drawing.assign_product(ifc, relating_product=wall, related_object=label)
+        ifcopenshell.api.drawing.assign_product(ifc, relating_product=wall, related_object=dimension)
+        assert subject.get_assigned_annotations(wall) == [label, dimension]
+        assert subject.get_assigned_annotations(other_wall) == []
+
+    def test_only_annotations_are_returned(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        wall = ifc.createIfcWall()
+        label = ifc.createIfcAnnotation()
+        task = ifc.createIfcTask()
+        ifcopenshell.api.drawing.assign_product(ifc, relating_product=wall, related_object=label)
+        ifcopenshell.api.drawing.assign_product(ifc, relating_product=wall, related_object=task)
+        assert subject.get_assigned_annotations(wall) == [label]
+
+
 class TestImportDrawings(NewFile):
     def test_run(self):
         ifc = ifcopenshell.file()


### PR DESCRIPTION
Closes #9030.

`bim.select_assigned_product` walks from an annotation to the product it is assigned to. This adds the missing inverse, `bim.select_assigned_annotations`: given the current selection, it walks `IfcProduct.ReferencedBy` → `IfcRelAssignsToProduct` and selects every `IfcAnnotation` that references those elements.

### Behaviour

- Acts on the whole selection, so it works for a set of elements at once. The active object is included when it isn't part of the selection, so the panel button always acts on what the panel is showing.
- Additive selection, matching `select_assigned_product`, which leaves the annotation selected when it selects the product.
- Grid axes get the same special case as `get_assigned_product`: an axis is not a product, so its annotations hang off the grid's `IfcRelAssignsToProduct` and are matched by `Name` == `AxisTag`. Selecting axis `A` does not pull in axis `B`'s tag.
- Annotations in drawings that aren't loaded are not in the view layer and can't be selected. They are counted and reported rather than silently dropped or throwing — *"Selected 3 of 7 assigned annotations, 4 are in drawings that aren't loaded."*

### Structure

- `tool.Drawing.get_assigned_annotations` is the exact inverse of `get_assigned_product`, with tests for the product case, the filtering of non-annotation related objects, and the empty case.
- `tool.Drawing.select_assigned_annotations` returns `(found, selected)` so the operator can report the difference.
- `core.drawing.select_assigned_annotations` follows the existing delegation pattern.

### UI

- **Product Assignments panel.** It previously only polled for `IfcAnnotation`. It now also appears for products that have annotations assigned and shows the other side of the same relationship — a count, the annotation names (capped at 10), and a select button. One panel for one relationship, rather than a second concept.
- **Object context menu.** A *Select Assigned Annotations* entry next to the existing *Go to Drawing*, shown only when the active element actually has annotations.

### Testing

`TestGetAssignedAnnotations` in `test/tool/test_drawing.py` covers the lookup. The IFC-level logic was additionally exercised against a live `ifcopenshell.file()`: product → annotations, non-annotations filtered out, multiple rels merged without duplicates, grid axis vs. grid, non-products and orphan axes returning empty, and round-tripping as the exact inverse of `get_assigned_product`.

The Blender-side selection behaviour (view-layer skipping, active object, panel draw) has not been exercised in an automated test and would benefit from a click-through by a reviewer.

Generated with the assistance of an AI coding tool.
