### PR TITLE
Bonsai: add missing poll() to six operators that throw on first use

### DIFF
--- a/src/bonsai/bonsai/bim/module/covetool/operator.py
+++ b/src/bonsai/bonsai/bim/module/covetool/operator.py
@@ -55,6 +55,13 @@ class RunSimpleAnalysis(bpy.types.Operator):
     bl_idname = "bim.covetool_run_simple_analysis"
     bl_label = "Run Simple Analysis"
 
+    @classmethod
+    def poll(cls, context):
+        if not tool.Blender.get_covetool_props().projects:
+            cls.poll_message_set("Login to cove.tool and select a project first.")
+            return False
+        return True
+
     def execute(self, context):
         props = tool.Blender.get_covetool_props()
         simple_analysis = props.simple_analysis
@@ -91,6 +98,13 @@ class RunSimpleAnalysis(bpy.types.Operator):
 class RunAnalysis(bpy.types.Operator):
     bl_idname = "bim.covetool_run_analysis"
     bl_label = "Run Analysis"
+
+    @classmethod
+    def poll(cls, context):
+        if not tool.Blender.get_covetool_props().projects:
+            cls.poll_message_set("Login to cove.tool and select a project first.")
+            return False
+        return True
 
     def execute(self, context):
         props = tool.Blender.get_covetool_props()

--- a/src/bonsai/bonsai/bim/module/diff/operator.py
+++ b/src/bonsai/bonsai/bim/module/diff/operator.py
@@ -18,6 +18,7 @@
 
 import json
 import logging
+import os
 
 import bpy
 import ifcdiff
@@ -48,6 +49,14 @@ class VisualiseDiff(bpy.types.Operator):
     bl_idname = "bim.visualise_diff"
     bl_label = "Visualise Diff"
     bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context):
+        diff_json_file = tool.Blender.get_diff_props().diff_json_file
+        if not diff_json_file or not os.path.exists(diff_json_file):
+            cls.poll_message_set("Select an existing diff JSON file first.")
+            return False
+        return True
 
     def execute(self, context):
         ifc_file = tool.Ifc.get()
@@ -227,6 +236,14 @@ class SelectDiffObjects(bpy.types.Operator):
     bl_label = "Select Diff Objects"
     bl_options = {"REGISTER", "UNDO"}
     mode: bpy.props.StringProperty()
+
+    @classmethod
+    def poll(cls, context):
+        diff_json_file = tool.Blender.get_diff_props().diff_json_file
+        if not diff_json_file or not os.path.exists(diff_json_file):
+            cls.poll_message_set("Select an existing diff JSON file first.")
+            return False
+        return True
 
     def execute(self, context):
         ifc_file = tool.Ifc.get()

--- a/src/bonsai/bonsai/bim/module/gis/operator.py
+++ b/src/bonsai/bonsai/bim/module/gis/operator.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 import bpy
 from bpy.types import Operator
 
@@ -24,6 +26,14 @@ class BIM_OT_cityjson2ifc(Operator):
     bl_idname = "bim.convert_cityjson2ifc"
     bl_label = "Convert CityJSON to IFC"
     bl_context = "scene"
+
+    @classmethod
+    def poll(cls, context):
+        input_path = context.scene.ifccityjson_properties.input
+        if not input_path or not os.path.exists(input_path):
+            cls.poll_message_set("Select an existing CityJSON input file first.")
+            return False
+        return True
 
     def execute(self, context):
         from cjio import cityjson
@@ -51,6 +61,14 @@ class BIM_OT_find_cityjson_lod(Operator):
     bl_idname = "bim.find_cityjson_lod"
     bl_label = "Find LODs in CityJSON File"
     bl_context = "scene"
+
+    @classmethod
+    def poll(cls, context):
+        input_path = context.scene.ifccityjson_properties.input
+        if not input_path or not os.path.exists(input_path):
+            cls.poll_message_set("Select an existing CityJSON input file first.")
+            return False
+        return True
 
     def execute(self, context):
         from cjio import cityjson


### PR DESCRIPTION
Three operators throw an unhandled traceback at the user because they have no `poll()` at all. All three crash before mutating anything, so nothing is corrupted; the failure is a Python traceback in the interface.

**`covetool`**: `RunSimpleAnalysis` and `RunAnalysis` index `props.projects[props.active_project_index]` on a collection that is empty before login. Reproduced: `IndexError: bpy_prop_collection[index]: index 0 out of range, size 0`.

**`diff`**: `VisualiseDiff` and `SelectDiffObjects` call `open(props.diff_json_file, "r")` where the path defaults to `""`. The panel draws the button unconditionally, since its `active_file != "NONE"` guard does not help when `active_file` defaults to `"NEW"`. Reproduced: `FileNotFoundError: [Errno 2] No such file or directory: ''`.

**`gis`**: `BIM_OT_find_cityjson_lod` and `BIM_OT_cityjson2ifc` call `cjio.cityjson.load(props.input)` with `input` defaulting to `""`. Both buttons are drawn unconditionally. Reproduced: `FileNotFoundError` from inside the bundled `cjio` library.

Each now has a `poll()` so the button is disabled with a message rather than throwing. Verified in headless Blender: all six operators crashed before, all six are cleanly blocked after, and the diff module's happy path (a valid JSON file) still reaches `{'FINISHED'}`.

**Deliberately not included:** `misc/operator.py`'s `assert (space := tool.Blender.get_view3d_space())` fails when no 3D viewport exists. The same pattern appears in eleven other places across `drawing`, `bcf`, `search` and `clash`, so it reads as an accepted tradeoff rather than an oversight, and fixing two instances in isolation would make the codebase less consistent rather than more.

Generated with the assistance of an AI coding tool.
