### PR TITLE
util.selector: set_element_value casts "no" to True for boolean attributes

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -776,9 +776,10 @@ def set_element_value(
                         elif data_type == "integer":
                             value = int(value)
                         elif data_type == "boolean":
-                            if value in ("True", "true", "TRUE", "Yes", "1"):
+                            normalised_value = value.lower() if isinstance(value, str) else value
+                            if normalised_value in ("true", "yes", "1"):
                                 value = True
-                            elif value in ("False", "false", "FALSE", "No", "0"):
+                            elif normalised_value in ("false", "no", "0"):
                                 value = False
                             else:
                                 value = bool(value)

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -477,6 +477,20 @@ class TestSetElementValue(test.bootstrap.IFC4):
         subject.set_element_value(self.file, layer, "Material.Name", "Foo")
         assert material.Name == "Foo"
 
+    def test_set_boolean_attribute_is_case_insensitive(self):
+        # ParameterTakesPrecedence is a direct IfcBoolean attribute. Setting
+        # it via a plain string forces the setattr fast-path to fail and
+        # fall back to the type-cast branch in set_element_value, which used
+        # to special-case only "Yes"/"No" and silently coerce any other
+        # spelling ("no", "NO") to True via bool(value) (#8100 adjacent).
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcDoorType")
+        for value in ("Yes", "yes", "YES", "True", "true", "TRUE", "1"):
+            subject.set_element_value(self.file, element, "ParameterTakesPrecedence", value)
+            assert element.ParameterTakesPrecedence is True, value
+        for value in ("No", "no", "NO", "False", "false", "FALSE", "0"):
+            subject.set_element_value(self.file, element, "ParameterTakesPrecedence", value)
+            assert element.ParameterTakesPrecedence is False, value
+
 
 class TestSetElementValuePredefinedType(test.bootstrap.IFC4):
     def test_setting_an_element_predefined_type(self):


### PR DESCRIPTION
In the string-to-boolean cast branch of set_element_value, the false-spelling
tuple only recognised "False"/"false"/"FALSE"/"No"/"0". Any other casing
("no", "NO") fell through to the else branch's bool(value), and bool() of any
non-empty string is True, so setting a boolean attribute to "no" silently
stored True. "yes"/"YES" happened to still work only because a non-empty
string is truthy.

Normalise the value to lowercase before matching so every case variant of
true/false, yes/no and 1/0 is handled symmetrically.

Verified with a real IfcDoorType.ParameterTakesPrecedence (direct IfcBoolean
attribute): set_element_value(file, door_type, ["ParameterTakesPrecedence"],
"no") stored True before this change and False after.

This is separate from #8100 (open PR #8323), which fixes the same bool/int
ordering trap in FacetTransformer.compare used by filter_elements; that
code path is untouched here.

Generated with the assistance of an AI coding tool.

