### PR TITLE
Bonsai: fix IndexError showing loads on a member with a point load

### DIFF
--- a/src/bonsai/bonsai/bim/module/structural/load_decoration_data.py
+++ b/src/bonsai/bonsai/bim/module/structural/load_decoration_data.py
@@ -746,7 +746,10 @@ class ShaderInfo:
                 coords_for_shader = []
                 indices = []
             for info in self.info:
-                info["uniforms"][2][1] = maxforce
+                for uniform in info["uniforms"]:
+                    if uniform[0] == "maxload":
+                        uniform[1] = maxforce
+                        break
 
     def process_total_linear_loads(
         self,


### PR DESCRIPTION
get_linear_loads() calls get_point_shader_args() for discrete point
loads on a curve member (IfcStructuralLoadConfiguration with an
IfcStructuralLoadSingleForce value). That helper appends SINGLE FORCE
entries to self.info with only 2 uniforms (color, spacing) and SINGLE
MOMENT entries with only 1 (color). At the end of processing each
member, a normalisation pass did info["uniforms"][2][1] = maxforce on
every entry in self.info, assuming index 2 is always the "maxload"
uniform. Any curve member combining a distributed load with a
discrete point load (a common combined-load scenario) triggers this
in the same iteration: IndexError: list index out of range.

Reproduced with a real Bonsai-authored IfcStructuralCurveMember (via
bpy.ops.bim.add_element, same path as "Add Element" in the UI),
carrying both a CONST linear force and an IfcStructuralLoadConfiguration
point load, then calling ShaderInfo.update() directly (GPU shader
compilation was stubbed out since headless Blender has no draw
context; nothing else was touched). This produced the exact
IndexError at the reported line. Also checked the actual shaders in
shader.py: the SINGLE FORCE, SINGLE MOMENT and PLANAR LOAD shaders
never declare a "maxload" push_constant, only the DISTRIBUTED shaders
do, so positionally patching a "maxload" uniform onto the others
would not just be wrong, it would trade this crash for a GPU
uniform-not-found error at draw time.

Fixed by keying the update on the "maxload" name and skipping entries
that do not have that uniform, instead of assuming a fixed position.
This matches how decorator.py already consumes self.info: it iterates
"for key, value in info['uniforms']" without relying on position.

Generated with the assistance of an AI coding tool.

