### PR TITLE
Bonsai: default the plan cut to the active storey, not Origin (#9032)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -125,11 +125,15 @@ class DrawingsData:
     def location_hint(cls) -> list[tuple[tool.Drawing.LocationHintType, str, str]]:
         props = tool.Drawing.get_document_props()
         if props.target_view in ["PLAN_VIEW", "REFLECTED_PLAN_VIEW"]:
-            results = [("0", "Origin", "")]
-            results.extend(
-                [(str(s.id()), s.Name or "Unnamed", "") for s in tool.Ifc.get().by_type("IfcBuildingStorey")]
-            )
-            return results
+            origin = ("0", "Origin", "")
+            storeys = [(str(s.id()), s.Name or "Unnamed", "") for s in tool.Ifc.get().by_type("IfcBuildingStorey")]
+            if not storeys:
+                return [origin]
+            default_container = tool.Root.get_default_container()
+            if default_container and default_container.is_a("IfcBuildingStorey"):
+                default_id = str(default_container.id())
+                storeys.sort(key=lambda s: s[0] != default_id)
+            return storeys + [origin]
         elif props.target_view in ["MODEL_VIEW"]:
             return [(h.upper(), h, "") for h in ["Orthographic", "Perspective"]]
         return [(h.upper(), h, "") for h in ["North", "South", "East", "West"]]


### PR DESCRIPTION
Fixes #9032.

`location_hint` (`src/bonsai/bonsai/bim/module/drawing/prop.py:426`) has no `default`, so Blender pre-selects whatever `DrawingsData.location_hint()` returns first, and `("0", "Origin", "")` was hardcoded at position zero. @Plae-Blue-Dot points out that a cut at world Z=0 is rarely what anyone wants, and "MyStorey" in their screenshot is Bonsai's own auto-created storey from `core/project.py:53`.

Storeys now come first with Origin last, ordered so that `tool.Root.get_default_container()`'s storey leads. That reuses Bonsai's existing active-storey concept rather than introducing a new one, falls back to plain storey order when no default container is set, and returns Origin alone when the project has no storeys.

**Existing drawings cannot be affected.** The hint is read once at creation (`operator.py:173` -> `core/drawing.py:295` -> `generate_drawing_matrix`) and baked into the `IfcAnnotation`'s `ObjectPlacement`. Verified by creating a drawing at a storey cut, adding a second storey so the enum reordered, and confirming the existing drawing's camera Z stayed at `1.600000023841858`.

Red: `[('0', 'Origin', ''), ('39', 'My Storey', '')]`. Green: `[('39', 'My Storey', ''), ('0', 'Origin', '')]`. black and ruff clean.

One residual risk for @theoryshaw and @Moult: in a project using `default_container` for something other than the current working storey, the pre-selected storey may not be the expected one. The dropdown remains one click from any other storey or Origin.

Not verified: IFC2X3 (the code path is schema-agnostic, using `by_type("IfcBuildingStorey")` which exists in both), and no interactive click-through.

This PR was generated with the assistance of an AI coding tool.
