### PR TITLE
append_asset: fix O(n^2) reuse_identities scan

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -153,6 +153,7 @@ class SafeRemovalContext:
 
     file: ifcopenshell.file
     reuse_identities: dict[int, ifcopenshell.entity_instance]
+    new_reuse_identities: dict[int, int]
 
     assume_asset_uniqueness_by_name: bool
     """If `False`, then all job is done by `file.add`
@@ -163,10 +164,19 @@ class SafeRemovalContext:
         ifc_file: ifcopenshell.file,
         reuse_identities: dict[int, ifcopenshell.entity_instance],
         assume_asset_uniqueness_by_name: bool,
+        new_reuse_identities: Optional[dict[int, int]] = None,
     ):
         self.file = ifc_file
         self.reuse_identities = reuse_identities
         self.assume_asset_uniqueness_by_name = assume_asset_uniqueness_by_name
+        # Reverse index (new element id -> identity) of entries `reuse_identities`
+        # gained during the current `append_asset()` call. Lets `__exit__` find a
+        # removed element's identity in O(1) instead of scanning the whole
+        # `reuse_identities` dict, which otherwise grows with every past call
+        # sharing the same accumulator and makes each call O(n) regardless of how
+        # few elements it actually removes. Falls back to the full scan for any
+        # element it doesn't cover, so behaviour is unchanged either way.
+        self.new_reuse_identities = {} if new_reuse_identities is None else new_reuse_identities
 
     def __enter__(self):
         if not self.assume_asset_uniqueness_by_name:
@@ -182,9 +192,18 @@ class SafeRemovalContext:
         removed_identities: dict[ifcopenshell.entity_instance, int] = {}
         assert self.file.to_delete is not None
         removed_elements = self.file.to_delete
-        for identity, element in self.reuse_identities.items():
-            if element in removed_elements:
+        unresolved_elements: list[ifcopenshell.entity_instance] = []
+        for element in removed_elements:
+            identity = self.new_reuse_identities.pop(element.id(), None)
+            if identity is None:
+                unresolved_elements.append(element)
+            else:
                 removed_identities[element] = identity
+        if unresolved_elements:
+            unresolved_set = set(unresolved_elements)
+            for identity, element in self.reuse_identities.items():
+                if element in unresolved_set:
+                    removed_identities[element] = identity
         assert len(removed_identities) == len(removed_elements)
 
         # Actually remove elements.
@@ -210,10 +229,15 @@ class Usecase:
     reuse_identities: dict[int, ifcopenshell.entity_instance]
     """Mapping of old element ids to new elements, usually fiiled by ``file_add``."""
 
+    new_reuse_identities: dict[int, int]
+    """Reverse index (new element id -> identity) of ``reuse_identities`` entries
+    added during this call. See ``SafeRemovalContext``."""
+
     def execute(self):
         # mapping of old element ids to new elements
         self.added_elements: dict[int, ifcopenshell.entity_instance] = {}
         self.reuse_identities: dict[int, ifcopenshell.entity_instance] = self.settings["reuse_identities"]
+        self.new_reuse_identities: dict[int, int] = {}
         self.whitelisted_inverse_attributes = {}
         self.base_material_class = "IfcMaterial" if self.file.schema == "IFC2X3" else "IfcMaterialDefinition"
         self.assume_asset_uniqueness_by_name = self.settings["assume_asset_uniqueness_by_name"]
@@ -236,6 +260,16 @@ class Usecase:
         elif self.settings["element"].is_a("IfcPresentationStyle"):
             self.target_class = "IfcPresentationStyle"
             return self.append_presentation_style()
+
+    def map_reuse_identity(self, identity: int, new: ifcopenshell.entity_instance) -> ifcopenshell.entity_instance:
+        """Record ``identity -> new`` in ``reuse_identities`` and index it by
+        ``new``'s id in ``new_reuse_identities`` so ``SafeRemovalContext`` can
+        find a removed element's identity directly. All writes to
+        ``reuse_identities`` must go through this method to keep the index
+        in sync."""
+        self.reuse_identities[identity] = new
+        self.new_reuse_identities[new.id()] = identity
+        return new
 
     def by_guid(self, guid: str) -> Union[ifcopenshell.entity_instance, None]:
         try:
@@ -417,7 +451,9 @@ class Usecase:
             matrix = ifcopenshell.util.placement.get_local_placement(placement)
             matrix = ifcopenshell.util.geolocation.auto_local2global(self.settings["library"], matrix)
             matrix = ifcopenshell.util.geolocation.auto_global2local(self.file, matrix)
-            with SafeRemovalContext(self.file, self.reuse_identities, self.assume_asset_uniqueness_by_name):
+            with SafeRemovalContext(
+                self.file, self.reuse_identities, self.assume_asset_uniqueness_by_name, self.new_reuse_identities
+            ):
                 ifcopenshell.api.geometry.edit_object_placement(self.file, element, matrix, is_si=False)
 
         element_type = ifcopenshell.util.element.get_type(self.settings["element"])
@@ -527,7 +563,7 @@ class Usecase:
             new = existing_rel
         else:
             new = self.file.create_entity(element.is_a())
-            self.reuse_identities[element_identity] = new
+            self.map_reuse_identity(element_identity, new)
 
         for i, attribute in enumerate(element):
             new_attribute = None
@@ -593,7 +629,9 @@ class Usecase:
             for inverse in self.file.get_inverse(added_context):
                 ifcopenshell.util.element.replace_attribute(inverse, added_context, equivalent_existing_context)
 
-        with SafeRemovalContext(self.file, self.reuse_identities, self.assume_asset_uniqueness_by_name):
+        with SafeRemovalContext(
+            self.file, self.reuse_identities, self.assume_asset_uniqueness_by_name, self.new_reuse_identities
+        ):
             for added_context in added_contexts:
                 ifcopenshell.util.element.remove_deep2(self.file, added_context)
 
@@ -698,7 +736,7 @@ class Usecase:
                     (e for e in ifc_file.by_type(ifc_class) if getattr(e, attr_name) == subelement_id), None
                 )
                 if existing_org is not None:
-                    reuse_identities[element_identity] = existing_org
+                    self.map_reuse_identity(element_identity, existing_org)
                     return existing_org
 
         # Check if element already exists.
@@ -712,14 +750,14 @@ class Usecase:
                     (e for e in ifc_file.by_type("IfcProfileDef") if e.ProfileName == profile_name), None
                 )
                 if existing_profile is not None:
-                    reuse_identities[element_identity] = existing_profile
+                    self.map_reuse_identity(element_identity, existing_profile)
                     return existing_profile
 
         elif element.is_a("IfcMaterial"):
             material_name = element.Name
             existing_material = next((e for e in ifc_file.by_type("IfcMaterial") if e.Name == material_name), None)
             if existing_material is not None:
-                reuse_identities[element_identity] = existing_material
+                self.map_reuse_identity(element_identity, existing_material)
                 return existing_material
 
         elif ifc_class in MATERIAL_SETS:
@@ -729,7 +767,7 @@ class Usecase:
                 for candidate in ifc_file.by_type(ifc_class):
                     if getattr(candidate, name_attr) == material_set_name:
                         if self.material_sets_are_equal(element, candidate):
-                            reuse_identities[element_identity] = candidate
+                            self.map_reuse_identity(element_identity, candidate)
                             return candidate
 
         elif element.is_a("IfcPresentationStyle"):
@@ -737,7 +775,7 @@ class Usecase:
             if style_name is not None:
                 existing_style = next((e for e in ifc_file.by_type(ifc_class) if e.Name == style_name), None)
                 if existing_style is not None:
-                    reuse_identities[element_identity] = existing_style
+                    self.map_reuse_identity(element_identity, existing_style)
                     return existing_style
 
         elif ifc_class == "IfcApplication":
@@ -747,19 +785,19 @@ class Usecase:
                     (e for e in ifc_file.by_type("IfcApplication") if e.ApplicationIdentifier == app_id), None
                 )
                 if existing_app is not None:
-                    reuse_identities[element_identity] = existing_app
+                    self.map_reuse_identity(element_identity, existing_app)
                     return existing_app
 
         elif ifc_class == "IfcOrganization":
             existing_org = get_existing_element_(element)
             if existing_org is not None:
-                reuse_identities[element_identity] = existing_org
+                self.map_reuse_identity(element_identity, existing_org)
                 return existing_org
 
         elif ifc_class == "IfcPerson":
             existing_person = get_existing_element_(element)
             if existing_person is not None:
-                reuse_identities[element_identity] = existing_person
+                self.map_reuse_identity(element_identity, existing_person)
                 return existing_person
 
         elif ifc_class == "IfcPersonAndOrganization":
@@ -768,7 +806,7 @@ class Usecase:
             ):
                 for pao in ifc_file.by_type("IfcPersonAndOrganization"):
                     if pao.ThePerson == person and pao.TheOrganization == org:
-                        reuse_identities[element_identity] = pao
+                        self.map_reuse_identity(element_identity, pao)
                         return pao
 
         attrs: dict[int, Any] = {}
@@ -819,7 +857,7 @@ class Usecase:
 
         # Adding entity at the end just to keep it consistent with `file.add`.
         new = ifc_file.create_entity(ifc_class)
-        reuse_identities[element_identity] = new
+        self.map_reuse_identity(element_identity, new)
         for attr_index, attr_value in attrs.items():
             new[attr_index] = attr_value
 


### PR DESCRIPTION
`SafeRemovalContext.__exit__` scanned the entire `reuse_identities` dict on every `append_asset` call to find entries pointing at just-removed elements:

```python
for identity, element in self.reuse_identities.items():
    if element in removed_elements:
        ...
```

That dict is shared and grows across a batch, so each call costs O(current size) and N appends cost O(n^2).

**This is a second, independent quadratic term**, separate from the one open PR #9050 fixes (growing relationship member lists and layer item sets). #9050 never touches `SafeRemovalContext`, and `git merge-tree` between the two branches is clean, so they coexist.

### Measured before

Benchmarked in isolation, with each wall given private geometry and placement so the #9050 defect could not contaminate the numbers:

| N | time | exponent |
|---|---|---|
| 500 to 1000 | 0.83s to 2.51s | 1.60 |
| 1000 to 2000 | to 8.29s | 1.72 |
| 2000 to 4000 | to 30.86s | 1.90 |
| 4000 to 8000 | to 118.36s | **1.94** |

Control run with `assume_asset_uniqueness_by_name=False`, which skips this scan entirely: exponent 0.95 to 1.04 across the same range. That isolates the quadratic term to this code rather than anything else in the append path.

### Measured after

| N | before | after | speedup |
|---|---|---|---|
| 4000 | 30.86s | 5.02s | 6.1x |
| 8000 | 118.36s | 11.83s | 10.0x |

Exponent drops from 1.94 to 1.24. The speedup ratio grows with N, which is what confirms the quadratic term is gone rather than merely reduced.

### The change

A per-call reverse index maps new element id to identity, populated at every write site to `reuse_identities`, so `__exit__` resolves removed elements in O(1). The original full scan remains as a fallback for anything the index does not cover; it was instrumented and never triggered in any test.

### Correctness, which mattered more than the speed here

`reuse_identities` governs which elements get reused, so a wrong optimisation would corrupt output rather than merely slow it. Evidence, in increasing order of strength:

* `test/api/project/test_append_asset.py`: 77 passed
* `test/api/project/` full suite: 84 passed
* `src/ifcpatch/test/test_ExtractElements.py`: 11 passed, 1 pre-existing skip
* `ifcopenshell.validate.validate()` before and after: identical
* **Byte-for-byte identical output file** across a 300 wall extraction, after normalising the random GlobalIds

### Not tested

The full non-`project` test suite, IFC2X3 or IFC4X3 schema variants, concurrent appends, and N beyond 8000 on the pre-fix tree, for time budget reasons.

Generated with the assistance of an AI coding tool.
