### PR TITLE
Bonsai: pset reload no longer drops IFC4X3 psets

### DIFF
--- a/src/bonsai/bonsai/bim/module/pset/operator.py
+++ b/src/bonsai/bonsai/bim/module/pset/operator.py
@@ -577,4 +577,4 @@ class SavePsetAsTemplate(bpy.types.Operator, tool.PsetTemplate.PsetTemplateOpera
 
         template_file.write(IfcStore.pset_template_path)
         bonsai.bim.handler.refresh_ui_data()
-        bonsai.bim.schema.reload(ifc_file.schema)
+        bonsai.bim.schema.reload(ifc_file.schema_identifier)

--- a/src/bonsai/bonsai/bim/module/pset_template/operator.py
+++ b/src/bonsai/bonsai/bim/module/pset_template/operator.py
@@ -49,7 +49,7 @@ class AddPsetTemplateFile(bpy.types.Operator):
         ifcopenshell.api.pset_template.add_prop_template(template, pset_template=pset_template)
         template.write(filepath)
         bonsai.bim.handler.refresh_ui_data()
-        bonsai.bim.schema.reload(tool.Ifc.get().schema)
+        bonsai.bim.schema.reload(tool.Ifc.get().schema_identifier)
         props = tool.PsetTemplate.get_pset_template_props()
         props.pset_template_files = filepath
         tool.PsetTemplate.enable_editing_pset_template()
@@ -68,7 +68,7 @@ class AddPsetTemplate(bpy.types.Operator, tool.PsetTemplate.PsetTemplateOperator
         ifcopenshell.api.pset_template.add_prop_template(self.template_file, pset_template=template)
         self.template_file.write(IfcStore.pset_template_path)
         bonsai.bim.handler.refresh_ui_data()
-        bonsai.bim.schema.reload(tool.Ifc.get().schema)
+        bonsai.bim.schema.reload(tool.Ifc.get().schema_identifier)
         props = tool.PsetTemplate.get_pset_template_props()
         props.pset_templates = str(template.id())
 
@@ -89,7 +89,7 @@ class RemovePsetTemplate(bpy.types.Operator, tool.PsetTemplate.PsetTemplateOpera
         )
         self.template_file.write(IfcStore.pset_template_path)
         bonsai.bim.handler.refresh_ui_data()
-        bonsai.bim.schema.reload(tool.Ifc.get().schema)
+        bonsai.bim.schema.reload(tool.Ifc.get().schema_identifier)
         tool.Blender.ensure_enum_is_valid(props, "pset_templates")
 
 
@@ -182,7 +182,7 @@ class EditPsetTemplate(bpy.types.Operator, tool.PsetTemplate.PsetTemplateOperato
         bpy.ops.bim.disable_editing_pset_template()
         IfcStore.pset_template_file.write(IfcStore.pset_template_path)
         bonsai.bim.handler.refresh_ui_data()
-        bonsai.bim.schema.reload(tool.Ifc.get().schema)
+        bonsai.bim.schema.reload(tool.Ifc.get().schema_identifier)
 
 
 class SavePsetTemplateFile(bpy.types.Operator):
@@ -192,7 +192,7 @@ class SavePsetTemplateFile(bpy.types.Operator):
     def execute(self, context):
         IfcStore.pset_template_file.write(IfcStore.pset_template_path)
         bonsai.bim.handler.refresh_ui_data()
-        bonsai.bim.schema.reload(tool.Ifc.get().schema)
+        bonsai.bim.schema.reload(tool.Ifc.get().schema_identifier)
         return {"FINISHED"}
 
 
@@ -207,7 +207,7 @@ class RemovePsetTemplateFile(bpy.types.Operator):
         except:
             pass
         bonsai.bim.handler.refresh_ui_data()
-        bonsai.bim.schema.reload(tool.Ifc.get().schema)
+        bonsai.bim.schema.reload(tool.Ifc.get().schema_identifier)
 
         # Ensure enum is valid after deletion.
         self.props = tool.PsetTemplate.get_pset_template_props()
@@ -236,7 +236,7 @@ class AddPropTemplate(bpy.types.Operator, tool.PsetTemplate.PsetTemplateOperator
         bpy.ops.bim.disable_editing_prop_template()
         IfcStore.pset_template_file.write(IfcStore.pset_template_path)
         bonsai.bim.handler.refresh_ui_data()
-        bonsai.bim.schema.reload(tool.Ifc.get().schema)
+        bonsai.bim.schema.reload(tool.Ifc.get().schema_identifier)
         tool.PsetTemplate.enable_editing_prop_template(prop_template)
 
 
@@ -253,7 +253,7 @@ class RemovePropTemplate(bpy.types.Operator, tool.PsetTemplate.PsetTemplateOpera
         )
         IfcStore.pset_template_file.write(IfcStore.pset_template_path)
         bonsai.bim.handler.refresh_ui_data()
-        bonsai.bim.schema.reload(tool.Ifc.get().schema)
+        bonsai.bim.schema.reload(tool.Ifc.get().schema_identifier)
 
 
 class EditPropTemplate(bpy.types.Operator, tool.PsetTemplate.PsetTemplateOperator):
@@ -293,7 +293,7 @@ class EditPropTemplate(bpy.types.Operator, tool.PsetTemplate.PsetTemplateOperato
         IfcStore.pset_template_file.write(IfcStore.pset_template_path)
         bonsai.bim.handler.refresh_ui_data()
         if tool.Ifc.get():
-            bonsai.bim.schema.reload(tool.Ifc.get().schema)
+            bonsai.bim.schema.reload(tool.Ifc.get().schema_identifier)
 
 
 class SelectPsetTemplatesInUI(bpy.types.Operator):


### PR DESCRIPTION
On an IFC4X3 file, Bonsai silently loads **IFC4** property set and quantity templates instead of the IFC4X3 ones, after any of ten operators run.

### Root cause

`ifcopenshell.file` exposes two different things, and they are not interchangeable:

```
file.schema            = 'IFC4X3'
file.schema_identifier = 'IFC4X3_ADD2'
```

`bonsai/bim/schema.py` matches on the **edition**:

```python
def __init__(self, schema_identifier="IFC4"):
    if schema_identifier not in ("IFC2X3", "IFC4", "IFC4X3_ADD2"):
        schema_identifier = "IFC4"
```

So passing `"IFC4X3"` never matches and falls through to the `IFC4` default. Ten call sites passed `tool.Ifc.get().schema`, the base name, into `bonsai.bim.schema.reload()`: nine in `pset_template/operator.py` and one in `pset/operator.py`.

**The correct pattern already exists in the codebase.** `tool/ifc.py:77` calls `reload(IfcStore.file.schema_identifier)`. This aligns the ten outliers with it.

`ifcopenshell.util.pset.get_template`'s own docstring says the same thing: *"As in `file.schema_identifier`, not `file.schema`."*

### Consequence

The fallback is silent. An IFC4X3 project keeps working, but the applicable psets come from the wrong schema. Verified against the real `ifcopenshell.util.pset.get_template`: the IFC4X3 template exposes `Pset_LinearReferencingMethod` and similar for `IfcAlignment` and `IfcReferent`, while the IFC4 fallback raises `Entity with name 'IfcAlignment' not found in schema 'IFC4'` for the same lookup.

So on an IFC4X3 alignment project, the 4X3-only psets disappear from the UI after touching any pset template operator.

### Verification limitation, stated plainly

**This was not run through a live Blender session.** `bonsai.bim` and `bonsai.tool` eagerly import every submodule at package-import time, and resolving that transitive dependency chain (bcf, bsdd, xsdata, natsort, lxml, svgwrite, markdown-it-py, xmlschema, python-socketio, platformdirs, openpyxl and more) did not terminate within a reasonable budget.

What **was** verified directly: the `schema` versus `schema_identifier` values above, the exact membership check from `IfcSchema.__init__` reproduced verbatim, and the differing behaviour of the real `ifcopenshell.util.pset.get_template` between the two schemas.

### Manual check

1. Open an IFC4X3 project in Bonsai.
2. In Blender's Python console: `import bonsai.bim.schema; print(bonsai.bim.schema.ifc.psetqto.schema)`. Expect `IFC4X3_ADD2`.
3. Run any pset template operator, for example `bpy.ops.bim.add_pset_template()`.
4. Print it again. **Before this change it drops to `IFC4`; after, it stays `IFC4X3_ADD2`.**
5. Check that an `IfcAlignment` or `IfcReferent` object still lists 4X3-only psets in its applicable-pset dropdown afterwards.

### AI disclosure

Per AGENTS.md: this pull request is entirely AI-generated.
