### PR TITLE
core.nest: guard the value actually used, and add Nest.get_relating_object

### DIFF
--- a/src/bonsai/bonsai/core/nest.py
+++ b/src/bonsai/bonsai/core/nest.py
@@ -68,7 +68,7 @@ def unassign_object(
     # TODO: this branch is never used?
     if not relating_obj:
         relating_element = nest.get_relating_object(related_element)
-        if related_element:
+        if relating_element:
             relating_obj = ifc.get_object(relating_element)
     else:
         ifc.run("nest.unassign_object", related_objects=[related_element])

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -724,6 +724,7 @@ class Nest:
     def disable_editing(cls, obj): pass
     def enable_editing(cls, obj): pass
     def get_container(cls, element): pass
+    def get_relating_object(cls, related_element): pass
 
 
 @interface

--- a/src/bonsai/test/core/test_nest.py
+++ b/src/bonsai/test/core/test_nest.py
@@ -57,3 +57,16 @@ class TestUnassignObject:
         collector.assign("relating_obj").should_be_called()
         collector.assign("related_obj").should_be_called()
         subject.unassign_object(ifc, nest, collector, relating_obj="relating_obj", related_obj="related_obj")
+
+    def test_run_with_falsy_relating_obj_when_no_nest_parent_is_found(self, ifc, nest, collector):
+        # Unlike aggregate.unassign_object, relating_obj here has no Optional
+        # default, but nothing stops a caller from passing a falsy value
+        # anyway (type hints are not enforced at runtime), and the function
+        # body is written to handle exactly that: it looks the parent up
+        # itself via nest.get_relating_object(). When that lookup finds no
+        # nest parent, it must not call ifc.get_object() with that None
+        # result, and must not run any unassign/collector side effects.
+        ifc.get_entity("related_obj").should_be_called().will_return("element")
+        nest.get_container("element").should_be_called().will_return(None)
+        nest.get_relating_object("element").should_be_called().will_return(None)
+        subject.unassign_object(ifc, nest, collector, relating_obj=None, related_obj="related_obj")


### PR DESCRIPTION
unassign_object() looks up the nest parent itself when the caller
passes a falsy relating_obj. The lookup result was stored in
relating_element, but the code then checked the unrelated
related_element (already known truthy, asserted at function entry)
before calling ifc.get_object(relating_element). Same wrong-variable
typo already fixed in core.aggregate.unassign_object.

When related_obj has no nest parent, relating_element is None but
related_element is still truthy, so the guard passed anyway and the
function called ifc.get_object(None), which crashes on element.id().
Fixed by checking relating_element, the value actually being used.

Unlike aggregate.unassign_object, relating_obj here has no Optional
default: it is a required, non-optional-typed parameter, so there is
no supported "omit it" call shape. But nothing enforces that hint at
runtime, and the function body is written to handle a falsy
relating_obj anyway (the whole reason this branch exists). The sole
production caller, bim.nest_unassign_object, always passes a
relating_obj derived from a nest parent already confirmed to exist,
so this was not reachable through the UI. It is reachable by calling
the core function directly with relating_obj=None, which the added
test does.

Also adds get_relating_object to the abstract Nest interface in
core/tool.py: it was missing there even though core.nest calls it and
the concrete bonsai.tool.Nest implements it, so the mocked test
harness could not predict the call at all until this was added.

Generated with the assistance of an AI coding tool.

