### PR TITLE
ifcpatch: guard optional attributes in three recipes

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/AssignConstituentFractions.py
+++ b/src/ifcpatch/ifcpatch/recipes/AssignConstituentFractions.py
@@ -77,9 +77,13 @@ class Patcher:
                 if quantities:
                     element_quantities = quantities
                     break
-            assert element_quantities is not None
 
             if not element_quantities:
+                self.logger.warning(
+                    f"Skipping material constituent set #{constituent_set.id()}: none of its "
+                    f"{len(elements_sorted)} associated element(s) have layer-discriminated "
+                    "BaseQuantities to derive widths from."
+                )
                 continue
 
             # Calculate constituent widths and total width

--- a/src/ifcpatch/ifcpatch/recipes/ExtractPropertiesToSQLite.py
+++ b/src/ifcpatch/ifcpatch/recipes/ExtractPropertiesToSQLite.py
@@ -157,6 +157,10 @@ class Patcher(ifcpatch.BasePatcher):
                         properties.append(
                             PropertyRow(i, "IFC Material", f"Layer {idx + 1} Name", getattr(item, "Name", None))
                         )
+                        # Material is optional on IfcMaterialLayer.
+                        if material is None:
+                            self.logger.debug(f"Layer {idx + 1} of element #{element.id()} has no Material set.")
+                            continue
                         properties.append(PropertyRow(i, "IFC Material", f"Layer {idx + 1} Material", material.Name))
                         if category := getattr(material, "Category", None):
                             properties.append(PropertyRow(i, "IFC Material", f"Layer {idx + 1} Category", category))
@@ -164,6 +168,10 @@ class Patcher(ifcpatch.BasePatcher):
                     for idx, item in enumerate(material.MaterialProfiles or []):
                         material = item.Material
                         properties.append(PropertyRow(i, "IFC Material", f"Profile {idx + 1} Name", item.Name))
+                        # Material is optional on IfcMaterialProfile.
+                        if material is None:
+                            self.logger.debug(f"Profile {idx + 1} of element #{element.id()} has no Material set.")
+                            continue
                         properties.append(PropertyRow(i, "IFC Material", f"Profile {idx + 1} Material", material.Name))
                         if category := getattr(material, "Category", None):
                             properties.append(PropertyRow(i, "IFC Material", f"Profile {idx + 1} Category", category))

--- a/src/ifcpatch/ifcpatch/recipes/OffsetStoreyElevations.py
+++ b/src/ifcpatch/ifcpatch/recipes/OffsetStoreyElevations.py
@@ -42,6 +42,11 @@ class Patcher:
         project = self.file.by_type("IfcProject")[0]
         storeys = self.find_decomposed_ifc_class(project, "IfcBuildingStorey")
         for storey in storeys:
+            if storey.ObjectPlacement is None:
+                self.logger.warning(
+                    f"Skipping storey '{storey.Name or storey.GlobalId}': it has no ObjectPlacement to offset."
+                )
+                continue
             co = storey.ObjectPlacement.RelativePlacement.Location.Coordinates
             storey.ObjectPlacement.RelativePlacement.Location.Coordinates = (co[0], co[1], co[2] + float(self.z))
             co = storey.ObjectPlacement.RelativePlacement.Location.Coordinates

--- a/src/ifcpatch/test/test_AssignConstituentFractions.py
+++ b/src/ifcpatch/test/test_AssignConstituentFractions.py
@@ -1,0 +1,105 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2024 Louis Trümpler <louis@lt.plus>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import pytest
+
+import ifcopenshell
+import ifcopenshell.api.material
+import ifcopenshell.api.root
+import ifcopenshell.api.unit
+
+import ifcpatch
+import test.bootstrap
+
+
+class TestAssignConstituentFractions(test.bootstrap.IFC4):
+    # IfcMaterialConstituentSet is an IFC4+ concept (Reference View MVD), so
+    # this recipe is only meaningful on IFC4 and is not run against IFC2X3.
+
+    def add_layer_base_quantities(self, element, widths: dict[str, float]):
+        quantities = []
+        for name, width in widths.items():
+            width_qty = self.file.create_entity("IfcQuantityLength", Name="Width", LengthValue=width)
+            quantities.append(
+                self.file.create_entity(
+                    "IfcPhysicalComplexQuantity", Name=name, Discrimination="LAYER", HasQuantities=[width_qty]
+                )
+            )
+        qto = self.file.create_entity(
+            "IfcElementQuantity",
+            GlobalId=ifcopenshell.guid.new(),
+            Name="Qto_WallBaseQuantities",
+            Quantities=quantities,
+        )
+        self.file.create_entity(
+            "IfcRelDefinesByProperties",
+            GlobalId=ifcopenshell.guid.new(),
+            RelatedObjects=[element],
+            RelatingPropertyDefinition=qto,
+        )
+
+    def test_run(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        constituent_set = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialConstituentSet")
+        concrete = ifcopenshell.api.material.add_material(self.file, name="Concrete")
+        insulation = ifcopenshell.api.material.add_material(self.file, name="Insulation")
+        constituent1 = ifcopenshell.api.material.add_constituent(
+            self.file, constituent_set=constituent_set, material=concrete
+        )
+        constituent1.Name = "Concrete"
+        constituent2 = ifcopenshell.api.material.add_constituent(
+            self.file, constituent_set=constituent_set, material=insulation
+        )
+        constituent2.Name = "Insulation"
+        ifcopenshell.api.material.assign_material(
+            self.file, products=[wall], type="IfcMaterialConstituentSet", material=constituent_set
+        )
+        self.add_layer_base_quantities(wall, {"Concrete": 0.1, "Insulation": 0.2})
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "AssignConstituentFractions", "arguments": []})
+
+        constituents = {c.Name: c.Fraction for c in output.by_type("IfcMaterialConstituent")}
+        assert constituents["Concrete"] == pytest.approx(1 / 3)
+        assert constituents["Insulation"] == pytest.approx(2 / 3)
+
+    def test_skips_constituent_set_without_layer_quantities_instead_of_crashing(self):
+        # Regression test: a constituent set whose associated element has no
+        # *BaseQuantities (or none with a "layer" discriminated complex
+        # quantity) used to raise a bare AssertionError, aborting the whole
+        # patch. It must be skipped instead.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        constituent_set = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialConstituentSet")
+        concrete = ifcopenshell.api.material.add_material(self.file, name="Concrete")
+        constituent = ifcopenshell.api.material.add_constituent(
+            self.file, constituent_set=constituent_set, material=concrete
+        )
+        constituent.Name = "Concrete"
+        ifcopenshell.api.material.assign_material(
+            self.file, products=[wall], type="IfcMaterialConstituentSet", material=constituent_set
+        )
+        # No BaseQuantities at all on the wall.
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "AssignConstituentFractions", "arguments": []})
+
+        assert output.by_type("IfcMaterialConstituent")[0].Fraction is None

--- a/src/ifcpatch/test/test_ExtractPropertiesToSQLite.py
+++ b/src/ifcpatch/test/test_ExtractPropertiesToSQLite.py
@@ -1,0 +1,79 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2024 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import sqlite3
+
+import ifcopenshell.api.material
+import ifcopenshell.api.root
+
+import ifcpatch
+import test.bootstrap
+
+
+class ExtractPropertiesToSQLiteMixin:
+    def test_run(self):
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall", name="Wall")
+        db_path = ifcpatch.execute({"file": self.file, "recipe": "ExtractPropertiesToSQLite", "arguments": []})
+        db = sqlite3.connect(db_path)
+        rows = db.execute("SELECT global_id, ifc_class FROM elements WHERE ifc_class = 'IfcWall'").fetchall()
+        assert rows == [(wall.GlobalId, "IfcWall")]
+
+    def test_material_layer_without_material_does_not_crash(self):
+        # Regression test: IfcMaterialLayer.Material is OPTIONAL. A layer set
+        # containing a layer with no Material assigned used to raise
+        # AttributeError: 'NoneType' object has no attribute 'Name', aborting
+        # the whole extraction.
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        layer_set = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialLayerSet")
+        layer = self.file.create_entity("IfcMaterialLayer", Material=None, LayerThickness=0.1)
+        layer_set.MaterialLayers = [layer]
+        ifcopenshell.api.material.assign_material(
+            self.file, products=[wall], type="IfcMaterialLayerSet", material=layer_set
+        )
+
+        db_path = ifcpatch.execute({"file": self.file, "recipe": "ExtractPropertiesToSQLite", "arguments": []})
+
+        db = sqlite3.connect(db_path)
+        names = {row[0] for row in db.execute("SELECT name FROM properties WHERE set_name = 'IFC Material'")}
+        assert "Layer 1 Material" not in names
+
+
+class TestExtractPropertiesToSQLite(test.bootstrap.IFC4, ExtractPropertiesToSQLiteMixin):
+    def test_material_profile_without_material_does_not_crash(self):
+        # Same optional-attribute defect as above, for IfcMaterialProfile.Material.
+        # IfcMaterialProfileSet is IFC4+, so this is not run against IFC2X3.
+        beam = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBeam")
+        profile_set = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialProfileSet")
+        profile_def = self.file.create_entity("IfcRectangleProfileDef", ProfileType="AREA", XDim=0.1, YDim=0.2)
+        profile = self.file.create_entity("IfcMaterialProfile", Material=None, Profile=profile_def)
+        profile_set.MaterialProfiles = [profile]
+        ifcopenshell.api.material.assign_material(
+            self.file, products=[beam], type="IfcMaterialProfileSet", material=profile_set
+        )
+
+        db_path = ifcpatch.execute({"file": self.file, "recipe": "ExtractPropertiesToSQLite", "arguments": []})
+
+        db = sqlite3.connect(db_path)
+        names = {row[0] for row in db.execute("SELECT name FROM properties WHERE set_name = 'IFC Material'")}
+        assert "Profile 1 Material" not in names
+
+
+class TestExtractPropertiesToSQLiteIFC2X3(test.bootstrap.IFC2X3, ExtractPropertiesToSQLiteMixin):
+    pass

--- a/src/ifcpatch/test/test_OffsetStoreyElevations.py
+++ b/src/ifcpatch/test/test_OffsetStoreyElevations.py
@@ -1,0 +1,68 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2020, 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import numpy as np
+
+import ifcopenshell.api.aggregate
+import ifcopenshell.api.geometry
+import ifcopenshell.api.root
+
+import ifcpatch
+import test.bootstrap
+
+
+class TestOffsetStoreyElevations(test.bootstrap.IFC4):
+    def test_run(self):
+        project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        storey = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        ifcopenshell.api.aggregate.assign_object(self.file, relating_object=project, products=[site])
+        ifcopenshell.api.aggregate.assign_object(self.file, relating_object=site, products=[storey])
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=storey, matrix=np.eye(4))
+
+        ifcpatch.execute({"file": self.file, "recipe": "OffsetStoreyElevations", "arguments": [5]})
+
+        assert storey.Elevation == 5
+        assert storey.ObjectPlacement.RelativePlacement.Location.Coordinates[2] == 5
+
+    def test_skips_storey_without_object_placement_instead_of_crashing(self):
+        # Regression test: a storey with no ObjectPlacement (common when a
+        # storey is authored without geometry) used to raise
+        # AttributeError: 'NoneType' object has no attribute
+        # 'RelativePlacement', aborting the whole patch.
+        project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        storey_with_placement = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        storey_without_placement = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        ifcopenshell.api.aggregate.assign_object(self.file, relating_object=project, products=[site])
+        ifcopenshell.api.aggregate.assign_object(
+            self.file, relating_object=site, products=[storey_with_placement, storey_without_placement]
+        )
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=storey_with_placement, matrix=np.eye(4))
+        assert storey_without_placement.ObjectPlacement is None
+
+        ifcpatch.execute({"file": self.file, "recipe": "OffsetStoreyElevations", "arguments": [5]})
+
+        assert storey_with_placement.Elevation == 5
+        assert storey_without_placement.ObjectPlacement is None
+
+
+class TestOffsetStoreyElevationsIFC2X3(test.bootstrap.IFC2X3, TestOffsetStoreyElevations):
+    pass


### PR DESCRIPTION
AssignConstituentFractions, ExtractPropertiesToSQLite and
OffsetStoreyElevations each dereferenced an OPTIONAL IFC attribute
(IfcMaterialLayer.Material, IfcMaterialProfile.Material,
IfcBuildingStorey.ObjectPlacement) or a computed-but-unset local
without checking for None first, so a single unset attribute aborted
the whole batch run with an unhandled AssertionError or AttributeError.

AssignConstituentFractions.py: the assert on element_quantities made
the very next line, "if not element_quantities: continue", dead code.
Removed the assert and kept the skip, now with a warning naming the
constituent set so the reason for a missing Fraction is visible.

ExtractPropertiesToSQLite.py: guard both IfcMaterialLayer.Material and
IfcMaterialProfile.Material (both OPTIONAL per the schema) before
reading .Name; skip that one property row with a debug log rather than
aborting extraction of every other element in the model.

OffsetStoreyElevations.py: skip a storey with no ObjectPlacement, with
a warning naming the storey, instead of crashing before any storey is
offset.

MergeDuplicateTypes.py's own unguarded getattr(element_type, "Tag") on
IfcTypeProcess/IfcTypeResource is left untouched: outside contributor
theoryshaw already has an open PR (#8610) reworking the merge key on
that same file.

Generated with the assistance of an AI coding tool.

