### PR TITLE
ifc4d: guard two export crashes on valid IFC

### DIFF
--- a/src/ifc4d/ifc4d/ifc2msp.py
+++ b/src/ifc4d/ifc4d/ifc2msp.py
@@ -155,7 +155,7 @@ class Ifc2Msp:
             6: "Saturday",
             7: "Sunday",
         }
-        for working_time in calendar.WorkingTimes:
+        for working_time in calendar.WorkingTimes or []:
             if not working_time.RecurrencePattern or working_time.RecurrencePattern.RecurrenceType != "WEEKLY":
                 continue
 

--- a/src/ifc4d/ifc4d/ifc2p6.py
+++ b/src/ifc4d/ifc4d/ifc2p6.py
@@ -270,6 +270,8 @@ class Ifc2P6:
                     "START_FINISH": "Start to Finish",
                     "FINISH_START": "Finish to Start",
                     "FINISH_FINISH": "Finish to Finish",
+                    "NOTDEFINED": "Finish to Start",
+                    "USERDEFINED": "Finish to Start",
                     None: "Finish to Start",
                 }[rel.SequenceType]
 

--- a/src/ifc4d/test/test_ifc2msp_calendar.py
+++ b/src/ifc4d/test/test_ifc2msp_calendar.py
@@ -1,0 +1,53 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import tempfile
+from pathlib import Path
+
+import ifcopenshell
+import ifcopenshell.api.sequence
+
+from ifc4d.ifc2msp import Ifc2Msp
+
+
+class TestIfc2MspCalendarWithoutWorkingTimes:
+    def test_calendar_with_no_working_times_does_not_crash_the_export(self):
+        # WorkingTimes is an optional attribute on IfcWorkCalendar. A calendar
+        # created without any working time pattern (e.g. straight after
+        # ifcopenshell.api.sequence.add_work_calendar, before any
+        # add_work_time call) is valid IFC and leaves WorkingTimes as None.
+        # Before the fix, auto_detect_working_week iterated it directly and
+        # raised TypeError: 'NoneType' object is not iterable.
+        ifc_file = ifcopenshell.file()
+        ifc_file.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new(), Name="P")
+        work_schedule = ifcopenshell.api.sequence.add_work_schedule(ifc_file, name="Schedule A")
+        calendar = ifcopenshell.api.sequence.add_work_calendar(ifc_file, name="Cal A")
+        assert calendar.WorkingTimes is None
+        ifcopenshell.api.sequence.add_task(ifc_file, work_schedule=work_schedule, name="T1", identification="1")
+
+        converter = Ifc2Msp()
+        converter.file = ifc_file
+        converter.work_schedule = work_schedule
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            converter.xml = str(Path(tmp_dir) / "out.xml")
+            converter.execute()
+            xml = Path(converter.xml).read_text()
+
+        assert "<DayWorking>1</DayWorking>" in xml

--- a/src/ifc4d/test/test_ifc2p6_sequence_type.py
+++ b/src/ifc4d/test/test_ifc2p6_sequence_type.py
@@ -1,0 +1,99 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import datetime
+import re
+import tempfile
+from pathlib import Path
+
+import ifcopenshell
+import ifcopenshell.api.control
+import ifcopenshell.api.sequence
+
+from ifc4d.ifc2p6 import Ifc2P6
+
+
+class TestIfc2P6RelationshipType:
+    """IfcSequenceEnum has 6 members: START_START, START_FINISH, FINISH_START,
+    FINISH_FINISH, USERDEFINED, NOTDEFINED. Only the first 4 mapped to a P6
+    relationship type text; USERDEFINED and NOTDEFINED fell through a plain
+    dict lookup and raised KeyError, crashing the whole export.
+    """
+
+    @staticmethod
+    def build_ifc(sequence_type: "str | None") -> ifcopenshell.file:
+        ifc_file = ifcopenshell.file()
+        ifc_file.create_entity("IfcProject", GlobalId=ifcopenshell.guid.new(), Name="P")
+        schedule = ifcopenshell.api.sequence.add_work_schedule(ifc_file, name="Schedule A")
+        calendar = ifcopenshell.api.sequence.add_work_calendar(ifc_file, name="Cal A")
+        t1 = ifcopenshell.api.sequence.add_task(ifc_file, work_schedule=schedule, name="T1", identification="1")
+        t2 = ifcopenshell.api.sequence.add_task(ifc_file, work_schedule=schedule, name="T2", identification="2")
+        ifcopenshell.api.control.assign_control(ifc_file, relating_control=calendar, related_objects=[t1, t2])
+        for task in (t1, t2):
+            task_time = ifcopenshell.api.sequence.add_task_time(ifc_file, task=task)
+            ifcopenshell.api.sequence.edit_task_time(
+                ifc_file,
+                task_time=task_time,
+                attributes={"ScheduleDuration": "P1D", "ScheduleStart": "2024-01-01T08:00:00"},
+            )
+        rel = ifcopenshell.api.sequence.assign_sequence(ifc_file, relating_process=t1, related_process=t2)
+        if sequence_type is not None:
+            ifcopenshell.api.sequence.edit_sequence(
+                ifc_file, rel_sequence=rel, attributes={"SequenceType": sequence_type}
+            )
+        return ifc_file
+
+    @staticmethod
+    def export(ifc_file: ifcopenshell.file) -> str:
+        converter = Ifc2P6()
+        converter.file = ifc_file
+        converter.holiday_start_date = datetime.date(2024, 1, 1)
+        converter.holiday_finish_date = datetime.date(2024, 1, 1)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            converter.xml = str(Path(tmp_dir) / "out.xml")
+            converter.execute()
+            return Path(converter.xml).read_text()
+
+    def test_userdefined_sequence_type_does_not_crash_the_export(self):
+        # Before the fix: KeyError: 'USERDEFINED'.
+        ifc_file = self.build_ifc("USERDEFINED")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Relationship>.*?<Type>([^<]*)</Type>", xml) == ["Finish to Start"]
+
+    def test_notdefined_sequence_type_does_not_crash_the_export(self):
+        # Before the fix: KeyError: 'NOTDEFINED'.
+        ifc_file = self.build_ifc("NOTDEFINED")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Relationship>.*?<Type>([^<]*)</Type>", xml) == ["Finish to Start"]
+
+    def test_absent_sequence_type_still_defaults_to_finish_to_start(self):
+        ifc_file = self.build_ifc(None)
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Relationship>.*?<Type>([^<]*)</Type>", xml) == ["Finish to Start"]
+
+    def test_finish_start_sequence_type_is_still_mapped_correctly(self):
+        ifc_file = self.build_ifc("FINISH_START")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Relationship>.*?<Type>([^<]*)</Type>", xml) == ["Finish to Start"]
+
+    def test_start_start_sequence_type_is_still_mapped_correctly(self):
+        ifc_file = self.build_ifc("START_START")
+        xml = self.export(ifc_file)
+        assert re.findall(r"<Relationship>.*?<Type>([^<]*)</Type>", xml) == ["Start to Start"]


### PR DESCRIPTION
Two independent crashes in the schedule exporters, both triggered by valid IFC.

### 1. `ifc2p6.py`: a dict lookup over an enum that was missing two members

```python
}[rel.SequenceType]
```

The mapping covered `START_START`, `START_FINISH`, `FINISH_START`, `FINISH_FINISH` and `None`. `IfcSequenceEnum` has **six** members. `USERDEFINED` and `NOTDEFINED` were absent, so a schedule containing either raised `KeyError: 'USERDEFINED'` and **the entire P6 export failed**, not just that one relationship.

Verified against the schema rather than assumed:

```
IfcSequenceEnum members: ['START_START', 'START_FINISH', 'FINISH_START',
                          'FINISH_FINISH', 'USERDEFINED', 'NOTDEFINED']
```

Both now map to "Finish to Start", matching the existing treatment of an absent `SequenceType`.

### 2. `ifc2msp.py`: iterating an optional attribute

```python
for working_time in calendar.WorkingTimes:
```

`IfcWorkCalendar.WorkingTimes` is optional. A calendar created and not yet given a work time, which is exactly the state left by `ifcopenshell.api.sequence.add_work_calendar`, has it as `None`:

```
TypeError: 'NoneType' object is not iterable
```

Guarded with `or []`.

### Tests

`src/ifc4d/test/`, which had no test package before this. 6 tests covering both crashes plus the cases that already worked, so the existing mappings are pinned rather than just the new ones.

Verified not vacuous: reverting both source files while keeping the tests gives **3 failed, 3 passed**, with exactly:

```
TypeError: 'NoneType' object is not iterable
KeyError: 'USERDEFINED'
KeyError: 'NOTDEFINED'
```

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated, including the new test files, which carry the disclosure comment.
