### PR TITLE
ifcparse: check the result of fopen before using the FILE* (missing path kills the host process)

### DIFF
--- a/src/ifcparse/FileReader.cpp
+++ b/src/ifcparse/FileReader.cpp
@@ -46,6 +46,13 @@ struct FullBufferImpl final : FileReader::Impl {
 #else
         auto stream = fopen(fn.c_str(), "rb");
 #endif
+        if (stream == nullptr) {
+            // Missing or unreadable file. Leave the buffer empty so the
+            // caller sees a zero-length input and reports a read error;
+            // handing a null FILE* to the CRT below terminates the whole
+            // process instead of failing the parse.
+            return;
+        }
         fseek(stream, 0, SEEK_END);
         buf_.resize((size_t)ftell(stream));
         rewind(stream);
@@ -84,6 +91,13 @@ struct PagedFileImpl final : FileReader::Impl {
 #else
         fp_ = fopen(fn.c_str(), "rb");
 #endif
+        if (fp_ == nullptr) {
+            // As above: behave like an empty file rather than passing a
+            // null FILE* to fseek. get() then throws out_of_range for any
+            // position and fetchPage_() is never reached.
+            file_size_ = 0;
+            return;
+        }
         fseek(fp_, 0, SEEK_END);
         file_size_ = (size_t)ftell(fp_);
         rewind(fp_);


### PR DESCRIPTION
## Problem

Opening a path that does not exist **terminates the calling process**. No exception, nothing catchable:

```
exit code 0xC0000409   (fastfail — the MSVC CRT's response to a null FILE*)
```

`FullBufferImpl` and `PagedFileImpl` both open the file and use the handle without testing it:

```cpp
auto stream = _wfopen(fn_wide, L"rb");   // null when the file is missing
fseek(stream, 0, SEEK_END);              // null goes straight to the CRT
buf_.resize((size_t)ftell(stream));
```

It is reachable through the ordinary entry point: `IfcFile::initialize()` starts with `guess_file_type()`, which answers `FT_IFCSPF` for a path that does not exist — its own comment calls this *"just weird, but for consistency with earlier behaviour"* — so a missing path flows into the reader instead of being reported as an error.

Why this matters beyond a typo'd filename: a host application cannot defend against it. There is no exception, so no stack unwinding, so `try { … } catch (...)` does not help. Any GUI application embedding IfcOpenShell loses the user's unsaved work if a path is stale, a network share drops, or a file is deleted between listing and opening.

`PagedFileImpl`'s destructor already tests `fp_` for null, so the possibility was known — only the constructors do not check.

## Fix

Leave the reader empty when the open fails. Both implementations then behave exactly like a zero-length file: `size()` is 0, `get()` throws `out_of_range` for any position, `fetchPage_()` is never reached. The parse fails and `IfcFile::good()` reports it, which is something a caller can act on.

## Verification

Built `IfcParse` from this branch (schemas `2x3;4;4x3_add2`, MSVC 2022, OCCT 7.9.3) and read a non-existent path through `IfcParse::IfcFile`:

- **before**: process gone, exit `0xC0000409`, no output
- **after**: constructor returns, `good()` reports the failure, caller continues

The same test also still reads a valid minimal IFC4 file and reports a malformed one as an error, so the empty-reader path does not disturb normal parsing.