### PR TITLE
docs: fix seven broken api docstring examples

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/drawing/edit_text_literal.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/drawing/edit_text_literal.py
@@ -36,7 +36,8 @@ def edit_text_literal(
 
     .. code:: python
 
-        text = model.createIfcTextLiteral()
+        placement = model.createIfcAxis2Placement2D(model.createIfcCartesianPoint((0., 0.)))
+        text = model.createIfcTextLiteral("Draft text", placement, "LEFT")
         ifcopenshell.api.drawing.edit_text_literal(model,
             text_literal=text, attributes={"Literal": "MY ANNOTATION"})
     """

--- a/src/ifcopenshell-python/ifcopenshell/api/feature/remove_filling.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/feature/remove_filling.py
@@ -41,6 +41,9 @@ def remove_filling(file: ifcopenshell.file, element: ifcopenshell.entity_instanc
         # acoustic requirements.
         opening = ifcopenshell.api.root.create_entity(model, ifc_class="IfcOpeningElement")
 
+        # The opening voids the wall.
+        ifcopenshell.api.feature.add_feature(model, feature=opening, element=wall)
+
         # Create a door
         door = ifcopenshell.api.root.create_entity(model, ifc_class="IfcDoor")
 

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/assign_recurrence_pattern.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/assign_recurrence_pattern.py
@@ -99,7 +99,7 @@ def assign_recurrence_pattern(
 
         # We create a monthly recurrence
         pattern = ifcopenshell.api.sequence.assign_recurrence_pattern(model,
-            parent=work_time, recurrence_type="MONTHLY_BY_DAY_OF_MONTH")
+            parent=time, recurrence_type="MONTHLY_BY_DAY_OF_MONTH")
 
         # Specifically, the maintenance task must occur every 6 months
         ifcopenshell.api.sequence.edit_recurrence_pattern(model,

--- a/src/ifcopenshell-python/ifcopenshell/api/structural/assign_product.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/structural/assign_product.py
@@ -44,7 +44,7 @@ def assign_product(
 
         wall = ifcopenshell.api.root.create_entity(model, ifc_class="IfcWall")
         member = ifcopenshell.api.root.create_entity(
-            model, ifc_class="IfcStructuralSurfaceMember")
+            model, ifc_class="IfcStructuralSurfaceMember", predefined_type="SHELL")
         ifcopenshell.api.structural.assign_product(model,
             relating_product=member, related_object=wall)
     """

--- a/src/ifcopenshell-python/ifcopenshell/api/style/add_style.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/style/add_style.py
@@ -53,8 +53,17 @@ def add_style(
 
     .. code:: python
 
-        # Create a new surface style
+        # Create a new surface style. Note that on its own this style is not
+        # yet valid: it must be given at least one presentation item, such
+        # as via ifcopenshell.api.style.add_surface_style.
         style = ifcopenshell.api.style.add_style(model)
+
+        # Create a simple shading colour and transparency.
+        ifcopenshell.api.style.add_surface_style(model,
+            style=style, ifc_class="IfcSurfaceStyleShading", attributes={
+                "SurfaceColour": {"Name": None, "Red": 1.0, "Green": 0.8, "Blue": 0.8},
+                "Transparency": 0., # 0 is opaque, 1 is transparent
+            })
     """
 
     kwargs = {"Name": name}

--- a/src/ifcopenshell-python/ifcopenshell/api/style/edit_presentation_style.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/style/edit_presentation_style.py
@@ -36,8 +36,14 @@ def edit_presentation_style(
 
     .. code:: python
 
-        # Create a new surface style
+        # Create a new surface style with at least one presentation item,
+        # since a bare style without any is not yet valid.
         style = ifcopenshell.api.style.add_style(model)
+        ifcopenshell.api.style.add_surface_style(model,
+            style=style, ifc_class="IfcSurfaceStyleShading", attributes={
+                "SurfaceColour": {"Name": None, "Red": 1.0, "Green": 0.8, "Blue": 0.8},
+                "Transparency": 0.,
+            })
 
         # Change the name of the style to "Foo"
         ifcopenshell.api.style.edit_presentation_style(model, style=style, attributes={"Name": "Foo"})

--- a/src/ifcopenshell-python/ifcopenshell/api/system/assign_flow_control.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/system/assign_flow_control.py
@@ -43,8 +43,8 @@ def assign_flow_control(
 
     .. code:: python
 
-        flow_element = model.createIfcFlowSegment()
-        flow_control = model.createIfcController()
+        flow_element = ifcopenshell.api.root.create_entity(model, ifc_class="IfcFlowSegment")
+        flow_control = ifcopenshell.api.root.create_entity(model, ifc_class="IfcController")
         relation = ifcopenshell.api.system.assign_flow_control(
             model, related_flow_control=flow_control, relating_flow_element=flow_element
         )


### PR DESCRIPTION
Seven `ifcopenshell.api` docstring examples do not work. **The functions themselves are correct**; only the published examples are wrong. This is a documentation fix, deliberately kept separate from the data-corruption fixes found in the same audit.

These matter because sphinx-autoapi renders them as the API documentation, so anyone copying one gets a file that fails validation, or an example that does not run at all.

| Function | What is wrong with the example |
|---|---|
| `drawing.edit_text_literal` | Creates an `IfcTextLiteral` with no `Placement` or `Path`, both non-optional |
| `feature.remove_filling` | Never voids the wall, so the `IfcOpeningElement` is already invalid before the function under demonstration is even called |
| `sequence.assign_recurrence_pattern` | Copy-paste error: passes `parent=work_time` a second time instead of `parent=time`, so the non-optional `Recurrence` is never set |
| `structural.assign_product` | Creates an `IfcStructuralSurfaceMember` with no `predefined_type`, which is non-optional for that class |
| `style.add_style` | Shows only step one of a two-step pattern the function's own docstring describes as required |
| `style.edit_presentation_style` | Same root cause, inherited from using `add_style` alone |
| `system.assign_flow_control` | Uses raw `model.createIfcFlowSegment()` and `createIfcController()`, bypassing the required `GlobalId` |

In every case the invalidity was confirmed to exist **before** the documented function runs, so the function is not implicated. For `style.add_style`, `add_surface_style`'s own example, which shows both steps, was confirmed to produce a clean file.

### How these were found

By extracting and executing all 270 runnable `ifcopenshell.api` docstring examples and validating each result. 15 produced invalid files; these 7 were the ones where the fault was in the example rather than the code.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
