### PR TITLE
ifc2ca: stop point loads crashing the load-case parser

### DIFF
--- a/src/ifc2ca/ifc2ca.py
+++ b/src/ifc2ca/ifc2ca.py
@@ -611,6 +611,9 @@ class Ifc2CA:
                     MX = np.array([tempMX, tempMY, tempMZ]).dot(element["orientation"][:, 0])
                     MY = np.array([tempMX, tempMY, tempMZ]).dot(element["orientation"][:, 1])
                     MZ = np.array([tempMX, tempMY, tempMZ]).dot(element["orientation"][:, 2])
+                # a point load has no length to project against, in either GLOBAL_COORDS or LOCAL_COORDS
+                force_projection_coeff = 1.0
+                moment_projection_coeff = 1.0
 
             elif action.is_a("IfcStructuralLinearAction") and load.is_a("IfcStructuralLoadLinearForce"):
                 FX = tempFX = load.LinearForceX if load.LinearForceX is not None else 0.0


### PR DESCRIPTION
add_action_loads() initialised force_projection_coeff and
moment_projection_coeff to None for Vertex/Edge elements, then only
ever assigned them inside the IfcStructuralLinearAction branch. The
IfcStructuralPointAction branch (a concentrated force at a node, the
most common IFC structural load type) left both None. The very next
loop then asserted they were not None before multiplying them into
the accumulated load, so any load case containing a point load raised
a bare AssertionError and aborted parse_model(), in both
GLOBAL_COORDS and LOCAL_COORDS.

A point load has no length to project against (that concept only
applies to distributed/linear loads), so set both coefficients to 1.0
unconditionally once the point load's components are resolved.

Verified by calling add_action_loads() directly against real
ifcopenshell entities: before the fix a GLOBAL_COORDS ForceX=100
point load raised AssertionError; after the fix it accumulates
FX=100.0 as expected. A second case with a LOCAL_COORDS point load on
a member rotated 90 degrees about Z confirms the local-to-global axis
transform still produces the hand-derived result (local X of 100
becomes global Y of 100).

Generated with the assistance of an AI coding tool.

