### PR TITLE
util.unit: fix 1000x area and 1000000x volume conversion errors

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -676,9 +676,9 @@ def convert(value: float, from_prefix: Optional[str], from_unit: str, to_prefix:
         return value * (1 / si_conversions[to_unit.lower()])
     elif to_prefix:
         value *= 1 / get_prefix_multiplier(to_prefix)
-        if "SQUARE" in from_unit:
+        if "SQUARE" in to_unit:
             value *= 1 / get_prefix_multiplier(to_prefix)
-        elif "CUBIC" in from_unit:
+        elif "CUBIC" in to_unit:
             value *= 1 / get_prefix_multiplier(to_prefix)
             value *= 1 / get_prefix_multiplier(to_prefix)
     return value
@@ -752,12 +752,21 @@ def format_length(
     :returns: The formatted string, such as 1' - 5 1/2".
     """
     if unit_system == "imperial":
+        # A negative value is negated up front and formatted as a positive
+        # magnitude, then the sign is reapplied once to the finished string.
+        # Negating feet and inches independently produces malformed output
+        # like "-1' - -6\"" for -1.5 feet.
+        sign = "-" if value < 0 else ""
+        value = abs(value)
+
         if input_unit == "foot":
             feet = int(value)
             inches = (value - feet) * 12
         elif input_unit == "inch":
             inches = value % 12
             feet = int(round((value - inches) / 12))
+        else:
+            raise ValueError(f"Unexpected input_unit {input_unit!r}. Use 'foot' or 'inch'.")
 
         # Round to the nearest 1/N
         nearest = round(inches * precision)
@@ -769,24 +778,25 @@ def format_length(
         if frac.denominator == 1:
             if suppress_zero_inches and frac.numerator == 0:
                 if output_unit == "foot":
-                    return f"{feet}'"
-                return f'{feet * 12}"'
+                    return f"{sign}{feet}'"
+                return f'{sign}{feet * 12}"'
             if output_unit == "foot":
-                return f"{feet}' - {frac.numerator}\""
-            return f'{(feet * 12) + frac.numerator}"'
+                return f"{sign}{feet}' - {frac.numerator}\""
+            return f'{sign}{(feet * 12) + frac.numerator}"'
         if frac.numerator > frac.denominator:
             remainder = frac.numerator % frac.denominator
             whole = int((frac.numerator - remainder) / frac.denominator)
             if output_unit == "foot":
-                return f"{feet}' - {whole} {remainder}/{frac.denominator}\""
-            return f'{(feet * 12) + whole} {remainder}/{frac.denominator}"'
+                return f"{sign}{feet}' - {whole} {remainder}/{frac.denominator}\""
+            return f'{sign}{(feet * 12) + whole} {remainder}/{frac.denominator}"'
         # When we have a proper fraction (numerator < denominator), show "0 frac"
         if output_unit == "foot":
-            return f"{feet}' - 0 {frac.numerator}/{frac.denominator}\""
-        return f'{feet * 12} {frac.numerator}/{frac.denominator}"'
+            return f"{sign}{feet}' - 0 {frac.numerator}/{frac.denominator}\""
+        return f'{sign}{feet * 12} {frac.numerator}/{frac.denominator}"'
     elif unit_system == "metric":
         rounded_val = round(value / precision) * precision
         return f"{rounded_val:.{decimal_places}f}"
+    raise ValueError(f"Unexpected unit_system {unit_system!r}. Use 'metric' or 'imperial'.")
 
 
 def is_attr_type(

--- a/src/ifcopenshell-python/test/util/test_unit.py
+++ b/src/ifcopenshell-python/test/util/test_unit.py
@@ -186,6 +186,16 @@ class TestConvert(test.bootstrap.IFC4):
         assert subject.convert(1, None, "SQUARE_METRE", "MILLI", "SQUARE_METRE") == 1000000
         assert subject.convert(1, None, "CUBIC_METRE", "MILLI", "CUBIC_METRE") == 1000000000
 
+    def test_area_and_volume_conversion_based_units_are_scaled_by_prefix_squared_and_cubed(self):
+        # Regression test: converting a non-SI area/volume unit (as named per
+        # IFC4 Annex A, lower-case e.g. "square foot") to a prefixed SI unit
+        # (upper-case enumerant, e.g. "SQUARE_METRE") must square/cube the
+        # prefix multiplier, the same as converting between two SI units does.
+        assert subject.convert(1, None, "square foot", "MILLI", "SQUARE_METRE") == pytest.approx(92903.04)
+        assert subject.convert(1, "MILLI", "SQUARE_METRE", None, "square foot") == pytest.approx(1 / 92903.04)
+        assert subject.convert(1, None, "cubic foot", "MILLI", "CUBIC_METRE") == pytest.approx(28316846.71168849)
+        assert subject.convert(1, "MILLI", "CUBIC_METRE", None, "cubic foot") == pytest.approx(1 / 28316846.71168849)
+
 
 class TestCalculateUnitScale(test.bootstrap.IFC4):
     def test_prefix_and_conversion_based_units_are_considered(self):
@@ -236,6 +246,24 @@ class TestFormatLength(test.bootstrap.IFC4):
         assert (
             subject.format_length(25.23, 4, unit_system="imperial", input_unit="inch", output_unit="inch") == '25 1/4"'
         )
+
+    def test_negative_values_get_a_single_leading_sign(self):
+        assert subject.format_length(-1.5, 1, unit_system="imperial", input_unit="foot") == "-1' - 6\""
+        assert subject.format_length(-0.5, 1, unit_system="imperial", input_unit="foot") == "-0' - 6\""
+        assert subject.format_length(-13.25, 16, unit_system="imperial", input_unit="foot", output_unit="inch") == (
+            '-159"'
+        )
+        assert subject.format_length(-1.23456, 0.01, unit_system="metric") == "-1.23"
+
+    def test_invalid_unit_system_raises_instead_of_returning_none(self):
+        with pytest.raises(ValueError):
+            subject.format_length(1.5, 1, unit_system="Imperial")
+        with pytest.raises(ValueError):
+            subject.format_length(1.5, 1, unit_system="Metric")
+
+    def test_invalid_input_unit_raises_a_clear_error(self):
+        with pytest.raises(ValueError):
+            subject.format_length(1.5, 1, unit_system="imperial", input_unit="bogus")
 
 
 class TestIsAttrType(test.bootstrap.IFC4):


### PR DESCRIPTION
convert() squares/cubes the SI prefix multiplier for area/volume units
by checking "SQUARE"/"CUBIC" substrings in the unit name. The check on
the to_prefix side tested from_unit instead of to_unit, which happened
to be masked whenever from_unit and to_unit share the same casing
convention. Real IFC files name conversion-based units in lower case
(IFC4 Annex A, e.g. "square foot") and SI units in the upper-case
enumerant (e.g. "SQUARE_METRE"), so "SQUARE" in from_unit silently
evaluated false and the prefix was applied only once instead of
squared/cubed. Converting 1 square foot to square millimetres returned
92.903 instead of 92903.04 (1000x low); 1 cubic foot to cubic
millimetres returned 28.32 instead of 28316846.7 (1,000,000x low). The
reverse direction (SI to imperial) was unaffected because it returns
before reaching this branch.

Also fixes three format_length() defects:
- Negative values produced malformed output like "-1' - -6\"" for -1.5
  feet because feet and inches were negated independently. The sign is
  now taken once from the input value and applied once to the finished
  string.
- unit_system values that don't match the "metric"/"imperial" literal
  exactly (e.g. "Imperial") fell through both branches and returned
  None despite the -> str annotation. Now raises ValueError.
- An unrecognised input_unit raised a confusing UnboundLocalError from
  deep inside the function. Now raises ValueError up front.

Added regression tests for both directions across prefixes with
realistic unit-name casing, and for the format_length defects.

Generated with the assistance of an AI coding tool.

