### PR TITLE
ifc2ca: guard optional boundary stiffness values

### DIFF
--- a/src/ifc2ca/ifc2ca.py
+++ b/src/ifc2ca/ifc2ca.py
@@ -354,29 +354,32 @@ class Ifc2CA:
 
         if geometry_type == "Vertex":
             return {
-                "dx": condition.TranslationalStiffnessX.wrappedValue,
-                "dy": condition.TranslationalStiffnessY.wrappedValue,
-                "dz": condition.TranslationalStiffnessZ.wrappedValue,
-                "drx": condition.RotationalStiffnessX.wrappedValue,
-                "dry": condition.RotationalStiffnessY.wrappedValue,
-                "drz": condition.RotationalStiffnessZ.wrappedValue,
+                "dx": condition.TranslationalStiffnessX and condition.TranslationalStiffnessX.wrappedValue,
+                "dy": condition.TranslationalStiffnessY and condition.TranslationalStiffnessY.wrappedValue,
+                "dz": condition.TranslationalStiffnessZ and condition.TranslationalStiffnessZ.wrappedValue,
+                "drx": condition.RotationalStiffnessX and condition.RotationalStiffnessX.wrappedValue,
+                "dry": condition.RotationalStiffnessY and condition.RotationalStiffnessY.wrappedValue,
+                "drz": condition.RotationalStiffnessZ and condition.RotationalStiffnessZ.wrappedValue,
             }
 
         if geometry_type == "Edge":
             return {
-                "dx": condition.TranslationalStiffnessByLengthX.wrappedValue,
-                "dy": condition.TranslationalStiffnessByLengthY.wrappedValue,
-                "dz": condition.TranslationalStiffnessByLengthZ.wrappedValue,
-                "drx": condition.RotationalStiffnessByLengthX.wrappedValue,
-                "dry": condition.RotationalStiffnessByLengthY.wrappedValue,
-                "drz": condition.RotationalStiffnessByLengthZ.wrappedValue,
+                "dx": condition.TranslationalStiffnessByLengthX
+                and condition.TranslationalStiffnessByLengthX.wrappedValue,
+                "dy": condition.TranslationalStiffnessByLengthY
+                and condition.TranslationalStiffnessByLengthY.wrappedValue,
+                "dz": condition.TranslationalStiffnessByLengthZ
+                and condition.TranslationalStiffnessByLengthZ.wrappedValue,
+                "drx": condition.RotationalStiffnessByLengthX and condition.RotationalStiffnessByLengthX.wrappedValue,
+                "dry": condition.RotationalStiffnessByLengthY and condition.RotationalStiffnessByLengthY.wrappedValue,
+                "drz": condition.RotationalStiffnessByLengthZ and condition.RotationalStiffnessByLengthZ.wrappedValue,
             }
 
         if geometry_type == "Face":
             return {
-                "dx": condition.TranslationalStiffnessByAreaX.wrappedValue,
-                "dy": condition.TranslationalStiffnessByAreaY.wrappedValue,
-                "dz": condition.TranslationalStiffnessByAreaZ.wrappedValue,
+                "dx": condition.TranslationalStiffnessByAreaX and condition.TranslationalStiffnessByAreaX.wrappedValue,
+                "dy": condition.TranslationalStiffnessByAreaY and condition.TranslationalStiffnessByAreaY.wrappedValue,
+                "dz": condition.TranslationalStiffnessByAreaZ and condition.TranslationalStiffnessByAreaZ.wrappedValue,
             }
 
     def parse_element(self, element: ios.entity_instance):


### PR DESCRIPTION
`Ifc2CA.get_boundary_condition` read every stiffness component and immediately unwrapped it:

```python
"dx": condition.TranslationalStiffnessX.wrappedValue,
```

**Every attribute of `IfcBoundaryNodeCondition` is optional**, verified against the schema:

```
Name                     optional=True
TranslationalStiffnessX  optional=True
TranslationalStiffnessY  optional=True
TranslationalStiffnessZ  optional=True
RotationalStiffnessX     optional=True
RotationalStiffnessY     optional=True
RotationalStiffnessZ     optional=True
```

A partially specified boundary condition is therefore valid IFC, and is common in practice: a support that restrains translation but not rotation simply leaves the rotational components unset. Reading one raised `AttributeError: 'NoneType' object has no attribute 'wrappedValue'`.

Each read is now guarded, so an unset component comes through as `None` rather than crashing the conversion. The same change is applied to the `Vertex`, `Edge` and `Face` branches, which had the identical pattern against `IfcBoundaryNodeCondition`, `...ByLength` and `...ByArea` respectively.

### Honest scope note

**There are no tests here.** `src/ifc2ca` has no test infrastructure, and adding one would mean standing up a fixture harness for a package that has never had one, which is a larger change than this fix and does not belong in it. The schema optionality was verified programmatically across IFC2X3, IFC4 and IFC4X3_ADD2; the crash follows directly from unwrapping a `None`.

Flagging that plainly rather than implying a level of verification this did not get.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
