### PR TITLE
ifcsverchok: stop batched node inputs overwriting each other

### DIFF
--- a/src/ifcsverchok/nodes/ifc/api.py
+++ b/src/ifcsverchok/nodes/ifc/api.py
@@ -81,8 +81,10 @@ class SvIfcApi(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.SvIfcCor
     def process(self):
         module_usecase = self.get_module_usecase()
         if module_usecase:
+            self.results_out = []
             self.sv_input_names = [i.name for i in self.inputs]
             super().process()
+            self.outputs["file"].sv_set(self.results_out)
 
     def get_module_usecase(self) -> Union[list[str], None]:
         usecase = self.inputs["usecase"].sv_get()[0][0]
@@ -92,7 +94,7 @@ class SvIfcApi(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.SvIfcCor
     def generate_node(self, module: str, usecase: str) -> None:
         try:
             node_data = ifcopenshell.api.extract_docs(module, usecase)
-        except:
+        except AttributeError:
             print("Node not yet implemented:", module, usecase)
             return
         while len(self.inputs) > 1:
@@ -112,7 +114,7 @@ class SvIfcApi(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.SvIfcCor
         if usecase:
             settings = dict(zip(self.sv_input_names[1:], setting_values))
             settings = {k: v for k, v in settings.items() if v != ""}
-            self.outputs["file"].sv_set([ifcopenshell.api.run(usecase, **settings)])
+            self.results_out.append(ifcopenshell.api.run(usecase, **settings))
 
 
 def register():

--- a/src/ifcsverchok/nodes/ifc/by_query.py
+++ b/src/ifcsverchok/nodes/ifc/by_query.py
@@ -51,12 +51,14 @@ class SvIfcByQuery(bpy.types.Node, SverchCustomTreeNode, helper.SvIfcCore):
         if not self.inputs["query"].sv_get()[0][0]:
             return
         self.file = SvIfcStore.get_file()
+        self.entities_out = []
         self.sv_input_names = ["query"]
         super().process()
+        self.outputs["Entity"].sv_set(self.entities_out)
 
     def process_ifc(self, query: str) -> None:
         elements = ifcopenshell.util.selector.filter_elements(self.file, query)
-        self.outputs["Entity"].sv_set(elements)
+        self.entities_out.extend(elements)
 
 
 def register():

--- a/src/ifcsverchok/nodes/ifc/by_type.py
+++ b/src/ifcsverchok/nodes/ifc/by_type.py
@@ -125,20 +125,24 @@ class SvIfcByType(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.SvIfc
             self.ifc_products = get_ifc_products(self, bpy.context)
             self.ifc_classes = get_ifc_classes(self, bpy.context)
         self.sv_input_names = ["ifc_product", "ifc_class", "custom_ifc_class"]
+        # Accumulated across every process_ifc() call below, since a linked
+        # socket can carry more than one ifc_class/custom_ifc_class value and
+        # each call must contribute to the output, not replace it.
+        self.entities_out = []
+        self.entity_ids_out = []
         super().process()
+        self.outputs["Entities"].sv_set(self.entities_out)
+        self.outputs["Entity Ids"].sv_set(self.entity_ids_out)
 
     def process_ifc(self, ifc_product, ifc_class, custom_ifc_class):
         if custom_ifc_class:
             entities = self.file.by_type(custom_ifc_class)
-            self.outputs["Entities"].sv_set(entities)
-            self.outputs["Entity Ids"].sv_set([e.id() for e in entities])
         elif ifc_class:
             entities = self.file.by_type(ifc_class)
-            self.outputs["Entities"].sv_set(self.file.by_type(ifc_class))
-            self.outputs["Entity Ids"].sv_set([e.id() for e in entities])
         else:
-            self.outputs["Entities"].sv_set([])
-            self.outputs["Entity Ids"].sv_set([])
+            entities = []
+        self.entities_out.extend(entities)
+        self.entity_ids_out.extend(e.id() for e in entities)
 
 
 def register():

--- a/src/ifcsverchok/nodes/ifc/create_file.py
+++ b/src/ifcsverchok/nodes/ifc/create_file.py
@@ -67,12 +67,14 @@ class SvIfcCreateFile(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.S
 
     def process(self):
         self.sv_input_names = ["schema"]
+        self.file_out: list[ifcopenshell.file] = []
         super().process()
+        self.outputs["file"].sv_set([self.file_out])
 
     def process_ifc(self, schema: str) -> None:
         guid = ifcopenshell.guid.new()
         ifcsverchok.helper.ifc_files[guid] = ifcopenshell.file(schema=schema)
-        self.outputs["file"].sv_set([[ifcsverchok.helper.ifc_files[guid]]])
+        self.file_out.append(ifcsverchok.helper.ifc_files[guid])
 
 
 def register():

--- a/src/ifcsverchok/nodes/ifc/get_attribute.py
+++ b/src/ifcsverchok/nodes/ifc/get_attribute.py
@@ -70,8 +70,13 @@ class SvIfcGetAttribute(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper
                 self.value_out.append(entity[int(attribute_name)])
             else:
                 self.value_out.append(entity.get_info()[attribute_name])
-        except:
-            pass
+        except (KeyError, IndexError, ValueError):
+            # Keep a placeholder so value_out stays aligned, entity by
+            # entity, with the input entity list. Silently dropping the
+            # entry here would shift every later entity one position
+            # earlier and misalign the output against callers that zip it
+            # back against their own entity list.
+            self.value_out.append(None)
 
 
 def register():

--- a/src/ifcsverchok/nodes/ifc/get_property.py
+++ b/src/ifcsverchok/nodes/ifc/get_property.py
@@ -69,8 +69,13 @@ class SvIfcGetProperty(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.
         for entity in self.entities:
             try:
                 self.value_out.append(ifcopenshell.util.element.get_psets(entity)[pset_name][prop_name])
-            except:
-                pass
+            except KeyError:
+                # Keep a placeholder so value_out stays aligned, entity by
+                # entity, with self.entities. Silently dropping the entry
+                # here would shift every later entity one position earlier
+                # and misalign the output against callers that zip it back
+                # against their own entity list.
+                self.value_out.append(None)
         self.outputs["value"].sv_set(self.value_out)
 
 

--- a/src/ifcsverchok/nodes/ifc/quick_project_setup.py
+++ b/src/ifcsverchok/nodes/ifc/quick_project_setup.py
@@ -72,7 +72,9 @@ class SvIfcQuickProjectSetup(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.h
 
     def process(self):
         self.sv_input_names = [i.name for i in self.inputs]
+        self.file_out = []
         super().process()
+        self.outputs["file"].sv_set([self.file_out])
 
     def process_ifc(self, *setting_values):
         settings = dict(zip(self.sv_input_names, setting_values))
@@ -90,7 +92,7 @@ class SvIfcQuickProjectSetup(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.h
             project_name=settings["project_name"],
         )
 
-        self.outputs["file"].sv_set([[file]])
+        self.file_out.append(file)
 
 
 def register():

--- a/src/ifcsverchok/nodes/ifc/read_file.py
+++ b/src/ifcsverchok/nodes/ifc/read_file.py
@@ -43,12 +43,14 @@ class SvIfcReadFile(bpy.types.Node, SverchCustomTreeNode, ifcsverchok.helper.SvI
 
     def process(self):
         self.sv_input_names = ["path"]
+        self.file_out: list[ifcopenshell.file] = []
         super().process()
+        self.outputs["file"].sv_set([self.file_out])
 
     def process_ifc(self, path: str) -> None:
         guid = ifcopenshell.guid.new()
         ifcsverchok.helper.ifc_files[guid] = ifcopenshell.open(path)
-        self.outputs["file"].sv_set([[ifcsverchok.helper.ifc_files[guid]]])
+        self.file_out.append(ifcsverchok.helper.ifc_files[guid])
 
 
 def register():


### PR DESCRIPTION
SvIfcByType.process_ifc() called self.outputs[...].sv_set() directly.
The base class SvIfcCore.process() dispatches process_ifc() once per
value when a linked socket carries more than one ifc_class or
custom_ifc_class (e.g. selecting both IfcWall and IfcDoor at once).
Each sv_set() call replaces the previous one, so only the last class
processed survived in the output; earlier classes were silently
dropped with no error.

Fixed by accumulating entities and entity ids across every
process_ifc() call and calling sv_set() once after the batch
completes, matching the pattern already used by SvIfcAdd and other
working nodes in this package.

Reproduced by copying the exact process()/process_ifc() logic into a
standalone script and mocking file.by_type() and the output sockets
(bpy/sverchok are not importable outside Blender): feeding
["IfcWall", "IfcDoor"] into ifc_class produced only IfcDoor entities
before the fix, and both classes' entities after.

Generated with the assistance of an AI coding tool.

Same bug class as 120383d3 (IFC By Type). SvIfcCore.process()
(src/ifcsverchok/helper.py:36-51) dispatches process_ifc() once per
value when a linked socket carries multiple items, per Sverchok's
batching convention. by_query.py, api.py, read_file.py, create_file.py
and quick_project_setup.py called self.outputs[...].sv_set() directly
inside process_ifc(), so each call replaced the previous one and only
the last batch item survived.

Fixed by accumulating into a list across every process_ifc() call and
calling sv_set() once after the batch completes, matching the pattern
already used by SvIfcAdd, SvIfcAddPset, SvIfcAddSpatialElement and
SvIfcSelectBlenderObjects.

Also narrowed a bare except in api.py's generate_node() to
AttributeError (the actual failure mode when a usecase or module
doesn't exist), since a bare except also swallows KeyboardInterrupt
and SystemExit.

Reproduced by copying the exact process()/process_ifc() logic into a
standalone script and mocking the socket sv_get()/sv_set() calls
(bpy/sverchok are not importable outside Blender): feeding two values
into a batched socket produced only the second value's output before
the fix, and both values' output after.

Generated with the assistance of an AI coding tool.

get_attribute.py and get_property.py loop over a flat list of entities
and append to a flat output list, one value per entity. Both had a
bare except: pass around the per-entity lookup. If entity N raised
(e.g. a missing attribute or property), nothing was appended for it,
so every later entity's value shifted one position earlier. In a node
graph, where a downstream node commonly zips this output back against
its own entity list, that silently misaligns values against the wrong
entities instead of raising or leaving an obvious gap.

Chose to append None on failure rather than let the exception
propagate: one bad entity in a large batch would otherwise abort the
whole node for every entity, and a None is easy for downstream nodes
to filter or notice, whereas a silently shifted list looks correct
until it's found wrong. Narrowed the bare except to the exceptions the
respective lookups can actually raise (KeyError, IndexError and
ValueError for get_attribute's entity[index]/get_info() lookup;
KeyError for get_property's get_psets() lookup), so
KeyboardInterrupt/SystemExit are no longer swallowed either.

Reproduced with a standalone script exercising the same try/except
body against a three-entity list where the middle entity is missing
the requested attribute/property: before the fix the output list was
two items long with the third entity's value in the second slot; after
the fix it stays three items long with None in the failing slot.

Generated with the assistance of an AI coding tool.

