### PR TITLE
ifcpatch: fix Optimise crash on unset attribute

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/Optimise.py
+++ b/src/ifcpatch/ifcpatch/recipes/Optimise.py
@@ -127,6 +127,14 @@ class Patcher:
 
             else:
                 info_to_id[info] = id
-                instance_mapping[inst] = self.optimized_file.create_entity(inst.is_a(), *map(map_value, inst))
+                # Assigned per index, not positionally: create_entity()
+                # rejects None in a mandatory slot, which a parseable but
+                # non-compliant file can legitimately contain.
+                new_inst = self.optimized_file.create_entity(inst.is_a())
+                for idx, value in enumerate(map(map_value, inst)):
+                    if value is None:
+                        continue
+                    new_inst[idx] = value
+                instance_mapping[inst] = new_inst
 
         self.file = self.optimized_file

--- a/src/ifcpatch/test/test_Optimise.py
+++ b/src/ifcpatch/test/test_Optimise.py
@@ -91,6 +91,21 @@ class TestOptimise(test.bootstrap.IFC4):
         assert len(output.by_type("IfcPolyline")) == 1
 
 
+class TestOptimiseUnsetMandatoryAttribute(test.bootstrap.IFC2X3):
+    def test_entity_with_an_unset_mandatory_attribute_is_preserved_not_crashed(self):
+        # IfcOpenShell does not enforce schema-mandatory attributes on
+        # create/read, so a real (if non-compliant) file can contain an
+        # entity like this. Optimise must not crash on it.
+        material_layer_set = self.file.create_entity("IfcMaterialLayerSet")
+        assert material_layer_set.MaterialLayers is None
+
+        output = ifcpatch.execute({"file": self.file, "recipe": "Optimise", "arguments": []})
+
+        optimised = output.by_type("IfcMaterialLayerSet")
+        assert len(optimised) == 1
+        assert optimised[0].MaterialLayers is None
+
+
 GRAPH = {4: {2, 3}, 2: {1}, 3: {1}, 1: set()}
 
 


### PR DESCRIPTION
`Optimise` recreates every entity by passing all attributes positionally:

```python
self.optimized_file.create_entity(inst.is_a(), *map(map_value, inst))
```

IfcOpenShell does not enforce schema-mandatory attributes on read or on `create_entity`, so a real file, **including one IfcOpenShell itself authored**, can contain something like `IfcMaterialLayerSet($,$)`. Passing `None` into a mandatory slot then raises:

```
TypeError: attribute 'MaterialLayers' is not optional
```

and the whole optimisation run dies on a single malformed entity.

The fix creates the entity empty and assigns per index, skipping `None`, which matches the already-unset default on a fresh entity. A non-compliant but parseable file now optimises losslessly instead of crashing, preserving the unset state rather than inventing a value for it.

Reproduced with a minimal one-entity file. Regression test `TestOptimiseUnsetMandatoryAttribute` added, verified failing on the old code and passing on the new. `test_Optimise.py` passes 7 of 7, and the full `src/ifcpatch/test/` suite passes apart from 5 pre-existing unrelated failures in `test_MergeProject.py`.

### Audit context

Found by auditing all 38 recipes. **22 were skipped because one of our own open PRs already touches them**, leaving 16 audited in full. A grep for the `by_type(...)[0]` shape returned zero hits.

One hypothesis was ruled out by measurement rather than assumption: `RecycleNonRootedElements` hashes `tuple(element)`, which would fail if any attribute came back as a raw Python `list`. It does not; ifcopenshell always returns nested tuples for list-typed attributes, so `hash()` never fails there. Not shipped.

Generated with the assistance of an AI coding tool.
