### PR TITLE
util: fix seven :param: entries that name arguments the functions do not have

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/alignment.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/alignment.py
@@ -69,7 +69,7 @@ def station_as_string(file: ifcopenshell.file, sta: float):
     Returns a stringized version of a station. Example 100.0 is 1+00.00 as a stationing string.
     If the project units are SI-based, the string is in the format xxx+yyy.zzz
     If the project units are Emperial-based, the string is in the format xx+yy.zz
-    :param station: the station to be stringized
+    :param sta: the station to be stringized
     :return: stringized station
     """
 

--- a/src/ifcopenshell-python/ifcopenshell/util/constraint.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/constraint.py
@@ -41,7 +41,7 @@ def get_constrained_elements(constraint: ifcopenshell.entity_instance) -> set[if
     """
     Retrieves the elements constrained by a `constraint`.
 
-    :param product: The IFC element.
+    :param constraint: The IfcConstraint.
     :return: Set of elements constrained by a `constrant`.
     """
     elements = set()
@@ -55,7 +55,7 @@ def get_metrics(constraint: ifcopenshell.entity_instance) -> list[ifcopenshell.e
     """
     Retrieves the list of nested constraints for a IfcObjective `constraint`.
 
-    :param product: IfcObjective constraint.
+    :param constraint: IfcObjective constraint.
     :return: List of nested constraints.
     """
 

--- a/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/geolocation.py
@@ -316,7 +316,7 @@ def z2e(z: float, orthogonal_height: float = 0.0, scale: float = 1.0, factor_z: 
     :param scale: The unit scale such that local ordinate * scale = map
         ordinate. E.g. if your project is in millimeters but your CRS is in
         meters, your scale should be 0.001.
-    :param factor_x: The combined scale factor for the Z value to convert from
+    :param factor_z: The combined scale factor for the Z value to convert from
         local coordinates to map coordinates. Your surveyor will typically know
         this number and approximate it as a constant on a small site. This is
         typically just 1.0, as average combined scale factors usually only
@@ -543,8 +543,6 @@ def auto_global2local(
 
     :param ifc_file: The IFC file
     :param matrix: A 4x4 numpy matrix representing local coordinates.
-    :param should_return_in_map_units: If true, the result is given in map units.
-        If false, the result will be converted back into project units.
     :param is_specified_in_map_units: True if the input matrix is in map units.
     :return: A numpy 4x4 array matrix representing global coordinates.
     """

--- a/src/ifcopenshell-python/ifcopenshell/util/placement.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/placement.py
@@ -133,7 +133,7 @@ def get_cartesiantransformationoperator3d(inst: ifcopenshell.entity_instance) ->
     Note that in general you will not need to call this directly. See
     ``get_mappeditem_transformation`` instead.
 
-    :param item: The IfcCartesianTransformationOperator entity
+    :param inst: The IfcCartesianTransformationOperator entity
     :return: A 4x4 numpy transformation matrix
     """
     origin = np.array(inst.LocalOrigin.Coordinates)

--- a/src/ifcopenshell-python/ifcopenshell/util/shape_builder.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/shape_builder.py
@@ -186,7 +186,7 @@ def np_rotation_matrix(
 ) -> np.ndarray:
     """Get rotation matrix. Designed to be similar to mathutils Matrix.Rotation but to use numpy.
 
-    :param float: Rotation angle, in radians.
+    :param angle: Rotation angle, in radians.
     :param size: Matrix size ([2;4]).
     :param axis: Rotation axis.
         For 2x2 matrices Z assumed by default and argument can be omitted,


### PR DESCRIPTION
Seven `:param:` entries in `ifcopenshell.util` name arguments the functions do not have. Found mechanically rather than by reading: a script walked **all 154 `:param:`-documented functions in `ifcopenshell.util`** and diffed the documented names against `inspect.signature`.

| Function | Documented | Actual |
|---|---|---|
| `util/constraint.py` `get_constrained_elements`, `get_metrics` | `product` | `constraint` |
| `util/geolocation.py` `z2e` | `factor_x` | `factor_z` |
| `util/geolocation.py` `auto_global2local` | `should_return_in_map_units` | `is_specified_in_map_units` |
| `util/alignment.py` `station_as_string` | `station` | `sta` |
| `util/placement.py` `get_cartesiantransformationoperator3d` | `item` | `inst` |
| `util/shape_builder.py` `np_rotation_matrix` | `float` | `angle` |

The last one documents a *type* rather than a parameter name.

`auto_global2local`'s is a copy-paste artefact: `should_return_in_map_units` is a real parameter, but of its sibling functions `auto_local2global`, `auto_e2z` and `auto_z2e`. Its own parameter was already documented correctly on a separate line, so the stale entry was purely additive.

**These are documentation errors, not code errors**, so the docstrings are corrected and no behaviour changes. Same class as the `AGS2IFC` docstring fix that merged as #8957.

Re-running the signature diff after the change leaves **0 mismatches across all 154 functions**, so this class is exhausted in `ifcopenshell.util` rather than merely sampled.

## Found alongside, filed separately

The same audit found something that is **not** a documentation error: `assign_recurrence_pattern` documents recurrence with `Interval` and `Occurrences`, and the matching logic in `util/sequence.py` returns `False` for every day whenever either is set. Fixing the docs there would hide a real gap, so it is raised as issue **#9134** instead.

Generated with the assistance of an AI coding tool.
