### PR TITLE
Bonsai: guard optional RepresentationType concat

### DIFF
--- a/src/bonsai/bonsai/bim/module/geometry/data.py
+++ b/src/bonsai/bonsai/bim/module/geometry/data.py
@@ -126,7 +126,7 @@ class RepresentationsData:
             resolved_representation = ifcopenshell.util.representation.resolve_representation(representation)
 
             if resolved_representation != representation:
-                representation_type = resolved_representation.RepresentationType + "*"
+                representation_type = (resolved_representation.RepresentationType or "") + "*"
 
             is_active = (
                 representation.id() == active_representation_id


### PR DESCRIPTION
`RepresentationsData.representations()` concatenated an optional attribute:

```python
representation_type = resolved_representation.RepresentationType + "*"
```

`IfcRepresentation.RepresentationType` is optional in every schema:

```
IFC2X3 / IFC4 / IFC4X3_ADD2   IfcRepresentation.RepresentationType: optional=True

expression from the code -> TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

The existing `representation_type or ""` guard three lines further down never runs, because this line raises first.

**This panel refreshes on every redraw of the Geometry tab's Representations panel**, so any valid file containing a mapped or typed representation whose source has no `RepresentationType` crashes it just by being open with that panel visible.

### Reproduction

Built real entities with `ifcopenshell.file()`: an `IfcShapeRepresentation` with `RepresentationType=None`, wrapped by an `IfcMappedItem` and `IfcRepresentationMap`. Called the real `ifcopenshell.util.representation.resolve_representation()` on the outer representation, confirmed it resolves to the `None`-typed source, then evaluated the exact expression from the code and got the `TypeError` above.

`bpy` is unavailable in this environment, so this is a reproduction of the failing expression against real entities, **not** a full-stack run through Bonsai's UI.

### The audit behind it, and a finding about the method

46 `data.py` files exist under `bim/module/`. **16 were skipped for conflicts** with our own open PRs, leaving 30 audited, 4582 lines read in full.

**A targeted grep for the usual optional attributes (`.Name`, `.Description`, `.ObjectType` and similar) returned 32 hits, and every single one was a false positive** or already guarded with `or ""`, `getattr(..., default)`, or a surrounding try/except.

**The one real defect was not in that grep's results.** It involves `RepresentationType`, which was not on the pattern list, and was found only by reading every file line by line. That is worth recording: a grep-driven sweep of this shape has a blind spot exactly the size of the attribute list you thought to grep for, and the hit rate on the patterns you do pick can be zero while a real defect sits outside them.

Eight of the sixteen conflicts were **not** on the exclusion list I was given and had to be found independently, including `system/data.py`, which is touched by a pushed branch with **no PR** and is therefore invisible to `gh pr list` entirely. It only surfaced through `git diff --name-only origin/v0.8.0...bimvoice/<branch>`.

### Verification

`black` and `ruff` clean. `pytest test/core -o addopts=""` passes 390 of 391; the single error is a pre-existing, unrelated core bootstrap mock mismatch in `test/core/test_root.py`, and nothing under `bonsai/core` was touched here.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
