### PR TITLE
file: raise AttributeError for bad rocksdb attr

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/file.py
+++ b/src/ifcopenshell-python/ifcopenshell/file.py
@@ -353,6 +353,8 @@ class rocksdb_lazy_instance:
         attr = attribute_lookup(self.storage.schema_identifier, self.is_a()).get(name)
         if isinstance(attr, int):
             return self[attr]
+        elif attr is None:
+            raise AttributeError("entity instance of type '%s' has no attribute '%s'" % (self.is_a(), name))
         else:
             entity_indices, attribute_index = attr
 

--- a/src/ifcopenshell-python/test/test_streaming_rocksdb_and_simpletyperefs.py
+++ b/src/ifcopenshell-python/test/test_streaming_rocksdb_and_simpletyperefs.py
@@ -119,5 +119,25 @@ def test_rocks():
         gc.collect()
 
 
+def test_rocks_storage_getattr_invalid_attribute():
+    # Regression test: rocksdb_lazy_instance.__getattr__() looked up the
+    # attribute name in a dict and, without checking for a miss, unpacked
+    # the result as a 2-tuple. An unrecognized attribute name crashed with
+    # "TypeError: cannot unpack non-iterable NoneType object" instead of
+    # the AttributeError entity_instance.__getattr__() raises for the same
+    # situation.
+    with tempfile.TemporaryDirectory() as d:
+        rfn = os.path.join(d, os.path.basename(fn))
+        ifcopenshell.convert_path_to_rocksdb(fn, rfn)
+
+        f = ifcopenshell.open(rfn)
+        inst = f.storage.by_id(1)
+        with pytest.raises(AttributeError):
+            inst.NotARealAttribute
+
+        del f
+        gc.collect()
+
+
 if __name__ == "__main__":
     pytest.main(["-sx", __file__])


### PR DESCRIPTION
`rocksdb_lazy_instance.__getattr__` unpacked its lookup result as a 2-tuple without checking for a miss:

```python
attr = attribute_lookup(self.storage.schema_identifier, self.is_a()).get(name)
if isinstance(attr, int):
    return self[attr]
else:
    entity_indices, attribute_index = attr      # attr can be None
```

Any unknown attribute name on a rocksdb-backed instance therefore gave:

```
TypeError: cannot unpack non-iterable NoneType object
```

**This breaks every `getattr(inst, name, default)` and `hasattr()` caller**, since both rely on `AttributeError` to fall back and neither catches `TypeError`. Reachable through the public `file.storage` API.

The fix raises `AttributeError` with the same wording `entity_instance` already uses for this case, so the two backends behave alike.

Reproduced against a real rocksdb conversion of `test/files/basic.ifc`. Regression test added, verified red before the fix and green after.

Generated with the assistance of an AI coding tool.
