### PR TITLE
ifcfm: guard COBie zone and container lookups, and add the package's first tests

### DIFF
--- a/src/ifcfm/Makefile
+++ b/src/ifcfm/Makefile
@@ -19,6 +19,10 @@
 PACKAGE_NAME:=ifcfm
 include ../common.mk
 
+.PHONY: test
+test:
+	pytest -p no:pytest-blender test.py
+
 .PHONY: qa
 qa:
 	black .

--- a/src/ifcfm/ifcfm/basic.py
+++ b/src/ifcfm/ifcfm/basic.py
@@ -148,7 +148,7 @@ def get_element_type_data(ifc_file: ifcopenshell.file, element: ifcopenshell.ent
 
 def get_element_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entity_instance) -> dict[str, Any]:
     space = ifcopenshell.util.element.get_container(element)
-    space_name = space.Name if space.is_a("IfcSpace") else None
+    space_name = space.Name if space and space.is_a("IfcSpace") else None
     systems = ifcopenshell.util.system.get_element_systems(element)
     system = systems[0].Name if systems else None
     psets = ifcopenshell.util.element.get_psets(element)

--- a/src/ifcfm/ifcfm/basic.py
+++ b/src/ifcfm/ifcfm/basic.py
@@ -149,12 +149,14 @@ def get_element_type_data(ifc_file: ifcopenshell.file, element: ifcopenshell.ent
 def get_element_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entity_instance) -> dict[str, Any]:
     space = ifcopenshell.util.element.get_container(element)
     space_name = space.Name if space and space.is_a("IfcSpace") else None
+    element_type = ifcopenshell.util.element.get_type(element)
+    type_name = element_type.Name if element_type else None
     systems = ifcopenshell.util.system.get_element_systems(element)
     system = systems[0].Name if systems else None
     psets = ifcopenshell.util.element.get_psets(element)
     return {
         "Name": element.Name,
-        "TypeName": ifcopenshell.util.element.get_type(element).Name,
+        "TypeName": type_name,
         "SpaceName": space_name,
         "SystemName": system,
         "OrganizationName": get_owner_name(element),

--- a/src/ifcfm/ifcfm/cobie24.py
+++ b/src/ifcfm/ifcfm/cobie24.py
@@ -579,7 +579,7 @@ def get_type_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entity_inst
 
 def get_component_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entity_instance) -> dict[str, Any]:
     space = ifcopenshell.util.element.get_container(element)
-    space_name = space.Name if space.is_a("IfcSpace") else None
+    space_name = space.Name if space and space.is_a("IfcSpace") else None
 
     type_name = None
     relating_type = ifcopenshell.util.element.get_type(element)

--- a/src/ifcfm/ifcfm/cobie24.py
+++ b/src/ifcfm/ifcfm/cobie24.py
@@ -441,7 +441,7 @@ def get_zone_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entity_inst
 
     name = zone.Name
     parent = ifcopenshell.util.element.get_aggregate(zone)
-    if parent and val(parent.Name):
+    if parent and val(parent.Name) and val(name):
         name = parent.Name + "-" + name
 
     category = get_category(zone)

--- a/src/ifcfm/ifcfm/cobie24legacy.py
+++ b/src/ifcfm/ifcfm/cobie24legacy.py
@@ -477,7 +477,7 @@ def get_zone_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entity_inst
 
     name = zone.Name
     parent = ifcopenshell.util.element.get_aggregate(zone)
-    if parent and val(parent.Name):
+    if parent and val(parent.Name) and val(name):
         name = parent.Name + "-" + name
 
     category = get_category(zone)

--- a/src/ifcfm/ifcfm/cobie24legacy.py
+++ b/src/ifcfm/ifcfm/cobie24legacy.py
@@ -634,7 +634,7 @@ def get_type_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entity_inst
 
 def get_component_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entity_instance) -> dict[str, Any]:
     space = ifcopenshell.util.element.get_container(element)
-    space_name = space.Name if space.is_a("IfcSpace") else None
+    space_name = space.Name if space and space.is_a("IfcSpace") else None
 
     type_name = None
     relating_type = ifcopenshell.util.element.get_type(element)

--- a/src/ifcfm/test.py
+++ b/src/ifcfm/test.py
@@ -1,0 +1,113 @@
+# IfcFM - IFC for facility management
+# Copyright (C) 2023 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcFM.
+#
+# IfcFM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcFM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcFM.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcfm.basic as basic
+import ifcfm.cobie24 as cobie24
+import ifcfm.cobie24legacy as cobie24legacy
+import ifcopenshell
+import ifcopenshell.api.aggregate
+import ifcopenshell.api.root
+import ifcopenshell.api.spatial
+import ifcopenshell.api.unit
+import ifcopenshell.util.element
+
+
+def setup_project() -> tuple[
+    ifcopenshell.file,
+    ifcopenshell.entity_instance,
+    ifcopenshell.entity_instance,
+    ifcopenshell.entity_instance,
+    ifcopenshell.entity_instance,
+]:
+    ifc_file = ifcopenshell.file(schema="IFC4")
+    project = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject", name="Test Project")
+    unit = ifcopenshell.api.unit.add_si_unit(ifc_file, unit_type="LENGTHUNIT", prefix="MILLI")
+    ifcopenshell.api.unit.assign_unit(ifc_file, units=[unit])
+    site = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSite", name="Site")
+    building = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuilding", name="Building")
+    storey = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey", name="Storey")
+    ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=project, products=[site])
+    ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=site, products=[building])
+    ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=building, products=[storey])
+    return ifc_file, project, site, building, storey
+
+
+class TestUnassignedComponentGuard:
+    """Regression tests for the crash fixed in 4e322d7: get_container() can
+    legitimately return None for a component that isn't (yet) placed in a
+    spatial container. Elements/get_element_data must not crash on that, in
+    all three presets."""
+
+    def test_basic_element_with_no_container_does_not_crash(self):
+        ifc_file, *_ = setup_project()
+        door = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoor", name="D01")
+        assert ifcopenshell.util.element.get_container(door) is None
+
+        data = basic.get_element_data(ifc_file, door)
+        assert data["SpaceName"] is None
+
+    def test_cobie24_component_with_no_container_does_not_crash(self):
+        ifc_file, *_ = setup_project()
+        door = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoor", name="D01")
+        assert ifcopenshell.util.element.get_container(door) is None
+
+        data = cobie24.get_component_data(ifc_file, door)
+        assert data["Space"] is None
+
+    def test_cobie24legacy_component_with_no_container_does_not_crash(self):
+        ifc_file, *_ = setup_project()
+        door = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoor", name="D01")
+        assert ifcopenshell.util.element.get_container(door) is None
+
+        data = cobie24legacy.get_component_data(ifc_file, door)
+        assert data["Space"] is None
+
+
+class TestContainedComponentHappyPath:
+    """The unassigned-container guard must not affect elements that DO have
+    a spatial container: the Space/SpaceName column must still be populated."""
+
+    def test_basic_element_in_space_reports_space_name(self):
+        ifc_file, project, site, building, storey = setup_project()
+        space = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSpace", name="Room 101")
+        ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=storey, products=[space])
+        door = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoor", name="D01")
+        ifcopenshell.api.spatial.assign_container(ifc_file, relating_structure=space, products=[door])
+
+        data = basic.get_element_data(ifc_file, door)
+        assert data["SpaceName"] == "Room 101"
+
+    def test_cobie24_component_in_space_reports_space_name(self):
+        ifc_file, project, site, building, storey = setup_project()
+        space = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSpace", name="Room 101")
+        ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=storey, products=[space])
+        door = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoor", name="D01")
+        ifcopenshell.api.spatial.assign_container(ifc_file, relating_structure=space, products=[door])
+
+        data = cobie24.get_component_data(ifc_file, door)
+        assert data["Space"] == "Room 101"
+
+    def test_cobie24legacy_component_in_space_reports_space_name(self):
+        ifc_file, project, site, building, storey = setup_project()
+        space = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSpace", name="Room 101")
+        ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=storey, products=[space])
+        door = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoor", name="D01")
+        ifcopenshell.api.spatial.assign_container(ifc_file, relating_structure=space, products=[door])
+
+        data = cobie24legacy.get_component_data(ifc_file, door)
+        assert data["Space"] == "Room 101"

--- a/src/ifcfm/test.py
+++ b/src/ifcfm/test.py
@@ -23,6 +23,7 @@ import ifcopenshell
 import ifcopenshell.api.aggregate
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
+import ifcopenshell.api.type
 import ifcopenshell.api.unit
 import ifcopenshell.util.element
 
@@ -111,3 +112,57 @@ class TestContainedComponentHappyPath:
 
         data = cobie24legacy.get_component_data(ifc_file, door)
         assert data["Space"] == "Room 101"
+
+
+class TestUntypedElementGuard:
+    """Regression test for basic.py:157: get_type() legitimately returns
+    None for an element with no assigned IfcTypeObject, which is ordinary
+    valid IFC. TypeName must fall back to None instead of crashing."""
+
+    def test_basic_element_with_no_type_does_not_crash(self):
+        ifc_file, *_ = setup_project()
+        door = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoor", name="D01")
+        assert ifcopenshell.util.element.get_type(door) is None
+
+        data = basic.get_element_data(ifc_file, door)
+        assert data["TypeName"] is None
+
+    def test_basic_element_with_type_reports_type_name(self):
+        ifc_file, *_ = setup_project()
+        door_type = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoorType", name="DT01")
+        door = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcDoor", name="D01")
+        ifcopenshell.api.type.assign_type(
+            ifc_file, related_objects=[door], relating_type=door_type, should_map_representations=False
+        )
+
+        data = basic.get_element_data(ifc_file, door)
+        assert data["TypeName"] == "DT01"
+
+
+class TestZoneDataUnnamedZone:
+    """cobie24.get_zone_data concatenated parent.Name + "-" + zone.Name
+    unguarded. Name is optional on IfcRoot, so an unnamed IfcZone nested
+    under a named IfcZone raised TypeError: can only concatenate str (not
+    "NoneType") to str."""
+
+    def test_unnamed_zone_with_named_parent_does_not_crash(self):
+        ifc_file, *_ = setup_project()
+        zone = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcZone", name=None)
+        parent_zone = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcZone", name="Group A")
+        ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=parent_zone, products=[zone])
+        assert zone.Name is None
+        assert ifcopenshell.util.element.get_aggregate(zone).Name == "Group A"
+
+        data = cobie24.get_zone_data(ifc_file, (zone, None))
+        assert data["Name"] is None
+
+    def test_named_zone_with_named_parent_prefixes_name(self):
+        # Happy path: the guard must not affect the original prefixing
+        # behaviour when both names are present.
+        ifc_file, *_ = setup_project()
+        zone = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcZone", name="Wet Areas")
+        parent_zone = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcZone", name="Group A")
+        ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=parent_zone, products=[zone])
+
+        data = cobie24.get_zone_data(ifc_file, (zone, None))
+        assert data["Name"] == "Group A-Wet Areas"

--- a/src/ifcfm/test.py
+++ b/src/ifcfm/test.py
@@ -166,3 +166,33 @@ class TestZoneDataUnnamedZone:
 
         data = cobie24.get_zone_data(ifc_file, (zone, None))
         assert data["Name"] == "Group A-Wet Areas"
+
+
+class TestZoneDataUnnamedZoneLegacy:
+    """Identical bug to TestZoneDataUnnamedZone above, in the cobie24legacy
+    preset: cobie24legacy.get_zone_data concatenated parent.Name + "-" +
+    zone.Name unguarded. Name is optional on IfcRoot, so an unnamed IfcZone
+    nested under a named IfcZone raised TypeError: can only concatenate str
+    (not "NoneType") to str."""
+
+    def test_unnamed_zone_with_named_parent_does_not_crash(self):
+        ifc_file, *_ = setup_project()
+        zone = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcZone", name=None)
+        parent_zone = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcZone", name="Group A")
+        ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=parent_zone, products=[zone])
+        assert zone.Name is None
+        assert ifcopenshell.util.element.get_aggregate(zone).Name == "Group A"
+
+        data = cobie24legacy.get_zone_data(ifc_file, (zone, None))
+        assert data["Name"] is None
+
+    def test_named_zone_with_named_parent_prefixes_name(self):
+        # Happy path: the guard must not affect the original prefixing
+        # behaviour when both names are present.
+        ifc_file, *_ = setup_project()
+        zone = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcZone", name="Wet Areas")
+        parent_zone = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcZone", name="Group A")
+        ifcopenshell.api.aggregate.assign_object(ifc_file, relating_object=parent_zone, products=[zone])
+
+        data = cobie24legacy.get_zone_data(ifc_file, (zone, None))
+        assert data["Name"] == "Group A-Wet Areas"


### PR DESCRIPTION
get_container() can legitimately return None for a component that is
not (yet) placed in an IfcSpace/IfcBuildingStorey, which is valid IFC.
basic.py, cobie24.py and cobie24legacy.py all called
space.is_a("IfcSpace") on that result unguarded, so a single
unassigned component crashed the entire Component/Elements sheet
export with an AttributeError, producing no COBie deliverable at all
instead of a row with a blank Space column.

AI disclosure: this fix was written with the assistance of an AI
coding tool; the crash was reproduced against a hand-built IFC4 file
with an unassigned IfcDoor before and after the change.

Generated with the assistance of an AI coding tool.

src/ifcfm had zero test files and its only CI workflow is a manual PyPI
publish with no test step, so the guard added in 4e322d7 had nothing
protecting it against regression. Add test.py plus a Makefile test
target, mirroring the pattern in src/ifcdiff, covering the guard across
all three presets (basic, cobie24, cobie24legacy): an element with no
spatial container must not crash the export, and a normally-contained
element still produces its expected Space/SpaceName value.

Not wired into ci.yml; that is a maintainer decision about CI minutes
and dependency installation (odfpy, openpyxl, pandas).

AI disclosure: this test suite was written with the assistance of an AI
coding tool. Verified to fail with AttributeError against the code as it
stood before 4e322d7 and to pass with the guard in place.

Generated with the assistance of an AI coding tool.

Two more None-unsafe call sites found while adding test coverage
around 4e322d7's spatial-container guard, one line below it:

basic.py:157 called ifcopenshell.util.element.get_type(element).Name
unguarded. get_type() legitimately returns None for an element with no
assigned IfcTypeObject, which is ordinary valid IFC, so any untyped
element crashed the Elements sheet export with AttributeError.

cobie24.get_zone_data concatenated parent.Name + "-" + zone.Name
unguarded. Name is optional on IfcRoot, so an unnamed IfcZone nested
under a named parent IfcZone crashed the Zone sheet export with
TypeError: can only concatenate str (not "NoneType") to str.

Both reproduced against a hand-built IFC4 file before the fix and
covered by new tests.

AI disclosure: this fix was written with the assistance of an AI coding
tool.

Generated with the assistance of an AI coding tool.

Name is optional on IfcRoot, so an unnamed IfcZone nested under a
named aggregate parent raised TypeError: can only concatenate str
(not "NoneType") to str at parent.Name + "-" + name. This is the
same bug fixed in cobie24.py in 85502b9, applied identically here to
keep the two presets consistent. Reproduced against a hand-built
IFC4 file before the fix and covered by new tests mirroring the
existing TestZoneDataUnnamedZone class.

Generated with the assistance of an AI coding tool.

