### PR TITLE
ifcpatch: make FixRevit2025TINs runnable (IFC2X3, self.file order, docstring)

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/FixRevit2025TINs.py
+++ b/src/ifcpatch/ifcpatch/recipes/FixRevit2025TINs.py
@@ -58,7 +58,8 @@ class Patcher:
 
         After that, it will:
 
-        1. Reassign everything to an IfcGeographicElement
+        1. Reassign everything to an IfcGeographicElement. Skipped on IFC2X3,
+            where this class does not exist.
         2. Detect boundary edges and create an edge-only IfcVirtualElement.
             Good for clean viz in Revit.
         3. Create a copy of the object which has no sharp faces. This will
@@ -137,9 +138,14 @@ class Patcher:
             if not obj.data.polygons:
                 continue
             element = tool.Ifc.get_entity(obj)
-            element.PredefinedType = "USERDEFINED"
             element.ObjectType = "TIN"
-            element = ifcopenshell.util.schema.reassign_class(tool.Ifc.get(), element, "IfcGeographicElement")
+            if tool.Ifc.get().schema == "IFC2X3":
+                self.logger.warning(
+                    f"{element} was not reassigned to IfcGeographicElement: this class does not exist in IFC2X3."
+                )
+            else:
+                element.PredefinedType = "USERDEFINED"
+                element = ifcopenshell.util.schema.reassign_class(tool.Ifc.get(), element, "IfcGeographicElement")
 
             bm = bmesh.new()
             bm.from_mesh(obj.data)

--- a/src/ifcpatch/ifcpatch/recipes/FixRevit2025TINs.py
+++ b/src/ifcpatch/ifcpatch/recipes/FixRevit2025TINs.py
@@ -124,6 +124,7 @@ class Patcher:
         props = tool.Project.get_project_props()
         props.should_use_native_meshes = True
         bpy.ops.bim.load_project(filepath=self.filepath)
+        self.file = tool.Ifc.get()
 
         old_history_size = tool.Ifc.get().history_size
         old_undo_steps = bpy.context.preferences.edit.undo_steps
@@ -169,8 +170,6 @@ class Patcher:
 
         tool.Ifc.get().history_size = old_history_size
         bpy.context.preferences.edit.undo_steps = old_undo_steps
-
-        self.file = tool.Ifc.get()
 
     def create_edges(self, obj: bpy.types.Object) -> None:
         import bmesh  # pyright: ignore[reportMissingImports]  # ty:ignore[unresolved-import]

--- a/src/ifcpatch/ifcpatch/recipes/FixRevit2025TINs.py
+++ b/src/ifcpatch/ifcpatch/recipes/FixRevit2025TINs.py
@@ -106,7 +106,7 @@ class Patcher:
 
         .. code:: python
 
-            ifcpatch.execute({"input": "input.ifc", "recipe": "FixRevit2025TINs", "arguments": []})
+            ifcpatch.execute({"input": "input.ifc", "recipe": "FixRevit2025TINs", "arguments": ["input.ifc"]})
         """
         self.file = file
         self.filepath = filepath


### PR DESCRIPTION
Three commits making `FixRevit2025TINs` actually runnable. The recipe exists to fix Revit 2025 TIN exports, and Revit's default export is IFC2x3.

**1. Crash on IFC2X3.** Line 142 unconditionally called `reassign_class(..., "IfcGeographicElement")`, a class that only exists from IFC4 onwards. In practice the crash came one line earlier, at `element.PredefinedType = "USERDEFINED"`: most IFC2X3 occurrence classes have no `PredefinedType`, since it was only added broadly to occurrence entities in IFC4. Only 11 `IfcProduct` subtypes carry it in IFC2X3 (`IfcCovering`, `IfcElementAssembly`, `IfcFooting`, `IfcPile`, `IfcRailing`, `IfcSlab`, `IfcTendon` and the four structural member classes), and `IfcBuildingElementProxy`, which is what these exports produce, is not one of them.

What makes this clearly a defect rather than an unsupported configuration: **the file already contains a dedicated `create_curves_from_curve_ifc2x3` method** for the IFC2X3 boundary-curve case, selected by an existing `if self.file.schema == "IFC2X3":` branch. IFC2X3 support was written into this recipe and was simply unreachable behind the earlier crash.

There is no faithful IFC2X3 equivalent of `IfcGeographicElement`, so rather than substituting a semantically wrong class the element keeps its original class on IFC2X3, still tagged `ObjectType = "TIN"`, with a logged warning, letting the rest of the recipe including that IFC2X3 curve path run to completion.

**2. `self.file` read before it was set.** `self.file` was assigned from the loaded model *after* the object loop, but `create_edges` reads `self.file.schema` from inside that loop, and `create_curves_from_curve_ifc2x3` reaches `self.file` again through `create_cartesian_point`. Fixed by moving the assignment to immediately after `bpy.ops.bim.load_project`, which covers both call sites.

**3. Docstring example could not run.** The example passed `"arguments": []` while `filepath` is a required parameter with no default, so a copy-paste raised `TypeError: missing 1 required positional argument: 'filepath'`. The same docstring already stated that `filepath` is required, so the prose and the example contradicted each other. Fixed the example.

**Scope of verification.** Everything above was verified at the schema and call layers against the compiled wrapper. The Blender path (`bpy.ops.bim.load_project` and the bmesh work) was **not** exercised end to end.

Generated with the assistance of an AI coding tool.
