### PR TITLE
bsdd: run tests offline and guard optional class-property fields

### DIFF
--- a/src/bsdd/bsdd.py
+++ b/src/bsdd/bsdd.py
@@ -1028,11 +1028,15 @@ def apply_ifc_classification_properties(
         predefinedValue = prop.get("predefinedValue")
         if not predefinedValue or prop.get("propertyDomainName") != "IFC":
             continue
-        pset = psets.get(prop["propertySet"])
+        # propertySet is NotRequired; skip properties without one.
+        property_set = prop.get("propertySet")
+        if not property_set:
+            continue
+        pset = psets.get(property_set)
         if pset:
             pset = ifc_file.by_id(pset["id"])
         else:
-            pset = ifcopenshell.api.pset.add_pset(ifc_file, product=element, name=prop["propertySet"])
-        if prop["dataType"] == "boolean":
+            pset = ifcopenshell.api.pset.add_pset(ifc_file, product=element, name=property_set)
+        if prop.get("dataType") == "boolean":
             predefinedValue = predefinedValue == "TRUE"
         ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties={prop["name"]: predefinedValue})

--- a/src/bsdd/pyproject.toml
+++ b/src/bsdd/pyproject.toml
@@ -49,3 +49,9 @@ extend = "../../pyproject.toml"
 lint.select = [
   "F401",  # unused imports
 ]
+
+[tool.pytest.ini_options]
+markers = [
+  "network: hits the live bSDD API; deselected by default, run with -m network",
+]
+addopts = "-m 'not network'"

--- a/src/bsdd/tests/test_bsdd.py
+++ b/src/bsdd/tests/test_bsdd.py
@@ -1,61 +1,131 @@
+"""Offline tests for bsdd.Client.
+
+These run against stubbed responses instead of calling the live bSDD API, so
+they run without network access and are safe to collect and run in CI. For
+tests against the real bSDD API, see test_bsdd_live.py (opt-in, `network`
+marker, never runs by default).
+"""
+
+import types
+
+import pytest
+
 from bsdd import Client
 
-client = Client()
+IFC4X3_URI = "https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3"
+NBS_URI = "https://identifier.buildingsmart.org/uri/nbs/uniclass/2015"
+LIGHT_FIXTURE_URI = f"{IFC4X3_URI}/class/IfcLightFixture"
 
-ifc4x3_uri = next(l["uri"] for l in client.get_dictionary()["dictionaries"] if "4.3" in l["uri"])
-nbs_uri = next(l["uri"] for l in client.get_dictionary()["dictionaries"] if "Uniclass 2015" == l["name"])
+DICTIONARIES = {
+    "dictionaries": [
+        {"name": "IFC", "uri": IFC4X3_URI},
+        {"name": "Uniclass 2015", "uri": NBS_URI},
+    ]
+}
+
+IFC4X3_CLASSES = {
+    "classes": [
+        {"code": "IfcBoiler", "uri": f"{IFC4X3_URI}/class/IfcBoiler"},
+        {"code": "IfcLightFixture", "uri": LIGHT_FIXTURE_URI},
+    ]
+}
+
+NBS_CLASSES = {"classes": [{"code": "Ac", "uri": f"{NBS_URI}/class/Ac"}]}
+
+LIGHT_FIXTURE_PROPERTIES = [
+    {"name": "Maintenance Factor"},
+    {"name": "Light Fixture Mounting Type"},
+]
+
+LIGHT_FIXTURE_RELATIONS = {
+    "classRelations": [
+        {"className": "Electrical unit for light-line system", "classUri": f"{IFC4X3_URI}/class/ElecUnit"},
+        {"className": "Tubelight system", "classUri": f"{IFC4X3_URI}/class/Tubelight"},
+    ]
+}
+
+HEAT_PUMP_CLASSES = {
+    "classes": [
+        {"name": "Air source heat pump systems"},
+        {"name": "Ground source heat pump systems"},
+        {"name": "Water source heat pump systems"},
+    ]
+}
+
+PROPERTIES = {"properties": [{"name": f"Property {i}"} for i in range(5)]}
 
 
-def get_ifc_classes():
-    return client.get_classes(ifc4x3_uri, use_nested_classes=False, class_type="Class")
+def _fake_get(self, endpoint, params=None, is_auth_required=False):
+    params = params or {}
+    if endpoint.startswith("Dictionary/v") and endpoint.endswith("/Classes"):
+        uri = params.get("Uri")
+        if uri == IFC4X3_URI:
+            return IFC4X3_CLASSES
+        if uri == NBS_URI:
+            return NBS_CLASSES
+        raise AssertionError(f"unstubbed dictionary classes uri: {uri!r}")
+    if endpoint.startswith("Dictionary/v") and endpoint.endswith("/Properties"):
+        return PROPERTIES
+    if endpoint.startswith("Dictionary/v"):
+        return DICTIONARIES
+    if endpoint.startswith("Class/Relations/v"):
+        return LIGHT_FIXTURE_RELATIONS
+    if endpoint.startswith("Class/Properties/v"):
+        return {"classProperties": LIGHT_FIXTURE_PROPERTIES}
+    if endpoint.startswith("Class/Search/v"):
+        return HEAT_PUMP_CLASSES
+    if endpoint.startswith("Class/v"):
+        return {"classProperties": LIGHT_FIXTURE_PROPERTIES}
+    raise AssertionError(f"unstubbed endpoint: {endpoint!r}")
 
 
-def get_nbs_classes():
-    return client.get_classes(nbs_uri, use_nested_classes=False, class_type="Class", offset=0, limit=5)
+@pytest.fixture
+def client():
+    stub = Client()
+    stub.get = types.MethodType(_fake_get, stub)
+    return stub
 
 
-def test_get_dictionary():
+def test_get_dictionary(client):
     li_names = [l["name"] for l in client.get_dictionary()["dictionaries"]]
-    assert "Uniclass 2015" and "IFC" in li_names
+    assert "Uniclass 2015" in li_names
+    assert "IFC" in li_names
 
 
-def test_get_ifc_classes():
-    ifc4x3_classes = get_ifc_classes()
-    assert "IfcBoiler" and "IfcLightFixture" in [l["code"] for l in ifc4x3_classes["classes"]]
+def test_get_ifc_classes(client):
+    codes = [l["code"] for l in client.get_classes(IFC4X3_URI, use_nested_classes=False, class_type="Class")["classes"]]
+    assert "IfcBoiler" in codes
+    assert "IfcLightFixture" in codes
 
 
-def test_get_nbs_classes():
-    nbs_classes = get_nbs_classes()
+def test_get_nbs_classes(client):
+    nbs_classes = client.get_classes(NBS_URI, use_nested_classes=False, class_type="Class", offset=0, limit=5)
     assert "Ac" in [l["code"] for l in nbs_classes["classes"]]
 
 
-def test_get_class():
-    uri_light_fixture = next(l for l in get_ifc_classes()["classes"] if "IfcLightFixture" == l["code"])["uri"]
-    # TODO: fix deprecation warning.
-    ifc4x3_light_fixture = client.get_class(uri_light_fixture)
-    assert "Maintenance Factor" and "Light Fixture Mounting Type" in [
-        l["name"] for l in ifc4x3_light_fixture["classProperties"]
-    ]
+def test_get_class(client):
+    ifc4x3_light_fixture = client.get_class(LIGHT_FIXTURE_URI)
+    names = [l["name"] for l in ifc4x3_light_fixture["classProperties"]]
+    assert "Maintenance Factor" in names
+    assert "Light Fixture Mounting Type" in names
 
 
-def test_get_class_relations():
-    uri_light_fixture = next(l for l in get_ifc_classes()["classes"] if "IfcLightFixture" == l["code"])["uri"]
-    ifc4x3_light_fixture_relations = client.get_class_relations(uri_light_fixture, True)
-    assert "Electrical unit for light-line system" and "Tubelight system" in [
-        r["className"] for r in ifc4x3_light_fixture_relations["classRelations"]
-    ]
+def test_get_class_relations(client):
+    ifc4x3_light_fixture_relations = client.get_class_relations(LIGHT_FIXTURE_URI, True)
+    names = [r["className"] for r in ifc4x3_light_fixture_relations["classRelations"]]
+    assert "Electrical unit for light-line system" in names
+    assert "Tubelight system" in names
 
 
-def test_get_class_properties():
-    uri_light_fixture = next(l for l in get_ifc_classes()["classes"] if "IfcLightFixture" == l["code"])["uri"]
-    ifc4x3_light_fixture_properties = client.get_class_properties(uri_light_fixture)
-    assert "Maintenance Factor" and "Light Fixture Mounting Type" in [
-        l["name"] for l in ifc4x3_light_fixture_properties["classProperties"]
-    ]
+def test_get_class_properties(client):
+    ifc4x3_light_fixture_properties = client.get_class_properties(LIGHT_FIXTURE_URI)
+    names = [l["name"] for l in ifc4x3_light_fixture_properties["classProperties"]]
+    assert "Maintenance Factor" in names
+    assert "Light Fixture Mounting Type" in names
 
 
-def test_search_class():
-    ss_heat_pump_sys = client.search_class("Ss_60_40_36", [nbs_uri])
+def test_search_class(client):
+    ss_heat_pump_sys = client.search_class("Ss_60_40_36", [NBS_URI])
     li = [l + "source heat pump systems" for l in ["Air ", "Ground ", "Water "]]
     assert (
         len(li) < 8
@@ -64,6 +134,6 @@ def test_search_class():
         assert l in [_["name"] for _ in ss_heat_pump_sys["classes"]]
 
 
-def test_get_properties():
-    pr = client.get_properties(ifc4x3_uri, offset=0, limit=5)
+def test_get_properties(client):
+    pr = client.get_properties(IFC4X3_URI, offset=0, limit=5)
     assert len(pr["properties"]) == 5

--- a/src/bsdd/tests/test_bsdd_live.py
+++ b/src/bsdd/tests/test_bsdd_live.py
@@ -1,0 +1,106 @@
+"""Live tests for bsdd.Client against the real bSDD API.
+
+These hit the network and are opt-in only: every test in this module carries
+the `network` marker, which is deselected by default (see pyproject.toml).
+Run explicitly with:
+
+    python -m pytest tests/test_bsdd_live.py -m network
+
+All fetches happen lazily inside fixtures, not at module import time, so this
+file can still be collected without network access; only running a test in
+it requires the network.
+"""
+
+import pytest
+
+from bsdd import Client
+
+pytestmark = pytest.mark.network
+
+
+@pytest.fixture(scope="module")
+def client():
+    return Client()
+
+
+@pytest.fixture(scope="module")
+def dictionaries(client):
+    return client.get_dictionary()["dictionaries"]
+
+
+@pytest.fixture(scope="module")
+def ifc4x3_uri(dictionaries):
+    return next(l["uri"] for l in dictionaries if "4.3" in l["uri"])
+
+
+@pytest.fixture(scope="module")
+def nbs_uri(dictionaries):
+    return next(l["uri"] for l in dictionaries if "Uniclass 2015" == l["name"])
+
+
+@pytest.fixture(scope="module")
+def ifc4x3_classes(client, ifc4x3_uri):
+    return client.get_classes(ifc4x3_uri, use_nested_classes=False, class_type="Class")
+
+
+@pytest.fixture(scope="module")
+def nbs_classes(client, nbs_uri):
+    return client.get_classes(nbs_uri, use_nested_classes=False, class_type="Class", offset=0, limit=5)
+
+
+@pytest.fixture(scope="module")
+def light_fixture_uri(ifc4x3_classes):
+    return next(l for l in ifc4x3_classes["classes"] if "IfcLightFixture" == l["code"])["uri"]
+
+
+def test_get_dictionary(dictionaries):
+    li_names = [l["name"] for l in dictionaries]
+    assert "Uniclass 2015" in li_names
+    assert "IFC" in li_names
+
+
+def test_get_ifc_classes(ifc4x3_classes):
+    codes = [l["code"] for l in ifc4x3_classes["classes"]]
+    assert "IfcBoiler" in codes
+    assert "IfcLightFixture" in codes
+
+
+def test_get_nbs_classes(nbs_classes):
+    assert "Ac" in [l["code"] for l in nbs_classes["classes"]]
+
+
+def test_get_class(client, light_fixture_uri):
+    # TODO: fix deprecation warning.
+    ifc4x3_light_fixture = client.get_class(light_fixture_uri)
+    names = [l["name"] for l in ifc4x3_light_fixture["classProperties"]]
+    assert "Maintenance Factor" in names
+    assert "Light Fixture Mounting Type" in names
+
+
+def test_get_class_relations(client, light_fixture_uri):
+    ifc4x3_light_fixture_relations = client.get_class_relations(light_fixture_uri, True)
+    names = [r["className"] for r in ifc4x3_light_fixture_relations["classRelations"]]
+    assert "Electrical unit for light-line system" in names
+    assert "Tubelight system" in names
+
+
+def test_get_class_properties(client, light_fixture_uri):
+    ifc4x3_light_fixture_properties = client.get_class_properties(light_fixture_uri)
+    names = [l["name"] for l in ifc4x3_light_fixture_properties["classProperties"]]
+    assert "Maintenance Factor" in names
+    assert "Light Fixture Mounting Type" in names
+
+
+def test_search_class(client, nbs_uri):
+    ss_heat_pump_sys = client.search_class("Ss_60_40_36", [nbs_uri])
+    li = [l + "source heat pump systems" for l in ["Air ", "Ground ", "Water "]]
+    assert (
+        len(li) < 8
+    )  # I think it should be 4 but just validating it isn't overfetching with some space for future change
+    for l in li:
+        assert l in [_["name"] for _ in ss_heat_pump_sys["classes"]]
+
+
+def test_get_properties(client, ifc4x3_uri):
+    pr = client.get_properties(ifc4x3_uri, offset=0, limit=5)
+    assert len(pr["properties"]) == 5


### PR DESCRIPTION
Three issues in src/bsdd found in a repo audit.

test_bsdd.py had five assertions of the shape `assert "X" and "Y" in li`,
which Python evaluates as `assert "X" and ("Y" in li)`. Since "X" is always
truthy, the first name was never actually checked. Fixed to check both
names explicitly, following the loop shape already used in
test_search_class.

The same file made live bSDD API calls at module import time, so it could
not even be collected without network access, and ci-bsdd-pypi.yaml is
workflow_dispatch-only and never runs `make test`, so none of this has ever
run in CI. Restructured test_bsdd.py to stub Client.get() with canned
responses so the suite runs offline and deterministically. The original
live-API tests are kept in test_bsdd_live.py, fetching lazily through
fixtures (not at import time) and marked with a `network` pytest marker
that is deselected by default via addopts in pyproject.toml, so `make test`
runs offline while `pytest tests -m network` still exercises the real API.
No coverage was dropped, only relocated and marked.

apply_ifc_classification_properties() subscripted prop["propertySet"] and
prop["dataType"] directly, both NotRequired in ClassPropertyContractV1, so
a class property missing either field raised KeyError. Switched to .get()
and skip the property when propertySet is absent (there is nowhere to
write it), matching the defensive handling already in
bonsai/tool/bsdd.py's Bsdd.get_class_properties().

Generated with the assistance of an AI coding tool.

