### PR TITLE
Bonsai: handle IFC2X3 virtual space boundaries with no related element

### DIFF
--- a/src/bonsai/bonsai/bim/module/boundary/data.py
+++ b/src/bonsai/bonsai/bim/module/boundary/data.py
@@ -39,6 +39,10 @@ class SpaceBoundariesData:
         results = []
         element = tool.Ifc.get_entity(bpy.context.active_object)
         for rel in element.BoundedBy or []:
-            description = f"{rel.id()} > {rel.RelatedBuildingElement.is_a()}/{rel.RelatedBuildingElement.Name}"
+            related_element = rel.RelatedBuildingElement
+            if related_element:
+                description = f"{rel.id()} > {related_element.is_a()}/{related_element.Name}"
+            else:
+                description = f"{rel.id()} > Virtual"
             results.append({"id": rel.id(), "description": description})
         return results


### PR DESCRIPTION
SpaceBoundariesData.boundaries() called rel.RelatedBuildingElement.is_a()
unguarded. RelatedBuildingElement is legitimately unset for a virtual
space boundary (PhysicalOrVirtualBoundary=VIRTUAL): IFC2X3 declares
the attribute OPTIONAL on IfcRelSpaceBoundary (confirmed with
declaration_by_name("IfcRelSpaceBoundary").all_attributes(), which
also shows IFC4 marks it required, so ifcopenshell.create_entity()
itself refuses a null value there for an IFC4 file, but a real IFC2X3
model can carry a null RelatedBuildingElement on a virtual boundary
without being malformed). Opening such a file and looking at the
Space Boundaries panel on the containing space raised AttributeError:
'NoneType' object has no attribute 'is_a'.

The same module's operator.py (get_colour) already guards this exact
field with "element = ifc_boundary.RelatedBuildingElement; if not
element: ...". data.py now matches that idiom instead of assuming the
field is always populated.

Reproduced with a real IFC2X3 project (bpy.ops.bim.create_project),
an IfcSpace with two IfcRelSpaceBoundary relationships (one physical
with an IfcWall, one virtual with RelatedBuildingElement=None), then
calling SpaceBoundariesData.boundaries() directly: before the fix,
AttributeError at the reported line; after the fix, the physical
boundary resolves to "IfcWall/Wall1" and the virtual one to "Virtual",
no crash.

Generated with the assistance of an AI coding tool.

