### PR TITLE
sequence: name tasks so they satisfy the WHERE rule

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/add_task.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/add_task.py
@@ -28,7 +28,7 @@ def add_task(
     file: ifcopenshell.file,
     work_schedule: Optional[ifcopenshell.entity_instance] = None,
     parent_task: Optional[ifcopenshell.entity_instance] = None,
-    name: Optional[str] = None,
+    name: str = "Unnamed",
     description: Optional[str] = None,
     identification: Optional[str] = None,
     predefined_type: str = "NOTDEFINED",
@@ -72,7 +72,9 @@ def add_task(
     :param parent_task: The parent task, if the task is to be a subtask or
         child task. This is mutually exclusive with the work_schedule
         parameter.
-    :param name: The name of the task.
+    :param name: The name of the task. IfcTask requires a Name in IFC4 and
+        later, so an unset name defaults to "Unnamed" rather than staying
+        blank.
     :param description: The description of the task.
     :param identification: The identification code of the task.
     :param predefined_type: The predefined type of the task. Common ones

--- a/src/ifcopenshell-python/test/api/sequence/test_add_task.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_add_task.py
@@ -1,0 +1,44 @@
+# This file was generated with the assistance of an AI coding tool.
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import ifcopenshell.api.sequence
+import test.bootstrap
+
+
+# NOTE: sequence module features relies on entities introduced in IFC4
+# therefore no IFC2X3 tests
+class TestAddTask(test.bootstrap.IFC4):
+    def test_task_is_named_by_default(self):
+        # IfcTask carries a WHERE rule (exists(SELF.Name)) that plain schema
+        # validation does not check but ifcopenshell.validate.validate(...,
+        # express_rules=True) does. Bonsai's "Add Task" / "Add Summary Task"
+        # operators call this api with no name= argument at all, so an
+        # unnamed default here means a real, silently invalid IfcTask.
+        task = ifcopenshell.api.sequence.add_task(self.file)
+        assert task.Name is not None
+        assert task.Name == "Unnamed"
+
+    def test_task_name_is_still_overridable(self):
+        task = ifcopenshell.api.sequence.add_task(self.file, name="Excavation")
+        assert task.Name == "Excavation"
+
+
+class TestAddTaskIFC4X3(test.bootstrap.IFC4X3, TestAddTask):
+    pass


### PR DESCRIPTION
Every task Bonsai creates is schema-invalid, in a way ordinary validation cannot see.

`IfcTask.Name` is **optional at the EXPRESS attribute level** but carries a WHERE rule making it mandatory:

```
IfcTask.Name attribute-level optional = True
express rule: exists(SELF.Name)  ->  Violated by: False
```

`ifcopenshell.validate.validate(model, logger)` does **not** evaluate WHERE rules; its own docstring says so. Only `express_rules=True` catches this, which is why it went unnoticed.

### It is reachable through normal use, not just in an example

Bonsai calls the api with no name argument at all:

```
src/bonsai/bonsai/core/sequence.py:155   ifc.run("sequence.add_task", work_schedule=work_schedule)
src/bonsai/bonsai/core/sequence.py:163   ifc.run("sequence.add_task", parent_task=parent_task)
```

Those back "Add Summary Task" and "Add Task". So **every task a user adds through the interface** gets `Name = None` and violates the rule. Bonsai authors IFC natively, so this is written straight into the user's model.

The fix defaults `name` to `"Unnamed"`, which is this codebase's established placeholder: `or "Unnamed"` appears in roughly 186 places across Bonsai, and `document/add_information.py` already creates entities with `"Name": "Unnamed"` for the same reason.

An explicit name is still honoured, which is covered by its own test.

### Tests

`test/api/sequence/test_add_task.py`, covering both the default and the override, run for IFC4 and IFC4X3.

### Scope note

This fixes the one case proven reachable from Bonsai's UI. The same WHERE rule applies to other types, including `IfcWindowType`, `IfcFurnitureType` and `IfcWallType`, and those have not been audited for reachability here. Flagging that rather than quietly implying the class is fully addressed.

Also worth recording separately: **the WHERE-rule executor segfaults intermittently and non-deterministically**, crashing then succeeding on retry with identical input. That is a robustness problem in its own right and is not addressed here.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated, including the new test file, which carries the disclosure comment.
