### PR TITLE
ifcpatch: make RemoveRevitUniformatClassification work on IFC2X3

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/RemoveRevitUniformatClassification.py
+++ b/src/ifcpatch/ifcpatch/recipes/RemoveRevitUniformatClassification.py
@@ -18,6 +18,14 @@
 
 
 class Patcher:
+    # IfcClassificationItem and IfcClassificationItemRelationship are IFC2X3
+    # only, IfcExternalReference covers IfcClassificationReference everywhere.
+    DEPENDENT_CLASSES = (
+        "IfcExternalReference",
+        "IfcClassificationItem",
+        "IfcClassificationItemRelationship",
+    )
+
     def __init__(self, file, logger):
         """Removes the built-in Revit Uniformat classification.
 
@@ -45,15 +53,26 @@ class Patcher:
             for rel in self.file.by_type("IfcRelAssociatesClassification"):
                 if not rel.RelatingClassification:
                     self.file.remove(rel)
+            if self.file.schema == "IFC2X3":
+                continue
             for rel in self.file.by_type("IfcExternalReferenceRelationship"):
                 if not rel.RelatingReference:
                     self.file.remove(rel)
 
     def get_references(self, classification):
+        # IFC2X3 has no HasReferences inverse on IfcClassification or
+        # IfcClassificationReference, so the dependents are resolved through the
+        # inverse index instead of a schema specific inverse attribute.
         results = []
-        if not classification.HasReferences:
-            return results
-        for reference in classification.HasReferences:
-            results.append(reference)
-            results.extend(self.get_references(reference))
+        seen = set()
+        queue = [classification]
+        while queue:
+            for inverse in self.file.get_inverse(queue.pop()):
+                if inverse.id() in seen:
+                    continue
+                if not any(inverse.is_a(c) for c in self.DEPENDENT_CLASSES):
+                    continue
+                seen.add(inverse.id())
+                results.append(inverse)
+                queue.append(inverse)
         return results

--- a/src/ifcpatch/test/test_RemoveRevitUniformatClassification.py
+++ b/src/ifcpatch/test/test_RemoveRevitUniformatClassification.py
@@ -1,0 +1,95 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Written with the assistance of an AI coding tool.
+
+
+import ifcopenshell
+import ifcopenshell.api.root
+
+import ifcpatch
+import test.bootstrap
+
+
+class TestRemoveRevitUniformatClassification(test.bootstrap.IFC4):
+    def add_reference(
+        self, identification: str, name: str, source: ifcopenshell.entity_instance
+    ) -> ifcopenshell.entity_instance:
+        attributes = {"Location": "", "Name": name, "ReferencedSource": source}
+        if self.file.schema == "IFC2X3":
+            attributes["ItemReference"] = identification
+        else:
+            attributes["Identification"] = identification
+        return self.file.create_entity("IfcClassificationReference", **attributes)
+
+    def associate(self, reference: ifcopenshell.entity_instance, element: ifcopenshell.entity_instance) -> None:
+        self.file.create_entity(
+            "IfcRelAssociatesClassification",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedObjects=[element],
+            RelatingClassification=reference,
+        )
+
+    def test_run(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        uniformat = self.file.create_entity("IfcClassification", Source="Uniformat", Edition="1998", Name="Uniformat")
+        self.associate(self.add_reference("B2010", "Exterior Walls", uniformat), wall)
+
+        ifcpatch.execute({"file": self.file, "recipe": "RemoveRevitUniformatClassification", "arguments": []})
+
+        assert not self.file.by_type("IfcClassification")
+        assert not self.file.by_type("IfcClassificationReference")
+        assert not self.file.by_type("IfcRelAssociatesClassification")
+
+    def test_other_classifications_are_kept(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        uniformat = self.file.create_entity("IfcClassification", Source="Uniformat", Edition="1998", Name="Uniformat")
+        self.associate(self.add_reference("B2010", "Exterior Walls", uniformat), wall)
+        omniclass = self.file.create_entity("IfcClassification", Source="Omniclass", Edition="2012", Name="Omniclass")
+        self.associate(self.add_reference("23-13", "Walls", omniclass), wall)
+
+        ifcpatch.execute({"file": self.file, "recipe": "RemoveRevitUniformatClassification", "arguments": []})
+
+        assert [c.Name for c in self.file.by_type("IfcClassification")] == ["Omniclass"]
+        assert len(self.file.by_type("IfcClassificationReference")) == 1
+        assert len(self.file.by_type("IfcRelAssociatesClassification")) == 1
+
+    def test_nested_references_are_removed(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        uniformat = self.file.create_entity("IfcClassification", Source="Uniformat", Edition="1998", Name="Uniformat")
+        parent = self.add_reference("B2010", "Exterior Walls", uniformat)
+        self.associate(self.add_reference("B2010.10", "Exterior Wall Construction", parent), wall)
+
+        ifcpatch.execute({"file": self.file, "recipe": "RemoveRevitUniformatClassification", "arguments": []})
+
+        assert not self.file.by_type("IfcClassification")
+        assert not self.file.by_type("IfcClassificationReference")
+        assert not self.file.by_type("IfcRelAssociatesClassification")
+
+
+class TestRemoveRevitUniformatClassificationIFC2X3(test.bootstrap.IFC2X3, TestRemoveRevitUniformatClassification):
+    def test_classification_items_are_removed(self):
+        uniformat = self.file.create_entity("IfcClassification", Source="Uniformat", Edition="1998", Name="Uniformat")
+        facet = self.file.create_entity("IfcClassificationNotationFacet", NotationValue="B2010")
+        notation = self.file.create_entity("IfcClassificationNotation", NotationFacets=[facet])
+        self.file.create_entity("IfcClassificationItem", Notation=notation, ItemOf=uniformat, Title="Exterior Walls")
+
+        ifcpatch.execute({"file": self.file, "recipe": "RemoveRevitUniformatClassification", "arguments": []})
+
+        assert not self.file.by_type("IfcClassification")
+        assert not self.file.by_type("IfcClassificationItem")


### PR DESCRIPTION
The recipe exists solely to undo a Revit export bug, and Revit's default
export is IFC2x3 Coordination View 2.0. On exactly that input it raised
AttributeError and did nothing.

Root cause: get_references walked IfcClassification.HasReferences, an
inverse attribute that only exists in IFC4. IFC2X3 IfcClassification
declares a single inverse, Contains, and IFC2X3
IfcClassificationReference declares none at all, so there is no inverse
attribute to walk in that schema. The patch loop then also called
by_type("IfcExternalReferenceRelationship"), a class introduced in IFC4.

The dependents are now resolved through the file's inverse index rather
than a schema specific inverse attribute, which covers the IFC4 nested
IfcClassificationReference tree and the IFC2X3 IfcClassificationItem
structure with the same traversal. The IfcExternalReferenceRelationship
sweep is skipped on IFC2X3.

Observed before, on an IFC2X3 file holding one Uniformat classification,
one IfcClassificationReference and one IfcRelAssociatesClassification:

  AttributeError: entity instance of type 'IFC2X3.IfcClassification'
  has no attribute 'HasReferences'

Observed after: IfcClassification 1 -> 0, IfcClassificationReference
1 -> 0, IfcRelAssociatesClassification 1 -> 0. A second, non-Uniformat
classification in the same file survives untouched. IFC4 counts are
unchanged.

Adds test/test_RemoveRevitUniformatClassification.py covering both
schemas; its four IFC2X3 cases fail on the previous code.

Generated with the assistance of an AI coding tool.

