### PR TITLE
ifcfm: warn when a duplicate key drops data

### DIFF
--- a/src/ifcfm/ifcfm/__init__.py
+++ b/src/ifcfm/ifcfm/__init__.py
@@ -22,6 +22,7 @@ import csv
 import importlib
 import os
 import re
+import warnings
 from collections import defaultdict
 from collections.abc import Callable
 from pathlib import Path
@@ -128,9 +129,12 @@ class Parser:
 
                 if data:
                     key = "-".join([str(data[k]) for k in category_config["keys"]])
-                    # TODO: duplicate_keys are never used?
                     if key in self.categories[category_name]:
                         self.duplicate_keys.append((self.categories[category_name][key], data))
+                        warnings.warn(
+                            f"Duplicate key '{key}' in category '{category_name}': "
+                            "an earlier element with this key is being dropped from the export."
+                        )
                     self.categories[category_name][key] = data
 
     def federate(self, paths: list[str]) -> None:

--- a/src/ifcfm/test/test_parser.py
+++ b/src/ifcfm/test/test_parser.py
@@ -1,0 +1,50 @@
+# IfcFM - IFC for facility management
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcFM.
+#
+# IfcFM is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcFM is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcFM.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell
+import ifcopenshell.api.root
+import pytest
+
+import ifcfm
+
+
+class TestParserDuplicateKeys:
+    @staticmethod
+    def setup_ifc_file() -> ifcopenshell.file:
+        ifc_file = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject")
+        return ifc_file
+
+    def test_duplicate_key_warns_and_keeps_last_element(self) -> None:
+        # Two systems sharing the same Name collide on the same category
+        # key. The earlier one used to vanish from every exported format
+        # with no warning. It must now be reported.
+        ifc_file = self.setup_ifc_file()
+        ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSystem", name="HVAC")
+        second_system = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSystem", name="HVAC")
+
+        parser = ifcfm.Parser(preset="basic")
+        with pytest.warns(UserWarning, match="Duplicate key"):
+            parser.parse(ifc_file)
+
+        assert len(parser.duplicate_keys) == 1
+        systems = parser.categories["Systems"]
+        assert len(systems) == 1
+        assert systems["HVAC"]["ModelID"] == second_system.GlobalId


### PR DESCRIPTION
`Parser.parse()` silently overwrote elements sharing a key, so the dropped element vanished from every exported CSV, ODS and XLSX with no signal to the user.

The overwritten element was recorded in a `duplicate_keys` list that nothing ever read.

Demonstrated with a model containing two `IfcSpace` entities sharing a `Name`: only one survived to export. Two spaces in, one space out, no warning.

The fix emits `warnings.warn` naming the dropped key, so the loss is at least visible. Deduplicating or disambiguating the key is a larger behavioural decision and is deliberately not attempted here.

Regression test verified red before and green after.

Generated with the assistance of an AI coding tool.
