### PR TITLE
Bonsai: fix KeyError in 4D animation colors

### DIFF
--- a/src/bonsai/bonsai/tool/sequence.py
+++ b/src/bonsai/bonsai/tool/sequence.py
@@ -1419,9 +1419,17 @@ class Sequence(bonsai.core.tool.Sequence):
         bpy.context.scene.frame_end = int(settings["start_frame"] + settings["total_frames"] + 1)
 
     @classmethod
+    def get_animation_color(cls, colors, predefined_type):
+        if predefined_type and predefined_type in colors:
+            return colors[predefined_type].color
+        if "NOTDEFINED" in colors:
+            return colors["NOTDEFINED"].color
+        return (0.2, 0.2, 0.2)
+
+    @classmethod
     def animate_input(cls, obj, start_frame, product_frame, animation_type):
         props = cls.get_animation_props()
-        color = props.task_input_colors[product_frame["type"]].color
+        color = cls.get_animation_color(props.task_input_colors, product_frame["type"])
         if product_frame["type"] in ["LOGISTIC", "MOVE", "DISPOSAL"]:
             cls.animate_destruction(obj, start_frame, product_frame, color, animation_type)
         else:
@@ -1430,7 +1438,7 @@ class Sequence(bonsai.core.tool.Sequence):
     @classmethod
     def animate_output(cls, obj, start_frame, product_frame, animation_type):
         props = cls.get_animation_props()
-        color = props.task_output_colors[product_frame["type"]].color
+        color = cls.get_animation_color(props.task_output_colors, product_frame["type"])
         if product_frame["type"] in ["CONSTRUCTION", "INSTALLATION", "NOTDEFINED"]:
             cls.animate_creation(obj, start_frame, product_frame, color)
         elif product_frame["type"] in ["DEMOLITION", "DISMANTLE", "DISPOSAL", "REMOVAL"]:


### PR DESCRIPTION
`animate_input` and `animate_output` indexed a colour collection directly by a task's `PredefinedType`:

```python
color = props.task_input_colors[product_frame["type"]].color
```

Two ways that fails, both on ordinary data:

**1. A `PredefinedType` the seed dict does not know.** `load_default_animation_color_scheme` seeds the collection from the IFC4 task groups. `IfcTaskTypeEnum` gained **nine** members in IFC4X3:

```
IFC4         : 14 members
IFC4X3_ADD2  : 23 members
added        : ADJUSTMENT, CALIBRATION, EMERGENCY, INSPECTION, SAFETY,
               SHUTDOWN, STARTUP, TESTING, TROUBLESHOOTING
```

**2. No `PredefinedType` at all.** It is optional, and it is `None` immediately after `ifcopenshell.api.sequence.add_task` creates a task, so this does not need an exotic file.

Confirmed against a real Blender `CollectionProperty`:

```
'NOTDEFINED' in coll   -> True
'ADJUSTMENT' in coll   -> False
coll['ADJUSTMENT']     -> KeyError: key "ADJUSTMENT" not found
coll[None]             -> TypeError: invalid key, must be a string
```

Either exception propagates out of the whole `animate_objects` loop, so **one unrecognised task stops the entire 4D animation**, not just that task's colour.

A `get_animation_color` helper now falls back to the `NOTDEFINED` entry, then to a neutral grey. The short-circuit in `predefined_type and predefined_type in colors` also avoids passing `None` as a key.

### The rest of the audit, which is mostly proven zeros

This came from enumerating enum dispatch across Bonsai: about 30 files touching `PredefinedType`, a codebase-wide scan for dict literals with three or more enum-shaped keys (19 hits), elif chains (0 qualifying), and targeted checks of ten enums against the schema.

**One bug.** Everything else was either exhaustive against the schema, used `.get()` or `.setdefault()` with a safe default, or was a closed Bonsai-internal UI enum never populated from arbitrary IFC data. Specifically confirmed complete: `IfcSequenceEnum` 6 of 6 in `tool/sequence.py`, `IfcRecurrenceTypeEnum` 8 of 8 in both `tool/sequence.py` and `sequence/ui.py`, `IfcFlowDirectionEnum` 4 of 4 in `system/ui.py` and `system/operator.py`.

That matters because the same shape recently killed an entire schedule export elsewhere in the repo, so knowing Bonsai is largely clean of it is worth having.

### Verification limitation, stated plainly

`ifcopenshell` cannot be imported into the Blender available on this machine, so the crash and the fixed behaviour were verified against a real Blender `CollectionProperty` harness rather than through a full Bonsai 4D animation run. The enum membership was verified programmatically against the schema.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
