### PR TITLE
util.element: fix KeyError in get_quantities(verbose=True), the twin of a fix already applied to get_properties

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/element.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/element.py
@@ -370,7 +370,7 @@ def get_quantities(
             if verbose:
                 results[quantity_name] = {
                     "id": data["id"],
-                    "class": data["class"],
+                    "class": data["type"],
                     "value": results[quantity_name],
                 }
     return results

--- a/src/ifcopenshell-python/test/util/test_element.py
+++ b/src/ifcopenshell-python/test/util/test_element.py
@@ -279,6 +279,39 @@ class TestGetQuantitiesIFC4(test.bootstrap.IFC4):
         ifcopenshell.api.pset.edit_qto(self.file, qto=qto, properties={"x": 42})
         assert subject.get_quantities(qto.Quantities) == {"x": 42}
 
+    def test_getting_complex_quantities_verbose(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        qto = ifcopenshell.api.pset.add_qto(self.file, product=element, name="qto")
+        sub_quantity = self.file.create_entity("IfcQuantityLength", Name="sub", LengthValue=1.0)
+        complex_quantity = self.file.create_entity(
+            "IfcPhysicalComplexQuantity",
+            Name="complex",
+            Discrimination="usage",
+            HasQuantities=[sub_quantity],
+        )
+        qto.Quantities = [complex_quantity]
+        quantities = subject.get_quantities(qto.Quantities, verbose=True)
+        quantity_value = quantities["complex"]["value"]
+        nested_quantity = quantity_value["properties"]["sub"]
+        assert quantities == {
+            "complex": {
+                "id": complex_quantity.id(),
+                "class": "IfcPhysicalComplexQuantity",
+                "value": {
+                    "Discrimination": "usage",
+                    "id": complex_quantity.id(),
+                    "type": "IfcPhysicalComplexQuantity",
+                    "properties": {
+                        "sub": {
+                            "id": nested_quantity["id"],
+                            "class": "IfcQuantityLength",
+                            "value": 1.0,
+                        }
+                    },
+                },
+            }
+        }
+
 
 class TestGetPropertiesIFC4(test.bootstrap.IFC4):
     def test_getting_no_properties_when_none_are_available(self):


### PR DESCRIPTION
`get_quantities(..., verbose=True)` raises `KeyError: 'class'` on any element quantity set containing a nested `IfcPhysicalComplexQuantity`.

At `util/element.py:373`:

```python
"class": data["class"],
```

but `data` comes from `quantity.get_info()`, which never has a `class` key:

```
get_info() keys: ['Description', 'Discrimination', 'HasQuantities', 'Name', 'Quality', 'Usage', 'id', 'type']
has 'class'? False   |   has 'type'? True
```

## This is the same bug its sibling already had fixed

`get_properties()` in the same file does the correct thing in three places (lines 474, 483 and 492):

```python
"class": data["type"],
```

Both faults were introduced together in `b77df1892`. The `get_properties` instance was fixed by @Andrej730 in `a3efa7e9ee`, *"util.element - fix IfcComplexProperty KeyError when verbose=True (#7921)"*. **The `get_quantities` twin was never touched.**

The regression test added alongside that fix, `test_getting_complex_properties_verbose`, likewise has no quantities equivalent, which is exactly why this survived.

## Effect

A crash on a read path, so nothing is corrupted, but `get_property_definition(pset, verbose=True)` is called from `bonsai/tool/pset.py`, so **the pset editing panel fails to open** for any element carrying a complex quantity.

```
before: KeyError: 'class'
after:  {'Complex': {'id': 4, 'class': 'IfcPhysicalComplexQuantity', 'value': {...}}}
```

Adds `test_getting_complex_quantities_verbose`, mirroring the properties test that already existed. Confirmed failing before and passing after; `test_element.py` is green at 156.

## Wider result from the same sweep

This came out of a hunt for one archetype: a correct pattern applied at one site and missed at its neighbour. Worth recording that the same sweep checked the **`remove_deep2` owner-history guard across 89 call sites in about 65 files and found no remaining gaps**, so that particular family is now exhausted rather than merely unexamined. The `assign`/`unassign` pairs in `aggregate` and `spatial`, and `remove_layer` versus `remove_constituent`, were also compared and are correctly symmetric.

Generated with the assistance of an AI coding tool.
