### PR TITLE
util.schema: reassign_class silently dropped falsy-but-set attribute values

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/schema.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/schema.py
@@ -254,7 +254,7 @@ def reassign_class(
     for attribute in declaration.all_attributes():
         name = attribute.name()
         old_attribute = info.get(name, None)
-        if old_attribute:
+        if old_attribute is not None:
             if ifcopenshell.util.attribute.get_primitive_type(attribute) == "enum":
                 if old_attribute in ifcopenshell.util.attribute.get_enum_items(attribute):
                     new_attributes[name] = old_attribute

--- a/src/ifcopenshell-python/test/api/root/test_reassign_class.py
+++ b/src/ifcopenshell-python/test/api/root/test_reassign_class.py
@@ -196,6 +196,15 @@ class TestReassignClass(test.bootstrap.IFC4):
         assert len(self.file.by_type("IfcWallType")) == 0
         assert len(self.file.by_type("IfcSlab")) == 1
 
+    def test_keeping_a_falsy_but_set_attribute_value(self):
+        # A Name of "" is meaningfully different to a Name that was never set
+        # (None). It must survive a class reassignment rather than being
+        # silently dropped because it happens to be falsy in Python.
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element.Name = ""
+        new = ifcopenshell.api.root.reassign_class(self.file, product=element, ifc_class="IfcSlab")
+        assert new.Name == ""
+
 
 class TestReassignClassIFC4X3(test.bootstrap.IFC4X3, TestReassignClass):
     pass


### PR DESCRIPTION
`reassign_class` copies an element's attributes onto the new class. It filtered them with a truthiness test:

```python
old_attribute = info.get(name, None)
if old_attribute:
```

`info.get(name, None)` already returns `None` when an attribute is absent or genuinely unset, so the truthiness check adds nothing except collapsing every **falsy but deliberately set** value into the same bucket as "unset". Those values were then silently dropped instead of copied.

Affected values include `""`, `0`, `0.0`, `False` and empty aggregates.

Measured:

```
wall = IfcWall(Name="")
new_wall = reassign_class(f, wall, "IfcWallStandardCase")

before:  new_wall.Name -> None   (the empty name is lost)
after:   new_wall.Name -> ""     (preserved)
```

This is user-facing rather than internal: `ifcopenshell.api.root.reassign_class` is what backs Bonsai's Change Class operation, so changing an element's class quietly discarded any attribute the user had set to a falsy value. The fix is `is not None`, which preserves the existing behaviour for genuinely unset attributes.

No existing test covered this case.

**Related instance, deliberately not changed here:** `ifcopenshell/api/root/create_entity.py` does `element.Name = name or None`, which turns an intentional `name=""` into `None` by the same reasoning. It is a separate file and a separate decision (an empty name on creation may well be intended to mean "unset"), so it is flagged rather than bundled in.

Generated with the assistance of an AI coding tool.
