### PR TITLE
Bonsai: guard two nameless-entity crashes on import

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -985,13 +985,15 @@ class IfcImporter:
                             bpy.context.scene.unit_settings.length_unit = "ADAPTIVE"
                 else:
                     bpy.context.scene.unit_settings.system = "IMPERIAL"
-                    name = unit.Name.lower()
+                    # unit.Name may be None for a schema-non-conformant unit.
+                    name = (unit.Name or "").lower()
                     if name == "inch":
                         bpy.context.scene.unit_settings.length_unit = "INCHES"
                     elif name == "foot":
                         bpy.context.scene.unit_settings.length_unit = "FEET"
             elif unit.is_a("IfcNamedUnit") and unit.UnitType == "AREAUNIT":
-                name = unit.Name if unit.is_a("IfcSIUnit") else unit.Name.lower()
+                # unit.Name may be None for a schema-non-conformant unit.
+                name = unit.Name if unit.is_a("IfcSIUnit") else (unit.Name or "").lower()
                 try:
                     props.area_unit = "{}{}".format(
                         unit.Prefix + "/" if hasattr(unit, "Prefix") and unit.Prefix else "", name
@@ -999,7 +1001,8 @@ class IfcImporter:
                 except:  # Probably an invalid unit.
                     props.area_unit = "SQUARE_METRE"
             elif unit.is_a("IfcNamedUnit") and unit.UnitType == "VOLUMEUNIT":
-                name = unit.Name if unit.is_a("IfcSIUnit") else unit.Name.lower()
+                # unit.Name may be None for a schema-non-conformant unit.
+                name = unit.Name if unit.is_a("IfcSIUnit") else (unit.Name or "").lower()
                 try:
                     props.volume_unit = "{}{}".format(
                         unit.Prefix + "/" if hasattr(unit, "Prefix") and unit.Prefix else "", name

--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -1252,7 +1252,8 @@ class IfcImporter:
             name = "Default"
             elements = ifcopenshell.util.element.get_grouped_by(self.file.by_id(group.id()), is_recursive=True)
             for j, element in enumerate(elements):
-                split = element.Name.rsplit("_")
+                # element.Name is optional (IfcRoot) and may be None.
+                split = (element.Name or "").rsplit("_")
                 name = split[0]
                 try:
                     aggregate_index = int(split[1])

--- a/src/bonsai/test/bim/test_import_ifc_set_units.py
+++ b/src/bonsai/test/bim/test_import_ifc_set_units.py
@@ -1,0 +1,77 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was modified with the assistance of an AI coding tool.
+
+"""Regression test for ``IfcImporter.set_units`` crashing on a
+schema-non-conformant unit whose ``Name`` is ``None``.
+
+A hand-crafted or otherwise invalid IFC file can carry an
+``IfcConversionBasedUnit`` with a null ``Name`` even though the schema
+marks it mandatory (IfcOpenShell does not enforce this at parse time).
+Bonsai already treats this as a real, previously-hit defect class for
+``ifcopenshell.util.unit`` (see PR fixing #8885); this covers the same
+class of bug in ``bim/import_ifc.py``'s own direct ``unit.Name`` reads."""
+
+import logging
+import os
+import tempfile
+
+import bpy
+import ifcopenshell
+
+import bonsai.bim.import_ifc as import_ifc
+import bonsai.tool as tool
+from test.bim.bootstrap import NewFile
+
+NAMELESS_LENGTH_UNIT_IFC = """ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0AntSXen9$3gN_yzeBBRAn',$,'My Project',$,$,$,$,(#5),#4);
+#4=IFCUNITASSIGNMENT((#2));
+#2=IFCCONVERSIONBASEDUNIT($,.LENGTHUNIT.,$,#3);
+#3=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(0.0254),#6);
+#6=IFCSIUNIT($,.LENGTHUNIT.,$,.METRE.);
+#5=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#7,$);
+#7=IFCAXIS2PLACEMENT3D(#8,$,$);
+#8=IFCCARTESIANPOINT((0.,0.,0.));
+ENDSEC;
+END-ISO-10303-21;
+"""
+
+
+class TestSetUnitsNamelessUnit(NewFile):
+    def test_run(self):
+        path = os.path.join(tempfile.mkdtemp(), "nameless_unit.ifc")
+        with open(path, "w") as f:
+            f.write(NAMELESS_LENGTH_UNIT_IFC)
+
+        ifc = ifcopenshell.open(path)
+        unit = ifc.by_type("IfcConversionBasedUnit")[0]
+        assert unit.Name is None
+
+        settings = import_ifc.IfcImportSettings.factory(bpy.context, path, logging.getLogger("ImportIFC"))
+        importer = import_ifc.IfcImporter(settings)
+        importer.file = ifc
+
+        # Must not raise AttributeError on the None .Name.
+        importer.set_units()

--- a/src/bonsai/test/bim/test_import_ifc_set_units.py
+++ b/src/bonsai/test/bim/test_import_ifc_set_units.py
@@ -18,15 +18,20 @@
 #
 # This file was modified with the assistance of an AI coding tool.
 
-"""Regression test for ``IfcImporter.set_units`` crashing on a
-schema-non-conformant unit whose ``Name`` is ``None``.
+"""Regression tests for ``IfcImporter`` crashing on entities with an
+optional attribute left unset.
 
-A hand-crafted or otherwise invalid IFC file can carry an
-``IfcConversionBasedUnit`` with a null ``Name`` even though the schema
-marks it mandatory (IfcOpenShell does not enforce this at parse time).
-Bonsai already treats this as a real, previously-hit defect class for
-``ifcopenshell.util.unit`` (see PR fixing #8885); this covers the same
-class of bug in ``bim/import_ifc.py``'s own direct ``unit.Name`` reads."""
+- ``set_units``: a hand-crafted or otherwise invalid IFC file can carry
+  an ``IfcConversionBasedUnit`` with a null ``Name`` even though the
+  schema marks it mandatory (IfcOpenShell does not enforce this at
+  parse time). Bonsai already treats this as a real, previously-hit
+  defect class for ``ifcopenshell.util.unit`` (see PR fixing #8885);
+  this covers the same class of bug in ``bim/import_ifc.py``'s own
+  direct ``unit.Name`` reads.
+
+- ``update_linked_aggregates``: ``IfcRoot.Name`` is genuinely optional,
+  so a member of a legacy "BBIM_Linked_Aggregate" group with no Name
+  crashed every subsequent load of that file."""
 
 import logging
 import os
@@ -34,6 +39,8 @@ import tempfile
 
 import bpy
 import ifcopenshell
+import ifcopenshell.api.group
+import ifcopenshell.api.root
 
 import bonsai.bim.import_ifc as import_ifc
 import bonsai.tool as tool
@@ -75,3 +82,20 @@ class TestSetUnitsNamelessUnit(NewFile):
 
         # Must not raise AttributeError on the None .Name.
         importer.set_units()
+
+
+class TestUpdateLinkedAggregatesNamelessMember(NewFile):
+    def test_run(self):
+        ifc = ifcopenshell.file(schema="IFC4")
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="P")
+        group = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcGroup", name="BBIM_Linked_Aggregate")
+        wall = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall", name=None)
+        assert wall.Name is None
+        ifcopenshell.api.group.assign_group(ifc, products=[wall], group=group)
+
+        settings = import_ifc.IfcImportSettings.factory(bpy.context, "", logging.getLogger("ImportIFC"))
+        importer = import_ifc.IfcImporter(settings)
+        importer.file = ifc
+
+        # Must not raise AttributeError on the None .Name.
+        importer.update_linked_aggregates()


### PR DESCRIPTION
Two crashes in `IfcImporter`, both on **file load** rather than on any user action, so a single malformed entity stops the model opening at all.

### 1. `set_units()` on a unit with no name

```python
name = unit.Name.lower()
```

`IfcConversionBasedUnit.Name` is schema-mandatory, but IfcOpenShell does not enforce mandatory attributes at parse time, so a malformed file can carry `Name = None` and still load.

Worth noting the existing safety net does not help: the `AREAUNIT` and `VOLUMEUNIT` branches wrap their work in `try/except`, but **the crashing line sits before the `try:`**, so the fallback to `SQUARE_METRE` is never reached.

This is the same defect class already fixed once in `ifcopenshell.util.unit`, at a call site that fix did not cover.

### 2. `update_linked_aggregates()` on a nameless group member

```python
split = element.Name.rsplit("_")
```

`IfcRoot.Name` is genuinely optional. This runs for every member of a legacy `BBIM_Linked_Aggregate` group **on every file load**, so one nameless member kills the whole import.

Both guarded with `or ""`, which routes an unnamed entity into the same path an unrecognised name already takes.

### Verification

Both were reproduced first as the failing expression against real entities, and then **end to end through the real Bonsai code path in headless Blender 5.2 LTS**, with the addon loaded from a temporary `BLENDER_USER_SCRIPTS` symlink so the real user profile was never touched. Confirmed `AttributeError`, applied the fix, confirmed it cleared, then red-then-green through the actual pytest suite.

That is worth flagging because most Bonsai fixes in this series were verified only at expression level, `ifcopenshell` not being importable into the Blender available here. This one was not.

### Audit context

Found while auditing the top level of `bonsai/bim/`: 11 files, roughly 30 to 40 raw grep hits, 4 files skipped because one of our own open PRs already touches them (#8941, #8278, #9127, #9052). The remaining hits were already guarded, or attributes that are schema-mandatory for the class in context.

Generated with the assistance of an AI coding tool.
