### PR TITLE
ifcwrap: fix two SIGSEGVs on defined and enumeration types

### DIFF
--- a/src/ifcwrap/IfcParseWrapper.i
+++ b/src/ifcwrap/IfcParseWrapper.i
@@ -575,12 +575,25 @@ private:
 		if (arg_type == IfcUtil::Argument_STRING) {
 			self->set_attribute_value(i, a);	
 		} else if (arg_type == IfcUtil::Argument_ENUMERATION) {
-			const IfcParse::entity* value_entity = $self->declaration().schema()->declaration_by_name($self->declaration().type())->as_entity();
-			if (!value_entity) {
+			const IfcParse::declaration* decl = $self->declaration().schema()->declaration_by_name($self->declaration().type());
+			const IfcParse::parameter_type* pt = 0;
+			if (const IfcParse::entity* value_entity = decl->as_entity()) {
+				pt = value_entity->attribute_by_index(i)->type_of_attribute();
+			} else if (i == 0) {
+				// A defined type can wrap an enumeration, as some IFC4.3 release
+				// candidates did, so resolve through its declared type as well.
+				if (const IfcParse::type_declaration* td = decl->as_type_declaration()) {
+					pt = td->declared_type();
+				}
+			}
+			const IfcParse::named_type* nt = pt ? pt->as_named_type() : 0;
+			const IfcParse::enumeration_type* enum_type = nt ? nt->declared_type()->as_enumeration_type() : 0;
+			if (!enum_type && i == 0) {
+				enum_type = decl->as_enumeration_type();
+			}
+			if (!enum_type) {
 				throw IfcParse::IfcException("Attribute not set");
 			}
-			const IfcParse::enumeration_type* enum_type = value_entity->
-			attribute_by_index(i)->type_of_attribute()->as_named_type()->declared_type()->as_enumeration_type();
 			self->set_attribute_value(i, EnumerationReference(enum_type, enum_type->lookup_enum_offset(a)));
 		} else if (arg_type == IfcUtil::Argument_BINARY) {
 			if (IfcUtil::valid_binary_string(a)) {

--- a/src/ifcwrap/IfcParseWrapper.i
+++ b/src/ifcwrap/IfcParseWrapper.i
@@ -523,7 +523,7 @@ private:
 	}
 
 	void setArgumentAsNull(unsigned int i) {
-		bool is_optional = $self->declaration().as_entity()->attribute_by_index(i)->optional();
+		bool is_optional = $self->declaration().as_entity() && $self->declaration().as_entity()->attribute_by_index(i)->optional();
 		if (is_optional) {
 			self->set_attribute_value(i, Blank{});
 		} else {

--- a/src/ifcwrap/IfcParseWrapper.i
+++ b/src/ifcwrap/IfcParseWrapper.i
@@ -580,8 +580,8 @@ private:
 			if (const IfcParse::entity* value_entity = decl->as_entity()) {
 				pt = value_entity->attribute_by_index(i)->type_of_attribute();
 			} else if (i == 0) {
-				// A defined type can wrap an enumeration, as some IFC4.3 release
-				// candidates did, so resolve through its declared type as well.
+				// e.g. IfcFacilityPart.PredefinedType: IfcFacilityPartTypeSelect (IFC4X3 RC1-4)
+				// is a select of enums, so resolve through the declared type as well.
 				if (const IfcParse::type_declaration* td = decl->as_type_declaration()) {
 					pt = td->declared_type();
 				}

--- a/src/ifcwrap/IfcParseWrapper.i
+++ b/src/ifcwrap/IfcParseWrapper.i
@@ -580,8 +580,9 @@ private:
 			if (const IfcParse::entity* value_entity = decl->as_entity()) {
 				pt = value_entity->attribute_by_index(i)->type_of_attribute();
 			} else if (i == 0) {
-				// e.g. IfcFacilityPart.PredefinedType: IfcFacilityPartTypeSelect (IFC4X3 RC1-4)
-				// is a select of enums, so resolve through the declared type as well.
+				// A defined type can wrap an enumeration, so resolve through its
+				// declared type as well. No such case is reachable in any schema
+				// currently built; this guard is defensive.
 				if (const IfcParse::type_declaration* td = decl->as_type_declaration()) {
 					pt = td->declared_type();
 				}

--- a/src/ifcwrap/IfcParseWrapper.i
+++ b/src/ifcwrap/IfcParseWrapper.i
@@ -461,7 +461,8 @@ private:
 	}
 
 	AttributeValue get_argument(const std::string& a) {
-		auto i = $self->declaration().as_entity()->attribute_index(a);
+		auto entity_decl = $self->declaration().as_entity();
+		auto i = entity_decl ? entity_decl->attribute_index(a) : -1;
 		if (i == -1) {
 			throw std::runtime_error("Attribute '" + a + "' not found on entity named " + $self->declaration().name());
 		}
@@ -574,7 +575,11 @@ private:
 		if (arg_type == IfcUtil::Argument_STRING) {
 			self->set_attribute_value(i, a);	
 		} else if (arg_type == IfcUtil::Argument_ENUMERATION) {
-			const IfcParse::enumeration_type* enum_type = $self->declaration().schema()->declaration_by_name($self->declaration().type())->as_entity()->
+			const IfcParse::entity* value_entity = $self->declaration().schema()->declaration_by_name($self->declaration().type())->as_entity();
+			if (!value_entity) {
+				throw IfcParse::IfcException("Attribute not set");
+			}
+			const IfcParse::enumeration_type* enum_type = value_entity->
 			attribute_by_index(i)->type_of_attribute()->as_named_type()->declared_type()->as_enumeration_type();
 			self->set_attribute_value(i, EnumerationReference(enum_type, enum_type->lookup_enum_offset(a)));
 		} else if (arg_type == IfcUtil::Argument_BINARY) {


### PR DESCRIPTION
> **These changes have NOT been compiled or run.** The crashes below are reproduced and the root causes identified to the line, but the build could not be completed on this machine. Please treat this as a diagnosis with proposed one-line guards rather than a tested patch. Build details at the end.

Two confirmed segfaults, both reachable from ordinary Python, both in `src/ifcwrap/IfcParseWrapper.i`, both the same archetype.

## Crash 1: instantiating any defined or enumeration type with `None`

```python
>>> f.create_entity("IfcDuration", None)
Segmentation fault (exit code 139)
```

`setArgumentAsNull` dereferenced `declaration().as_entity()` unguarded. That returns null for a defined type or an enumeration type.

## Crash 2: `get_argument(name)` on any defined type

```python
>>> f.create_entity("IfcDuration", "P1D").wrapped_data.get_argument("wrappedValue")
Segmentation fault (exit code 139)
```

Same unguarded dereference at line 463. **The sibling `get_argument_index(const std::string&)` seven lines below already guards the identical call**, which is what identified it.

The guard here costs nothing, because the function already has an `if (i == -1)` branch raising a clean `std::runtime_error`. A null declaration simply routes into that existing path.

## Crash surface, measured

Every defined type and every enumeration type is affected: `IfcLabel`, `IfcText`, `IfcIdentifier`, `IfcDuration`, `IfcDateTime`, `IfcInteger`, `IfcReal`, `IfcBoolean`, and enums such as `IfcElementCompositionEnum`.

**Regular entities were never affected.** They already raise a clean `TypeError`, and an optional attribute set to `None` is still accepted. Only direct instantiation or inspection of a defined or enumeration type crashed.

## Why the wrapper and not the parser

A survey of roughly 140 downcast call sites found the parser layer consistently guarded. `src/ifcparse/*.cpp`, `IfcFile.cpp` and `storage.h` all check before dereferencing, and their storage layer independently converts wrong-type and out-of-range access into clean `IfcException`s. `IfcFile::getUnit()` looked exploitable but was tested and rejected for exactly that reason: `get_attribute_value` throws first.

**The `%extend` methods in the wrapper have no equivalent safety net**, which is why the archetype survives there and nowhere else. The two fixed here plus the one in the first commit appear to be the complete set in that file.

A third instance in `setArgumentAsString`'s `Argument_ENUMERATION` branch is also guarded here, but is **latent rather than live**: enumerating every schema present in this build (IFC2X3, IFC4, IFC4X1, IFC4X2 and the IFC4X3 variants) found none defining a type declaration that aliases an enumeration type, so no input appears to reach it. It is guarded because it is the same file, the same pattern and a one-line change. Some IFC4X3 release candidates are absent from this build, so that check is not exhaustive.

Unguarded sites in `parse_ifcxml.cpp` were deliberately left alone: `IfcParse::parse_ifcxml()` throws `"IFC-XML import temporarily disabled"` at function entry, so that code is unreachable by maintainer choice. Verified by calling it.

## How this was found

Through a real caller, fixed separately in #9110: `api/sequence/duplicate_task.py` assumed `IfcLagTime.LagValue` was always an `IfcDuration`, but it can be an `IfcRatioMeasure`. The float went through `ifc2datetime()`, which returns `None` for a float, and that `None` reached `create_entity`.

## Build status, stated plainly

The docker build image is `linux/amd64` only, so on an Apple Silicon host it runs under QEMU emulation. A stale root-owned ccache volume failed the first run; after fixing that, the second run reached real compilation and `cc1plus` was **OOM-killed** at default parallelism against the container's 8 GB ceiling. A retry at reduced parallelism had no realistic completion time, so it was stopped rather than left running for hours.

Whether a native arm64 build path exists was **not** established.

So: both crashes are reproduced with real exit codes captured directly rather than through a pipe, the root causes are identified to the line, and the guards follow the conventions of neighbouring methods in the same file. **They have not been built.** Anyone with a working native build can confirm in seconds, and I would rather hand over an honest diagnosis than claim a verification I did not perform.

Generated with the assistance of an AI coding tool.
