### PR TITLE
ifcedit: stop str shadowing more specific Union alternatives

### DIFF
--- a/src/ifcedit/ifcedit/coerce.py
+++ b/src/ifcedit/ifcedit/coerce.py
@@ -65,8 +65,14 @@ def coerce_value(
                 return None
         if value_str is None and type(None) in args:
             return None
-        # Try each non-None type in order
-        for t in non_none_types:
+        # Try each non-None type in order, but always try `str` last. Coercing to
+        # `str` never raises, so trying it before a more specific alternative
+        # (e.g. Union[str, entity_instance]) makes that alternative unreachable
+        # dead code and silently returns the raw string instead of resolving it.
+        ordered_types = [t for t in non_none_types if t is not str]
+        if str in non_none_types:
+            ordered_types.append(str)
+        for t in ordered_types:
             try:
                 return coerce_value(value_str, t, model, lookup_file)
             except (ValueError, TypeError):

--- a/src/ifcedit/tests/test_coerce.py
+++ b/src/ifcedit/tests/test_coerce.py
@@ -78,6 +78,28 @@ class TestUnionCoercion:
         result = coerce_value("42", Union[int, None])
         assert result == 42
 
+    def test_union_str_int_prefers_int_for_numeric_string(self):
+        # str never raises, so it must not shadow a more specific alternative
+        # like int just because it happens to be listed first in the Union.
+        result = coerce_value("42", Union[str, int])
+        assert result == 42
+        assert isinstance(result, int)
+
+    def test_union_str_entity_resolves_entity_by_id(self, model):
+        # Regression: coerce_value used to always resolve Union[str, entity_instance]
+        # to a plain string, because coercing to `str` never raises and was tried
+        # first, making the entity_instance alternative unreachable. This meant
+        # ifcopenshell.api.classification.add_classification(classification="<id>")
+        # always took the "create a new custom classification named '<id>'" path,
+        # even when the caller intended to reference an existing entity by ID.
+        wall = model.by_type("IfcWall")[0]
+        result = coerce_value(str(wall.id()), Union[str, ifcopenshell.entity_instance], model)
+        assert result == wall
+
+    def test_union_str_entity_falls_back_to_str_when_not_an_id(self, model):
+        result = coerce_value("MyCustomClassification", Union[str, ifcopenshell.entity_instance], model)
+        assert result == "MyCustomClassification"
+
 
 class TestLiteralCoercion:
     def test_valid_literal(self):


### PR DESCRIPTION
coerce_value tried Union alternatives in declaration order and kept
the first one that did not raise. Coercing to str never raises, so
any Union listing str before a more specific type (entity_instance,
int, float...) made that other type unreachable.

This silently broke functions like
ifcopenshell.api.classification.add_classification, whose
classification parameter is typed Union[str, entity_instance]: a
caller passing an existing IfcClassification's step ID always got it
coerced to the literal string of that ID instead of the resolved
entity, so add_classification took the "create a brand new
classification named after the ID" path instead of reusing/migrating
the referenced one, with no error reported.

Reorder the Union trial so str is always attempted last, since it is
the only alternative that can never fail.

Generated with the assistance of an AI coding tool.

