### PR TITLE
ifcpatch: fail clearly when IfcProject is missing

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/OffsetStoreyElevations.py
+++ b/src/ifcpatch/ifcpatch/recipes/OffsetStoreyElevations.py
@@ -39,7 +39,10 @@ class Patcher:
         self.z = float(z)
 
     def patch(self):
-        project = self.file.by_type("IfcProject")[0]
+        projects = self.file.by_type("IfcProject")
+        if not projects:
+            raise ValueError("The file has no IfcProject, so there is nothing to process.")
+        project = projects[0]
         storeys = self.find_decomposed_ifc_class(project, "IfcBuildingStorey")
         for storey in storeys:
             co = storey.ObjectPlacement.RelativePlacement.Location.Coordinates

--- a/src/ifcpatch/ifcpatch/recipes/RemoveSiteRepresentation.py
+++ b/src/ifcpatch/ifcpatch/recipes/RemoveSiteRepresentation.py
@@ -33,7 +33,10 @@ class Patcher:
         self.logger = logger
 
     def patch(self):
-        project = self.file.by_type("IfcProject")[0]
+        projects = self.file.by_type("IfcProject")
+        if not projects:
+            raise ValueError("The file has no IfcProject, so there is nothing to process.")
+        project = projects[0]
         sites = self.find_decomposed_ifc_class(project, "IfcSite")
         for site in sites:
             site.Representation = None

--- a/src/ifcpatch/ifcpatch/recipes/ResetSpatialElementLocations.py
+++ b/src/ifcpatch/ifcpatch/recipes/ResetSpatialElementLocations.py
@@ -57,7 +57,10 @@ class Patcher:
         self.only_xy = only_xy
 
     def patch(self) -> None:
-        project = self.file.by_type("IfcProject")[0]
+        projects = self.file.by_type("IfcProject")
+        if not projects:
+            raise ValueError("The file has no IfcProject, so there is nothing to process.")
+        project = projects[0]
         queue = [project]
         while queue:
             element = queue.pop()

--- a/src/ifcpatch/ifcpatch/recipes/SetRefElevation.py
+++ b/src/ifcpatch/ifcpatch/recipes/SetRefElevation.py
@@ -45,7 +45,10 @@ class Patcher:
         self.elevation = float(elevation)
 
     def patch(self):
-        project = self.file.by_type("IfcProject")[0]
+        projects = self.file.by_type("IfcProject")
+        if not projects:
+            raise ValueError("The file has no IfcProject, so there is nothing to process.")
+        project = projects[0]
         sites = self.find_decomposed_ifc_class(project, "IfcSite")
         for site in sites:
             site.RefElevation = float(self.elevation)

--- a/src/ifcpatch/test/test_OffsetStoreyElevations.py
+++ b/src/ifcpatch/test/test_OffsetStoreyElevations.py
@@ -1,0 +1,53 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import numpy as np
+import pytest
+
+import ifcopenshell.api.aggregate
+import ifcopenshell.api.geometry
+import ifcopenshell.api.root
+import ifcopenshell.api.unit
+
+import ifcpatch
+import test.bootstrap
+
+
+class TestOffsetStoreyElevations(test.bootstrap.IFC4):
+    def test_run(self):
+        project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        unit = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="LENGTHUNIT")
+        ifcopenshell.api.unit.assign_unit(self.file, units=[unit])
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[site], relating_object=project)
+        storey = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcBuildingStorey")
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[storey], relating_object=site)
+        ifcopenshell.api.geometry.edit_object_placement(self.file, product=storey, matrix=np.eye(4))
+        ifcpatch.execute({"file": self.file, "recipe": "OffsetStoreyElevations", "arguments": [5]})
+        assert storey.ObjectPlacement.RelativePlacement.Location.Coordinates == (0.0, 0.0, 5.0)
+        assert storey.Elevation == 5.0
+
+    def test_raises_on_missing_project(self):
+        with pytest.raises(ValueError):
+            ifcpatch.execute({"file": self.file, "recipe": "OffsetStoreyElevations", "arguments": [5]})
+
+
+class TestOffsetStoreyElevationsIFC2X3(test.bootstrap.IFC2X3, TestOffsetStoreyElevations):
+    pass

--- a/src/ifcpatch/test/test_RemoveSiteRepresentation.py
+++ b/src/ifcpatch/test/test_RemoveSiteRepresentation.py
@@ -1,0 +1,45 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import pytest
+
+import ifcopenshell.api.aggregate
+import ifcopenshell.api.root
+
+import ifcpatch
+import test.bootstrap
+
+
+class TestRemoveSiteRepresentation(test.bootstrap.IFC4):
+    def test_run(self):
+        project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[site], relating_object=project)
+        site.Representation = self.file.create_entity("IfcProductDefinitionShape", Representations=[])
+        ifcpatch.execute({"file": self.file, "recipe": "RemoveSiteRepresentation", "arguments": []})
+        assert site.Representation is None
+
+    def test_raises_on_missing_project(self):
+        with pytest.raises(ValueError):
+            ifcpatch.execute({"file": self.file, "recipe": "RemoveSiteRepresentation", "arguments": []})
+
+
+class TestRemoveSiteRepresentationIFC2X3(test.bootstrap.IFC2X3, TestRemoveSiteRepresentation):
+    pass

--- a/src/ifcpatch/test/test_ResetSpatialElementLocations.py
+++ b/src/ifcpatch/test/test_ResetSpatialElementLocations.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
+
 import ifcopenshell.api.aggregate
 import ifcopenshell.api.geometry
 import ifcopenshell.api.root
@@ -60,6 +62,10 @@ class TestResetSpatialElementLocations(test.bootstrap.IFC4):
         ifcpatch.execute({"file": self.file, "recipe": "ResetSpatialElementLocations", "arguments": ["", True]})
         m = ifcopenshell.util.placement.get_local_placement(site.ObjectPlacement)
         assert np.allclose(m, m2)
+
+    def test_raises_on_missing_project(self):
+        with pytest.raises(ValueError):
+            ifcpatch.execute({"file": self.file, "recipe": "ResetSpatialElementLocations", "arguments": ["", False]})
 
 
 class TestResetSpatialElementLocationsIFC2X3(test.bootstrap.IFC2X3, TestResetSpatialElementLocations):

--- a/src/ifcpatch/test/test_SetRefElevation.py
+++ b/src/ifcpatch/test/test_SetRefElevation.py
@@ -1,0 +1,44 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import pytest
+
+import ifcopenshell.api.aggregate
+import ifcopenshell.api.root
+
+import ifcpatch
+import test.bootstrap
+
+
+class TestSetRefElevation(test.bootstrap.IFC4):
+    def test_run(self):
+        project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        site = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSite")
+        ifcopenshell.api.aggregate.assign_object(self.file, products=[site], relating_object=project)
+        ifcpatch.execute({"file": self.file, "recipe": "SetRefElevation", "arguments": [42]})
+        assert site.RefElevation == 42.0
+
+    def test_raises_on_missing_project(self):
+        with pytest.raises(ValueError):
+            ifcpatch.execute({"file": self.file, "recipe": "SetRefElevation", "arguments": [42]})
+
+
+class TestSetRefElevationIFC2X3(test.bootstrap.IFC2X3, TestSetRefElevation):
+    pass


### PR DESCRIPTION
Four recipes indexed `by_type("IfcProject")[0]` with no length check. On a file with no `IfcProject` they raised a bare `IndexError: list index out of range`, which tells the user nothing about what is actually wrong with their file.

Reproduced by running each recipe against a file containing an `IfcSite` but no `IfcProject`:

```
=== RemoveSiteRepresentation      IndexError list index out of range
=== SetRefElevation               IndexError list index out of range
=== OffsetStoreyElevations        IndexError list index out of range
=== ResetSpatialElementLocations  IndexError list index out of range
```

After:

```
=== RemoveSiteRepresentation      ValueError The file has no IfcProject, so there is nothing to process.
=== SetRefElevation               ValueError The file has no IfcProject, so there is nothing to process.
=== OffsetStoreyElevations        ValueError The file has no IfcProject, so there is nothing to process.
=== ResetSpatialElementLocations  ValueError The file has no IfcProject, so there is nothing to process.
```

This deliberately keeps failing rather than silently doing nothing. A file with no `IfcProject` is not valid IFC, so the right behaviour is to say so plainly and let the producer be fixed, not to quietly no-op and let a broken file continue through a pipeline.

**Files:** `RemoveSiteRepresentation.py`, `SetRefElevation.py`, `OffsetStoreyElevations.py`, `ResetSpatialElementLocations.py`.

### Tests

Three of these four recipes had no tests at all. This adds them, plus a missing-project case for all four. 16 pass on this branch.

Verified the tests actually catch the defect rather than passing vacuously: reverting the four recipe files to `v0.8.0` while keeping the new tests gives **8 failed, 8 passed**, with every failure reporting the original `IndexError: list index out of range`.

Behaviour on valid files is unchanged, confirmed by the non-regression tests: `RemoveSiteRepresentation` clears `site.Representation`, `SetRefElevation` sets `RefElevation` to 42.0, `OffsetStoreyElevations` moves `(0.0, 0.0, 0.0)` to `(0.0, 0.0, 5.0)`, and `ResetSpatialElementLocations` resets as before.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated, including the new test files, which carry the disclosure comment.
