### PR TITLE
Bonsai: stop Link IFC duplicating and reloading when a click is repeated

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1452,6 +1452,14 @@ class LinkIfc(bpy.types.Operator, ImportHelper, tool.Ifc.Operator):
             props = tool.Project.get_project_props()
             filepath = tool.Ifc.get_uri(filepath, use_relative_path=self.use_relative_path)
 
+            # A queued repeat click (or any other repeat invocation) that lands
+            # after this same file was already linked with this same query used
+            # to add a second, identical row and reload the whole model again
+            # from scratch (#9029). Skip instead of silently duplicating.
+            if any(link.filepath == filepath and link.query == self.query for link in props.links):
+                self.report({"INFO"}, f"'{Path(filepath).name}' is already linked, skipping duplicate.")
+                continue
+
             new = props.links.add()
             if tool.Ifc.get():
                 if not (document := existing_links.get(filepath)):
@@ -1545,7 +1553,9 @@ class LoadLink(bpy.types.Operator, tool.Ifc.Operator):
             return {"CANCELLED"}
         self.filepath_ = filepath
         if filepath.suffix.lower().endswith(".ifc"):
-            return self.link_ifc()
+            message = f"Linking '{filepath.name}'... large models can take a while."
+            with tool.Project.report_linking_progress(context, message):
+                return self.link_ifc()
 
     def link_blend(self, filepath: Path) -> None:
         with bpy.data.libraries.load(str(filepath), link=True) as (data_from, data_to):

--- a/src/bonsai/bonsai/tool/project.py
+++ b/src/bonsai/bonsai/tool/project.py
@@ -18,10 +18,12 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
 from collections import defaultdict
+from collections.abc import Iterator
 from math import radians
 from pathlib import Path
 from typing import (
@@ -306,6 +308,36 @@ class Project(bonsai.core.tool.Project):
     @classmethod
     def run_root_reload_grid_decorator(cls) -> None:
         tool.Root.reload_grid_decorator()
+
+    @classmethod
+    @contextlib.contextmanager
+    def report_linking_progress(cls, context: bpy.types.Context, message: str) -> Iterator[None]:
+        """Show a WAIT cursor and a status bar message while a link loads.
+
+        Linking a file runs a separate, headless Blender subprocess to parse
+        and cache the model (see ``LoadLink.link_ifc``), so there is no
+        incremental progress to report back from it, only that it is running
+        and for how long so far (#9029). This deliberately does not fake a
+        percentage; see ``tool.Patch.report_progress`` for the equivalent on
+        the IfcPatch side, which can show real percentages because recipes
+        run in-process and can log their own progress.
+        """
+        window = getattr(context, "window", None)
+        if window is not None:
+            window.cursor_modal_set("WAIT")
+        try:
+            context.workspace.status_text_set(message)
+        except Exception:
+            pass
+        try:
+            yield
+        finally:
+            if window is not None:
+                window.cursor_modal_restore()
+            try:
+                context.workspace.status_text_set(None)
+            except Exception:
+                pass
 
     @classmethod
     def get_linked_models_documents(cls) -> dict[str, ifcopenshell.entity_instance]:

--- a/src/bonsai/bonsai/tool/project.py
+++ b/src/bonsai/bonsai/tool/project.py
@@ -316,11 +316,11 @@ class Project(bonsai.core.tool.Project):
 
         Linking a file runs a separate, headless Blender subprocess to parse
         and cache the model (see ``LoadLink.link_ifc``), so there is no
-        incremental progress to report back from it, only that it is running
-        and for how long so far (#9029). This deliberately does not fake a
-        percentage; see ``tool.Patch.report_progress`` for the equivalent on
-        the IfcPatch side, which can show real percentages because recipes
-        run in-process and can log their own progress.
+        incremental progress to report back from it, only that it is
+        running (#9029). This deliberately does not fake a percentage; see
+        ``tool.Patch.report_progress`` for the equivalent on the IfcPatch
+        side, which can show real percentages because recipes run
+        in-process and can log their own progress.
         """
         window = getattr(context, "window", None)
         if window is not None:


### PR DESCRIPTION
Refs #9029. @Plae-Blue-Dot reported that IfcPatch and Link IFC give no feedback after a click, and that clicking again freezes or crashes Blender.

**The "click twice" problem is not a race, and that changes the fix.** Blender dispatches operators sequentially on one thread, so a queued second click cannot begin until the first blocking call has already returned. An "is running" flag would therefore never catch it, because the flag is clear by the time the second invocation arrives. The real defect is that `bim.link_ifc` is **not idempotent**: invoking it again with the same file and the same query added a second identical row and reloaded the entire model from scratch.

Measured before the change: calling `bim.link_ifc()` twice against the same file left `props.links` holding two identical entries. After it, the second call reports `'<name>' is already linked, skipping duplicate.` and the list still holds one. A different query on the same file is still treated as distinct, which is intentional.

That matters for the reporter's actual complaint. Every impatient re-click used to queue another full reload of a model that was already loading, so the operation took longer the more times you clicked it, which is a good way to make Blender look hung.

**Progress feedback.** This adds a WAIT cursor and a status bar message for the duration of the link. It deliberately **does not show a percentage.** Linking runs a separate headless Blender subprocess to parse and cache the model, and there is no channel back to the parent process to report partial progress, so any percentage would be invented. Wiring real progress out of that subprocess, for example through a polled temp file and a modal timer, is a larger change and is not attempted here.

`ExecuteIfcPatch` is untouched, because our open PR #8988 already adds real progress reporting there, and it can show genuine percentages since recipes run in-process.

**What is NOT fixed, stated plainly.** The window still becomes unresponsive during the operation. That is inherent to running the work synchronously on Blender's main thread and cannot be fixed without moving to a threaded or modal design. And we could **not** reproduce an actual crash from repeat clicking; no code path was found where two invocations genuinely overlap, and the issue carries no crash log. It is possible the reporter's "crash" was an operating system force-quit after prolonged unresponsiveness, but there is no evidence either way and this PR does not claim to fix a crash.

Generated with the assistance of an AI coding tool.
