### PR TITLE
ifcopenshell.template: fix timestring ignoring an explicit timestamp of 0

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/template.py
+++ b/src/ifcopenshell-python/ifcopenshell/template.py
@@ -64,7 +64,10 @@ DEFAULTS = {
     "project_globalid": lambda d: compress(uuid.uuid4().hex),
     "schema_identifier": lambda d: "IFC4",
     "timestamp": lambda d: int(time.time()),
-    "timestring": lambda d: time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(d.get("timestamp") or time.time())),
+    "timestring": lambda d: time.strftime(
+        "%Y-%m-%dT%H:%M:%S",
+        time.gmtime(d["timestamp"] if d.get("timestamp") is not None else time.time()),
+    ),
     "mvd": lambda d: (
         "ReferenceView_V1.2"
         if d.get("schema_identifier") == "IFC4"


### PR DESCRIPTION
create(timestamp=0) computed the FILE_NAME timestring with
`d.get("timestamp") or time.time()`, which treats 0 (a legitimate
epoch timestamp) as unset because 0 is falsy. The header ended up
with the current wall-clock time in FILE_NAME while IFCOWNERHISTORY
correctly stored CreationDate=0, an inconsistent pair of dates in
the same file. Switched to an explicit None check so an explicit
timestamp of 0 is honoured the same way any other explicit
timestamp is.

Generated with the assistance of an AI coding tool.
