### PR TITLE
Bonsai: accumulate quantity names across quantity sets instead of overwriting

### DIFF
--- a/src/bonsai/bonsai/bim/module/cost/data.py
+++ b/src/bonsai/bonsai/bim/module/cost/data.py
@@ -394,7 +394,7 @@ class CostItemQuantitiesData:
         names = set()
         qtos = ifcopenshell.util.element.get_psets(element, qtos_only=True)
         for qset, quantities in qtos.items():
-            names = set(quantities.keys())
+            names.update(quantities.keys())
         return [(n, n, "") for n in names if n != "id"]
 
     @classmethod
@@ -407,5 +407,5 @@ class CostItemQuantitiesData:
         names = set()
         qtos = ifcopenshell.util.element.get_psets(element, qtos_only=True)
         for qset, quantities in qtos.items():
-            names = set(quantities.keys())
+            names.update(quantities.keys())
         return [(n, n, "") for n in names if n != "id"]


### PR DESCRIPTION
CostData.process_quantity_names() and resource_quantity_names() looped
over a task's or resource's qtos.items() and reassigned names = set(...)
on each iteration instead of accumulating into it. Only the last quantity
set's names survived, so AssignCostItemQuantity's dropdown silently
omitted quantities from every other quantity set on the same element.
Changed to names.update(quantities.keys()) so all quantity sets
contribute.

Generated with the assistance of an AI coding tool.

