### PR TITLE
util.selector: match boolean properties by True/False

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -1258,12 +1258,23 @@ class FacetTransformer(lark.Transformer):
             return result
         elif isinstance(value, str):
             try:
-                if isinstance(element_value, int):
+                if isinstance(element_value, bool):
+                    # bool subclasses int, so handle it before the numeric
+                    # branches. A boolean property should match every common
+                    # spelling ("True"/"false"/etc) the same way "1"/"0" already do,
+                    # instead of falling into int(value) and raising.
+                    if value in ("True", "true", "TRUE", "1"):
+                        value = True
+                    elif value in ("False", "false", "FALSE", "0"):
+                        value = False
+                elif isinstance(element_value, int):
                     value = int(value)
                 elif isinstance(element_value, float):
                     value = float(value)
 
-                if isinstance(element_value, (int, float)):
+                if isinstance(element_value, bool):
+                    result = element_value == value
+                elif isinstance(element_value, (int, float)):
                     operator = comparison.lstrip("!")
                     if operator == ">=":
                         result = element_value >= value

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -317,6 +317,29 @@ class TestFilterElements(test.bootstrap.IFC4):
         assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status!=New") == {element2}
         assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status!=Temporary") == {element, element2}
 
+    def test_selecting_by_boolean_property(self):
+        # bool subclasses int, so a naive isinstance(element_value, int) check
+        # matches booleans first and tries int(value) on a non-numeric string
+        # like "True", which raises and is swallowed, silently returning no
+        # match. Booleans must be handled before the numeric branches.
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"IsExternal": True})
+        pset2 = ifcopenshell.api.pset.add_pset(self.file, product=element2, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset2, properties={"IsExternal": False})
+        for true_value in ("TRUE", "True", "true", "1"):
+            assert subject.filter_elements(self.file, f"IfcWall, Pset_WallCommon.IsExternal={true_value}") == {
+                element
+            }, true_value
+        for false_value in ("FALSE", "False", "false", "0"):
+            assert subject.filter_elements(self.file, f"IfcWall, Pset_WallCommon.IsExternal={false_value}") == {
+                element2
+            }, false_value
+        # A non-boolean-spelling string never matches a boolean property, and
+        # must not raise either.
+        assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.IsExternal=Maybe") == set()
+
     def test_selecting_by_property_with_comparisons(self):
         element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")


### PR DESCRIPTION
FacetTransformer.compare checked isinstance(element_value, int) before
isinstance(element_value, bool). Since bool subclasses int, comparing a
boolean property against a string query hit the int branch first, so
int("True") raised and the bare except swallowed it, silently returning
no match. Only the uppercase TRUE/FALSE grammar keywords and the 1/0
spellings worked; anything else, including Python's own str(True)
spelling, failed to match with no error shown to the user.

Handle bool before the numeric branches and coerce the common string
spellings (True/true/TRUE/1, False/false/FALSE/0) to the boolean before
comparing. Regression test covers True, False, 1, 0 and a non-boolean
string, matched against both a True and a False element.

This supersedes open PR #8323, which fixed the same bug but on a branch
that is 273 commits behind v0.8.0; its own CI (compile-and-test,
lint-formatting) fails as a result. This branch applies the identical
minimal fix rebased onto current v0.8.0, so #8323 can be closed once
this is merged.

Generated with the assistance of an AI coding tool.

