### PR TITLE
Bonsai: guard five crashes on valid IFC files

### DIFF
--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -721,10 +721,7 @@ class Drawing(bonsai.core.tool.Drawing):
                 ifc_path = os.path.dirname(ifc_path)
             return os.path.abspath(os.path.join(ifc_path, document.Location))
         if document.is_a("IfcDocumentInformation"):
-            if tool.Ifc.get_schema() == "IFC2X3":
-                references = document.DocumentReferences
-            else:
-                references = document.HasDocumentReferences
+            references = cls.get_document_references(document)
             for reference in references:
                 if description and cls.get_reference_description(reference) != description:
                     continue

--- a/src/bonsai/bonsai/tool/library.py
+++ b/src/bonsai/bonsai/tool/library.py
@@ -77,9 +77,9 @@ class Library(bonsai.core.tool.Library):
         props = cls.get_library_props()
         props.references.clear()
         if tool.Ifc.get_schema() == "IFC2X3":
-            references = library.LibraryReference
+            references = library.LibraryReference or []
         else:
-            references = library.HasLibraryReferences
+            references = library.HasLibraryReferences or []
         for reference in references:
             new = props.references.add()
             new.ifc_definition_id = reference.id()

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -224,7 +224,7 @@ class Model(bonsai.core.tool.Model):
         material = ifcopenshell.util.element.get_material(element)
         if not material or not material.is_a("IfcMaterialConstituentSet"):
             return props
-        for constituent in material.MaterialConstituents:
+        for constituent in material.MaterialConstituents or []:
             name = (constituent.Name or "").lower()
             if name in constituents:
                 props[f"{name}_material"] = str(constituent.Material.id())
@@ -1703,7 +1703,10 @@ class Model(bonsai.core.tool.Model):
     def get_element_matrix(cls, element: ifcopenshell.entity_instance, keep_local: bool = False) -> Matrix:
         placement = element.ObjectPlacement
         if keep_local:
-            placement = ifcopenshell.util.placement.get_axis2placement(placement.RelativePlacement)
+            if placement is None:
+                placement = np.eye(4)
+            else:
+                placement = ifcopenshell.util.placement.get_axis2placement(placement.RelativePlacement)
         else:
             placement = ifcopenshell.util.placement.get_local_placement(placement)
         return Matrix(placement)

--- a/src/bonsai/bonsai/tool/profile.py
+++ b/src/bonsai/bonsai/tool/profile.py
@@ -86,6 +86,8 @@ class Profile(bonsai.core.tool.Profile):
     @classmethod
     def get_profile(cls, element: ifcopenshell.entity_instance) -> Union[ifcopenshell.entity_instance, None]:
         representations = element.Representation
+        if representations is None:
+            return None
         for representation in representations.Representations:
             if not representation.is_a("IfcShapeRepresentation"):
                 continue


### PR DESCRIPTION
Five functions in `bonsai/tool/` dereference IFC attributes that the schema marks optional, so a valid file crashes them.

| File | Function | Attribute | Failure |
|---|---|---|---|
| `drawing.py` | `get_document_uri` | `IfcDocumentInformation.DocumentReferences` | `TypeError: 'NoneType' object is not iterable` |
| `library.py` | `import_references` | `IfcLibraryInformation.LibraryReference` | same |
| `model.py` | `get_constituents_props_data` | `IfcMaterialConstituentSet.MaterialConstituents` | same |
| `model.py` | `get_element_matrix` | `IfcProduct.ObjectPlacement` | `AttributeError` |
| `profile.py` | `get_profile` | `IfcProduct.Representation` | `AttributeError` |

Optionality verified against the schema rather than assumed:

```
IFC2X3  IfcDocumentInformation.DocumentReferences:      forward, optional=True
IFC2X3  IfcLibraryInformation.LibraryReference:         forward, optional=True
IFC4    IfcMaterialConstituentSet.MaterialConstituents: forward, optional=True
```

Two of these are reachable without an unusual file. A **freshly created constituent set**, made through Bonsai's own `add_material_set` API, has no constituents until one is added. And `get_profile` is called from `patch_non_parametric_mep_segment`, which **by design targets segments likely to lack a shape representation**.

`get_document_uri` now routes through this file's own `get_document_references` helper, which already handles both the IFC2X3 forward attribute and the IFC4 inverse, so the fix removes a duplicated schema branch rather than adding a guard beside it.

`get_element_matrix` returns an identity matrix when there is no placement, matching what its sibling branch already gets from `get_local_placement`, which handles `None` internally.

### The audit behind this, which is mostly a proven zero

`bonsai/tool/` is 63 files. The method was to build the set of attribute names that are **optional on every entity declaring them across all three schemas** (605 names), grep for chained reads of those names, then read every hit in context.

| Outcome | Count |
|---|---|
| Raw grep hits | 164 |
| False positives from name collisions | ~35 |
| Already correctly guarded | ~15 |
| Declined as unreachable | 3 |
| Already fixed in open PR #9103 | 1 |
| **Real, fixed** | **5** |

**The ~35 collisions are worth knowing about**, because they are what makes this shape expensive to audit by grep alone: attribute names collide with `bpy.types.Region`, Blender's `Matrix.Scale`, `isodate.Duration`, and appear inside comments and f-strings, where `None` interpolates harmlessly rather than raising.

Two candidates were dropped **after** tracing further, because they route through `get_local_placement`, which explicitly handles `None`. Three more were declined as genuinely unreachable: `profile.duplicate_profile` (the UI only lists named profiles, matching its own comment) and two `resource.py` functions whose callers create or gate the optional attribute first, at `core/resource.py:75` and `ui.py:260`.

### Verification limitation

`bpy` is unavailable in this environment, so these are reproductions of the exact failing expressions against real entities built with `ifcopenshell.file()`, **not** full-stack runs through Bonsai's UI. Stating that plainly.

`pytest test/core -o addopts=""` passes 390 of 390. The `test/tool/` suite requires `bpy` and could not be run.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
