### PR TITLE
ifcdiff: report an element whose IFC class changed

### DIFF
--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -281,6 +281,12 @@ class IfcDiff:
         return 1e-4
 
     def diff_element(self, old, new):
+        is_changed = False
+        if new.GlobalId and old.is_a() != new.is_a():
+            self.change_register.setdefault(new.GlobalId, {}).update(
+                {"class_changed": {"old": old.is_a(), "new": new.is_a()}}
+            )
+            is_changed = True
         diff = DeepDiff(
             [a for a in old if not isinstance(a, (ifcopenshell.entity_instance, tuple))],
             [a for a in new if not isinstance(a, (ifcopenshell.entity_instance, tuple))],
@@ -290,6 +296,8 @@ class IfcDiff:
         )
         if diff and new.GlobalId:
             self.change_register.setdefault(new.GlobalId, {}).update({"attributes_changed": True})
+            is_changed = True
+        if is_changed:
             return True
 
     def diff_element_relationships(self, old, new):

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -27,6 +27,7 @@ import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
 import ifcopenshell.util.representation
+import ifcopenshell.util.schema
 
 import ifcdiff
 
@@ -98,6 +99,27 @@ class TestIfcDiff:
         assert ifc_diff.added_elements == set()
         assert ifc_diff.deleted_elements == set()
         assert ifc_diff.change_register == {wall.GlobalId: {"attributes_changed": True}}
+
+    def test_changed_class_is_reported(self):
+        # Regression test: an element reclassified to a different IFC class,
+        # with the same GlobalId and otherwise identical attribute values,
+        # must be reported. diff_element previously only ran DeepDiff over
+        # direct attributes and never compared is_a(), so a reclassified
+        # element was silently treated as unchanged.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWallStandardCase", name="Foo")
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        ifcopenshell.util.schema.reassign_class(new_file, wall_new, "IfcColumn")
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file)
+        ifc_diff.diff()
+        assert ifc_diff.added_elements == set()
+        assert ifc_diff.deleted_elements == set()
+        assert ifc_diff.change_register == {
+            wall.GlobalId: {"class_changed": {"old": "IfcWallStandardCase", "new": "IfcColumn"}}
+        }
 
     def test_property_diff_exports_to_json(self):
         # Regression test for #8905: comparing "property" relationships makes


### PR DESCRIPTION
diff_element ran DeepDiff over an element's direct attributes but never
compared is_a(). An element whose class changed entirely (same GlobalId,
same attribute values, e.g. a wall reclassified to a column) was reported
as unchanged: change_register stayed empty.

Compare is_a() alongside the existing attribute diff and record it under
a new class_changed key (old/new class names), separate from
attributes_changed since a reclassification is not an attribute edit.

Verified this does not make routine schema migrations noisy: running the
IFC4 -> IFC4X3 upgrade recipe (ifcpatch Migrate) over a wall, slab and
column produces zero class_changed entries, because our Migrator does not
rewrite deprecated-but-still-valid classes like IfcWallStandardCase. A
genuinely lossy downgrade that does reclassify (IFC4 -> IFC2X3, IfcLamp
falling back to IfcBuildingElementProxy) is correctly flagged, which is
the information the diff is supposed to surface.

This contribution was generated with the assistance of an AI coding tool.

