### PR TITLE
Bonsai: guard non-IFC active object crash

### DIFF
--- a/src/bonsai/bonsai/bim/module/misc/operator.py
+++ b/src/bonsai/bonsai/bim/module/misc/operator.py
@@ -247,6 +247,9 @@ class GetConnectedSystemElements(bpy.types.Operator, tool.Ifc.Operator):
             return "{} ({})".format(e.Name, e.GlobalId)
 
         start = tool.Ifc.get_entity(bpy.context.active_object)
+        if not start:
+            self.report({"ERROR"}, "Active object is not an IFC element.")
+            return {"CANCELLED"}
 
         connected_elements = []
 


### PR DESCRIPTION
`GetConnectedSystemElements` crashes when the active object is not an IFC element.

Its `poll()` checks the **selection**, but the code reads the **active object**, and those are not the same thing. You can have IFC objects selected while the active object is a plain Blender mesh, an empty, or a camera:

```python
@classmethod
def poll(cls, context):
    return context.selected_objects and tool.Ifc.get()
...
start = tool.Ifc.get_entity(bpy.context.active_object)   # can be None
```

`start` then goes straight into `pprint_element()`, which does `"{} ({})".format(e.Name, e.GlobalId)`:

```
AttributeError: 'NoneType' object has no attribute 'Name'
```

The fix reports a clear error and cancels, which is the pattern **every other function in this same file already uses** for the same situation.

Reproduced against a real entity rather than inferred. `bpy` is unavailable in this environment, so this is a reproduction of the failing expression, not a full run through Blender's UI.

Found by auditing all 54 `bim/module/*/operator.py` files. **40 of those were skipped because one of our own open PRs already touches them**, leaving 14 free; 46 grep hits in those 14 were all false positives, and this was found by reading the files in full.

Generated with the assistance of an AI coding tool.
