### PR TITLE
Bonsai: fix three IFC2X3-only defects

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -416,15 +416,15 @@ class DecoratorData:
 
             # Type keys
             elif key.startswith("type."):
-                if hasattr(element, "IsTypedBy") and element.IsTypedBy:
-                    element_type = element.IsTypedBy[0].RelatingType
+                element_type = ifcopenshell.util.element.get_type(element)
+                if element_type and element_type != element:
                     attr_name = key.split(".", 1)[1]
                     if hasattr(element_type, attr_name):
                         return getattr(element_type, attr_name)
 
             elif key == "types.count":
-                if hasattr(element, "IsTypedBy") and element.IsTypedBy:
-                    element_type = element.IsTypedBy[0].RelatingType
+                element_type = ifcopenshell.util.element.get_type(element)
+                if element_type and element_type != element:
                     occurrence_count = 0
                     if hasattr(element_type, "Types"):
                         for rel in element_type.Types:
@@ -1095,8 +1095,10 @@ class ElementValuesData:
     def _get_type_keys(cls, element):
         keys = []
 
-        if hasattr(element, "IsTypedBy") and element.IsTypedBy:
-            element_type = element.IsTypedBy[0].RelatingType
+        element_type = ifcopenshell.util.element.get_type(element)
+        is_typed = element_type and element_type != element
+
+        if is_typed:
             if hasattr(element_type, "Name") and element_type.Name:
                 keys.append(("type.Name", f"Type Name: {element_type.Name}"))
 
@@ -1108,8 +1110,7 @@ class ElementValuesData:
                         occurrence_count += len(rel.RelatedObjects)
             keys.append(("occurrences.count", f"Occurrence Count: {occurrence_count}"))
 
-        elif hasattr(element, "IsTypedBy") and element.IsTypedBy:
-            element_type = element.IsTypedBy[0].RelatingType
+        elif is_typed:
             occurrence_count = 0
             if hasattr(element_type, "Types"):
                 for rel in element_type.Types:

--- a/src/bonsai/bonsai/tool/georeference.py
+++ b/src/bonsai/bonsai/tool/georeference.py
@@ -160,9 +160,9 @@ class Georeference(bonsai.core.tool.Georeference):
 
     @classmethod
     def import_true_north(cls) -> None:
-        if tool.Ifc.get_schema() == "IFC2X3":
-            return
-
+        # TrueNorth is a plain IfcGeometricRepresentationContext attribute in
+        # both IFC2X3 and IFC4+, unlike CRS/MapConversion, so no schema
+        # branch is needed here.
         props = cls.get_georeference_props()
         props.is_changing_angle = True
         props.true_north_abscissa = "0"

--- a/src/bonsai/bonsai/tool/qto.py
+++ b/src/bonsai/bonsai/tool/qto.py
@@ -103,7 +103,6 @@ class Qto(bonsai.core.tool.Qto):
         base_qto_definition = None
         base_qto_definition_name: Union[str, None] = None
         for rel in product.IsDefinedBy or []:
-            definition = rel.RelatingPropertyDefinition
             if not rel.is_a("IfcRelDefinesByProperties"):
                 continue
             definition = rel.RelatingPropertyDefinition

--- a/src/bonsai/test/tool/test_georeference.py
+++ b/src/bonsai/test/tool/test_georeference.py
@@ -146,6 +146,20 @@ class TestImportTrueNorth(NewFile):
         assert props.true_north_ordinate == "2.0"
         assert props.true_north_angle == "-26.5650512"
 
+    def test_run_ifc2x3(self):
+        # TrueNorth is a plain attribute in IFC2X3 too, so it must import
+        # the same as IFC4, not silently stay at the default.
+        ifc = ifcopenshell.file(schema="IFC2X3")
+        tool.Ifc.set(ifc)
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject")
+        context = ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        context.TrueNorth = ifc.createIfcDirection((1.0, 2.0, 0.0))
+        subject.import_true_north()
+        props = tool.Georeference.get_georeference_props()
+        assert props.true_north_abscissa == "1.0"
+        assert props.true_north_ordinate == "2.0"
+        assert props.true_north_angle == "-26.5650512"
+
 
 class TestExportProjectedCRS(NewFile):
     def test_run(self):

--- a/src/bonsai/test/tool/test_qto.py
+++ b/src/bonsai/test/tool/test_qto.py
@@ -23,6 +23,7 @@ import ifcopenshell.api.context
 import ifcopenshell.api.cost
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
+import ifcopenshell.api.type
 import ifcopenshell.api.unit
 import ifcopenshell.util.pset
 
@@ -201,6 +202,20 @@ class TestGetBaseQto(test.bim.bootstrap.NewFile):
         tool.Ifc.link(wall, wall_obj)
         product = tool.Ifc.get_entity(wall_obj)
         assert not subject.get_base_qto(product) == True
+
+    def test_ifc2x3_typed_product(self):
+        # In IFC2X3, IsDefinedBy also carries IfcRelDefinesByType (no
+        # separate IsTypedBy inverse), so a typed product must not crash.
+        ifc = ifcopenshell.file(schema="IFC2X3")
+        tool.Ifc.set(ifc)
+        wall_type = ifc.createIfcWallType()
+        wall = ifc.createIfcWall()
+        wall_obj = bpy.data.objects.new("Object", bpy.data.meshes.new("Mesh"))
+        tool.Ifc.link(wall, wall_obj)
+        ifcopenshell.api.type.assign_type(ifc, related_objects=[wall], relating_type=wall_type)
+        product = tool.Ifc.get_entity(wall_obj)
+        pset_qto = ifcopenshell.api.pset.add_qto(ifc, product=wall, name="Qto_WallBaseQuantities")
+        assert subject.get_base_qto(product).id() == pset_qto.get_info()["id"]
 
 
 class TestGetRelatedCostItemQuantities(test.bim.bootstrap.NewFile):


### PR DESCRIPTION
Three defects that only appear on IFC2X3 files, found by diffing schema declarations rather than by reading code. A large share of files in the wild are still IFC2X3, and this codebase is written and tested mostly against IFC4, so the two diverge silently.

The root difference behind two of the three, verified programmatically:

```
IFC2X3: IfcObject inverses: IsDefinedBy=True   IsTypedBy=False
IFC4  : IfcObject inverses: IsDefinedBy=True   IsTypedBy=True
```

IFC4 introduced a separate `IsTypedBy` inverse for typing. IFC2X3 has no such thing, so a typed product's `IsDefinedBy` carries `IfcRelDefinesByType` **as well as** `IfcRelDefinesByProperties`.

### 1. `tool/qto.py`, `get_base_qto()` crashed on any typed IFC2X3 element

It read `rel.RelatingPropertyDefinition` before checking `rel.is_a("IfcRelDefinesByProperties")`. `IfcRelDefinesByType` has no such attribute, so it raised `AttributeError`.

This was unreachable on IFC4, because typing goes through `IsTypedBy` there and never appears in `IsDefinedBy`. On IFC2X3 it fires for any typed element.

The fix removes a dead duplicate read so the existing `is_a` guard runs first.

### 2. `bim/module/drawing/data.py` silently dropped type information on IFC2X3

`ElementValuesData` used `hasattr(element, "IsTypedBy")` to find an element's type for schedule and annotation keys. On IFC2X3 that attribute does not exist at all, so the check was always false and every IFC2X3 typed element produced an **empty "Type" key category, with no error**, despite genuinely having a type.

This is the quieter of the three and arguably the worst: no crash, just missing data in generated schedules.

Both call sites now use `ifcopenshell.util.element.get_type()`, which already branches on schema correctly, with a guard for the case where it returns the element itself because the element is already a type.

### 3. `tool/georeference.py` never showed the stored True North on IFC2X3

`import_true_north()` had an unconditional early return for IFC2X3, so the edit form always displayed the default `0 / 1 / 0` rather than the persisted value.

That guard was incorrect. `TrueNorth` is a plain attribute on `IfcGeometricRepresentationContext` in **both** schemas:

```
IFC2X3: IfcGeometricRepresentationContext has TrueNorth=True
IFC4  : IfcGeometricRepresentationContext has TrueNorth=True
```

Unlike CRS and MapConversion, which genuinely do differ and are correctly pset-backed for IFC2X3 elsewhere in the same file. The write side, `edit_true_north()`, already had no schema restriction, so reading and writing disagreed.

### Declined, and why

The `ifcopenshell.api.cost` module is broken far more deeply on IFC2X3: `IfcCostItem` there has only `GlobalId, OwnerHistory, Name, Description, ObjectType`, with **no `CostQuantities` or `CostValues` at all**, so the whole parametric cost-quantity feature fails immediately. Making that work means redesigning IFC2X3 cost storage, likely via property sets, across roughly 15 call sites. That is a feature, not a bug fix, so it is deliberately out of scope here.

### Tests, and an honest limitation

IFC2X3 test cases were added to the existing `TestGetBaseQto` and the georeference tool tests.

**Those tests could not be executed here.** `bpy` is unavailable on this machine, confirmed by a direct collection failure, so Bonsai's pytest suites cannot run. Each fix was instead verified by reproducing the exact failing expression against real IFC2X3 and IFC4 entities through the worktree source, red before and green after. Saying that plainly rather than implying the suites were run.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
