### PR TITLE
Bonsai: stop showing a legitimate zero cost-item quantity as 1

### DIFF
--- a/src/bonsai/bonsai/tool/cost.py
+++ b/src/bonsai/bonsai/tool/cost.py
@@ -948,7 +948,7 @@ class Cost(bonsai.core.tool.Cost):
                 new.name = cost_item.Name or "Unnamed"
                 new.ifc_definition_id = cost_item.id()
                 quantity, unit = cls.calculate_parametric_quantity(cost_item, product)
-                new.total_quantity = quantity or 1
+                new.total_quantity = quantity or 0
                 new.unit_symbol = unit or ""
                 new.total_cost_quantity = ifcopenshell.util.cost.get_total_quantity(cost_item)
 

--- a/src/bonsai/test/tool/test_cost.py
+++ b/src/bonsai/test/tool/test_cost.py
@@ -17,7 +17,12 @@
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import bpy
+import ifcopenshell
 import ifcopenshell.api.cost
+import ifcopenshell.api.pset
+import ifcopenshell.api.root
+import ifcopenshell.api.unit
 
 import bonsai.core.tool
 import bonsai.tool as tool
@@ -43,3 +48,25 @@ class TestDisableEditingCostItemParent(NewFile):
         subject.disable_editing_cost_item_parent()
         assert props.active_cost_item_id == 0
         assert props.change_cost_item_parent is not False
+
+
+class TestLoadProductCostItems(NewFile):
+    def test_a_legitimate_zero_quantity_is_not_shown_as_one(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="My Project")
+        ifcopenshell.api.unit.assign_unit(ifc)
+        wall = ifc.createIfcWall()
+        wall_obj = bpy.data.objects.new("Object", bpy.data.meshes.new("Mesh"))
+        tool.Ifc.link(wall, wall_obj)
+        product = tool.Ifc.get_entity(wall_obj)
+
+        schedule = ifcopenshell.api.cost.add_cost_schedule(ifc)
+        item = ifcopenshell.api.cost.add_cost_item(ifc, cost_schedule=schedule)
+        qto = ifcopenshell.api.pset.add_qto(ifc, product=wall, name="Qto_WallBaseQuantities")
+        # A wall fully covered by openings can legitimately have a NetArea of 0.
+        ifcopenshell.api.pset.edit_qto(ifc, qto=qto, properties={"NetArea": 0.0})
+        ifcopenshell.api.cost.assign_cost_item_quantity(ifc, cost_item=item, products=[wall], prop_name="NetArea")
+
+        subject.load_product_cost_items(product)
+        assert tool.Cost.get_cost_props().product_cost_items[0].total_quantity == 0


### PR DESCRIPTION
tool.Cost.load_product_cost_items() fell back to `quantity or 1`
when populating the "assigned cost items" list for a selected
product. A product whose quantity assigned to a cost item is
genuinely 0 (e.g. a wall with 0 net area once fully covered by
openings) was displayed as 1 instead, misrepresenting the cost
basis in the UI.

The sibling function load_cost_item_quantity_assignments(), which
computes the same value from the opposite direction (cost item to
product), already used `total_quantity or 0`, a no-op fallback that
preserves 0. Match it.

Display-only: props.product_cost_items is a transient UI list, not
written back into the IFC file.

Generated with the assistance of an AI coding tool.
