### PR TITLE
validate: raise cleanly on unsupported sqlite

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -429,19 +429,19 @@ def validate(f: Union[ifcopenshell.file, str], logger: Union[Logger, json_logger
         pprint(logger.statements)
     """
 
-    # Originally there was no way in Python to distinguish on an entity instance attribute value whether the
-    # value supplied in the model was NIL ($) or 'missing because derived in subtype' (*). For validation this
-    # however this may be important, and hence a feature switch has been implemented to return *-values as
-    # instances of a dedicated type `ifcopenshell.ifcopenshell_wrapper.attribute_value_derived`.
-    attribute_value_derived_org = ifcopenshell.ifcopenshell_wrapper.get_feature("use_attribute_value_derived")
-    ifcopenshell.ifcopenshell_wrapper.set_feature("use_attribute_value_derived", True)
-
     if isinstance(f, ifcopenshell.sqlite):
         raise NotImplementedError(
             "ifcopenshell.validate.validate() does not support ifcopenshell.sqlite files: "
             "the sqlite backend does not retain the full IFC header or entity attribute data "
             "needed for validation."
         )
+
+    # Originally there was no way in Python to distinguish on an entity instance attribute value whether the
+    # value supplied in the model was NIL ($) or 'missing because derived in subtype' (*). For validation this
+    # however this may be important, and hence a feature switch has been implemented to return *-values as
+    # instances of a dedicated type `ifcopenshell.ifcopenshell_wrapper.attribute_value_derived`.
+    attribute_value_derived_org = ifcopenshell.ifcopenshell_wrapper.get_feature("use_attribute_value_derived")
+    ifcopenshell.ifcopenshell_wrapper.set_feature("use_attribute_value_derived", True)
 
     filename = None
 

--- a/src/ifcopenshell-python/ifcopenshell/validate.py
+++ b/src/ifcopenshell-python/ifcopenshell/validate.py
@@ -436,6 +436,13 @@ def validate(f: Union[ifcopenshell.file, str], logger: Union[Logger, json_logger
     attribute_value_derived_org = ifcopenshell.ifcopenshell_wrapper.get_feature("use_attribute_value_derived")
     ifcopenshell.ifcopenshell_wrapper.set_feature("use_attribute_value_derived", True)
 
+    if isinstance(f, ifcopenshell.sqlite):
+        raise NotImplementedError(
+            "ifcopenshell.validate.validate() does not support ifcopenshell.sqlite files: "
+            "the sqlite backend does not retain the full IFC header or entity attribute data "
+            "needed for validation."
+        )
+
     filename = None
 
     if isinstance(logger, json_logger):

--- a/src/ifcopenshell-python/test/test_validate.py
+++ b/src/ifcopenshell-python/test/test_validate.py
@@ -18,9 +18,11 @@
 
 import glob
 import os
+import tempfile
 
 import pytest
 
+import ifcopenshell
 import ifcopenshell.validate
 
 
@@ -39,6 +41,25 @@ def test_file(file):
         assert len(logger.statements) > 0
     if file.startswith("pass-"):
         assert len(logger.statements) == 0
+
+
+def test_validate_rejects_sqlite_file_instead_of_crashing():
+    # ifcopenshell.sqlite only keeps a partial, query-oriented header (see
+    # ifcopenshell.sql.sqlite.header), so it cannot be validated. Regression
+    # test for validate() previously raising an unguarded AttributeError
+    # deep inside validate_ifc_header() instead of failing cleanly.
+    from ifcpatch.recipes import Ifc2Sql
+
+    ifc_path = os.path.join(os.path.dirname(__file__), "files", "basic.ifc")
+    ifc_file = ifcopenshell.open(ifc_path)
+    with tempfile.NamedTemporaryFile(suffix=".ifcsqlite") as tmp:
+        Ifc2Sql.Patcher(ifc_file, database=tmp.name).patch()
+        ifc_sqlite = ifcopenshell.open(tmp.name)
+        assert isinstance(ifc_sqlite, ifcopenshell.sqlite)
+
+        logger = ifcopenshell.validate.json_logger()
+        with pytest.raises(NotImplementedError):
+            ifcopenshell.validate.validate(ifc_sqlite, logger)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`validate()` crashes on an `ifcopenshell.sqlite` file.

The sqlite backend's `header` only mimics `file_description.description`, but `validate_ifc_header()` unconditionally reads `header.file_name.name` and similar, so it raises `AttributeError` on the stub `SimpleNamespace`.

This is reachable from Bonsai's "Validate IFC File" operator, since `tool.Ifc.get()` can legitimately return an `ifcopenshell.sqlite`.

It now raises `NotImplementedError` up front, naming the reason: the sqlite backend does not retain the full IFC header or entity attribute data that validation needs. **No working functionality is removed.** Validation never worked on these files; it crashed obscurely. This replaces that with a clear error.

### A bug introduced and then fixed within this branch

The second commit fixes a mistake in the first. The guard originally sat **after** the `use_attribute_value_derived` C++ feature flag was flipped on, so raising early leaked that global into later parse and serialise calls. It was caught by running the full suite together, which is exactly how cross-test pollution surfaces and why the guard now sits before any state mutation.

Regression test added, verified red before the fix and green after.

Generated with the assistance of an AI coding tool.
