### PR TITLE
Bonsai: fix linked-element geometry slice index space for hidden faces

### DIFF
--- a/src/bonsai/bonsai/tool/project.py
+++ b/src/bonsai/bonsai/tool/project.py
@@ -733,7 +733,7 @@ class Project(bonsai.core.tool.Project):
             index = obj_guids.index(guid)
             if index in obj_hidden_indices:
                 assert False, "Unexpected. Why would you need the geometry for the hidden element?"
-            obj_guid_ids = cls.get_linked_element_guid_ids(obj, skip_hidden=False)
+            obj_guid_ids = cls.get_linked_element_guid_ids(obj, skip_hidden=True)
             guid_end_index = obj_guid_ids[index]
             guid_start_index = index and obj_guid_ids[index - 1]
             return slice(guid_start_index, guid_end_index)


### PR DESCRIPTION
get_linked_element_geom_slice slices into the mesh polygon index space
that excludes hidden faces, but built its cumulative guid_ids with
get_linked_element_guid_ids(obj, skip_hidden=False), the raw,
un-shifted index space, so the returned slice was wrong whenever any
face was hidden. The sibling call two lines up (get_guid_by_face_index)
already uses skip_hidden=True; align this one.

This supersedes PR #8560, which has the identical one-line fix but is
208 commits behind origin/v0.8.0 and fails compile-and-test/lint on
stale-branch drift alone. This branch rebases the same fix onto
current origin/v0.8.0 (8deefe497c); a maintainer can close #8560 in
favour of this one.

Verified in headless Blender: test/tool/test_project.py::TestGettingLinkedElementGeomSlice
goes from 2 failed / 3 passed to 5 passed. Full test/tool/ suite run
before and after: identical set of 794 pre-existing harness errors
(unrelated, addon-registration artifact of the headless test rig), only
the 2 target tests change from FAILED to PASSED, no new failures.

This change was made with the assistance of an AI tool.


This PR was generated with the assistance of an AI coding tool.
