### PR TITLE
Bonsai: guard three unnamed-entity crashes where a sibling method already had the fallback

### DIFF
--- a/src/bonsai/bonsai/bim/module/georeference/data.py
+++ b/src/bonsai/bonsai/bim/module/georeference/data.py
@@ -116,7 +116,7 @@ class GeoreferenceData:
                 del projected_crs["type"]
                 if projected_crs["MapUnit"]:
                     unit = projected_crs["MapUnit"]
-                    projected_crs["MapUnit"] = (getattr(unit, "Prefix", "") or "") + unit.Name
+                    projected_crs["MapUnit"] = (getattr(unit, "Prefix", "") or "") + (unit.Name or "")
                 return projected_crs
         return {}
 

--- a/src/bonsai/bonsai/bim/module/pset_template/data.py
+++ b/src/bonsai/bonsai/bim/module/pset_template/data.py
@@ -124,7 +124,10 @@ class PsetTemplatesData:
             props = tool.PsetTemplate.get_pset_template_props()
             IfcStore.pset_template_path = props.pset_template_files
             IfcStore.pset_template_file = ifcopenshell.open(IfcStore.pset_template_path)
-        return [(str(t.id()), t.Name, "") for t in IfcStore.pset_template_file.by_type("IfcPropertySetTemplate")]
+        return [
+            (str(t.id()), t.Name or "Unnamed", "")
+            for t in IfcStore.pset_template_file.by_type("IfcPropertySetTemplate")
+        ]
 
     @classmethod
     def pset_template(cls) -> dict[str, Any]:

--- a/src/bonsai/bonsai/bim/module/structural/data.py
+++ b/src/bonsai/bonsai/bim/module/structural/data.py
@@ -64,11 +64,13 @@ class LoadGroupDecorationData:
         if props.activity_type == "Action":
             groups = m.LoadedBy or []
             for g in groups:
-                ret.append((str(g.id()), ".   " + abrv[g.PredefinedType] + "   " + g.Name, ""))
+                ret.append((str(g.id()), ".   " + abrv[g.PredefinedType] + "   " + (g.Name or ""), ""))
                 related_objects = [rel.RelatedObjects for rel in g.IsGroupedBy]
                 for item in related_objects:
                     for subgoup in [sg for sg in item if sg.is_a("IfcStructuralLoadGroup")]:
-                        ret.append((str(subgoup.id()), ".       " + abrv[subgoup.PredefinedType] + subgoup.Name, ""))
+                        ret.append(
+                            (str(subgoup.id()), ".       " + abrv[subgoup.PredefinedType] + (subgoup.Name or ""), "")
+                        )
 
         elif props.activity_type == "External Reaction":
             groups = m.HasResults or []


### PR DESCRIPTION
Three crashes found by looking for a specific shape: **a fallback applied to one method while a sibling in the same file, doing the same thing, was missed.** Each was reproduced against a real parsed entity or a real Blender property registration, not inferred.

**`structural/data.py` - unnamed load group breaks the Structural dropdown.**
`LoadGroupDecorationData.load_groups_to_show()` concatenates `abrv[g.PredefinedType] + g.Name` in its "Action" branch, while the "External Reaction" branch two lines below already guards the same field with `or ""`. `IfcStructuralLoadGroup.Name` and `IfcStructuralLoadCase.Name` are both `optional()=True`, so no parse caveat is even needed. Loading `IFCSTRUCTURALLOADGROUP('...',$,$,$,$,.LOAD_GROUP.,.PERMANENT_G.,.LOAD_GROUP.,$,$)` and evaluating the original expression gives `TypeError: can only concatenate str (not "NoneType") to str`. This list also feeds a live `EnumProperty` items callback, so it would fail in the enum layer too; the concatenation just fails first. The subgroup line below had the same defect and is fixed with it.

**`pset_template/data.py` - unnamed pset template breaks its dropdown.**
`PsetTemplatesData.pset_templates()` builds `(str(t.id()), t.Name, "")` unguarded. `IfcPropertySetTemplate.Name` is `optional()=True`. Reproduced in headless Blender: registering an `EnumProperty` whose callback returns `(id, None, "")` raises `TypeError: EnumProperty(...): expected a tuple containing (identifier, name, description)` and logs `WARNING current value '0' matches no enum`. With the fallback, neither appears.

**`georeference/data.py` - unnamed map unit breaks the Georeferencing panel.**
`GeoreferenceData.projected_crs()` has the asymmetry on a single line: `(getattr(unit, "Prefix", "") or "") + unit.Name`. `Prefix` is guarded against both absence and `None`; `Name` immediately beside it is not. `IfcSIUnit.Name` is schema-mandatory, but `ifcopenshell.open()` does not enforce mandatory attributes on parse, so `IFCSIUNIT($,.LENGTHUNIT.,$,$)` loads with `Name` as `None` and the expression raises the same `TypeError`. This runs from the panel's `draw()`, so it would break that panel on every redraw for the rest of the session.

**On the pattern itself.** This is the same defect class as `classification/data.py`, where a guard added in `f945a94` left two sibling call sites unfixed. Checking history on these three files shows none of them ever had the guard, so these are first-time fixes rather than missed follow-ups. Counting the classification sites, the shape has now appeared at least six times across `bim/module/*/data.py`, which suggests it is worth a lint rule or a shared helper rather than case-by-case patching. Happy to follow up with that if it would be useful.

**No stock-UI reproduction exists for any of the three.** Every precondition (an unnamed load group, pset template, or map unit) comes from opening a file authored with `Name = $`. Bonsai's own authoring operators always populate a Name, so these only affect imported data.

Several further instances were found in `library/data.py`, `cost/data.py`, `owner/data.py` and `system/data.py` but deliberately left out of this PR to avoid colliding with other in-flight work on those files.

Generated with the assistance of an AI coding tool.
