### PR TITLE
Bonsai: find drawing fonts on macOS and Linux too

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -17,7 +17,6 @@
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
 import math
-import os
 from collections.abc import Generator, Iterator
 from functools import cache
 from math import acos, atan, cos, degrees, pi, radians, sin
@@ -42,6 +41,7 @@ from mathutils import Matrix, Vector
 import bonsai.bim.module.drawing.helper as helper
 import bonsai.tool as tool
 from bonsai.bim.module.drawing.data import DecoratorData, DrawingsData
+from bonsai.bim.module.drawing.font_resolver import find_system_font
 from bonsai.bim.module.drawing.helper import format_distance
 from bonsai.bim.module.drawing.shaders import add_offsets, add_verts_sequence
 
@@ -2066,24 +2066,16 @@ class DecorationsHandler:
             drawing_font_path = tool.Blender.get_data_dir_path(Path("fonts") / drawing_font)
 
             if not drawing_font_path.is_file():
-                # 2 — Fallback search: Windows font directories
-                # TODO - Linux
-                win_font_dirs = [
-                    Path(os.environ.get("WINDIR", "C:\\Windows")) / "Fonts",
-                    # Add any custom enterprise paths here if needed
-                ]
-
-                found_font = None
-                for font_dir in win_font_dirs:
-                    candidate = font_dir / drawing_font
-                    if candidate.is_file():
-                        found_font = candidate
-                        break
+                # 2 — Fallback search: the OS's own font directories, so users can
+                # point this preference at any font already installed on their
+                # system (for example, one with broader glyph coverage than the
+                # bundled default).
+                found_font = find_system_font(drawing_font)
 
                 if found_font:
                     drawing_font_path = found_font
                 else:
-                    print(f"[BIM] Font '{drawing_font}' not found in addon or Windows fonts.")
+                    print(f"[BIM] Font '{drawing_font}' not found in addon or system font directories.")
                     return  # Bail out without assigning fonts
 
             font_id = blf.load(str(drawing_font_path))

--- a/src/bonsai/bonsai/bim/module/drawing/font_resolver.py
+++ b/src/bonsai/bonsai/bim/module/drawing/font_resolver.py
@@ -1,0 +1,83 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026 Bonsai contributors
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was written with the assistance of an AI coding tool.
+
+"""Cross-platform lookup for a drawing font that is not bundled with Bonsai.
+
+Bonsai ships a single default annotation font (OpenGost Type B TT), which does
+not cover every Latin-script glyph (for example Scandinavian letters such as
+AE/OE/AA, umlauts, etc). Users who need those glyphs can point the "Drawing
+Font" preference at any TrueType/OpenType font already installed on their
+system. This module contains the OS-aware search logic in isolation from bpy
+so it can be unit tested without a running Blender instance.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Optional
+
+
+def system_font_directories(system: Optional[str] = None) -> list[Path]:
+    """Return the conventional font install directories for an OS.
+
+    `system` defaults to the live `platform.system()` value ("Windows",
+    "Darwin", "Linux", ...) and is otherwise accepted as a parameter purely
+    so this can be unit tested for every OS from any host.
+    """
+    system = system if system is not None else platform.system()
+    if system == "Windows":
+        return [Path(os.environ.get("WINDIR", "C:\\Windows")) / "Fonts"]
+    if system == "Darwin":
+        return [
+            Path("/System/Library/Fonts"),
+            Path("/Library/Fonts"),
+            Path.home() / "Library" / "Fonts",
+        ]
+    # Linux and other unix-likes.
+    return [
+        Path("/usr/share/fonts"),
+        Path("/usr/local/share/fonts"),
+        Path.home() / ".fonts",
+        Path.home() / ".local" / "share" / "fonts",
+    ]
+
+
+def find_font_in_directories(font_name: str, search_dirs: Iterable[Path]) -> Optional[Path]:
+    """Search `search_dirs` (including subfolders) for a file named `font_name`."""
+    if not font_name:
+        return None
+    for font_dir in search_dirs:
+        if not font_dir.is_dir():
+            continue
+        candidate = font_dir / font_name
+        if candidate.is_file():
+            return candidate
+        for match in font_dir.rglob(font_name):
+            if match.is_file():
+                return match
+    return None
+
+
+def find_system_font(font_name: str, system: Optional[str] = None) -> Optional[Path]:
+    """Search this OS's conventional font directories for `font_name`."""
+    return find_font_in_directories(font_name, system_font_directories(system))

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -343,6 +343,13 @@ class DocPreferences(bpy.types.PropertyGroup):
     drawing_font: StringProperty(
         default="OpenGost Type B TT.ttf",
         name="Drawing Font",
+        description=(
+            "Font used for text in the 3D viewport and drawings. Browse to any "
+            "TrueType/OpenType font installed on your system if the bundled "
+            "default is missing glyphs you need (for example, non-English "
+            "characters)."
+        ),
+        subtype="FILE_PATH",
     )
     magic_font_scale: bpy.props.FloatProperty(
         default=0.004118616,

--- a/src/bonsai/test/bim/module/drawing/test_font_resolver.py
+++ b/src/bonsai/test/bim/module/drawing/test_font_resolver.py
@@ -1,0 +1,106 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026 Bonsai contributors
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was written with the assistance of an AI coding tool.
+
+"""No bpy or mathutils dependency: this module is deliberately pure so it can
+run under plain pytest, without a Blender instance."""
+
+from pathlib import Path
+
+from bonsai.bim.module.drawing.font_resolver import (
+    find_font_in_directories,
+    find_system_font,
+    system_font_directories,
+)
+
+
+class TestSystemFontDirectories:
+    def test_windows_only_checks_the_windows_fonts_folder(self):
+        dirs = system_font_directories("Windows")
+        assert dirs == [Path("C:\\Windows") / "Fonts"]
+
+    def test_darwin_includes_user_and_system_font_folders(self):
+        dirs = system_font_directories("Darwin")
+        assert Path("/System/Library/Fonts") in dirs
+        assert Path("/Library/Fonts") in dirs
+        assert (Path.home() / "Library" / "Fonts") in dirs
+
+    def test_linux_includes_user_and_system_font_folders(self):
+        dirs = system_font_directories("Linux")
+        assert Path("/usr/share/fonts") in dirs
+        assert (Path.home() / ".fonts") in dirs
+
+
+class TestFindFontInDirectories:
+    def test_finds_a_font_directly_inside_a_search_dir(self, tmp_path):
+        font_dir = tmp_path / "Fonts"
+        font_dir.mkdir()
+        font_file = font_dir / "MyScandinavianFont.ttf"
+        font_file.write_bytes(b"fake-ttf-data")
+
+        result = find_font_in_directories("MyScandinavianFont.ttf", [font_dir])
+
+        assert result == font_file
+
+    def test_finds_a_font_nested_in_a_subfolder(self, tmp_path):
+        font_dir = tmp_path / "Fonts"
+        nested = font_dir / "Collections" / "Vendor"
+        nested.mkdir(parents=True)
+        font_file = nested / "MyScandinavianFont.ttf"
+        font_file.write_bytes(b"fake-ttf-data")
+
+        result = find_font_in_directories("MyScandinavianFont.ttf", [font_dir])
+
+        assert result == font_file
+
+    def test_returns_none_when_not_found(self, tmp_path):
+        font_dir = tmp_path / "Fonts"
+        font_dir.mkdir()
+
+        result = find_font_in_directories("Missing.ttf", [font_dir])
+
+        assert result is None
+
+    def test_skips_a_search_dir_that_does_not_exist(self, tmp_path):
+        missing_dir = tmp_path / "does-not-exist"
+
+        result = find_font_in_directories("Anything.ttf", [missing_dir])
+
+        assert result is None
+
+    def test_empty_font_name_returns_none(self, tmp_path):
+        assert find_font_in_directories("", [tmp_path]) is None
+
+
+class TestFindSystemFont:
+    def test_reproduces_the_reported_bug_font_not_found_on_macos(self, monkeypatch, tmp_path):
+        """This is the exact regression: before the fix, the fallback search only
+        checked Windows font directories, so any Mac (or Linux) user whose
+        chosen font was not in Bonsai's bundled fonts folder got no font at
+        all, even though the font was sitting right there on their system."""
+        mac_fonts_dir = tmp_path / "Library" / "Fonts"
+        mac_fonts_dir.mkdir(parents=True)
+        font_file = mac_fonts_dir / "OpenGOSTtypeA-Regular.ttf"
+        font_file.write_bytes(b"fake-ttf-data")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        result = find_system_font("OpenGOSTtypeA-Regular.ttf", system="Darwin")
+
+        assert result == font_file


### PR DESCRIPTION
Fixes #6995.

The drawing font fallback searched only the Windows font directory:

```python
Path(os.environ.get("WINDIR", "C:\\Windows")) / "Fonts"
```

so on macOS and Linux it found nothing at all, and text needing accented or non-Latin glyphs rendered as tofu boxes.

Reproduced on a real Mac: the baseline lookup returns `None` for a font that genuinely exists at `/Library/Fonts/Arial Unicode.ttf` on the same machine.

This adds OS-aware search directories for Windows, macOS and Linux, and makes the Drawing Font preference a file path so any installed font can be picked directly instead of typing a bare filename.

### Verified still needed

Issue #6995 is open, unassigned and has no comments, and no open PR references it.

### Tests

9 tests in `test_font_resolver.py`, run inside headless Blender because the import chain needs `bpy`.

Verified not vacuous: reverting only the body of `system_font_directories()` to the Windows-only behaviour turns 3 of the 9 red, including `test_reproduces_the_reported_bug_font_not_found_on_macos`.

### Manual check

1. Edit, then Preferences, then Add-ons, find Bonsai and expand its preferences.
2. Expand the Drawing section and find the Drawing Font field.
3. Expected: a file browser icon beside the field. Click it and pick any installed TrueType or OpenType font.
4. Generate a drawing containing text with accented characters.
5. Expected: the characters render as correct glyphs rather than boxes.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
