### PR TITLE
Bonsai: fix the Library panel crashing on IFC2X3 library references

### DIFF
--- a/src/bonsai/bonsai/bim/module/library/data.py
+++ b/src/bonsai/bonsai/bim/module/library/data.py
@@ -74,7 +74,8 @@ class LibrariesData:
             return []
         results = []
         data = tool.Ifc.get().by_id(reference_id).get_info()
-        del data["ReferencedLibrary"]
+        if tool.Ifc.get_schema() != "IFC2X3":
+            del data["ReferencedLibrary"]
         for key, value in data.items():
             if key in ["id", "type"]:
                 continue


### PR DESCRIPTION
LibrariesData.reference_attributes() unconditionally deleted
ReferencedLibrary from an IfcLibraryReference's get_info() dict, an
IFC4-only attribute. On IFC2X3, where IfcLibraryReference has no
ReferencedLibrary attribute at all, this raised KeyError as soon as a
user selected a library reference in the Library panel. Guard the
delete the same way library_attributes() already guards its
IFC2X3-only VersionDate delete two methods above.

AI-assisted: findings and fix verified by hand (reproduced the
KeyError against a live IFC2X3 file inside a headless Blender session
running the addon, confirmed the fix clears it and the existing
library test suite still passes).
Generated with the assistance of an AI coding tool.

