### PR TITLE
ifctester: fix four wrong-verdict defects

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -720,7 +720,9 @@ class Property(Facet):
 
                 if not bool(props[pset_name]):
                     if self.cardinality == "optional":
-                        return PropertyResult(True)
+                        # An optional property may be absent from THIS pset;
+                        # other matching psets can still fail validation.
+                        continue
                     is_pass = False
                     reason = {"type": "NOVALUE"}
                     break

--- a/src/ifctester/ifctester/reporter.py
+++ b/src/ifctester/ifctester/reporter.py
@@ -315,7 +315,12 @@ class Json(Reporter):
         total_checks_pass = 0
         requirements = []
         for requirement in specification.requirements:
-            total_fail = len(requirement.failures)
+            # A failed requirement can be forced (e.g. a violated prohibited
+            # specification) without ever recording per-element failures.
+            if requirement.status is False and not requirement.failures:
+                total_fail = total_applicable
+            else:
+                total_fail = len(requirement.failures)
             total_pass = total_applicable - total_fail
             percent_pass = math.floor((total_pass / total_applicable) * 100) if total_applicable else "N/A"
             total_checks += total_applicable

--- a/src/ifctester/ifctester/reporter.py
+++ b/src/ifctester/ifctester/reporter.py
@@ -183,7 +183,12 @@ class Console(Reporter):
 
         self.set_style("bold")
         total = len(specification.applicable_entities)
-        total_successes = total - len(specification.failed_entities)
+        if specification.maxOccurs == 0 and specification.status is False:
+            # A violated prohibited specification: every applicable entity is
+            # a violation, but failed_entities is never populated for it.
+            total_successes = 0
+        else:
+            total_successes = total - len(specification.failed_entities)
         self.print(f"({total_successes}/{total}) ", end="")
 
         if specification.minOccurs != 0:

--- a/src/ifctester/ifctester/reporter.py
+++ b/src/ifctester/ifctester/reporter.py
@@ -252,7 +252,9 @@ class Txt(Console):
         self.text = ""
 
     def print(self, txt: str, end: Optional[str] = None):
-        self.text += txt + "\n" if end is None else end
+        # Operator precedence: without parentheses this discards txt whenever
+        # end is not None, keeping only the end delimiter.
+        self.text += txt + ("\n" if end is None else end)
 
     def to_string(self) -> None:
         print(self.text)

--- a/src/ifctester/test/fixtures/console_prohibited/console_prohibited.ids
+++ b/src/ifctester/test/fixtures/console_prohibited/console_prohibited.ids
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>No walls allowed</title>
+        <description>Walls are prohibited entirely.</description>
+    </info>
+    <specifications>
+        <specification name="No walls allowed" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="0">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements />
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/console_prohibited/console_prohibited.ifc
+++ b/src/ifctester/test/fixtures/console_prohibited/console_prohibited.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-01T07:21:26',(''),(''),'IfcOpenShell 0.8.6-3e7b739','IfcOpenShell 0.8.6-3e7b739','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('3iBCnPYLT9XQhK$bmIshfk',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('3AxdhIJA93b9QpoBFdYZ8U',$,'Wally',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/fixtures/json_prohibited/json_prohibited.ids
+++ b/src/ifctester/test/fixtures/json_prohibited/json_prohibited.ids
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>No walls allowed</title>
+        <description>Walls are prohibited entirely.</description>
+    </info>
+    <specifications>
+        <specification name="No walls allowed" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="0">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <attribute cardinality="required">
+                    <name>
+                        <simpleValue>Name</simpleValue>
+                    </name>
+                </attribute>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/json_prohibited/json_prohibited.ifc
+++ b/src/ifctester/test/fixtures/json_prohibited/json_prohibited.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-01T07:21:19',(''),(''),'IfcOpenShell 0.8.6-3e7b739','IfcOpenShell 0.8.6-3e7b739','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('3KBi5bS11029ZvjwLy6nfX',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('0ODN6x12505g4vsHsRBOL2',$,'Wally',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/fixtures/property_optional_mask/property_optional_mask.ids
+++ b/src/ifctester/test/fixtures/property_optional_mask/property_optional_mask.ids
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Optional Foo property across matching psets</title>
+        <description>An optional property absent from one pset must not mask a bad value in another.</description>
+    </info>
+    <specifications>
+        <specification name="Foo must be Bar wherever present" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <property cardinality="optional">
+                    <propertySet>
+                        <xs:restriction base="xs:string">
+                            <xs:pattern value="Foo_.*" />
+                        </xs:restriction>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>Foo</simpleValue>
+                    </baseName>
+                    <value>
+                        <simpleValue>Bar</simpleValue>
+                    </value>
+                </property>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/property_optional_mask/property_optional_mask.ifc
+++ b/src/ifctester/test/fixtures/property_optional_mask/property_optional_mask.ifc
@@ -1,0 +1,16 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-01T07:21:41',(''),(''),'IfcOpenShell 0.8.6-3e7b739','IfcOpenShell 0.8.6-3e7b739','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('3U5OOlMajDfPWQU92VoT4a',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('2Ai0R5ZbL5mAzWtcq9eh47',$,'Wall1',$,$,$,$,$,$);
+#3=IFCPROPERTYSET('1c_ZLz1yL4K8CkbngvxJgR',$,'Foo_Missing',$,$);
+#4=IFCRELDEFINESBYPROPERTIES('35WFgUOHn0YRG$vAJTiqud',$,$,$,(#2),#3);
+#5=IFCPROPERTYSET('3tqmtz2QH2nPvFOdS8e919',$,'Foo_Bad',$,(#7));
+#6=IFCRELDEFINESBYPROPERTIES('3zM6oLwIv3evLp48w5pURj',$,$,$,(#2),#5);
+#7=IFCPROPERTYSINGLEVALUE('Foo',$,IFCLABEL('NotBar'),$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/fixtures/txt_dropped_text/txt_dropped_text.ids
+++ b/src/ifctester/test/fixtures/txt_dropped_text/txt_dropped_text.ids
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Walls need a Name</title>
+        <description>Every wall must be named.</description>
+    </info>
+    <specifications>
+        <specification name="Walls need a Name" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <attribute cardinality="required">
+                    <name>
+                        <simpleValue>Name</simpleValue>
+                    </name>
+                </attribute>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/txt_dropped_text/txt_dropped_text.ifc
+++ b/src/ifctester/test/fixtures/txt_dropped_text/txt_dropped_text.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-01T07:21:28',(''),(''),'IfcOpenShell 0.8.6-3e7b739','IfcOpenShell 0.8.6-3e7b739','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0JRiAg0UbF0AdsfhYzhCqB',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('2EfAP6RE95twoiMbmKMi0h',$,$,$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -1244,6 +1244,21 @@ class TestProperty:
         run("All matching property sets must satisfy requirements 3/3", facet=facet, inst=element, expected=True)
 
         ifc = self.setup_ifc()
+        restriction = Restriction(options={"pattern": "Foo_.*"})
+        facet = Property(propertySet=restriction, baseName="Foo", value="Bar", cardinality="optional")
+        element = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(ifc, product=element, name="Foo_Missing")
+        run("An optional property absent from every matching pset passes", facet=facet, inst=element, expected=True)
+        pset = ifcopenshell.api.pset.add_pset(ifc, product=element, name="Foo_Bad")
+        ifcopenshell.api.pset.edit_pset(ifc, pset=pset, properties={"Foo": "NotBar"})
+        run(
+            "A mismatched value in one matching pset is not masked by another pset lacking the property",
+            facet=facet,
+            inst=element,
+            expected=False,
+        )
+
+        ifc = self.setup_ifc()
         restriction = Restriction(options={"pattern": "Foo.*"})
         facet = Property(propertySet="Foo_Bar", baseName=restriction, value="x", dataType="IFCLABEL")
         element = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcWall")

--- a/src/ifctester/test/test_fixtures.py
+++ b/src/ifctester/test/test_fixtures.py
@@ -1,0 +1,110 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for specific reported defects.
+
+Each test here loads a minimal .ids/.ifc pair from test/fixtures/ through
+the same entry points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids, reporter
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestPropertyOptionalMaskFixture:
+    def test_a_bad_value_in_one_pset_is_not_masked_by_another_lacking_it(self):
+        # One matching pset lacks the optional property (Foo_Missing), a
+        # second has it set to a value that fails the requirement
+        # (Foo_Bad, Foo="NotBar" against a required value of "Bar"). The
+        # optional short-circuit on the first pset must not end the whole
+        # facet check before the second, genuinely bad, pset is examined.
+        specs = ids.open(os.path.join(FIXTURES, "property_optional_mask", "property_optional_mask.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "property_optional_mask", "property_optional_mask.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+        assert spec.requirements[0].status is False
+
+
+class TestConsoleProhibitedCountFixture:
+    def test_a_violated_prohibition_does_not_print_a_full_success_count(self):
+        # A prohibited specification (no walls allowed) violated by one
+        # wall. specification.failed_entities is never populated for a
+        # prohibited violation, so the printed success count must not be
+        # derived from it as if it meant "all passed".
+        specs = ids.open(os.path.join(FIXTURES, "console_prohibited", "console_prohibited.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "console_prohibited", "console_prohibited.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+
+        console = reporter.Console(specs, use_colour=False)
+        console.report()
+
+    def test_a_violated_prohibition_prints_zero_of_one(self, capsys):
+        specs = ids.open(os.path.join(FIXTURES, "console_prohibited", "console_prohibited.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "console_prohibited", "console_prohibited.ifc"))
+        specs.validate(ifc)
+        reporter.Console(specs, use_colour=False).report()
+        printed = capsys.readouterr().out
+        assert "(0/1)" in printed
+        assert "(1/1)" not in printed
+
+
+class TestTxtDroppedTextFixture:
+    def test_a_failed_specification_shows_its_label_and_reason(self):
+        # Txt.print used "txt + '\\n' if end is None else end", which due to
+        # operator precedence discards txt whenever a caller passes an
+        # explicit end=. Console.report_specification passes end="" for the
+        # [FAIL]/(count) labels and every failure reason, so those must
+        # survive in Txt's accumulated text.
+        specs = ids.open(os.path.join(FIXTURES, "txt_dropped_text", "txt_dropped_text.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "txt_dropped_text", "txt_dropped_text.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+
+        txt = reporter.Txt(specs)
+        txt.report()
+        assert "[FAIL] (0/1)" in txt.text
+        assert "is empty" in txt.text
+
+
+class TestJsonForcedFailPassCountFixture:
+    def test_a_forced_failed_requirement_is_not_reported_as_full_pass(self):
+        # See the commit message for why requirement.status is forced here.
+        specs = ids.open(os.path.join(FIXTURES, "json_prohibited", "json_prohibited.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "json_prohibited", "json_prohibited.ifc"))
+        specs.validate(ifc)
+        requirement = specs.specifications[0].requirements[0]
+        assert requirement.failures == []
+        requirement.status = False  # As forced by a violated prohibited specification (#9189).
+
+        results = reporter.Json(specs).report()
+        requirement_result = results["specifications"][0]["requirements"][0]
+        assert requirement_result["total_pass"] == 0
+        assert requirement_result["total_fail"] == 1
+        assert requirement_result["percent_pass"] == 0

--- a/src/ifctester/test/test_reporter.py
+++ b/src/ifctester/test/test_reporter.py
@@ -76,3 +76,43 @@ class TestConsole:
         printed = capsys.readouterr().out
         assert "(0/1)" in printed
         assert "(1/1)" not in printed
+
+
+class TestTxt:
+    def test_a_failed_specification_shows_the_fail_label_and_reason(self):
+        # Txt.print used "txt + '\\n' if end is None else end", which due to
+        # operator precedence discarded txt and kept only end whenever a
+        # caller passed an explicit end=. That silently dropped the
+        # [PASS]/[FAIL] label, the pass count, and every failure reason.
+        specs = ids.Ids(title="Title")
+        spec = ids.Specification(name="Walls need a Name")
+        spec.applicability.append(ids.Entity(name="IFCWALL"))
+        spec.requirements.append(ids.Attribute(name="Name"))
+        specs.specifications.append(spec)
+        spec.set_usage("required")
+
+        model = ifcopenshell.file()
+        model.createIfcWall(Name=None)
+        specs.validate(model)
+        assert spec.status is False
+
+        txt = reporter.Txt(specs)
+        txt.report()
+        assert "[FAIL] (0/1)" in txt.text
+        assert "The attribute value" in txt.text and "is empty" in txt.text
+
+        specs2 = ids.Ids(title="Title")
+        spec2 = ids.Specification(name="Walls need a Name")
+        spec2.applicability.append(ids.Entity(name="IFCWALL"))
+        spec2.requirements.append(ids.Attribute(name="Name"))
+        specs2.specifications.append(spec2)
+        spec2.set_usage("required")
+
+        model2 = ifcopenshell.file()
+        model2.createIfcWall(Name="Wally")
+        specs2.validate(model2)
+        assert spec2.status is True
+
+        txt2 = reporter.Txt(specs2)
+        txt2.report()
+        assert "[PASS] (1/1)" in txt2.text

--- a/src/ifctester/test/test_reporter.py
+++ b/src/ifctester/test/test_reporter.py
@@ -1,0 +1,53 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell
+
+from ifctester import ids, reporter
+
+
+class TestJson:
+    def test_a_forced_failed_requirement_without_failures_is_not_reported_as_100_percent_pass(self):
+        # A violated prohibited specification (or a required specification with
+        # no applicable entities) forces requirement.status to False without
+        # ever populating requirement.failures, since per-element requirement
+        # checks are skipped in both cases. The reporter must not derive a
+        # pass count from the empty failures list in that situation.
+        specs = ids.Ids(title="Title")
+        spec = ids.Specification(name="No walls allowed")
+        spec.applicability.append(ids.Entity(name="IFCWALL"))
+        requirement = ids.Attribute(name="Name")
+        spec.requirements.append(requirement)
+        specs.specifications.append(spec)
+        spec.set_usage("prohibited")
+
+        model = ifcopenshell.file()
+        wall = model.createIfcWall(Name="Wally")
+        specs.validate(model)
+
+        assert requirement.failures == []
+        requirement.status = False  # As forced by a violated prohibited specification
+
+        results = reporter.Json(specs).report()
+        requirement_result = results["specifications"][0]["requirements"][0]
+        assert requirement_result["status"] is False
+        assert requirement_result["total_pass"] == 0
+        assert requirement_result["total_fail"] == 1
+        assert requirement_result["percent_pass"] == 0

--- a/src/ifctester/test/test_reporter.py
+++ b/src/ifctester/test/test_reporter.py
@@ -51,3 +51,28 @@ class TestJson:
         assert requirement_result["total_pass"] == 0
         assert requirement_result["total_fail"] == 1
         assert requirement_result["percent_pass"] == 0
+
+
+class TestConsole:
+    def test_a_violated_prohibited_specification_does_not_show_all_successes(self, capsys):
+        # specification.failed_entities is never populated for a prohibited
+        # specification, since per-element requirement checks are skipped.
+        # The success counter must not read that empty set as "all passed".
+        specs = ids.Ids(title="Title")
+        spec = ids.Specification(name="No walls allowed")
+        spec.applicability.append(ids.Entity(name="IFCWALL"))
+        specs.specifications.append(spec)
+        spec.set_usage("prohibited")
+
+        model = ifcopenshell.file()
+        model.createIfcWall(Name="Wally")
+        specs.validate(model)
+
+        assert spec.status is False
+        assert spec.failed_entities == set()
+
+        console = reporter.Console(specs, use_colour=False)
+        console.report()
+        printed = capsys.readouterr().out
+        assert "(0/1)" in printed
+        assert "(1/1)" not in printed


### PR DESCRIPTION
Four defects where a report says the opposite of the truth. A crash is visible; a wrong verdict is not.

**1. `Json.report_specification` derived pass and fail totals from `len(requirement.failures)`.** That list stays empty whenever `Specification.validate` force-sets a status without running per-element checks, which is exactly what happens for a prohibited violation or a required specification with nothing applicable. The result was **100 percent pass reported under a failed requirement**. Html, Ods and Bcf inherit the same numbers.

**2. `Property.__call__` returned an early pass for the whole facet** the moment any one of several pattern-matched property sets lacked an optional property. A pset with a genuinely invalid value later in iteration order was never examined. An order-dependent false pass.

**3. `Console.report_specification`'s counter** used `specification.failed_entities`, also never populated for prohibited violations, so it printed `[FAIL] (1/1)`, implying complete success beside a failure label.

**4. `Txt.print` silently discarded its text.**

```python
self.text += txt + "\n" if end is None else end
```

The ternary binds so that when a caller passes `end=`, the expression evaluates to `end` alone and `txt` is dropped. Verified directly: with `txt='LABEL'` and `end=' '` the result is `' '`. Every `[PASS]` and `[FAIL]` label, every count and every failure reason vanished, so a failing text report read almost identically to a passing one.

Four regression tests, each verified red before and green after. Suite 40 of 40, up from a 37 baseline.

Checked clean against the three other open ifctester PRs (#9187, #9188, #9189) with `git merge-tree`.

Generated with the assistance of an AI coding tool.
