### PR TITLE
ifccsv: stop a blank spreadsheet cell writing "nan" into the model

### DIFF
--- a/src/ifccsv/Makefile
+++ b/src/ifccsv/Makefile
@@ -20,6 +20,10 @@ PACKAGE_NAME:=ifccsv.py
 IS_MODULE:=true
 include ../common.mk
 
+.PHONY: test
+test:
+	pytest -p no:pytest-blender test.py
+
 .PHONY: qa
 qa:
 	black .

--- a/src/ifccsv/ifccsv.py
+++ b/src/ifccsv/ifccsv.py
@@ -497,6 +497,14 @@ class IfcCsv:
         for i, value in enumerate(row):
             if i == 0:
                 continue  # Skip GlobalId
+            if isinstance(value, float) and value != value:
+                # A blank XLSX/ODS cell is read back by pandas as float `nan`
+                # (not as an empty string or None), since pandas cannot tell a
+                # blank cell apart from a genuinely missing one. Without this,
+                # `nan` falls through the checks below untouched and later gets
+                # stringified, silently setting the IFC attribute to the
+                # literal text "nan" instead of clearing it.
+                value = empty
             if value == null:
                 value = None
             elif value == empty:

--- a/src/ifccsv/test.py
+++ b/src/ifccsv/test.py
@@ -1,0 +1,79 @@
+# IfcCSV - A utility to interact with IFC data through CSV.
+# Copyright (C) 2020, 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcCSV.
+#
+# IfcCSV is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcCSV is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcCSV.  If not, see <http://www.gnu.org/licenses/>.
+
+import tempfile
+import os
+
+import openpyxl
+import ifcopenshell
+import ifcopenshell.api.root
+import ifcopenshell.api.unit
+
+import ifccsv
+
+
+def setup_project() -> ifcopenshell.file:
+    ifc_file = ifcopenshell.file(schema="IFC4")
+    ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject")
+    ifcopenshell.api.unit.assign_unit(ifc_file)
+    return ifc_file
+
+
+class TestIfcCsv:
+    def test_blank_xlsx_cell_does_not_corrupt_attribute(self):
+        # Regression test: a blank XLSX/ODS cell is read back by pandas as
+        # float `nan`, not as an empty string or None (pandas cannot tell a
+        # blank cell apart from a genuinely missing one). Before the fix,
+        # `nan` fell through process_row's null/empty checks untouched and
+        # was later stringified, silently setting the IFC attribute to the
+        # literal text "nan" instead of clearing it - even though the user
+        # only deleted a cell's content in Excel.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+        wall.Name = "Original Name"
+        wall.Description = "Original Description"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            xlsx_path = os.path.join(tmp_dir, "user_edited.xlsx")
+            wb = openpyxl.Workbook()
+            ws = wb.active
+            ws.append(["GlobalId", "Name", "Description"])
+            ws.append([wall.GlobalId, "Original Name", None])  # Description cell left blank
+            wb.save(xlsx_path)
+
+            ifc_csv = ifccsv.IfcCsv()
+            ifc_csv.Import(ifc_file, xlsx_path, attributes=["Name", "Description"])
+
+        assert wall.Description == "", f"expected an empty string, got {wall.Description!r}"
+
+    def test_xlsx_roundtrip_of_empty_string_is_stable(self):
+        # Reimporting an unchanged XLSX export should be a no-op, even for an
+        # attribute that was explicitly an empty string (as opposed to None).
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+        wall.Name = ""
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            xlsx_path = os.path.join(tmp_dir, "export.xlsx")
+            ifc_csv = ifccsv.IfcCsv()
+            ifc_csv.export(ifc_file, [wall], ["Name"], output=xlsx_path, format="xlsx")
+
+            ifc_csv2 = ifccsv.IfcCsv()
+            ifc_csv2.Import(ifc_file, xlsx_path, attributes=["Name"])
+
+        assert wall.Name == "", f"expected an empty string, got {wall.Name!r}"


### PR DESCRIPTION
process_row() only recognised the null/empty markers as strings. pandas
represents a blank spreadsheet cell as float nan, not as an empty string
or None, so that nan value fell through untouched and later got
stringified by set_element_value's coercion fallback, silently setting
the IFC attribute to the literal text "nan" instead of clearing it.

This corrupts a very ordinary workflow: export to XLSX, delete a cell's
content in Excel, reimport. It also affects reimporting an unmodified
export whenever an attribute is exported as an empty string, since
pandas/openpyxl write "" as a blank cell too.

Normalise nan to the configured empty marker before the existing
null/empty/bool checks, so a blank cell round-trips to "" like it did
before pandas read it back.

Added src/ifccsv/test.py (this package had no test suite) with a
regression test reproducing the blank-cell scenario directly, plus one
for the empty-string export/reimport round-trip. Also added a `test`
Makefile target matching ifcdiff's, so `make test` works locally; CI
does not invoke it yet (ci.yml has no ifccsv test step at all), which
is a separate decision for the maintainer.

Generated with the assistance of an AI coding tool.

