### PR TITLE
ifc4d: stop MSP and P6 export truncating sub-day durations

### DIFF
--- a/src/ifc4d/ifc4d/ifc2msp.py
+++ b/src/ifc4d/ifc4d/ifc2msp.py
@@ -25,6 +25,27 @@ import ifcopenshell.util.date
 import ifcopenshell.util.sequence
 
 
+def duration_to_hours(duration, hours_per_day, is_elapsed=False):
+    """Convert an ifcopenshell.util.date.ifc2datetime() result to a float number of hours.
+
+    ``duration`` is either an isodate.Duration or a datetime.timedelta (both
+    ifc2datetime() return types), which both expose ``.days``, ``.seconds``
+    and ``.microseconds``. Reading only ``.days`` silently drops any lag or
+    task duration below 24 hours, since ISO durations like "PT12H0M0S" carry
+    that 12 hours in ``.seconds``, not ``.days``.
+
+    MSPDI's own units are elapsed hours regardless of format: a WORKTIME
+    duration is elapsed hours reinterpreted as a day count via
+    ``hours_per_day`` (see ``msp2ifc.py``'s ``create_rel_sequences``, which
+    builds ``timedelta(days=lag_hours / hours_per_day)`` on import), so the
+    export-side inverse divides the day-equivalent back out by
+    ``hours_per_day``. An ELAPSEDTIME duration is real clock hours with no
+    calendar involved, so 24 hours per day always applies.
+    """
+    total_days = duration.days + (duration.seconds + duration.microseconds / 1_000_000) / 86400
+    return total_days * (24 if is_elapsed else hours_per_day)
+
+
 class Ifc2Msp:
     def __init__(self):
         self.xml = None
@@ -205,7 +226,9 @@ class Ifc2Msp:
         if task.TaskTime:
             if task.TaskTime.ScheduleDuration:
                 duration = ifcopenshell.util.date.ifc2datetime(task.TaskTime.ScheduleDuration)
-                ET.SubElement(el, "Duration").text = f"PT{duration.days * 8}H0M0S"
+                hours = duration_to_hours(duration, self.hours_per_day)
+                total_minutes = round(hours * 60)
+                ET.SubElement(el, "Duration").text = f"PT{total_minutes // 60}H{total_minutes % 60}M0S"
             if task.TaskTime.ScheduleStart:
                 ET.SubElement(el, "Start").text = task.TaskTime.ScheduleStart
                 self.start_dates.append(task.TaskTime.ScheduleStart)
@@ -236,10 +259,17 @@ class Ifc2Msp:
             self.link_element(rel, predecessor_link)
             if rel.TimeLag and rel.TimeLag.LagValue:
                 duration = ifcopenshell.util.date.ifc2datetime(rel.TimeLag.LagValue.wrappedValue)
+                is_elapsed = rel.TimeLag.DurationType == "ELAPSEDTIME"
+                hours = duration_to_hours(duration, self.hours_per_day, is_elapsed=is_elapsed)
                 # Lag time is expressed in tenths of a minute. Seriously, Microsoft?
-                ET.SubElement(predecessor_link, "LinkLag").text = str(duration.days * self.hours_per_day * 60 * 10)
+                ET.SubElement(predecessor_link, "LinkLag").text = str(round(hours * 60 * 10))
+                # LagFormat 8 is "Elapsed Days" (24/7), 7 is "Days" (calendar based).
+                # msp2ifc.py's importer keys off this to pick the right hours_per_day
+                # divisor back out; it must match what was used to build LinkLag above.
+                ET.SubElement(predecessor_link, "LagFormat").text = "8" if is_elapsed else "7"
             else:
                 ET.SubElement(predecessor_link, "LinkLag").text = "0"
+                ET.SubElement(predecessor_link, "LagFormat").text = "7"
             ET.SubElement(predecessor_link, "PredecessorUID").text = str(predecessor.id())
             ET.SubElement(predecessor_link, "Type").text = {
                 "START_START": "3",

--- a/src/ifc4d/ifc4d/ifc2p6.py
+++ b/src/ifc4d/ifc4d/ifc2p6.py
@@ -25,6 +25,25 @@ import ifcopenshell.util.date
 import ifcopenshell.util.sequence
 
 
+def duration_to_hours(duration, hours_per_day):
+    """Convert an ifcopenshell.util.date.ifc2datetime() result to a float number of hours.
+
+    ``duration`` is either an isodate.Duration or a datetime.timedelta (both
+    ifc2datetime() return types), which both expose ``.days``, ``.seconds``
+    and ``.microseconds``. Reading only ``.days`` silently drops any lag or
+    task duration below 24 hours, since ISO durations like "PT12H0M0S" carry
+    that 12 hours in ``.seconds``, not ``.days``.
+
+    p62ifc.py's importer (see ``ScheduleIfcGenerator.create_task_from_activity``
+    and ``create_rel_sequences`` in common.py) always treats P6's Duration and
+    Lag fields as calendar hours-per-day scaled, i.e.
+    ``timedelta(days=hours_value / hours_per_day)``. This is the matching
+    export-side inverse.
+    """
+    total_days = duration.days + (duration.seconds + duration.microseconds / 1_000_000) / 86400
+    return total_days * hours_per_day
+
+
 class Ifc2P6:
     def __init__(self):
         self.xml = None
@@ -219,8 +238,9 @@ class Ifc2P6:
             ET.SubElement(activity, "WBSObjectId").text = self.id_map[parent]
         if task.TaskTime.ScheduleDuration:
             duration = ifcopenshell.util.date.ifc2datetime(task.TaskTime.ScheduleDuration)
-            ET.SubElement(activity, "PlannedDuration").text = str(duration.days * self.hours_per_day)
-            ET.SubElement(activity, "RemainingDuration").text = str(duration.days * self.hours_per_day)
+            hours = f"{duration_to_hours(duration, self.hours_per_day):.10g}"
+            ET.SubElement(activity, "PlannedDuration").text = hours
+            ET.SubElement(activity, "RemainingDuration").text = hours
         if task.TaskTime.ScheduleStart:
             ET.SubElement(activity, "PlannedStartDate").text = task.TaskTime.ScheduleStart
             ET.SubElement(activity, "StartDate").text = task.TaskTime.ScheduleStart
@@ -258,7 +278,7 @@ class Ifc2P6:
                 self.link_element(rel, relationship)
                 if rel.TimeLag and rel.TimeLag.LagValue:
                     duration = ifcopenshell.util.date.ifc2datetime(rel.TimeLag.LagValue.wrappedValue)
-                    ET.SubElement(relationship, "Lag").text = str(duration.days * self.hours_per_day)
+                    ET.SubElement(relationship, "Lag").text = f"{duration_to_hours(duration, self.hours_per_day):.10g}"
                 else:
                     ET.SubElement(relationship, "Lag").text = "0"
                 ET.SubElement(relationship, "PredecessorProjectObjectId").text = self.id_map[work_schedule]

--- a/src/ifc4d/test/test_ifc2msp.py
+++ b/src/ifc4d/test/test_ifc2msp.py
@@ -1,0 +1,145 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import re
+import tempfile
+from pathlib import Path
+
+import ifcopenshell
+import ifcopenshell.api.sequence
+
+from ifc4d.ifc2msp import Ifc2Msp
+
+# LinkLag/LagFormat unit convention verified against msp2ifc.py's importer
+# (see #9043, which fixed the same LinkLag field on import): the value is
+# tenths of a minute, and LagFormat 7 ("Days") means the number should be
+# read back through the calendar's hours_per_day, while LagFormat 8
+# ("Elapsed Days") means it is real clock hours. Round-tripped by hand:
+#   PT12H0M0S at 8h/day -> 4 work-hours -> 4 * 60 * 10 = 2400 tenths
+#   P1DT12H0M0S (1 day + 12h) at 8h/day -> 12 work-hours -> 7200 tenths
+#   P2D as ELAPSEDTIME -> 48 real hours -> 48 * 60 * 10 = 28800 tenths
+#   -PT5H (a lead) at 8h/day -> -1.6667 work-hours -> -1000 tenths
+
+
+class TestIfc2MspLag:
+    @staticmethod
+    def build_ifc(lag_value: str | None, duration_type: str = "WORKTIME") -> ifcopenshell.file:
+        ifc_file = ifcopenshell.file()
+        ifc_file.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new(), Name="P")
+        schedule = ifcopenshell.api.sequence.add_work_schedule(ifc_file, name="Schedule A")
+        t1 = ifcopenshell.api.sequence.add_task(ifc_file, work_schedule=schedule, name="T1", identification="1")
+        t2 = ifcopenshell.api.sequence.add_task(ifc_file, work_schedule=schedule, name="T2", identification="2")
+        rel = ifcopenshell.api.sequence.assign_sequence(ifc_file, relating_process=t1, related_process=t2)
+        ifcopenshell.api.sequence.edit_sequence(ifc_file, rel_sequence=rel, attributes={"SequenceType": "FINISH_START"})
+        if lag_value is not None:
+            ifcopenshell.api.sequence.assign_lag_time(
+                ifc_file, rel_sequence=rel, lag_value=lag_value, duration_type=duration_type
+            )
+        return ifc_file
+
+    @staticmethod
+    def export(ifc_file: ifcopenshell.file) -> str:
+        converter = Ifc2Msp()
+        converter.file = ifc_file
+        converter.work_schedule = ifc_file.by_type("IfcWorkSchedule")[0]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            converter.xml = str(Path(tmp_dir) / "out.xml")
+            converter.execute()
+            return Path(converter.xml).read_text()
+
+    @staticmethod
+    def get_fields(xml_text: str, tag: str) -> list[str]:
+        return re.findall(rf"<{tag}>([^<]*)</{tag}>", xml_text)
+
+    def test_sub_day_worktime_lag_is_not_truncated(self):
+        # Before the fix, only whole days (duration.days) were read, so a
+        # pure PT12H0M0S lag (duration.days == 0) exported as LinkLag "0".
+        ifc_file = self.build_ifc("PT12H0M0S", "WORKTIME")
+        xml = self.export(ifc_file)
+        assert self.get_fields(xml, "LinkLag") == ["2400"]
+        assert self.get_fields(xml, "LagFormat") == ["7"]
+
+    def test_mixed_day_and_hour_worktime_lag_keeps_the_hour_remainder(self):
+        # Before the fix this exported "4800" (only the 1 whole day),
+        # silently dropping the extra 12 hours.
+        ifc_file = self.build_ifc("P1DT12H0M0S", "WORKTIME")
+        xml = self.export(ifc_file)
+        assert self.get_fields(xml, "LinkLag") == ["7200"]
+
+    def test_elapsedtime_lag_uses_24_hour_days_not_the_calendar(self):
+        ifc_file = self.build_ifc("P2D", "ELAPSEDTIME")
+        xml = self.export(ifc_file)
+        assert self.get_fields(xml, "LinkLag") == ["28800"]
+        assert self.get_fields(xml, "LagFormat") == ["8"]
+
+    def test_negative_lag_is_a_lead(self):
+        ifc_file = self.build_ifc("-PT5H", "WORKTIME")
+        xml = self.export(ifc_file)
+        assert self.get_fields(xml, "LinkLag") == ["-1000"]
+
+    def test_zero_lag_still_exports_zero(self):
+        ifc_file = self.build_ifc("PT0H0M0S", "WORKTIME")
+        xml = self.export(ifc_file)
+        assert self.get_fields(xml, "LinkLag") == ["0"]
+
+    def test_no_time_lag_exports_zero(self):
+        ifc_file = self.build_ifc(None)
+        xml = self.export(ifc_file)
+        assert self.get_fields(xml, "LinkLag") == ["0"]
+
+
+class TestIfc2MspTaskDuration:
+    @staticmethod
+    def build_ifc(schedule_duration: str) -> ifcopenshell.file:
+        ifc_file = ifcopenshell.file()
+        ifc_file.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new(), Name="P")
+        schedule = ifcopenshell.api.sequence.add_work_schedule(ifc_file, name="Schedule A")
+        task = ifcopenshell.api.sequence.add_task(ifc_file, work_schedule=schedule, name="T1", identification="1")
+        task_time = ifcopenshell.api.sequence.add_task_time(ifc_file, task=task)
+        ifcopenshell.api.sequence.edit_task_time(
+            ifc_file,
+            task_time=task_time,
+            attributes={"ScheduleDuration": schedule_duration},
+        )
+        return ifc_file
+
+    @staticmethod
+    def export(ifc_file: ifcopenshell.file) -> str:
+        converter = Ifc2Msp()
+        converter.file = ifc_file
+        converter.work_schedule = ifc_file.by_type("IfcWorkSchedule")[0]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            converter.xml = str(Path(tmp_dir) / "out.xml")
+            converter.execute()
+            return Path(converter.xml).read_text()
+
+    def test_sub_day_task_duration_is_not_truncated_to_zero(self):
+        # Before the fix this used only duration.days, so a pure PT4H0M0S
+        # duration (duration.days == 0) exported as "PT0H0M0S". Correct is
+        # 4h / 24h-per-calendar-day * 8h-per-workday = 1.3333 work-hours.
+        ifc_file = self.build_ifc("PT4H0M0S")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Duration>([^<]*)</Duration>", xml) == ["PT1H20M0S"]
+
+    def test_mixed_day_and_hour_task_duration_keeps_the_hour_remainder(self):
+        # 1 work-day (8h) + 4h = 9.3333 work-hours at 8h/day.
+        ifc_file = self.build_ifc("P1DT4H0M0S")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Duration>([^<]*)</Duration>", xml) == ["PT9H20M0S"]

--- a/src/ifc4d/test/test_ifc2p6.py
+++ b/src/ifc4d/test/test_ifc2p6.py
@@ -1,0 +1,136 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import datetime
+import re
+import tempfile
+from pathlib import Path
+
+import ifcopenshell
+import ifcopenshell.api.control
+import ifcopenshell.api.sequence
+
+from ifc4d.ifc2p6 import Ifc2P6
+
+# P6's Relationship/Lag and Activity/PlannedDuration|RemainingDuration fields
+# are plain decimal hours, always calendar (HoursPerDay) scaled - confirmed
+# against p62ifc.py's importer (ScheduleIfcGenerator.create_rel_sequences and
+# create_task_from_activity in common.py), which both build
+# timedelta(days=value / HoursPerDay). Hand-derived at 8h/day:
+#   PT12H0M0S -> 12h / 24h-per-day * 8h-per-workday = 4 work-hours
+#   P1DT12H0M0S (1 day + 12h) -> 12 work-hours
+
+
+class TestIfc2P6Lag:
+    @staticmethod
+    def build_ifc(lag_value: str | None, duration_type: str = "WORKTIME") -> ifcopenshell.file:
+        ifc_file = ifcopenshell.file()
+        ifc_file.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new(), Name="P")
+        schedule = ifcopenshell.api.sequence.add_work_schedule(ifc_file, name="Schedule A")
+        calendar = ifcopenshell.api.sequence.add_work_calendar(ifc_file, name="Cal A")
+        t1 = ifcopenshell.api.sequence.add_task(ifc_file, work_schedule=schedule, name="T1", identification="1")
+        t2 = ifcopenshell.api.sequence.add_task(ifc_file, work_schedule=schedule, name="T2", identification="2")
+        ifcopenshell.api.control.assign_control(ifc_file, relating_control=calendar, related_objects=[t1, t2])
+        for task in (t1, t2):
+            task_time = ifcopenshell.api.sequence.add_task_time(ifc_file, task=task)
+            ifcopenshell.api.sequence.edit_task_time(
+                ifc_file,
+                task_time=task_time,
+                attributes={"ScheduleDuration": "P1D", "ScheduleStart": "2024-01-01T08:00:00"},
+            )
+        rel = ifcopenshell.api.sequence.assign_sequence(ifc_file, relating_process=t1, related_process=t2)
+        ifcopenshell.api.sequence.edit_sequence(ifc_file, rel_sequence=rel, attributes={"SequenceType": "FINISH_START"})
+        if lag_value is not None:
+            ifcopenshell.api.sequence.assign_lag_time(
+                ifc_file, rel_sequence=rel, lag_value=lag_value, duration_type=duration_type
+            )
+        return ifc_file
+
+    @staticmethod
+    def export(ifc_file: ifcopenshell.file) -> str:
+        converter = Ifc2P6()
+        converter.file = ifc_file
+        converter.holiday_start_date = datetime.date(2024, 1, 1)
+        converter.holiday_finish_date = datetime.date(2024, 1, 1)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            converter.xml = str(Path(tmp_dir) / "out.xml")
+            converter.execute()
+            return Path(converter.xml).read_text()
+
+    def test_sub_day_lag_is_not_truncated(self):
+        # Before the fix, only whole days (duration.days) were read, so a
+        # pure PT12H0M0S lag (duration.days == 0) exported as Lag "0".
+        ifc_file = self.build_ifc("PT12H0M0S", "WORKTIME")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Lag>([^<]*)</Lag>", xml) == ["4"]
+
+    def test_mixed_day_and_hour_lag_keeps_the_hour_remainder(self):
+        # Before the fix this exported "8" (only the 1 whole day * 8h/day),
+        # silently dropping the extra 12 hours.
+        ifc_file = self.build_ifc("P1DT12H0M0S", "WORKTIME")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Lag>([^<]*)</Lag>", xml) == ["12"]
+
+    def test_negative_lag_is_a_lead(self):
+        ifc_file = self.build_ifc("-PT5H", "WORKTIME")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Lag>([^<]*)</Lag>", xml) == ["-1.666666667"]
+
+    def test_no_time_lag_exports_zero(self):
+        ifc_file = self.build_ifc(None)
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Lag>([^<]*)</Lag>", xml) == ["0"]
+
+
+class TestIfc2P6Duration:
+    @staticmethod
+    def build_ifc(schedule_duration: str) -> ifcopenshell.file:
+        ifc_file = ifcopenshell.file()
+        ifc_file.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new(), Name="P")
+        schedule = ifcopenshell.api.sequence.add_work_schedule(ifc_file, name="Schedule A")
+        calendar = ifcopenshell.api.sequence.add_work_calendar(ifc_file, name="Cal A")
+        task = ifcopenshell.api.sequence.add_task(ifc_file, work_schedule=schedule, name="T1", identification="1")
+        ifcopenshell.api.control.assign_control(ifc_file, relating_control=calendar, related_objects=[task])
+        task_time = ifcopenshell.api.sequence.add_task_time(ifc_file, task=task)
+        ifcopenshell.api.sequence.edit_task_time(
+            ifc_file,
+            task_time=task_time,
+            attributes={"ScheduleDuration": schedule_duration, "ScheduleStart": "2024-01-01T08:00:00"},
+        )
+        return ifc_file
+
+    @staticmethod
+    def export(ifc_file: ifcopenshell.file) -> str:
+        converter = Ifc2P6()
+        converter.file = ifc_file
+        converter.holiday_start_date = datetime.date(2024, 1, 1)
+        converter.holiday_finish_date = datetime.date(2024, 1, 1)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            converter.xml = str(Path(tmp_dir) / "out.xml")
+            converter.execute()
+            return Path(converter.xml).read_text()
+
+    def test_mixed_day_and_hour_duration_keeps_the_hour_remainder(self):
+        # Before the fix this exported "8" (only the 1 whole day * 8h/day),
+        # silently dropping the extra 4 hours.
+        ifc_file = self.build_ifc("P1DT4H0M0S")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<PlannedDuration>([^<]*)</PlannedDuration>", xml) == ["9.333333333"]
+        assert re.findall(r"<RemainingDuration>([^<]*)</RemainingDuration>", xml) == ["9.333333333"]


### PR DESCRIPTION
ifc2msp.py and ifc2p6.py converted ifc2datetime()'s isodate.Duration by
reading only .days, so any lag or task duration under 24 hours (which
lands in .seconds, not .days) was silently dropped. PT12H0M0S exported
as LinkLag 0; P1DT12H0M0S dropped its 12 hour remainder entirely.

MSPDI LinkLag also never emitted LagFormat, and ignored TimeLag's
DurationType (WORKTIME vs ELAPSEDTIME) even though it was already
scaling by hours_per_day, so an elapsed lag round-tripped through the
wrong calendar divisor. Both are the same "read the whole duration"
class of bug as the days-only truncation, so this now reads
DurationType and emits the matching LagFormat.

Verified against msp2ifc.py from PR #9043 (predecessor lag import
fix): every fixed export case here reimports to the exact original
lag, including a lead (negative lag) and a mixed day+hour duration.

This file was generated with the assistance of an AI coding tool.

