### PR TITLE
Bonsai: add a Status Classes toggle to drawings (#9033)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -236,6 +236,28 @@ def update_target_view_camera(self: "BIMCameraProperties", context: bpy.types.Co
     update_layer(self, context, "TargetView", self.target_view)
 
 
+def update_has_status_classes(self: "BIMCameraProperties", context: bpy.types.Context) -> None:
+    assert context.scene
+    if not self.update_props:
+        return
+    if not context.scene.camera or context.scene.camera.data != self.id_data:
+        return
+    element = tool.Ifc.get_entity(context.scene.camera)
+    if not element:
+        return
+    query = tool.Drawing.STATUS_METADATA_QUERY
+    metadata = tool.Drawing.get_drawing_metadata(element)
+    if self.has_status_classes:
+        if query in metadata:
+            return
+        metadata.append(query)
+    else:
+        if query not in metadata:
+            return
+        metadata = [m for m in metadata if m != query]
+    update_layer(self, context, "Metadata", ", ".join(metadata))
+
+
 def update_layer(self: "BIMCameraProperties", context: bpy.types.Context, name: str, value: Any) -> None:
     assert context.scene
     if not self.update_props:
@@ -587,6 +609,14 @@ class BIMCameraProperties(PropertyGroup):
         default=False,
         update=get_update_layer_callback("render_flush", "RenderFlush"),
     )
+    has_status_classes: BoolProperty(
+        name="Status Classes",
+        description="Tag every drawn element with its phase/status (NEW, EXISTING, DEMOLISH, ...) "
+        "as an SVG class, so the stylesheet can hatch each phase differently.\n"
+        "Adds the '/Pset_.*Common/.Status' selector query to EPset_Drawing.Metadata",
+        default=False,
+        update=update_has_status_classes,
+    )
     target_view: EnumProperty(
         name="Target View",
         default="PLAN_VIEW",
@@ -630,6 +660,7 @@ class BIMCameraProperties(PropertyGroup):
         has_underlay: bool
         has_linework: bool
         has_annotation: bool
+        has_status_classes: bool
         target_view: TargetView
 
         representation: str

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -115,6 +115,9 @@ class BIM_PT_camera(Panel):
             row.prop(props, "cut_mode")
 
         row = self.layout.row()
+        row.prop(props, "has_status_classes")
+
+        row = self.layout.row()
         row.prop(props, "use_edge_classification")
         if props.use_edge_classification:
             row = self.layout.row()

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -84,6 +84,7 @@ class Drawing(bonsai.core.tool.Drawing):
     LocationHintLiteral = Literal["PERSPECTIVE", "ORTHOGRAPHIC", "NORTH", "SOUTH", "EAST", "WEST"]
     LOCATION_HINT_LITERALS = ("PERSPECTIVE", "ORTHOGRAPHIC", "NORTH", "SOUTH", "EAST", "WEST")
     LocationHintType = Union[LocationHintLiteral, str]
+    STATUS_METADATA_QUERY = "/Pset_.*Common/.Status"
 
     # ObjectType: annotation_name, description, icon, data_type
     # fmt: off
@@ -1089,11 +1090,13 @@ class Drawing(bonsai.core.tool.Drawing):
         camera_props.render_sharp = True
         camera_props.ridge_angle_min_degrees = 45.0
         camera_props.render_flush = False
+        camera_props.has_status_classes = False
         camera.shift_x = 0.0
         camera.shift_y = 0.0
 
         pset = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing")
         if pset:
+            camera_props.has_status_classes = cls.STATUS_METADATA_QUERY in cls.get_drawing_metadata(drawing)
             if "TargetView" in pset:
                 camera_props.target_view = pset["TargetView"]
             if "Scale" in pset:
@@ -2325,7 +2328,7 @@ class Drawing(bonsai.core.tool.Drawing):
 
     @classmethod
     def get_drawing_metadata(cls, drawing: ifcopenshell.entity_instance) -> list[str]:
-        pset_data = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing")
+        pset_data = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing") or {}
         metadata_str = pset_data.get("Metadata", "") or ""
         return [v_ for v in metadata_str.split(",") if (v_ := v.strip())]
 

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -157,6 +157,103 @@ class TestImportCameraProps(NewFile):
         assert props.ridge_angle_min_degrees == pytest.approx(30.0)
         assert props.render_flush is True
 
+    def test_defaults_status_classes_off_when_pset_is_absent(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        drawing = ifc.createIfcAnnotation(ObjectType="DRAWING")
+        camera = bpy.data.cameras.new("Camera")
+
+        subject.import_camera_props(drawing, camera)
+
+        assert subject.get_camera_props(camera).has_status_classes is False
+
+    def test_imports_status_classes_from_drawing_metadata(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        drawing = ifc.createIfcAnnotation(ObjectType="DRAWING")
+        pset = ifcopenshell.api.pset.add_pset(ifc, product=drawing, name="EPset_Drawing")
+        ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"Metadata": "Name, /Pset_.*Common/.Status"})
+        camera = bpy.data.cameras.new("Camera")
+
+        subject.import_camera_props(drawing, camera)
+
+        assert subject.get_camera_props(camera).has_status_classes is True
+
+    def test_unrelated_metadata_does_not_enable_status_classes(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        drawing = ifc.createIfcAnnotation(ObjectType="DRAWING")
+        pset = ifcopenshell.api.pset.add_pset(ifc, product=drawing, name="EPset_Drawing")
+        ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"Metadata": "Name, id"})
+        camera = bpy.data.cameras.new("Camera")
+
+        subject.import_camera_props(drawing, camera)
+
+        assert subject.get_camera_props(camera).has_status_classes is False
+
+
+class TestStatusClassesToggle(NewFile):
+    def create_active_drawing_camera(self) -> tuple[ifcopenshell.file, ifcopenshell.entity_instance]:
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        camera_obj = subject.create_camera("Camera", mathutils.Matrix(), "ORTHOGRAPHIC", "PLAN_VIEW")
+        drawing = ifc.createIfcAnnotation(ObjectType="DRAWING")
+        tool.Ifc.link(drawing, camera_obj)
+        bpy.context.scene.camera = camera_obj
+        return ifc, drawing
+
+    def test_enabling_writes_the_status_query_to_metadata(self):
+        ifc, drawing = self.create_active_drawing_camera()
+
+        subject.get_camera_props(bpy.context.scene.camera).has_status_classes = True
+
+        assert subject.get_drawing_metadata(drawing) == ["/Pset_.*Common/.Status"]
+
+    def test_enabling_preserves_metadata_the_user_already_typed(self):
+        ifc, drawing = self.create_active_drawing_camera()
+        pset = ifcopenshell.api.pset.add_pset(ifc, product=drawing, name="EPset_Drawing")
+        ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"Metadata": "Name"})
+
+        subject.get_camera_props(bpy.context.scene.camera).has_status_classes = True
+
+        assert subject.get_drawing_metadata(drawing) == ["Name", "/Pset_.*Common/.Status"]
+
+    def test_disabling_removes_only_the_status_query(self):
+        ifc, drawing = self.create_active_drawing_camera()
+        pset = ifcopenshell.api.pset.add_pset(ifc, product=drawing, name="EPset_Drawing")
+        ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"Metadata": "Name, /Pset_.*Common/.Status, id"})
+        props = subject.get_camera_props(bpy.context.scene.camera)
+        subject.import_camera_props(drawing, bpy.context.scene.camera.data)
+        assert props.has_status_classes is True
+
+        props.has_status_classes = False
+
+        assert subject.get_drawing_metadata(drawing) == ["Name", "id"]
+
+    def test_enabling_matches_typing_the_query_by_hand(self):
+        ifc, drawing = self.create_active_drawing_camera()
+        hand_typed = ifc.createIfcAnnotation(ObjectType="DRAWING")
+        pset = ifcopenshell.api.pset.add_pset(ifc, product=hand_typed, name="EPset_Drawing")
+        ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"Metadata": "/Pset_.*Common/.Status"})
+
+        subject.get_camera_props(bpy.context.scene.camera).has_status_classes = True
+
+        toggled_pset = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing")
+        hand_typed_pset = ifcopenshell.util.element.get_pset(hand_typed, "EPset_Drawing")
+        assert toggled_pset["Metadata"] == hand_typed_pset["Metadata"]
+
+    def test_disabling_an_already_disabled_toggle_does_not_touch_the_drawing(self):
+        ifc, drawing = self.create_active_drawing_camera()
+        props = subject.get_camera_props(bpy.context.scene.camera)
+        props.has_status_classes = True
+        props.has_status_classes = False
+        snapshot = ifc.to_string()
+
+        props.has_status_classes = False
+
+        assert ifc.to_string() == snapshot
+        assert subject.get_drawing_metadata(drawing) == []
+
 
 class TestSyncPerspectiveCameraShifts(NewFile):
     def test_round_trips_perspective_camera_shifts_through_drawing_pset(self):


### PR DESCRIPTION
Addresses #9033 from @Plae-Blue-Dot.

Phase hatching currently requires typing `/Pset_.*Common/.Status` into `EPset_Drawing.Metadata` on every camera by hand. This adds a **Status Classes** checkbox to the Active Drawing panel that writes that exact query into that exact field.

## How it works today

`EPset_Drawing.Metadata` is a comma-separated list of selector queries, read at `tool/drawing.py:2327` and turned into SVG classes at `bim/module/drawing/operator.py:1474`, where `canonicalise_class_name` maps `/Pset_.*Common/.Status` plus `DEMOLISH` to the class `PsetCommonStatus-DEMOLISH`.

Nothing writes `Metadata` at drawing creation. `core/drawing.py:315-341` sets thirteen `EPset_Drawing` properties and `Metadata` is not among them, which is exactly why it has to be typed per camera.

## What this changes

The checkbox writes real IFC and derives its own state from real IFC. No new pset property is invented and the consumption path is untouched. `import_camera_props` ticks the box when the query is already present, so drawings where a user typed it by hand show as already enabled.

**It defaults to off.** Ticking it changes the `class` attribute of every element in the output SVG, so switching it on for existing drawings could make a custom stylesheet start matching rules written for other purposes.

Also fixes a latent crash found on the way: `get_drawing_metadata` called `.get()` on the result of `get_pset()` without a guard, raising `AttributeError: 'NoneType' object has no attribute 'get'` for any drawing with no `EPset_Drawing`.

## Open question for @theoryshaw and @Moult

Should this default to on? Suggested answer: **not for existing drawings**, and if at all, only for newly created ones via a one-line `"Metadata": "/Pset_.*Common/.Status"` in `core/drawing.py`. That touches zero existing files and still gives the reporter what they want going forward. Happy to follow up either way.

## Evidence

End-to-end through the real `CreateDrawing.get_svg_classes` on an `IfcWall` with `Pset_WallCommon.Status = DEMOLISH`:

```
A untouched   classes = ['IfcWall', 'material-null']
B hand-typed  classes = ['IfcWall', 'material-null', 'PsetCommonStatus-DEMOLISH']
C toggled     classes = ['IfcWall', 'material-null', 'PsetCommonStatus-DEMOLISH']
D untoggled   classes = ['IfcWall', 'material-null']
```

Case A matters most: an untouched drawing has no `EPset_Drawing` pset at all, so the feature writes nothing until ticked. Toggling matches hand-typing exactly, and unticking restores the original classes.

8 new tests, red on a pristine `v0.8.0` tree, green here. `test/tool` shows the same 2 pre-existing `test_project.py` failures on both trees and nothing else; `test/core` 390 passed on both.

## Not included

- `EPset_Status.Status` is not covered. `bim.assign_status` falls back to that pset when a class has no common one, so those elements get no class. It would emit a second class name that no existing stylesheet targets, so it is left as a follow-up.
- No default hatching. The shipped `default.css` contains zero `PsetCommonStatus` rules, so a stylesheet is still required. Shipping default phase hatching is a separate drawing-convention decision.

Worth noting for @Plae-Blue-Dot: `bim.duplicate_drawing` already copies `EPset_Drawing` wholesale, so setting the query once and duplicating that drawing carries it forward. That works today.

This PR was generated with the assistance of an AI coding tool.
