### PR TITLE
ifcpatch: fix three recipes reporting the wrong thing to the user

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/AddGeometricRepresentationToAlignment.py
+++ b/src/ifcpatch/ifcpatch/recipes/AddGeometricRepresentationToAlignment.py
@@ -33,7 +33,7 @@ class Patcher(ifcpatch.BasePatcher):
 
         .. code:: python
 
-            model = ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "AddGeometricRepresentationAlignment"})
+            model = ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "AddGeometricRepresentationToAlignment"})
         """
         super().__init__(file, logger)
         self.file_patched: ifcopenshell.file

--- a/src/ifcpatch/ifcpatch/recipes/MergeStyles.py
+++ b/src/ifcpatch/ifcpatch/recipes/MergeStyles.py
@@ -46,12 +46,12 @@ class Patcher(ifcpatch.BasePatcher):
             uniques = {}
             i = 0
             for element in self.file.by_type(ifc_class):
-                ifc_class = element.is_a()
+                element_class = element.is_a()
                 key = "-".join([str(a) for a in element])
-                if unique := uniques.get(ifc_class, {}).get(key, None):
+                if unique := uniques.get(element_class, {}).get(key, None):
                     ifcopenshell.util.element.replace_element(element, unique)
                     self.file.remove(element)
                     i += 1
                 else:
-                    uniques.setdefault(ifc_class, {})[key] = element
+                    uniques.setdefault(element_class, {})[key] = element
             print(f"Replaced {i} {ifc_class}")

--- a/src/ifcpatch/ifcpatch/recipes/RegenerateGlobalIds.py
+++ b/src/ifcpatch/ifcpatch/recipes/RegenerateGlobalIds.py
@@ -70,7 +70,7 @@ class Patcher:
                         ifcopenshell.guid.expand(element.GlobalId)
                     except:
                         element.GlobalId = ifcopenshell.guid.new()
-                    invalid_ids += 1
+                        invalid_ids += 1
                 guids.add(element.GlobalId)
 
             print("Replaced %s duplicate GlobalIds" % duplicates)

--- a/src/ifcpatch/test/test_AddGeometricRepresentationToAlignment.py
+++ b/src/ifcpatch/test/test_AddGeometricRepresentationToAlignment.py
@@ -1,0 +1,38 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import re
+
+from ifcpatch.recipes.AddGeometricRepresentationToAlignment import Patcher
+
+
+class TestAddGeometricRepresentationToAlignmentDocstring:
+    """Regression test: the docstring's example was copy-pasteable as-is by
+    users, and is shown as CLI/Bonsai UI help text, but it quoted a recipe
+    name ("AddGeometricRepresentationAlignment") that does not match this
+    module's actual name, so copying it verbatim raised
+    ModuleNotFoundError."""
+
+    def test_docstring_example_recipe_name_matches_the_module_name(self):
+        doc = Patcher.__init__.__doc__
+        assert doc is not None
+        match = re.search(r'"recipe":\s*"([^"]+)"', doc)
+        assert match is not None, "docstring example must quote a recipe name"
+        assert match.group(1) == "AddGeometricRepresentationToAlignment"

--- a/src/ifcpatch/test/test_MergeStyles.py
+++ b/src/ifcpatch/test/test_MergeStyles.py
@@ -1,0 +1,63 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.style
+
+import ifcpatch
+import test.bootstrap
+
+
+class TestMergeStyles(test.bootstrap.IFC4):
+    def _add_shading_style(self):
+        style = ifcopenshell.api.style.add_style(self.file)
+        ifcopenshell.api.style.add_surface_style(
+            self.file,
+            style=style,
+            ifc_class="IfcSurfaceStyleShading",
+            attributes={"SurfaceColour": {"Name": None, "Red": 1.0, "Green": 0.0, "Blue": 0.0}},
+        )
+        return style
+
+    def test_merges_identical_styles(self):
+        self._add_shading_style()
+        self._add_shading_style()
+        assert len(self.file.by_type("IfcPresentationStyle")) == 2
+
+        ifcpatch.execute({"file": self.file, "recipe": "MergeStyles", "arguments": []})
+
+        assert len(self.file.by_type("IfcPresentationStyle")) == 1
+
+    def test_summary_reports_the_requested_class_not_the_last_elements_subtype(self, capsys):
+        # Regression test: the loop rebound the outer "ifc_class" loop
+        # variable to each element's concrete subtype (e.g. IfcSurfaceStyle
+        # for an IfcPresentationStyle element), so the final summary line
+        # reported that subtype instead of the class that was actually
+        # requested.
+        self._add_shading_style()
+        self._add_shading_style()
+
+        ifcpatch.execute({"file": self.file, "recipe": "MergeStyles", "arguments": []})
+
+        lines = capsys.readouterr().out.strip().splitlines()
+        assert lines[-1] == "Replaced 1 IfcPresentationStyle"
+
+
+class TestMergeStylesIFC2X3(test.bootstrap.IFC2X3, TestMergeStyles):
+    pass

--- a/src/ifcpatch/test/test_RegenerateGlobalIds.py
+++ b/src/ifcpatch/test/test_RegenerateGlobalIds.py
@@ -44,6 +44,21 @@ class TestRegenerateGlobalIds(test.bootstrap.IFC4):
         assert len(new_guids) == 3
         assert len(new_guids.intersection(used_guids)) == 2
 
+    def test_only_duplicates_does_not_overcount_valid_unique_guids(self, capsys):
+        # Regression test: the "Replaced N invalid GlobalIds" summary must
+        # only count GlobalIds that were actually replaced. It previously
+        # counted every element that reached the length/prefix check,
+        # whether or not ifcopenshell.guid.expand() raised.
+        project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        guids_before = {project.GlobalId, wall.GlobalId}
+
+        ifcpatch.execute({"file": self.file, "recipe": "RegenerateGlobalIds", "arguments": [True]})
+
+        assert {project.GlobalId, wall.GlobalId} == guids_before
+        output = capsys.readouterr().out
+        assert "Replaced 0 invalid GlobalIds" in output
+
 
 class TestRegenerateGlobalIdsIFC2X3(test.bootstrap.IFC2X3, TestRegenerateGlobalIds):
     pass


### PR DESCRIPTION
The "Replaced N invalid GlobalIds" summary incremented invalid_ids
unconditionally after the try/except, not only inside the except
branch, so it counted every element that reached that branch
regardless of whether ifcopenshell.guid.expand() actually raised. A
5-root file with all-valid unique GlobalIds printed "Replaced 5
invalid GlobalIds" while 0 were changed. The counter now only
increments when a GlobalId is actually replaced.

Generated with the assistance of an AI coding tool.

The example code in the class docstring, which is surfaced as CLI and
Bonsai UI help text, quoted "recipe": "AddGeometricRepresentationAlignment",
a name that does not exist. Copying it verbatim into ifcpatch.execute()
raises ModuleNotFoundError, since the recipe name must match this
module's filename, AddGeometricRepresentationToAlignment.

Generated with the assistance of an AI coding tool.

The loop rebound the outer "ifc_class" loop variable (IfcColourRgb /
IfcSurfaceStyleShading / IfcPresentationStyle) to each element's own
is_a() inside the body, so by the time the summary printed, it
reported the last merged element's concrete subtype instead of the
class that was actually requested. Running over IfcPresentationStyle
printed "Replaced 1 IfcSurfaceStyle". The element's concrete class is
now tracked in its own variable, leaving the outer loop variable
intact for the summary.

Generated with the assistance of an AI coding tool.

