### PR TITLE
cost: fix CostQuantities left empty on removal

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/cost/remove_cost_item_quantity.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/cost/remove_cost_item_quantity.py
@@ -48,4 +48,4 @@ def remove_cost_item_quantity(
         return
     quantities = list(cost_item.CostQuantities or [])
     quantities.remove(physical_quantity)
-    cost_item.CostQuantities = quantities
+    cost_item.CostQuantities = quantities or None

--- a/src/ifcopenshell-python/test/api/cost/test_remove_cost_item_quantity.py
+++ b/src/ifcopenshell-python/test/api/cost/test_remove_cost_item_quantity.py
@@ -1,0 +1,59 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.cost
+import ifcopenshell.guid
+import ifcopenshell.validate
+import test.bootstrap
+
+
+class TestRemoveCostItemQuantity(test.bootstrap.IFC4):
+    def test_removing_the_last_quantity_leaves_a_valid_cost_item(self):
+        schedule = ifcopenshell.api.cost.add_cost_schedule(self.file)
+        item = ifcopenshell.api.cost.add_cost_item(self.file, cost_schedule=schedule)
+        quantity = ifcopenshell.api.cost.add_cost_item_quantity(
+            self.file, cost_item=item, ifc_class="IfcQuantityVolume"
+        )
+        # Give the quantity a second inverse so it is not simply purged, and
+        # the CostQuantities-emptying branch is exercised instead.
+        self.file.create_entity("IfcElementQuantity", GlobalId=ifcopenshell.guid.new(), Quantities=[quantity])
+        assert item.CostQuantities
+
+        ifcopenshell.api.cost.remove_cost_item_quantity(self.file, cost_item=item, physical_quantity=quantity)
+
+        # An empty list is not a valid value: CostQuantities is either unset
+        # or has at least one member.
+        assert item.CostQuantities is None
+
+        logger = ifcopenshell.validate.json_logger()
+        ifcopenshell.validate.validate(self.file, logger)
+        assert not logger.statements, logger.statements
+
+    def test_removing_one_of_several_quantities_keeps_the_others(self):
+        schedule = ifcopenshell.api.cost.add_cost_schedule(self.file)
+        item = ifcopenshell.api.cost.add_cost_item(self.file, cost_schedule=schedule)
+        quantity1 = ifcopenshell.api.cost.add_cost_item_quantity(
+            self.file, cost_item=item, ifc_class="IfcQuantityVolume"
+        )
+        quantity2 = ifcopenshell.api.cost.add_cost_item_quantity(self.file, cost_item=item, ifc_class="IfcQuantityArea")
+        self.file.create_entity("IfcElementQuantity", GlobalId=ifcopenshell.guid.new(), Quantities=[quantity1])
+
+        ifcopenshell.api.cost.remove_cost_item_quantity(self.file, cost_item=item, physical_quantity=quantity1)
+
+        assert item.CostQuantities == (quantity2,)


### PR DESCRIPTION
`cost.remove_cost_item_quantity` left `IfcCostItem.CostQuantities = ()` when the last quantity was removed. The attribute is optional, but its aggregate is declared `list [1:?]`, so an **empty list is not a legal value**; the attribute has to be unset instead.

Validator output before the fix:

```
With attribute:
    <attribute CostQuantities?: <list [1:?] of <entity IfcPhysicalQuantity>>>
Value:
    ()
Not valid
```

Fixed with `quantities or None`, the identical precedent already applied to its sibling `unassign_cost_item_quantity` in #9161.

### Tests

`test/api/cost/test_remove_cost_item_quantity.py`. Verified not vacuous: reverting only the source while keeping the test fails with `AssertionError: assert () is None`.

### The audit behind this, which is mostly a proven zero

This came from enumerating **every** `remove_*` and `unassign_*` function under `ifcopenshell.api` and checking each against schema cardinality, rather than waiting for a docstring example to happen to trip one.

| | |
|---|---|
| Functions enumerated | 89 |
| Excluded (already in open PRs or reported) | 5 |
| Audited | 84 |
| Distinct entity types cross-referenced against schema cardinality | 64 |
| Last-member cases actually constructed and validated | 9 |
| **Genuine defects confirmed by validator error** | **5** |
| Fixed here | 1 |

**The large majority of the 84 were already correctly guarded**, using `len(x) == 1` checks, singleton comparisons, or an existing fallback to `None` or delete-the-relationship. That is the useful headline: this defect class is not endemic, it is concentrated in a handful of places.

Also confirmed benign by direct test, not by assumption: `material.remove_constituent`, `sequence.remove_work_time` and `sequence.remove_time_period` all auto-null correctly on last-member removal. `pset_template.remove_prop_template` silently no-ops on the last template via `remove_deep2`'s inverse guard, which does not corrupt data.

Three aggregates could not be reached at all through the current API surface, because no `add_*` function populates them: `IfcStructuralAnalysisModel.LoadedBy`, `IfcStructuralLoadConfiguration.Values`, `IfcMaterialClassificationRelationship.MaterialClassifications`.

### Four confirmed defects deliberately not fixed here

`material.remove_layer`, `material.remove_profile`, `material.remove_list_item` and `grid.remove_grid_axis` all leave illegal empty aggregates, and all four need a decision rather than a patch. The obvious fix for the material cases was tried and **rejected because it trades one invalid state for a worse one**: cascade-deleting the emptied set leaves `IfcRelAssociatesMaterial.RelatingMaterial = None`, which is a mandatory single-value attribute. Filed separately with the full reasoning rather than shipping something that moves the corruption instead of removing it.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated, including the new test file, which carries the disclosure comment.
