### PR TITLE
Bonsai: fix the boundary-condition filter crashing on a string subscript

### DIFF
--- a/src/bonsai/bonsai/bim/module/structural/operator.py
+++ b/src/bonsai/bonsai/bim/module/structural/operator.py
@@ -853,7 +853,7 @@ class LoadBoundaryConditions(bpy.types.Operator):
             names = [boundary_condition.Name or "Unnamed" for boundary_condition in conditions]
             for boundary_condition in conditions:
                 if (
-                    names.count(boundary_condition["Name"] or "Unnamed") > 1
+                    names.count(boundary_condition.Name or "Unnamed") > 1
                     and self.file.get_total_inverses(boundary_condition) < 2
                 ):
                     continue


### PR DESCRIPTION
LoadBoundaryConditions subscripted an entity_instance with a string
key (boundary_condition["Name"]) instead of using attribute access.
entity_instance.__getitem__ only accepts an integer attribute index,
so this raised TypeError on the first iteration whenever the
"filtered" toggle was enabled and any IfcBoundaryCondition existed,
crashing the Structural tab's boundary conditions panel every time.
The sibling LoadStructuralLoads operator already uses the correct
.Name attribute access for the same dedup logic.

AI disclosure: change identified and verified with the assistance of
an AI coding tool, which ran the fix against the compiled
ifcopenshell engine to confirm the crash and the corrected behaviour.

Generated with the assistance of an AI coding tool.

