### PR TITLE
api.georeference: apply the IFC2X3 pset value types the loop computes

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/georeference/edit_georeferencing.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/georeference/edit_georeferencing.py
@@ -89,6 +89,7 @@ def edit_georeferencing(
         if projected_crs:
             if crs := ifcopenshell.util.element.get_pset(project, "ePSet_ProjectedCRS"):
                 crs = file.by_id(crs["id"])
+                crs_properties = {}
                 for k, v in projected_crs.items():
                     if k == "Description":
                         v = file.createIfcText(v)
@@ -96,16 +97,21 @@ def edit_georeferencing(
                         v = file.createIfcLabel(v)
                     elif v is not None:
                         v = file.createIfcIdentifier(v)
-                ifcopenshell.api.pset.edit_pset(file, crs, properties=projected_crs)
+                    crs_properties[k] = v
+                ifcopenshell.api.pset.edit_pset(file, crs, properties=crs_properties)
         if coordinate_operation:
             if conversion := ifcopenshell.util.element.get_pset(project, "ePSet_MapConversion"):
                 conversion = file.by_id(conversion["id"])
+                conversion_properties = {}
                 for k, v in coordinate_operation.items():
-                    if k in ("XAxisAbscissa", "XAxisOrdinate", "Scale"):
+                    if v is None:
+                        pass
+                    elif k in ("XAxisAbscissa", "XAxisOrdinate", "Scale"):
                         v = file.createIfcReal(v)
                     else:
                         v = file.createIfcLengthMeasure(v)
-                ifcopenshell.api.pset.edit_pset(file, conversion, properties=coordinate_operation)
+                    conversion_properties[k] = v
+                ifcopenshell.api.pset.edit_pset(file, conversion, properties=conversion_properties)
         return
     if projected_crs:
         crs = file.by_type("IfcProjectedCRS")[0]

--- a/src/ifcopenshell-python/test/api/georeference/test_edit_georeferencing.py
+++ b/src/ifcopenshell-python/test/api/georeference/test_edit_georeferencing.py
@@ -18,6 +18,7 @@
 
 import ifcopenshell.api.context
 import ifcopenshell.api.georeference
+import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.util.element
 import test.bootstrap
@@ -84,3 +85,24 @@ class TestEditGeoreferencingIFC2X3(test.bootstrap.IFC2X3):
         conversion = ifcopenshell.util.element.get_pset(project, "ePSet_MapConversion", verbose=True)
         for name in ("XAxisAbscissa", "Scale"):
             assert self.file.by_id(conversion[name]["id"]).NominalValue.is_a("IfcReal")
+
+    def test_editing_a_map_conversion_property_never_seeded_by_add_georeferencing(self):
+        # XAxisAbscissa and Scale above are not seeded by add_georeferencing
+        # either, but that assertion alone cannot prove the loop wraps values
+        # correctly: a raw, unwrapped Python float also falls back to
+        # IfcReal in edit_pset's own type inference, so it passes whether or
+        # not edit_georeferencing wraps the value at all.
+        #
+        # Eastings takes the IfcLengthMeasure branch instead, so an unwrapped
+        # float would fall back to IfcReal, not IfcLengthMeasure, and this
+        # assertion actually distinguishes the two. This simulates an
+        # IFC2X3 file authored by another tool: the ePSet_MapConversion
+        # pset exists (so edit_georeferencing's own lookup succeeds) but
+        # Eastings itself was never seeded by add_georeferencing, so
+        # edit_pset must add it as a brand new property instead of
+        # inheriting the type of an existing one.
+        project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.pset.add_pset(self.file, project, "ePSet_MapConversion")
+        ifcopenshell.api.georeference.edit_georeferencing(self.file, coordinate_operation={"Eastings": 100.0})
+        conversion = ifcopenshell.util.element.get_pset(project, "ePSet_MapConversion", verbose=True)
+        assert self.file.by_id(conversion["Eastings"]["id"]).NominalValue.is_a("IfcLengthMeasure")

--- a/src/ifcopenshell-python/test/api/georeference/test_edit_georeferencing.py
+++ b/src/ifcopenshell-python/test/api/georeference/test_edit_georeferencing.py
@@ -62,3 +62,25 @@ class TestEditGeoreferencingIFC2X3(test.bootstrap.IFC2X3):
         assert self.file.by_id(conversion["Eastings"]["id"]).NominalValue.is_a("IfcLengthMeasure")
         assert conversion["Northings"]["value"] == 234.56
         assert conversion["OrthogonalHeight"]["value"] == 0
+
+    def test_editing_georeferencing_properties_not_seeded_by_add_georeferencing(self):
+        project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.georeference.add_georeferencing(self.file)
+        ifcopenshell.api.georeference.edit_georeferencing(
+            self.file,
+            projected_crs={
+                "Description": "Amersfoort / RD New",
+                "GeodeticDatum": "Amersfoort",
+                "VerticalDatum": "NAP",
+                "MapProjection": "RD",
+                "MapZone": "1",
+            },
+            coordinate_operation={"XAxisAbscissa": 0.866, "Scale": 0.99956},
+        )
+        crs = ifcopenshell.util.element.get_pset(project, "ePSet_ProjectedCRS", verbose=True)
+        assert self.file.by_id(crs["Description"]["id"]).NominalValue.is_a("IfcText")
+        for name in ("GeodeticDatum", "VerticalDatum", "MapProjection", "MapZone"):
+            assert self.file.by_id(crs[name]["id"]).NominalValue.is_a("IfcIdentifier")
+        conversion = ifcopenshell.util.element.get_pset(project, "ePSet_MapConversion", verbose=True)
+        for name in ("XAxisAbscissa", "Scale"):
+            assert self.file.by_id(conversion[name]["id"]).NominalValue.is_a("IfcReal")


### PR DESCRIPTION
edit_georeferencing wraps each IFC2X3 pset value in its correct IFC type
(IfcText for Description, IfcIdentifier for the other IfcProjectedCRS
attributes, IfcReal or IfcLengthMeasure for the map conversion), but the
wrapped value was assigned to the loop variable and then thrown away. The
original, unwrapped dict was passed to pset.edit_pset, so the whole loop
was a dead store.

edit_pset keeps the type of a property that already exists, which is why
this went unnoticed: add_georeferencing seeds Name, Eastings, Northings
and OrthogonalHeight with the right types, and those are the only ones
the existing test covers. Every attribute that add_georeferencing does
not seed took edit_pset's inferred fallback instead. Setting Description,
GeodeticDatum, VerticalDatum, MapProjection and MapZone on an IFC2X3
project stored all five as IfcLabel rather than IfcText or IfcIdentifier.

Collect the wrapped values into a new dict and pass that instead. The
caller's dict is left unmutated, and a None value is passed through
unwrapped so a property can still be unset.

The added test covers the attributes add_georeferencing does not seed.

Generated with the assistance of an AI coding tool.

The coordinate_operation half of the fix in the previous commit had no test
that could actually fail against the old dead-store bug. The two properties
it asserted on, XAxisAbscissa and Scale, both fall back to IfcReal in
edit_pset's own type inference for a raw, unwrapped Python float, which is
exactly the type edit_georeferencing's wrap loop was also trying to produce
for them. So those two assertions pass identically whether or not
edit_georeferencing actually wraps the value.

Verified by reverting only edit_georeferencing.py to the pre-fix dead-store
version and re-running the existing test: it still passed on those two
properties.

Eastings takes the IfcLengthMeasure branch instead, where an unwrapped float
would fall back to IfcReal, not IfcLengthMeasure, so asserting on it actually
distinguishes wrapped from unwrapped. The new test also seeds
ePSet_MapConversion directly instead of going through add_georeferencing, so
Eastings is a genuinely new property (not one whose existing type edit_pset
would otherwise just retain), matching the it-came-from-another-tool
scenario described in the previous commit. Confirmed red against the pre-fix
edit_georeferencing.py and green against the fixed one.

Generated with the assistance of an AI coding tool.

