### PR TITLE
Bonsai: 1-click drawing style changes

### DIFF
--- a/src/bonsai/bonsai/bim/__init__.py
+++ b/src/bonsai/bonsai/bim/__init__.py
@@ -102,6 +102,7 @@ for name in modules.keys():
 
 
 classes = [
+    operator.ApplyDrawingAssetsDir,
     operator.BIM_OT_add_section_plane,
     operator.BIM_OT_delete_object,
     operator.BIM_OT_remove_section_plane,

--- a/src/bonsai/bonsai/bim/module/drawing/__init__.py
+++ b/src/bonsai/bonsai/bim/module/drawing/__init__.py
@@ -93,6 +93,7 @@ classes = (
     operator.OpenSheet,
     operator.OrderTextLiteralDown,
     operator.OrderTextLiteralUp,
+    operator.OverrideDrawingStyles,
     operator.ReloadDrawingStyles,
     operator.RemoveDrawing,
     operator.RemoveDrawingFromSheet,

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -2708,6 +2708,66 @@ class RemoveDrawing(bpy.types.Operator, tool.Ifc.Operator):
             props.should_draw_decorations = False
 
 
+class OverrideDrawingStyles(bpy.types.Operator, tool.Ifc.Operator):
+    bl_idname = "bim.override_drawing_styles"
+    bl_label = "Override Drawing Styles"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = (
+        "Overwrite the currently selected drawing's Stylesheet, Markers, Symbols, Patterns,\n"
+        "Shading Styles and Current Shading Style with the current default drawing style paths\n"
+        "(Bonsai preferences, or the project's BBIM_Documentation overrides if set).\n\n"
+        "SHIFT+CLICK to override all checked drawings in the Drawings list"
+    )
+
+    drawing: bpy.props.IntProperty()
+    override_all: bpy.props.BoolProperty(name="Override All", default=False, options={"SKIP_SAVE"})
+
+    @classmethod
+    def poll(cls, context):
+        if not tool.Drawing.get_active_drawing_item():
+            cls.poll_message_set("No drawing selected.")
+            return False
+        return True
+
+    def invoke(self, context, event):
+        # override all checked drawings on shift+click
+        # make sure to use SKIP_SAVE on property, otherwise it might get stuck
+        if event.type == "LEFTMOUSE" and event.shift:
+            self.override_all = True
+        return self.execute(context)
+
+    def _execute(self, context):
+        ifc_file = tool.Ifc.get()
+        props = tool.Drawing.get_document_props()
+        if self.override_all:
+            drawings = [
+                tool.Ifc.get().by_id(d.ifc_definition_id) for d in props.drawings if d.is_drawing and d.is_selected
+            ]
+        else:
+            if not self.drawing:
+                self.report({"ERROR"}, "No drawing selected")
+                return {"CANCELLED"}
+            drawings = [tool.Ifc.get().by_id(self.drawing)]
+
+        properties: dict[str, Union[str, None]] = {
+            resource: tool.Drawing.get_default_drawing_resource_path(resource)
+            for resource in tool.Drawing.RESOURCE_TYPES
+        }
+        properties["CurrentShadingStyle"] = tool.Drawing.get_default_shading_style()
+
+        for drawing in drawings:
+            pset = tool.Pset.get_element_pset(drawing, "EPset_Drawing")
+            if pset is None:
+                pset = ifcopenshell.api.pset.add_pset(ifc_file, product=drawing, name="EPset_Drawing")
+            # NOTE: edit_pset mutates the properties dict it's given (it deletes keys as it
+            # updates existing properties), so each drawing needs its own copy.
+            ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties=dict(properties))
+
+        bonsai.bim.handler.refresh_ui_data()
+        self.report({"INFO"}, f"Overrode drawing styles for {len(drawings)} drawing(s).")
+        return {"FINISHED"}
+
+
 class DrawingStyleJson(TypedDict):
     render_type: "RenderType"
     raster_style: dict[str, Any]

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -334,6 +334,10 @@ class BIM_PT_drawings(Panel):
 
                 row3.operator("bim.copy_annotation_to_drawing", icon="PASTEDOWN", text="")
 
+                row3.operator("bim.override_drawing_styles", icon="COPYDOWN", text="").drawing = (
+                    active_drawing.ifc_definition_id
+                )
+
                 row3.operator("bim.select_all_drawings", icon="CHECKBOX_HLT", text="")
                 row3.operator("bim.create_drawing", text="", icon="OUTPUT")
                 row3.operator("bim.convert_svg_to_dxf", text="", icon="SEQ_PREVIEW").view = active_drawing.name

--- a/src/bonsai/bonsai/bim/operator.py
+++ b/src/bonsai/bonsai/bim/operator.py
@@ -362,6 +362,38 @@ class SelectDir(bpy.types.Operator, ImportHelper):
         return ImportHelper.invoke(self, context, event)
 
 
+class ApplyDrawingAssetsDir(bpy.types.Operator):
+    bl_idname = "bim.apply_drawing_assets_dir"
+    bl_label = "Apply Assets Directory To All Drawing Style Paths"
+    bl_options = {"REGISTER", "UNDO"}
+    bl_description = (
+        "Set the default stylesheet, schedule stylesheet, markers, symbols, patterns and shading "
+        "styles paths below from the assets directory above, using Bonsai's standard asset filenames "
+        "(default.css, schedule.css, markers.svg, symbols.svg, patterns.svg, shading_styles.json), "
+        "instead of setting each path one by one"
+    )
+
+    # Maps DocPreferences path property name to the standard Bonsai asset filename.
+    ASSET_FILENAMES = {
+        "stylesheet_path": "default.css",
+        "schedules_stylesheet_path": "schedule.css",
+        "markers_path": "markers.svg",
+        "symbols_path": "symbols.svg",
+        "patterns_path": "patterns.svg",
+        "shadingstyles_path": "shading_styles.json",
+    }
+
+    def execute(self, context):
+        dprops = tool.Blender.get_addon_preferences().doc
+        assets_dir = dprops.assets_dir.replace("\\", "/")
+        if assets_dir and not assets_dir.endswith("/"):
+            assets_dir += "/"
+        for prop_name, filename in self.ASSET_FILENAMES.items():
+            setattr(dprops, prop_name, assets_dir + filename)
+        self.report({"INFO"}, "Applied assets directory to all six drawing style paths.")
+        return {"FINISHED"}
+
+
 class WinRegistryKeys(Enum):
     __bonsai_key = "bonsai.ifc"
     # Have to list all keys here

--- a/src/bonsai/bonsai/bim/ui.py
+++ b/src/bonsai/bonsai/bim/ui.py
@@ -312,6 +312,17 @@ class DocPreferences(bpy.types.PropertyGroup):
         default=os.path.join("drawings") + os.path.sep,
         name="Default Drawings Directory",
     )
+    assets_dir: StringProperty(
+        default=os.path.join("drawings", "assets") + os.path.sep,
+        name="Default Drawing Style Assets Directory",
+        description=(
+            "Folder holding the drawing style asset files (stylesheet, schedule stylesheet, markers, "
+            "symbols, patterns, shading styles). Click 'Apply' below to set all six paths in this "
+            "section at once from this folder, using Bonsai's standard asset filenames, instead of "
+            "setting each one individually"
+        ),
+        subtype="DIR_PATH",
+    )
     stylesheet_path: StringProperty(
         default=os.path.join("drawings", "assets", "default.css"),
         name="Default Stylesheet",
@@ -372,6 +383,7 @@ class DocPreferences(bpy.types.PropertyGroup):
         layouts_dir: str
         titleblocks_dir: str
         drawings_dir: str
+        assets_dir: str
         stylesheet_path: str
         schedules_stylesheet_path: str
         markers_path: str
@@ -833,6 +845,9 @@ class BIM_ADDON_preferences(bpy.types.AddonPreferences):
         layout.prop(dprops, "layouts_dir")
         layout.prop(dprops, "titleblocks_dir")
         layout.prop(dprops, "drawings_dir")
+        row = layout.row(align=True)
+        row.prop(dprops, "assets_dir")
+        row.operator("bim.apply_drawing_assets_dir", text="", icon="COPYDOWN")
         layout.prop(dprops, "stylesheet_path")
         layout.prop(dprops, "schedules_stylesheet_path")
         layout.prop(dprops, "markers_path")


### PR DESCRIPTION
Fixes #6647.

Setting up drawing styles meant filling in six separate preference paths by hand, one per asset file, every time. This adds a single "assets directory" preference plus an Apply button that fills all six from one folder, and a button to push the current styles onto drawings that already exist.

### What it does

* **Apply**: point at one folder containing `default.css`, `schedule.css`, `markers.svg`, `symbols.svg`, `patterns.svg` and `shading_styles.json`, click once, and all six path fields are filled.
* **Override Drawing Styles**: updates the active drawing. Shift-click updates every checked drawing instead.

### Verified

Run live in headless Blender against the worktree source, using a throwaway `BLENDER_USER_RESOURCES` directory so no real profile was touched.

* Apply filled all six preference paths from a single folder.
* Override updated only the active drawing on a plain click, and every checked drawing on shift-click.

There are no automated tests for this area, so the behaviour was checked by driving the operators directly.

**One real bug this had to solve, worth flagging to a reviewer.** `ifcopenshell.api.pset.edit_pset` mutates the `properties` dict passed to it, which its own docstring states: "Note that provided `properties` might be mutated in the process." Without the defensive `dict(properties)` copy, overriding several drawings in one action silently left every drawing after the first with stale paths. Confirmed by reintroducing the mutation and watching the second drawing keep its old values.

### Issue still live

#6647 is open, unassigned, and no open PR duplicates it. Checked before building, since old feature requests here are often already implemented.

### Manual check

1. Edit, then Preferences, then Add-ons, find Bonsai and expand its preferences.
2. Under the documentation settings, set "Default Drawing Style Assets Directory" to a folder holding the six asset files.
3. Click the Apply button beside that field. Expected: the six path fields below now all point into that folder.
4. In the Drawings panel, select a drawing and click "Override Drawing Styles". Expected: a report saying 1 drawing was overridden.
5. Tick several drawings, then shift-click the same button. Expected: all ticked drawings are overridden, and each one's `EPset_Drawing` paths match the new folder.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
