### PR TITLE
Bonsai: harden AssignDocument against a stale/typo'd object name

### DIFF
--- a/src/bonsai/bonsai/bim/module/document/operator.py
+++ b/src/bonsai/bonsai/bim/module/document/operator.py
@@ -180,8 +180,10 @@ class AssignDocument(bpy.types.Operator, tool.Ifc.Operator):
     document: bpy.props.IntProperty()
 
     def _execute(self, context):
-        objs = [bpy.data.objects[self.obj]] if self.obj else tool.Blender.get_selected_objects()
+        objs = [bpy.data.objects.get(self.obj)] if self.obj else tool.Blender.get_selected_objects()
         for obj in objs:
+            if not obj:
+                continue
             element = tool.Ifc.get_entity(obj)
             if element:
                 core.assign_document(tool.Ifc, product=element, ifc_document=tool.Ifc.get().by_id(self.document))


### PR DESCRIPTION
AssignDocument._execute() indexed bpy.data.objects[self.obj] directly,
which raises KeyError if the StringProperty names an object that no
longer exists. The sibling UnassignDocument already guards this with
bpy.data.objects.get(self.obj) plus a None check; AssignDocument did
not.

Not reachable from the shipped UI: both draw() call sites in
document/ui.py only ever set the document property on this operator,
never obj, so this is defensive hardening for the public StringProperty
(script/API callers), not a fix for a user-facing crash.

Verified live in a headless Blender instance loading Bonsai from an
isolated copy: pre-change, calling bpy.ops.bim.assign_document(obj="missing")
raises KeyError at operator.py:183; post-change it returns FINISHED and
is skipped, while a real object name still assigns the document
correctly.

Generated with the assistance of an AI coding tool.
