### PR TITLE
Bonsai: fix nest label crash off-screen

### DIFF
--- a/src/bonsai/bonsai/bim/module/nest/decorator.py
+++ b/src/bonsai/bonsai/bim/module/nest/decorator.py
@@ -221,6 +221,8 @@ class NestModeDecorator(tool.Blender.ViewportDecorator):
         blf.color(self.font_id, *color)
         text = aggregate_obj.name
         text_coords = view3d_utils.location_3d_to_region_2d(region, rv3d, aggregate_obj.location)
+        if not text_coords:
+            return
         text_length = blf.dimensions(self.font_id, text)
         text_coords[0] -= text_length[0] / 2
         text_coords[1] -= 20


### PR DESCRIPTION
`NestModeDecorator.draw_nest_name` indexed the result of a viewport projection without checking it:

```python
text_coords = view3d_utils.location_3d_to_region_2d(region, rv3d, aggregate_obj.location)
text_length = blf.dimensions(self.font_id, text)
text_coords[0] -= text_length[0] / 2
```

Blender returns `None` from `location_3d_to_region_2d` when the point projects behind the viewport camera, which happens routinely while navigating. The result is `TypeError: 'NoneType' object is not subscriptable`, in a draw handler that runs on **every redraw** while "Enable Editing Nest" is active.

The sibling `AggregateModeDecorator.draw_aggregate_name` has the identical call **with** the guard already present, so this was a copy-paste that dropped it. The fix restores the same two lines.

### Verification

Reproduced end to end in headless Blender 5.2, loading the real Bonsai addon from a temporary `BLENDER_USER_SCRIPTS` symlink so the real profile was never touched, and monkeypatching `location_3d_to_region_2d` to return `None`, which is its documented behaviour for off-screen points. Before the fix: `TypeError`. After: no crash.

Generated with the assistance of an AI coding tool.
