### PR TITLE
Bonsai: guard optional attrs in two read paths

### DIFF
--- a/src/bonsai/bonsai/bim/module/aggregate/data.py
+++ b/src/bonsai/bonsai/bim/module/aggregate/data.py
@@ -87,7 +87,7 @@ class AggregateData:
                 r
                 for r in getattr(aggregate, "HasAssignments", []) or []
                 if r.is_a("IfcRelAssignsToGroup")
-                if "BBIM_Linked_Aggregate" in r.RelatingGroup.Name
+                if "BBIM_Linked_Aggregate" in (r.RelatingGroup.Name or "")
             ),
             None,
         )

--- a/src/bonsai/bonsai/tool/structural.py
+++ b/src/bonsai/bonsai/tool/structural.py
@@ -197,7 +197,8 @@ class Structural(bonsai.core.tool.Structural):
         :return: IfcTopologyRepresentation if it's valid.
         """
         vertex_representation, undefined_representation = None, None
-        # At least 1 representation is mandatory in IFC for IfcStructuralPointConnection.
+        if not product.Representation:
+            return None
         for rep in product.Representation.Representations:
             rep: ifcopenshell.entity_instance
             rep_type: str = rep.RepresentationType


### PR DESCRIPTION
Two read paths in Bonsai dereference IFC attributes that the schema marks optional, so a valid file crashes them.

### 1. `bim/module/aggregate/data.py`

```python
if "BBIM_Linked_Aggregate" in r.RelatingGroup.Name
```

`IfcGroup.Name` is inherited from `IfcRoot` and is **optional in IFC2X3, IFC4 and IFC4X3_ADD2**. A group with no name gives:

```
TypeError: argument of type 'NoneType' is not iterable
```

Guarded with `or ""`, so an unnamed group simply does not match the marker.

### 2. `tool/structural.py`, `get_vertex_representation`

```python
# At least 1 representation is mandatory in IFC for IfcStructuralPointConnection.
for rep in product.Representation.Representations:
```

**That comment is incorrect.** `IfcStructuralPointConnection.Representation` is optional in all three schemas, and there is no WHERE rule imposing the constraint the comment claims. A point connection without a representation gives:

```
AttributeError: 'NoneType' object has no attribute 'Representations'
```

The comment is replaced with a guard returning `None`, which is a value the function already returns for other "nothing usable here" cases, so callers handle it.

### Reproduced

Both were run against real entity instances rather than argued from the schema alone:

```
tool/structural.py   for rep in product.Representation.Representations:
   -> AttributeError: 'NoneType' object has no attribute 'Representations'

aggregate/data.py    "BBIM_Linked_Aggregate" in r.RelatingGroup.Name
   -> TypeError: argument of type 'NoneType' is not iterable
```

With the guards applied the same inputs return `None` and `False` respectively.

`ifcopenshell.validate` raises no complaint about either absent attribute. It flags one unrelated item, that the minimal test fixture does not connect the point connection to a structural member, which is a property of the fixture rather than of the missing representation.

### Honest scope note

There are no tests here. Bonsai's `tool` and `data` layers need a running Blender, and `ifcopenshell` could not be imported into the Blender available on this machine, so the crashes were reproduced at the level of the exact failing expressions on real `IfcGroup` and `IfcStructuralPointConnection` instances, not through Bonsai's full call stack. The schema optionality was verified programmatically across all three schemas.

Both files were checked against every open PR and every branch on our fork; nothing else touches them.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
