### PR TITLE
ifccityjson: apply the CityJSON transform, fixing 1000x geometry

### DIFF
--- a/src/ifccityjson/ifccityjson/cityjson2ifc/cityjson2ifc.py
+++ b/src/ifccityjson/ifccityjson/cityjson2ifc/cityjson2ifc.py
@@ -150,9 +150,9 @@ class Cityjson2ifc:
 
     def create_metadata(self):
         # Georeferencing
-        self.properties["local_translation"] = None
+        self.properties["local_translation"] = {"Eastings": 0.0, "Northings": 0.0, "OrthogonalHeight": 0.0}
         self.properties["local_scale"] = None
-        if self.city_model.is_transformed:
+        if self.city_model.transform is not None:
             self.properties["local_scale"] = self.city_model.transform["scale"]
             local_translation = self.city_model.transform["translate"]
             self.properties["local_translation"] = {


### PR DESCRIPTION
__main__.py always loads city models with cjio's transform=False, so the
vertices we receive are always raw and un-transformed. cjio sets
is_transformed=False unconditionally in that mode, even when the source
file declares a transform block. create_metadata() gated scale/translate
handling on is_transformed, so for any transformed CityJSON (the common
case for real-world exports, e.g. 3DBAG) the scale was never applied to
vertices: coordinates were written to IFC as raw, unscaled integers,
silently producing geometry off by the scale factor (measured 1000x on a
0.001 scale file). When the file also had an EPSG CRS, local_translation
stayed None and building the IfcMapConversion crashed with a TypeError.

Fix: check city_model.transform (the transform metadata itself) instead
of is_transformed, and default local_translation to a zero offset instead
of None so a file with an EPSG but no transform block no longer crashes.

Generated with the assistance of an AI coding tool.

