### PR TITLE
nest.change_nest: nest items with no old parent

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/nest/change_nest.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/nest/change_nest.py
@@ -26,17 +26,16 @@ def change_nest(
     file: ifcopenshell.file, item: ifcopenshell.entity_instance, new_parent: ifcopenshell.entity_instance
 ) -> None:
     """Assigns a cost item to a new parent cost item"""
-    if not item.Nests:
-        return
-    nests = item.Nests[0]
-    related_objects = list(nests.RelatedObjects)
-    related_objects.remove(item)
-    if related_objects:
-        nests.RelatedObjects = related_objects
-        ifcopenshell.api.owner.update_owner_history(file, element=nests)
-    else:
-        history = nests.OwnerHistory
-        file.remove(nests)
-        if history:
-            ifcopenshell.util.element.remove_deep2(file, history)
+    if item.Nests:
+        nests = item.Nests[0]
+        related_objects = list(nests.RelatedObjects)
+        related_objects.remove(item)
+        if related_objects:
+            nests.RelatedObjects = related_objects
+            ifcopenshell.api.owner.update_owner_history(file, element=nests)
+        else:
+            history = nests.OwnerHistory
+            file.remove(nests)
+            if history:
+                ifcopenshell.util.element.remove_deep2(file, history)
     ifcopenshell.api.nest.assign_object(file, related_objects=[item], relating_object=new_parent)

--- a/src/ifcopenshell-python/test/api/nest/test_change_nest.py
+++ b/src/ifcopenshell-python/test/api/nest/test_change_nest.py
@@ -1,0 +1,43 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 IfcOpenShell contributors
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.nest
+import ifcopenshell.api.root
+import ifcopenshell.util.element
+import test.bootstrap
+
+
+class TestChangeNest(test.bootstrap.IFC4):
+    def test_nesting_an_item_that_had_no_previous_parent(self):
+        # A root item, one that isn't nested under anything yet, must still
+        # be assignable to a new parent.
+        item = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcTask")
+        new_parent = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcTask")
+        ifcopenshell.api.nest.change_nest(self.file, item=item, new_parent=new_parent)
+        assert ifcopenshell.util.element.get_nest(item) == new_parent
+
+    def test_moving_an_item_to_a_new_parent(self):
+        old_parent = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcTask")
+        new_parent = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcTask")
+        item = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcTask")
+        ifcopenshell.api.nest.assign_object(self.file, related_objects=[item], relating_object=old_parent)
+        ifcopenshell.api.nest.change_nest(self.file, item=item, new_parent=new_parent)
+        assert ifcopenshell.util.element.get_nest(item) == new_parent
+        assert not old_parent.IsNestedBy


### PR DESCRIPTION
`change_nest` failed to attach an item that had no current parent.

```python
if not item.Nests:
    return
```

That guard was written to skip **detaching** from an old parent. But the re-parenting work followed it, so the early return skipped the attach as well. Calling `change_nest` on an item with no `Nests` relationship, such as a root-level cost item, silently did nothing.

Bonsai's cost item "change parent" drag reaches this directly, via `bonsai/core/cost.py`.

The fix scopes the guard to the detach step alone, leaving the attach to run in both cases.

Regression test verified red before and green after. Nest suite 24 of 24, cost suite 31 of 31.

Generated with the assistance of an AI coding tool.
