### PR TITLE
ifcopenshell.api: fix a segfault duplicating ratio-lag tasks, and zero-length durations being rejected

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/resource/edit_resource_time.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/resource/edit_resource_time.py
@@ -82,7 +82,7 @@ class Usecase:
             metrics = ifcopenshell.util.constraint.get_metric_constraints(resource, "Usage." + name)
             if metrics and ifcopenshell.util.constraint.is_hard_constraint(metrics[0]):
                 continue
-            if value:
+            if value is not None:
                 if "Start" in name or "Finish" in name or name == "StatusTime":
                     value = ifcopenshell.util.date.datetime2ifc(value, "IfcDateTime")
                 elif name == "ScheduleWork" or name == "ActualWork" or name == "RemainingTime":

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/duplicate_task.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/duplicate_task.py
@@ -21,7 +21,6 @@ import ifcopenshell.api.nest
 import ifcopenshell.api.owner
 import ifcopenshell.api.sequence
 import ifcopenshell.guid
-import ifcopenshell.util.date
 import ifcopenshell.util.element
 
 
@@ -157,16 +156,22 @@ class Usecase:
                             relating_process=relating_process,
                             related_process=related_process,
                         )
-                        if inverse.TimeLag:
-                            ifcopenshell.api.sequence.assign_lag_time(
+                        if inverse.TimeLag and inverse.TimeLag.LagValue is not None:
+                            # LagValue may be an IfcDuration (ISO 8601 string) or an
+                            # IfcRatioMeasure (a plain float, e.g. a percentage of the
+                            # predecessor's duration). assign_lag_time only creates
+                            # duration-typed lags, so create a placeholder and let
+                            # edit_lag_time set the value with the correct type.
+                            new_lag_time = ifcopenshell.api.sequence.assign_lag_time(
                                 self.file,
                                 rel_sequence=rel,
-                                lag_value=(
-                                    ifcopenshell.util.date.ifc2datetime(inverse.TimeLag.LagValue.wrappedValue)
-                                    if inverse.TimeLag.LagValue
-                                    else None
-                                ),
+                                lag_value="P0D",
                                 duration_type=inverse.TimeLag.DurationType,
+                            )
+                            ifcopenshell.api.sequence.edit_lag_time(
+                                self.file,
+                                lag_time=new_lag_time,
+                                attributes={"LagValue": inverse.TimeLag.LagValue.wrappedValue},
                             )
 
     def create_object_reference(

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/edit_work_plan.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/edit_work_plan.py
@@ -45,7 +45,7 @@ def edit_work_plan(
             work_plan=work_plan, attributes={"Description": "Construction of phase 1"})
     """
     for name, value in attributes.items():
-        if value:
+        if value is not None:
             if "Date" in name or "Time" in name:
                 value = ifcopenshell.util.date.datetime2ifc(value, "IfcDateTime")
             elif name == "Duration" or name == "TotalFloat":

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/edit_work_schedule.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/edit_work_schedule.py
@@ -49,7 +49,7 @@ def edit_work_schedule(
             work_schedule=work_schedule, attributes={"Description": "3 crane design option"})
     """
     for name, value in attributes.items():
-        if value:
+        if value is not None:
             if "Date" in name or "Time" in name:
                 value = ifcopenshell.util.date.datetime2ifc(value, "IfcDateTime")
             elif name == "Duration" or name == "TotalFloat":

--- a/src/ifcopenshell-python/test/api/resource/test_edit_resource_time.py
+++ b/src/ifcopenshell-python/test/api/resource/test_edit_resource_time.py
@@ -1,0 +1,66 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+
+import ifcopenshell.api.resource
+import ifcopenshell.api.root
+import test.bootstrap
+
+
+# NOTE: resource module features relies on entities introduced in IFC4
+# therefore no IFC2X3 tests
+class TestEditResourceTime(test.bootstrap.IFC4):
+    def test_editing_schedule_work_to_a_zero_duration(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource")
+        resource_time = ifcopenshell.api.resource.add_resource_time(self.file, resource=resource)
+
+        # A caller may legitimately pass a zero-length timedelta (e.g. "the
+        # resource did no work in this period"). A falsy value is not the
+        # same as an unset one, and must still go through IfcDuration
+        # serialisation instead of being written raw.
+        ifcopenshell.api.resource.edit_resource_time(
+            self.file, resource_time=resource_time, attributes={"ScheduleWork": datetime.timedelta(0)}
+        )
+        assert resource_time.ScheduleWork == "P0D"
+
+    def test_editing_actual_work_to_a_zero_duration(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource")
+        resource_time = ifcopenshell.api.resource.add_resource_time(self.file, resource=resource)
+
+        ifcopenshell.api.resource.edit_resource_time(
+            self.file, resource_time=resource_time, attributes={"ActualWork": datetime.timedelta(0)}
+        )
+        assert resource_time.ActualWork == "P0D"
+
+    def test_editing_schedule_work_to_none_clears_it(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource")
+        resource_time = ifcopenshell.api.resource.add_resource_time(self.file, resource=resource)
+
+        ifcopenshell.api.resource.edit_resource_time(
+            self.file, resource_time=resource_time, attributes={"ScheduleWork": "PT8H"}
+        )
+        assert resource_time.ScheduleWork == "PT8H"
+
+        ifcopenshell.api.resource.edit_resource_time(
+            self.file, resource_time=resource_time, attributes={"ScheduleWork": None}
+        )
+        assert resource_time.ScheduleWork is None

--- a/src/ifcopenshell-python/test/api/sequence/test_duplicate_task.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_duplicate_task.py
@@ -1,0 +1,66 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021-2022 Dion Moult <dion@thinkmoult.com>, Yassine Oualid <yassine@sigmadimensions.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.api.root
+import ifcopenshell.api.sequence
+import test.bootstrap
+
+
+class TestDuplicateTask(test.bootstrap.IFC4):
+    def test_duplicating_a_predecessor_with_a_duration_lag(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        schedule = ifcopenshell.api.sequence.add_work_schedule(self.file, name="Schedule")
+        task1 = ifcopenshell.api.sequence.add_task(self.file, work_schedule=schedule, name="Task 1")
+        task2 = ifcopenshell.api.sequence.add_task(self.file, work_schedule=schedule, name="Task 2")
+        rel = ifcopenshell.api.sequence.assign_sequence(self.file, relating_process=task1, related_process=task2)
+        lag = ifcopenshell.api.sequence.assign_lag_time(self.file, rel_sequence=rel, lag_value="P2D")
+
+        originals, duplicates = ifcopenshell.api.sequence.duplicate_task(self.file, task=task1)
+        duplicate_task1 = duplicates[0]
+
+        duplicate_rels = list(duplicate_task1.IsPredecessorTo)
+        assert len(duplicate_rels) == 1
+        duplicate_lag = duplicate_rels[0].TimeLag
+        assert duplicate_lag is not None
+        assert duplicate_lag.LagValue.is_a("IfcDuration")
+        assert duplicate_lag.LagValue.wrappedValue == "P2D"
+        # the original relationship and lag are untouched
+        assert lag.LagValue.wrappedValue == "P2D"
+
+    def test_duplicating_a_predecessor_with_a_ratio_lag(self):
+        # A lag time may also be expressed as a ratio of the predecessor's
+        # own duration (e.g. "50% of task 1's duration") instead of a fixed
+        # IfcDuration. Duplicating the predecessor must not crash and must
+        # preserve the ratio, not silently turn it into a duration lag.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        schedule = ifcopenshell.api.sequence.add_work_schedule(self.file, name="Schedule")
+        task1 = ifcopenshell.api.sequence.add_task(self.file, work_schedule=schedule, name="Task 1")
+        task2 = ifcopenshell.api.sequence.add_task(self.file, work_schedule=schedule, name="Task 2")
+        rel = ifcopenshell.api.sequence.assign_sequence(self.file, relating_process=task1, related_process=task2)
+        lag = ifcopenshell.api.sequence.assign_lag_time(self.file, rel_sequence=rel, lag_value="P1D")
+        ifcopenshell.api.sequence.edit_lag_time(self.file, lag_time=lag, attributes={"LagValue": 0.5})
+
+        originals, duplicates = ifcopenshell.api.sequence.duplicate_task(self.file, task=task1)
+        duplicate_task1 = duplicates[0]
+
+        duplicate_rels = list(duplicate_task1.IsPredecessorTo)
+        assert len(duplicate_rels) == 1
+        duplicate_lag = duplicate_rels[0].TimeLag
+        assert duplicate_lag is not None
+        assert duplicate_lag.LagValue.is_a("IfcRatioMeasure")
+        assert duplicate_lag.LagValue.wrappedValue == 0.5

--- a/src/ifcopenshell-python/test/api/sequence/test_edit_work_plan.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_edit_work_plan.py
@@ -1,0 +1,47 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+
+import ifcopenshell.api.sequence
+import test.bootstrap
+
+
+# NOTE: sequence module features relies on entities introduced in IFC4
+# therefore no IFC2X3 tests
+class TestEditWorkPlan(test.bootstrap.IFC4):
+    def test_editing_duration_to_a_zero_length_value(self):
+        self.file.create_entity("IfcProject")
+        work_plan = ifcopenshell.api.sequence.add_work_plan(self.file)
+
+        # A zero-length duration is a legitimate, falsy value and must still
+        # be serialised as IfcDuration, not written raw.
+        ifcopenshell.api.sequence.edit_work_plan(
+            self.file, work_plan=work_plan, attributes={"Duration": datetime.timedelta(0)}
+        )
+        assert work_plan.Duration == "P0D"
+
+    def test_editing_duration_to_none_clears_it(self):
+        self.file.create_entity("IfcProject")
+        work_plan = ifcopenshell.api.sequence.add_work_plan(self.file)
+
+        ifcopenshell.api.sequence.edit_work_plan(self.file, work_plan=work_plan, attributes={"Duration": "P2D"})
+        assert work_plan.Duration == "P2D"
+
+        ifcopenshell.api.sequence.edit_work_plan(self.file, work_plan=work_plan, attributes={"Duration": None})
+        assert work_plan.Duration is None

--- a/src/ifcopenshell-python/test/api/sequence/test_edit_work_schedule.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_edit_work_schedule.py
@@ -1,0 +1,60 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+
+import ifcopenshell.api.sequence
+import test.bootstrap
+
+
+# NOTE: sequence module features relies on entities introduced in IFC4
+# therefore no IFC2X3 tests
+class TestEditWorkSchedule(test.bootstrap.IFC4):
+    def test_editing_duration_to_a_zero_length_value(self):
+        self.file.create_entity("IfcProject")
+        work_schedule = ifcopenshell.api.sequence.add_work_schedule(self.file)
+
+        # A zero-length duration is a legitimate, falsy value and must still
+        # be serialised as IfcDuration, not written raw.
+        ifcopenshell.api.sequence.edit_work_schedule(
+            self.file, work_schedule=work_schedule, attributes={"Duration": datetime.timedelta(0)}
+        )
+        assert work_schedule.Duration == "P0D"
+
+    def test_editing_total_float_to_a_zero_length_value(self):
+        self.file.create_entity("IfcProject")
+        work_schedule = ifcopenshell.api.sequence.add_work_schedule(self.file)
+
+        ifcopenshell.api.sequence.edit_work_schedule(
+            self.file, work_schedule=work_schedule, attributes={"TotalFloat": datetime.timedelta(0)}
+        )
+        assert work_schedule.TotalFloat == "P0D"
+
+    def test_editing_duration_to_none_clears_it(self):
+        self.file.create_entity("IfcProject")
+        work_schedule = ifcopenshell.api.sequence.add_work_schedule(self.file)
+
+        ifcopenshell.api.sequence.edit_work_schedule(
+            self.file, work_schedule=work_schedule, attributes={"Duration": "P2D"}
+        )
+        assert work_schedule.Duration == "P2D"
+
+        ifcopenshell.api.sequence.edit_work_schedule(
+            self.file, work_schedule=work_schedule, attributes={"Duration": None}
+        )
+        assert work_schedule.Duration is None


### PR DESCRIPTION
Two defects in the scheduling APIs. The second one **kills the process**, which is why this is being raised now rather than batched.

## 1. Duplicating a task with a percentage-based lag segfaults the interpreter

`IfcLagTime.LagValue` can be an `IfcDuration` (a fixed lag) **or** an `IfcRatioMeasure` (a lag expressed as a percentage of the predecessor's duration). `cascade_schedule.py` and `edit_lag_time.py` already handle both. `duplicate_task.py`'s `copy_sequence_relationship` assumed duration only.

For a ratio lag it passed the raw float through `ifc2datetime()`, which returns `None` for a float, and that `None` reached `create_entity`. The result is not an exception:

```
>>> f.create_entity("IfcDuration", None)
Segmentation fault (exit code 139)
```

I reproduced that directly against a compiled build. The whole interpreter dies, so in Bonsai this takes the user's **entire unsaved session** with it. The trigger is duplicating any predecessor task that uses a percentage lag, which is a documented and supported feature.

Fixed by reusing `assign_lag_time` and `edit_lag_time`, which are already type-correct for both cases, instead of hand-rolling the conversion. Both duration and ratio lags now round-trip.

**Worth flagging separately for the core library:** `create_entity` segfaulting on a `None` where a `STRING` is expected is a robustness bug in its own right, independent of this caller. It should raise, as it does for a wrong-typed value (`TypeError: ... expecting value of type 'STRING', got 'timedelta'`). That looks like a C++ or SWIG layer question rather than a Python one, so it is reported here rather than patched.

## 2. A zero-length duration cannot be saved

`edit_resource_time.py`, `edit_work_plan.py` and `edit_work_schedule.py` all guarded the `IfcDuration` conversion with `if value:`. A `datetime.timedelta(0)` is falsy, so the conversion was skipped and the raw Python object was assigned straight onto the entity:

```
TypeError: attribute 'ScheduleWork' for entity 'IFC4.IfcResourceTime' is expecting value of type 'STRING', got 'timedelta'.
```

Bonsai reaches this directly, because `helper.parse_duration()` returns exactly that falsy `timedelta` whenever a duration field is set to zero. Recording a resource that did no work, or a zero-duration schedule, are both legitimate and both were impossible.

Note this **refuses the edit rather than corrupting the file**, so no bad data is written; the action is simply unusable. `edit_task_time.py` already used `is not None` for the equivalent check, so this matches existing precedent in the same subsystem rather than inventing a convention.

## Reported, not fixed

`edit_resource_time.py`'s `attributes.get("ScheduleWork") and ...` guard is falsy when `ScheduleWork` is `0`, so a stale `ScheduleFinish` can survive alongside a zero-work edit. Unlike the equivalent in `edit_task_time.py`, no downstream recompute masks it. It is narrower and harder to argue is wrong rather than intentional, so it is flagged rather than changed.

## Tests

Adds 10 regression tests across four new files. `test/api/` goes from 1445 to 1455 passing, with no failures either side. The roughly 10 `test/api/sequence` collection errors in this environment are a missing `networkx`; installing it gives a clean 66 of 66 before and after.

Generated with the assistance of an AI coding tool.
