### PR TITLE
Bonsai: guard three None dereferences found by a bim/module audit

### DIFF
--- a/src/bonsai/bonsai/bim/module/classification/data.py
+++ b/src/bonsai/bonsai/bim/module/classification/data.py
@@ -66,7 +66,9 @@ class ClassificationsData:
     def available_classifications(cls):
         if not IfcStore.classification_file:
             return []
-        return [(str(e.id()), e.Name, "") for e in IfcStore.classification_file.by_type("IfcClassification")]
+        return [
+            (str(e.id()), e.Name or "Unnamed", "") for e in IfcStore.classification_file.by_type("IfcClassification")
+        ]
 
     @classmethod
     def classification_source(cls) -> tool.Blender.BLENDER_ENUM_ITEMS:
@@ -122,7 +124,7 @@ class ReferencesData:
 
     @classmethod
     def classifications(cls):
-        return [(str(e.id()), e.Name, "") for e in tool.Ifc.get().by_type("IfcClassification")]
+        return [(str(e.id()), e.Name or "Unnamed", "") for e in tool.Ifc.get().by_type("IfcClassification")]
 
 
 class ObjectClassificationsData(ReferencesData):

--- a/src/bonsai/bonsai/bim/module/cost/ui.py
+++ b/src/bonsai/bonsai/bim/module/cost/ui.py
@@ -747,9 +747,10 @@ class BIM_UL_cost_items_trait:
         if cost_item["AssignedCostRate"] is not None:
             op = row.operator("bim.show_assigned_cost_rate", text="", emboss=False, icon="ZOOM_IN")
             identification = cost_item["AssignedCostRate"].Identification
-            op.parent_cost_schedule_name = CostSchedulesData.data["cost_items"][cost_item["AssignedCostRate"].id()][
+            parent_cost_schedule = CostSchedulesData.data["cost_items"][cost_item["AssignedCostRate"].id()][
                 "ParentCostSchedule"
-            ].Name
+            ]
+            op.parent_cost_schedule_name = parent_cost_schedule.Name if parent_cost_schedule is not None else "-"
             op.assigned_rate_identification = identification if identification is not None else "XXX"
             op.assigned_rate_name = cost_item["AssignedCostRate"].Name or ""
             op.assigned_rate_description = cost_item["AssignedCostRate"].Description or ""

--- a/src/bonsai/bonsai/bim/module/type/operator.py
+++ b/src/bonsai/bonsai/bim/module/type/operator.py
@@ -245,6 +245,9 @@ class SelectType(bpy.types.Operator):
         if self.relating_type:  # if operator button sends a relating_type, the iterator only selects this one type
             element = tool.Ifc.get().by_id(self.relating_type)
             obj = tool.Ifc.get_object(element)
+            if obj is None:
+                self.report({"WARNING"}, "Type has no corresponding Blender object to select.")
+                return {"CANCELLED"}
             selected_objs = [obj]
         else:  # else, the iterator selects all the types of all the selected objects
             selected_objs = context.selected_objects


### PR DESCRIPTION
Three unrelated `None` dereferences found by an audit of `src/bonsai/bonsai/bim/module/`. Each is one commit. All three were reproduced by running the real operator or draw function against synthetic data, not by reading the code.

**`classification/data.py` - classification with no Name breaks the dropdown.**
`IfcClassification.Name` is schema-mandatory, but `ifcopenshell.open()` does not enforce mandatory attributes on parse, proven by loading a raw STEP file containing `IFCCLASSIFICATION($,$,$,$)`, where `Name` arrives as `None`. Both `available_classifications()` and `ReferencesData.classifications()` built `(id, e.Name, "")` enum tuples directly. Passing `None` as an enum item's name raises `TypeError` inside Blender's C layer and the dropdown silently degrades to an unusable empty value. Note the sibling `ClassificationsData.classifications()` in the same file already had `or "Unnamed"`, added in `f945a94`; these are two call sites that fix missed.

**`cost/ui.py` - assigned cost rate with no parent schedule.**
`ifcopenshell.util.cost.get_cost_schedule()` returns `None` when a cost item is neither nested nor assigned to a schedule, which is valid for an item used only as a rate. `draw_assigned_rate_column` dereferenced `["ParentCostSchedule"].Name` unguarded, while the three fields immediately below it already guard with `is not None` / `or ""`. It is called from a live UIList row, so it raises on every redraw. Measured: `AttributeError: 'NoneType' object has no attribute 'Name'`.

**`type/operator.py` - Select Type on a type with no linked Blender object.**
`tool.Ifc.get_object(element)` returns `None` when an `IfcTypeObject` has no linked object. `AnnotationData.relating_types()` lists types straight from `by_type("IfcTypeProduct")` with no check that one exists, and `IfcStore.get_object`'s own docstring documents undo/redo invalidating stored references. Measured: running the real `bpy.ops.bim.select_type` raised `AttributeError: 'NoneType' object has no attribute 'is_a'`.

**Testing.** Each fix has a targeted live reproduction that failed before and passes after. The full `pytest-blender` suite was not run; that plugin is absent here and bonsai tests are commented out in `ci.yml`. Note none of these three is reachable through Bonsai's own authoring UI - all require an imported file or an undo-heavy session - so there is no stock-UI click sequence to demonstrate them.

Generated with the assistance of an AI coding tool.
