### PR TITLE
api: fix an orphaned boundary condition and two crashes on default input

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/drawing/assign_product.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/drawing/assign_product.py
@@ -66,6 +66,9 @@ def assign_product(
             if getattr(axis, attribute, None):
                 grid = getattr(axis, attribute)[0]
                 break
+        if grid is None:
+            # An orphaned grid axis that isn't part of any grid yet.
+            return None
         for rel in grid.ReferencedBy or []:
             if rel.Name == axis.AxisTag and related_object in rel.RelatedObjects:
                 return

--- a/src/ifcopenshell-python/ifcopenshell/api/structural/remove_structural_connection_condition.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/structural/remove_structural_connection_condition.py
@@ -32,7 +32,7 @@ def remove_structural_connection_condition(file: ifcopenshell.file, relation: if
     if relation.AppliedCondition:
         ifcopenshell.api.structural.remove_structural_boundary_condition(
             file,
-            connection=relation.RelatedStructuralConnection,
+            connection=relation,
         )
     history = relation.OwnerHistory
     file.remove(relation)

--- a/src/ifcopenshell-python/ifcopenshell/api/structural/remove_structural_load_case.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/structural/remove_structural_load_case.py
@@ -34,4 +34,5 @@ def remove_structural_load_case(file: ifcopenshell.file, load_case: ifcopenshell
             ifcopenshell.util.element.remove_deep2(file, history)
     history = load_case.OwnerHistory
     file.remove(load_case)
-    ifcopenshell.util.element.remove_deep2(file, history)
+    if history:
+        ifcopenshell.util.element.remove_deep2(file, history)

--- a/src/ifcopenshell-python/test/api/drawing/test_assign_product.py
+++ b/src/ifcopenshell-python/test/api/drawing/test_assign_product.py
@@ -49,6 +49,16 @@ class TestAssignProduct(test.bootstrap.IFC4):
         ifcopenshell.api.drawing.assign_product(self.file, relating_product=axis, related_object=line)
         assert len(self.file.by_type("IfcRelAssignsToProduct")) == 1
 
+    def test_assigning_a_grid_axis_not_part_of_any_grid_does_not_crash(self):
+        # An orphaned IfcGridAxis (e.g. from a malformed or third party
+        # authored file) has no PartOfU/PartOfV/PartOfW, so there is no grid
+        # to assign the product to.
+        axis = self.file.createIfcGridAxis(AxisTag="A")
+        line = self.file.createIfcAnnotation()
+        result = ifcopenshell.api.drawing.assign_product(self.file, relating_product=axis, related_object=line)
+        assert result is None
+        assert len(self.file.by_type("IfcRelAssignsToProduct")) == 0
+
 
 class TestAssignProductIFC2X3(test.bootstrap.IFC2X3, TestAssignProduct):
     pass

--- a/src/ifcopenshell-python/test/api/structural/test_remove_structural_connection_condition.py
+++ b/src/ifcopenshell-python/test/api/structural/test_remove_structural_connection_condition.py
@@ -1,0 +1,47 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.root
+import ifcopenshell.api.structural
+import test.bootstrap
+
+
+class TestRemoveStructuralConnectionCondition(test.bootstrap.IFC4):
+    def test_removing_a_connection_condition_also_purges_the_boundary_condition(self):
+        member = ifcopenshell.api.root.create_entity(
+            self.file, ifc_class="IfcStructuralCurveMember", predefined_type="RIGID_JOINED_MEMBER"
+        )
+        connection = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcStructuralPointConnection")
+        rel = ifcopenshell.api.structural.add_structural_member_connection(
+            self.file, relating_structural_member=member, related_structural_connection=connection
+        )
+        ifcopenshell.api.structural.add_structural_boundary_condition(self.file, connection=rel)
+        assert len(self.file.by_type("IfcBoundaryCondition")) == 1
+
+        ifcopenshell.api.structural.remove_structural_connection_condition(self.file, relation=rel)
+
+        assert len(self.file.by_type("IfcRelConnectsStructuralMember")) == 0
+        # The boundary condition was assigned to the relation (not the bare
+        # connection), so it must be purged along with the relation instead
+        # of being left as an orphan with no inverses.
+        assert len(self.file.by_type("IfcBoundaryCondition")) == 0
+
+
+class TestRemoveStructuralConnectionConditionIFC2X3(test.bootstrap.IFC2X3, TestRemoveStructuralConnectionCondition):
+    pass

--- a/src/ifcopenshell-python/test/api/structural/test_remove_structural_load_case.py
+++ b/src/ifcopenshell-python/test/api/structural/test_remove_structural_load_case.py
@@ -1,0 +1,33 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.structural
+import test.bootstrap
+
+
+class TestRemoveStructuralLoadCase(test.bootstrap.IFC4):
+    # IfcStructuralLoadCase does not exist in IFC2X3, so add_structural_load_case
+    # (and therefore this test) is IFC4+ only.
+    def test_removing_a_structural_load_case_without_owner_history(self):
+        # OwnerHistory is not set by add_structural_load_case, so it is None
+        # by default. Removal must not crash on that common case.
+        load_case = ifcopenshell.api.structural.add_structural_load_case(self.file, name="LC1")
+        assert load_case.OwnerHistory is None
+        ifcopenshell.api.structural.remove_structural_load_case(self.file, load_case=load_case)
+        assert len(self.file.by_type("IfcStructuralLoadCase")) == 0


### PR DESCRIPTION
Three defects in the structural and drawing APIs. Two are crashes on ordinary input; one silently leaves an orphaned entity in the file.

## 1. Removing a connection condition orphans the boundary condition

`remove_structural_connection_condition` checks one entity and then removes from a different one:

```python
if relation.AppliedCondition:                              # the relation's condition
    remove_structural_boundary_condition(
        file,
        connection=relation.RelatedStructuralConnection,    # a different entity
    )
```

`add_structural_boundary_condition` stores the condition on the **relation** (`connection.AppliedCondition = condition`), and both `IfcRelConnectsStructuralMember` and `IfcStructuralConnection` legitimately have their own `AppliedCondition`. So the condition it detects is never the one it removes.

Measured:

```
after add   : IfcBoundaryCondition count = 1
              rel.AppliedCondition = #4=IfcBoundaryNodeCondition(...)
after remove: IfcBoundaryCondition count = 1
   ORPHANED: #4=IfcBoundaryNodeCondition(...) inverses: 0
```

The removal reports success and the entity stays in the file with no inverses, so **it is written into the saved model** as an orphan.

## 2. Removing a load case crashes when it has no OwnerHistory

`remove_structural_load_case` calls `remove_deep2` on `OwnerHistory` without checking it exists:

```
AttributeError: 'NoneType' object has no attribute 'wrapped_data'
```

`add_structural_load_case` never sets an owner history, so **the default case crashes**. Five sibling functions in the same module already guard this: `remove_structural_analysis_model`, `remove_structural_load_group`, `remove_actor`, `unassign_actor` and others. This one was the holdout.

## 3. Assigning a drawing product crashes on an orphaned grid axis

`drawing/assign_product.py` leaves `grid` as `None` when an `IfcGridAxis` has empty `PartOfU`, `PartOfV` and `PartOfW`, then dereferences `grid.ReferencedBy`.

Its sibling `unassign_product.py` already tolerates exactly this: it assigns `relating_product = grid` and the loop simply matches nothing. The assign side now behaves the same way.

This is an edge case rather than a common path. `ifcopenshell.api.grid.create_grid_axis` always attaches the parent atomically, so it needs a malformed or imported file to reach. Reported as such rather than overstated.

## Tests

`remove_structural_load_case` and `remove_structural_connection_condition` had **no test coverage at all**, which is why both survived. New tests for each, plus an orphan-axis case added to `test_assign_product.py`. All four modules together: 172 passing, no regressions.

## Flagged for a maintainer, not fixed

`add_structural_load_case` creates a bare `IfcStructuralLoadCase`, which **does not exist in IFC2X3** (confirmed by schema lookup: `RuntimeError: Entity with name 'IfcStructuralLoadCase' not found in schema 'IFC2X3'`). IFC2X3 expresses the same concept as `IfcStructuralLoadGroup` with `PredefinedType=LOAD_CASE`. That is a schema-mapping decision rather than a bug in this pass's scope, so it is raised rather than guessed at.

Generated with the assistance of an AI coding tool.
