### PR TITLE
ifcopenshell.api: fix three defects that write wrong data into the file

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/cost/edit_cost_value_formula.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cost/edit_cost_value_formula.py
@@ -69,7 +69,7 @@ class Usecase:
         if not ifc:
             ifc = ifcopenshell.api.cost.add_cost_value(self.file, parent=parent)
         if "AppliedValue" in data:
-            if data["AppliedValue"]:
+            if data["AppliedValue"] is not None:
                 ifc.AppliedValue = self.file.createIfcMonetaryMeasure(data["AppliedValue"])
             else:
                 ifc.AppliedValue = None

--- a/src/ifcopenshell-python/ifcopenshell/api/material/set_shape_aspect_constituents.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/material/set_shape_aspect_constituents.py
@@ -87,7 +87,7 @@ def set_shape_aspect_constituents(
     should_create_new_material_set = False
     if material := ifcopenshell.util.element.get_material(element):
         if (
-            material.is_a("IfcMaterialConstituent")
+            material.is_a("IfcMaterialConstituentSet")
             and len(names := [c.Name for c in material.MaterialConstituents]) == len(materials)
             and set(names) == set(materials.keys())
         ):

--- a/src/ifcopenshell-python/ifcopenshell/api/style/assign_material_style.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/style/assign_material_style.py
@@ -242,6 +242,6 @@ class Usecase:
             self.file.remove(self.style)
             self.style = reuse_item
 
-        reuse_item.Styles = (self.settings["style"],)
+        reuse_item.Styles = (self.style,)
         reuse_item.Name = self.settings["style"].Name
         return reuse_item

--- a/src/ifcopenshell-python/test/api/cost/test_edit_cost_value_formula.py
+++ b/src/ifcopenshell-python/test/api/cost/test_edit_cost_value_formula.py
@@ -1,0 +1,54 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.api.cost
+import test.bootstrap
+
+
+class TestEditCostValueFormula(test.bootstrap.IFC4):
+    def test_setting_an_explicit_zero_value(self):
+        schedule = ifcopenshell.api.cost.add_cost_schedule(self.file)
+        item = ifcopenshell.api.cost.add_cost_item(self.file, cost_schedule=schedule)
+        value = ifcopenshell.api.cost.add_cost_value(self.file, parent=item)
+
+        # A formula of exactly "0" is a legitimate, explicit cost of zero
+        # (e.g. "included at no extra cost"). It must not be silently
+        # dropped down to an unset (None) applied value.
+        ifcopenshell.api.cost.edit_cost_value_formula(self.file, cost_value=value, formula="0")
+        assert value.AppliedValue is not None
+        assert value.AppliedValue.wrappedValue == 0.0
+
+    def test_setting_a_non_zero_value(self):
+        schedule = ifcopenshell.api.cost.add_cost_schedule(self.file)
+        item = ifcopenshell.api.cost.add_cost_item(self.file, cost_schedule=schedule)
+        value = ifcopenshell.api.cost.add_cost_value(self.file, parent=item)
+
+        ifcopenshell.api.cost.edit_cost_value_formula(self.file, cost_value=value, formula="42")
+        assert value.AppliedValue.wrappedValue == 42.0
+
+    def test_clearing_a_value_with_a_blank_formula(self):
+        schedule = ifcopenshell.api.cost.add_cost_schedule(self.file)
+        item = ifcopenshell.api.cost.add_cost_item(self.file, cost_schedule=schedule)
+        value = ifcopenshell.api.cost.add_cost_value(self.file, parent=item)
+
+        ifcopenshell.api.cost.edit_cost_value_formula(self.file, cost_value=value, formula="42")
+        assert value.AppliedValue is not None
+
+        # An intentionally blank formula clears the applied value back to unset.
+        ifcopenshell.api.cost.edit_cost_value_formula(self.file, cost_value=value, formula="")
+        assert value.AppliedValue is None

--- a/src/ifcopenshell-python/test/api/material/test_set_shape_aspect_constituents.py
+++ b/src/ifcopenshell-python/test/api/material/test_set_shape_aspect_constituents.py
@@ -1,0 +1,93 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.api.context
+import ifcopenshell.api.geometry
+import ifcopenshell.api.material
+import ifcopenshell.api.root
+import ifcopenshell.util.element
+import ifcopenshell.util.shape_builder
+import test.bootstrap
+
+
+class TestSetShapeAspectConstituents(test.bootstrap.IFC4):
+    def setup_element(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        model = ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        body = ifcopenshell.api.context.add_context(
+            self.file, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=model
+        )
+        builder = ifcopenshell.util.shape_builder.ShapeBuilder(self.file)
+        item = builder.sphere()
+        rep = builder.get_representation(body, [item])
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWindow")
+        ifcopenshell.api.geometry.assign_representation(self.file, product=element, representation=rep)
+        return element, body
+
+    def test_reuses_existing_constituent_set_when_names_match(self):
+        element, body = self.setup_element()
+        aluminium = ifcopenshell.api.material.add_material(self.file, name="AL01", category="aluminium")
+        glass = ifcopenshell.api.material.add_material(self.file, name="GLZ01", category="glass")
+        materials = {"Framing": aluminium, "Glazing": glass}
+
+        ifcopenshell.api.material.set_shape_aspect_constituents(
+            self.file, element=element, context=body, materials=materials
+        )
+        material_set = ifcopenshell.util.element.get_material(element)
+        assert material_set.is_a("IfcMaterialConstituentSet")
+        constituents = {c.Name: c for c in material_set.MaterialConstituents}
+
+        # Simulate the user (or another API call) customising a constituent,
+        # e.g. setting a quantity fraction, after the set was first created.
+        constituents["Framing"].Fraction = 0.42
+
+        # Calling the function again with the exact same materials must reuse
+        # the existing constituent set rather than tearing it down and
+        # rebuilding it, otherwise any such customisation is silently lost.
+        ifcopenshell.api.material.set_shape_aspect_constituents(
+            self.file, element=element, context=body, materials=materials
+        )
+
+        material_set_again = ifcopenshell.util.element.get_material(element)
+        assert material_set_again == material_set
+        constituents_again = {c.Name: c for c in material_set_again.MaterialConstituents}
+        assert constituents_again["Framing"] == constituents["Framing"]
+        assert constituents_again["Framing"].Fraction == 0.42
+
+    def test_recreates_constituent_set_when_names_differ(self):
+        element, body = self.setup_element()
+        aluminium = ifcopenshell.api.material.add_material(self.file, name="AL01", category="aluminium")
+        glass = ifcopenshell.api.material.add_material(self.file, name="GLZ01", category="glass")
+
+        ifcopenshell.api.material.set_shape_aspect_constituents(
+            self.file, element=element, context=body, materials={"Framing": aluminium}
+        )
+        material_set = ifcopenshell.util.element.get_material(element)
+        old_framing = next(c for c in material_set.MaterialConstituents if c.Name == "Framing")
+        # Tag the original constituent so we can tell, regardless of any STEP
+        # id recycling, whether it is the same instance after the next call.
+        old_framing.Description = "ORIGINAL_TAG"
+
+        ifcopenshell.api.material.set_shape_aspect_constituents(
+            self.file, element=element, context=body, materials={"Framing": aluminium, "Glazing": glass}
+        )
+        material_set_again = ifcopenshell.util.element.get_material(element)
+        assert {c.Name for c in material_set_again.MaterialConstituents} == {"Framing", "Glazing"}
+        # The names differ from the original set, so it must have been torn
+        # down and rebuilt: the tagged constituent must not survive.
+        assert all(c.Description != "ORIGINAL_TAG" for c in material_set_again.MaterialConstituents)

--- a/src/ifcopenshell-python/test/api/style/test_assign_material_style.py
+++ b/src/ifcopenshell-python/test/api/style/test_assign_material_style.py
@@ -56,9 +56,11 @@ class TestAssignMaterialStyleIFC2X3(test.bootstrap.IFC2X3):
         if self.file.schema != "IFC2X3":
             assert representation.Items[0].Styles == (style2,)
         else:
-            # IfcPresentationStyleAssignment
+            # IfcStyledItem.Styles is SET OF IfcPresentationStyleAssignment in IFC2X3,
+            # so the reused item must keep wrapping the style, not hold it directly.
             assert len(representation.Items[0].Styles) == 1
-            assert representation.Items[0].Styles == (style2,)
+            assert representation.Items[0].Styles[0].is_a("IfcPresentationStyleAssignment")
+            assert representation.Items[0].Styles[0].Styles == (style2,)
 
 
 class TestAssignMaterialStyleIFC4(test.bootstrap.IFC4, TestAssignMaterialStyleIFC2X3):


### PR DESCRIPTION
Three defects in the `api/` tree, found by auditing for silently wrong values rather than crashes. **All three write incorrect data permanently into the user's IFC file**, so none of them is transient.

## 1. `api/material/set_shape_aspect_constituents.py` loses constituent data on every edit

The reuse check tested `material.is_a("IfcMaterialConstituent")`, but `get_material()` on an element returns the **`IfcMaterialConstituentSet`**, never a bare constituent. That condition can never be true, so the reuse path was dead and every call unassigned and recreated the constituents even when the names already matched.

Measured: with `Fraction=0.42` set on constituent id 19, a second call with an identical `materials` dict produced new constituent ids 23 and 24 with `Fraction` back to `None`. The user's data is gone.

This is called from Bonsai's parametric door and window regeneration, so it runs on **every geometry edit**.

## 2. `api/style/assign_material_style.py` writes schema-invalid IFC2X3

The reuse branch assigned `self.settings["style"]`, the raw unwrapped style, instead of `self.style`, which is wrapped for IFC2X3. Confirmed by schema introspection that this is invalid rather than merely untidy:

```
IFC2X3  IfcStyledItem.Styles -> SET [1:?] OF IfcPresentationStyleAssignment
IFC4    IfcStyledItem.Styles -> SET [1:?] OF IfcStyleAssignmentSelect
```

IFC4 accepts a bare `IfcPresentationStyle`; **IFC2X3 does not**. Running `ifcopenshell.validate.validate()` on the output confirms it: `#7=IfcStyledItem($,(#10),$)` with `#10=IfcSurfaceStyle(...)` reports `Not valid`, expecting an `IfcPresentationStyleAssignment`.

**An existing test asserted the buggy behaviour, and I have changed it.** `test/api/style/test_assign_material_style.py::TestAssignMaterialStyleIFC2X3::test_run` asserted `representation.Items[0].Styles == (style2,)` for the reuse path, which is exactly the invalid output. It even carried a `# IfcPresentationStyleAssignment` comment while asserting the unwrapped style, suggesting the intent was right and the assertion was not. It now asserts the wrapper is preserved and still wraps the same style. **Please sanity-check that change specifically**, since correcting a test that encoded the old behaviour deserves a second opinion.

## 3. `api/cost/edit_cost_value_formula.py` turns a zero cost into no cost

`if data["AppliedValue"]:` treats a legitimate `0.0` as absent, so the formula `"0"` produced `AppliedValue = None` instead of `IfcMonetaryMeasure(0.0)`. A zero cost and an uncosted item are different things, and only one of them is what the user typed.

Verified `unserialise_cost_value` really does yield `0.0` there, and confirmed that a genuinely blank formula still clears the value to `None` after the fix.

## Deliberately not fixed

- `api/cost/copy_cost_item_values.py` passes the wrong parent to `remove_cost_value`, but the branch is unreachable through the public API, because `get_total_inverses` is 1 for any value created that way. Reported rather than patched.
- `api/aggregate/assign_object.py` and `api/spatial/assign_container.py` round-trip an ordered list through a `set()`, scrambling child order on every edit. These are EXPRESS `SET`s where order carries no meaning, so it is a UX annoyance rather than a wrong value.
- `api/style/assign_material_style.py` has genuinely dead code just above fix 2 (`reuse_item.is_a("IfcPresentationStyleAssignment")` can never be true, since `reuse_item` is always an `IfcStyledItem`). Harmless but a second latent bug; fixing it properly means deciding intended behaviour, which is a design question rather than a mechanical change.

## Tests

`test/api/material` 89 passed, `test/api/style` 63 passed, plus a new `test/api/cost/test_edit_cost_value_formula.py`. Each fix was confirmed failing before and passing after, individually. The full `test/api` run shows 10 pre-existing failures from a missing `networkx` in this environment, present before and after these changes.

Generated with the assistance of an AI coding tool.
