### PR TITLE
ifcfm: fix four COBie export crashes on valid IFC

### DIFF
--- a/src/ifcfm/ifcfm/cobie24.py
+++ b/src/ifcfm/ifcfm/cobie24.py
@@ -53,7 +53,7 @@ def get_floors(ifc_file: ifcopenshell.file) -> list[ifcopenshell.entity_instance
     return [
         e
         for e in ifc_file.by_type("IfcBuildingStorey")
-        if ifcopenshell.util.element.get_aggregate(e).is_a("IfcBuilding")
+        if (parent := ifcopenshell.util.element.get_aggregate(e)) and parent.is_a("IfcBuilding")
     ]
 
 

--- a/src/ifcfm/ifcfm/cobie24.py
+++ b/src/ifcfm/ifcfm/cobie24.py
@@ -947,7 +947,10 @@ def get_coordinate_data_(element: ifcopenshell.entity_instance) -> Generator[dic
 
 
 def get_unit_type_name(ifc_file: ifcopenshell.file, unit_type: str) -> Union[str, None]:
-    for unit in ifc_file.by_type("IfcUnitAssignment")[0].Units:
+    unit_assignments = ifc_file.by_type("IfcUnitAssignment")
+    if not unit_assignments:
+        return None
+    for unit in unit_assignments[0].Units:
         if unit.is_a("IfcNamedUnit") and unit.UnitType == unit_type:
             if unit.is_a("IfcSIUnit"):
                 prefix = (unit.Prefix or "").lower()

--- a/src/ifcfm/ifcfm/cobie24.py
+++ b/src/ifcfm/ifcfm/cobie24.py
@@ -940,7 +940,7 @@ def get_coordinate_data_(element: ifcopenshell.entity_instance) -> Generator[dic
     }
     for category, point in zip(categories, bbox):
         box_point_data = {
-            "Name": element_name + category,
+            "Name": (element_name or "") + category,
             "CoordinateXAxis": point[0],
             "CoordinateYAxis": point[1],
             "CoordinateZAxis": point[2],

--- a/src/ifcfm/ifcfm/cobie24.py
+++ b/src/ifcfm/ifcfm/cobie24.py
@@ -690,8 +690,10 @@ def get_connection_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entit
         or val(element.Name)
     )
     name = val(element.Name)
-    row_name1 = val(ifcopenshell.util.system.get_port_element(element.RelatingPort).Name)
-    row_name2 = val(ifcopenshell.util.system.get_port_element(element.RelatedPort).Name)
+    relating_element = ifcopenshell.util.system.get_port_element(element.RelatingPort)
+    related_element = ifcopenshell.util.system.get_port_element(element.RelatedPort)
+    row_name1 = val(relating_element.Name) if relating_element else None
+    row_name2 = val(related_element.Name) if related_element else None
     return {
         "Name": name,
         "CreatedBy": get_created_by(element),

--- a/src/ifcfm/ifcfm/cobie24legacy.py
+++ b/src/ifcfm/ifcfm/cobie24legacy.py
@@ -937,7 +937,10 @@ def get_attribute_data(
 
 
 def get_unit_type_name(ifc_file: ifcopenshell.file, unit_type: str) -> Union[str, None]:
-    for unit in ifc_file.by_type("IfcUnitAssignment")[0].Units:
+    unit_assignments = ifc_file.by_type("IfcUnitAssignment")
+    if not unit_assignments:
+        return None
+    for unit in unit_assignments[0].Units:
         if unit.is_a("IfcNamedUnit") and unit.UnitType == unit_type:
             if unit.is_a("IfcSIUnit"):
                 prefix = (unit.Prefix or "").lower()

--- a/src/ifcfm/ifcfm/cobie24legacy.py
+++ b/src/ifcfm/ifcfm/cobie24legacy.py
@@ -749,8 +749,10 @@ def get_connection_data(ifc_file: ifcopenshell.file, element: ifcopenshell.entit
         or val(element.Name)
     )
     name = val(element.Name)
-    row_name1 = val(ifcopenshell.util.system.get_port_element(element.RelatingPort).Name)
-    row_name2 = val(ifcopenshell.util.system.get_port_element(element.RelatedPort).Name)
+    relating_element = ifcopenshell.util.system.get_port_element(element.RelatingPort)
+    related_element = ifcopenshell.util.system.get_port_element(element.RelatedPort)
+    row_name1 = val(relating_element.Name) if relating_element else None
+    row_name2 = val(related_element.Name) if related_element else None
     return {
         "key": str(name) + str(connection_type) + str(row_name1) + str(row_name2),
         "Name": name,

--- a/src/ifcfm/ifcfm/cobie24legacy.py
+++ b/src/ifcfm/ifcfm/cobie24legacy.py
@@ -49,7 +49,7 @@ def get_floors(ifc_file: ifcopenshell.file) -> list[ifcopenshell.entity_instance
     return [
         e
         for e in ifc_file.by_type("IfcBuildingStorey")
-        if ifcopenshell.util.element.get_aggregate(e).is_a("IfcBuilding")
+        if (parent := ifcopenshell.util.element.get_aggregate(e)) and parent.is_a("IfcBuilding")
     ]
 
 


### PR DESCRIPTION
Four crashes in the COBie exporters, each triggered by valid IFC.

1. **`get_floors`**: called `get_aggregate(e).is_a("IfcBuilding")` unguarded. An `IfcBuildingStorey` with no `Decomposes` relationship, an orphan storey, returns `None` and crashes the export.
2. **`get_unit_type_name`**: indexed `by_type("IfcUnitAssignment")[0]`. `IfcProject.UnitsInContext` is optional, so a project with no units defined crashed the whole Facility sheet.
3. **`get_connection_data`**: `get_port_element()` returns `None` for a port that is not nested under an element, and the result was dereferenced for `.Name`, crashing the Connection sheet.
4. **`get_coordinate_data_`**: concatenated `element_name + category`. `IfcSpace.Name` is optional, so an unnamed space that still carries real geometry crashed the Coordinate sheet with `TypeError: can only concatenate str`.

Each fix is applied to both `cobie24.py` and `cobie24legacy.py` where the pattern appears in both.

### Verified

Every one was reproduced by running the exporter against a hand-built IFC4 file before the change, and re-run afterwards, including a happy-path check so the guards do not silently swallow real data. The unnamed-space case was reproduced with actual box geometry rather than a stub, since the crash only occurs once the element reaches coordinate extraction.

### Not duplicated

Several nearby spots in the same files, the `get_container` and `get_type` guards in `get_element_data`, name concatenation in `get_zone_data`, and `get_component_data`, are already fixed by open PR #9061. I read that PR's diff first and deliberately left those alone.

### No tests

`src/ifcfm` had no test infrastructure before #9061, and this adds none. Each fix was verified by direct execution instead, as described above. Flagging that plainly rather than implying coverage this does not have.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
