### PR TITLE
geom: tree.select and select_box accept int coords

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/main.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/main.py
@@ -434,11 +434,18 @@ class tree(ifcopenshell_wrapper.tree):
         return [entity_instance(e) for e in ifcopenshell_wrapper.tree.select(*args)]
 
     def select_box(self, value, **kwargs) -> list[entity_instance]:
+        def is_coord_triple(v):
+            return isinstance(v, (list, tuple)) and len(v) == 3 and all(isinstance(c, (int, float)) for c in v)
+
         def unwrap(value):
             if isinstance(value, entity_instance):
                 return value.wrapped_data
             elif hasattr(value, "Get"):
                 return value.Get()[:3], value.Get()[3:]
+            elif isinstance(value, (list, tuple)) and len(value) == 2 and all(map(is_coord_triple, value)):
+                # Coordinates need to be actual floats, otherwise the Bnd_Box
+                # typemap cannot resolve and raises a confusing TypeError.
+                return tuple(tuple(float(c) for c in corner) for corner in value)
             return value
 
         args = [self, unwrap(value)]

--- a/src/ifcopenshell-python/ifcopenshell/geom/main.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/main.py
@@ -399,11 +399,22 @@ class tree(ifcopenshell_wrapper.tree):
         ],
         **kwargs,
     ) -> list[entity_instance]:
+        def is_point_triple(value):
+            return (
+                isinstance(value, (list, tuple))
+                and len(value) == 3
+                and all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in value)
+            )
+
         def unwrap(value):
             if isinstance(value, entity_instance):
                 return value.wrapped_data
             elif all(map(lambda v: hasattr(value, v), "XYZ")):
                 return value.X(), value.Y(), value.Z()
+            elif is_point_triple(value):
+                # Coordinates need to be actual floats, otherwise SWIG cannot
+                # resolve the gp_Pnt overload and raises a confusing TypeError.
+                return tuple(float(v) for v in value)
             return value
 
         args = [self, unwrap(value)]
@@ -411,7 +422,7 @@ class tree(ifcopenshell_wrapper.tree):
             args.append(kwargs.get("completely_within", False))
             if "extend" in kwargs:
                 args.append(kwargs["extend"])
-        elif isinstance(value, (list, tuple)) and len(value) == 3 and set(map(type, value)) == {float}:
+        elif is_point_triple(value):
             if "extend" in kwargs:
                 args.append(kwargs["extend"])
         elif has_occ:

--- a/src/ifcopenshell-python/test/test_create_shape.py
+++ b/src/ifcopenshell-python/test/test_create_shape.py
@@ -194,6 +194,22 @@ class TestAssignObject:
         assert len(set(vs)) == 12
 
 
+class TestTree:
+    def test_select_by_point_accepts_int_coordinates(self):
+        # Regression test: passing an int (or mixed int/float) coordinate
+        # triple used to raise a confusing SWIG TypeError instead of being
+        # treated as a point, because the dispatch required every element
+        # to be exactly `float`.
+        settings = ifcopenshell.geom.settings()
+        settings.set("use-world-coords", True)
+        ifc_file = ifcopenshell.open(fn)
+        tree = ifcopenshell.geom.tree()
+        tree.add_file(ifc_file, settings)
+
+        assert tree.select((0, 0, 0)) == tree.select((0.0, 0.0, 0.0))
+        assert tree.select((0, 0.0, 0)) == tree.select((0.0, 0.0, 0.0))
+
+
 def test_iterator():
     # just test some permutations of invocation
     settings = ifcopenshell.geom.settings()

--- a/src/ifcopenshell-python/test/test_create_shape.py
+++ b/src/ifcopenshell-python/test/test_create_shape.py
@@ -209,6 +209,18 @@ class TestTree:
         assert tree.select((0, 0, 0)) == tree.select((0.0, 0.0, 0.0))
         assert tree.select((0, 0.0, 0)) == tree.select((0.0, 0.0, 0.0))
 
+    def test_select_box_accepts_int_coordinates(self):
+        # Same defect as above, for the (min, max) corner pair of select_box.
+        settings = ifcopenshell.geom.settings()
+        settings.set("use-world-coords", True)
+        ifc_file = ifcopenshell.open(fn)
+        tree = ifcopenshell.geom.tree()
+        tree.add_file(ifc_file, settings)
+
+        box_int = ((0, 0, 0), (10, 10, 10))
+        box_float = ((0.0, 0.0, 0.0), (10.0, 10.0, 10.0))
+        assert tree.select_box(box_int) == tree.select_box(box_float)
+
 
 def test_iterator():
     # just test some permutations of invocation


### PR DESCRIPTION
`tree.select((0, 0, 0))` fails.

The point-coordinate dispatch required every element to be exactly a `float`:

```python
elif isinstance(value, (list, tuple)) and len(value) == 3 and set(map(type, value)) == {float}:
```

So a tuple containing an integer fell through every branch and was forwarded unchanged to the C++ overload set, which has no int-tuple overload for `gp_Pnt`:

```
TypeError: Wrong number or type of arguments for overloaded function 'tree_select'
```

`select_box()` had the same defect for the `(min, max)` corner-pair form, where integers fail to resolve the `Bnd_Box` typemap.

Writing `(0, 0, 0)` rather than `(0.0, 0.0, 0.0)` is entirely natural, and the resulting error names a C++ symbol and gives no hint that the fix is to add decimal points. Both entry points now coerce integer coordinates to float.

`bool` is excluded from the point form, since `bool` is a subclass of `int` and a boolean triple is far more likely a mistake than a coordinate.

### Verification

Reproduced live against `src/bonsai/test/files/snap.ifc`. Two regression tests added to `test/test_create_shape.py`, verified red before the fix and green after. The suite passes 9, with one pre-existing unrelated failure (`TestGeomSettings::test_settings`, a stale local C++ wrapper against current `SETTING` literals).

### Reported, not fixed

`tree.select_box(box, extend=...)` fails for **any** box argument, including all-floats, because the C++ binding has no three-argument `Bnd_Box` overload, unlike the entity and point overloads which do. That needs a change to the binding rather than to this wrapper, so it is out of scope here.

### Audit context

Found while auditing `ifcopenshell/geom/` and `ifcopenshell/express/`. All `bimvoice` branches were diffed against these directories to separate real conflicts (open PRs #8519, #8528, #8588, plus #9179 which was already excluded) from stale branches whose apparent diffs were pure reformatting noise.

Around 28 further candidates were examined and declined as unreachable from user data, being guarded either by the fixed EXPRESS grammar or by static checked-in CSV rather than by anything an IFC file can influence.

Generated with the assistance of an AI coding tool.
