### PR TITLE
util.cost: stop get_product_quantity_names resurrecting names after an empty intersection

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/cost.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/cost.py
@@ -320,14 +320,17 @@ def get_cost_schedule_types(file: ifcopenshell.file) -> list[dict[str, str]]:
 
 
 def get_product_quantity_names(elements: list[ifcopenshell.entity_instance]) -> list[str]:
-    names = set()
+    names: Optional[set[str]] = None
     for element in elements or []:
         potential_names = set()
         qtos = get_psets(element, qtos_only=True)
         for qset, quantities in qtos.items():
             potential_names.update(quantities.keys())
-        names = names.intersection(potential_names) if names else potential_names
-    return [n for n in names if n != "id"]
+        # `names is None` marks "not yet initialised", distinct from an
+        # empty set, which means the intersection has already excluded
+        # every quantity name and must stay empty.
+        names = potential_names if names is None else names.intersection(potential_names)
+    return [n for n in (names or set()) if n != "id"]
 
 
 def get_cost_schedule(cost_item: ifcopenshell.entity_instance) -> ifcopenshell.entity_instance:

--- a/src/ifcopenshell-python/test/util/test_cost.py
+++ b/src/ifcopenshell-python/test/util/test_cost.py
@@ -19,6 +19,7 @@
 
 import ifcopenshell.api.control
 import ifcopenshell.api.cost
+import ifcopenshell.api.pset
 import test.bootstrap
 import ifcopenshell.api.root
 
@@ -49,3 +50,32 @@ class TestGetCostItemForProduct(test.bootstrap.IFC4):
         cost_schedule = ifcopenshell.api.cost.add_cost_schedule(model)
         item1 = ifcopenshell.api.cost.add_cost_item(model, cost_schedule=cost_schedule)
         assert list(subject.get_cost_items_for_product(element)) == []
+
+
+class TestGetProductQuantityNames(test.bootstrap.IFC4):
+    def add_element_with_qto(self, quantities):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        qto = ifcopenshell.api.pset.add_qto(self.file, product=element, name="Qto_Test")
+        ifcopenshell.api.pset.edit_qto(self.file, qto=qto, properties=quantities)
+        return element
+
+    def test_intersection_of_all_elements(self):
+        a = self.add_element_with_qto({"Length": 1.0, "Width": 2.0})
+        b = self.add_element_with_qto({"Length": 5.0, "Height": 3.0})
+        assert subject.get_product_quantity_names([a, b]) == ["Length"]
+
+    def test_no_shared_quantity_stays_empty_regardless_of_order(self):
+        # B has no quantities at all, so nothing is common to all three
+        # elements. A later element (C) sharing a name with A alone must not
+        # resurrect a name into the result: once the intersection is empty,
+        # it must stay empty no matter what comes next.
+        a = self.add_element_with_qto({"Length": 1.0, "Width": 2.0})
+        b = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")  # no Qto assigned
+        c = self.add_element_with_qto({"Length": 5.0})
+        assert subject.get_product_quantity_names([a, b, c]) == []
+        # Order must not matter.
+        assert subject.get_product_quantity_names([a, c, b]) == []
+        assert subject.get_product_quantity_names([b, a, c]) == []
+
+    def test_no_elements(self):
+        assert subject.get_product_quantity_names([]) == []


### PR DESCRIPTION
`get_product_quantity_names` returns the quantity names common to every selected element, so the UI can offer only quantities that all of them actually have. It used an empty set as its "not yet initialised" marker:

```python
names = set()
...
names = names.intersection(potential_names) if names else potential_names
```

An empty set is falsy, so the moment the running intersection **legitimately** became empty, the next element's names replaced it instead of intersecting with it. A name that is not common to all elements gets resurrected.

**Reproduced on a real IFC file.** Three elements: A has `Length` and `Width`, B has no quantity set at all, C has `Length`. Nothing is common to all three, because B has none, so the correct answer is `[]`.

| Order | Before | After |
|---|---|---|
| A, B, C | `['Length']` (wrong) | `[]` |
| A, C, B | `[]` (right by luck) | `[]` |

The result depended on selection order, which is the tell: the same three elements gave two different answers depending on which one was iterated last. The wrong answer is the dangerous direction, since it offers a quantity that some selected elements do not have.

The fix uses `None` as the sentinel so that "not yet initialised" and "the intersection is genuinely empty" stop being the same state.

**No existing test asserted the old behaviour** (nothing referenced this function under `test/`), so nothing had to be corrected. A regression test is added covering both orders, since a test using only one order would have passed against the buggy code.

Full `test/util/` suite after the change: 371 passed, with one pre-existing unrelated failure in `test/util/scripts/test_validate_stub.py` that is present before this change too and is caused by a stale prebuilt binary in this environment.

Generated with the assistance of an AI coding tool.
