### PR TITLE
bcf: fix v3 crash on missing extensions.xml

### DIFF
--- a/src/bcf/bcf/v3/bcfxml.py
+++ b/src/bcf/bcf/v3/bcfxml.py
@@ -82,7 +82,7 @@ class BcfXml:
     @property
     def extensions(self) -> Optional[mdl.Extensions]:
         """BCF extensions."""
-        if not self._extensions and self._zip_file:
+        if not self._extensions and self._zip_file and zipfile.Path(self._zip_file, "extensions.xml").exists():
             self._extensions = self._xml_handler.parse(self._zip_file.read("extensions.xml"), mdl.Extensions)
         return self._extensions
 

--- a/src/bcf/tests/v3/test_bcf_xml.py
+++ b/src/bcf/tests/v3/test_bcf_xml.py
@@ -1,6 +1,7 @@
 """BCF XML tests."""
 
 import uuid
+import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -120,3 +121,20 @@ def test_equality_with_wrong_object(build_sample) -> None:
 
 def test_topic_equality_with_wrong_object(build_sample) -> None:
     assert build_sample[1] != "Wrong object"
+
+
+def test_extensions_missing_from_file(xml_handler) -> None:
+    """extensions.xml is optional per the BCF v3 spec, loading a file without it must not crash."""
+    with TemporaryDirectory() as tmp_dir:
+        file_path = Path(tmp_dir) / "no_extensions.bcf"
+        with zipfile.ZipFile(file_path, "w") as bcf_zip:
+            bcf_zip.writestr(
+                "bcf.version",
+                '<Version VersionId="3.0" xmlns="http://www.buildingsmart.org/API/BCF-XML/V3"></Version>',
+            )
+            bcf_zip.writestr(
+                "project.bcfp",
+                '<ProjectInfo xmlns="http://www.buildingsmart.org/API/BCF-XML/V3"></ProjectInfo>',
+            )
+        with BcfXml.load(file_path, xml_handler=xml_handler) as parsed:
+            assert parsed.extensions is None


### PR DESCRIPTION
`BcfXml.extensions` reads `extensions.xml` unconditionally:

```python
if not self._extensions and self._zip_file:
    self._extensions = self._xml_handler.parse(self._zip_file.read("extensions.xml"), mdl.Extensions)
```

That file is an **optional** member of a BCF v3 archive, so any valid BCF that omits it raises:

```
KeyError: "There is no item named 'extensions.xml' in the archive"
```

This file already handles optional members correctly two properties above, and the fix uses that exact pattern:

```python
# project_info, existing code
if not self._project_info and self._zip_file and zipfile.Path(self._zip_file, "project.bcfp").exists():
```

`DocumentsHandler.load` in `bcf/v3/document.py` guards `documents.xml` the same way. The property's return type is **already** `Optional[mdl.Extensions]`, so returning `None` is the declared contract rather than new behaviour.

Reachable from anything that touches `.extensions` on a loaded `BcfXml`, including the class's own `__eq__`.

Verified red then green directly: stashed the fix, reproduced the `KeyError`, restored it, confirmed the property returns `None`. Regression test `test_extensions_missing_from_file` added; the full `src/bcf` suite passes 26.

### Audit context

Found while sweeping `ifc5d`, `ifccsv`, `ifcclash`, `ifcdiff` and `bcf`. **8 files were skipped because one of our own open PRs already touches them** (#9116, #9143, #9113, #9120), two of which surfaced only by diffing branch contents rather than through `gh pr list`, since a pushed branch with no PR is invisible to it.

Generated with the assistance of an AI coding tool.
