### PR TITLE
geometry.unassign_representation: fix None crash

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/unassign_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/unassign_representation.py
@@ -46,18 +46,20 @@ class Usecase:
     def unassign_product_representation(
         self, product: ifcopenshell.entity_instance, representation: ifcopenshell.entity_instance
     ) -> None:
-        representations = list(product.Representation.Representations or [])
+        product_def = product.Representation
+        if not product_def:
+            return
+        representations = list(product_def.Representations or [])
         if representation not in representations:
             return
         representations.remove(representation)
         if not representations:
-            product_def = product.Representation
             # TODO: should somehow find matching shape aspect and remove it
             # even before the last representation is removed.
             self.process_shape_aspects(product_def)
             self.file.remove(product_def)
         else:
-            product.Representation.Representations = representations
+            product_def.Representations = representations
 
     def unassign_type_representation(self) -> None:
         matching_representation_map = None

--- a/src/ifcopenshell-python/test/api/geometry/test_unassign_representation.py
+++ b/src/ifcopenshell-python/test/api/geometry/test_unassign_representation.py
@@ -77,6 +77,12 @@ class TestUnassignRepresentation(test.bootstrap.IFC4):
         assert not wall.Representation
         assert len(self.file.by_type("IfcProductDefinitionShape")) == 0
 
+    def test_unassigning_a_representation_from_a_product_without_any_representation(self):
+        wall = self.file.createIfcWall()
+        representation = self.file.createIfcShapeRepresentation()
+        ifcopenshell.api.geometry.unassign_representation(self.file, product=wall, representation=representation)
+        assert not wall.Representation
+
 
 class TestUnassignRepresentationIFC2X3(test.bootstrap.IFC2X3, TestUnassignRepresentation):
     pass


### PR DESCRIPTION
`unassign_representation` crashes on a product that has no representation yet.

```python
representations = list(product.Representation.Representations or [])
```

`IfcProduct.Representation` is optional in every schema, so a freshly created element, for example a wall before any geometry is added, gives:

```
AttributeError: 'NoneType' object has no attribute 'Representations'
```

The function already treats "this representation is not assigned to this product" as a **no-op**, returning quietly a few lines below. A product with no representation at all is the same situation and should behave the same way, so the fix returns early rather than raising.

The change also hoists `product.Representation` into the local `product_def` that the function already declared further down, removing a duplicated attribute read.

Reproduced live in the built interpreter before fixing. Regression test added and verified red before the change and green after; the file's existing suite passes 8 of 8.

Generated with the assistance of an AI coding tool.
