### PR TITLE
ifcclash/ifccsv: stop dropping a real clash, a wrong summary total, and silently ignored Country on reimport

### DIFF
--- a/src/ifcclash/ifcclash/ifcclash.py
+++ b/src/ifcclash/ifcclash/ifcclash.py
@@ -140,7 +140,13 @@ class Clasher:
             element1 = result.a
             element2 = result.b
 
-            processed_results[f"{element1.get_argument(0)}-{element2.get_argument(0)}"] = ClashResult(
+            # Keyed by object identity, not GlobalId: a GlobalId is only unique
+            # within a single file, and a clash set can federate several
+            # sources. Two distinct, genuine clash pairs whose GlobalIds
+            # happen to collide across sources would otherwise silently
+            # overwrite each other here, dropping one real clash from the
+            # output with no error or warning.
+            processed_results[f"{id(element1)}-{id(element2)}"] = ClashResult(
                 a_global_id=element1.get_argument(0),
                 b_global_id=element2.get_argument(0),
                 a_ifc_class=element1.is_a(),

--- a/src/ifccsv/ifccsv.py
+++ b/src/ifccsv/ifccsv.py
@@ -490,8 +490,13 @@ class IfcCsv:
         bool_false: str,
         concat: str,
     ) -> None:
-        # Patterns to skip during import (substrings)
-        SKIP_PATTERNS = {"count", "material"}
+        # Read-only pseudo-attributes to skip during import. These are exact
+        # path segments recognised by ifcopenshell.util.selector (e.g. the
+        # "count" in "type.count", or "material"/"mat" in "material.Name"),
+        # not substrings of an ordinary attribute name. Matching on substring
+        # instead of segment previously skipped unrelated attributes such as
+        # "Country", "Discount", "AccountNumber", or "MaterialCost".
+        SKIP_SEGMENTS = {"count", "material", "mat"}
 
         try:
             element = ifc_file.by_guid(row[0])
@@ -511,8 +516,8 @@ class IfcCsv:
                 value = False
             key = attributes[i] or headers[i]
 
-            # Skip keys containing certain patterns
-            if any(pattern in key.lower() for pattern in SKIP_PATTERNS):
+            # Skip read-only pseudo-attributes (matched as whole path segments).
+            if any(segment in SKIP_SEGMENTS for segment in key.lower().split(".")):
                 continue
 
             ifcopenshell.util.selector.set_element_value(ifc_file, element, key, value, concat=concat)

--- a/src/ifccsv/ifccsv.py
+++ b/src/ifccsv/ifccsv.py
@@ -130,8 +130,12 @@ class IfcCsv:
             else:
                 self.headers.append(attribute)
 
-        self.group_results(groups, attributes)
+        # Summarise before grouping: a summary column need not be one of the
+        # group's aggregated columns, and grouping collapses rows, so summing
+        # post-group would silently total only the surviving representative
+        # rows instead of every exported element.
         self.summarise_results(summaries, attributes)
+        self.group_results(groups, attributes)
         self.sort_results(sort, attributes, include_global_id)
         self.format_results(formatting, attributes, null)
 


### PR DESCRIPTION
Three defects across `ifcclash` and `ifccsv`. The first drops a genuine clash from the report, which is the failure mode nobody catches, because nothing tells you a clash was omitted.

## 1. A real clash silently disappears when GlobalIds collide across sources

`ifcclash.py::process_clash_set` keyed its results dict by the pair of GlobalIds:

```python
processed_results[f"{element1.get_argument(0)}-{element2.get_argument(0)}"] = ClashResult(...)
```

**GlobalId is only unique within a single file.** A clash set federates several sources, so two entirely different and independently genuine clash pairs can produce the same key, and the second overwrites the first.

Reproduced with hand-built geometry whose intersections are known: source A has two walls genuinely crossing near the origin, source C has two different walls genuinely crossing 500 m away, with source C's walls reusing source A's GlobalIds. Ground truth is **two** clashes.

| | Clashes reported |
|---|---|
| Before | **1** (the near-origin pair silently dropped) |
| After | 2 |

Fixed by keying on Python object identity. The `a_global_id` and `b_global_id` fields that consumers actually read are unchanged.

This is the same defect class as open PR **#9057**, but on the **output** side. #9057 fixes deduplication on the *input* side of `add_collision_objects` and does not touch this dict, verified against its diff. The two compose rather than overlap, and #9057's own regression test still fails on this branch, as it should, because that fix is not part of this change.

## 2. Spreadsheet summary row disagreed with the rows above it

`ifccsv.py::export` computed the SUM, AVERAGE, MIN and MAX summary **after** grouping had already collapsed rows. A summary column that was not also a grouping column therefore totalled only the last surviving row per group.

Measured with three elements of area 100, 150 and 100 grouped by category: the summary read **250** where the correct total is **350**.

Fixed by summarising before grouping. SUM, MIN and MAX are associative so already-correct cases are unaffected, and AVERAGE improves from an average over arbitrary surviving rows to a true average.

Reaches the exported spreadsheet.

## 3. Re-importing an edited spreadsheet silently ignored `Country`

`process_row` skips read-only pseudo-attributes using:

```python
SKIP_PATTERNS = {"count", "material"}
...
if any(pattern in key.lower() for pattern in SKIP_PATTERNS):
```

Substring matching here was a deliberate choice (`862713cda4`, whose comment reads "Patterns to skip during import (substrings)"), but it catches more than intended, because **`"count"` is a substring of `"country"`**.

So editing `Pset_Address.Country` in an exported spreadsheet and re-importing left the original value untouched, with no error and no warning. `Discount`, `AccountNumber` and `MaterialCost` are affected the same way.

Checking `ifcopenshell.util.selector`, these are exact path-segment pseudo-attributes, never substrings of a longer name, so matching segments exactly preserves the original intent while removing the collateral damage. Verified live: the value now updates on reimport, and the genuinely read-only keys are still skipped.

## On locale exposure, since a sibling package had it

A sibling audit found `ifc5d`'s importer corrupting re-imports by 100x on a comma-decimal locale via `locale.atof()`. **`ifccsv` does not have that exposure.** It uses plain `float()` throughout, and `ifcopenshell.util.selector`'s numeric coercions are plain `float()`/`int()` as well. Checked rather than assumed.

## On tests

Deliberately none added here. Neither package has a committed test suite, and open PRs #9057 and #9060 are the first ever proposed for them, so adding files would collide on creation. All three fixes were verified red-then-green by direct execution, and the ifcclash case additionally reuses #9057's own fixture helpers so the two can be checked together. Worth folding regression cases for these three into whichever of those test suites lands first.

Generated with the assistance of an AI coding tool.
