### PR TITLE
docs: fix ten API examples that cannot run

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/cost/copy_cost_schedule.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cost/copy_cost_schedule.py
@@ -34,7 +34,7 @@ def copy_cost_schedule(
     .. code:: python
 
         schedule = ifcopenshell.api.cost.add_cost_schedule(model)
-        new_schedule = ifcopenshell.api.cost.copy_cost_schedule(schedule)
+        new_schedule = ifcopenshell.api.cost.copy_cost_schedule(model, schedule)
     """
     # Shared code logic with copy_work_schedule.
     new_schedule = ifcopenshell.util.element.copy(file, cost_schedule)

--- a/src/ifcopenshell-python/ifcopenshell/api/cost/remove_cost_item_quantity.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cost/remove_cost_item_quantity.py
@@ -40,7 +40,7 @@ def remove_cost_item_quantity(
         quantity = ifcopenshell.api.cost.add_cost_item_quantity(model,
             cost_item=item, ifc_class="IfcQuantityVolume")
         # Let's change our mind and delete it
-        ifcopenshell.api.cost.remove_cost_item(model,
+        ifcopenshell.api.cost.remove_cost_item_quantity(model,
             cost_item=item, physical_quantity=quantity)
     """
     if file.get_total_inverses(physical_quantity) == 1:

--- a/src/ifcopenshell-python/ifcopenshell/api/material/remove_list_item.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/material/remove_list_item.py
@@ -39,7 +39,7 @@ def remove_list_item(
 
         # Create a material list for aluminium windows.
         material_set = ifcopenshell.api.material.add_material_set(model,
-            name="Window", set_type="IfcMaterialMaterialList")
+            name="Window", set_type="IfcMaterialList")
 
         aluminium = ifcopenshell.api.material.add_material(model, name="AL01", category="aluminium")
         glass = ifcopenshell.api.material.add_material(model, name="GLZ01", category="glass")

--- a/src/ifcopenshell-python/ifcopenshell/api/nest/unassign_object.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/nest/unassign_object.py
@@ -37,7 +37,7 @@ def unassign_object(file: ifcopenshell.file, related_objects: list[ifcopenshell.
 
     .. code:: python
 
-        task = ifcopenshell.api.root.create_entity(model, ifc_class="IfcTasks")
+        task = ifcopenshell.api.root.create_entity(model, ifc_class="IfcTask")
         subtask1 = ifcopenshell.api.root.create_entity(model, ifc_class="IfcTask")
         subtask2 = ifcopenshell.api.root.create_entity(model, ifc_class="IfcTask")
         ifcopenshell.api.nest.assign_object(model, related_objects=[subtask1], relating_object=task)

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/assign_work_plan.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/assign_work_plan.py
@@ -47,7 +47,7 @@ def assign_work_plan(
         schedule = ifcopenshell.api.sequence.add_work_schedule(model, name="Construction Schedule A")
 
         # ... you can assign the work plan afterwards.
-        ifcopenshell.api.sequence.assign_work_plan(work_schedule=schedule, work_plan=work_plan)
+        ifcopenshell.api.sequence.assign_work_plan(model, work_schedule=schedule, work_plan=work_plan)
     """
     # TODO: this is an ambiguity by buildingSMART
     # See https://forums.buildingsmart.org/t/is-the-ifcworkschedule-project-declaration-mutually-exclusive-to-aggregation-within-a-relating-ifcworkplan/3510

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/unassign_product.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/unassign_product.py
@@ -51,10 +51,10 @@ def unassign_product(
         wall = ifcopenshell.api.root.create_entity(model, ifc_class="IfcWall")
 
         # Let's construct that wall!
-        ifcopenshell.api.sequence.assign_product(relating_product=wall, related_object=task)
+        ifcopenshell.api.sequence.assign_product(model, relating_product=wall, related_object=task)
 
         # Change our mind.
-        ifcopenshell.api.sequence.unassign_product(relating_product=wall, related_object=task)
+        ifcopenshell.api.sequence.unassign_product(model, relating_product=wall, related_object=task)
     """
     for rel in related_object.HasAssignments or []:
         if not rel.is_a("IfcRelAssignsToProduct") or rel.RelatingProduct != relating_product:

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/unassign_recurrence_pattern.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/unassign_recurrence_pattern.py
@@ -46,7 +46,7 @@ def unassign_recurrence_pattern(file: ifcopenshell.file, recurrence_pattern: ifc
             parent=work_time, recurrence_type="WEEKLY")
 
         # Change our mind, let's just maintain it whenever we feel like it.
-        ifcopenshell.api.sequence.unassign_recurrence_pattern(recurrence_pattern=pattern)
+        ifcopenshell.api.sequence.unassign_recurrence_pattern(model, recurrence_pattern=pattern)
     """
     for time_period in recurrence_pattern.TimePeriods or []:
         file.remove(time_period)

--- a/src/ifcopenshell-python/ifcopenshell/api/system/unassign_flow_control.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/system/unassign_flow_control.py
@@ -41,12 +41,12 @@ def unassign_flow_control(
         flow_element = file.createIfcFlowSegment()
         flow_control = file.createIfcController()
         relation = ifcopenshell.api.system.assign_flow_control(
-            file, relating_control=flow_control, related_object=flow_element
+            file, relating_flow_element=flow_element, related_flow_control=flow_control
         )
 
         # und unassign it
         ifcopenshell.api.system.unassign_flow_control(file,
-            relating_control=flow_control, related_object=flow_element
+            relating_flow_element=flow_element, related_flow_control=flow_control
         )
     """
 

--- a/src/ifcopenshell-python/ifcopenshell/api/unit/add_derived_unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/unit/add_derived_unit.py
@@ -59,7 +59,7 @@ def add_derived_unit(
         time = ifcopenshell.api.unit.add_si_unit(model, unit_type="TIMEUNIT")
         #4=IfcSIUnit(*,.TIMEUNIT.,$,.SECOND.)
 
-        linear_velocity = ifcopenshell.api.unit.add_derived_unit(model, 'LINEARVELOCITY', None, {length : 1, time : -1})
+        linear_velocity = ifcopenshell.api.unit.add_derived_unit(model, 'LINEARVELOCITYUNIT', None, {length : 1, time : -1})
         #10=IfcDerivedUnitElement(#2, 1)
         #11=IfcDerivedUnitElement(#4, -1)
         #12=IfcDerivedUnit((#10,#11),.LINEARVELOCITY.,$)

--- a/src/ifcopenshell-python/ifcopenshell/api/unit/edit_named_unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/unit/edit_named_unit.py
@@ -41,7 +41,7 @@ def edit_named_unit(file: ifcopenshell.file, unit: ifcopenshell.entity_instance,
         unit = ifcopenshell.api.unit.add_context_dependent_unit(model, name="BOXES")
 
         # Uh, crates? Boxes? Whatever.
-        ifcopenshell.api.unit.edit_named_unit(model, unit=unit, attibutes={"Name": "CRATES"})
+        ifcopenshell.api.unit.edit_named_unit(model, unit=unit, attributes={"Name": "CRATES"})
     """
     for name, value in attributes.items():
         if name == "Dimensions":


### PR DESCRIPTION
Ten `ifcopenshell.api` docstring examples could not execute at all. The functions are correct; the published examples are broken, and they ship as documentation through sphinx-autoapi.

| Function | Defect in the example |
|---|---|
| `unit.edit_named_unit` | typo: `attibutes` |
| `sequence.unassign_product` | missing the `model` argument |
| `sequence.assign_work_plan` | missing the `model` argument |
| `sequence.unassign_recurrence_pattern` | missing the `model` argument |
| `cost.copy_cost_schedule` | missing the `model` argument |
| `system.unassign_flow_control` | wrong keyword arguments |
| `cost.remove_cost_item_quantity` | calls a different function entirely |
| `material.remove_list_item` | `IfcMaterialMaterialList` does not exist in any schema |
| `nest.unassign_object` | `IfcTasks` is not an entity |
| `unit.add_derived_unit` | uses `LINEARVELOCITY` where the same docstring elsewhere correctly says `LINEARVELOCITYUNIT` |

Each fix was verified by re-running the example before and after.

### Two of these fixes exposed further real gaps, reported not fixed

Once the examples stopped crashing they reached genuine defects underneath:

- **`system.unassign_flow_control`** shares a root cause with `system.assign_flow_control`, which is already flagged separately.
- **`nest.unassign_object`** shows that `root.create_entity(ifc_class="IfcTask")` leaves the mandatory `IsMilestone` unset.

Neither is touched here, since both are API code changes rather than documentation fixes.

### Context: what the wider sweep established

These came from executing all 271 `ifcopenshell.api` docstring examples against fresh models on three schemas and validating the results.

**IFC4X3_ADD2 is identical to IFC4**, with the same set of failing and invalid functions, proven by direct set comparison rather than inferred. So there is no IFC4X3-specific invalidity to chase.

**IFC2X3 is materially worse** (34 invalid against 16) and two real causes explain most of it. `IfcProject.RepresentationContexts` and `UnitsInContext` are **mandatory in IFC2X3 but optional in IFC4**, and `IfcCostSchedule.ID` is mandatory in IFC2X3 while `cost.add_cost_schedule` never sets it, unlike `owner/add_person.py` which already carries the `if schema == "IFC2X3"` pattern. That second one is a genuine API defect and is flagged for follow-up, not fixed here.

### A defect class nothing had checked before

Plain `validate()` does not evaluate EXPRESS WHERE rules; its own docstring says so. Running with `express_rules=True` surfaced a class no previous pass could see: **`exists(SELF.Name)`**. `Name` is optional at the attribute level but a WHERE rule makes it mandatory for several types, including `IfcTask`, `IfcWindowType`, `IfcFurnitureType` and `IfcWallType`, so any example calling `root.create_entity` without `name=` violates the schema in a way plain validation never reports.

Also worth flagging separately: **the WHERE-rule executor segfaults intermittently and non-deterministically**, crashing and then succeeding on a retry with identical input. That is a robustness problem in its own right and was not chased here.

### A correction to the earlier sweep

The harness leaked process-global state. `owner.create_owner_history`'s example legitimately monkeypatches `ifcopenshell.api.owner.settings`, and nothing reset it between examples, so the patch leaked into every alphabetically later one. Calling `factory_reset()` before each example drops the IFC4 invalid count from 15 to 14 and removes `owner.edit_application`, which was therefore **a false positive of the harness, not a defect**. Confirmed independently.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
