### PR TITLE
api: fix a 1000x placement error on shared matrices, and 2D profiles written as invalid IFC

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/edit_object_placement.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/edit_object_placement.py
@@ -81,7 +81,7 @@ class Usecase:
         self.builder = ShapeBuilder(self.file)
 
         if not self.settings["is_si"]:
-            self.convert_matrix_to_si(self.settings["matrix"])
+            self.settings["matrix"] = self.convert_matrix_to_si(self.settings["matrix"])
 
         children_settings = []
         if not self.settings["should_transform_children"]:
@@ -114,10 +114,17 @@ class Usecase:
 
         return new_placement
 
-    def convert_matrix_to_si(self, matrix: NPArrayOfFloats):
+    def convert_matrix_to_si(self, matrix: NPArrayOfFloats) -> NPArrayOfFloats:
+        # Return a converted copy rather than mutating in place: callers may
+        # reuse the same matrix object across several edit_object_placement()
+        # calls (e.g. multiple elements sharing one IfcLocalPlacement), and an
+        # in-place mutation would silently apply the unit conversion twice on
+        # the second call.
+        matrix = np.array(matrix, dtype=float, copy=True)
         matrix[0][3] *= self.unit_scale
         matrix[1][3] *= self.unit_scale
         matrix[2][3] *= self.unit_scale
+        return matrix
 
     def get_placement_rel_to(self) -> Union[ifcopenshell.entity_instance, None]:
         product = self.settings["product"]

--- a/src/ifcopenshell-python/ifcopenshell/api/profile/add_arbitrary_profile_with_voids.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/profile/add_arbitrary_profile_with_voids.py
@@ -95,10 +95,18 @@ class Usecase:
                     )
                 )
         else:
-            outer_curve = self.file.create_entity(
-                "IfcIndexedPolyCurve",
-                (self.file.create_entity("IfcCartesianPointList3D", ifc_safe_vector_type(outer_points))),
-            )
+            outer_dimensions = outer_points.shape[1]
+            if outer_dimensions == 2:
+                outer_ifc_points = self.file.create_entity(
+                    "IfcCartesianPointList2D", ifc_safe_vector_type(outer_points)
+                )
+            elif outer_dimensions == 3:
+                outer_ifc_points = self.file.create_entity(
+                    "IfcCartesianPointList3D", ifc_safe_vector_type(outer_points)
+                )
+            else:
+                assert False, f"Invalid dimensions: {outer_dimensions}."
+            outer_curve = self.file.create_entity("IfcIndexedPolyCurve", outer_ifc_points)
             for inner_point in inner_points:
                 dimensions = inner_point.shape[1]
                 if dimensions == 2:

--- a/src/ifcopenshell-python/test/api/geometry/test_edit_object_placement.py
+++ b/src/ifcopenshell-python/test/api/geometry/test_edit_object_placement.py
@@ -77,6 +77,37 @@ class TestEditObjectPlacement(test.bootstrap.IFC4):
             ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement), matrix_millimeters
         )
 
+    def test_reusing_the_same_matrix_object_for_multiple_elements_does_not_double_convert_units(self):
+        # Regression test: convert_matrix_to_si used to mutate the caller's
+        # matrix object in place. Reusing that same object across a second
+        # edit_object_placement() call (e.g. multiple elements sharing one
+        # IfcLocalPlacement) applied the unit scale a second time, silently
+        # writing a corrupted placement for every element after the first.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        element1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        matrix = numpy.array(
+            (
+                (1.0, 0.0, 0.0, 1000.0),
+                (0.0, 1.0, 0.0, 2000.0),
+                (0.0, 0.0, 1.0, 3000.0),
+                (0.0, 0.0, 0.0, 1.0),
+            )
+        )
+        matrix_before = matrix.copy()
+
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=element1, matrix=matrix, is_si=False)
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=element2, matrix=matrix, is_si=False)
+
+        assert numpy.array_equal(matrix, matrix_before), "caller's matrix must not be mutated"
+        assert numpy.array_equal(
+            ifcopenshell.util.placement.get_local_placement(element1.ObjectPlacement), matrix_before
+        )
+        assert numpy.array_equal(
+            ifcopenshell.util.placement.get_local_placement(element2.ObjectPlacement), matrix_before
+        )
+
     def test_changing_an_object_placement(self):
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
         ifcopenshell.api.unit.assign_unit(self.file)

--- a/src/ifcopenshell-python/test/api/profile/test_add_arbitrary_profile_with_voids.py
+++ b/src/ifcopenshell-python/test/api/profile/test_add_arbitrary_profile_with_voids.py
@@ -1,0 +1,52 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.api.profile
+import test.bootstrap
+
+
+class TestAddArbitraryProfileWithVoidsIFC4(test.bootstrap.IFC4):
+    def test_2d_profile_uses_a_2d_point_list_for_the_outer_curve(self):
+        # Regression test for #4240: a previous fix made the inner curves
+        # respect the coordinate dimensionality, but left the outer curve
+        # hardcoded to IfcCartesianPointList3D. Passing 2D coordinates (as
+        # documented) then wrote 2-tuples into a list typed for 3-tuples,
+        # violating IfcCartesianPointList3D.CoordList, and made the profile's
+        # OuterCurve.Dim resolve to 3, violating
+        # IfcArbitraryClosedProfileDef.WR1 (outercurve.Dim == 2).
+        profile = ifcopenshell.api.profile.add_arbitrary_profile_with_voids(
+            self.file,
+            outer_profile=[(0.0, 0.0), (0.4, 0.0), (0.4, 0.4), (0.0, 0.4), (0.0, 0.0)],
+            inner_profiles=[[(0.1, 0.1), (0.3, 0.1), (0.3, 0.3), (0.1, 0.3), (0.1, 0.1)]],
+            name="Test",
+        )
+        outer_points = profile.OuterCurve.Points
+        assert outer_points.is_a("IfcCartesianPointList2D")
+        assert all(len(co) == 2 for co in outer_points.CoordList)
+        assert profile.OuterCurve.Dim == 2
+
+    def test_3d_profile_still_uses_a_3d_point_list_for_the_outer_curve(self):
+        profile = ifcopenshell.api.profile.add_arbitrary_profile_with_voids(
+            self.file,
+            outer_profile=[(0.0, 0.0, 0.0), (0.4, 0.0, 0.0), (0.4, 0.4, 0.0), (0.0, 0.4, 0.0), (0.0, 0.0, 0.0)],
+            inner_profiles=[[(0.1, 0.1, 0.0), (0.3, 0.1, 0.0), (0.3, 0.3, 0.0), (0.1, 0.3, 0.0), (0.1, 0.1, 0.0)]],
+            name="Test",
+        )
+        outer_points = profile.OuterCurve.Points
+        assert outer_points.is_a("IfcCartesianPointList3D")
+        assert all(len(co) == 3 for co in outer_points.CoordList)

--- a/src/ifcopenshell-python/test/api/spatial/test_assign_container.py
+++ b/src/ifcopenshell-python/test/api/spatial/test_assign_container.py
@@ -103,6 +103,61 @@ class TestAssignContainer(test.bootstrap.IFC4):
         assert subelement.ObjectPlacement.PlacementRelTo.PlacesObject[0] == element2
         assert numpy.array_equal(ifcopenshell.util.placement.get_local_placement(subelement.ObjectPlacement), matrix1)
 
+    def test_assigning_a_container_does_not_shift_a_sibling_sharing_the_placement(self):
+        # Regression test for #9114: IfcObjectPlacement.PlacesObject has
+        # cardinality 0:*, so several products may share one IfcLocalPlacement,
+        # and other products' placements may legitimately be expressed
+        # PlacementRelTo that shared placement. edit_object_placement()'s
+        # get_children_settings() captures a single matrix per referenced
+        # placement and reuses that same array object across every product
+        # referencing it. Reassigning the moved product's container then
+        # mutated that shared array in place while relocating the first
+        # sibling, silently corrupting the position captured for every
+        # sibling processed afterwards (e.g. an unrelated IfcWall on the
+        # same storey, sent to the origin).
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        storey1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        storey2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        moved_element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSlab")
+        sibling1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        sibling2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+
+        ifcopenshell.api.spatial.assign_container(self.file, products=[moved_element], relating_structure=storey1)
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=moved_element, is_si=False)
+        # Mimic a real (if unusual) model where a spatial structure directly
+        # reuses one of its contained element's placement, so that other
+        # elements placed relative to the storey end up relative to it too.
+        storey1.ObjectPlacement = moved_element.ObjectPlacement
+
+        ifcopenshell.api.spatial.assign_container(self.file, products=[sibling1], relating_structure=storey1)
+        sibling_matrix = numpy.array(
+            (
+                (1.0, 0.0, 0.0, 1000.0),
+                (0.0, 1.0, 0.0, 2000.0),
+                (0.0, 0.0, 1.0, 3000.0),
+                (0.0, 0.0, 0.0, 1.0),
+            )
+        )
+        ifcopenshell.api.geometry.edit_object_placement(
+            self.file, product=sibling1, matrix=sibling_matrix.copy(), is_si=False
+        )
+        # Force sibling2 to literally reuse sibling1's IfcLocalPlacement, exactly
+        # as several elements may legitimately do in a real model.
+        ifcopenshell.api.spatial.assign_container(self.file, products=[sibling2], relating_structure=storey1)
+        sibling2.ObjectPlacement = sibling1.ObjectPlacement
+
+        expected_matrix = ifcopenshell.util.placement.get_local_placement(sibling2.ObjectPlacement)
+
+        ifcopenshell.api.spatial.assign_container(self.file, products=[moved_element], relating_structure=storey2)
+
+        assert numpy.array_equal(
+            ifcopenshell.util.placement.get_local_placement(sibling1.ObjectPlacement), expected_matrix
+        ), "sibling1 must keep its global position"
+        assert numpy.array_equal(
+            ifcopenshell.util.placement.get_local_placement(sibling2.ObjectPlacement), expected_matrix
+        ), "sibling2 must keep its global position, not be moved towards the origin"
+
     def test_not_updating_placement_if_placement_is_not_relative(self):
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
         ifcopenshell.api.unit.assign_unit(self.file)


### PR DESCRIPTION
Two defects that write wrong data into the file.

## 1. A shared placement matrix is scaled twice, misplacing every element after the first

`convert_matrix_to_si()` scaled the translation column **in place**:

```python
def convert_matrix_to_si(self, matrix):
    matrix[0][3] *= self.unit_scale
    ...
```

It mutates the caller's array and returns nothing. `IfcObjectPlacement.PlacesObject` has cardinality `0:*`, so several products legitimately share one placement, and `regenerate_wall_representation.py` reuses a single `matrix` object across every element that does. The second and later calls scale an already-scaled array.

Measured on a millimetre project:

```
caller's matrix translation BEFORE any call: [1000. 2000. 3000.]
caller's matrix translation AFTER first call: [1. 2. 3.]

wall1 stored coords: (1000.0, 2000.0, 3000.0)
wall2 stored coords: (1.0, 2.0, 3.0)     <- same input matrix
```

A 1000x placement error, written into the file, from passing the same matrix twice.

**The test suite has been working around this for a long time without naming it.** `test_edit_object_placement.py` passes `matrix.copy()` in **34 places**. Every one of those copies is defending against this mutation. That is why the existing 39 tests pass and why the defect survived: the tests never exercise the contract that the API does not modify its input.

Fixed by returning a converted copy rather than mutating in place. A regression test now passes the bare array.

## 2. A 2D arbitrary profile with voids is written as invalid IFC

This is a **half-applied fix from 2024**. Commit `0ee07fb8cc` ("See #4240. Fix bug where 2D arbitrary profiles were invalid IFC (used 3D point lists not 2D)") added a dimension check so 2D input produces `IfcCartesianPointList2D`. It applied that to `inner_curves` and left `outer_curve`, **two lines above**, hardcoded:

```python
outer_curve = self.file.create_entity(
    "IfcIndexedPolyCurve",
    (self.file.create_entity("IfcCartesianPointList3D", ...)),      # always 3D
)
for inner_point in inner_points:
    dimensions = inner_point.shape[1]
    if dimensions == 2: ...                                         # correctly branched
```

So calling this with 2D coordinates, exactly as its own docstring example shows, writes 2-tuples into an `IfcCartesianPointList3D` whose `CoordList` is typed `LIST[3:3]`.

`validate(..., express_rules=True)` reports both a `CoordList` type violation and `IfcArbitraryClosedProfileDef.WR1` failing, since `outercurve.Dim` resolves to 3 where the rule requires 2.

Fixed by applying the same check the inner loop already uses. **No test covered this function at all**, which is why the half-applied fix went unnoticed; one is added covering both the 2D and 3D cases.

## Noted, not changed

`api/cogo/bearing2dd.py`'s docstring says it returns radians while it returns degrees. It has no callers yet, so nothing is written wrongly; flagged rather than fixed.

`api/cogo/add_survey_point.py` assigns `context.WorldCoordinateSystem` directly as an `ObjectPlacement`. That is already what open PR #9074 addresses, so it is not duplicated here.

Generated with the assistance of an AI coding tool.
