### PR TITLE
express: fail clean when rules are missing

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/express/rule_executor.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rule_executor.py
@@ -101,6 +101,12 @@ def run(f: ifcopenshell.file, logger: Logger) -> None:
         current_dir_files = {fn.lower(): fn for fn in os.listdir(".")}
         schema_name = str(f.schema_identifier).split(" ")[-1].lower()
         schema_path = current_dir_files.get(schema_name + ".exp")
+        if schema_path is None:
+            ifcopenshell.settings.unpack_non_aggregate_inverses = orig
+            raise FileNotFoundError(
+                f"Couldn't find express rules for schema '{f.schema_identifier}': no precompiled rules and "
+                f"no '{schema_name}.exp' in the current folder '{os.getcwd()}'."
+            ) from e
         fn = schema_path[:-4] + ".py"
         if not os.path.exists(fn):
             subprocess.run([sys.executable, "-m", "ifcopenshell.express.rule_compiler", schema_path, fn], check=True)

--- a/src/ifcopenshell-python/test/test_rules.py
+++ b/src/ifcopenshell-python/test/test_rules.py
@@ -45,5 +45,23 @@ def test_file(filename):
         assert len(results) == 0
 
 
+def test_missing_rules_reports_clean_error(tmp_path, monkeypatch):
+    # Regression test: for a schema with no precompiled rules and no matching
+    # .exp in the current folder, run() previously crashed with an opaque
+    # "'NoneType' object is not subscriptable" TypeError instead of a clear
+    # FileNotFoundError, unlike the equivalent fallback in validate.py and
+    # entity_instance.py.
+    class FakeFile:
+        schema_identifier = "NOTASCHEMA"
+
+        def __iter__(self):
+            return iter(())
+
+    monkeypatch.chdir(tmp_path)
+    logger = ifcopenshell.validate.json_logger()
+    with pytest.raises(FileNotFoundError):
+        ifcopenshell.express.rule_executor.run(FakeFile(), logger)
+
+
 if __name__ == "__main__":
     pytest.main(["-sx", __file__, "--import-mode=importlib"])


### PR DESCRIPTION
The fallback that looks for a schema's `.exp` file in the current directory did not check whether it found one:

```python
schema_path = current_dir_files.get(schema_name + ".exp")
fn = schema_path[:-4] + ".py"
```

On a miss that gives `TypeError: 'NoneType' object is not subscriptable`, which tells the user nothing about what went wrong.

`validate.py` and `entity_instance.py` already guard this identical pattern. The fix follows them and raises `FileNotFoundError` naming both the schema and the directory that was searched.

Reachable via `python -m ifcopenshell.express.rule_executor`, or `validate(f, logger, express_rules=True)` against a schema whose `.exp` is not in the working directory.

The fix also restores `ifcopenshell.settings.unpack_non_aggregate_inverses` before raising, which the early exit would otherwise skip, leaving a global modified for the rest of the process.

Regression test added, verified red before the fix and green after.

Generated with the assistance of an AI coding tool.
