### PR TITLE
Bonsai: constrain the generic Attributes panel to schema-valid numeric ranges

### DIFF
--- a/src/bonsai/bonsai/bim/helper.py
+++ b/src/bonsai/bonsai/bim/helper.py
@@ -272,6 +272,23 @@ def import_attribute(
 
 ATTRIBUTE_MIN_MAX_CONSTRAINTS = {"IfcMaterialLayer": {"Priority": {"value_min": 0, "value_max": 100}}}
 
+# `Attribute.value_min`/`value_max` (bim/prop.py) are an inclusive clamp applied by
+# `set_numerical_value()` every time `int_value`/`float_value` is written (typed in the UI,
+# dragged on a slider, or set from Python), not a Blender RNA `min=`/`max=` kwarg. An inclusive
+# clamp cannot express a strict "self > 0.0" EXPRESS WHERE rule exactly: `value_min = 0.0` still
+# lets 0.0 through. Bonsai already accepts this same limitation for dedicated dimension properties
+# by using a small epsilon as the practical minimum instead (PR #9087: `min=0.01` for the drawing
+# camera's width/height; PR #9123: `min=0.001` for IfcDoor/IfcWindow overall dimensions). This
+# constant reuses that approach for the generic Attributes panel, which serves many different
+# measure types (length, plane angle, ratio, heating value) reused across ~196 attributes, so it
+# is deliberately smaller than either of those two dimension-specific values: 1e-4 sits a full
+# order of magnitude above Bonsai's own default model geometric precision of 1e-5 (see
+# `get_length_decimal_places()`/#3129), so a value clamped up to this epsilon will not round back
+# down to the schema-invalid 0.0 on export, while still being negligible for every unit this is
+# applied to. It is an approximation of "> 0.0", not an exact expression of it; excluding the
+# always-invalid 0.0 is the improvement being made here.
+STRICTLY_POSITIVE_FLOAT_MIN = 1e-4
+
 
 def add_attribute_min_max(attribute: W.attribute, attribute_blender: bonsai.bim.prop.Attribute) -> None:
     if attribute_blender.ifc_class in ATTRIBUTE_MIN_MAX_CONSTRAINTS:
@@ -281,9 +298,66 @@ def add_attribute_min_max(attribute: W.attribute, attribute_blender: bonsai.bim.
             setattr(attribute_blender, constraint + "_constraint", True)
     attribute_type = attribute.type_of_attribute()
 
-    if attribute_type._is("IfcPositiveLengthMeasure") or attribute_type._is("IfcNonNegativeLengthMeasure"):
-        attribute_blender.value_min = 0.0
+    def set_min(value: float) -> None:
+        attribute_blender.value_min = value
         attribute_blender.value_min_constraint = True
+
+    def set_max(value: float) -> None:
+        attribute_blender.value_max = value
+        attribute_blender.value_max_constraint = True
+
+    # Types below are every measure/simple type in IFC4's express/rules that constrains a plain
+    # numeric value (WR1-style rules on REAL/INTEGER base types), re-derived directly from
+    # `ifcopenshell/express/rules/IFC4.py`. Select types, aggregates and enumerations are out of
+    # scope: aggregates never reach this function (`import_attribute` returns before calling it),
+    # and enumerations/booleans have no numeric bound to enforce.
+    #
+    # `self >= 0.0` -> exact with an inclusive min, no approximation needed.
+    if attribute_type._is("IfcNonNegativeLengthMeasure"):
+        set_min(0.0)
+    # `self > 0.0` (float) -> cannot be expressed exactly by an inclusive clamp; see
+    # STRICTLY_POSITIVE_FLOAT_MIN above.
+    elif attribute_type._is("IfcPositiveLengthMeasure"):
+        set_min(STRICTLY_POSITIVE_FLOAT_MIN)
+    elif attribute_type._is("IfcPositiveRatioMeasure"):
+        set_min(STRICTLY_POSITIVE_FLOAT_MIN)
+    elif attribute_type._is("IfcPositivePlaneAngleMeasure"):
+        set_min(STRICTLY_POSITIVE_FLOAT_MIN)
+    elif attribute_type._is("IfcHeatingValueMeasure"):
+        # Only reachable on IFC2X3 (IfcFuelProperties.Lower/HigherHeatingValue); IFC4 and
+        # IFC4X3 drop the entities that carry it, but Bonsai still supports authoring IFC2X3.
+        set_min(STRICTLY_POSITIVE_FLOAT_MIN)
+    # `0.0 <= self <= 1.0` -> both bounds inclusive, exact.
+    elif attribute_type._is("IfcNormalisedRatioMeasure"):
+        set_min(0.0)
+        set_max(1.0)
+    # `0.0 <= self <= 14.0` -> exact.
+    elif attribute_type._is("IfcPHMeasure"):
+        # Only reachable on IFC2X3 (IfcWaterProperties.PHLevel).
+        set_min(0.0)
+        set_max(14.0)
+    # Integer types: `self > 0` on an integer is exactly `self >= 1`, no approximation needed.
+    elif attribute_type._is("IfcCardinalPointReference"):
+        set_min(1)
+    # `0 < self <= 3` on an integer is exactly `1 <= self <= 3`.
+    elif attribute_type._is("IfcDimensionCount"):
+        set_min(1)
+        set_max(3)
+    # `1 <= self <= 31/12` -> exact.
+    elif attribute_type._is("IfcDayInMonthNumber"):
+        # Only reachable on IFC2X3 (IfcCalendarDate.DayComponent).
+        set_min(1)
+        set_max(31)
+    elif attribute_type._is("IfcMonthInYearNumber"):
+        # Only reachable on IFC2X3 (IfcCalendarDate.MonthComponent).
+        set_min(1)
+        set_max(12)
+    # IfcSpecularRoughness, IfcPositiveInteger and IfcDayInWeekNumber are also WR1-constrained
+    # simple types, but no entity in IFC2X3, IFC4 or IFC4X3 (the three schemas Bonsai supports,
+    # see `IfcStore.schema_identifiers`) exposes any of them as a direct attribute type, checked
+    # by enumerating every entity's attributes in all three schemas. This function is only ever
+    # called for a real entity attribute (`import_attribute` returns before calling it for
+    # aggregates/entities), so a branch for them here would be dead code. Not added.
 
 
 def add_attribute_enum_items_descriptions(


### PR DESCRIPTION
The generic Attributes panel lets users store values that violate EXPRESS WHERE rules. `add_attribute_min_max` previously constrained only two measure types, and got one of those two wrong:

```python
if attribute_type._is("IfcPositiveLengthMeasure") or attribute_type._is("IfcNonNegativeLengthMeasure"):
    attribute_blender.value_min = 0.0
```

`IfcNonNegativeLengthMeasure` is `self >= 0.0`, so a minimum of zero is exactly right. **`IfcPositiveLengthMeasure` is `self > 0.0`, so this permits the one value the rule forbids.** Everything else got no constraint at all.

Measured before the change, setting `IfcCircleProfileDef.Radius` to `0.0` through the real import and export path:

```
Rule IfcPositiveLengthMeasure.WR1:
    (self > 0.0)
Violated by:
    (0.0 > 0.0)
```

After it, the same attempt clamps and `validate(..., express_rules=True)` returns no violations.

## How the constraint actually works, since it changes the fix

`value_min` is **not** a Blender RNA `min=` kwarg. It is a custom setter in `bim/prop.py`:

```python
def set_numerical_value(self, value_name, new_value):
    if self.value_min_constraint and new_value < self.value_min:
        new_value = self.value_min
    ...
```

That clamps **inclusively on every write**, and `export_attributes` reads the already-clamped value, so whatever it permits reaches the IFC file. Being inclusive, it cannot express a strict `> 0.0` exactly.

## What is exact and what is approximate, stated plainly

**Exact**, because the rule is inclusive: `IfcNonNegativeLengthMeasure` (unchanged at 0.0), `IfcNormalisedRatioMeasure` (0 to 1), `IfcPHMeasure` (0 to 14), `IfcCardinalPointReference` (min 1), `IfcDimensionCount` (1 to 3), `IfcDayInMonthNumber` (1 to 31), `IfcMonthInYearNumber` (1 to 12).

**Approximate**, because `> 0.0` cannot be expressed by an inclusive clamp: `IfcPositiveLengthMeasure`, `IfcPositiveRatioMeasure`, `IfcPositivePlaneAngleMeasure`, `IfcHeatingValueMeasure`. These use a shared epsilon of `1e-4`.

The epsilon is deliberately smaller than the dimension-specific precedents already in the codebase (`min=0.01` for the drawing camera in #9087, `min=0.001` for door and window overall dimensions in #9123), because this function serves many unit types at once. It sits an order of magnitude above Bonsai's default geometric precision of `1e-5`, so a clamped value will not round back down to zero on export. The reasoning is documented in the code rather than left as a bare literal.

**This is an approximation of the rule, not an expression of it.** Excluding the always-invalid zero is the improvement; a user can still type a value smaller than the epsilon intends to allow.

## Deliberately not added

`IfcSpecularRoughness`, `IfcPositiveInteger` and `IfcDayInWeekNumber` are constrained types, but enumerating every entity attribute across IFC2X3, IFC4 and IFC4X3_ADD2 found **none used as a direct attribute type**, so a branch for them would be dead code. Not checked for IFC4X1 or IFC4X2, which Bonsai's New Project dialog does not offer.

## Scope note

The existing `ATTRIBUTE_MIN_MAX_CONSTRAINTS` table and the `IfcNonNegativeLengthMeasure` behaviour are untouched. This is the follow-up that #9123 explicitly scoped out as needing its own change.

Our open #8278 adds a function immediately after this one and uses its trailing lines as diff context, so whichever merges second needs a re-anchor. There is no semantic clash.

Generated with the assistance of an AI coding tool.
