### PR TITLE
bsdd, ifcdiff: respect explicitly passed falsy params

### DIFF
--- a/src/bsdd/bsdd.py
+++ b/src/bsdd/bsdd.py
@@ -739,13 +739,18 @@ class Client:
         This API replaces Domain
         """
         endpoint = f"Dictionary/v{version}/Classes"
-        params = {"Uri": dictionary_uri}
-        for param, value in {
+        # UseNestedClasses, offset and limit always have a meaningful value (False/0 are not
+        # "unset"), so they must always be sent. ClassType and languageCode use "" to mean
+        # "no filter", so those stay conditional.
+        params = {
+            "Uri": dictionary_uri,
             "UseNestedClasses": use_nested_classes,
-            "ClassType": class_type,
-            "languageCode": language_code,
             "offset": offset,
             "limit": limit,
+        }
+        for param, value in {
+            "ClassType": class_type,
+            "languageCode": language_code,
         }.items():
             if value:
                 params[param] = value

--- a/src/bsdd/tests/test_bsdd_offline.py
+++ b/src/bsdd/tests/test_bsdd_offline.py
@@ -1,0 +1,85 @@
+# bSDD - Python bSDD library
+# Copyright (C) 2026 IfcOpenShell contributors
+#
+# This file is part of bSDD.
+#
+# bSDD is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# bSDD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with bSDD.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Offline tests for request-parameter construction. These never touch the network:
+Client.get() is monkeypatched to capture what would have been sent instead of making
+an HTTP call."""
+
+from bsdd import Client
+
+
+def _client_with_captured_get(monkeypatch):
+    captured = {}
+
+    def fake_get(self, endpoint, params=None, is_auth_required=False):
+        captured["endpoint"] = endpoint
+        captured["params"] = params
+        return {}
+
+    monkeypatch.setattr(Client, "get", fake_get)
+    return Client(), captured
+
+
+def test_get_classes_sends_use_nested_classes_false(monkeypatch):
+    # Regression test: get_classes() used to build its request params with a blanket
+    # `if value:` filter, which is falsy for `use_nested_classes=False`. Explicitly
+    # asking for a flat (non-nested) class list therefore silently dropped
+    # `UseNestedClasses` from the request, so the server would fall back to its
+    # nested-tree default instead of honouring the caller's choice.
+    client, captured = _client_with_captured_get(monkeypatch)
+
+    client.get_classes(
+        "https://identifier.buildingsmart.org/uri/buildingsmart/ifc-4.3/class/IfcWall",
+        use_nested_classes=False,
+        search_text="Wall",
+    )
+
+    assert captured["params"]["UseNestedClasses"] is False
+    assert captured["params"]["SearchText"] == "Wall"
+
+
+def test_get_classes_sends_zero_offset(monkeypatch):
+    # offset=0 is a meaningful, explicit "start from the first result", not "unset".
+    client, captured = _client_with_captured_get(monkeypatch)
+
+    client.get_classes("uri-x", offset=0, limit=50)
+
+    assert captured["params"]["offset"] == 0
+    assert captured["params"]["limit"] == 50
+
+
+def test_get_classes_default_is_nested(monkeypatch):
+    client, captured = _client_with_captured_get(monkeypatch)
+
+    client.get_classes("uri-x")
+
+    assert captured["params"]["UseNestedClasses"] is True
+    assert captured["params"]["ClassType"] == "Class"
+    assert "SearchText" not in captured["params"]
+
+
+def test_get_classes_empty_class_type_is_still_omitted(monkeypatch):
+    # class_type="" (used by search_in_dictionary's Dictionary/Classes fallback) means
+    # "no ClassType filter" and must stay omitted, unlike UseNestedClasses/offset/limit.
+    client, captured = _client_with_captured_get(monkeypatch)
+
+    client.get_classes("uri-x", use_nested_classes=False, class_type="", related_ifc_entity="IfcWall")
+
+    assert "ClassType" not in captured["params"]
+    assert captured["params"]["RelatedIfcEntity"] == "IfcWall"
+    assert captured["params"]["UseNestedClasses"] is False

--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -277,7 +277,8 @@ class IfcDiff:
     def get_precision(self) -> float:
         contexts = [c for c in self.new.by_type("IfcGeometricRepresentationContext") if c.ContextType == "Model"]
         if contexts:
-            return contexts[0].Precision or 1e-4
+            precision = contexts[0].Precision
+            return precision if precision is not None else 1e-4
         return 1e-4
 
     def diff_element(self, old, new):

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -122,6 +122,31 @@ class TestIfcDiff:
                 results = json.load(f)
             assert "Pset_WallCommon" in str(results["changed"][wall.GlobalId]["properties_changed"])
 
+    def test_explicit_zero_precision_is_respected(self):
+        # Regression test: IfcGeometricRepresentationContext.Precision is an
+        # optional attribute, so 0.0 is a legitimate, explicit "compare
+        # exactly" value and must not be confused with "not set". get_precision()
+        # previously used `contexts[0].Precision or 1e-4`, which is falsy for
+        # 0.0 too, silently widening the tolerance back to 1e-4 and causing a
+        # small but real property change to be missed entirely.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        pset = ifcopenshell.api.pset.add_pset(ifc_file, product=wall, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties={"ThermalTransmittance": 1.0})
+        model_context = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+        model_context.Precision = 0.0
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        pset_new = new_file.by_id(pset.id())
+        ifcopenshell.api.pset.edit_pset(new_file, pset=pset_new, properties={"ThermalTransmittance": 1.00005})
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["property"])
+        assert ifc_diff.get_precision() == 0.0
+        ifc_diff.diff()
+        assert wall.GlobalId in ifc_diff.change_register
+        assert ifc_diff.change_register[wall.GlobalId]["properties_changed"]
+
     def test_changed_geometry(self):
         ifc_file = setup_project()
         wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")


### PR DESCRIPTION
Two independent instances of the same mistake: treating an explicitly passed falsy value as "not supplied".

### bsdd: `UseNestedClasses=False` and `offset=0` were dropped

`Client.get_classes()` built its query string with a `if value:` filter over all five optional parameters. `False` and `0` are falsy, so passing them was indistinguishable from passing nothing, and the server applied its own defaults instead.

Reproduced with `Client.get` stubbed:

```
get_classes('uri-x', use_nested_classes=False, search_text='Wall')
  -> {'Uri': 'uri-x', 'ClassType': 'Class', 'limit': 1000, 'SearchText': 'Wall'}
```

`UseNestedClasses` is simply absent. The caller asked for nested classes to be excluded and silently got them included.

`UseNestedClasses`, `offset` and `limit` always carry meaning, so they are now always sent. `ClassType` and `languageCode` genuinely use the empty string to mean "no filter", so those stay conditional. That asymmetry is the reason this was not a one-line change.

### ifcdiff: an explicit `Precision=0.0` was silently widened

```python
return contexts[0].Precision or 1e-4
```

`IfcGeometricRepresentationContext.Precision` is optional in IFC2X3, IFC4 and IFC4X3_ADD2, and its type `IfcReal` permits `0.0`. So `or` cannot distinguish "absent" from "explicitly zero", and a file asking for exact comparison got a 1e-4 tolerance instead.

**This is the dangerous direction for a diff tool: it reports no change where a change exists.** Reproduced by changing a wall's `ThermalTransmittance` from 1.0 to 1.00005 in a file with `Precision` set to 0.0. `get_precision()` returned `0.0001` and the change register came back empty.

Now `precision if precision is not None else 1e-4`, which distinguishes the two cases correctly.

### Tests

4 tests in `src/bsdd/tests/test_bsdd_offline.py`, 1 in `src/ifcdiff/test.py` (7/7 pass).

Verified not vacuous: reverting only `bsdd.py` turns 3 of the 4 red with `KeyError: 'UseNestedClasses'` and `KeyError: 'offset'`; reverting only `ifcdiff.py` fails with `assert 0.0001 == 0.0`.

Both are the same defect class, which is why they are together here rather than as two near-identical PRs. Happy to split if preferred.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
