### PR TITLE
core.aggregate: guard the value actually used in unassign_object

### DIFF
--- a/src/bonsai/bonsai/core/aggregate.py
+++ b/src/bonsai/bonsai/core/aggregate.py
@@ -65,7 +65,7 @@ def unassign_object(
     container = aggregate.get_container(related_element)
     if not relating_obj:
         relating_element = aggregate.get_relating_object(related_element)
-        if related_element:
+        if relating_element:
             relating_obj = ifc.get_object(relating_element)
     if relating_obj:
         ifc.run("aggregate.unassign_object", products=[related_element])

--- a/src/bonsai/test/core/test_aggregate.py
+++ b/src/bonsai/test/core/test_aggregate.py
@@ -59,3 +59,13 @@ class TestUnassignObject:
         collector.assign("relating_obj").should_be_called()
         collector.assign("related_obj").should_be_called()
         subject.unassign_object(ifc, aggregate, collector, relating_obj="relating_obj", related_obj="related_obj")
+
+    def test_run_without_relating_obj_when_no_aggregate_is_found(self, ifc, aggregate, collector):
+        # relating_obj is Optional and defaults to None: the function must look
+        # it up itself via aggregate.get_relating_object(). When that lookup
+        # finds no aggregate, it must not call ifc.get_object() with that
+        # None result, and must not run any unassign/collector side effects.
+        ifc.get_entity("related_obj").should_be_called().will_return("element")
+        aggregate.get_container("element").should_be_called().will_return(None)
+        aggregate.get_relating_object("element").should_be_called().will_return(None)
+        subject.unassign_object(ifc, aggregate, collector, related_obj="related_obj")


### PR DESCRIPTION
unassign_object() looks up the relating object itself when the caller
omits relating_obj. The lookup result was stored in relating_element,
but the code then checked the unrelated related_element (already known
truthy at that point) before calling ifc.get_object(relating_element).

When an object has no aggregate parent, relating_element is None but
related_element is still truthy, so the guard passed anyway and the
function called ifc.get_object(None), which crashes on element.id(),
and then proceeded to run the unassign and collector side effects on
garbage data. Fixed by checking relating_element, the value actually
being used.

No caller currently omits relating_obj, so this was latent rather than
already crashing in production, but the Optional default exists
specifically to support that call shape.

Generated with the assistance of an AI coding tool.

