### PR TITLE
util/api: fix two crashes reading unset optional attrs

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/resource/calculate_resource_usage.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/resource/calculate_resource_usage.py
@@ -36,7 +36,7 @@ def calculate_resource_usage(file: ifcopenshell.file, resource: ifcopenshell.ent
         return
 
     task = ifcopenshell.util.resource.get_task_assignments(resource)
-    if not task or not task.TaskTime:
+    if not task or not task.TaskTime or not task.TaskTime.ScheduleDuration:
         return
 
     if not task.TaskTime.DurationType or task.TaskTime.DurationType == "WORKTIME":

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -480,7 +480,8 @@ def get_property_unit(
         entity = prop.wrapped_data.declaration().as_entity()
         measure_class = entity.attribute_by_index(3).type_of_attribute().declared_type().name()
     elif prop.is_a("IfcPropertySingleValue"):
-        measure_class = prop.NominalValue.is_a()
+        if value := prop.NominalValue:
+            measure_class = value.is_a()
     elif prop.is_a("IfcPropertyEnumeratedValue"):
         if prop.EnumerationReference:
             if unit := prop.EnumerationReference.Unit:

--- a/src/ifcopenshell-python/test/api/resource/test_calculate_resource_usage.py
+++ b/src/ifcopenshell-python/test/api/resource/test_calculate_resource_usage.py
@@ -1,0 +1,65 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.resource
+import ifcopenshell.api.root
+import ifcopenshell.api.sequence
+import test.bootstrap
+
+
+# NOTE: resource module features relies on entities introduced in IFC4
+# therefore no IFC2X3 tests
+class TestCalculateResourceUsage(test.bootstrap.IFC4):
+    def test_calculating_usage_from_a_scheduled_duration(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource")
+        ifcopenshell.api.resource.add_resource_time(self.file, resource=resource)
+        resource.Usage.ScheduleWork = "P2D"
+
+        task = ifcopenshell.api.sequence.add_task(self.file)
+        task_time = ifcopenshell.api.sequence.add_task_time(self.file, task=task)
+        ifcopenshell.api.sequence.edit_task_time(self.file, task_time=task_time, attributes={"ScheduleDuration": "P1D"})
+        ifcopenshell.api.sequence.assign_process(self.file, relating_process=task, related_object=resource)
+
+        ifcopenshell.api.resource.calculate_resource_usage(self.file, resource=resource)
+        assert resource.Usage.ScheduleUsage == 6.0
+
+    def test_no_crash_when_task_time_has_no_scheduled_duration(self):
+        # A task time with a start date but no duration is a valid, deliberately
+        # supported state (see TestEditTaskTime.
+        # test_editing_just_a_start_date_with_no_duration_or_finish).
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+
+        resource = ifcopenshell.api.resource.add_resource(self.file, ifc_class="IfcLaborResource")
+        ifcopenshell.api.resource.add_resource_time(self.file, resource=resource)
+        resource.Usage.ScheduleWork = "P2D"
+
+        task = ifcopenshell.api.sequence.add_task(self.file)
+        task_time = ifcopenshell.api.sequence.add_task_time(self.file, task=task)
+        ifcopenshell.api.sequence.edit_task_time(
+            self.file,
+            task_time=task_time,
+            attributes={"ScheduleDuration": None, "ScheduleStart": "2000-01-01T09:00:00"},
+        )
+        ifcopenshell.api.sequence.assign_process(self.file, relating_process=task, related_object=resource)
+
+        ifcopenshell.api.resource.calculate_resource_usage(self.file, resource=resource)
+        assert resource.Usage.ScheduleUsage is None

--- a/src/ifcopenshell-python/test/util/test_unit.py
+++ b/src/ifcopenshell-python/test/util/test_unit.py
@@ -119,6 +119,13 @@ class TestGetPropertyUnit(test.bootstrap.IFC4):
         prop.Unit = length2
         assert subject.get_property_unit(prop, self.file) == length2
 
+    def test_single_value_without_nominal_value(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        length = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="LENGTHUNIT", prefix="MILLI")
+        ifcopenshell.api.unit.assign_unit(self.file, units=[length])
+        prop = self.file.createIfcPropertySingleValue(Name="Foo", NominalValue=None)
+        assert subject.get_property_unit(prop, self.file) is None
+
     def test_enumerated_value(self):
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
         length = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="LENGTHUNIT", prefix="MILLI")


### PR DESCRIPTION
Continuing the pattern from #9147: schema-optional attributes read and used without a None guard, so a valid IFC file crashes the code.

### 1. `util/unit.py` `get_property_unit`, IfcPropertySingleValue branch

`NominalValue` is optional on `IfcPropertySingleValue` in IFC2X3, IFC4 and IFC4X3_ADD2. Every sibling branch in this same function already guards its value before calling `.is_a()` on it (IfcPropertyEnumeratedValue, IfcPropertyListValue, IfcPropertyBoundedValue), but the IfcPropertySingleValue branch called `prop.NominalValue.is_a()` unconditionally.

Verified with a property carrying only a `Name` and no `NominalValue` (a valid, minimal property):

```
AttributeError: 'NoneType' object has no attribute 'is_a'
```

This function is called from the Bonsai cost UI, `ifctester`'s measure-restriction facets, `ifc5d`'s cost/qto exports, and `ifcfm`'s COBie export, so a property with no value set crashes any of those paths.

Fix: guard `NominalValue` the same way every other branch already guards its value, matching the existing idiom in the function.

### 2. `api/resource/calculate_resource_usage.py`

`IfcTaskTime.ScheduleDuration` is optional in IFC4 and IFC4X3_ADD2, and this is a deliberately supported state (see the existing test `TestEditTaskTime.test_editing_just_a_start_date_with_no_duration_or_finish`, e.g. a task with only a start date entered). The function already guarded `TaskTime` being unset, but not `ScheduleDuration` being unset.

`ifcopenshell.util.date.ifc2datetime()` silently returns `None` for `None` input rather than raising, so the crash surfaces one call later:

```
task_duration = ifcopenshell.util.date.ifc2datetime(task.TaskTime.ScheduleDuration)
seconds = task_duration.days * hours_per_day * 60 * 60
AttributeError: 'NoneType' object has no attribute 'days'
```

This is reachable from ordinary scheduling: `api/sequence/edit_task_time.py` calls `calculate_resource_usage()` for every resource assigned to a task whenever that task's time is edited, so editing the time of a task with an assigned resource and no duration set crashes.

Fix: add `ScheduleDuration` to the existing early-return guard, matching the guard style already used for `Usage`/`ScheduleWork` a few lines above.

### Not fixed: a third candidate, ruled out as unreachable

`api/pset/edit_qto.py` `get_canonical_property_type` reads `prop_template.TemplateType[2:]` unconditionally, and `TemplateType` is optional on `IfcSimplePropertyTemplate`. Constructing the `Usecase` directly and calling it reproduces a `TypeError: 'NoneType' object is not subscriptable`. However `qto_template` is only ever sourced from IfcOpenShell's own bundled buildingSMART template library (`ifcopenshell.util.pset.get_template`), never from the file being edited. Grepping all three bundled template files (`Pset_IFC2X3.ifc`, `Pset_IFC4_ADD2.ifc`, `Pset_IFC4X3.ifc`) shows zero `IfcSimplePropertyTemplate` entries with a blank `TemplateType`, so no current caller can trigger this. Not shipped as a fix; noted here for completeness.

### Tests

- `src/ifcopenshell-python/test/util/test_unit.py`: `test_single_value_without_nominal_value`.
- `src/ifcopenshell-python/test/api/resource/test_calculate_resource_usage.py` (new file): a normal-duration case and the no-duration crash case.

Verified not vacuous, in both directions: reverting each fix individually against an unchanged test file reproduces the exact production traceback quoted above; the sibling test in each file is unaffected either way.

### AI disclosure

Per AGENTS.md: this pull request is AI-generated, including the new test file, which carries the disclosure comment.