### PR TITLE
ifcpatch: AssignConstituentFractions silently skipped constituents with zero width

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/AssignConstituentFractions.py
+++ b/src/ifcpatch/ifcpatch/recipes/AssignConstituentFractions.py
@@ -146,7 +146,8 @@ class Patcher:
                 continue
 
             constituent_name = constituent.Name.strip()
-            if width := element_quantities.get(constituent_name):
+            width = element_quantities.get(constituent_name)
+            if width is not None:
                 constituent_widths[constituent] = width * unit_scale
                 total_width += width * unit_scale
             else:


### PR DESCRIPTION
`AssignConstituentFractions` computes each material constituent's `Fraction` from its width. The recipe already takes care to preserve a zero width when gathering quantities:

```python
and v.get("properties", {}).get("Width", "") is not None
```

But the consumer that uses those widths re-tested the already-validated value with a truthy walrus:

```python
if width := element_quantities.get(constituent_name):
```

`0.0` is falsy, so a constituent with a genuine zero width fell into the `else` branch and was logged as "No width found". Its `Fraction` was then never set.

**The two halves of the same function pipeline disagreed**: one deliberately preserves `0.0`, the other silently discards it.

Zero width is a real modelling case, not a degenerate one. A membrane, a gap, or an air layer recorded with a nominal zero thickness is legitimate, and its correct fraction is `0.0`, which is meaningfully different from "no fraction recorded".

**Measured on an IFC4 wall** with an `IfcMaterialConstituentSet` and `Qto_WallBaseQuantities` widths of 0.0, 0.1 and 0.2:

| Constituent | Width | Before | After |
|---|---|---|---|
| Membrane | 0.0 | `Fraction = None` | `Fraction = 0.0` |
| Insulation | 0.1 | `0.333...` | `0.333...` |
| Board | 0.2 | `0.667...` | `0.667...` |

The expected `0.0` was derived independently as `0.0 / 0.3`, not from the patched output. The other two fractions are unchanged, confirming the fix does not disturb the normal path.

**This is written into the file.** `Fraction` is set on the actual `IfcMaterialConstituent` entities, so the omission persists in the saved model.

**No test is added here deliberately.** Our open PR #9066 creates this recipe's first test file, and adding another would collide on file creation. `git merge-tree` confirms this change composes cleanly with #9066 today. A zero-width case is worth adding to that test file once it lands, since #9066's tests currently exercise only 0.1 and 0.2 and would not have caught this.

Generated with the assistance of an AI coding tool.
