### PR TITLE
api.cogo: give survey point annotations a valid IfcObjectPlacement

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/cogo/add_survey_point.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cogo/add_survey_point.py
@@ -47,7 +47,7 @@ def add_survey_point(
     representation = file.createIfcProductDefinitionShape(Representations=[shape_representation])
     annotation = file.createIfcAnnotation(
         ifcopenshell.guid.new(),
-        ObjectPlacement=context.WorldCoordinateSystem,
+        ObjectPlacement=file.createIfcLocalPlacement(RelativePlacement=context.WorldCoordinateSystem),
         Representation=representation,
         PredefinedType="SURVEY",
     )


### PR DESCRIPTION
add_survey_point assigned IfcGeometricRepresentationContext.WorldCoordinateSystem
(an IfcAxis2Placement3D) directly to IfcAnnotation.ObjectPlacement, which requires
an IfcObjectPlacement (e.g. IfcLocalPlacement). Every survey point annotation
created by this API therefore held an attribute of the wrong entity type, which
ifcopenshell.validate flags as invalid on every file it touches. Because
assign_container only localizes placements that are already IfcLocalPlacement,
the wrong-typed placement was left untouched afterwards too.

Wrap the WorldCoordinateSystem placement in an IfcLocalPlacement, the same
pattern used elsewhere in the api (e.g. geometry.edit_object_placement), so
the annotation is still located at the world origin/orientation as the
docstring describes, but through a schema-valid attribute.

Verified: ifcopenshell.validate reported the ObjectPlacement type error before
the fix and is silent after. test/api suite: 1445 passed before and after
(one pre-existing, unrelated alignment test failure caused by a stale
prebuilt geometry engine was excluded from both runs, see PR description).

Generated with the assistance of an AI coding tool.

