### PR TITLE
Bonsai: guard Calculate Object Volumes against non-manifold meshes

### DIFF
--- a/src/bonsai/bonsai/bim/module/qto/helper.py
+++ b/src/bonsai/bonsai/bim/module/qto/helper.py
@@ -36,8 +36,51 @@ def calculate_faces_areas(objs: list[bpy.types.Object], context: bpy.types.Conte
     return calculate_mesh_quantity(objs, context, lambda bm: sum(f.calc_area() for f in bm.faces if f.select))
 
 
-def calculate_volumes(objs: list[bpy.types.Object], context: bpy.types.Context) -> float:
-    return calculate_mesh_quantity(objs, context, lambda bm: bm.calc_volume())
+def is_manifold(bm: bmesh.types.BMesh) -> bool:
+    """Checks whether a bmesh is a closed, consistently oriented manifold.
+
+    bm.calc_volume() sums signed tetrahedra via the divergence theorem, which
+    assumes a watertight mesh with matching face winding across every edge.
+    A non-manifold mesh (open, or with inconsistent winding) gives a
+    plausible-looking but wrong volume instead of an error, see
+    https://github.com/IfcOpenShell/IfcOpenShell/issues/6125.
+
+    :param bm: A bmesh instance.
+    :return: True if every edge is shared by exactly two faces with matching winding.
+    """
+    return all(edge.is_contiguous for edge in bm.edges)
+
+
+def calculate_volumes(objs: list[bpy.types.Object], context: bpy.types.Context) -> tuple[float, list[str]]:
+    """Sum the bmesh volume of the given mesh objects.
+
+    Non-manifold objects are excluded from the sum, since bm.calc_volume()
+    silently returns a wrong number for them instead of failing loudly
+    (#6125). Their names are returned so the caller can warn the user
+    rather than reporting an incomplete total without saying so.
+
+    :param objs: iterable of mesh objects
+    :param context: current execution context
+    :returns: total volume of the manifold objects, and the names of any
+        objects skipped for being non-manifold.
+    """
+    result = 0.0
+    non_manifold_names = []
+    edit_mode = context.active_object.mode == "EDIT"
+    for obj in objs:
+        assert isinstance(obj.data, bpy.types.Mesh)
+        if edit_mode:
+            bm = bmesh.from_edit_mesh(obj.data)
+        else:
+            bm = bmesh.new()
+            bm.from_mesh(obj.data)
+        if is_manifold(bm):
+            result += bm.calc_volume()
+        else:
+            non_manifold_names.append(obj.name)
+        if not edit_mode:
+            bm.free()
+    return result, non_manifold_names
 
 
 def calculate_mesh_quantity(

--- a/src/bonsai/bonsai/bim/module/qto/operator.py
+++ b/src/bonsai/bonsai/bim/module/qto/operator.py
@@ -83,7 +83,16 @@ class CalculateObjectVolumes(bpy.types.Operator):
         return context.selected_objects and context.active_object
 
     def execute(self, context):
-        result = helper.calculate_volumes([o for o in context.selected_objects if o.type == "MESH"], context)
+        result, non_manifold_names = helper.calculate_volumes(
+            [o for o in context.selected_objects if o.type == "MESH"], context
+        )
+        if non_manifold_names:
+            self.report(
+                {"WARNING"},
+                "Volume not calculated for non-manifold object(s): "
+                + ", ".join(non_manifold_names)
+                + ". Result excludes them and is incomplete.",
+            )
         tool.Qto.set_qto_result(result)
         return {"FINISHED"}
 


### PR DESCRIPTION
calculate_volumes in bim/module/qto/helper.py summed bm.calc_volume()
across the selected objects with no check, the same divergence-theorem
bug reported on #6125 (17.71 m3 against a 1.82 m3 bounding box). PR
#8503 fixes the ifcopenshell.util.shape/QTO path but not this one:
the interactive "Calculate Object Volumes" operator (bim.calculate_
object_volumes) still handed a plausible-looking wrong number straight
to the redo panel.

Added is_manifold, matching #8503's calculator.py precedent by using
Blender's own edge.is_contiguous (exactly two faces per edge, matching
winding), so the same defect is caught the same way on both the
ifcopenshell.util.shape path and the Blender bmesh path.

For this operator, silently skipping felt worse than telling the user:
someone just clicked a button expecting a number. calculate_volumes now
excludes non-manifold objects from the sum and returns their names, and
the operator reports a WARNING listing them so the total is visibly
flagged as incomplete rather than silently wrong.

Verified against a unit test cube (size 2, volume 8) with one face's
winding flipped in place: before this change calculate_volumes summed
it to 5.333 (wrong); after, it returns 0.0 for that object with the
name flagged, and 8.0 when mixed with a valid cube (the bad one
excluded, not just zeroed into the total).

Two other instances of the same unguarded bm.calc_volume() call were
found and deliberately left alone: scripts/get_volume_by_material.py
and scripts/gbxml.py. Measured scripts/get_volume_by_material.py's
own splitting-by-material approach on a simple two-material cube: both
material subsets come back non-manifold (8 bad edges each), so a
manifold guard there would skip the common case entirely rather than
fix it, that script's approach needs a design change, not a guard.
scripts/gbxml.py could not be exercised in this environment (missing
the bspy dependency) so it was left untouched rather than edited
unverified.

Generated with the assistance of an AI coding tool.

