### PR TITLE
sequence: fix cascade_schedule crash on IFC2X3

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/cascade_schedule.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/cascade_schedule.py
@@ -133,7 +133,9 @@ class Usecase:
             print("... which is cyclically a predecessor to ...", task)
             raise RecursionError("Recursive tasks found. Could not cascade schedule.")
 
-        if not task.TaskTime:
+        # IfcTaskTime does not exist in IFC2X3, so IfcTask has no TaskTime
+        # attribute at all there. Treat that the same as "no time set yet".
+        if not getattr(task, "TaskTime", None):
             return
 
         duration = (

--- a/src/ifcopenshell-python/test/api/sequence/test_cascade_schedule.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_cascade_schedule.py
@@ -24,8 +24,8 @@ import ifcopenshell.api.sequence
 import test.bootstrap
 
 
-# NOTE: sequence module features relies on entities introduced in IFC4
-# therefore no IFC2X3 tests
+# NOTE: task time cascading relies on IfcTaskTime, introduced in IFC4,
+# so most tests here are IFC4 only. See TestCascadeScheduleIfc2X3 below.
 class TestCascadeSchedule(test.bootstrap.IFC4):
     def test_doing_nothing_if_the_task_has_no_successors(self):
         task = ifcopenshell.api.sequence.add_task(self.file)
@@ -177,3 +177,18 @@ class TestCascadeSchedule(test.bootstrap.IFC4):
             ifcopenshell.api.sequence.assign_lag_time(
                 self.file, rel_sequence=rel, lag_value=lag, duration_type="WORKTIME"
             )
+
+
+class TestCascadeScheduleIfc2X3(test.bootstrap.IFC2X3):
+    def test_doing_nothing_since_ifctasktime_does_not_exist_in_ifc2x3(self):
+        # IfcTask has no TaskTime attribute at all in IFC2X3 (IfcTaskTime was
+        # only introduced in IFC4), so there is nothing to cascade.
+        task = ifcopenshell.api.sequence.add_task(self.file)
+        assert not hasattr(task, "TaskTime")
+        ifcopenshell.api.sequence.cascade_schedule(self.file, task=task)
+
+    def test_assign_sequence_does_not_crash_when_cascading_afterwards(self):
+        task = ifcopenshell.api.sequence.add_task(self.file)
+        task2 = ifcopenshell.api.sequence.add_task(self.file)
+        rel = ifcopenshell.api.sequence.assign_sequence(self.file, relating_process=task, related_process=task2)
+        assert rel.is_a("IfcRelSequence")


### PR DESCRIPTION
`cascade_schedule.py` unconditionally reads `task.TaskTime`. **That attribute does not exist on `IfcTask` in IFC2X3 at all**, because `IfcTaskTime` was only introduced in IFC4:

```
IFC2X3  IfcTask has TaskTime: False
IFC4    IfcTask has TaskTime: True
```

So it raises:

```
AttributeError: entity instance of type 'IFC2X3.IfcTask' has no attribute 'TaskTime'
```

This also breaks `assign_sequence`, an ordinary and otherwise IFC2X3-supported operation, because it calls `cascade_schedule` as an automatic side effect.

### Reachability, stated honestly

**This is not reachable from Bonsai's interface.** Bonsai already hides the entire 4D and sequence panel tree on IFC2X3 via `file.schema != "IFC2X3"` polls in `ui.py`. It is reachable from direct script use of `ifcopenshell.api.sequence`, which is a supported way to use this library.

### Why degrade rather than fail fast

Both options were considered. Failing fast was rejected because `assign_sequence`, `edit_sequence` and similar are **legitimate operations that already work on IFC2X3**, and they call `cascade_schedule` only as a side effect. Raising there would block valid task sequencing for no benefit, since a schema with no `IfcTaskTime` genuinely has nothing to cascade.

Degrading also matches what the siblings in this same directory already do: `add_task.py`, `add_work_plan.py` and `add_work_schedule.py` all explicitly accommodate IFC2X3 rather than raise. And it matches the function's own existing idiom, `if not task.TaskTime: return`, so a missing attribute is now treated the same as an unset one via `getattr(task, "TaskTime", None)`.

### Tests

`TestCascadeScheduleIfc2X3` added to `test/api/sequence/test_cascade_schedule.py`. Verified red with the `AttributeError` on both new tests before the fix, green after. 12 of 12 pass in that file and 68 of 68 across `test/api/sequence/`.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
