### PR TITLE
Bonsai: don't crash the profile decorator's exit callback when nothing is selected

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -1044,9 +1044,17 @@ class EnableEditingExtrusionAxis(bpy.types.Operator, tool.Ifc.Operator):
 
 def disable_editing_extrusion_axis(context):
     ProfileDecorator.uninstall()
-    bpy.ops.object.mode_set(mode="OBJECT")
 
+    # This is also used as the decorator's exit_edit_mode_callback, which
+    # can fire with no active object (e.g. the user deselected everything
+    # while editing). mode_set requires an active object to poll, so guard
+    # both that call and the rest of the cleanup below. See #9006.
     obj = context.active_object
+    if obj is None:
+        return {"CANCELLED"}
+    if obj.mode == "EDIT":
+        bpy.ops.object.mode_set(mode="OBJECT")
+
     element = tool.Ifc.get_entity(obj)
     body = ifcopenshell.util.representation.get_representation(element, "Model", "Body", "MODEL_VIEW")
 

--- a/src/bonsai/bonsai/bim/module/model/railing.py
+++ b/src/bonsai/bonsai/bim/module/model/railing.py
@@ -1164,14 +1164,18 @@ class EnableEditingRailingPath(bpy.types.Operator, tool.Ifc.Operator):
 
 
 def cancel_editing_railing_path(context: bpy.types.Context) -> set[str]:
-    obj = context.active_object
-    assert obj
-    props = tool.Model.get_railing_props(obj)
-
     ProfileDecorator.uninstall()
+
+    # This is also used as the decorator's exit_edit_mode_callback, which
+    # can fire with no active object (e.g. the user deselected everything
+    # while editing). See #9006.
+    obj = context.active_object
+    if obj is None:
+        return {"CANCELLED"}
+    props = tool.Model.get_railing_props(obj)
     props.is_editing_path = False
 
-    if bpy.context.active_object.mode == "EDIT":
+    if obj.mode == "EDIT":
         bpy.ops.object.mode_set(mode="OBJECT")
 
     if props.railing_type == "FRAMELESS_PANEL":

--- a/src/bonsai/bonsai/bim/module/model/roof.py
+++ b/src/bonsai/bonsai/bim/module/model/roof.py
@@ -849,11 +849,15 @@ class EnableEditingRoofPath(bpy.types.Operator, tool.Ifc.Operator):
 
 
 def cancel_editing_roof_path(context: bpy.types.Context) -> set[str]:
-    obj = context.active_object
-    assert obj
-    props = tool.Model.get_roof_props(obj)
-
     ProfileDecorator.uninstall()
+
+    # This is also used as the decorator's exit_edit_mode_callback, which
+    # can fire with no active object (e.g. the user deselected everything
+    # while editing). See #9006.
+    obj = context.active_object
+    if obj is None:
+        return {"CANCELLED"}
+    props = tool.Model.get_roof_props(obj)
     props.is_editing_path = False
 
     update_roof_modifier_bmesh(obj)

--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -582,9 +582,17 @@ class DisableEditingSketchExtrusionProfile(bpy.types.Operator, tool.Ifc.Operator
 
 def disable_editing_extrusion_profile(context):
     ProfileDecorator.uninstall()
-    bpy.ops.object.mode_set(mode="OBJECT")
 
+    # This is also used as the decorator's exit_edit_mode_callback, which
+    # can fire with no active object (e.g. the user deselected everything
+    # while editing). mode_set requires an active object to poll, so guard
+    # both that call and the rest of the cleanup below. See #9006.
     obj = context.active_object
+    if obj is None:
+        return {"CANCELLED"}
+    if obj.mode == "EDIT":
+        bpy.ops.object.mode_set(mode="OBJECT")
+
     element = tool.Ifc.get_entity(obj)
     body = ifcopenshell.util.representation.get_representation(element, "Model", "Body", "MODEL_VIEW")
 

--- a/src/bonsai/test/bim/module/model/test_exit_edit_mode_callback_no_active_object.py
+++ b/src/bonsai/test/bim/module/model/test_exit_edit_mode_callback_no_active_object.py
@@ -1,0 +1,100 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression tests for #9006's second traceback: the ``exit_edit_mode_callback``
+functions wired into ``ProfileDecorator.install()`` crashed when the decorator
+invoked them with no active object.
+
+``ProfileDecorator.__call__`` (``bonsai/bim/module/model/decorator.py``) is a
+per-frame ``SpaceView3D`` draw handler. Since commit ``1961cd905ee`` (2026-05-28,
+"Fix parametric framework live-session regressions"), it treats
+``context.active_object is None`` the same as "no longer in edit mode": it
+uninstalls itself and fires ``exit_edit_mode_callback()`` -- see decorator.py:167.
+
+That guard was only added to the decorator's own ``obj.mode`` read (which
+used to crash outright on ``None``). The four callbacks it can invoke were
+never updated to expect ``obj`` to be ``None``:
+
+- ``slab.disable_editing_extrusion_profile``
+- ``profile.disable_editing_extrusion_axis``
+
+Both called ``bpy.ops.object.mode_set(mode="OBJECT")`` unconditionally before
+even reading ``context.active_object``. ``mode_set``'s poll() requires an
+active object, so this raised ``RuntimeError: ... Context missing active
+object`` -- the exact second traceback attached to #9006 (from
+``slab.disable_editing_extrusion_profile``, reached via the door-type-with-no-profile
+repro: the polyline draw operator has no active object at all, so the decorator's
+guard fires the callback with ``obj=None``).
+
+- ``railing.cancel_editing_railing_path``
+- ``roof.cancel_editing_roof_path``
+
+Both instead ``assert obj`` before doing anything else, so they crashed with
+``AssertionError`` in the same scenario -- less alarming in the log than an
+operator RuntimeError, but still an unhandled exception raised from a draw
+handler.
+
+All four now guard ``obj is None`` and return ``{"CANCELLED"}`` instead of
+touching ``bpy.ops.object.mode_set`` or any per-object state."""
+
+import bpy
+import pytest
+
+import bonsai.bim.module.model.profile as profile
+import bonsai.bim.module.model.railing as railing
+import bonsai.bim.module.model.roof as roof
+import bonsai.bim.module.model.slab as slab
+
+pytestmark = pytest.mark.model
+
+
+@pytest.fixture
+def no_active_object():
+    """Clear Blender's active object for the test body, reproducing the state
+    ``ProfileDecorator.__call__`` detects right before it fires
+    ``exit_edit_mode_callback()`` with no object to hand it. Restores whatever
+    was active afterwards so this doesn't leak into other tests."""
+    previous = bpy.context.view_layer.objects.active
+    bpy.context.view_layer.objects.active = None
+    assert bpy.context.active_object is None
+    try:
+        yield
+    finally:
+        bpy.context.view_layer.objects.active = previous
+
+
+def test_disable_editing_extrusion_profile_no_active_object(no_active_object):
+    """slab.py -- the exact crash site quoted in #9006's second traceback."""
+    assert slab.disable_editing_extrusion_profile(bpy.context) == {"CANCELLED"}
+
+
+def test_disable_editing_extrusion_axis_no_active_object(no_active_object):
+    """profile.py -- identical unguarded mode_set pattern."""
+    assert profile.disable_editing_extrusion_axis(bpy.context) == {"CANCELLED"}
+
+
+def test_cancel_editing_railing_path_no_active_object(no_active_object):
+    """railing.py -- crashed with AssertionError instead of RuntimeError."""
+    assert railing.cancel_editing_railing_path(bpy.context) == {"CANCELLED"}
+
+
+def test_cancel_editing_roof_path_no_active_object(no_active_object):
+    """roof.py -- crashed with AssertionError instead of RuntimeError."""
+    assert roof.cancel_editing_roof_path(bpy.context) == {"CANCELLED"}


### PR DESCRIPTION
This is the **second** crash reported on #9006, not the one fixed by #9028. The two are separate bugs in different functions that happen to share an issue number:

- **#9028** fixes the routing crash in `create_profiles_from_polyline` (`profile.py:1151`, `workspace.py`, `tool/model.py`).
- **This PR** fixes the `exit_edit_mode_callback` crash in `disable_editing_extrusion_axis` (`profile.py:1044`) and three siblings.

They touch `profile.py` in disjoint regions and `git merge-tree` reports a clean merge between the two branches and against `v0.8.0`.

## Root cause

Commit `1961cd905ee` (2026-05-28, "Fix parametric framework live-session regressions") added an `obj is None` guard to `ProfileDecorator.__call__`, a per-frame `SpaceView3D` draw handler:

```python
if obj is None or obj.mode != "EDIT":
    if exit_edit_mode_callback:
        ProfileDecorator.uninstall()
        exit_edit_mode_callback()
```

That stopped the decorator crashing on `obj.mode` when nothing is selected, but the four callbacks it can now invoke with `obj=None` were never updated:

- `slab.py:583` `disable_editing_extrusion_profile` and `profile.py:1045` `disable_editing_extrusion_axis` call `bpy.ops.object.mode_set(mode="OBJECT")` unconditionally before reading `context.active_object`. That operator's `poll()` requires an active object, producing exactly the `RuntimeError: Operator bpy.ops.object.mode_set.poll() Context missing active object` in the report.
- `railing.py:1166` `cancel_editing_railing_path` and `roof.py:851` `cancel_editing_roof_path` both `assert obj`, giving an `AssertionError` in the same scenario.

It triggers when the user deselects everything while editing an extrusion profile or a railing or roof path, since the handler runs on the next viewport redraw.

## Fix

All four check `obj is None` first and return `{"CANCELLED"}`. `mode_set` is only called when `obj.mode == "EDIT"`.

## Testing

New `test_exit_edit_mode_callback_no_active_object.py`, run in real headless Blender. Red on the pre-fix code: 4 failed, with `slab.py` and `profile.py` raising the reported `RuntimeError` and `railing.py` and `roof.py` raising `AssertionError`. Green after: 4 passed. Full model suite afterwards: 472 passed, 62 deselected.

Not hand-tested interactively. The trigger is a viewport-redraw edge case that is awkward to provoke reliably by hand, so the automated real-Blender test is the strongest evidence available.

This PR was generated with the assistance of an AI coding tool.
