### PR TITLE
ifcbimtester: fix eight crashes in step definitions

### DIFF
--- a/src/ifcbimtester/bimtester/features/steps/aggregation/en.py
+++ b/src/ifcbimtester/bimtester/features/steps/aggregation/en.py
@@ -189,7 +189,7 @@ def check_if_element_exists_by_types_with_attribute_name(ifc_types, attribute_na
 
 def check_starts_with(attribute_name, value, elements):
     """Make sure at least an element of the list has a attribute starting with the value"""
-    if any(hasattr(x, attribute_name) and getattr(x, attribute_name).startswith(value) for x in elements):
+    if any(getattr(x, attribute_name, None) and getattr(x, attribute_name).startswith(value) for x in elements):
         return True
     return False
 

--- a/src/ifcbimtester/bimtester/features/steps/application/en.py
+++ b/src/ifcbimtester/bimtester/features/steps/application/en.py
@@ -24,7 +24,9 @@ from bimtester.lang import _
 @step('The IFC file must be exported by application full name "{fullname}"')
 def step_impl(context, fullname):
 
-    real_fullname = IfcStore.file.by_type("IfcApplication")[0].ApplicationFullName
+    applications = IfcStore.file.by_type("IfcApplication")
+    assert applications, _("The IFC file does not have any exporting application recorded")
+    real_fullname = applications[0].ApplicationFullName
     assert real_fullname == fullname, (
         "The IFC file was not exported by application full name {} "
         "instead it was exported by application full name {}".format(fullname, real_fullname)
@@ -34,7 +36,9 @@ def step_impl(context, fullname):
 @step('The IFC file must be exported by application identifier "{identifier}"')
 def step_impl(context, identifier):
 
-    real_identifier = IfcStore.file.by_type("IfcApplication")[0].ApplicationIdentifier
+    applications = IfcStore.file.by_type("IfcApplication")
+    assert applications, _("The IFC file does not have any exporting application recorded")
+    real_identifier = applications[0].ApplicationIdentifier
     assert (
         real_identifier == identifier
     ), "The IFC file was not exported by application identifier {} " "instead it was exported by identifier {}".format(
@@ -45,7 +49,9 @@ def step_impl(context, identifier):
 @step('The IFC file must be exported by the application version "{version}"')
 def step_impl(context, version):
 
-    real_version = IfcStore.file.by_type("IfcApplication")[0].Version
+    applications = IfcStore.file.by_type("IfcApplication")
+    assert applications, _("The IFC file does not have any exporting application recorded")
+    real_version = applications[0].Version
     assert (
         real_version == version
     ), "The IFC file was not exported by application version {} " "instead it was exported by version {}".format(

--- a/src/ifcbimtester/bimtester/features/steps/attributes_eleclasses/en.py
+++ b/src/ifcbimtester/bimtester/features/steps/attributes_eleclasses/en.py
@@ -59,7 +59,7 @@ def step_impl(context, ifc_class, pattern):
 
     elements = IfcStore.file.by_type(ifc_class)
     for element in elements:
-        if not re.search(pattern, element.Name):
+        if not element.Name or not re.search(pattern, element.Name):
             assert False
 
 

--- a/src/ifcbimtester/bimtester/features/steps/attributes_psets/en.py
+++ b/src/ifcbimtester/bimtester/features/steps/attributes_psets/en.py
@@ -63,9 +63,9 @@ def step_impl(context, ifc_class, property_path, pattern):
             assert False
 
         prop = pset[property_name]
-        # get_psets returns just strings
+        # get_psets can return non-string types (bool, int, float, ...)
 
-        if not re.search(pattern, prop):
+        if not re.search(pattern, str(prop)):
             assert False
 
 

--- a/src/ifcbimtester/bimtester/features/steps/attributes_qsets/en.py
+++ b/src/ifcbimtester/bimtester/features/steps/attributes_qsets/en.py
@@ -32,6 +32,8 @@ def step_impl(context, ifc_class, qto_name, quantity_name):
         if not element.IsDefinedBy:
             assert False
         for relationship in element.IsDefinedBy:
+            if not relationship.is_a("IfcRelDefinesByProperties"):
+                continue
             if relationship.RelatingPropertyDefinition.Name == qto_name:
                 for quantity in relationship.RelatingPropertyDefinition.Quantities:
                     if quantity.Name == quantity_name:

--- a/src/ifcbimtester/bimtester/features/steps/geolocation/en.py
+++ b/src/ifcbimtester/bimtester/features/steps/geolocation/en.py
@@ -190,8 +190,8 @@ def step_impl(context, number):
     number = util.assert_number(number)
     if IfcStore.file.schema == "IFC2X3":
         return check_ifc2x3_geolocation("EPset_MapConversion", "Height", number)
-    abscissa = check_ifc4_geolocation("IfcMapConversion", "XAxisAbscissa", should_assert=False)
-    ordinate = check_ifc4_geolocation("IfcMapConversion", "XAxisOrdinate", should_assert=False)
+    abscissa = check_ifc4_geolocation("IfcMapConversion", "XAxisAbscissa", should_assert=False) or 0
+    ordinate = check_ifc4_geolocation("IfcMapConversion", "XAxisOrdinate", should_assert=False) or 0
     actual_value = round(ifcopenshell.util.geolocation.xaxis2angle(abscissa, ordinate), 3)
     value = round(number, 3)
     assert actual_value == value, _('We expected a value of "{}" but instead got "{}"').format(value, actual_value)

--- a/src/ifcbimtester/bimtester/features/steps/model_federation/en.py
+++ b/src/ifcbimtester/bimtester/features/steps/model_federation/en.py
@@ -83,9 +83,9 @@ def step_impl(context, guid, easting, northing, elevation):
         float(map_conversion["Eastings"]),
         float(map_conversion["Northings"]),
         float(map_conversion["OrthogonalHeight"]),
-        float(map_conversion["XAxisAbscissa"]),
-        float(map_conversion["XAxisOrdinate"]),
-        float(map_conversion["Scale"]),
+        float(map_conversion["XAxisAbscissa"] if map_conversion["XAxisAbscissa"] is not None else 1.0),
+        float(map_conversion["XAxisOrdinate"] if map_conversion["XAxisOrdinate"] is not None else 0.0),
+        float(map_conversion["Scale"] if map_conversion["Scale"] is not None else 1.0),
     )
     element_x = round(e, get_decimal_points(easting))
     element_y = round(n, get_decimal_points(northing))

--- a/src/ifcbimtester/bimtester/util.py
+++ b/src/ifcbimtester/bimtester/util.py
@@ -89,7 +89,7 @@ def assert_attribute(element, name, value=None):
 def assert_pset(element, pset_name, prop_name=None, value=None):
     if value == "NULL":
         value = None
-    psets = ifcopenshell.util.element.get_psets(site)
+    psets = ifcopenshell.util.element.get_psets(element)
     if pset_name not in psets:
         assert False, _("The element {} does not have a property set named {}").format(element, pset_name)
     if prop_name is None:


### PR DESCRIPTION
Eight crashes in BIMTester's step definitions, found while sweeping sibling packages for unguarded optional attributes.

**Please read the note at the bottom about this package's status before spending review time on it.**

### The one that is not an optional-attribute bug

`bimtester/util.py`, `assert_pset`:

```python
def assert_pset(element, pset_name, prop_name=None, value=None):
    ...
    psets = ifcopenshell.util.element.get_psets(site)
```

`site` is not defined anywhere in that function. The parameter is `element`. **This raises `NameError` on every single call**, not on some inputs. It affects every IFC2X3 geolocation step and any custom feature file using pset assertions.

### The other seven, all optional attributes dereferenced unguarded

- **`geolocation/en.py`**: `xaxis2angle(None, None)` when `IfcMapConversion` has no `XAxisAbscissa` or `XAxisOrdinate`. Both optional.
- **`model_federation/en.py`**: the same optionality reaching `float(None)` on the way into `xyz2enh`. Defaulted to the values that function already documents.
- **`application/en.py`**: `by_type("IfcApplication")[0]` on a file with no application recorded. `OwnerHistory` is optional throughout IFC4.
- **`attributes_qsets/en.py`**: assumed every `IsDefinedBy` relationship is an `IfcRelDefinesByProperties`. Under IFC2X3 it can also be `IfcRelDefinesByType`, which has no `RelatingPropertyDefinition`, so any typed element crashed the step.
- **`attributes_psets/en.py`**: assumed `get_psets()` always returns strings, following a stale comment. A boolean or numeric property crashed `re.search`.
- **`attributes_eleclasses/en.py`**: `re.search(pattern, element.Name)` on an unnamed element.
- **`aggregation/en.py`**, `check_starts_with`: used `hasattr`, which confirms an attribute exists but says nothing about whether it is `None`.

### Verified

All eight reproduced against hand-built IFC files before the change and re-verified after, with happy-path checks alongside.

### Status of this package, stated plainly

`src/ifcbimtester` appears **dormant**. It is not in `ci.yml`, it is not referenced from any workflow, packaging or build configuration, and every commit touching it for a long time has been mechanical: `black .`, import sorting, a Ruff fix, a BlenderBIM to Bonsai rename.

The `assert_pset` defect is itself evidence of that. A function that raises `NameError` on **every** call cannot have been executed in a long time.

So this may not be worth your review time, and I would rather say so than quietly add eight commits to a queue. Three ways to read it, all reasonable:

1. Merge it, since the fixes are small, verified and independent.
2. Ignore it, if the package is on its way out.
3. Treat the `NameError` as a signal that BIMTester needs either CI coverage or a deprecation notice, which is a bigger decision than this PR.

If you want only the `NameError` fix and not the other seven, say so and I will reduce it to that single commit.

### No tests

The package has no test infrastructure and this adds none, consistent with the precedent for untested packages here. Verification was by direct execution, described above.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
