### PR TITLE
pset.edit_pset: fix untemplated list-value crash

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/pset/edit_pset.py
@@ -339,7 +339,7 @@ class Usecase:
             elif isinstance(value, (tuple, list)):
                 if not value:
                     continue
-                for pset_template in self.pset_template.HasPropertyTemplates:
+                for pset_template in self.pset_template.HasPropertyTemplates if self.pset_template else ():
                     if pset_template.Name != name:
                         continue
 

--- a/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
+++ b/src/ifcopenshell-python/test/api/pset/test_edit_pset.py
@@ -330,3 +330,12 @@ class TestEditPsetIFC4(test.bootstrap.IFC4, TestEditPsetIFC2X3):
         assert len(pset.HasProperties[0].ListValues) == 3
         assert set(map(ifcopenshell.entity_instance.is_a, pset.HasProperties[0].ListValues)) == {"IfcIdentifier"}
         assert list(map(operator.itemgetter(0), pset.HasProperties[0].ListValues)) == ["One", "Two", "Three"]
+
+    def test_adding_a_list_valued_property_to_an_untemplated_pset_raises_instead_of_crashing(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Custom_Pset")
+        try:
+            ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Foo": ["One", "Two"]})
+            assert False, "Expected a NotImplementedError, not a successful call."
+        except NotImplementedError:
+            pass


### PR DESCRIPTION
Adding a list-valued property to **any custom property set** crashes.

`add_new_properties` iterates the pset template unconditionally:

```python
for pset_template in self.pset_template.HasPropertyTemplates:
```

`self.pset_template` is `None` whenever the pset name has no matching template, which is the normal case for a user-defined pset:

```
AttributeError: 'NoneType' object has no attribute 'HasPropertyTemplates'
```

Two things show this is unintended rather than a deliberate restriction:

* `get_primary_measure_type`, two methods away in the same class, already guards with `if self.pset_template:`.
* The analogous "no template matched by name" case already raises a clear `NotImplementedError("No template found...")`. So this path was meant to report, not crash.

The fix applies the existing guard so an untemplated pset falls through to that same intended behaviour.

Reproduced live in the built interpreter before fixing. Regression test added and verified red before the change and green after; the file's existing suite passes 28 of 28.

Generated with the assistance of an AI coding tool.
