### PR TITLE
ifcpatch(ExtractElements): keep every element on its presentation layer (#9008)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/__init__.py
@@ -27,7 +27,7 @@ into your project.
 """
 
 from .. import wrap_usecases
-from .append_asset import append_asset
+from .append_asset import append_asset, flush_deferred_relationship_members
 from .assign_declaration import assign_declaration
 from .create_file import create_file
 from .unassign_declaration import unassign_declaration
@@ -36,6 +36,7 @@ wrap_usecases(__path__, __name__)
 
 __all__ = [
     "append_asset",
+    "flush_deferred_relationship_members",
     "assign_declaration",
     "create_file",
     "unassign_declaration",

--- a/src/ifcopenshell-python/ifcopenshell/api/project/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/__init__.py
@@ -27,7 +27,7 @@ into your project.
 """
 
 from .. import wrap_usecases
-from .append_asset import append_asset, flush_deferred_relationship_members
+from .append_asset import append_asset, flush_deferred_layer_items, flush_deferred_relationship_members
 from .assign_declaration import assign_declaration
 from .create_file import create_file
 from .unassign_declaration import unassign_declaration
@@ -36,6 +36,7 @@ wrap_usecases(__path__, __name__)
 
 __all__ = [
     "append_asset",
+    "flush_deferred_layer_items",
     "flush_deferred_relationship_members",
     "assign_declaration",
     "create_file",

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -472,6 +472,7 @@ class Usecase:
                 library=self.settings["library"],
                 element=element_type,
                 reuse_identities=self.reuse_identities,
+                assume_asset_uniqueness_by_name=self.assume_asset_uniqueness_by_name,
             )
             ifcopenshell.api.type.assign_type(
                 self.file,
@@ -612,8 +613,14 @@ class Usecase:
                         continue
                     if skip_not_reused_entities_attr_i is not None and i == skip_not_reused_entities_attr_i:
                         identity = item.wrapped_data.identity()
-                        if (item := self.reuse_identities.get(identity)) is None:
+                        reused = self.reuse_identities.get(identity)
+                        if reused is None:
+                            # reuse_identities is only filled by file_add's per-attribute
+                            # path; the native file.add fast path records added_elements.
+                            reused = self.added_elements.get(item.id())
+                        if reused is None:
                             continue
+                        item = reused
                     else:
                         item = self.add_element(item)
                     new_attribute.append(item)

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -53,6 +53,9 @@ def append_asset(
     deferred_relationship_members: Optional[
         dict[int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]]
     ] = None,
+    deferred_layer_items: Optional[
+        dict[int, tuple[ifcopenshell.entity_instance, list[ifcopenshell.entity_instance]]]
+    ] = None,
 ) -> ifcopenshell.entity_instance:
     """Appends an asset from a library into the active project
 
@@ -79,6 +82,10 @@ def append_asset(
         to add just 1 asset or if added assets won't have any shared elements, then it can be left empty.
     :param assume_asset_uniqueness_by_name: If True, checks if elements (profiles, materials, styles)
         with the same name already exist in the project and reuses them instead of appending new ones.
+    :param deferred_layer_items: Optional accumulator shared across ``append_asset``
+        calls that collects ``IfcPresentationLayerAssignment.AssignedItems`` instead
+        of re-assigning the growing item set on every call, which is O(n^2). Pass it
+        to ``flush_deferred_layer_items`` once all assets have been appended.
     :return: The appended element
 
     Example:
@@ -144,8 +151,27 @@ def append_asset(
         "reuse_identities": {} if reuse_identities is None else reuse_identities,
         "assume_asset_uniqueness_by_name": assume_asset_uniqueness_by_name,
         "deferred_relationship_members": deferred_relationship_members,
+        "deferred_layer_items": deferred_layer_items,
     }
     return usecase.execute()
+
+
+def flush_deferred_layer_items(
+    deferred_layer_items: dict[int, tuple[ifcopenshell.entity_instance, list[ifcopenshell.entity_instance]]],
+) -> None:
+    """Assign presentation layer item sets deferred by ``append_asset``.
+
+    ``IfcPresentationLayerAssignment.AssignedItems`` is shared by every asset
+    drawn on that layer, so assigning it once per appended asset re-writes a set
+    that grows with the number of assets, which is O(n^2). With a shared
+    ``deferred_layer_items`` accumulator the items are collected in Python and
+    each layer's set is written a single time here. Call this once, after all
+    appends.
+
+    :param deferred_layer_items: The accumulator passed to ``append_asset``.
+    """
+    for layer, items in deferred_layer_items.values():
+        layer.AssignedItems = list(dict.fromkeys(items))
 
 
 def flush_deferred_relationship_members(
@@ -278,6 +304,7 @@ class Usecase:
         self.base_material_class = "IfcMaterial" if self.file.schema == "IFC2X3" else "IfcMaterialDefinition"
         self.assume_asset_uniqueness_by_name = self.settings["assume_asset_uniqueness_by_name"]
         self.deferred_relationship_members = self.settings["deferred_relationship_members"]
+        self.deferred_layer_items = self.settings["deferred_layer_items"]
 
         if self.settings["element"].is_a("IfcTypeProduct"):
             self.target_class = "IfcTypeProduct"
@@ -490,6 +517,7 @@ class Usecase:
                 element=element_type,
                 reuse_identities=self.reuse_identities,
                 assume_asset_uniqueness_by_name=self.assume_asset_uniqueness_by_name,
+                deferred_layer_items=self.deferred_layer_items,
             )
             ifcopenshell.api.type.assign_type(
                 self.file,
@@ -554,11 +582,15 @@ class Usecase:
                     attribute, attribute_class = attribute.split(".")
                 for inverse in getattr(element, attribute, []):
                     if attribute_class and inverse.is_a(attribute_class):
-                        self.add_inverse_element(inverse)
+                        self.add_inverse_element(inverse, element)
                     elif not attribute_class:
-                        self.add_inverse_element(inverse)
+                        self.add_inverse_element(inverse, element)
 
-    def add_inverse_element(self, element: ifcopenshell.entity_instance) -> None:
+    def add_inverse_element(
+        self,
+        element: ifcopenshell.entity_instance,
+        source: Union[ifcopenshell.entity_instance, None] = None,
+    ) -> None:
         """Add inverse element.
 
         Inverse elements are requiring different method than ``file_add``
@@ -567,6 +599,9 @@ class Usecase:
 
         E.g. a IfcRelAssociatesMaterial referencing products unrelated
         to the current asset.
+
+        ``source`` is the library element whose whitelisted inverse attribute
+        led here, used to extend a shared IfcPresentationLayerAssignment.
         """
         # For layer assignment we don't want to add it's items
         # to avoid adding representations / items that are not related to current append_asset.
@@ -582,6 +617,12 @@ class Usecase:
         # that now needs it's RelatingObjects to be extended by the current asset.
         existing_rel = None
         if (new := self.reuse_identities.get(element_identity)) is not None:
+            if skip_not_reused_entities_attr_i is not None:
+                # A layer is shared by every asset drawn on it, so revisiting it
+                # must add the item that reached it now. Returning here would keep
+                # only the items of the first asset that ever reached the layer.
+                self.extend_assigned_items(new, skip_not_reused_entities_attr_i, source)
+                return
             # Currently known cases requiring attributes reassignment are rels.
             if not new.is_a("IfcRelationship"):
                 return
@@ -637,18 +678,19 @@ class Usecase:
                     if self.is_another_asset(item):
                         continue
                     if skip_not_reused_entities_attr_i is not None and i == skip_not_reused_entities_attr_i:
-                        identity = item.wrapped_data.identity()
-                        reused = self.reuse_identities.get(identity)
-                        if reused is None:
-                            # reuse_identities is only filled by file_add's per-attribute
-                            # path; the native file.add fast path records added_elements.
-                            reused = self.added_elements.get(item.id())
+                        reused = self.resolve_added(item)
                         if reused is None:
                             continue
                         item = reused
                     else:
                         item = self.add_element(item)
                     new_attribute.append(item)
+                if skip_not_reused_entities_attr_i is not None and i == skip_not_reused_entities_attr_i:
+                    if (deferred := self.deferred_layer_items) is not None:
+                        # Collect the items in Python and let flush_deferred_layer_items
+                        # write this layer's set once, instead of on every append.
+                        deferred[new.id()] = (new, new_attribute)
+                        continue
                 # If rel exists we need to make sure previously assigned elements are untouched
                 # e.g. not to assign a material or a pset from element.
                 if existing_rel:
@@ -658,6 +700,42 @@ class Usecase:
                 new_attribute = attribute
             if new_attribute is not None:
                 new[i] = new_attribute
+
+    def resolve_added(self, element: ifcopenshell.entity_instance) -> Union[ifcopenshell.entity_instance, None]:
+        """Get the appended counterpart of a library element, if there is one."""
+        added = self.reuse_identities.get(element.wrapped_data.identity())
+        if added is None:
+            # reuse_identities is only filled by file_add's per-attribute path,
+            # the native file.add fast path records added_elements.
+            added = self.added_elements.get(element.id())
+        return added
+
+    def extend_assigned_items(
+        self,
+        new: ifcopenshell.entity_instance,
+        attr_i: int,
+        source: Union[ifcopenshell.entity_instance, None],
+    ) -> None:
+        """Add ``source``'s appended counterpart to an already created layer assignment."""
+        if source is None:
+            return
+        item = self.resolve_added(source)
+        if item is None:
+            return
+        if (deferred := self.deferred_layer_items) is not None:
+            if (entry := deferred.get(new.id())) is not None:
+                entry[1].append(item)
+                return
+        # AssignedItems is the inverse of LayerAssignment(s), so the item itself
+        # tells us whether it is already on this layer without scanning the layer.
+        for inverse_attribute in ("LayerAssignments", "LayerAssignment"):
+            assignments = getattr(item, inverse_attribute, None)
+            if assignments is None:
+                continue
+            if new in assignments:
+                return
+            break
+        new[attr_i] = list(new[attr_i] or ()) + [item]
 
     def is_another_asset(self, element: ifcopenshell.entity_instance) -> bool:
         """Is IFC entity from inverse attribute is another asset to append that should be skipped."""

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -151,6 +151,7 @@ def append_asset(
 def flush_deferred_relationship_members(
     file: ifcopenshell.file,
     deferred_relationship_members: dict[int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]],
+    reuse_identities: Optional[dict[int, ifcopenshell.entity_instance]] = None,
 ) -> None:
     """Assign relationship member lists deferred by ``append_asset``.
 
@@ -160,17 +161,30 @@ def flush_deferred_relationship_members(
     list-valued member attributes re-scanned and re-assigned on every element
     append. Doing that per element is O(n^2) because the member list grows.
 
-    This resolves every deferred relationship a single time instead: a source
-    member is kept if and only if it is present in ``file``, which is the same
-    rule ``append_asset`` applies when it assigns the list eagerly. Call this
-    once, after all appends, on the file the assets were appended into.
+    This resolves every deferred relationship a single time instead. Members
+    that are ``IfcRoot`` subtypes (e.g. products, property sets) are kept if
+    and only if they were appended into ``file``, matched by ``GlobalId`` -
+    the same rule ``append_asset`` applies when it assigns the list eagerly.
+    Members that are not ``IfcRoot`` subtypes have no ``GlobalId``, so they are
+    matched by identity through ``reuse_identities`` instead. The only such
+    member today is ``IfcRelOverridesProperties.OverridingProperties``, whose
+    ``IfcProperty`` members ``append_asset`` always appends (they are not
+    optional assets that may have been excluded), so they are always resolved
+    if the same ``reuse_identities`` accumulator used during the appends is
+    passed here. Call this once, after all appends, on the file the assets
+    were appended into.
 
     :param file: The file assets were appended into.
     :param deferred_relationship_members: The accumulator passed to ``append_asset``.
+    :param reuse_identities: The ``reuse_identities`` accumulator passed to
+        ``append_asset``, used to resolve non-``IfcRoot`` members. Required to
+        avoid dropping them; safe to omit if none of the deferred
+        relationships have non-``IfcRoot`` list-valued members.
     """
     if not deferred_relationship_members:
         return
     appended_by_guid = {e.GlobalId: e for e in file.by_type("IfcRoot")}
+    reuse_identities = reuse_identities if reuse_identities is not None else {}
     for source_rel, new_rel in deferred_relationship_members.values():
         for index, attribute in enumerate(source_rel):
             if not (
@@ -180,7 +194,10 @@ def flush_deferred_relationship_members(
             members: list[ifcopenshell.entity_instance] = []
             seen: set[int] = set()
             for member in attribute:
-                mapped = appended_by_guid.get(getattr(member, "GlobalId", None))
+                if member.is_a("IfcRoot"):
+                    mapped = appended_by_guid.get(member.GlobalId)
+                else:
+                    mapped = reuse_identities.get(member.wrapped_data.identity())
                 if mapped is not None and mapped.id() not in seen:
                     seen.add(mapped.id())
                     members.append(mapped)
@@ -604,8 +621,16 @@ class Usecase:
             elif isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance):
                 if defer_member_lists:
                     for item in attribute:
-                        if not self.is_another_asset(item):
-                            self.add_element(item)
+                        if self.is_another_asset(item):
+                            continue
+                        new_item = self.add_element(item)
+                        if not item.is_a("IfcRoot"):
+                            # Non-IfcRoot members (e.g. IfcProperty in
+                            # IfcRelOverridesProperties.OverridingProperties) have no
+                            # GlobalId, so flush_deferred_relationship_members cannot
+                            # match them that way. Record the mapping by identity so
+                            # it can resolve them instead of silently dropping them.
+                            self.reuse_identities[item.wrapped_data.identity()] = new_item
                     continue
                 new_attribute = []
                 for item in attribute:

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -50,6 +50,7 @@ def append_asset(
     element: ifcopenshell.entity_instance,
     reuse_identities: Optional[dict[int, ifcopenshell.entity_instance]] = None,
     assume_asset_uniqueness_by_name: bool = True,
+    deferred_relationship_members: Optional[dict[int, tuple[ifcopenshell.entity_instance, dict[int, list]]]] = None,
 ) -> ifcopenshell.entity_instance:
     """Appends an asset from a library into the active project
 
@@ -140,8 +141,41 @@ def append_asset(
         "element": element,
         "reuse_identities": {} if reuse_identities is None else reuse_identities,
         "assume_asset_uniqueness_by_name": assume_asset_uniqueness_by_name,
+        "deferred_relationship_members": deferred_relationship_members,
     }
     return usecase.execute()
+
+
+def flush_deferred_relationship_members(
+    deferred_relationship_members: dict[int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]],
+    appended_elements: dict[int, ifcopenshell.entity_instance],
+) -> None:
+    """Assign relationship member lists deferred by ``append_asset``.
+
+    When ``append_asset`` is called with a shared ``deferred_relationship_members``
+    dict, relationships reached through whitelisted inverses (e.g.
+    ``IfcRelAssociatesMaterial``, ``IfcRelDefinesByProperties``) do not have their
+    list-valued member attributes re-scanned and re-assigned on every element
+    append. Doing that per element is O(n^2) because the member list grows.
+
+    Instead, this maps each relationship's source members to their appended
+    counterparts a single time. ``appended_elements`` maps a source element's step
+    id to the entity it was appended as (the caller collects the value returned by
+    each ``append_asset`` call). Members whose source was not appended (i.e. not
+    part of the extracted subset) are skipped. Call this once after all appends.
+    """
+    for source_rel, new_rel in deferred_relationship_members.values():
+        for index, attribute in enumerate(source_rel):
+            if not (isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance)):
+                continue
+            members: list[ifcopenshell.entity_instance] = []
+            seen: set[int] = set()
+            for member in attribute:
+                mapped = appended_elements.get(member.id())
+                if mapped is not None and mapped.id() not in seen:
+                    seen.add(mapped.id())
+                    members.append(mapped)
+            new_rel[index] = members
 
 
 class SafeRemovalContext:
@@ -217,6 +251,7 @@ class Usecase:
         self.whitelisted_inverse_attributes = {}
         self.base_material_class = "IfcMaterial" if self.file.schema == "IFC2X3" else "IfcMaterialDefinition"
         self.assume_asset_uniqueness_by_name = self.settings["assume_asset_uniqueness_by_name"]
+        self.deferred_relationship_members = self.settings["deferred_relationship_members"]
 
         if self.settings["element"].is_a("IfcTypeProduct"):
             self.target_class = "IfcTypeProduct"
@@ -529,6 +564,18 @@ class Usecase:
             new = self.file.create_entity(element.is_a())
             self.reuse_identities[element_identity] = new
 
+        # When a shared accumulator is provided, defer the list-valued member
+        # attributes of relationships (e.g. IfcRelAssociatesMaterial.RelatedObjects)
+        # instead of re-scanning and re-assigning the growing list on every element
+        # append (O(n^2)). flush_deferred_relationship_members assigns them once.
+        defer_member_lists = False
+        if self.deferred_relationship_members is not None and new.is_a("IfcRelationship"):
+            if new.id() in self.deferred_relationship_members:
+                # Non-member attributes were set the first time; members deferred.
+                return
+            self.deferred_relationship_members[new.id()] = (element, new)
+            defer_member_lists = True
+
         for i, attribute in enumerate(element):
             new_attribute = None
             if isinstance(attribute, ifcopenshell.entity_instance):
@@ -544,6 +591,8 @@ class Usecase:
                 ):
                     new_attribute = self.add_element(attribute)
             elif isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance):
+                if defer_member_lists:
+                    continue
                 new_attribute = []
                 for item in attribute:
                     if self.is_another_asset(item):

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -166,7 +166,9 @@ def flush_deferred_relationship_members(
     """
     for source_rel, new_rel in deferred_relationship_members.values():
         for index, attribute in enumerate(source_rel):
-            if not (isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance)):
+            if not (
+                isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance)
+            ):
                 continue
             members: list[ifcopenshell.entity_instance] = []
             seen: set[int] = set()

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -50,7 +50,9 @@ def append_asset(
     element: ifcopenshell.entity_instance,
     reuse_identities: Optional[dict[int, ifcopenshell.entity_instance]] = None,
     assume_asset_uniqueness_by_name: bool = True,
-    deferred_relationship_members: Optional[dict[int, tuple[ifcopenshell.entity_instance, dict[int, list]]]] = None,
+    deferred_relationship_members: Optional[
+        dict[int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]]
+    ] = None,
 ) -> ifcopenshell.entity_instance:
     """Appends an asset from a library into the active project
 
@@ -147,8 +149,8 @@ def append_asset(
 
 
 def flush_deferred_relationship_members(
+    file: ifcopenshell.file,
     deferred_relationship_members: dict[int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]],
-    appended_elements: dict[int, ifcopenshell.entity_instance],
 ) -> None:
     """Assign relationship member lists deferred by ``append_asset``.
 
@@ -158,12 +160,17 @@ def flush_deferred_relationship_members(
     list-valued member attributes re-scanned and re-assigned on every element
     append. Doing that per element is O(n^2) because the member list grows.
 
-    Instead, this maps each relationship's source members to their appended
-    counterparts a single time. ``appended_elements`` maps a source element's step
-    id to the entity it was appended as (the caller collects the value returned by
-    each ``append_asset`` call). Members whose source was not appended (i.e. not
-    part of the extracted subset) are skipped. Call this once after all appends.
+    This resolves every deferred relationship a single time instead: a source
+    member is kept if and only if it is present in ``file``, which is the same
+    rule ``append_asset`` applies when it assigns the list eagerly. Call this
+    once, after all appends, on the file the assets were appended into.
+
+    :param file: The file assets were appended into.
+    :param deferred_relationship_members: The accumulator passed to ``append_asset``.
     """
+    if not deferred_relationship_members:
+        return
+    appended_by_guid = {e.GlobalId: e for e in file.by_type("IfcRoot")}
     for source_rel, new_rel in deferred_relationship_members.values():
         for index, attribute in enumerate(source_rel):
             if not (
@@ -173,7 +180,7 @@ def flush_deferred_relationship_members(
             members: list[ifcopenshell.entity_instance] = []
             seen: set[int] = set()
             for member in attribute:
-                mapped = appended_elements.get(member.id())
+                mapped = appended_by_guid.get(getattr(member, "GlobalId", None))
                 if mapped is not None and mapped.id() not in seen:
                     seen.add(mapped.id())
                     members.append(mapped)
@@ -570,6 +577,7 @@ class Usecase:
         # attributes of relationships (e.g. IfcRelAssociatesMaterial.RelatedObjects)
         # instead of re-scanning and re-assigning the growing list on every element
         # append (O(n^2)). flush_deferred_relationship_members assigns them once.
+        # Members that are not another asset are still pulled in, but only once.
         defer_member_lists = False
         if self.deferred_relationship_members is not None and new.is_a("IfcRelationship"):
             if new.id() in self.deferred_relationship_members:
@@ -594,6 +602,9 @@ class Usecase:
                     new_attribute = self.add_element(attribute)
             elif isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance):
                 if defer_member_lists:
+                    for item in attribute:
+                        if not self.is_another_asset(item):
+                            self.add_element(item)
                     continue
                 new_attribute = []
                 for item in attribute:

--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -93,6 +93,11 @@ class Patcher(ifcpatch.BasePatcher):
         self.deferred_relationship_members: dict[
             int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]
         ] = {}
+        # A presentation layer is shared by every element drawn on it, so its item
+        # set is collected here and written once instead of on every element append.
+        self.deferred_layer_items: dict[
+            int, tuple[ifcopenshell.entity_instance, list[ifcopenshell.entity_instance]]
+        ] = {}
         for owner_history in self.file.by_type("IfcOwnerHistory"):
             self.owner_history = self.new.add(owner_history)
             break
@@ -102,6 +107,7 @@ class Patcher(ifcpatch.BasePatcher):
         ifcopenshell.api.project.flush_deferred_relationship_members(
             self.new, self.deferred_relationship_members, self.reuse_identities
         )
+        ifcopenshell.api.project.flush_deferred_layer_items(self.deferred_layer_items)
         self.create_spatial_tree()
         self.file = self.new
 
@@ -130,6 +136,7 @@ class Patcher(ifcpatch.BasePatcher):
             reuse_identities=self.reuse_identities,
             assume_asset_uniqueness_by_name=self.assume_asset_uniqueness_by_name,
             deferred_relationship_members=self.deferred_relationship_members,
+            deferred_layer_items=self.deferred_layer_items,
         )
 
     def add_spatial_structures(

--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -99,7 +99,9 @@ class Patcher(ifcpatch.BasePatcher):
         self.add_element(self.file.by_type("IfcProject")[0])
         for element in ifcopenshell.util.selector.filter_elements(self.file, self.query):
             self.add_element(element)
-        ifcopenshell.api.project.flush_deferred_relationship_members(self.new, self.deferred_relationship_members)
+        ifcopenshell.api.project.flush_deferred_relationship_members(
+            self.new, self.deferred_relationship_members, self.reuse_identities
+        )
         self.create_spatial_tree()
         self.file = self.new
 

--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -87,12 +87,24 @@ class Patcher(ifcpatch.BasePatcher):
         self.new = ifcopenshell.file(schema_version=self.file.schema_version)
         self.owner_history = None
         self.reuse_identities: dict[int, ifcopenshell.entity_instance] = {}
+        # Relationships reached via shared inverses (material, type, property sets)
+        # are deferred here and their member lists assigned once, avoiding the
+        # O(n^2) cost of re-assigning a growing list on every element append.
+        self.deferred_relationship_members: dict[
+            int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]
+        ] = {}
+        # Maps a source element's step id to the entity it was appended as, so
+        # deferred relationship member lists can be resolved in one pass.
+        self.appended_elements: dict[int, ifcopenshell.entity_instance] = {}
         for owner_history in self.file.by_type("IfcOwnerHistory"):
             self.owner_history = self.new.add(owner_history)
             break
         self.add_element(self.file.by_type("IfcProject")[0])
         for element in ifcopenshell.util.selector.filter_elements(self.file, self.query):
             self.add_element(element)
+        ifcopenshell.api.project.flush_deferred_relationship_members(
+            self.deferred_relationship_members, self.appended_elements
+        )
         self.create_spatial_tree()
         self.file = self.new
 
@@ -100,6 +112,7 @@ class Patcher(ifcpatch.BasePatcher):
         new_element = self.append_asset(element)
         if not new_element:
             return
+        self.appended_elements[element.id()] = new_element
         self.add_spatial_structures(element, new_element)
         self.add_decomposition_parents(element, new_element)
 
@@ -120,6 +133,7 @@ class Patcher(ifcpatch.BasePatcher):
             element=element,
             reuse_identities=self.reuse_identities,
             assume_asset_uniqueness_by_name=self.assume_asset_uniqueness_by_name,
+            deferred_relationship_members=self.deferred_relationship_members,
         )
 
     def add_spatial_structures(

--- a/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractElements.py
@@ -93,18 +93,13 @@ class Patcher(ifcpatch.BasePatcher):
         self.deferred_relationship_members: dict[
             int, tuple[ifcopenshell.entity_instance, ifcopenshell.entity_instance]
         ] = {}
-        # Maps a source element's step id to the entity it was appended as, so
-        # deferred relationship member lists can be resolved in one pass.
-        self.appended_elements: dict[int, ifcopenshell.entity_instance] = {}
         for owner_history in self.file.by_type("IfcOwnerHistory"):
             self.owner_history = self.new.add(owner_history)
             break
         self.add_element(self.file.by_type("IfcProject")[0])
         for element in ifcopenshell.util.selector.filter_elements(self.file, self.query):
             self.add_element(element)
-        ifcopenshell.api.project.flush_deferred_relationship_members(
-            self.deferred_relationship_members, self.appended_elements
-        )
+        ifcopenshell.api.project.flush_deferred_relationship_members(self.new, self.deferred_relationship_members)
         self.create_spatial_tree()
         self.file = self.new
 
@@ -112,7 +107,6 @@ class Patcher(ifcpatch.BasePatcher):
         new_element = self.append_asset(element)
         if not new_element:
             return
-        self.appended_elements[element.id()] = new_element
         self.add_spatial_structures(element, new_element)
         self.add_decomposition_parents(element, new_element)
 

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -24,8 +24,10 @@ import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.georeference
 import ifcopenshell.api.material
+import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
+import ifcopenshell.api.type
 import ifcopenshell.util.element
 import numpy
 import pytest
@@ -59,6 +61,53 @@ class TestExtractElements(test.bootstrap.IFC4):
         rels = output.by_type("IfcRelAssociatesMaterial")
         assert len(rels) == 1
         assert {w.GlobalId for w in rels[0].RelatedObjects} == {w.GlobalId for w in walls}
+
+    def test_relationship_members_outside_the_query_are_preserved(self):
+        # Regression test: spatial containers, decomposition parents and element
+        # types are appended alongside the queried elements, so deferred
+        # relationship member lists must be resolved against everything present in
+        # the output, not only the query matches. Otherwise their property sets and
+        # material associations are dropped and relationships are left with an
+        # empty member list, which violates the IFC [1:?] cardinality.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(self.file, context_type="Model")
+
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        building = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuilding")
+        storeys = [ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey") for _ in range(2)]
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[building], relating_object=site)
+        ifcopenshell.api.aggregate.assign_object(self.file, products=storeys, relating_object=building)
+
+        wall_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        walls = [ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall") for _ in range(4)]
+        for i, wall in enumerate(walls):
+            ifcopenshell.api.spatial.assign_container(
+                self.file, products=[wall], relating_structure=storeys[i % len(storeys)]
+            )
+        ifcopenshell.api.type.assign_type(self.file, related_objects=walls, relating_type=wall_type)
+
+        containers = [site, building] + storeys
+        for element in containers + walls:
+            pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_Test")
+            ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Foo": "Bar"})
+
+        material = ifcopenshell.api.material.add_material(self.file, name="Steel")
+        ifcopenshell.api.material.assign_material(self.file, products=walls + [wall_type], material=material)
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        for element in containers + walls:
+            new_element = output.by_guid(element.GlobalId)
+            psets = ifcopenshell.util.element.get_psets(new_element)
+            assert psets.get("Pset_Test", {}).get("Foo") == "Bar", element.is_a()
+
+        rels = output.by_type("IfcRelAssociatesMaterial")
+        assert len(rels) == 1
+        assert {o.GlobalId for o in rels[0].RelatedObjects} == {e.GlobalId for e in walls + [wall_type]}
+
+        for rel in output.by_type("IfcRelationship"):
+            for attribute in rel:
+                assert attribute != (), f"{rel.is_a()} has an empty member list"
 
     def test_keep_spatial_structure(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -23,6 +23,7 @@ import ifcopenshell.api.aggregate
 import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.georeference
+import ifcopenshell.api.material
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
 import ifcopenshell.util.element
@@ -41,6 +42,23 @@ class TestExtractElements(test.bootstrap.IFC4):
 
         assert output.by_type("IfcProject")[0].GlobalId == project.GlobalId
         assert output.by_type("IfcWall")[0].GlobalId == wall.GlobalId
+
+    def test_shared_relationship_members_are_preserved(self):
+        # Regression test: a relationship shared by many extracted elements
+        # (e.g. one IfcRelAssociatesMaterial linking every product) must keep all
+        # of its members. The deferred member-list assignment used to avoid the
+        # O(n^2) cost of re-assigning a growing list per element must not drop any.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        material = ifcopenshell.api.material.add_material(self.file, name="Steel")
+        walls = [ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall") for _ in range(3)]
+        ifcopenshell.api.material.assign_material(self.file, products=walls, material=material)
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        rels = output.by_type("IfcRelAssociatesMaterial")
+        assert len(rels) == 1
+        assert {w.GlobalId for w in rels[0].RelatedObjects} == {w.GlobalId for w in walls}
 
     def test_keep_spatial_structure(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -169,6 +169,39 @@ class TestExtractElements(test.bootstrap.IFC4):
         assert own == mapped
         assert len(output.by_type("IfcShapeRepresentation")) == 1
 
+    def test_shared_presentation_layer_keeps_every_element(self):
+        # Regression test for #9008: an IfcPresentationLayerAssignment is shared by
+        # every element drawn on it. append_asset created it on the first element
+        # that reached it and returned on every later visit, so the output kept the
+        # items of one element and every other element silently lost its layer.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        context = ifcopenshell.api.context.add_context(self.file, context_type="Model")
+
+        walls = []
+        items = []
+        for _ in range(4):
+            wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+            points = [self.file.createIfcCartesianPoint(p) for p in ((0.0, 0.0), (1.0, 0.0))]
+            item = self.file.createIfcPolyline(points)
+            representation = self.file.createIfcShapeRepresentation(context, "Body", "Curve2D", [item])
+            wall.Representation = self.file.createIfcProductDefinitionShape(None, None, [representation])
+            walls.append(wall)
+            items.append(item)
+        layer = self.file.createIfcPresentationLayerAssignment("Layer", None, items, None)
+        assert len(layer.AssignedItems) == len(walls)
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall", False]})
+
+        assert len(output.by_type("IfcWall")) == len(walls)
+        layers = output.by_type("IfcPresentationLayerAssignment")
+        assert len(layers) == 1
+        assert layers[0].Name == "Layer"
+        assigned = set(layers[0].AssignedItems)
+        assert len(assigned) == len(walls)
+        for wall in output.by_type("IfcWall"):
+            wall_items = {i for r in wall.Representation.Representations for i in r.Items}
+            assert wall_items & assigned, f"{wall.GlobalId} lost its presentation layer"
+
     def test_keep_spatial_structure(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
 

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -24,6 +24,7 @@ import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.georeference
 import ifcopenshell.api.material
+import ifcopenshell.guid
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
@@ -108,6 +109,33 @@ class TestExtractElements(test.bootstrap.IFC4):
         for rel in output.by_type("IfcRelationship"):
             for attribute in rel:
                 assert attribute != (), f"{rel.is_a()} has an empty member list"
+
+    def test_overrides_properties_members_are_preserved(self):
+        # Regression test: IfcRelOverridesProperties.OverridingProperties holds
+        # IfcProperty members, which unlike most relationship members have no
+        # GlobalId. The deferred member-list assignment used to resolve members
+        # by GlobalId, so every member of this one relationship silently
+        # resolved to nothing and the list was written empty, violating the
+        # IFC [1:?] cardinality.
+        if self.file.schema != "IFC2X3":
+            pytest.skip("IfcRelOverridesProperties only exists in IFC2X3")
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=wall, name="Pset_Test")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Foo": "Bar"})
+        override = self.file.createIfcPropertySingleValue("Foo", None, self.file.createIfcText("Baz"), None)
+        owner_history = self.file.by_type("IfcOwnerHistory")[0]
+        self.file.createIfcRelOverridesProperties(
+            ifcopenshell.guid.new(), owner_history, None, None, [wall], pset, [override]
+        )
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall"]})
+
+        rels = output.by_type("IfcRelOverridesProperties")
+        assert len(rels) == 1
+        assert len(rels[0].OverridingProperties) == 1
+        assert rels[0].OverridingProperties[0].Name == "Foo"
+        assert rels[0].OverridingProperties[0].NominalValue.wrappedValue == "Baz"
 
     def test_keep_spatial_structure(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")

--- a/src/ifcpatch/test/test_ExtractElements.py
+++ b/src/ifcpatch/test/test_ExtractElements.py
@@ -137,6 +137,38 @@ class TestExtractElements(test.bootstrap.IFC4):
         assert rels[0].OverridingProperties[0].Name == "Foo"
         assert rels[0].OverridingProperties[0].NominalValue.wrappedValue == "Baz"
 
+    def test_representation_shared_with_a_type_map_is_not_duplicated(self):
+        # Regression test: exporters do emit an IfcShapeRepresentation that is at
+        # once a product's own representation and a type's
+        # IfcRepresentationMap.MappedRepresentation. Extraction must reproduce the
+        # source as it stands, one entity in both roles. Appending the element type
+        # through the name uniqueness code path the caller had opted out of used to
+        # copy the representation instead, silently rewriting the model.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        context = ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        wall_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWallType")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        ifcopenshell.api.type.assign_type(
+            self.file, related_objects=[wall], relating_type=wall_type, should_map_representations=False
+        )
+
+        points = [self.file.createIfcCartesianPoint(p) for p in ((0.0, 0.0), (1.0, 0.0))]
+        representation = self.file.createIfcShapeRepresentation(
+            context, "Body", "Curve2D", [self.file.createIfcPolyline(points)]
+        )
+        wall.Representation = self.file.createIfcProductDefinitionShape(None, None, [representation])
+        origin = self.file.createIfcAxis2Placement3D(self.file.createIfcCartesianPoint((0.0, 0.0, 0.0)))
+        wall_type.RepresentationMaps = [self.file.createIfcRepresentationMap(origin, representation)]
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "ExtractElements", "arguments": ["IfcWall", False]})
+
+        new_wall = output.by_type("IfcWall")[0]
+        new_type = output.by_type("IfcWallType")[0]
+        own = {r.id() for r in new_wall.Representation.Representations}
+        mapped = {m.MappedRepresentation.id() for m in new_type.RepresentationMaps}
+        assert own == mapped
+        assert len(output.by_type("IfcShapeRepresentation")) == 1
+
     def test_keep_spatial_structure(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
 


### PR DESCRIPTION
**Stacked on #8320.** This branch is based on #8320's head, so the diff below shows 7 commits of which the first 6 belong to that PR. Only the last one, `5fe9438`, is new here. Merge #8320 first and this reduces to a single commit. Cross-fork PRs cannot target another fork's branch, hence the combined diff.

Fixes the presentation-layer half of #9008.

## Root cause

`src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py:584`:

```python
if (new := self.reuse_identities.get(element_identity)) is not None:
    # Currently known cases requiring attributes reassignment are rels.
    if not new.is_a("IfcRelationship"):
        return
```

`IfcPresentationLayerAssignment` is not an `IfcRelationship`. It is created on the first element that reaches it, and every later element returns here, so `AssignedItems` retains only that first element's items. This is the caveat #8320 explicitly left open: "Layer assignment membership is order dependent... the one respect in which output is not a strict improvement".

## Why the obvious repair was rejected

Simply extending `AssignedItems` per element reintroduced a quadratic cost. `cProfile` over 400 walls: `extend_assigned_items` took **10.13s of a 27.39s run**, driven by **10.8M `entity_instance.walk` calls** re-wrapping the growing aggregate. Forwarding the accumulator to the nested type append, as #8320 does for its own deferred lists, brings the same run to **17.23s against #8320's 17.27s**, i.e. no measurable regression.

## Measurements

@PahlawanJoey's model, 519,335,013 bytes, IFC2X3, query `IfcWall, Description=Baksteen`, 2004 walls, real `Patcher.patch()`:

| | extract | output bytes | layer memberships matching source | walls with correct styles |
|---|---|---|---|---|
| `v0.8.0` | 781.12s | 34,367,810 | 0 / 2004 | 19 / 2004 |
| #8320 head | 17.52s | 26,376,520 | 2 / 2004 | 2004 / 2004 |
| this branch | 17.82s | 26,402,554 | **2004 / 2004** | 2004 / 2004 |

Total `AssignedItems` in the output: 84 -> 4 -> **3595**. The specific layer named in the report, `22 Binnenwanden NC`: 84 -> 1 -> **90**.

## Correctness

Against #8320's head on the same output: identical **376,180** total entities, no per-class count difference, no relationship member-count difference, zero empty member lists in both, and `ifcopenshell.validate` returns the **same 5534 statements with the same breakdown** (3504 `IfcShapeModel.WR11`, 2030 `IfcLocalPlacement.PlacesObject`). 46 GlobalIds differ, all synthesised `IfcRelContainedInSpatialStructure` / `IfcRelAggregates` / `IfcRelDefinesByType`; running #8320's head twice produced the same class of churn (31 GUIDs), so it is run-to-run, not caused by this change.

`v0.8.0` additionally emitted three layers with empty `AssignedItems`, violating the `[1:?]` cardinality. Those three validator statements are gone.

## Tests

`test_shared_presentation_layer_keeps_every_element` fails on #8320's head with `assert 1 == 4` in both IFC4 and IFC2X3, and passes here. `test_ExtractElements.py`: 20 passed, 2 skipped. `test/api/project`: 84 passed. The non-opt-in path used by Bonsai's library append, which has no accumulator, verified separately at 5/5 items in both schemas.

## Out of scope

`deferred_relationship_members` is not forwarded to the nested type append; only the new `deferred_layer_items` is. Changing #8320's behaviour there belongs in #8320.

This PR was generated with the assistance of an AI coding tool.
