### PR TITLE
ifctester: stop unrecognised boolean spellings matching True

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -40,11 +40,13 @@ def cast_to_value(from_value, to_value):
             # Casting str -> float means that notation like '1e3' is preserved
             # We do not cast to int because 42.0 == 42 and 42.3 != 42
             return float(from_value)
-        elif target_type == "bool":
+        elif target_type == "bool" and isinstance(from_value, str):
             if from_value in ("true", "1"):
                 return True
             elif from_value in ("false", "0"):
                 return False
+            # Any other spelling is not a boolean, so it must not match either state
+            return None
         return builtins.__dict__[target_type](from_value)
     except ValueError:
         pass

--- a/src/ifctester/test/fixtures/property_boolean_unrecognised_spelling/property_boolean_unrecognised_spelling.ids
+++ b/src/ifctester/test/fixtures/property_boolean_unrecognised_spelling/property_boolean_unrecognised_spelling.ids
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Unrecognised boolean spelling</title>
+        <description>IsExternal must be off, an unrecognised boolean spelling.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must have IsExternal=off" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <property dataType="IFCBOOLEAN" cardinality="required">
+                    <propertySet>
+                        <simpleValue>Pset_WallCommon</simpleValue>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>IsExternal</simpleValue>
+                    </baseName>
+                    <value>
+                        <simpleValue>off</simpleValue>
+                    </value>
+                </property>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/property_boolean_unrecognised_spelling/property_boolean_unrecognised_spelling.ifc
+++ b/src/ifctester/test/fixtures/property_boolean_unrecognised_spelling/property_boolean_unrecognised_spelling.ifc
@@ -1,0 +1,14 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-07T00:00:00',(''),(''),'IfcOpenShell','IfcOpenShell','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('3Fu_ePwY1DZxzRl9jojPIx',$,'W',$,$,$,$,$,$);
+#3=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
+#4=IFCPROPERTYSET('2Fu_ePwY1DZxzRl9jojPIx',$,'Pset_WallCommon',$,(#3));
+#5=IFCRELDEFINESBYPROPERTIES('4Fu_ePwY1DZxzRl9jojPIx',$,$,$,(#2),#4);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -652,6 +652,29 @@ class TestAttribute:
         facet = Attribute(name="IsMilestone", value="1")
         run("Booleans can be specified as a 0 or 1 2/2", facet=facet, inst=element, expected=False)
 
+        ifc = ifcopenshell.file()
+        element = ifc.createIfcTask(IsMilestone=True)
+        for value in ("False", "FALSE", "no", "off"):
+            facet = Attribute(name="IsMilestone", value=value)
+            run(
+                f"A boolean spelled as {value} never matches a true attribute",
+                facet=facet,
+                inst=element,
+                expected=False,
+            )
+        for value in ("True", "TRUE", "yes", "on"):
+            facet = Attribute(name="IsMilestone", value=value)
+            run(
+                f"A boolean spelled as {value} never matches a true attribute",
+                facet=facet,
+                inst=element,
+                expected=False,
+            )
+        facet = Attribute(name="IsMilestone", value="true")
+        run("A lowercase true matches a true attribute", facet=facet, inst=element, expected=True)
+        facet = Attribute(name="IsMilestone", value="false")
+        run("A lowercase false does not match a true attribute", facet=facet, inst=element, expected=False)
+
         facet = Attribute(name="EditionDate", value="2022-01-01")
         ifc = ifcopenshell.file()
         run(
@@ -1089,6 +1112,20 @@ class TestProperty:
         run("Booleans can be specified as as a 0 or 1 1/2", facet=facet, inst=element, expected=True)
         facet = Property(propertySet="Foo_Bar", baseName="Foo", value="1", dataType="IFCBOOLEAN")
         run("Booleans can be specified as as a 0 or 1 2/2", facet=facet, inst=element, expected=False)
+
+        ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"Foo": ifc.createIfcBoolean(True)})
+        for value in ("False", "FALSE", "no", "off", "True", "TRUE", "yes", "on"):
+            facet = Property(propertySet="Foo_Bar", baseName="Foo", value=value, dataType="IFCBOOLEAN")
+            run(
+                f"A boolean spelled as {value} never matches a true property",
+                facet=facet,
+                inst=element,
+                expected=False,
+            )
+        facet = Property(propertySet="Foo_Bar", baseName="Foo", value="true", dataType="IFCBOOLEAN")
+        run("A lowercase true matches a true property", facet=facet, inst=element, expected=True)
+        facet = Property(propertySet="Foo_Bar", baseName="Foo", value="false", dataType="IFCBOOLEAN")
+        run("A lowercase false does not match a true property", facet=facet, inst=element, expected=False)
 
         facet = Property(propertySet="Foo_Bar", baseName="Foo", value="2022-01-01", dataType="IFCDATE")
         ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"Foo": ifc.createIfcDate("2022-01-01")})
@@ -1696,6 +1733,18 @@ class TestRestriction:
         assert restriction == "bar"
         assert restriction != "Foo"
         assert restriction != "baz"
+
+    def test_boolean_enumeration(self):
+        restriction = Restriction(options={"enumeration": ["true"]})
+        assert restriction == True
+        assert restriction != False
+        restriction = Restriction(options={"enumeration": ["false"]})
+        assert restriction == False
+        assert restriction != True
+        for option in ("True", "TRUE", "False", "FALSE", "yes", "no"):
+            restriction = Restriction(options={"enumeration": [option]})
+            assert restriction != True
+            assert restriction != False
 
     def test_bounds(self):
         restriction = Restriction(options={"minInclusive": 0, "maxExclusive": 10}, base="integer")

--- a/src/ifctester/test/test_fixture_property_boolean_unrecognised_spelling.py
+++ b/src/ifctester/test/test_fixture_property_boolean_unrecognised_spelling.py
@@ -1,0 +1,47 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression test for a specific reported defect.
+
+An IDS value with an unrecognised boolean spelling (here "off") used to fall
+through to bool(value), which is True for any non-empty string. That made an
+unrecognised spelling match a true boolean property, turning a genuine
+violation into a false pass.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "property_boolean_unrecognised_spelling")
+SPEC = os.path.join(FIXTURES, "property_boolean_unrecognised_spelling.ids")
+MODEL = os.path.join(FIXTURES, "property_boolean_unrecognised_spelling.ifc")
+
+
+class TestPropertyBooleanUnrecognisedSpellingFixture:
+    def test_unrecognised_spelling_does_not_match_a_true_value(self):
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(MODEL)
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.requirements[0].status is False
+        assert spec.status is False


### PR DESCRIPTION
cast_to_value() recognised only "true", "1", "false" and "0" as booleans,
then fell through to builtins.bool(from_value) for everything else. Because
bool() of any non-empty string is True, an IDS value such as "False",
"FALSE", "no" or "off" silently compared equal to a property or attribute
whose value was true. The requirement was reported as met.

The failure was one-sided. An unrecognised spelling never matched a false
value, so it only ever turned a violation into a pass. An IDS requiring
Pset_WallCommon.IsExternal to be "False" reported PASS for a wall whose
IsExternal is .T., certifying a model that does not comply.

test_facet.py already asserted the intended semantics for the false side:
"Booleans must be specified as lowercase strings" checks that value="False"
does not match IfcBoolean(False). The mirror case against IfcBoolean(True)
was untested, which is where the wrong result lived.

An unrecognised spelling now yields no value at all, so it matches neither
state, on the Attribute facet, the Property facet, and xs:enumeration
restrictions. Non-string inputs keep their previous coercion path.

Generated with the assistance of an AI coding tool.

