### PR TITLE
ifcpatch: fix SetWorldCoordinateSystem writing 3D data into IfcAxis2Placement2D

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/SetWorldCoordinateSystem.py
+++ b/src/ifcpatch/ifcpatch/recipes/SetWorldCoordinateSystem.py
@@ -84,9 +84,21 @@ class Patcher:
                     self.file.createIfcDirection(x.tolist()),
                 )
             elif context.ContextType == "Plan":
+                if self.z:
+                    self.logger.warning(
+                        "SetWorldCoordinateSystem: a Plan context's WorldCoordinateSystem is an "
+                        "IfcAxis2Placement2D and cannot hold a Z coordinate. Z has been dropped."
+                    )
+                if self.ax or self.ay:
+                    self.logger.warning(
+                        "SetWorldCoordinateSystem: a Plan context's WorldCoordinateSystem is an "
+                        "IfcAxis2Placement2D and cannot be tilted out of plane. The X and Y rotations "
+                        "have been ignored; only the Z rotation was applied."
+                    )
+                plan_angle = math.radians(self.az)
                 context.WorldCoordinateSystem = self.file.createIfcAxis2Placement2D(
-                    self.file.createIfcCartesianPoint((self.x, self.y, self.z)),
-                    self.file.createIfcDirection(x.tolist()),
+                    self.file.createIfcCartesianPoint((self.x, self.y)),
+                    self.file.createIfcDirection((math.cos(plan_angle), math.sin(plan_angle))),
                 )
 
     def identity_matrix(self):


### PR DESCRIPTION
For a Plan context, the recipe wrote the raw (x, y, z) point and a
3D-derived direction into an IfcAxis2Placement2D, silently producing
Location.Dim == 3 and RefDirection.Dim == 3. This violates the
LocationIs2D and RefDirIs2D WHERE rules on IfcAxis2Placement2D, and
ifcopenshell.validate() does not catch it by default since express
WHERE rule checking is opt-in (express_rules=True).

A Plan context's WorldCoordinateSystem is fundamentally 2D by schema,
so Z and the X/Y tilt rotations have no representable meaning there.
Drop them and emit a proper 2D point and a 2D direction built from
only the Z rotation, warning via the logger when data is discarded so
the loss is not silent.

Generated with the assistance of an AI coding tool.
