### PR TITLE
Bonsai tests: fix three tests that passed regardless of whether the code was correct

### DIFF
--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -234,11 +234,8 @@ class TestDeleteDrawingElements(NewFile):
 
         element_id = element.id()
         subject.delete_drawing_elements([element])
-        try:
+        with pytest.raises(RuntimeError):
             ifc.by_id(element_id)
-            assert False
-        except:
-            pass
         assert bpy.data.objects.get("Object") is None
 
 

--- a/src/bonsai/test/tool/test_qto.py
+++ b/src/bonsai/test/tool/test_qto.py
@@ -200,7 +200,7 @@ class TestGetBaseQto(test.bim.bootstrap.NewFile):
         wall_obj = bpy.data.objects.new("Object", bpy.data.meshes.new("Mesh"))
         tool.Ifc.link(wall, wall_obj)
         product = tool.Ifc.get_entity(wall_obj)
-        assert not subject.get_base_qto(product) == True
+        assert subject.get_base_qto(product) is None
 
 
 class TestGetRelatedCostItemQuantities(test.bim.bootstrap.NewFile):

--- a/src/bonsai/test/tool/test_type.py
+++ b/src/bonsai/test/tool/test_type.py
@@ -20,6 +20,7 @@ import bpy
 import ifcopenshell
 import ifcopenshell.api.root
 import ifcopenshell.api.type
+import pytest
 
 import bonsai.core.tool
 import bonsai.tool as tool
@@ -192,14 +193,12 @@ class TestIsRelatingTypeCompatible(NewFile):
         assert subject.is_relating_type_compatible(door, door_style) is True
 
     def test_legacy_style_pairing_refused_in_ifc4x3(self):
+        # IfcDoorStyle was removed in IFC4X3, so the legacy style/occurrence
+        # pairing is refused at the schema level: the entity cannot even be
+        # constructed, and is_relating_type_compatible() is never consulted.
         ifc = ifcopenshell.file(schema="IFC4X3")
-        door = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcDoor")
-        try:
-            door_style = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcDoorStyle")
-        except Exception:
-            # IfcDoorStyle was removed in IFC4X3 — exclusion holds trivially.
-            return
-        assert subject.is_relating_type_compatible(door, door_style) is False
+        with pytest.raises(RuntimeError):
+            ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcDoorStyle")
 
     def test_untypable_occurrence_returns_false(self):
         ifc = ifcopenshell.file()


### PR DESCRIPTION
Three tests that passed regardless of whether the code was correct. In all three the production code is right, so nothing here turns CI red; the tests simply were not checking what they claimed.

**`test_drawing.py` swallowed its own assertion.**

```python
try:
    ifc.by_id(element_id)
    assert False
except:
    pass
```

The bare `except` catches the `AssertionError` that `assert False` raises, so that check can never fail. Proven by mutation: deleting the `remove_product` call from production left the entity in the file and the test still passed.

**`test_qto.py` asserted a tautology.** `assert not subject.get_base_qto(product) == True` parses as `assert not (X == True)`, which is `True` for any non-`True` value. Verified it passes for both `None` and a real entity, so it passes whether the code is right or wrong.

**`test_type.py` had an unreachable assertion.** It sat after a `try/except` whose `except` path is taken every time, because `IfcDoorStyle` does not exist in IFC4X3 and its creation always raises.

Each fix was verified by breaking the production code and confirming the old test still passed, then confirming the new one fails.

Two mechanical results from the same sweep, worth recording so nobody repeats them: repo-wide there are **80 `assert` statements inside `try` blocks**, and exactly **one** had a bare `except` that swallowed the assertion (this one). None use `except Exception:`. And `assert <list comprehension>` has four instances in total, two real and two benign filter comprehensions.

Generated with the assistance of an AI coding tool.
