### PR TITLE
Bonsai: constrain properties that can write schema-invalid zero measures

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/prop.py
+++ b/src/bonsai/bonsai/bim/module/model/prop.py
@@ -864,9 +864,11 @@ class BIMWindowProperties(PropertyGroup):
         update=window_type_prop_update,
     )
     overall_height: bpy.props.FloatProperty(
-        name="Overall Height", default=0.9, subtype="DISTANCE", update=update_window
+        name="Overall Height", default=0.9, min=0.001, subtype="DISTANCE", update=update_window
     )
-    overall_width: bpy.props.FloatProperty(name="Overall Width", default=0.6, subtype="DISTANCE", update=update_window)
+    overall_width: bpy.props.FloatProperty(
+        name="Overall Width", default=0.6, min=0.001, subtype="DISTANCE", update=update_window
+    )
 
     # lining properties
     lining_depth: bpy.props.FloatProperty(
@@ -1216,14 +1218,14 @@ class BIMDoorProperties(PropertyGroup):
     overall_height: bpy.props.FloatProperty(
         name="Overall Height",
         default=2.0,
-        min=0,
+        min=0.001,
         subtype="DISTANCE",
         update=update_door,
     )
     overall_width: bpy.props.FloatProperty(
         name="Overall Width",
         default=0.9,
-        min=0,
+        min=0.001,
         subtype="DISTANCE",
         update=update_door,
     )

--- a/src/bonsai/bonsai/bim/module/resource/prop.py
+++ b/src/bonsai/bonsai/bim/module/resource/prop.py
@@ -97,7 +97,7 @@ def updateResourceUsage(self: "Resource", context: object) -> None:
 class Resource(PropertyGroup):
     name: StringProperty(name="Name", update=updateResourceName)
     ifc_definition_id: IntProperty(name="IFC Definition ID")
-    schedule_usage: FloatProperty(name="Schedule Usage", update=updateResourceUsage)
+    schedule_usage: FloatProperty(name="Schedule Usage", min=0.01, update=updateResourceUsage)
     has_children: BoolProperty(name="Has Children")
     is_expanded: BoolProperty(name="Is Expanded")
     level_index: IntProperty(name="Level Index")

--- a/src/bonsai/bonsai/bim/module/sequence/prop.py
+++ b/src/bonsai/bonsai/bim/module/sequence/prop.py
@@ -390,7 +390,7 @@ class WorkPlan(PropertyGroup):
 class TaskResource(PropertyGroup):
     name: StringProperty(name="Name", update=updateAssignedResourceName)
     ifc_definition_id: IntProperty(name="IFC Definition ID")
-    schedule_usage: FloatProperty(name="Schedule Usage", update=updateAssignedResourceUsage)
+    schedule_usage: FloatProperty(name="Schedule Usage", min=0.01, update=updateAssignedResourceUsage)
 
     if TYPE_CHECKING:
         name: str


### PR DESCRIPTION
Setting a door or window's Overall Width or Height to zero throws an unhandled traceback at the user, and the property layer allowed it.

## The crash

`IfcDoor.OverallWidth` and `OverallHeight` are `IfcPositiveLengthMeasure`, whose EXPRESS WHERE rule is `assert (self > 0.0) is not False`. **Zero is schema-invalid**, not merely unhelpful. Same for `IfcWindow`.

The door properties declared `min=0`, which permits **exactly** zero, and the window properties declared no minimum at all. Going through the real edit flow (`bim.enable_editing_door`, set the width to 0, `bim.finish_editing_door`) raises:

```
IndexError: index 1 is out of bounds for axis 0 with size 1
```

from `ifcopenshell.api.geometry.add_door_representation` inside `shape_builder.get_rectangle_coords`. The window path has the same shape and no guard at all.

Fixed by declaring `min=0.001` so Blender's RNA layer clamps before the value is ever stored, which is the approach already taken for the drawing camera's width and height in #9087. After the change the same sequence completes normally and `ifcopenshell.validate.validate(..., express_rules=True)` reports zero violations.

## Schedule Usage silently discarded the user's input

`IfcResourceTime.ScheduleUsage` is an `IfcPositiveRatioMeasure`, so zero is likewise invalid. The update callback in `resource/prop.py` correctly refuses to write a zero, but the property had no minimum, so a user could type `0`, see `0` in the interface, and have the model quietly keep its previous value with no feedback at all. The interface and the file disagreed and nothing said so.

`min=0.01` is added to both `Resource.schedule_usage` and the equivalent `TaskResource.schedule_usage` in `sequence/prop.py`, which carries the identical shape.

**The existing guards were deliberately left in place.** They are protecting the schema, and removing them would write an invalid `IfcPositiveRatioMeasure` into the file. Constraining the property is the correct layer.

## Scope

These four properties were found by enumerating the constrained measure types from `express/rules/IFC4.py` (14 of them, including `IfcNormalisedRatioMeasure` bounded 0 to 1, `IfcPHMeasure` bounded 0 to 14, and `IfcPositiveInteger`), then tracing which Bonsai properties are written into attributes of those types.

Several candidates were checked and rejected: the door and window lining and mullion properties feed the shape builder's dictionary rather than real `IfcDoorLiningProperties` entities, so no schema-invalid write is possible through them, and the lining depth and thickness properties already carry `min=0.001`.

**A wider gap was found and is deliberately not addressed here.** `bim/helper.py`'s `add_attribute_min_max`, which constrains the generic Attributes panel, sets `value_min = 0.0` for `IfcPositiveLengthMeasure` (so exactly zero still passes, though the rule is strictly greater than zero) and has no handling at all for `IfcPositiveRatioMeasure`, `IfcNormalisedRatioMeasure`, `IfcPositivePlaneAngleMeasure`, `IfcPositiveInteger` or the bounded date and pH types. That is shared runtime machinery affecting most of the 196 attributes typed with these measures, so it warrants its own change rather than being folded in here.

Generated with the assistance of an AI coding tool.
