### PR TITLE
ifctester: fix crash on unset layer material

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -977,7 +977,7 @@ class Material(Facet):
                         [
                             getattr(item, "Name", None),
                             getattr(item, "Category", None),
-                            item.Material.Name,
+                            getattr(item.Material, "Name", None),
                             getattr(item.Material, "Category", None),
                         ]
                     )
@@ -985,7 +985,12 @@ class Material(Facet):
                 values = {material.Name}
                 for item in material.MaterialProfiles or []:
                     values.update(
-                        [item.Name, item.Category, item.Material.Name, getattr(item.Material, "Category", None)]
+                        [
+                            item.Name,
+                            item.Category,
+                            getattr(item.Material, "Name", None),
+                            getattr(item.Material, "Category", None),
+                        ]
                     )
             elif material.is_a("IfcMaterialConstituentSet"):
                 values = {material.Name}

--- a/src/ifctester/test/fixtures/material_unset_crash/material_unset_crash.ids
+++ b/src/ifctester/test/fixtures/material_unset_crash/material_unset_crash.ids
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Wall material must be Foo</title>
+        <description>An unassigned layer material must not crash the check.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must use material Foo" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <material cardinality="required">
+                    <value>
+                        <simpleValue>Foo</simpleValue>
+                    </value>
+                </material>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/material_unset_crash/material_unset_crash.ifc
+++ b/src/ifctester/test/fixtures/material_unset_crash/material_unset_crash.ifc
@@ -1,0 +1,14 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-01T07:28:07',(''),(''),'IfcOpenShell 0.8.6-3e7b739','IfcOpenShell 0.8.6-3e7b739','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('2mRWS3xbb0LvGZ65ieP29w',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('3wmKOX$yX8Gvm6EiMCCQMt',$,'Wall1',$,$,$,$,$,$);
+#3=IFCMATERIALLAYERSET((#5),'Unnamed',$);
+#4=IFCRELASSOCIATESMATERIAL('12_KhXBO93A9gCh9NfR6Jl',$,$,$,(#2),#3);
+#5=IFCMATERIALLAYER($,0.10000000000000001,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -1443,6 +1443,8 @@ class TestMaterial:
         material.Name = "Bar"
         material.Category = "Foo"
         run("Any material Category in a layer set will pass a value check", facet=facet, inst=element, expected=True)
+        layer.Material = None
+        run("A layer with no Material does not crash the value check", facet=facet, inst=element, expected=False)
 
         ifc = ifcopenshell.file()
         facet = Material(value="Foo")
@@ -1463,6 +1465,8 @@ class TestMaterial:
         material.Name = "Bar"
         material.Category = "Foo"
         run("Any material category in a profile set will pass a value check", facet=facet, inst=element, expected=True)
+        profile.Material = None
+        run("A profile with no Material does not crash the value check", facet=facet, inst=element, expected=False)
 
         ifc = ifcopenshell.file()
         facet = Material(value="Foo")

--- a/src/ifctester/test/test_fixtures.py
+++ b/src/ifctester/test/test_fixtures.py
@@ -1,0 +1,48 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for specific reported defects.
+
+Each test here loads a minimal .ids/.ifc pair from test/fixtures/ through
+the same entry points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestMaterialUnsetCrashFixture:
+    def test_an_unassigned_layer_material_does_not_crash_the_run(self):
+        # A wall with an IfcMaterialLayerSet whose single layer has no
+        # Material assigned (a valid air gap). Pre-fix, Material.__call__
+        # read item.Material.Name unconditionally and raised AttributeError,
+        # aborting the whole IDS run rather than just this one check.
+        specs = ids.open(os.path.join(FIXTURES, "material_unset_crash", "material_unset_crash.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "material_unset_crash", "material_unset_crash.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+        assert spec.requirements[0].status is False


### PR DESCRIPTION
`Material.__call__` read `item.Material.Name` unconditionally for `IfcMaterialLayerSet` and `IfcMaterialProfileSet` members.

`Material` is optional on both `IfcMaterialLayer` and `IfcMaterialProfile`, confirmed via `all_attributes()[...].optional()`. An unassigned layer, an air gap for instance, is valid IFC. Reading it raised `AttributeError` and **aborted the entire IDS run**, not just that one check.

Regression test added, verified red before the fix and green after.

Generated with the assistance of an AI coding tool.
