### PR TITLE
cost: stop edit_cost_value orphaning the old UnitBasis into the file

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/cost/edit_cost_value.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cost/edit_cost_value.py
@@ -60,5 +60,9 @@ def edit_cost_value(
                 )
                 value = file.create_entity("IfcMeasureWithUnit", value_component, value["UnitComponent"])
             if old_unit_basis:
-                ifcopenshell.util.element.remove_deep2(file, old_unit_basis)
+                # cost_value still references old_unit_basis at this point, so
+                # remove_deep2 would see an inverse outside the subgraph and
+                # silently do nothing. also_consider tells it to disregard that
+                # inverse, which is exactly what the argument is for.
+                ifcopenshell.util.element.remove_deep2(file, old_unit_basis, also_consider=[cost_value])
         setattr(cost_value, name, value)

--- a/src/ifcopenshell-python/test/api/cost/test_edit_cost_value.py
+++ b/src/ifcopenshell-python/test/api/cost/test_edit_cost_value.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
+
 import ifcopenshell.api.cost
 import ifcopenshell.api.unit
 import test.bootstrap
@@ -50,6 +52,8 @@ class TestEditCostValue(test.bootstrap.IFC4):
         )
         assert value.UnitBasis is not None
         assert value.UnitBasis.id() != old_basis_id
+        with pytest.raises(RuntimeError):
+            self.file.by_id(old_basis_id)
 
     def test_clearing_unit_basis(self):
         schedule = ifcopenshell.api.cost.add_cost_schedule(self.file)


### PR DESCRIPTION
Every time a cost value's `UnitBasis` is reassigned, the old one is orphaned into the file instead of being purged.

## The mechanism

`remove_deep2` documents that **"the start element must have no inverses"**, and it silently does nothing when that precondition is not met. `edit_cost_value` called it on the old `UnitBasis` **before** reassigning the attribute:

```python
if old_unit_basis:
    ifcopenshell.util.element.remove_deep2(file, old_unit_basis)
setattr(cost_value, name, value)
```

At that point `cost_value.UnitBasis` still points at `old_unit_basis`, so the purge sees an inverse outside the subgraph and does nothing at all.

## Measured on a fresh IFC4 model

Setting a `UnitBasis` and then replacing it:

| | `IfcMeasureWithUnit` count | old entity |
|---|---|---|
| Before | 1 then **2** | still resolvable by id |
| After | 1 then **1** | purged |

So the orphaned `IfcMeasureWithUnit` and its value component accumulate on every edit. Nothing errors, the file still opens, and it grows quietly.

## The fix

`also_consider=[cost_value]`, which is the documented mechanism for exactly this situation. Its own docstring: *"remove_deep2 will not remove elements in also_consider. Instead, it is only used as a consideration for whether or not an element has all inverses fully contained in the subgraph."* So the one inverse from `cost_value` is disregarded when deciding containment, without adding `cost_value` to the deletion set.

Reordering the statements would also work, but this keeps the change to a single argument and states the intent explicitly.

## The test that was hiding it

`test_editing_unit_basis_removes_old_deeply` promised in its name to check deep removal and **never verified any removal at all**. Proven by mutation: deleting the `remove_deep2` call outright from production left the test green.

It now asserts the old element is genuinely gone, so this is covered going forward. That test fix is included here rather than shipped separately, since on its own it would simply turn CI red.

Found while auditing the test suite for assertions that pass regardless of whether the code is correct.

Generated with the assistance of an AI coding tool.
