### PR TITLE
test_rules: run the whole EXPRESS rule corpus instead of a coincidental subset

### DIFF
--- a/src/ifcopenshell-python/test/conftest.py
+++ b/src/ifcopenshell-python/test/conftest.py
@@ -1,0 +1,7 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--rule",
+        action="store",
+        default=None,
+        help="Only run test_rules.py fixtures whose filename contains this substring.",
+    )

--- a/src/ifcopenshell-python/test/test_rules.py
+++ b/src/ifcopenshell-python/test/test_rules.py
@@ -1,6 +1,5 @@
 import glob
 import os
-import sys
 
 import pytest
 import tabulate
@@ -9,14 +8,18 @@ import ifcopenshell.express.rule_executor
 import ifcopenshell.validate
 
 
-@pytest.mark.parametrize(
-    "filename",
-    [
+def pytest_generate_tests(metafunc):
+    if "filename" not in metafunc.fixturenames:
+        return
+    rule = metafunc.config.getoption("--rule")
+    filenames = [
         fn
         for fn in glob.glob(os.path.join(os.path.dirname(__file__), "fixtures/rules/*.ifc"))
-        if len(sys.argv) < 2 or sys.argv[1] in os.path.basename(fn)
-    ],
-)
+        if not rule or rule in os.path.basename(fn)
+    ]
+    metafunc.parametrize("filename", filenames, ids=[os.path.basename(fn) for fn in filenames])
+
+
 def test_file(filename):
     base = os.path.basename(filename)
     file = ifcopenshell.open(filename)


### PR DESCRIPTION
test_file's parametrize list was filtered with `sys.argv[1] in
os.path.basename(fn)`, reading the raw process argv instead of a
pytest-native option. Under a bare `pytest` invocation sys.argv[1] is
pytest's own first CLI token, never a match, so the 138-fixture EXPRESS
rule corpus in test/fixtures/rules collapses to an empty parametrize and
pytest reports it as a single skipped test rather than an error. Under
CI's actual invocation (pytest -p no:pytest-blender -n $NPROCS test ...)
sys.argv[1] is "-p", which happens to substring-match 47 of the 138
fixtures, so CI has been silently running a coincidental 34% slice of
the corpus with no signal anything was wrong.

Replaced the module-level list comprehension with a pytest_generate_tests
hook plus a --rule CLI option (added via a new test/conftest.py). This
runs the full corpus by default under any pytest invocation, still
allows filtering to one rule for local debugging via --rule, and no
longer collides with pytest's own argv.

Verified all 138 fixtures collect and pass under the fixed harness
(63 fail- fixtures each raise a violation, 75 pass- fixtures raise none).

Generated with the assistance of an AI coding tool.

