### PR TITLE
util.placement: build an orthonormal basis in a2p

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/placement.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/placement.py
@@ -34,6 +34,11 @@ def a2p(o: Iterable[float], z: Iterable[float], x: Iterable[float]) -> MatrixTyp
     IFC uses a right-handed coordinate system, so it is not necessary to
     provide the Y axis.
 
+    The X axis is projected onto the plane normal to the Z axis, as prescribed
+    by the IfcBuildAxes and IfcFirstProjAxis EXPRESS functions. The result is
+    therefore always orthonormal, even if the supplied X axis is not
+    perpendicular to the supplied Z axis.
+
     :param o: The origin (i.e. location) of the matrix
     :param z: The +Z vector / axis of the matrix
     :param x: The +X vector / axis of the matrix
@@ -43,10 +48,23 @@ def a2p(o: Iterable[float], z: Iterable[float], x: Iterable[float]) -> MatrixTyp
     z = z / np.linalg.norm(z)
     y = np.cross(z, x)
     y = y / np.linalg.norm(y)
+    x = np.cross(y, z)
     r = np.eye(4)
     r[:-1, :-1] = x, y, z
     r[-1, :-1] = o
     return r.T
+
+
+def _default_ref_direction(z: np.ndarray) -> np.ndarray:
+    """Picks a default X axis that is not parallel to the given Z axis
+
+    Used where RefDirection is absent and the X axis is therefore ours to
+    choose. Mirrors the fallback in the geometry kernel's matrix4 constructor.
+    """
+    x = np.array((1.0, 0.0, 0.0))
+    if np.linalg.norm(np.cross(z, x)) < 1e-7:
+        x = np.array((0.0, 0.0, 1.0))
+    return x
 
 
 def get_axis2placement(placement: ifcopenshell.entity_instance) -> MatrixType:
@@ -63,7 +81,10 @@ def get_axis2placement(placement: ifcopenshell.entity_instance) -> MatrixType:
     ifc_class = placement.is_a()
     if ifc_class in ("IfcAxis2Placement3D", "IfcAxis2PlacementLinear"):
         z = np.array(placement.Axis.DirectionRatios if placement.Axis else (0, 0, 1))
-        x = np.array(placement.RefDirection.DirectionRatios if placement.RefDirection else (1, 0, 0))
+        if placement.RefDirection:
+            x = np.array(placement.RefDirection.DirectionRatios)
+        else:
+            x = _default_ref_direction(z)
         location = placement.Location
         if coordinates := getattr(location, "Coordinates", None):
             o = coordinates
@@ -86,7 +107,7 @@ def get_axis2placement(placement: ifcopenshell.entity_instance) -> MatrixType:
     elif ifc_class == "IfcAxis1Placement":
         axis = placement.Axis
         z = np.array(axis.DirectionRatios if axis else (0, 0, 1))
-        x = np.array((1, 0, 0))
+        x = _default_ref_direction(z)
         o = placement.Location.Coordinates
 
     else:

--- a/src/ifcopenshell-python/test/util/test_placement.py
+++ b/src/ifcopenshell-python/test/util/test_placement.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import numpy as np
+
 import ifcopenshell.util.placement as subject
 import test.bootstrap
 
@@ -40,3 +42,68 @@ class TestGetStoreyElevationIFC4(test.bootstrap.IFC4):
         assert subject.get_storey_elevation(storey) == 0.0
         building = self.file.createIfcBuilding()
         assert subject.get_storey_elevation(building) == 0.0
+
+
+def assert_orthonormal(matrix):
+    rotation = matrix[:3, :3]
+    assert not np.any(np.isnan(matrix)), f"matrix contains NaN:\n{matrix}"
+    assert np.allclose(rotation.T @ rotation, np.eye(3)), f"matrix is not orthonormal:\n{matrix}"
+    assert np.isclose(np.linalg.det(rotation), 1.0), f"determinant is not 1:\n{matrix}"
+
+
+class TestA2P(test.bootstrap.IFC4):
+    def test_deriving_the_x_axis_by_projection_when_it_is_not_perpendicular_to_z(self):
+        # IfcBuildAxes derives the X axis by projecting RefDirection onto the
+        # plane normal to Axis, so (1, 0, 1) against Z becomes (1, 0, 0).
+        matrix = subject.a2p((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 1.0))
+        assert np.allclose(matrix[:3, 0], (1.0, 0.0, 0.0))
+        assert np.allclose(matrix[:3, 1], (0.0, 1.0, 0.0))
+        assert np.allclose(matrix[:3, 2], (0.0, 0.0, 1.0))
+        assert_orthonormal(matrix)
+
+    def test_keeping_an_already_perpendicular_x_axis_unchanged(self):
+        matrix = subject.a2p((1.0, 2.0, 3.0), (0.0, 0.0, 1.0), (0.0, 1.0, 0.0))
+        assert np.allclose(matrix[:3, 0], (0.0, 1.0, 0.0))
+        assert np.allclose(matrix[:3, 1], (-1.0, 0.0, 0.0))
+        assert np.allclose(matrix[:3, 2], (0.0, 0.0, 1.0))
+        assert np.allclose(matrix[:3, 3], (1.0, 2.0, 3.0))
+        assert_orthonormal(matrix)
+
+
+class TestGetAxis2PlacementOrthonormalityIFC4(test.bootstrap.IFC4):
+    def placement_3d(self, axis, ref_direction=None):
+        return self.file.createIfcAxis2Placement3D(
+            self.file.createIfcCartesianPoint((0.0, 0.0, 0.0)),
+            self.file.createIfcDirection(axis) if axis else None,
+            self.file.createIfcDirection(ref_direction) if ref_direction else None,
+        )
+
+    def test_axis2placement3d_with_a_non_perpendicular_ref_direction(self):
+        matrix = subject.get_axis2placement(self.placement_3d((0.0, 0.0, 1.0), (1.0, 0.0, 1.0)))
+        assert np.allclose(matrix[:3, 0], (1.0, 0.0, 0.0))
+        assert_orthonormal(matrix)
+
+    def test_axis2placement3d_along_x_without_a_ref_direction(self):
+        # A valid file: RefDirection is optional, so the X axis is ours to pick
+        # and it must not be parallel to Axis.
+        for axis in ((1.0, 0.0, 0.0), (-1.0, 0.0, 0.0)):
+            matrix = subject.get_axis2placement(self.placement_3d(axis))
+            assert np.allclose(matrix[:3, 2], axis)
+            assert_orthonormal(matrix)
+
+    def test_axis2placement3d_along_the_other_axes_without_a_ref_direction(self):
+        for axis in ((0.0, 0.0, 1.0), (0.0, 1.0, 0.0), (0.0, 0.0, -1.0)):
+            matrix = subject.get_axis2placement(self.placement_3d(axis))
+            assert np.allclose(matrix[:3, 2], axis)
+            assert_orthonormal(matrix)
+
+    def test_axis1placement_along_x(self):
+        # IfcAxis1Placement has no RefDirection attribute at all, so an axis of
+        # (1, 0, 0) is perfectly valid and must not produce NaN.
+        placement = self.file.createIfcAxis1Placement(
+            self.file.createIfcCartesianPoint((0.0, 0.0, 0.0)),
+            self.file.createIfcDirection((1.0, 0.0, 0.0)),
+        )
+        matrix = subject.get_axis2placement(placement)
+        assert np.allclose(matrix[:3, 2], (1.0, 0.0, 0.0))
+        assert_orthonormal(matrix)


### PR DESCRIPTION
a2p used the supplied X axis verbatim. IfcBuildAxes derives the X axis by
projecting RefDirection onto the plane normal to Axis (IfcFirstProjAxis), and
the geometry kernel does exactly that in taxonomy::matrix4::init, where X is
recomputed as Y cross Z. The Python util never got the equivalent of that, so
the two disagreed on the same placement.

With Axis (0,0,1) and RefDirection (1,0,1), a legal combination since the
schema only forbids RefDirection parallel to Axis, the kernel returns the
identity rotation while a2p returned an X axis of (0.7071, 0, 0.7071). The
resulting matrix is not a rotation at all: X dot Z is 0.7071 instead of 0 and
the determinant is 0.7071 instead of 1, so every element placed through it is
sheared and shrunk by 29 percent, silently.

Separately, the X axis fallback of (1,0,0) was used unconditionally where
RefDirection is absent. For IfcAxis2Placement3D with Axis (1,0,0) or (-1,0,0),
and for IfcAxis1Placement, which has no RefDirection attribute at all, the
fallback is parallel to Axis, so the cross product is zero and the matrix came
back with NaN entries. All of these are valid files and the kernel handles
them. The default now falls back to (0,0,1) when it would be parallel, as the
kernel's matrix4 constructor does.

Both are verified against the C++ engine on the same entities: the rotation
parts now agree to 0.0, where the non-perpendicular case previously differed
by 0.7071 and the axis-aligned cases produced 3 NaN entries out of 16.

Well formed placements, where RefDirection is already perpendicular to Axis,
are unaffected, since Y cross Z reproduces X exactly for an orthonormal frame.

The 2D RefDirection branch is deliberately left alone, as it is already
covered by open PRs #8586 and #8307.

Generated with the assistance of an AI coding tool.

