### PR TITLE
Bonsai: fix three TypeError crashes concatenating an unguarded optional Name

### DIFF
--- a/src/bonsai/bonsai/tool/georeference.py
+++ b/src/bonsai/bonsai/tool/georeference.py
@@ -65,7 +65,7 @@ class Georeference(bonsai.core.tool.Georeference):
                 new.is_optional = True
                 new.enum_items = json.dumps(
                     {
-                        u.id(): (getattr(u, "Prefix", "") or "") + u.Name
+                        u.id(): (getattr(u, "Prefix", "") or "") + (u.Name or "")
                         for u in tool.Ifc.get().by_type("IfcNamedUnit")
                         if u.UnitType == "LENGTHUNIT"
                     }

--- a/src/bonsai/bonsai/tool/sequence.py
+++ b/src/bonsai/bonsai/tool/sequence.py
@@ -1577,7 +1577,7 @@ class Sequence(bonsai.core.tool.Sequence):
         string_resources = ""
         resources_usage = ""
         for resource in resources:
-            string_resources += resource.Name + ", "
+            string_resources += (resource.Name or "Unnamed") + ", "
             resources_usage += str(resource.Usage.ScheduleUsage) + ", " if resource.Usage else "-, "
 
         schedule_start = task_time.ScheduleStart if task_time else ""

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -580,7 +580,7 @@ class Spatial(bonsai.core.tool.Spatial):
                 return
 
         # this spatial element has a unique orientation
-        orientation_name = container.is_a() + "/" + container.Name
+        orientation_name = container.is_a() + "/" + (container.Name or "Unnamed")
 
         # stash selected objects
         active_object = bpy.context.view_layer.objects.active


### PR DESCRIPTION
Three `TypeError` crashes from string concatenation with an unguarded optional `Name`. Each was reproduced by evaluating the actual pre-fix expression against a real `ifcopenshell`-parsed entity holding `Name = None`, and each sits next to code that already guards the same kind of value.

**`tool/georeference.py`** - `(getattr(unit, "Prefix", "") or "") + unit.Name`. The asymmetry is on one line: `Prefix` is guarded against both a missing attribute and `None`, `Name` beside it is not. `IfcSIUnit.Name` is schema-mandatory, but `ifcopenshell.open()` does not enforce mandatory attributes on parse, so a `$` in the file loads as `None`. Reached through `bim.enable_editing_georeferencing`, so it breaks the Edit Georeferencing panel.

**`tool/spatial.py`** - `create_orientation_slot()` builds `container.is_a() + "/" + container.Name`, while `import_spatial_element()` in the same file already uses `element.Name or "Unnamed"`. `Name` is `optional()=True` on `IfcSite`, `IfcBuilding`, `IfcBuildingStorey` and `IfcSpace`. Reached via `bim.set_default_container`, so clicking an unnamed container in the Spatial Decomposition tree raises.

**`tool/sequence.py`** - `create_new_task_json()` does `string_resources += resource.Name + ", "`, while `task_name = task.Name or "Unnamed"` twenty lines below **in the same function** is guarded. `Name` is `optional()=True` on every `IfcConstructionResource` subtype. Reached from Generate Gantt Chart and from the web gantt in `tool/web.py`.

Each fix copies the convention already present in its own file rather than introducing a new one.

**Scope of verification, stated precisely.** The crash mechanism was reproduced directly: the literal pre-fix expression was evaluated against real parsed STEP data with `Name = None` and raised `TypeError: can only concatenate str (not "NoneType") to str` in all three cases. The operators were **not** additionally driven end to end through a windowed Blender session, and there is no stock-UI reproduction, because every precondition requires a file authored with `Name = $`; Bonsai's own authoring operators always populate these fields.

**On the wider pattern.** This shape, a guard applied at one site while an equivalent site nearby was missed, has now been found eleven times across `data.py`, `prop.py`, `ui.py` and `tool/*.py`, introduced by different authors over several years, and in one case by a bug fix that replaced a safe comparison with an unguarded call. That is starting to look like a systemic gap rather than a series of oversights, so a small shared helper for reading an optional `Name` for display, plus a lint or CI grep for concatenation against an unguarded `.Name`, would likely be worth more than continuing to patch these one at a time. Happy to prepare that if it would be welcome.

Generated with the assistance of an AI coding tool.
