### PR TITLE
ifcpatch: fix wrong docstrings that break copy-pasted examples

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/FixArchiCADToRevitSpaces.py
+++ b/src/ifcpatch/ifcpatch/recipes/FixArchiCADToRevitSpaces.py
@@ -59,7 +59,7 @@ class Patcher:
 
         .. code:: python
 
-            ifcpatch.execute({"input": "input.ifc", "recipe": "FixArchiCADToRevitSpaces", "arguments": []})
+            ifcpatch.execute({"input": "input.ifc", "recipe": "FixArchiCADToRevitSpaces", "arguments": ["input.ifc"]})
         """
         self.file = file
         self.logger = logger

--- a/src/ifcpatch/ifcpatch/recipes/FixRevitTINs.py
+++ b/src/ifcpatch/ifcpatch/recipes/FixRevitTINs.py
@@ -70,7 +70,7 @@ class Patcher:
 
         .. code:: python
 
-            ifcpatch.execute({"input": "input.ifc", "recipe": "FixRevitTINs", "arguments": []})
+            ifcpatch.execute({"input": "input.ifc", "recipe": "FixRevitTINs", "arguments": ["input.ifc"]})
         """
         self.file = file
         self.filepath = filepath

--- a/src/ifcpatch/ifcpatch/recipes/PatchStationReferentPosition.py
+++ b/src/ifcpatch/ifcpatch/recipes/PatchStationReferentPosition.py
@@ -10,7 +10,7 @@ import ifcpatch
 
 class Patcher(ifcpatch.BasePatcher):
     def __init__(self, file: ifcopenshell.file, logger: Union[Logger, None] = None):
-        """Adds a zero length segments to alignment layouts
+        """Sets the missing ObjectPlacement of alignment station referents based on their Pset_Stationing Station value
 
         Example:
 

--- a/src/ifcpatch/ifcpatch/recipes/ResetAbsoluteCoordinates.py
+++ b/src/ifcpatch/ifcpatch/recipes/ResetAbsoluteCoordinates.py
@@ -85,13 +85,13 @@ class Patcher:
             ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ResetAbsoluteCoordinates", "arguments": []})
 
             # Reset all coordinates with an ordinate larger than 1000 arbitrarily
-            ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ResetAbsoluteCoordinates", "arguments": [True, 1000]})
+            ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ResetAbsoluteCoordinates", "arguments": ["Geometry", True, 1000]})
 
             # Reset all coordinates with an ordinate larger than 1000000 by -50000,-20000,0
-            ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ResetAbsoluteCoordinates", "arguments": [False, 1000000, -50000,-20000,0]})
+            ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ResetAbsoluteCoordinates", "arguments": ["Geometry", False, 1000000, -50000,-20000,0]})
 
             # Reset all coordinates with an ordinate larger than 1000 by -500,-200,0
-            ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ResetAbsoluteCoordinates", "arguments": [False, 1000, -500,-200,0]})
+            ifcpatch.execute({"input": "input.ifc", "file": model, "recipe": "ResetAbsoluteCoordinates", "arguments": ["Geometry", False, 1000, -500,-200,0]})
         """
         self.file = file
         self.logger = logger


### PR DESCRIPTION
PatchStationReferentPosition's docstring opened with "Adds a zero
length segments to alignment layouts", copy-pasted from
AddZeroLengthSegmentToAlignment. The code actually sets the missing
ObjectPlacement of alignment station referents from their
Pset_Stationing Station value; the Example block already had the
correct recipe name.

ResetAbsoluteCoordinates, FixArchiCADToRevitSpaces and FixRevitTINs
had examples that do not match their __init__ signature: three
ResetAbsoluteCoordinates examples omitted the leading "mode" argument
(verified: raises AttributeError, 'bool'/'int' object has no
attribute 'lower'), and the FixArchiCADToRevitSpaces/FixRevitTINs
examples omitted the required "filepath" argument (verified: raises
TypeError, missing 1 required positional argument).

FixRevit2025TINs has the identical missing-filepath defect but is
left untouched here because another in-flight branch already touches
its docstring.

Generated with the assistance of an AI coding tool.
