### PR TITLE
Bonsai: fix nine crashes on valid IFC files

### DIFF
--- a/src/bonsai/bonsai/bim/module/classification/operator.py
+++ b/src/bonsai/bonsai/bim/module/classification/operator.py
@@ -259,7 +259,8 @@ class EnableEditingClassificationReference(bpy.types.Operator):
         props.reference_attributes.clear()
         ifc_reference = tool.Ifc.get().by_id(self.reference)
         bonsai.bim.helper.import_attributes(ifc_reference, props.reference_attributes)
-        props.classification_system_name = ifc_reference.ReferencedSource.Name or ""
+        source = ifc_reference.ReferencedSource
+        props.classification_system_name = (source.Name or "") if source else ""
         props.active_reference_id = self.reference
         return {"FINISHED"}
 
@@ -487,8 +488,10 @@ class ChangeClassificationLevel(bpy.types.Operator):
             new.has_references = bool(reference.HasReferences)
             new.referenced_source
         assert reference
-        if reference.ReferencedSource.is_a("IfcClassificationReference"):
-            props.active_library_referenced_source = reference.ReferencedSource.ReferencedSource.id()
+        source = reference.ReferencedSource
+        if source and source.is_a("IfcClassificationReference"):
+            nested_source = source.ReferencedSource
+            props.active_library_referenced_source = nested_source.id() if nested_source else 0
         else:
             props.active_library_referenced_source = 0
         return {"FINISHED"}

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -3168,10 +3168,11 @@ class AddScheduleToSheet(bpy.types.Operator, tool.Ifc.Operator):
         active_sheet = tool.Drawing.get_active_sheet()
         ifc_file = tool.Ifc.get()
         schedule = tool.Ifc.get().by_id(active_schedule.ifc_definition_id)
-        if tool.Ifc.get_schema() == "IFC2X3":
-            schedule_location = tool.Drawing.get_path_with_ext(schedule.DocumentReferences[0].Location, "svg")
-        else:
-            schedule_location = tool.Drawing.get_path_with_ext(schedule.HasDocumentReferences[0].Location, "svg")
+        schedule_references = tool.Drawing.get_document_references(schedule)
+        if not schedule_references:
+            self.report({"ERROR"}, "The schedule must be generated before adding to a sheet.")
+            return
+        schedule_location = tool.Drawing.get_path_with_ext(schedule_references[0].Location, "svg")
 
         sheet = tool.Ifc.get().by_id(active_sheet.ifc_definition_id)
         if not sheet.is_a("IfcDocumentInformation"):
@@ -3241,10 +3242,11 @@ class AddReferenceToSheet(bpy.types.Operator, tool.Ifc.Operator):
         active_sheet = tool.Drawing.get_active_sheet()
         ifc_file = tool.Ifc.get()
         extref = tool.Ifc.get().by_id(active_reference.ifc_definition_id)
-        if tool.Ifc.get_schema() == "IFC2X3":
-            extref_location = tool.Drawing.get_path_with_ext(extref.DocumentReferences[0].Location, "svg")
-        else:
-            extref_location = tool.Drawing.get_path_with_ext(extref.HasDocumentReferences[0].Location, "svg")
+        extref_references = tool.Drawing.get_document_references(extref)
+        if not extref_references:
+            self.report({"ERROR"}, "The reference must be generated before adding to a sheet.")
+            return
+        extref_location = tool.Drawing.get_path_with_ext(extref_references[0].Location, "svg")
 
         sheet = tool.Ifc.get().by_id(active_sheet.ifc_definition_id)
         if not sheet.is_a("IfcDocumentInformation"):

--- a/src/bonsai/bonsai/bim/module/geometry/operator.py
+++ b/src/bonsai/bonsai/bim/module/geometry/operator.py
@@ -3465,6 +3465,8 @@ class UnassignRepresentationItemStyle(bpy.types.Operator, tool.Ifc.Operator):
             element = tool.Ifc.get_entity(obj)
             if not element:
                 continue  # Skip if no IFC entity is found
+            if not element.Representation:
+                continue  # Skip if the element has no geometric representation
 
             representation_item_id = element.Representation.Representations[0].Items[0].id()
             representation_item = tool.Ifc.get_entity_by_id(representation_item_id)

--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -543,6 +543,8 @@ class DumbProfileJoiner:
             # Openings should move with the host overall ...
             # ... except their position should stay the same along the local Z axis of the wall
             for opening in [r.RelatedOpeningElement for r in element.HasOpenings]:
+                if not opening.ObjectPlacement:
+                    continue
                 percent = tool.Cad.edge_percent(self.body[0], (previous_origin, (previous_matrix @ Vector((0, 0, 1)))))
                 is_z_offset_increased = True if percent < 0 else False
 

--- a/src/bonsai/bonsai/bim/module/structural/data.py
+++ b/src/bonsai/bonsai/bim/module/structural/data.py
@@ -73,7 +73,7 @@ class LoadGroupDecorationData:
         elif props.activity_type == "External Reaction":
             groups = m.HasResults or []
             for g in groups:
-                result_name = g.ResultForLoadGroup.Name or ""
+                result_name = (g.ResultForLoadGroup.Name or "") if g.ResultForLoadGroup else ""
                 group_name = g.Name or ""
                 ret.append((str(g.id()), group_name + " " + result_name, ""))
 

--- a/src/bonsai/bonsai/bim/module/structural/load_decoration_data.py
+++ b/src/bonsai/bonsai/bim/module/structural/load_decoration_data.py
@@ -599,6 +599,8 @@ class ShaderInfo:
                 continue
 
             blender_object = tool.Ifc.get_object_by_identifier(getattr(member, "GlobalId", None))
+            if not blender_object or not blender_object.data or len(blender_object.data.vertices) < 2:
+                continue
 
             start_co = blender_object.matrix_world @ blender_object.data.vertices[0].co
             end_co = blender_object.matrix_world @ blender_object.data.vertices[1].co

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -2687,7 +2687,7 @@ class Geometry(bonsai.core.tool.Geometry):
         # clean up the orphaned mesh with ifc id of the original object to avoid confusion
         # IfcGridAxis keeps the same mesh data (it's pointing to ifc id 0, so it's not a problem)
         if new and temp_data and not new.is_a("IfcGridAxis"):
-            if new.is_a("IfcRelSpaceBoundary"):
+            if new.is_a("IfcRelSpaceBoundary") and new.ConnectionGeometry:
                 surface = new.ConnectionGeometry.SurfaceOnRelatingElement
                 temp_data.name = f"0/{surface.id()}"
                 tool.Ifc.link(surface, temp_data)

--- a/src/bonsai/bonsai/tool/pset.py
+++ b/src/bonsai/bonsai/tool/pset.py
@@ -321,7 +321,10 @@ class Pset(bonsai.core.tool.Pset):
     def import_enumerated_value_from_template(
         cls, prop_template: ifcopenshell.entity_instance, data: dict[str, Any], props: bpy.types.PropertyGroup
     ) -> None:
-        enum_items = [v.wrappedValue for v in prop_template.Enumerators.EnumerationValues]
+        enumerators = prop_template.Enumerators
+        if not enumerators or not enumerators.EnumerationValues:
+            return
+        enum_items = [v.wrappedValue for v in enumerators.EnumerationValues]
         selected_enum_items = data.get(prop_template.Name, []) or []
 
         prop = props.properties.add()
@@ -408,7 +411,7 @@ class Pset(bonsai.core.tool.Pset):
                     continue
                 cls.import_single_value_from_template(pset_template, prop_template, simplified_data, props)
 
-            elif prop_template.TemplateType.startswith("Q_"):
+            elif prop_template.TemplateType and prop_template.TemplateType.startswith("Q_"):
                 cls.import_single_value_from_template(pset_template, prop_template, simplified_data, props)
 
             elif prop_template.TemplateType == "P_ENUMERATEDVALUE":

--- a/src/bonsai/bonsai/tool/pset_template.py
+++ b/src/bonsai/bonsai/tool/pset_template.py
@@ -72,12 +72,13 @@ class PsetTemplate(bonsai.core.tool.PsetTemplate):
                 if prop.Name in added_prop_names:
                     continue
                 added_prop_names.add(prop.Name)
+                nominal_value = prop.NominalValue if prop.is_a("IfcPropertySingleValue") else None
                 ifcopenshell.api.pset_template.add_prop_template(
                     template_file,
                     pset_template,
                     name=prop.Name,
                     description=prop.Description,
-                    primary_measure_type=prop.NominalValue.is_a(),
+                    primary_measure_type=nominal_value.is_a() if nominal_value else None,
                 )
         return pset_template
 


### PR DESCRIPTION
Nine crashes in Bonsai, each triggered by an IFC file that is valid but does not populate an optional attribute. Found by enumeration rather than inspection, and kept as nine standalone commits so each can be reviewed on its own.

### Method

The schema is the authority. I built the set of attribute names that are **optional on every entity declaring them**, across IFC2X3, IFC4 and IFC4X3_ADD2 (605 names), then scanned `bim/module/*/` and `tool/` for chained reads of those names, then hand-checked every hit for an outer guard.

**The hit rate matters more than the fixes.** Of 53 candidate sites:

| Outcome | Count |
|---|---|
| Already guarded, false positive | 29 |
| Skipped, already covered elsewhere | 4 |
| Stale, the flagged code no longer exists | 2 |
| Dead code, function has no caller | 1 |
| Declined, reachability too low to justify the change | 2 |
| Different root cause, flagged not fixed | 1 |
| **Real, fixed** | **13 lines in 9 commits** |

The 29 false positives are expected: a line-level scan cannot see a guard several lines above. Each was read in context before being dismissed.

### The fixes

1. **`classification/operator.py`**: `IfcClassificationReference.ReferencedSource` is optional. Editing a reference via the pencil icon, and drilling into a library, both dereferenced it unguarded.
2. **`drawing/operator.py`**: adding a schedule or reference to a sheet indexed `[0]` of a document reference list that can be empty on an externally authored file. Now uses the existing `tool.Drawing.get_document_references` helper, which already handles the IFC2X3 and IFC4 attribute split, and reports a clear error instead of crashing.
3. **`geometry/operator.py`**: Unassign Representation Item Style crashed when the selection included a spatial element with no representation.
4. **`model/profile.py`**: resizing a wall profile crashed on an opening with no `ObjectPlacement`.
5. **`structural/data.py`**: unset `ResultForLoadGroup` crashed the External Reaction dropdown.
6. **`structural/load_decoration_data.py`**: a curve member with no mesh data crashed viewport load decoration **on every redraw**, which is the worst of these to hit.
7. **`tool/geometry.py`**: Shift+D on a space boundary with no `ConnectionGeometry`.
8. **`tool/pset.py`**: unset `TemplateType` or `Enumerators` on a custom pset template.
9. **`tool/pset_template.py`**: Add Pset As Template crashed on a property that is not an `IfcPropertySingleValue`, or whose `NominalValue` is unset.

### What was deliberately not done

- **Two MEP port sites** were declined. `ObjectPlacement` is optional there, but a port without a placement is geometrically meaningless for routing, no authoring tool appears to omit it, and a safe fix needs error handling restructured across eight call sites in the MEP generator. That is disproportionate to the confidence it is ever reached.
- **One site in `sequence/operator.py` is a real bug but a different shape**, so it is not fixed here. It reads `NominalValue` inside a loop scoped to `IfcPropertyEnumeratedValue`, which never has that attribute at all, so it fails even when nothing is `None`. Bonsai's own `EPset_Status` template always authors that property as an `IfcPropertySingleValue`, so the branch is unreachable in normal use, but an externally authored file could reach it. Fixing it needs a design decision (should the loop also scan single values?) rather than a guard, so it is flagged for a separate pass.
- **One dead function** and **two stale sites** were left alone rather than "hardened". A guard against an unreachable state is noise a reviewer has to read.

### Verification

Every fix was reproduced against real `ifcopenshell` entities before and after the change, not argued from the schema alone.

**Honest limitation:** `ifcopenshell` could not be imported into the Blender available on this machine, so these are reproductions of the exact failing expressions against real entity instances, **not** full-stack runs through Bonsai's UI. The schema optionality behind each was verified programmatically across all three schemas.

Every touched file was checked against every open PR; the two with real proximity were confirmed to merge cleanly with `git merge-tree`. Files already covered by #9153 and #9100 were left untouched.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
