### PR TITLE
ifc4d: fix P6 XML project name always Unnamed

### DIFF
--- a/src/ifc4d/ifc4d/p62ifc.py
+++ b/src/ifc4d/ifc4d/p62ifc.py
@@ -89,7 +89,7 @@ class P62Ifc:
         root = tree.getroot()
         self.ns = {"pr": root.tag[1:].partition("}")[0]}
         project = root.find("pr:Project", self.ns)
-        self.project["Name"] = project.findtext("pr:Name") or "Unnamed"
+        self.project["Name"] = project.findtext("pr:Name", namespaces=self.ns) or "Unnamed"
         self.default_calendar_id = project.findtext("pr:ActivityDefaultCalendarObjectId", namespaces=self.ns)
         self.parse_calendar_xml(root)
         self.parse_calendar_xml(project)

--- a/src/ifc4d/test/test_p62ifc.py
+++ b/src/ifc4d/test/test_p62ifc.py
@@ -1,0 +1,49 @@
+# Ifc4D - IFC scheduling utility
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of Ifc4D.
+#
+# Ifc4D is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ifc4D is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Ifc4D.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import tempfile
+from pathlib import Path
+
+from ifc4d.p62ifc import P62Ifc
+
+P6_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<APIBusinessObjects xmlns="http://xmlns.oracle.com/Primavera/P6/V1/APIBusinessObjects">
+  <Project>
+    <ObjectId>1</ObjectId>
+    <Name>My Real Schedule Name</Name>
+    <ActivityDefaultCalendarObjectId>100</ActivityDefaultCalendarObjectId>
+  </Project>
+</APIBusinessObjects>
+"""
+
+
+class TestP62IfcParseXml:
+    def test_project_name_is_read_from_the_namespaced_xml(self) -> None:
+        # The P6 XML uses a default namespace, so every "pr:" tagged
+        # find/findtext call must pass namespaces=self.ns to resolve.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            xml_path = Path(tmpdir) / "schedule.xml"
+            xml_path.write_text(P6_XML)
+
+            importer = P62Ifc()
+            importer.xml = str(xml_path)
+            importer.parse_xml()
+
+        assert importer.project["Name"] == "My Real Schedule Name"


### PR DESCRIPTION
Every P6 XML import silently discarded the real schedule name and fell back to `"Unnamed"`.

```python
self.project["Name"] = project.findtext("pr:Name") or "Unnamed"                    # line 92
self.default_calendar_id = project.findtext("pr:ActivityDefault...", namespaces=self.ns)  # line 93
```

Line 92 omits `namespaces=self.ns`. **Every other lookup in the file passes it**, including the very next line. P6 XML uses a default namespace, so the prefixed query never matched, `findtext` returned `None`, and the `or "Unnamed"` fallback fired every single time.

Confirmed with a probe: `findtext` without the namespace map returns `None` even when the element is present.

Regression test verified red before and green after.

Generated with the assistance of an AI coding tool.
