### PR TITLE
bcf: fix a crash that loses the entire save, plus two silent data losses

### DIFF
--- a/src/bcf/bcf/v2/topic.py
+++ b/src/bcf/bcf/v2/topic.py
@@ -110,7 +110,7 @@ class TopicHandler:
             return self._reference_files
 
         for ref in self.header.file:
-            if ref.is_external:
+            if ref.is_external or not ref.reference:
                 continue
             real_path = self._topic_dir
             for path_part in ref.reference.split("/"):

--- a/src/bcf/bcf/v2/topic.py
+++ b/src/bcf/bcf/v2/topic.py
@@ -81,7 +81,7 @@ class TopicHandler:
 
     @property
     def bim_snippet(self) -> Optional[bytes]:
-        if not self._bim_snippet and self._topic_dir:
+        if self._bim_snippet is None and self._topic_dir:
             self._bim_snippet = self._load_bim_snippet()
         return self._bim_snippet
 
@@ -218,7 +218,7 @@ class TopicHandler:
         if not snippet or snippet.is_external:
             return
         ref_filename = Path(snippet.reference).name
-        if self.bim_snippet:
+        if self.bim_snippet is not None:
             destination_zip.writestr(f"{self.topic.guid}/{ref_filename}", self.bim_snippet)
 
     def _resolve_zip_path(self, reference: str) -> str:

--- a/src/bcf/bcf/v2/topic.py
+++ b/src/bcf/bcf/v2/topic.py
@@ -221,16 +221,29 @@ class TopicHandler:
         if self.bim_snippet:
             destination_zip.writestr(f"{self.topic.guid}/{ref_filename}", self.bim_snippet)
 
+    def _resolve_zip_path(self, reference: str) -> str:
+        """Resolve a topic-relative reference into its POSIX path inside the BCF zip.
+
+        Unlike walking self._topic_dir with joinpath()/parent, this doesn't rely on
+        zipfile.Path.at, which a freshly created topic (backed by a plain pathlib.Path,
+        not yet loaded from a zip) doesn't have.
+        """
+        parts = [self._topic_dir.name]
+        for path_part in reference.split("/"):
+            if path_part == "..":
+                if parts:
+                    parts.pop()
+            else:
+                parts.append(path_part)
+        return "/".join(parts)
+
     def _save_reference_files(self, destination_zip: ZipFileInterface) -> None:
         if not self.header:
             return
         for ref in self.header.file:
             if ref.is_external or not ref.reference:
                 continue
-            real_path = self._topic_dir
-            for path_part in ref.reference.split("/"):
-                real_path = real_path.parent if path_part == ".." else real_path.joinpath(path_part)
-            destination_zip.writestr(real_path.at, self.reference_files[ref.reference])
+            destination_zip.writestr(self._resolve_zip_path(ref.reference), self.reference_files[ref.reference])
 
     def _save_document_references(self, destination_zip: ZipFileInterface) -> None:
         if not self.topic:
@@ -238,10 +251,9 @@ class TopicHandler:
         for doc in self.topic.document_reference:
             if doc.is_external or not doc.referenced_document:
                 continue
-            real_path = self._topic_dir
-            for path_part in doc.referenced_document.split("/"):
-                real_path = real_path.parent if path_part == ".." else real_path.joinpath(path_part)
-            destination_zip.writestr(real_path.at, self.document_references[doc.referenced_document])
+            destination_zip.writestr(
+                self._resolve_zip_path(doc.referenced_document), self.document_references[doc.referenced_document]
+            )
 
     def add_viewpoint(self, element: entity_instance) -> VisualizationInfoHandler:
         """Add a viewpoint pointed at the placement of an IFC element to the topic.

--- a/src/bcf/bcf/v3/topic.py
+++ b/src/bcf/bcf/v3/topic.py
@@ -84,7 +84,7 @@ class TopicHandler:
 
     @property
     def bim_snippet(self) -> Optional[bytes]:
-        if not self._bim_snippet and self._topic_dir:
+        if self._bim_snippet is None and self._topic_dir:
             self._bim_snippet = self._load_bim_snippet()
         return self._bim_snippet
 
@@ -203,7 +203,7 @@ class TopicHandler:
         if not snippet or snippet.is_external:
             return
         ref_filename = Path(snippet.reference).name
-        if self.bim_snippet:
+        if self.bim_snippet is not None:
             destination_zip.writestr(f"{self.topic.guid}/{ref_filename}", self.bim_snippet)
 
     def _resolve_zip_path(self, reference: str) -> str:

--- a/src/bcf/bcf/v3/topic.py
+++ b/src/bcf/bcf/v3/topic.py
@@ -124,7 +124,7 @@ class TopicHandler:
             return self._reference_files
 
         for ref in self.header.files.file:
-            if ref.is_external:
+            if ref.is_external or not ref.reference:
                 continue
             real_path = self._topic_dir
             for path_part in ref.reference.split("/"):

--- a/src/bcf/bcf/v3/topic.py
+++ b/src/bcf/bcf/v3/topic.py
@@ -206,6 +206,22 @@ class TopicHandler:
         if self.bim_snippet:
             destination_zip.writestr(f"{self.topic.guid}/{ref_filename}", self.bim_snippet)
 
+    def _resolve_zip_path(self, reference: str) -> str:
+        """Resolve a topic-relative reference into its POSIX path inside the BCF zip.
+
+        Unlike walking self._topic_dir with joinpath()/parent, this doesn't rely on
+        zipfile.Path.at, which a freshly created topic (backed by a plain pathlib.Path,
+        not yet loaded from a zip) doesn't have.
+        """
+        parts = [self._topic_dir.name]
+        for path_part in reference.split("/"):
+            if path_part == "..":
+                if parts:
+                    parts.pop()
+            else:
+                parts.append(path_part)
+        return "/".join(parts)
+
     def _save_reference_files(self, destination_zip: ZipFileInterface) -> None:
         if not self.header:
             return
@@ -214,10 +230,7 @@ class TopicHandler:
         for ref in self.header.files.file:
             if ref.is_external or not ref.reference:
                 continue
-            real_path = self._topic_dir
-            for path_part in ref.reference.split("/"):
-                real_path = real_path.parent if path_part == ".." else real_path.joinpath(path_part)
-            destination_zip.writestr(real_path.at, self.reference_files[ref.reference])
+            destination_zip.writestr(self._resolve_zip_path(ref.reference), self.reference_files[ref.reference])
 
     def add_viewpoint(self, element: entity_instance) -> VisualizationInfoHandler:
         """


### PR DESCRIPTION
Three defects in BCF topic handling, present identically in both the v2 and v3 implementations. The first loses the user's entire save, not just one field.

## 1. Saving a new topic with an attached file crashes the whole save

`_save_reference_files` and `_save_document_references` do `destination_zip.writestr(real_path.at, ...)`. That `.at` attribute belongs to `zipfile.Path`, which is what backs a topic **loaded from** an existing `.bcfzip`. A **freshly created** topic is backed by a plain `pathlib.Path`, which has no `.at`:

```
zipfile.Path has .at : True  -> 'topic/'
pathlib.Path has .at : False
```

So the common path (create a BCF, add a topic, attach a header file or a document reference, save) raises `AttributeError: 'PosixPath' object has no attribute 'at'` and **`bcfxml.save()` fails entirely**. Not one field lost, the whole save.

Reproduced through the same sequence Bonsai's own operators use. Fixed by resolving the path inside the archive from the reference string directly, which does not depend on which `Path` flavour backs the topic. The helper handles `..` segments so relative references still resolve.

## 2. An empty BIM snippet becomes a dangling reference

`b""` is falsy. The `bim_snippet` getter treated a cached `b""` as "not loaded yet" and replaced it with `None` on the next read, after which the save skipped writing the file entirely, while `markup.bcf` still named it.

The result is a BCF that references a file which is not in the archive. A zero-byte snippet is unusual but legitimate, and reachable through Bonsai's own Add BIM Snippet operator if the chosen file happens to be empty.

Fixed with `is None` in both the getter and the save, so "absent" and "present but empty" stop being the same state.

## 3. One malformed header entry blocked access to every valid one

The `reference_files` property lacked the `not ref.reference` guard that `_save_reference_files` already had, so a header entry with `is_external=False` and no `Reference` element raised while the property was still building the dictionary for **all** files. One bad entry therefore made every other embedded file in that topic unreachable.

Fixed by skipping the malformed entry, matching what the save path already does.

## Round-trip verification

A v2 topic was built with every field populated, including the awkward ones: `index=0`, an empty comment string, labels, dates, a BIM snippet, a document reference, a related topic, a header file, three ordered comments, and a viewpoint with both a bitmap and a snapshot.

**Before these fixes the save crashed outright on two of those fields. After them every field survives the round trip, including comment ordering and the zero and empty-string cases.**

All 25 existing `src/bcf/tests` pass before and after. None of them exercise these three paths.

Note the same three bugs exist in v2 and v3 as duplicated code, so each commit fixes both.

Generated with the assistance of an AI coding tool.
