### PR TITLE
ifc4d: stop zero-duration milestones importing as one-day tasks

### DIFF
--- a/src/ifc4d/ifc4d/common.py
+++ b/src/ifc4d/ifc4d/common.py
@@ -292,10 +292,10 @@ class ScheduleIfcGenerator:
             attributes={
                 "ScheduleStart": activity["StartDate"],
                 "ScheduleFinish": activity["FinishDate"],
-                "DurationType": "WORKTIME" if activity["PlannedDuration"] else None,
+                "DurationType": "WORKTIME" if activity["PlannedDuration"] is not None else None,
                 "ScheduleDuration": (
-                    timedelta(days=float(activity["PlannedDuration"]) / float(calendar["HoursPerDay"] or 8)) or None
-                    if activity["PlannedDuration"]
+                    timedelta(days=float(activity["PlannedDuration"]) / float(calendar["HoursPerDay"] or 8))
+                    if activity["PlannedDuration"] is not None
                     else None
                 ),
             },

--- a/src/ifc4d/ifc4d/msp2ifc.py
+++ b/src/ifc4d/ifc4d/msp2ifc.py
@@ -282,8 +282,8 @@ class MSP2Ifc:
             attributes={
                 "ScheduleStart": task["Start"],
                 "ScheduleFinish": task["Finish"],
-                "DurationType": "WORKTIME" if task["Duration"] else None,
-                "ScheduleDuration": task["Duration"] if task["Duration"] else None,
+                "DurationType": "WORKTIME" if task["Duration"] is not None else None,
+                "ScheduleDuration": task["Duration"],
             },
         )
         for subtask_id in task["subtasks"]:

--- a/src/ifc4d/test/test_common.py
+++ b/src/ifc4d/test/test_common.py
@@ -1,0 +1,95 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import datetime
+
+import ifcopenshell
+import ifcopenshell.api.root
+import ifcopenshell.api.unit
+
+from ifc4d.common import ScheduleIfcGenerator
+
+# ScheduleIfcGenerator.create_task_from_activity() is shared by P62Ifc (P6 XML),
+# P6XER2Ifc (P6 XER) and PP2Ifc (Asta Powerproject). A zero-duration activity is
+# a normal, meaningful value (e.g. a milestone: PlannedDuration is explicitly 0
+# hours and StartDate == FinishDate). It must not silently turn into a full day.
+
+
+def build_settings(planned_duration):
+    return {
+        "work_plan": None,
+        "project": {"Name": "Test Project"},
+        "calendars": {
+            "C1": {
+                "Name": "Cal1",
+                "Type": "Global",
+                "HoursPerDay": "8",
+                "StandardWorkWeek": [],
+                "HolidayOrExceptions": {},
+            }
+        },
+        "wbs": {},
+        "root_activities": ["A1"],
+        "activities": {
+            "A1": {
+                "Name": "Activity",
+                "Identification": "1",
+                "StartDate": datetime.datetime(2024, 1, 1),
+                "FinishDate": datetime.datetime(2024, 1, 1),
+                "PlannedDuration": planned_duration,
+                "Status": "NotStarted",
+                "CalendarObjectId": "C1",
+                "ifc": None,
+            }
+        },
+        "relationships": {},
+        "resources": {},
+    }
+
+
+def convert(planned_duration) -> ifcopenshell.entity_instance:
+    ifc_file = ifcopenshell.file(schema="IFC4")
+    ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject", name="Test")
+    ifcopenshell.api.unit.assign_unit(ifc_file)
+    work_plan = ifc_file.create_entity("IfcWorkPlan")
+    generator = ScheduleIfcGenerator(ifc_file, None, build_settings(planned_duration))
+    generator.work_plan = work_plan
+    generator.create_ifc()
+    return generator.activities["A1"]["ifc"]
+
+
+class TestCreateTaskFromActivityZeroDuration:
+    def test_string_zero_duration_is_p0d_not_p1d(self):
+        # P62Ifc parses PlannedDuration as a string straight from XML .text.
+        task = convert("0")
+        assert task.TaskTime.ScheduleDuration == "P0D"
+        assert task.TaskTime.ScheduleFinish == task.TaskTime.ScheduleStart
+
+    def test_float_zero_duration_is_p0d_not_p1d(self):
+        # P6XER2Ifc (target_drtn_hr_cnt) and PP2Ifc (activity_duration for a
+        # MILESTONE bar) both pass PlannedDuration as a Python float.
+        task = convert(0.0)
+        assert task.TaskTime.ScheduleDuration == "P0D"
+        assert task.TaskTime.ScheduleFinish == task.TaskTime.ScheduleStart
+
+    def test_nonzero_duration_is_unaffected(self):
+        # 16 hours / 8 hours-per-day = 2 days.
+        task = convert("16")
+        assert task.TaskTime.ScheduleDuration == "P2D"

--- a/src/ifc4d/test/test_msp2ifc_duration.py
+++ b/src/ifc4d/test/test_msp2ifc_duration.py
@@ -1,0 +1,88 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import tempfile
+from pathlib import Path
+
+import ifcopenshell
+
+from ifc4d.msp2ifc import MSP2Ifc
+
+# A milestone task exported by MS Project has Duration=PT0H0M0S and
+# Start == Finish. Zero is the correct, meaningful duration for a milestone
+# and must not silently turn into a full day in the IFC file.
+MSPDI_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/project">
+  <Name>Milestone Test Project</Name>
+  <MinutesPerDay>480</MinutesPerDay>
+  <Tasks>
+    <Task>
+      <UID>1</UID>
+      <Name>Design sign-off milestone</Name>
+      <OutlineLevel>0</OutlineLevel>
+      <OutlineNumber>1</OutlineNumber>
+      <WBS>1</WBS>
+      <Duration>PT0H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <Start>2024-01-05T08:00:00</Start>
+      <Finish>2024-01-05T08:00:00</Finish>
+    </Task>
+    <Task>
+      <UID>2</UID>
+      <Name>Two day task</Name>
+      <OutlineLevel>0</OutlineLevel>
+      <OutlineNumber>2</OutlineNumber>
+      <WBS>2</WBS>
+      <Duration>PT16H0M0S</Duration>
+      <Priority>500</Priority>
+      <CalendarUID>-1</CalendarUID>
+      <Start>2024-01-08T08:00:00</Start>
+      <Finish>2024-01-09T16:00:00</Finish>
+    </Task>
+  </Tasks>
+  <Calendars/>
+</Project>
+"""
+
+
+def convert() -> ifcopenshell.file:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        xml_path = Path(tmp_dir) / "project.xml"
+        xml_path.write_text(MSPDI_XML)
+        converter = MSP2Ifc()
+        converter.xml = str(xml_path)
+        converter.execute()
+        return converter.file
+
+
+class TestMsp2IfcZeroDuration:
+    def test_milestone_zero_duration_is_p0d_not_p1d(self):
+        ifc_file = convert()
+        task = next(t for t in ifc_file.by_type("IfcTask") if t.Identification == "1")
+        assert task.IsMilestone is True
+        assert task.TaskTime.ScheduleDuration == "P0D"
+        assert task.TaskTime.ScheduleFinish == task.TaskTime.ScheduleStart
+
+    def test_nonzero_duration_is_unaffected(self):
+        # 16 hours / 8 hours-per-day (480 minutes-per-day) = 2 days.
+        ifc_file = convert()
+        task = next(t for t in ifc_file.by_type("IfcTask") if t.Identification == "2")
+        assert task.TaskTime.ScheduleDuration == "P2D"


### PR DESCRIPTION
Importing a construction programme from P6, Powerproject or Microsoft Project turned **every milestone into a one-day task**, and the corruption then exported back out as a real duration.

## The chain

`timedelta(0)`, `0.0` and `"0"` are all falsy in Python. Two import paths collapsed an explicit **zero** duration into **no** duration:

```python
# common.py, shared by p62ifc.py, p6xer2ifc.py and pp2ifc.py
"ScheduleDuration": (
    timedelta(days=float(activity["PlannedDuration"]) / float(calendar["HoursPerDay"] or 8)) or None
    if activity["PlannedDuration"]
    else None
),
```

That is the trap twice over: the trailing `or None` catches a computed `timedelta(0)`, and the `if activity["PlannedDuration"]` catches a raw `"0"` or `0.0`. `msp2ifc.py` had the same shape, and a milestone is exactly the case that produces it, since `Start == Finish` gives `timedelta(0)`.

With `ScheduleDuration` unset, `ifcopenshell.api.sequence.edit_task_time()` falls back to deriving the duration from start and finish. Its accumulator begins at one day and the loop body never runs when start equals finish, so it writes **`ScheduleDuration = "P1D"`**.

Correct value, derived independently: 0 hours divided by 8 hours per day is 0 days, which is `P0D`.

## Why this does not stay contained

`ScheduleDuration` is a persisted `IfcTaskTime` attribute, so the wrong value is written into the IFC file. Worse, the exporters test it for truthiness:

```
ifc2msp.py:206   if task.TaskTime.ScheduleDuration:
ifc2p6.py:220    if task.TaskTime.ScheduleDuration:
```

`"P1D"` is a non-empty string, so it passes that check and exports as a genuine one-day duration. A programme imported and re-exported therefore comes back with **every milestone shifted by a day**, with nothing anywhere reporting a problem.

## Tests

New `src/ifc4d/test/` covering the string-zero, float-zero and MSP milestone cases, exercised both through `ScheduleIfcGenerator` (which covers the P6 XML, P6 XER and Powerproject paths) and end to end through `MSP2Ifc.execute()` on a real MSPDI fixture. Three fail before and pass after:

```
before:  assert 'P1D' == 'P0D'   (3 failed, 2 passed)
after:   5 passed
```

Non-zero durations were regression-checked and are unchanged, giving `P2D` for 16 hours at 8 hours per day both before and after. There was no existing `src/ifc4d/` test suite, so nothing asserted the old behaviour.

## Two things found and deliberately not changed

**Open PR #9082 still crashes on a percentage lag.** `IfcLagTime.LagValue` may be an `IfcRatioMeasure` rather than a duration, and both `ifc2msp.py` and `ifc2p6.py` assume duration only. Measured: exporting a ratio lag raises `AttributeError: 'NoneType' object has no attribute 'days'`, because `ifc2datetime()` returns `None` for a bare float. #9082 touches those exact lines but its `duration_to_hours()` helper crashes the same way, so this is **flagged for whoever reviews #9082** rather than patched here, to avoid a competing change on the same lines.

**A domain question rather than a bug:** `pp2ifc.py` uses `max()` of a calendar's daily working hours as the single `HoursPerDay` divisor for all Powerproject duration conversions. On a calendar with uneven days, say short Fridays, that would skew every derived duration. Should it be an average, the calendar's declared standard hours, or is `max` intentional? Not changed without an answer.

Generated with the assistance of an AI coding tool.
