### PR TITLE
ifctester: warn instead of silently ignoring unsupported restrictions

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import builtins
 import re
+from decimal import Decimal, InvalidOperation
 from functools import lru_cache
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, Union
@@ -1010,6 +1011,25 @@ class Material(Facet):
         return MaterialResult(is_pass, reason)
 
 
+def to_finite_decimal(value: Any) -> Decimal:
+    try:
+        result = Decimal(str(value))
+    except InvalidOperation:
+        raise ValueError(f"Not a decimal value: {value!r}")
+    if not result.is_finite():
+        raise ValueError(f"Not a finite decimal value: {value!r}")
+    return result
+
+
+def get_fraction_digits(value: Any) -> int:
+    return max(0, -to_finite_decimal(value).normalize().as_tuple().exponent)
+
+
+def get_total_digits(value: Any) -> int:
+    scaled = to_finite_decimal(value).normalize().scaleb(get_fraction_digits(value))
+    return len(str(abs(int(scaled))))
+
+
 class Restriction:
     def __init__(self, options=None, base="string"):
         self.base = base
@@ -1090,13 +1110,10 @@ class Restriction:
                     if float(other) < float(value):
                         return False
                 elif constraint == "totalDigits":
-                    digits = re.sub(r"[^0-9]", "", str(other)).lstrip("0") or "0"
-                    if len(digits) > int(value):
+                    if get_total_digits(other) > int(value):
                         return False
                 elif constraint == "fractionDigits":
-                    text = str(other)
-                    fraction = text.split(".", 1)[1] if "." in text else ""
-                    if len(fraction) > int(value):
+                    if get_fraction_digits(other) > int(value):
                         return False
             except ValueError:
                 return False

--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -1089,6 +1089,15 @@ class Restriction:
                 elif constraint == "minInclusive":
                     if float(other) < float(value):
                         return False
+                elif constraint == "totalDigits":
+                    digits = re.sub(r"[^0-9]", "", str(other)).lstrip("0") or "0"
+                    if len(digits) > int(value):
+                        return False
+                elif constraint == "fractionDigits":
+                    text = str(other)
+                    fraction = text.split(".", 1)[1] if "." in text else ""
+                    if len(fraction) > int(value):
+                        return False
             except ValueError:
                 return False
         return True

--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import builtins
 import re
-from decimal import Decimal, InvalidOperation
+import warnings
 from functools import lru_cache
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, Union
@@ -1011,29 +1011,22 @@ class Material(Facet):
         return MaterialResult(is_pass, reason)
 
 
-def to_finite_decimal(value: Any) -> Decimal:
-    try:
-        result = Decimal(str(value))
-    except InvalidOperation:
-        raise ValueError(f"Not a decimal value: {value!r}")
-    if not result.is_finite():
-        raise ValueError(f"Not a finite decimal value: {value!r}")
-    return result
-
-
-def get_fraction_digits(value: Any) -> int:
-    return max(0, -to_finite_decimal(value).normalize().as_tuple().exponent)
-
-
-def get_total_digits(value: Any) -> int:
-    scaled = to_finite_decimal(value).normalize().scaleb(get_fraction_digits(value))
-    return len(str(abs(int(scaled))))
+# Not supported by IDS: buildingSMART/IDS developer-guide.md.
+UNSUPPORTED_RESTRICTIONS = frozenset({"totalDigits", "fractionDigits", "whiteSpace"})
 
 
 class Restriction:
     def __init__(self, options=None, base="string"):
         self.base = base
         self.options = options or {}
+        self._warn_unsupported()
+
+    def _warn_unsupported(self):
+        for constraint in sorted(UNSUPPORTED_RESTRICTIONS & self.options.keys()):
+            warnings.warn(
+                f"IDS does not support the '{constraint}' restriction; it is not "
+                "enforced and will be ignored during validation."
+            )
 
     def parse(self, ids_dict):
         if not ids_dict:
@@ -1049,6 +1042,7 @@ class Restriction:
                 self.options[key] = value["@value"]
             else:
                 self.options[key] = [v["@value"] for v in value]
+        self._warn_unsupported()
         return self
 
     def asdict(self) -> dict[str, Any]:
@@ -1108,12 +1102,6 @@ class Restriction:
                         return False
                 elif constraint == "minInclusive":
                     if float(other) < float(value):
-                        return False
-                elif constraint == "totalDigits":
-                    if get_total_digits(other) > int(value):
-                        return False
-                elif constraint == "fractionDigits":
-                    if get_fraction_digits(other) > int(value):
                         return False
             except ValueError:
                 return False

--- a/src/ifctester/test/fixtures/restriction_unsupported_fraction_digits/restriction_unsupported_fraction_digits.ids
+++ b/src/ifctester/test/fixtures/restriction_unsupported_fraction_digits/restriction_unsupported_fraction_digits.ids
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Unsupported fractionDigits restriction</title>
+        <description>fractionDigits is not part of the IDS restriction facets and must not be silently enforced.</description>
+    </info>
+    <specifications>
+        <specification name="Name must have at most 2 fraction digits" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <attribute cardinality="required">
+                    <name>
+                        <simpleValue>Name</simpleValue>
+                    </name>
+                    <value>
+                        <xs:restriction base="xs:decimal">
+                            <xs:fractionDigits value="2" fixed="false"/>
+                        </xs:restriction>
+                    </value>
+                </attribute>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/restriction_unsupported_fraction_digits/restriction_unsupported_fraction_digits.ifc
+++ b/src/ifctester/test/fixtures/restriction_unsupported_fraction_digits/restriction_unsupported_fraction_digits.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-07T00:00:00',(''),(''),'IfcOpenShell','IfcOpenShell','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('3Fu_ePwY1DZxzRl9jojPIx',$,'42.123456',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -1704,6 +1704,19 @@ class TestRestriction:
         assert restriction == 5
         assert restriction != -1
 
+    def test_total_digits(self):
+        restriction = Restriction(options={"totalDigits": 3}, base="decimal")
+        assert restriction == 123
+        assert restriction != 123456
+        assert restriction == -12
+        assert restriction == 0
+
+    def test_fraction_digits(self):
+        restriction = Restriction(options={"fractionDigits": 2}, base="decimal")
+        assert restriction == 3.14
+        assert restriction != 3.14159
+        assert restriction == 42
+
     def test_pattern(self):
         restriction = Restriction(options={"pattern": "[A-Z]{2}[0-9]{2}"})
         assert restriction == "AB01"

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -33,6 +33,7 @@ import ifcopenshell.api.type
 import ifcopenshell.api.unit
 import ifcopenshell.guid
 import ifcopenshell.util.pset
+import pytest
 
 import ifctester.facet
 import ifctester.ids
@@ -1704,30 +1705,21 @@ class TestRestriction:
         assert restriction == 5
         assert restriction != -1
 
-    def test_total_digits(self):
-        restriction = Restriction(options={"totalDigits": 3}, base="decimal")
-        assert restriction == 123
-        assert restriction != 123456
-        assert restriction == -12
-        assert restriction == 0
-        # IFC numeric attributes are floats, so str() adds a fractional part
-        # that is not a significant digit.
-        assert restriction == 100.0
-        assert restriction == "100.0"
-        # Trailing zeros in the fraction are not significant either.
-        assert restriction == "1.500"
-        # Nor are leading zeros: 0.001 is 1 x 10^-3, so one digit.
-        assert restriction == "0.001"
-        assert restriction != float("nan")
+    def test_total_digits_and_fraction_digits_are_not_enforced(self):
+        with pytest.warns(UserWarning, match="totalDigits"):
+            restriction = Restriction(options={"totalDigits": 3}, base="decimal")
+        assert restriction == 123456
+        assert restriction.asdict() == {"@base": "xs:decimal", "xs:totalDigits": [{"@value": 3}]}
 
-    def test_fraction_digits(self):
-        restriction = Restriction(options={"fractionDigits": 2}, base="decimal")
-        assert restriction == 3.14
-        assert restriction != 3.14159
-        assert restriction == 42
-        assert restriction == "3.140000"
-        assert restriction == 100.0
-        assert restriction != float("inf")
+        with pytest.warns(UserWarning, match="fractionDigits"):
+            restriction = Restriction(options={"fractionDigits": 2}, base="decimal")
+        assert restriction == 3.14159
+        assert restriction.asdict() == {"@base": "xs:decimal", "xs:fractionDigits": [{"@value": 2}]}
+
+    def test_white_space_is_not_enforced(self):
+        with pytest.warns(UserWarning, match="whiteSpace"):
+            restriction = Restriction(options={"whiteSpace": "collapse"}, base="string")
+        assert restriction == "  padded  "
 
     def test_pattern(self):
         restriction = Restriction(options={"pattern": "[A-Z]{2}[0-9]{2}"})

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -1710,12 +1710,24 @@ class TestRestriction:
         assert restriction != 123456
         assert restriction == -12
         assert restriction == 0
+        # IFC numeric attributes are floats, so str() adds a fractional part
+        # that is not a significant digit.
+        assert restriction == 100.0
+        assert restriction == "100.0"
+        # Trailing zeros in the fraction are not significant either.
+        assert restriction == "1.500"
+        # Nor are leading zeros: 0.001 is 1 x 10^-3, so one digit.
+        assert restriction == "0.001"
+        assert restriction != float("nan")
 
     def test_fraction_digits(self):
         restriction = Restriction(options={"fractionDigits": 2}, base="decimal")
         assert restriction == 3.14
         assert restriction != 3.14159
         assert restriction == 42
+        assert restriction == "3.140000"
+        assert restriction == 100.0
+        assert restriction != float("inf")
 
     def test_pattern(self):
         restriction = Restriction(options={"pattern": "[A-Z]{2}[0-9]{2}"})

--- a/src/ifctester/test/test_fixture_restriction_unsupported_fraction_digits.py
+++ b/src/ifctester/test/test_fixture_restriction_unsupported_fraction_digits.py
@@ -1,0 +1,60 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression test for a specific reported defect.
+
+buildingSMART/IDS developer-guide.md explicitly excludes the XSD
+totalDigits and fractionDigits facets from IDS. ifctester used to accept
+and round-trip a fractionDigits restriction from an .ids file but never
+enforced it and never told the author, so the constraint silently did
+nothing. It now still does not enforce it (IDS does not ask it to), but it
+must warn once the restriction is loaded, so the author learns the facet
+has no effect instead of finding out the hard way.
+"""
+
+import os
+import warnings
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "restriction_unsupported_fraction_digits")
+SPEC = os.path.join(FIXTURES, "restriction_unsupported_fraction_digits.ids")
+MODEL = os.path.join(FIXTURES, "restriction_unsupported_fraction_digits.ifc")
+
+
+class TestRestrictionUnsupportedFractionDigitsFixture:
+    def test_loading_the_restriction_warns(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            ids.open(SPEC)
+        assert any("fractionDigits" in str(w.message) for w in caught)
+
+    def test_restriction_is_not_enforced(self):
+        # 42.123456 has 6 fraction digits and would fail a fractionDigits=2
+        # restriction if it were enforced. IDS does not support this facet,
+        # so the wall must still pass.
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(MODEL)
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.requirements[0].status is True
+        assert spec.status is True

--- a/src/ifctester/test/test_ids.py
+++ b/src/ifctester/test/test_ids.py
@@ -77,6 +77,27 @@ class TestIds:
         specs2 = ids.from_string(xml)
         assert len(specs2.specifications) == 1
 
+    def test_reading_an_ids_with_totaldigits_warns_but_still_loads(self):
+        model = ifcopenshell.file()
+        wall = model.createIfcWall(Name="42.123456")
+        specs = ids.Ids()
+        spec = ids.Specification(name="Name")
+        spec.applicability.append(ids.Entity(name="IFCWALL"))
+        restriction = ids.Restriction(options={"fractionDigits": 2}, base="decimal")
+        spec.requirements.append(ids.Attribute(name="Name", value=restriction))
+        specs.specifications.append(spec)
+        xml = specs.to_string()
+        with pytest.warns(UserWarning, match="fractionDigits"):
+            specs2 = ids.from_string(xml)
+        run(
+            "fractionDigits is parsed but not enforced, so the wall still passes",
+            specs2,
+            model,
+            True,
+            [wall],
+            [],
+        )
+
     def test_create_an_ids_with_all_possible_information(self):
         specs = ids.Ids(
             title="title",


### PR DESCRIPTION
`Restriction` accepts `totalDigits`, `fractionDigits` and `whiteSpace` and then **silently ignores** them. A user writes a constraint, it is accepted without complaint, and it has no effect.

### What changed, and why this PR was reworked

The first version of this PR **enforced** those facets. That was wrong: the IDS specification excludes them.

`Documentation/ImplementersDocumentation/developer-guide.md`, line 54:

> XSD also includes a **Total Digits** and a **Fraction Digits** restriction. These will not be supported in IDS as they have limited utility.

Corroborated independently in `Documentation/ImplementersDocumentation/DataTypes.md`, whose "XML base types" table enumerates the valid facets per base type (annotation, pattern, enumeration, minLength, maxLength, length, minExclusive, maxExclusive, minInclusive, maxInclusive). **None of `totalDigits`, `fractionDigits` or `whiteSpace` appears anywhere in that table.**

So enforcing them would put IfcTester ahead of the spec. Measured on the previous version of this branch: `Attribute(name="Name", value=Restriction(options={"fractionDigits": 2}))` against `IfcWall(Name="42.123456")` returned `is_pass = False`, enforcing a facet IDS disclaims.

### But silently ignoring them is the worse option

Measured at the merge-base, which is current shipped behaviour: the same check returns `is_pass = True`. The constraint is accepted and does nothing, with nothing to tell the author.

That silent no-op is the failure class this project keeps finding elsewhere, so neither enforcing nor leaving it alone was right.

### What it does now

Warn and ignore. `UNSUPPORTED_RESTRICTIONS = {"totalDigits", "fractionDigits", "whiteSpace"}` with a `Restriction._warn_unsupported()` called from both `__init__` and `parse()`, so the warning fires on direct construction and on loading a real IDS file.

`warnings.warn()` is the existing convention in this codebase for unsupported conditions (`ifcopenshell/draw.py:493,573,575`, `geom/occ_utils.py:183`). Rejecting at parse would be new, stricter behaviour with no precedent: `Restriction.parse()` already accepts anything inside `<xs:restriction>`, and `ids.xsd` line 42 references the generic `xs:restriction` element, so such files are schema-valid regardless. Existing files keep loading.

`whiteSpace` is included because it is in the identical position, so the behaviour is consistent rather than decided facet by facet.

The enforcement code and its now-dead helpers (`to_finite_decimal`, `get_fraction_digits`, `get_total_digits`) are removed.

### Verified end to end

Built an IDS with a `fractionDigits` restriction, serialised it, reloaded it with `ids.from_string()`: a `UserWarning` naming the facet fires during load, the file still loads, and the specification passes against a 6-fraction-digit value, so it is ignored rather than enforced. Same confirmed for `whiteSpace`.

```
src/ifctester: 37 passed before, 40 passed after
```

### Note on the documentation

`restrictions.md` in the User Manual documents only Enumeration, Pattern, Bounds and Length, and never mentions that these facets are excluded. A reader consulting the User Manual alone would not know, which is how the first version of this PR came to be written. That gap has been raised with buildingSMART separately.

Generated with the assistance of an AI coding tool.
