### PR TITLE
copy_class: don't share the original's annotations with the duplicate (#9049, cause behind #4014)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/root/copy_class.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/root/copy_class.py
@@ -52,6 +52,11 @@ def copy_class(file: ifcopenshell.file, product: ifcopenshell.entity_instance) -
       will also be copied.
     * Path connectivity is not copied, as there is no guarantee that the
       connections are still valid.
+    * Annotations assigned to the product are not copied. They stay assigned to
+      the original only, so the copy starts with no annotations. Sharing them
+      would leave one annotation labelling two products, which is invalid.
+      Other objects assigned to the product, such as tasks that output it, are
+      still inherited by the copy.
 
     :param product: The IfcProduct to copy.
     :return: The copied product
@@ -135,6 +140,18 @@ class Usecase:
                 continue
             elif inverse.is_a("IfcRelDefinesByType") and inverse.RelatingType == from_element:
                 continue
+            elif inverse.is_a("IfcRelAssignsToProduct") and inverse.RelatingProduct == from_element:
+                # An annotation labels exactly one product, so it must not be shared. The
+                # generic branch below would copy the relationship and swap the product,
+                # leaving the original's annotations assigned to both products. See #4014.
+                # Other assignments are fine to inherit: the same relationship also holds
+                # tasks that output this product, and a task may output many products.
+                related_objects = [e for e in inverse.RelatedObjects if not e.is_a("IfcAnnotation")]
+                if not related_objects:
+                    continue
+                new_inverse = ifcopenshell.util.element.copy(self.file, inverse)
+                new_inverse.RelatedObjects = related_objects
+                new_inverse.RelatingProduct = to_element
             elif inverse.is_a("IfcRelVoidsElement") and inverse.RelatingBuildingElement == from_element:
                 opening = inverse.RelatedOpeningElement
                 # We don't copy filled openings, since there is no guarantee the filling is also copied

--- a/src/ifcopenshell-python/test/api/root/test_copy_class.py
+++ b/src/ifcopenshell-python/test/api/root/test_copy_class.py
@@ -24,10 +24,12 @@ import ifcopenshell.api.geometry
 import ifcopenshell.api.group
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
+import ifcopenshell.api.sequence
 import ifcopenshell.api.spatial
 import ifcopenshell.api.system
 import ifcopenshell.api.type
 import ifcopenshell.api.unit
+import ifcopenshell.guid
 import ifcopenshell.util.system
 import test.bootstrap
 
@@ -267,6 +269,53 @@ class TestCopyClass(test.bootstrap.IFC4):
         new = ifcopenshell.api.root.copy_class(self.file, product=element)
         assert len(self.file.by_type("IfcRelAssignsToGroup")) == 1
         assert new.HasAssignments[0].RelatingGroup == group
+
+    def assign_annotation_to_product(self, product, annotation):
+        return self.file.create_entity(
+            "IfcRelAssignsToProduct",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedObjects=[annotation],
+            RelatingProduct=product,
+        )
+
+    def test_not_copying_assigned_annotations_so_they_stay_on_the_original_product(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        annotation = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcAnnotation")
+        self.assign_annotation_to_product(element, annotation)
+        new = ifcopenshell.api.root.copy_class(self.file, product=element)
+        assert len(self.file.by_type("IfcRelAssignsToProduct")) == 1
+        assert len(annotation.HasAssignments) == 1
+        assert annotation.HasAssignments[0].RelatingProduct == element
+        assert not new.ReferencedBy
+
+    def test_maintaining_task_output_relationships_when_copying_a_product(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        task = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcTask")
+        ifcopenshell.api.sequence.assign_product(self.file, relating_product=element, related_object=task)
+        new = ifcopenshell.api.root.copy_class(self.file, product=element)
+        assert new.ReferencedBy
+        assert new.ReferencedBy[0].RelatedObjects == (task,)
+
+    def test_copying_a_product_keeps_task_outputs_but_drops_annotations_sharing_the_same_relationship(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        task = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcTask")
+        annotation = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcAnnotation")
+        # Both APIs append to relating_product.ReferencedBy[0], so one rel holds both.
+        ifcopenshell.api.sequence.assign_product(self.file, relating_product=element, related_object=task)
+        rel = element.ReferencedBy[0]
+        rel.RelatedObjects = list(rel.RelatedObjects) + [annotation]
+        new = ifcopenshell.api.root.copy_class(self.file, product=element)
+        assert new.ReferencedBy[0].RelatedObjects == (task,)
+        assert len(annotation.HasAssignments) == 1
+        assert annotation.HasAssignments[0].RelatingProduct == element
+
+    def test_copying_an_annotation_keeps_it_assigned_to_the_same_product(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        annotation = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcAnnotation")
+        self.assign_annotation_to_product(element, annotation)
+        new = ifcopenshell.api.root.copy_class(self.file, product=annotation)
+        assert len(self.file.by_type("IfcRelAssignsToProduct")) == 1
+        assert set(element.ReferencedBy[0].RelatedObjects) == {annotation, new}
 
 
 class TestCopyClassIFC2X3(test.bootstrap.IFC2X3):


### PR DESCRIPTION
Closes #9049. Very likely the missing cause behind #4014.

Duplicating a product that has annotations assigned to it does not give the copy its own annotations, and does not leave the copy without annotations either. `IfcRelAssignsToProduct` matched none of the special cases in `copy_indirect_attributes`, so it fell through to the generic `else` branch, where `value == from_element` matches at `RelatingProduct`. The whole relationship was copied with only that attribute swapped, so `RelatedObjects` still held the original's annotations and both products claimed them.

```python
f = ifcopenshell.file(schema="IFC4")
wall = ifcopenshell.api.root.create_entity(f, ifc_class="IfcWall")
annotation = ifcopenshell.api.root.create_entity(f, ifc_class="IfcAnnotation")
f.create_entity("IfcRelAssignsToProduct", GlobalId=ifcopenshell.guid.new(),
                RelatedObjects=[annotation], RelatingProduct=wall)

copy = ifcopenshell.api.root.copy_class(f, product=wall)
# before: annotation assigned to 1 product
# after:  annotation assigned to 2 products [wall, copy]
```

Every annotation involved then reports two assigned products, which is the symptom tracked in #4014. `get_assigned_product` returns whichever relationship comes first, so an annotation can silently label the wrong element, and `tool.Drawing.get_assigned_product_workaround` exists to paper over exactly this. In one production model 60 of 808 annotations were affected across 22 cloned relationship sets, with one annotation reaching three spaces after its space was duplicated twice.

### The fix is deliberately narrow

The relationship is now handled explicitly when the copied element is the `RelatingProduct`. Annotations are dropped from the copy, since an annotation labels exactly one product and must not be shared.

Everything else assigned to the product is still inherited. That matters: the same relationship carries the 4D **Output** link from a task to the product it builds, a task may legitimately output many products, and both `sequence.assign_product` and `drawing.assign_product` append to `relating_product.ReferencedBy[0]` — so a single relationship can hold a task and an annotation at once. Skipping the relationship wholesale would have silently stripped task outputs from every duplicated element. A relationship left with no related objects is skipped entirely.

### Relationship to other open work

- **#6621 / PR #8032** fix the cases where the *annotation* is duplicated, alone or together with its product. That guard requires the new element to be in `RelatedObjects`, so it never reaches this path, where the new element is the `RelatingProduct`. The two are complementary.
- **#8373 / #8374** clean up annotations that already have multiple products; they don't prevent them being created. #8373's own scope note says it "does not address how annotations accumulate multiple products in the first place (still under investigation)" — this is that path.

**Note for whoever merges:** PR #8032 needs a one-case update to work alongside this. Its case A only removes the duplicated annotation from the original product's relationship, relying on `copy_class` having cloned that relationship onto the new product so its case B could fix it up. Once `copy_class` stops doing that, nothing re-links the annotation copy and it ends up assigned to nothing. I've pushed that update to #8032's branch and verified it is safe in either merge order. Details in the comments on both PRs.

`tool.Drawing.clear_annotation_relationships`, which deletes the stale relationships this used to create when duplicating a drawing, becomes a no-op rather than a necessity.

### Testing

Four tests in `test_copy_class.py`: annotations stay on the original, task outputs are still inherited, a mixed relationship keeps the task and drops the annotation, and copying an annotation still leaves it assigned to the same product. The first and third fail without the fix.

The full ifcopenshell api suite passes — 1449 tests, excluding a pre-existing collection error in `test/api/alignment/test_update_fallback_position.py` that fails identically without these changes.

Generated with the assistance of an AI coding tool.
