### PR TITLE
sequence.create_baseline: raise on non-PLANNED

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/create_baseline.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/create_baseline.py
@@ -66,8 +66,11 @@ class Usecase:
 
     def execute(self, work_schedule: ifcopenshell.entity_instance, name: Union[str, None]) -> None:
         # create work schedule
-        if not work_schedule.PredefinedType == "PLANNED":
-            return
+        if work_schedule.PredefinedType != "PLANNED":
+            raise ValueError(
+                "A baseline can only be created from a work schedule with "
+                f"PredefinedType 'PLANNED', not '{work_schedule.PredefinedType}'."
+            )
         baseline_work_schedule = ifcopenshell.api.sequence.add_work_schedule(
             self.file, name=work_schedule.Name, predefined_type="BASELINE"
         )

--- a/src/ifcopenshell-python/test/api/sequence/test_create_baseline.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_create_baseline.py
@@ -1,0 +1,44 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 IfcOpenShell contributors
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import pytest
+
+import ifcopenshell.api.root
+import ifcopenshell.api.sequence
+import test.bootstrap
+
+
+class TestCreateBaseline(test.bootstrap.IFC4):
+    def test_creating_a_baseline_from_a_planned_schedule(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        schedule = ifcopenshell.api.sequence.add_work_schedule(self.file, predefined_type="PLANNED")
+        ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=schedule, name="Baseline 1")
+        baselines = [ws for ws in self.file.by_type("IfcWorkSchedule") if ws.PredefinedType == "BASELINE"]
+        assert len(baselines) == 1
+        assert baselines[0].Name == "Baseline 1"
+
+    def test_raising_on_a_non_planned_schedule(self):
+        # A schedule that isn't PLANNED (e.g. the ACTUAL default some
+        # authoring tools use) has nothing meaningful to baseline.
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        schedule = ifcopenshell.api.sequence.add_work_schedule(self.file, predefined_type="ACTUAL")
+        with pytest.raises(ValueError):
+            ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=schedule, name="Baseline 1")
+        assert len(self.file.by_type("IfcWorkSchedule")) == 1


### PR DESCRIPTION
`create_baseline` silently did nothing unless the work schedule's `PredefinedType` was exactly `"PLANNED"`:

```python
if not work_schedule.PredefinedType == "PLANNED":
    return
```

That condition is normally false. `add_work_schedule` defaults `PredefinedType` to `NOTDEFINED`, and Bonsai's own "Add Work Schedule" enum widget defaults to the first schema value, `ACTUAL`. So a user creating a schedule and clicking "Add Baseline" got **nothing, with no error**.

It now raises `ValueError` naming the actual type, so the caller learns why.

Regression test verified red before and green after. Sequence suite 68 of 68.

Generated with the assistance of an AI coding tool.
