### PR TITLE
ifctester: fix property table dataType silent fail

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -838,25 +838,30 @@ class Property(Facet):
                             if not column_values:
                                 continue
                             data_type = column_values[0].is_a()
-                            if self.dataType and data_type.lower() == self.dataType.lower():
-                                column_values = [v.wrappedValue for v in column_values]
-                                unit = units[f"{attribute}Unit"]
-                                if unit:
-                                    column_values = [
-                                        ifcopenshell.util.unit.convert(
-                                            v,
-                                            getattr(unit, "Prefix", None),
-                                            unit.Name,
-                                            None,
-                                            ifcopenshell.util.unit.si_type_names[unit.UnitType],
-                                        )
-                                        for v in column_values
-                                    ]
-                                values.extend(column_values)
+                            # A dataType constraint only keeps the matching column, not the whole property
+                            if self.dataType and data_type.lower() != self.dataType.lower():
+                                continue
+                            column_values = [v.wrappedValue for v in column_values]
+                            unit = units[f"{attribute}Unit"]
+                            if unit:
+                                column_values = [
+                                    ifcopenshell.util.unit.convert(
+                                        v,
+                                        getattr(unit, "Prefix", None),
+                                        unit.Name,
+                                        None,
+                                        ifcopenshell.util.unit.si_type_names[unit.UnitType],
+                                    )
+                                    for v in column_values
+                                ]
+                            values.extend(column_values)
                         if not values:
                             is_pass = False
-                            assert data_type is not None, prop_entity
-                            reason = {"type": "DATATYPE", "actual": data_type, "dataType": self.dataType}
+                            reason = (
+                                {"type": "DATATYPE", "actual": data_type, "dataType": self.dataType}
+                                if self.dataType
+                                else {"type": "NOVALUE"}
+                            )
                             break
                         props[pset_name][prop_entity.Name] = values
                     else:

--- a/src/ifctester/test/fixtures/property_table_datatype/property_table_datatype.ids
+++ b/src/ifctester/test/fixtures/property_table_datatype/property_table_datatype.ids
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Foo table property must be provided</title>
+        <description>No dataType constraint is given, only presence is required.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must have a Foo property" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <property cardinality="required">
+                    <propertySet>
+                        <simpleValue>Foo_Bar</simpleValue>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>Foo</simpleValue>
+                    </baseName>
+                </property>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/property_table_datatype/property_table_datatype.ifc
+++ b/src/ifctester/test/fixtures/property_table_datatype/property_table_datatype.ifc
@@ -1,0 +1,14 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-01T07:26:50',(''),(''),'IfcOpenShell 0.8.6-3e7b739','IfcOpenShell 0.8.6-3e7b739','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1nhsTz_$r6BeOLgcN8SIF$',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('13utb7NT92XeETAYRDaO9i',$,'Wall1',$,$,$,$,$,$);
+#3=IFCPROPERTYSET('1HGnS6x5H1fxZPtjfjLbBM',$,'Foo_Bar',$,(#5));
+#4=IFCRELDEFINESBYPROPERTIES('1m0umUiFT1A8$WTVSBRl6o',$,$,$,(#2),#3);
+#5=IFCPROPERTYTABLEVALUE('Foo',$,(IFCLABEL('X')),(IFCLENGTHMEASURE(1000.)),$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -1165,6 +1165,13 @@ class TestProperty:
         run("Any matching value in a table property will pass 2/3", facet=facet, inst=element, expected=True)
         facet = Property(propertySet="Foo_Bar", baseName="Foo", value="Y", dataType="IFCLABEL")
         run("Any matching value in a table property will pass 3/3", facet=facet, inst=element, expected=False)
+        facet = Property(propertySet="Foo_Bar", baseName="Foo")
+        run(
+            "A table property with values passes without a dataType constraint",
+            facet=facet,
+            inst=element,
+            expected=True,
+        )
 
         ifc = self.setup_ifc()
         element = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")

--- a/src/ifctester/test/test_fixtures.py
+++ b/src/ifctester/test/test_fixtures.py
@@ -1,0 +1,48 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for specific reported defects.
+
+Each test here loads a minimal .ids/.ifc pair from test/fixtures/ through
+the same entry points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestPropertyTableDatatypeFixture:
+    def test_table_property_with_a_real_value_passes_without_a_datatype_constraint(self):
+        # An IfcPropertyTableValue carrying a real value, checked by a
+        # Property requirement with no dataType constraint at all. With
+        # nothing to match against, the property's presence alone must be
+        # enough to pass.
+        specs = ids.open(os.path.join(FIXTURES, "property_table_datatype", "property_table_datatype.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "property_table_datatype", "property_table_datatype.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is True
+        assert spec.requirements[0].status is True


### PR DESCRIPTION
**Every `IfcPropertyTableValue` property was reported as failed**, regardless of its contents.

`Property.__call__`'s table branch only collected column values when `self.dataType` was both set and matching. With no `dataType` constraint, which is the common case, nothing was ever collected, so a property carrying real values was reported `DATATYPE` or `NOVALUE` failed even though no constraint had been requested.

This is a wrong verdict rather than a crash: a compliant model is told it is not.

The fix skips a column only on an **explicit** mismatch, preserving the existing per-column skip semantics when a `dataType` constraint is present. All pre-existing table tests still pass.

Regression test added, verified red before the fix and green after.

Generated with the assistance of an AI coding tool.
