### PR TITLE
ifcgeom: add a profile_point overload taking a plain double (fixes build with recent Boost)

### DIFF
--- a/src/ifcgeom/profile_helper.h
+++ b/src/ifcgeom/profile_helper.h
@@ -13,6 +13,14 @@ namespace ifcopenshell {
 			profile_point(const std::array<double, 2>& p, const boost::optional<double>& r = boost::none)
 				: xy(p), radius(r) {
 			}
+
+			// Recent Boost makes optional's converting constructor explicit,
+			// and an explicit constructor cannot be used in copy-initialization
+			// - which is what `{{x, y}, {radius}}` in the profile mappings is.
+			// Taking the double directly keeps every call site working.
+			profile_point(const std::array<double, 2>& p, double r)
+				: xy(p), radius(r) {
+			}
 		};
 
 		struct profile_point_with_edges {


### PR DESCRIPTION
## Problem

The profile mappings build their points like this:

```cpp
return profile_helper(m4, {
    {{-x, -y}, {f2}},
    ...
```

`f2` is a `double`; `profile_point`'s second member is a `boost::optional<double>`. That `{f2}` is copy-initialization, and in recent Boost (somewhere between 1.85 and 1.91) `optional`'s converting constructor became **explicit** — an explicit constructor cannot be used in copy-initialization. So every one of those call sites stops compiling:

```
MSVC 19.4x   : error C2664: cannot convert argument 2 from 'initializer list'
                            to 'const std::vector<profile_point>&'
clang-cl 22.1: error: chosen constructor is explicit in copy-initialization
```

Twelve translation units are affected — `IfcCShapeProfileDef`, `IfcIShapeProfileDef`, `IfcLShapeProfileDef`, `IfcTShapeProfileDef`, `IfcUShapeProfileDef`, `IfcZShapeProfileDef`, `IfcAsymmetricIShapeProfileDef`, `IfcCraneRailAShapeProfileDef`, `IfcRectangleProfileDef`, `IfcRectangleHollowProfileDef`, `IfcRoundedRectangleProfileDef`, `IfcTrapeziumProfileDef` — roughly 100 call sites.

## Fix

One overload that takes the `double` directly. No call site changes, and nothing changes for existing code: the `optional` overload still wins wherever an optional is passed.

## How it was isolated

The same build against **Boost 1.85 headers succeeds**, against **1.91 fails**, with `/permissive-` making no difference and the failure reproducing on a second, independent compiler (clang-cl) — whose diagnostic named the cause outright. That is what pointed at Boost rather than at the compiler.

## Verification

Schemas `2x3;4;4x3_add2` built with MSVC 2022 against Boost 1.91 and OCCT 7.9.3: `IfcParse`, `IfcGeom`, the schema mappings and `geometry_kernel_opencascade` all archive cleanly.

Presumably this is not seen in CI because it only builds on Ubuntu with GCC, which performs the conversion.