### PR TITLE
root: set mandatory Position on quick-add profiles

### DIFF
--- a/src/bonsai/bonsai/bim/module/root/operator.py
+++ b/src/bonsai/bonsai/bim/module/root/operator.py
@@ -678,6 +678,8 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
             ifcopenshell.api.pset.edit_pset(tool.Ifc.get(), pset=pset, properties={"LayerSetDirection": axis})
         elif representation_template == "PROFILESET" or representation_template.startswith("FLOW_SEGMENT_"):
             unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
+            # Position is mandatory on these profile defs in IFC2X3 (optional in IFC4).
+            builder = ifcopenshell.util.shape_builder.ShapeBuilder(tool.Ifc.get())
             materials = tool.Ifc.get().by_type("IfcMaterial")
             if materials:
                 material = materials[0]  # Arbitrarily pick a material
@@ -693,6 +695,7 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
                             "IfcRectangleProfileDef",
                             ProfileName="New Profile",
                             ProfileType="AREA",
+                            Position=builder.create_axis2_placement_2d(),
                             XDim=size,
                             YDim=size,
                         )
@@ -709,6 +712,7 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
                         "IfcRectangleProfileDef",
                         ProfileName=profile_name,
                         ProfileType="AREA",
+                        Position=builder.create_axis2_placement_2d(),
                         XDim=default_x_dim / unit_scale,
                         YDim=default_y_dim / unit_scale,
                     )
@@ -725,6 +729,7 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
                         "IfcRectangleHollowProfileDef",
                         ProfileName=profile_name,
                         ProfileType="AREA",
+                        Position=builder.create_axis2_placement_2d(),
                         XDim=default_x_dim / unit_scale,
                         YDim=default_y_dim / unit_scale,
                         WallThickness=default_thickness / unit_scale,
@@ -739,6 +744,7 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
                         "IfcCircleProfileDef",
                         ProfileName=profile_name,
                         ProfileType="AREA",
+                        Position=builder.create_axis2_placement_2d(),
                         Radius=(default_diameter / 2) / unit_scale,
                     )
                 elif representation_template == "FLOW_SEGMENT_CIRCULAR_HOLLOW":
@@ -749,6 +755,7 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
                         "IfcCircleHollowProfileDef",
                         ProfileName=profile_name,
                         ProfileType="AREA",
+                        Position=builder.create_axis2_placement_2d(),
                         Radius=(default_diameter / 2) / unit_scale,
                         WallThickness=default_thickness,
                     )
@@ -762,6 +769,7 @@ class AddElement(bpy.types.Operator, tool.Ifc.Operator):
                         "IfcUShapeProfileDef",
                         ProfileName=profile_name,
                         ProfileType="AREA",
+                        Position=builder.create_axis2_placement_2d(),
                         Depth=default_depth / unit_scale,
                         FlangeWidth=default_flange_width / unit_scale,
                         WebThickness=default_web_thickness / unit_scale,

--- a/src/bonsai/test/bim/module/root/test_flow_segment_profile_position_forward_compat.py
+++ b/src/bonsai/test/bim/module/root/test_flow_segment_profile_position_forward_compat.py
@@ -1,0 +1,99 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Forward-compat AST contract for the MEP quick-add profile Position fix.
+
+``Position`` is mandatory on ``IfcRectangleProfileDef``, ``IfcCircleProfileDef``,
+``IfcCircleHollowProfileDef``, ``IfcRectangleHollowProfileDef`` and
+``IfcUShapeProfileDef`` in IFC2X3 (it is only optional from IFC4 onward). The
+"Add Element" quick-add (``bim.add_element``) creates these profiles directly
+via ``file.create_entity(...)`` for the MEP flow segment templates, and would
+previously leave ``Position`` unset, producing an IFC2X3 file that fails
+schema validation.
+
+``bpy`` is not available in this test environment, so the operator's
+``execute()`` cannot be exercised directly. This test instead pins the fix at
+the source level: every ``create_entity`` call for one of the five profile
+classes above, within ``bonsai/bim/module/root/operator.py``, must pass a
+``Position`` keyword argument. A regression here (someone reintroducing one
+of these calls without ``Position``) will fail this test even without bpy.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.root
+
+BONSAI_ROOT_OPERATOR = Path(__file__).resolve().parents[4] / "bonsai" / "bim" / "module" / "root" / "operator.py"
+
+# Profile classes where Position is mandatory in IFC2X3 but optional in IFC4.
+PROFILE_CLASSES_REQUIRING_POSITION = {
+    "IfcRectangleProfileDef",
+    "IfcCircleProfileDef",
+    "IfcCircleHollowProfileDef",
+    "IfcRectangleHollowProfileDef",
+    "IfcUShapeProfileDef",
+}
+
+
+def _find_create_entity_profile_calls(tree: ast.Module) -> list[ast.Call]:
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "create_entity"):
+            continue
+        if not node.args:
+            continue
+        first_arg = node.args[0]
+        if not isinstance(first_arg, ast.Constant) or not isinstance(first_arg.value, str):
+            continue
+        if first_arg.value in PROFILE_CLASSES_REQUIRING_POSITION:
+            calls.append(node)
+    return calls
+
+
+def test_flow_segment_profile_create_entity_calls_set_position() -> None:
+    tree = ast.parse(BONSAI_ROOT_OPERATOR.read_text(encoding="utf-8"))
+    calls = _find_create_entity_profile_calls(tree)
+
+    # Sanity check: make sure the AST walk actually found the quick-add call
+    # sites, so this test cannot silently pass by finding nothing.
+    assert len(calls) >= 5, (
+        f"Expected to find at least 5 create_entity(...) calls for "
+        f"{sorted(PROFILE_CLASSES_REQUIRING_POSITION)} in {BONSAI_ROOT_OPERATOR.name}, "
+        f"found {len(calls)}. Did the MEP quick-add profile creation move or get renamed?"
+    )
+
+    missing_position = []
+    for call in calls:
+        ifc_class = call.args[0].value
+        kwarg_names = {kw.arg for kw in call.keywords if kw.arg is not None}
+        if "Position" not in kwarg_names:
+            missing_position.append((ifc_class, call.lineno))
+
+    assert not missing_position, (
+        "The following create_entity(...) calls omit the mandatory-in-IFC2X3 "
+        f"Position attribute: {missing_position}. This reproduces the bug where "
+        "MEP quick-add flow segments fail IFC2X3 validation."
+    )


### PR DESCRIPTION
`Position` is **mandatory in IFC2X3 and optional in IFC4** on every profile the MEP quick-add creates:

```
IFC2X3  Position optional:  Rectangle=False, RectangleHollow=False, Circle=False,
                            CircleHollow=False, UShape=False
IFC4    Position optional:  all True
```

`bim.add_element`, the "Add Element" quick-add that builds MEP flow segments, creates these profiles with raw `file.create_entity(...)` calls that never set `Position`. On IFC2X3 the result fails validation:

```
For instance:
    #1=IfcRectangleProfileDef(.AREA.,'New Profile',$,0.5,0.5)
With attribute:
    <attribute Position: <entity IfcAxis2Placement2D>>
Not optional
```

All five profile classes failed identically on IFC2X3 and passed on IFC4.

**Six call sites**, at lines 692, 708, 724, 738, 748 and 761 of `bim/module/root/operator.py`. All six fixed.

### Why not a shared helper

A helper was considered and rejected. Each site constructs a **different** profile class with different arguments, so a wrapper would add more indirection than the single argument it replaces. Instead this uses `ifcopenshell.util.shape_builder.ShapeBuilder`, which **this same operator already instantiates for placements**, so the fix follows the file's existing convention rather than introducing a new one. `Position` is passed unconditionally, which is harmless on IFC4 where it is merely optional.

### Test

`test_flow_segment_profile_position_forward_compat.py`, an AST test that parses `operator.py` and asserts every `create_entity` call for these five classes passes `Position`. It follows an existing pattern in this codebase and needs no `bpy`.

Verified red before the fix, listing all six offending lines, and green after.

### Verification limitation

`bpy` is unavailable in this environment, so `AddElement.execute()` could not be run directly. The reproduction was built from the **exact `create_entity` keyword arguments taken from each call site**, run against a real `ifcopenshell.file(schema="IFC2X3")` and validated. Stating that rather than implying a full UI run.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated, including the new test file, which carries the disclosure comment.
