### PR TITLE
ifctester: IFC2X3 predefined psets crash, and two Classification false verdicts

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -440,7 +440,7 @@ class Classification(Facet):
             if not is_pass:
                 reason = {"type": "VALUE", "actual": values}
 
-        if is_pass:
+        if is_pass and self.system:
             classifications = filter(None, (ifcopenshell.util.classification.get_classification(r) for r in references))
             systems = [r.Name for r in classifications]
             is_pass = any([self.system == s for s in systems])
@@ -920,7 +920,14 @@ class Property(Facet):
             return pset.Quantities
         elif pset.is_a("IfcMaterialProperties") or pset.is_a("IfcProfileProperties"):
             return pset.Properties
-        elif pset.is_a("IfcPreDefinedPropertySet"):
+        else:
+            # Predefined property sets (e.g. IfcDoorLiningProperties) store their
+            # values as direct attributes rather than IfcProperty entities. In
+            # IFC4 these are IfcPreDefinedPropertySet subtypes, but that abstract
+            # supertype does not exist in IFC2X3, so the same kind of entity
+            # (e.g. IfcWindowLiningProperties) falls straight through to here
+            # instead. ifcopenshell.util.element.get_property_definition() already
+            # treats this as its unconditional fallback, so mirror that here.
             return [
                 type("", (object,), {"Name": k, "Value": v})()
                 for k, v in pset.get_info().items()

--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -426,25 +426,38 @@ class Classification(Facet):
         for leaf_reference in leaf_references:
             references.update(ifcopenshell.util.classification.get_inherited_references(leaf_reference))
 
-        is_pass = bool(references)
-        reason = None
-
-        if not is_pass:
+        if not references:
             if self.cardinality == "optional":
                 return ClassificationResult(True)
             reason = {"type": "NOVALUE"}
+            if self.cardinality == "prohibited":
+                return ClassificationResult(True, {"type": "PROHIBITED"})
+            return ClassificationResult(False, reason)
 
-        if is_pass and self.value:
-            values = [getattr(r, "Identification", getattr(r, "ItemReference", None)) for r in references]
-            is_pass = any([self.value == v for v in values])
-            if not is_pass:
+        # A requested value and a requested system must both hold on the
+        # same reference: a wall classified as "ExpectedValue" under system
+        # "SystemB" must not pass a requirement for "ExpectedValue" under
+        # system "SystemA" just because some other, unrelated reference on
+        # the wall happens to use system "SystemA". self.value/self.system
+        # being unset (falsy) means that side of the pair is not checked.
+        values = []
+        systems = []
+        is_pass = False
+        for reference in references:
+            value = getattr(reference, "Identification", getattr(reference, "ItemReference", None))
+            classification = ifcopenshell.util.classification.get_classification(reference)
+            system = classification.Name if classification else None
+            values.append(value)
+            systems.append(system)
+            if (not self.value or self.value == value) and (not self.system or self.system == system):
+                is_pass = True
+                break
+
+        reason = None
+        if not is_pass:
+            if self.value and not any(self.value == v for v in values):
                 reason = {"type": "VALUE", "actual": values}
-
-        if is_pass and self.system:
-            classifications = filter(None, (ifcopenshell.util.classification.get_classification(r) for r in references))
-            systems = [r.Name for r in classifications]
-            is_pass = any([self.system == s for s in systems])
-            if not is_pass:
+            else:
                 reason = {"type": "SYSTEM", "actual": systems}
 
         if self.cardinality == "prohibited":

--- a/src/ifctester/test/fixtures/classification_system_value_pairing/classification_system_value_pairing.ids
+++ b/src/ifctester/test/fixtures/classification_system_value_pairing/classification_system_value_pairing.ids
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Classification system and value must match on the same reference</title>
+        <description>A wall must have a SystemA classification with value ExpectedValue. The wall in this fixture has two unrelated classification references: SystemA/WRONG and SystemB/ExpectedValue. Neither reference satisfies both constraints at once, so the requirement must fail.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must be classified as ExpectedValue under SystemA" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <classification cardinality="required">
+                    <value>
+                        <simpleValue>ExpectedValue</simpleValue>
+                    </value>
+                    <system>
+                        <simpleValue>SystemA</simpleValue>
+                    </system>
+                </classification>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/classification_system_value_pairing/classification_system_value_pairing.ifc
+++ b/src/ifctester/test/fixtures/classification_system_value_pairing/classification_system_value_pairing.ifc
@@ -1,0 +1,17 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T08:10:47',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPI0',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('3foV$XgsXBg9j1W4aNefvj',$,'Wall1',$,$,$,$,$,$);
+#3=IFCCLASSIFICATION($,$,$,'SystemA',$,$,$);
+#4=IFCCLASSIFICATIONREFERENCE($,'WRONG',$,#3,$,$);
+#5=IFCRELASSOCIATESCLASSIFICATION('05rScmOVzMoQXOfbYdtLYj',$,$,$,(#2),#4);
+#6=IFCCLASSIFICATION($,$,$,'SystemB',$,$,$);
+#7=IFCCLASSIFICATIONREFERENCE($,'ExpectedValue',$,#6,$,$);
+#8=IFCRELASSOCIATESCLASSIFICATION('15rScmOVzMoQXOfbYdtLYj',$,$,$,(#2),#7);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -864,6 +864,14 @@ class TestClassification:
             expected=True,
         )
 
+        facet = Classification(value="1")
+        run(
+            "A value-only facet with no system specified does not wrongly require a system match",
+            facet=facet,
+            inst=element1,
+            expected=True,
+        )
+
         facet = Classification(system="Foobar")
         run("Systems should match exactly 1/5", facet=facet, inst=project, expected=True)
         run("Systems should match exactly 2/5", facet=facet, inst=element0, expected=False)
@@ -1346,6 +1354,39 @@ class TestProperty:
         run("MASSUNIT uses Kg instead of g", facet=facet, inst=element, expected=True)
         prop.NominalValue = ifc.create_entity("IfcMassMeasure", 6.0)
         run("MASSUNIT uses Kg instead of g", facet=facet, inst=element, expected=False)
+
+    def test_ifc2x3_predefined_property_sets_expose_direct_attributes(self):
+        set_facet("property")
+
+        # IfcPreDefinedPropertySet does not exist in IFC2X3, so its former
+        # subtypes (e.g. IfcDoorLiningProperties) fall straight through to
+        # IfcPropertySetDefinition, storing values as direct attributes
+        # rather than IfcProperty entities. This used to crash with a
+        # TypeError instead of correctly matching (or failing) the value.
+        ifc = ifcopenshell.file(schema="IFC2X3")
+        door = ifc.create_entity("IfcDoor", GlobalId=ifcopenshell.guid.new())
+        lining = ifc.create_entity(
+            "IfcDoorLiningProperties",
+            GlobalId=ifcopenshell.guid.new(),
+            Name="Foo_Bar",
+            LiningDepth=0.05,
+        )
+        ifc.create_entity(
+            "IfcRelDefinesByProperties",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedObjects=[door],
+            RelatingPropertyDefinition=lining,
+        )
+
+        facet = Property(
+            propertySet="Foo_Bar", baseName="LiningDepth", value="0.05", dataType="IFCPOSITIVELENGTHMEASURE"
+        )
+        run("IFC2X3 predefined property sets expose direct attributes 1/2", facet=facet, inst=door, expected=True)
+
+        facet = Property(
+            propertySet="Foo_Bar", baseName="LiningDepth", value="0.9", dataType="IFCPOSITIVELENGTHMEASURE"
+        )
+        run("IFC2X3 predefined property sets expose direct attributes 2/2", facet=facet, inst=door, expected=False)
 
     def setup_ifc(self):
         ifc = ifcopenshell.file()

--- a/src/ifctester/test/test_fixture_classification_system_value_pairing.py
+++ b/src/ifctester/test/test_fixture_classification_system_value_pairing.py
@@ -1,0 +1,62 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for specific reported defects.
+
+Each test here loads a minimal .ids/.ifc pair from test/fixtures/ through
+the same entry points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestClassificationSystemValuePairingFixture:
+    def test_system_and_value_must_match_on_the_same_reference(self):
+        # The wall has two classification references: SystemA/WRONG and
+        # SystemB/ExpectedValue. The requirement asks for SystemA with
+        # value ExpectedValue. Neither single reference satisfies both, so
+        # the specification must fail, even though "SystemA" appears
+        # somewhere on the wall and "ExpectedValue" appears somewhere else
+        # on the wall.
+        specs = ids.open(
+            os.path.join(
+                FIXTURES,
+                "classification_system_value_pairing",
+                "classification_system_value_pairing.ids",
+            )
+        )
+        ifc = ifcopenshell.open(
+            os.path.join(
+                FIXTURES,
+                "classification_system_value_pairing",
+                "classification_system_value_pairing.ifc",
+            )
+        )
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+        assert spec.requirements[0].status is False


### PR DESCRIPTION
Three defects in `ifctester`, all in facet evaluation. The first two were the original scope; the third was found later and folded in here rather than opened as a competing PR, since it rewrites the same function.

## 1. IFC2X3 predefined property sets crash

`Property.get_properties()` only recognised predefined property sets such as `IfcDoorLiningProperties` via `is_a("IfcPreDefinedPropertySet")`. That abstract supertype does not exist in IFC2X3, so the same kind of entity falls through every branch, the method returns `None`, and evaluating a Property facet against a valid IFC2X3 file raises:

```
TypeError: 'NoneType' object is not iterable
```

`ifcopenshell.util.element.get_property_definition()` already handles this with an unconditional fallback reading the entity's direct attributes, regardless of schema. This mirrors that fallback rather than gating on a class name that only exists in IFC4.

## 2. Classification: a value-only facet wrongly required a system

A facet with only `value` set and no `system` compared `None` against every classification's `Name` and failed a requirement that should have passed, because the system check ran whenever `is_pass` was true rather than only when a system was actually requested.

## 3. Classification: value and system could match different references

Found while investigating [buildingSMART/IDS#417](https://github.com/buildingSMART/IDS/issues/417).

The value check and the system check each ran independently over every classification reference on the element:

```python
is_pass = any([self.value == v for v in values])
...
is_pass = any([self.system == s for s in systems])
```

So an element carrying two unrelated references, one matching the requested value and a **different** one matching the requested system, passed a requirement that no single reference satisfies. Measured: a wall with `SystemA/WRONG` and `SystemB/ExpectedValue` passed a requirement for `SystemA` plus `ExpectedValue`.

That is a false pass, which is the worst direction for a checker to be wrong in: the model violates the requirement and the report says it is fine, so nothing prompts anyone to look.

The two checks now run **paired, against the same reference**. That subsumes the fix in point 2 rather than stacking on it, since `not self.system or self.system == system` inside the same per-reference loop covers exactly the no-system-requested case. One coherent loop, not two guards.

## Verification

Each defect red-green proven separately:

* Point 1 and 2 against plain `v0.8.0`: `assert False is True` on the value-only classification case.
* Point 3 against this PR's own previous head, with the point 2 guard present but no pairing: `assert True is False` on `test_system_and_value_must_match_on_the_same_reference`.

Both green after. Full ifctester suite 39/39. New fixture in its own directory with its own test file.

Conflict-checked clean against #9203, #9205, #9250, #9261, #9263, #9268, #9272 and #9273, with a control pair confirming the check detects real conflicts.

Produced with AI assistance.
