### PR TITLE
ifctester: fix prohibited spec requirement status

### DIFF
--- a/src/ifctester/ifctester/ids.py
+++ b/src/ifctester/ifctester/ids.py
@@ -325,6 +325,8 @@ class Specification:
         elif self.maxOccurs == 0:  # Prohibited specification
             if self.applicable_entities:
                 self.status = False
+                for facet in self.requirements:
+                    facet.status = False
 
     def get_usage(self) -> Cardinality:
         if self.minOccurs != 0:

--- a/src/ifctester/test/fixtures/prohibited_requirement_status/prohibited_requirement_status.ids
+++ b/src/ifctester/test/fixtures/prohibited_requirement_status/prohibited_requirement_status.ids
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>No walls allowed</title>
+        <description>Walls are prohibited entirely.</description>
+    </info>
+    <specifications>
+        <specification name="No walls allowed" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="0">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <attribute cardinality="required">
+                    <name>
+                        <simpleValue>Name</simpleValue>
+                    </name>
+                </attribute>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/prohibited_requirement_status/prohibited_requirement_status.ifc
+++ b/src/ifctester/test/fixtures/prohibited_requirement_status/prohibited_requirement_status.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-01T07:25:05',(''),(''),'IfcOpenShell 0.8.6-3e7b739','IfcOpenShell 0.8.6-3e7b739','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Je7uHRPT2yvHZPV8zQ1VQ',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('0tlWWLGqb6BQjRopScFuNA',$,'Wally',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_fixtures.py
+++ b/src/ifctester/test/test_fixtures.py
@@ -1,0 +1,51 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for specific reported defects.
+
+Each test here loads a minimal .ids/.ifc pair from test/fixtures/ through
+the same entry points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestProhibitedRequirementStatusFixture:
+    def test_a_violated_prohibition_marks_its_requirement_failed(self):
+        # A prohibited specification (no walls allowed) violated by one
+        # wall. Specification.validate skips per-element requirement
+        # checks for a prohibited specification, so requirement.failures
+        # stays empty, but the requirement's own status must still be
+        # False, matching the specification it belongs to.
+        specs = ids.open(os.path.join(FIXTURES, "prohibited_requirement_status", "prohibited_requirement_status.ids"))
+        ifc = ifcopenshell.open(
+            os.path.join(FIXTURES, "prohibited_requirement_status", "prohibited_requirement_status.ifc")
+        )
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+        assert spec.requirements[0].status is False

--- a/src/ifctester/test/test_ids.py
+++ b/src/ifctester/test/test_ids.py
@@ -395,3 +395,17 @@ class TestSpecification:
             [wall],
             [],
         )
+
+    def test_prohibited_specification_with_requirements_shows_requirements_as_failed(self):
+        specs = ids.Ids(title="Title")
+        spec = ids.Specification(name="Name")
+        spec.applicability.append(ids.Entity(name="IFCWALL"))
+        spec.requirements.append(ids.Attribute(name="Name"))
+        specs.specifications.append(spec)
+        spec.set_usage("prohibited")
+
+        model = ifcopenshell.file()
+        model.createIfcWall(Name="Wally")
+        specs.validate(model)
+        assert spec.status is False
+        assert spec.requirements[0].status is False


### PR DESCRIPTION
For a **prohibited** specification (`maxOccurs=0`), requirement facets are deliberately never run against matched elements. So `facet.failures` stays empty, and `Specification.validate()`'s unconditional

```python
facet.status = not bool(facet.failures)
```

marks every requirement as **passed**, even when the specification itself fails because a prohibited element was found.

The Json, Html and Ods reporters then render green "pass" requirement rows directly underneath a red failing specification.

This is not a new design. The sibling branch, "required, but no applicable entities", already propagates `facet.status = False` correctly. The prohibited branch was simply missing the same two lines, and the fix adds them.

Regression test added, verified red before the fix and green after.

Generated with the assistance of an AI coding tool.
