### PR TITLE
api: stop classifying elements under the wrong classification system

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/classification/add_reference.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/classification/add_reference.py
@@ -21,6 +21,7 @@ from typing import Any, Optional, Union
 import ifcopenshell
 import ifcopenshell.api.owner
 import ifcopenshell.guid
+import ifcopenshell.util.classification
 import ifcopenshell.util.element
 import ifcopenshell.util.schema
 
@@ -159,7 +160,7 @@ class Usecase:
         return self.add_from_identification()
 
     def add_from_identification(self):
-        reference = self.get_existing_reference(self.settings["identification"])
+        reference = self.get_existing_reference(self.settings["identification"], self.settings["classification"])
         if not reference:
             reference = self.file.createIfcClassificationReference(
                 Name=self.settings["name"], ReferencedSource=self.settings["classification"]
@@ -178,7 +179,7 @@ class Usecase:
         else:
             identification = self.settings["reference"].Identification
 
-        reference = self.get_existing_reference(identification)
+        reference = self.get_existing_reference(identification, self.settings["classification"])
         if not reference:
             migrator = ifcopenshell.util.schema.Migrator()
 
@@ -212,14 +213,28 @@ class Usecase:
         self.update_relationships(reference)
         return reference
 
-    def get_existing_reference(self, identification: Optional[str] = None) -> Union[ifcopenshell.entity_instance, None]:
+    def get_existing_reference(
+        self,
+        identification: Optional[str] = None,
+        classification: Optional[ifcopenshell.entity_instance] = None,
+    ) -> Union[ifcopenshell.entity_instance, None]:
         for reference in self.file.by_type("IfcClassificationReference"):
             if self.file.schema == "IFC2X3":
-                if reference.ItemReference == identification:
-                    return reference
+                if reference.ItemReference != identification:
+                    continue
             else:
-                if reference.Identification == identification:
-                    return reference
+                if reference.Identification != identification:
+                    continue
+            # Matching on identification alone is not enough: two different
+            # classification systems may reuse the same identification (or
+            # both leave it unset), so scope the match to the classification
+            # being referenced to avoid reusing an unrelated reference.
+            if (
+                classification is not None
+                and ifcopenshell.util.classification.get_classification(reference) != classification
+            ):
+                continue
+            return reference
 
     def update_relationships(self, reference: ifcopenshell.entity_instance) -> None:
         root_rel, non_root_rel = None, None

--- a/src/ifcopenshell-python/ifcopenshell/api/unit/add_conversion_based_unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/unit/add_conversion_based_unit.py
@@ -72,7 +72,7 @@ def add_conversion_based_unit(
     value_component = file.create_entity("IfcReal", **{"wrappedValue": conversion_real})
     conversion_factor = file.createIfcMeasureWithUnit(value_component, si_unit)
 
-    if not conversion_offset:
+    if conversion_offset is None:
         conversion_offset = ifcopenshell.util.unit.si_offsets.get(name, 0)
 
     if conversion_offset:

--- a/src/ifcopenshell-python/test/api/classification/test_add_reference.py
+++ b/src/ifcopenshell-python/test/api/classification/test_add_reference.py
@@ -93,6 +93,44 @@ class TestAddReference(test.bootstrap.IFC4):
         )
         assert len(rel.RelatedObjects) == 2
 
+    def test_adding_a_reference_does_not_reuse_a_reference_from_another_classification(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        classification1 = ifcopenshell.api.classification.add_classification(self.file, classification="Uniclass")
+        classification2 = ifcopenshell.api.classification.add_classification(self.file, classification="MyCustom")
+
+        # Same identification, different classification systems: must not be merged.
+        reference1 = ifcopenshell.api.classification.add_reference(
+            self.file,
+            products=[element],
+            identification="X",
+            name="Foo",
+            classification=classification1,
+        )
+        reference2 = ifcopenshell.api.classification.add_reference(
+            self.file,
+            products=[element2],
+            identification="X",
+            name="Bar",
+            classification=classification2,
+        )
+        assert reference1 != reference2
+        assert reference2.Name == "Bar"
+        assert reference2.ReferencedSource == classification2
+
+        # No identification at all also must not collide across classifications.
+        element3 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        reference3 = ifcopenshell.api.classification.add_reference(
+            self.file,
+            products=[element3],
+            name="Baz",
+            classification=classification2,
+        )
+        assert reference3 != reference1
+        assert reference3.Name == "Baz"
+        assert reference3.ReferencedSource == classification2
+
     def test_adding_a_reference_to_a_resource_and_to_a_root(self):
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
         element = self.file.createIfcMaterial()

--- a/src/ifcopenshell-python/test/api/unit/test_add_conversion_based_unit.py
+++ b/src/ifcopenshell-python/test/api/unit/test_add_conversion_based_unit.py
@@ -110,6 +110,18 @@ class TestAddConversionBasedUnitIFC4(test.bootstrap.IFC4, TestAddConversionBased
         assert si_unit.Name == "KELVIN"
         assert unit.ConversionOffset == -459.67
 
+    def test_an_explicit_zero_offset_is_not_overridden_by_the_builtin_offset(self):
+        # conversion_offset=None means "use the builtin offset for this unit
+        # name if any", whereas an explicit 0.0 must be honoured as-is and
+        # not be silently replaced by fahrenheit's builtin -459.67.
+        unit = ifcopenshell.api.unit.add_conversion_based_unit(self.file, name="fahrenheit", conversion_offset=0.0)
+        assert unit.is_a("IfcConversionBasedUnit")
+        assert not unit.is_a("IfcConversionBasedUnitWithOffset")
+
+        unit = ifcopenshell.api.unit.add_conversion_based_unit(self.file, name="fahrenheit", conversion_offset=-100.0)
+        assert unit.is_a("IfcConversionBasedUnitWithOffset")
+        assert unit.ConversionOffset == -100.0
+
     def test_unknown_units_fall_back_to_userdefined(self):
         unknown_unit = ifcopenshell.api.unit.add_conversion_based_unit(self.file, name="unknown_unit")
         assert unknown_unit.UnitType == "USERDEFINED"


### PR DESCRIPTION
Two defects that write the wrong value into the model. The first misclassifies elements.

## 1. `classification/add_reference` reuses a reference from a different classification system

`get_existing_reference()` looked for an existing `IfcClassificationReference` by `Identification` alone (or `ItemReference` on IFC2X3), **with no regard for which `IfcClassification` it belongs to**. So a reference created under one classification system gets silently reused for a request against a completely different one.

Reproduced on a fresh IFC4 model with two classification systems:

```
wall1 asked for Name='Foo' under 'Uniclass'  -> got #8  Name='Foo' source='Uniclass'
wall2 asked for Name='Bar' under 'MyCustom'  -> got #8  Name='Foo' source='Uniclass'
```

The second wall is classified **under the wrong system, with a different element's name**, and this is written into the file. After the fix:

```
wall2 asked for Name='Bar' under 'MyCustom'  -> got #10 Name='Bar' source='MyCustom'
```

This is not an exotic case. It triggers whenever two systems are in use and either identifications are left unset (so every reference matches on `None`) or the same code appears in both systems, which is normal when mixing a national standard with an office one.

Fixed by scoping the match with `ifcopenshell.util.classification.get_classification(reference) == classification`. Verified on both IFC4 and IFC2X3, since the two schemas use different attribute names for the same thing.

## 2. `unit/add_conversion_based_unit` overrides an explicit zero offset

`if not conversion_offset:` could not distinguish "not specified" from an explicit `0.0`. Only `fahrenheit` carries a non-zero built-in offset (`-459.67`) in `util.unit.si_offsets`, so:

```python
add_conversion_based_unit(f, name="fahrenheit", conversion_offset=0.0)
```

silently wrote **-459.67** into the file instead of the caller's explicit `0.0`. Explicit non-zero overrides such as `-100.0` already worked and still do.

Fixed with an `is None` check, so "unset" and "explicitly zero" stop being the same state.

## Tests

New coverage for both, on IFC4 and IFC2X3 for the classification case. `test/api/classification` goes to 24 passing (22 pre-existing plus 2 new) and `test/api/unit` to 9 (8 plus 1), each confirmed failing before the change. **No existing test asserted the old behaviour**, so nothing had to be corrected.

## Noted while working, not changed

`api/classification/add_classification.py` does `self.file.by_type("IfcProject")[0]` unguarded, so it raises `IndexError` on a model with no project. That is arguably a legitimate precondition rather than a defect, and it belongs to a wider question about how the API should behave on project-less files, so it is reported rather than patched here.

Generated with the assistance of an AI coding tool.
