### PR TITLE
Bonsai: correct two twin-function inconsistencies in tool/

### DIFF
--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -2161,7 +2161,7 @@ class Blender(bonsai.core.tool.Blender):
     @classmethod
     def get_data_dir_paths(cls, relative_dir_path: Union[str, Path], glob_pattern: str) -> Generator[Path, None, None]:
         """Return paths based on glob pattern from the provided path in data folder.
-        Return paths from internal data folder first and then paths from the user data folder (if it exists)."""
+        Return paths from the user data folder first (if it exists), then paths from the internal data folder."""
         custom_path = cls.get_user_data_dir() / relative_dir_path
         if custom_path.is_dir():
             for filepath in custom_path.glob(glob_pattern):

--- a/src/bonsai/bonsai/tool/resource.py
+++ b/src/bonsai/bonsai/tool/resource.py
@@ -341,7 +341,7 @@ class Resource(bonsai.core.tool.Resource):
         start = time.time()
         csv2ifc = Ifc2Csv(file_path, tool.Ifc.get())
         csv2ifc.execute()
-        print("Importing Resources CSV finished in {:.2f} seconds".format(time.time() - start))
+        print("Exporting Resources CSV finished in {:.2f} seconds".format(time.time() - start))
 
     @classmethod
     def get_highlighted_resource(cls) -> Union[ifcopenshell.entity_instance, None]:


### PR DESCRIPTION
Two twin-function inconsistencies in `tool/`, both documentation or message only, no behaviour change.

**`get_data_dir_paths` documents the opposite of what it does.** Its docstring says paths come from the internal data folder first and then the user folder. The code yields the **user** folder first (`custom_path`), then the internal one. Its singular twin `get_data_dir_path` describes the precedence correctly ("If this path exists in user folder, it takes the precedence"), so the plural one is the outlier.

**`export_resources` reports the wrong operation.** It prints `"Importing Resources CSV finished"`, copy-pasted from `import_resources` directly above it, while constructing `Ifc2Csv`. It is exporting.

Both were found by a sweep for one archetype: a correct pattern applied at one site and missed at its immediate neighbour. Singular-versus-plural and import-versus-export twins turned out to be the richest shape for it.

Generated with the assistance of an AI coding tool.
