### PR TITLE
ifc5d: fix four wrong-number defects in cost export, cost import and weight quantities

### DIFF
--- a/src/ifc5d/ifc5d/csv2ifc.py
+++ b/src/ifc5d/ifc5d/csv2ifc.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 
 import csv
-import locale
 from pathlib import Path
 from typing import Optional, TypedDict, Union
 
@@ -165,7 +164,6 @@ class Csv2Ifc:
         self.headers = {}
 
         parents: dict[int, CostItem] = {}
-        locale.setlocale(locale.LC_ALL, "")  # set the system locale
 
         # TODO: 25-04-17 Deprecated 0 indices, should fully remove later.
         min_index = None
@@ -236,9 +234,13 @@ class Csv2Ifc:
             query = row[(self.headers["Query"])] if "Query" in self.headers else None
 
         if self.has_categories:
-            cost_values = {
-                col_name: locale.atof(row[col_i]) for col_name, col_i in self.categories.items() if row[col_i]
-            }
+            # Plain float(), not locale.atof(): our own exporter always writes
+            # period-decimal numbers regardless of the machine's locale (see
+            # ifc5Dspreadsheet.py), and the "Value"/"Quantity" columns below
+            # already parse with plain float() for the same reason. Using
+            # locale.atof() here silently corrupted every re-import on a
+            # comma-decimal locale (e.g. "1234.56" read back as 123456.0).
+            cost_values = {col_name: float(row[col_i]) for col_name, col_i in self.categories.items() if row[col_i]}
         else:
             assert "Value" in self.headers
             cost_values = row[self.headers["Value"]]

--- a/src/ifc5d/ifc5d/ifc5Dspreadsheet.py
+++ b/src/ifc5d/ifc5d/ifc5Dspreadsheet.py
@@ -147,7 +147,10 @@ class IfcDataGetter:
                 total_price = cost_value["applied_value"]
             else:
                 cost_category = "{}{}".format(category, " Cost")
-                cost_categories[cost_category] = cost_value["applied_value"]
+                # Multiple cost values can share a category (e.g. two uncategorised
+                # values both default to "General"). Accumulate them so the
+                # per-category column matches RateSubtotal, which sums every value.
+                cost_categories[cost_category] = cost_categories.get(cost_category, 0.0) + cost_value["applied_value"]
                 rate_subtotal += cost_value["applied_value"]
 
         data: CostItem = {

--- a/src/ifc5d/ifc5d/qto.py
+++ b/src/ifc5d/ifc5d/qto.py
@@ -427,6 +427,10 @@ class IfcOpenShell(QtoCalculator):
                                 value = cls.get_weight(element, geometry, calculation_type)
                                 if value is None:
                                     continue
+                                # get_weight() returns kilograms (density is authored in
+                                # kg/m3 against an SI m3 geometry volume); the unit
+                                # converter's SI reference point for mass is grams.
+                                value = cls.unit_converter.convert(value * 1000, "IfcMassMeasure")
                             elif formula.startswith("get_opening_"):
                                 value = cls.get_opening_quantity(geometry, formula)
                                 value = cls.unit_converter.convert(value, IfcOpenShell.raw_functions[formula].measure)
@@ -603,7 +607,11 @@ class IfcOpenShell(QtoCalculator):
             mass_per_length = ifcopenshell.util.element.get_pset(profile, "Pset_ProfileMechanical", "MassPerLength")
             if not isinstance(mass_per_length, float):
                 return None
-            mass += mass_per_length * item.Depth
+            # MassPerLength is authored in kg/m (SI); Depth is a raw number in the
+            # project's length unit (e.g. millimetres), so it must be scaled to SI
+            # metres before multiplying, matching the density-based branch which
+            # already works against an SI geometry volume.
+            mass += mass_per_length * item.Depth * cls.unit_scale
         return mass
 
     @staticmethod

--- a/src/ifc5d/test/test_csv2ifc.py
+++ b/src/ifc5d/test/test_csv2ifc.py
@@ -22,6 +22,7 @@ import tempfile
 from pathlib import Path
 
 import ifcopenshell
+import ifcopenshell.api.cost
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
 import ifcopenshell.util.cost
@@ -188,3 +189,26 @@ class TestSerialiseCostQuantities:
         result = ifc5d.ifc5Dspreadsheet.IfcDataGetter.serialise_cost_quantities(ifc_file, cost_item)
 
         assert json.loads(result) == [["Complex ERROR: Only IfcPhysicalSimpleQuantity is supported", 0.0, ""]]
+
+
+class TestCostCategoryTotals:
+    def test_two_cost_values_sharing_a_category_are_summed_not_overwritten(self):
+        # Two cost values with no Category set both default to "General". The
+        # per-category "General Cost" column must sum both, matching
+        # RateSubtotal (which already sums every non-"*" cost value).
+        ifc_file = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject", name="Test")
+        ifcopenshell.api.unit.assign_unit(ifc_file)
+        schedule = ifcopenshell.api.cost.add_cost_schedule(ifc_file, name="Sched")
+        item = ifcopenshell.api.cost.add_cost_item(ifc_file, cost_schedule=schedule)
+        item.Name = "Wall"
+
+        value1 = ifcopenshell.api.cost.add_cost_value(ifc_file, parent=item)
+        value1.AppliedValue = ifc_file.create_entity("IfcMonetaryMeasure", 100.0)
+        value2 = ifcopenshell.api.cost.add_cost_value(ifc_file, parent=item)
+        value2.AppliedValue = ifc_file.create_entity("IfcMonetaryMeasure", 250.0)
+
+        data = ifc5d.ifc5Dspreadsheet.IfcDataGetter.get_cost_items_data(ifc_file, item)[0]
+
+        assert data["RateSubtotal"] == pytest.approx(350.0)
+        assert data["cost_categories"]["General Cost"] == pytest.approx(350.0)

--- a/src/ifc5d/test/test_csv2ifc.py
+++ b/src/ifc5d/test/test_csv2ifc.py
@@ -212,3 +212,33 @@ class TestCostCategoryTotals:
 
         assert data["RateSubtotal"] == pytest.approx(350.0)
         assert data["cost_categories"]["General Cost"] == pytest.approx(350.0)
+
+
+class TestLocaleIndependentCostValueImport:
+    def test_category_cost_values_parse_with_plain_float_not_locale_atof(self, monkeypatch):
+        # Regression test: locale.atof() previously parsed the categories
+        # column, but our own exporter always writes period-decimal numbers
+        # regardless of the machine's locale (see ifc5Dspreadsheet.py), the
+        # same way the "Value"/"Quantity" columns already do with plain
+        # float(). On a comma-decimal locale (e.g. de_DE), locale.atof()
+        # silently multiplied every imported cost value by up to 1000x.
+        # Asserting locale.atof is never called keeps the test deterministic
+        # regardless of which locales happen to be installed on the runner.
+        import locale
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("locale.atof() must not be used to parse cost values")
+
+        monkeypatch.setattr(locale, "atof", fail_if_called)
+
+        importer = ifc5d.csv2ifc.Csv2Ifc(csv=None)
+        importer.has_categories = True
+        importer.has_rates = False
+        importer.has_formula = False
+        importer.categories = {"Material": 4}
+        importer.headers = {"Name": 0, "Unit": 1, "Identification": 2, "Description": 3, "Material Cost": 4}
+
+        row = ["Wall", "unit", "1", "", "1234.56"]
+        cost_data = importer.get_row_cost_data(row)
+
+        assert cost_data["CostValues"] == {"Material": 1234.56}

--- a/src/ifc5d/test/test_qto.py
+++ b/src/ifc5d/test/test_qto.py
@@ -20,6 +20,8 @@
 
 import ifcopenshell
 import ifcopenshell.api.context
+import ifcopenshell.api.material
+import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
 import pytest
@@ -90,3 +92,113 @@ class TestOpeningQuantities:
         assert quantities["Depth"] == pytest.approx(0.3)
         assert quantities["Area"] == pytest.approx(0.5)
         assert quantities["Volume"] == pytest.approx(0.15)
+
+
+class TestWeightUnitConversion:
+    """get_weight() must land in the project's declared MassUnit, and its
+    profile-based path must scale Depth (raw project length units) to SI
+    metres before multiplying by an SI MassPerLength (kg/m). Both stages were
+    silently skipping their unit conversion, only invisible for the common
+    METRE/KILOGRAM combination."""
+
+    def make_wall_cube(self, file, body, side: float) -> ifcopenshell.entity_instance:
+        """A `side` x `side` x `side` cube-shaped wall (in raw project length units)."""
+        f = file
+        wall = ifcopenshell.api.root.create_entity(f, ifc_class="IfcWall", name="TestWall")
+        wall.ObjectPlacement = f.createIfcLocalPlacement(
+            None, f.createIfcAxis2Placement3D(f.createIfcCartesianPoint((0.0, 0.0, 0.0)), None, None)
+        )
+        profile = f.createIfcRectangleProfileDef("AREA", None, None, side, side)
+        position = f.createIfcAxis2Placement3D(f.createIfcCartesianPoint((0.0, 0.0, 0.0)), None, None)
+        solid = f.createIfcExtrudedAreaSolid(profile, position, f.createIfcDirection((0.0, 0.0, 1.0)), side)
+        rep = f.createIfcShapeRepresentation(body, "Body", "SweptSolid", [solid])
+        wall.Representation = f.createIfcProductDefinitionShape(None, None, [rep])
+        return wall
+
+    def test_density_based_weight_converts_to_project_mass_unit(self):
+        # A 1000mm cube (= 1 real m^3) of 7850 kg/m3 steel weighs 7850kg in
+        # reality. The project's MassUnit is GRAM, so the stored NetWeight/
+        # GrossWeight must be 7,850,000, not the raw SI-kilogram 7850.
+        f = ifcopenshell.file(schema="IFC4")
+        ifcopenshell.api.root.create_entity(f, ifc_class="IfcProject", name="Test")
+        units = [
+            f.createIfcSIUnit(None, "LENGTHUNIT", "MILLI", "METRE"),
+            f.createIfcSIUnit(None, "AREAUNIT", None, "SQUARE_METRE"),
+            f.createIfcSIUnit(None, "VOLUMEUNIT", None, "CUBIC_METRE"),
+            f.createIfcSIUnit(None, "MASSUNIT", None, "GRAM"),
+        ]
+        ifcopenshell.api.unit.assign_unit(f, units=units)
+        model = ifcopenshell.api.context.add_context(f, context_type="Model")
+        body = ifcopenshell.api.context.add_context(
+            f, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=model
+        )
+
+        wall = self.make_wall_cube(f, body, 1000.0)
+        material = ifcopenshell.api.material.add_material(f, name="Steel")
+        material_pset = ifcopenshell.api.pset.add_pset(f, product=material, name="Pset_MaterialCommon")
+        ifcopenshell.api.pset.edit_pset(f, pset=material_pset, properties={"MassDensity": 7850.0})
+        ifcopenshell.api.material.assign_material(f, products=[wall], material=material)
+
+        rules = {
+            "calculators": {
+                "IfcOpenShell": {
+                    "IfcWall": {
+                        "Qto_WallBaseQuantities": {"NetWeight": "net_get_weight", "GrossWeight": "gross_get_weight"}
+                    }
+                }
+            }
+        }
+        results = ifc5d.qto.quantify(f, {wall}, rules)
+        quantities = results[wall]["Qto_WallBaseQuantities"]
+        assert quantities["NetWeight"] == pytest.approx(7_850_000.0)
+        assert quantities["GrossWeight"] == pytest.approx(7_850_000.0)
+
+    def test_profile_based_weight_scales_depth_to_si(self):
+        # A 100x200mm profile extruded 2000mm (= 2 real metres) with an
+        # authored MassPerLength of 50 kg/m weighs 100kg in reality
+        # (50 kg/m * 2m). The project's LengthUnit is MILLIMETRE, so Depth
+        # (a raw 2000.0) must be scaled to SI metres before the multiply.
+        f = ifcopenshell.file(schema="IFC4")
+        ifcopenshell.api.root.create_entity(f, ifc_class="IfcProject", name="Test")
+        units = [
+            f.createIfcSIUnit(None, "LENGTHUNIT", "MILLI", "METRE"),
+            f.createIfcSIUnit(None, "AREAUNIT", None, "SQUARE_METRE"),
+            f.createIfcSIUnit(None, "VOLUMEUNIT", None, "CUBIC_METRE"),
+            f.createIfcSIUnit(None, "MASSUNIT", "KILO", "GRAM"),
+        ]
+        ifcopenshell.api.unit.assign_unit(f, units=units)
+        model = ifcopenshell.api.context.add_context(f, context_type="Model")
+        body = ifcopenshell.api.context.add_context(
+            f, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=model
+        )
+
+        beam = ifcopenshell.api.root.create_entity(f, ifc_class="IfcBeam", name="Beam1")
+        beam.ObjectPlacement = f.createIfcLocalPlacement(
+            None, f.createIfcAxis2Placement3D(f.createIfcCartesianPoint((0.0, 0.0, 0.0)), None, None)
+        )
+        profile = f.createIfcRectangleProfileDef("AREA", "RectProfile", None, 100.0, 200.0)
+        position = f.createIfcAxis2Placement3D(f.createIfcCartesianPoint((0.0, 0.0, 0.0)), None, None)
+        solid = f.createIfcExtrudedAreaSolid(profile, position, f.createIfcDirection((0.0, 0.0, 1.0)), 2000.0)
+        rep = f.createIfcShapeRepresentation(body, "Body", "SweptSolid", [solid])
+        beam.Representation = f.createIfcProductDefinitionShape(None, None, [rep])
+
+        f.create_entity(
+            "IfcProfileProperties",
+            Name="Pset_ProfileMechanical",
+            ProfileDefinition=profile,
+            Properties=[
+                f.create_entity(
+                    "IfcPropertySingleValue",
+                    Name="MassPerLength",
+                    NominalValue=f.create_entity("IfcMassPerLengthMeasure", 50.0),
+                )
+            ],
+        )
+
+        rules = {
+            "calculators": {
+                "IfcOpenShell": {"IfcBeam": {"Qto_BeamBaseQuantities": {"GrossWeight": "gross_get_weight"}}}
+            }
+        }
+        results = ifc5d.qto.quantify(f, {beam}, rules)
+        assert results[beam]["Qto_BeamBaseQuantities"]["GrossWeight"] == pytest.approx(100.0)


### PR DESCRIPTION
Four wrong-number defects in the quantity and cost tooling. None of them crashes. Each produces a plausible-looking figure that reaches a spreadsheet or the IFC file, so nothing draws attention to it.

## 1. Cost values sharing a category overwrote each other

`ifc5Dspreadsheet.py::get_cost_items_data` assigned each `IfcCostValue` into its category slot rather than accumulating. Two values sharing a category, which happens whenever more than one value is uncategorised and both default to "General", meant only the last survived.

With values of 100.0 and 250.0, the exported "General Cost" column read **250.0** while `RateSubtotal` read the correct **350.0**. The same export therefore disagreed with itself.

`ifc2json.py` implements the same concept with `+=`, so this was the outlier rather than an intended convention.

**Reaches CSV, ODS and XLSX cost schedules.**

## 2. Re-importing our own export corrupted every cost on a comma-decimal locale

`csv2ifc.py::get_row_cost_data` parsed category columns with `locale.atof()`, but this tool's own exporter always writes period-decimal numbers regardless of machine locale. The `Value` and `Quantity` columns a few lines below already used plain `float()`, so the file contradicted itself.

On a `de_DE.UTF-8` machine, round-tripping this tool's own export of `1234.56` returned **123456.0**, a factor of 100, silently and with no warning.

Anyone outside a period-decimal locale who exports a cost schedule and re-imports it gets costs inflated by 10x to 1000x depending on the number of decimals.

## 3. Weight quantities skipped unit conversion, twice

In `qto.py::calculate`, seven formula branches feed the same `results[...] = value` assignment. Five call `unit_converter.convert`. The `get_weight` branch does not, even though its own docstring promises a value "in project units" while it computes from a density in SI.

With `MassUnit = GRAM` and 1 cubic metre of steel at 7850 kg/m3, it wrote **7850.0** instead of **7,850,000**.

`get_weight_profile_based` had a second instance: `MassPerLength (kg/m) * item.Depth` used the raw `Depth` without scaling to SI metres. With `LengthUnit = mm`, a 2000 mm beam at 50 kg/m gave **100,000** instead of **100.0**.

**These write directly into `IfcQuantityWeight` in the user's IFC file**, which is the most severe class here.

Worth noting for review: the other unconverted branch, `get_segment_length`, is **correct** to skip conversion, because it reads `XDim`, `YDim` and `Depth` straight from the IFC and those are already in project units. That is what makes `get_weight` identifiable as the anomaly rather than the rule.

## Flagged, not changed: an existing test in another open PR will need updating

Open PR **#9062** adds a `TestWeightQuantities` whose fixture sets `MASSUNIT=GRAM` but asserts SI kilogram values (`100.0`, `7850.0 * net_volume`). Those assertions encode the behaviour this PR corrects, so **once this lands they need multiplying by 1000**.

It is someone else's open PR, so it has been left untouched and called out here and in the commit message rather than edited.

## Deliberately not fixed

`ifc5Dspreadsheet.py::get_cost_item_quantity` sums raw quantity values across a cost item's assigned quantities **without checking they are the same quantity type**, and takes the displayed unit from the first one. A pre-existing `# NOTE: take_off_name is not used anywhere` comment suggests this was already known to be incomplete.

That is a domain question rather than an arithmetic bug: **should a cost item with mixed quantity types on its assigned quantities refuse to sum, warn, or is silent summation acceptable?** Left alone pending an answer.

## Tests

Adds regression tests to `test_qto.py` and `test_csv2ifc.py`, including a locale round-trip. `src/ifc5d/test/` is green at 24 passed, with the four new tests failing before these changes.

Generated with the assistance of an AI coding tool.
