### PR TITLE
Bonsai: raise, not no-op, on missing polygon

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/covering.py
+++ b/src/bonsai/bonsai/bim/module/model/covering.py
@@ -38,6 +38,8 @@ class AddInstanceFlooringCoveringFromCursor(bpy.types.Operator, tool.Ifc.Operato
             core.add_instance_flooring_covering_from_cursor(tool.Ifc, tool.Root, tool.Spatial)
         except core.NoDefaultContainer:
             return self.report({"ERROR"}, "Please set a default container to create the covering in.")
+        except core.NoPolygonFound:
+            return self.report({"ERROR"}, "No enclosed space was found at the cursor position.")
 
 
 class AddInstanceCeilingCoveringFromCursor(bpy.types.Operator, tool.Ifc.Operator):
@@ -55,6 +57,8 @@ class AddInstanceCeilingCoveringFromCursor(bpy.types.Operator, tool.Ifc.Operator
             core.add_instance_ceiling_covering_from_cursor(tool.Ifc, tool.Root, tool.Covering, tool.Spatial)
         except core.NoDefaultContainer:
             return self.report({"ERROR"}, "Please set a default container to create the covering in.")
+        except core.NoPolygonFound:
+            return self.report({"ERROR"}, "No enclosed space was found at the cursor position.")
 
 
 class RegenSelectedCoveringObject(bpy.types.Operator, tool.Ifc.Operator):
@@ -75,6 +79,8 @@ class RegenSelectedCoveringObject(bpy.types.Operator, tool.Ifc.Operator):
             core.regen_selected_covering_object(tool.Root, tool.Spatial)
         except core.NoDefaultContainer:
             return self.report({"ERROR"}, "Please set a default container to create the covering in.")
+        except core.NoPolygonFound:
+            return self.report({"ERROR"}, "No enclosed space was found at the cursor position.")
 
 
 class AddInstanceFlooringCoveringsFromWalls(bpy.types.Operator, tool.Ifc.Operator):

--- a/src/bonsai/bonsai/core/covering.py
+++ b/src/bonsai/bonsai/core/covering.py
@@ -49,7 +49,7 @@ def add_instance_flooring_covering_from_cursor(
     space_polygon = spatial.get_space_polygon_from_context_visible_objects(x, y)
 
     if isinstance(space_polygon, str):
-        return
+        raise NoPolygonFound(space_polygon)
 
     obj = spatial.create_object("Covering")
     spatial.set_obj_origin_to_cursor_position_and_zero_elevation(obj)
@@ -84,7 +84,7 @@ def add_instance_ceiling_covering_from_cursor(
     space_polygon = spatial.get_space_polygon_from_context_visible_objects(x, y)
 
     if isinstance(space_polygon, str):
-        return
+        raise NoPolygonFound(space_polygon)
 
     obj = spatial.create_object("Covering")
     spatial.set_obj_origin_to_cursor_position_and_zero_elevation(obj)
@@ -109,7 +109,7 @@ def regen_selected_covering_object(root: type[tool.Root], spatial: type[tool.Spa
     space_polygon = spatial.get_space_polygon_from_context_visible_objects(x, y)
 
     if isinstance(space_polygon, str):
-        return
+        raise NoPolygonFound(space_polygon)
 
     spatial.set_covering_representation_from_polygon(active_obj, space_polygon, polygon_is_si=True)
 
@@ -152,4 +152,8 @@ def add_instance_ceiling_coverings_from_walls(
 
 
 class NoDefaultContainer(Exception):
+    pass
+
+
+class NoPolygonFound(Exception):
     pass

--- a/src/bonsai/test/core/bootstrap.py
+++ b/src/bonsai/test/core/bootstrap.py
@@ -89,6 +89,13 @@ def demo():
 
 
 @pytest.fixture
+def covering():
+    prophet = Prophecy(bonsai.core.tool.Covering)
+    yield prophet
+    prophet.verify()
+
+
+@pytest.fixture
 def document():
     prophet = Prophecy(bonsai.core.tool.Document)
     yield prophet

--- a/src/bonsai/test/core/test_covering.py
+++ b/src/bonsai/test/core/test_covering.py
@@ -1,0 +1,69 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""No-polygon covering creation should raise, not silently do nothing.
+
+Without an enclosing polygon at the cursor, the three covering-from-cursor
+core functions used to just ``return`` after computing ``space_polygon``,
+leaving the user with no error and no created object. See NoPolygonFound.
+"""
+
+import pytest
+
+import bonsai.core.covering as subject
+from test.core.bootstrap import covering, ifc, root, spatial
+
+
+class TestAddInstanceFlooringCoveringFromCursorNoPolygon:
+    def test_raises_no_polygon_found(self, ifc, root, spatial):
+        root.get_default_container().should_be_called().will_return("container")
+        spatial.get_active_obj().should_be_called().will_return(None)
+        spatial.get_selected_objects().should_be_called().will_return([])
+        spatial.get_relating_type_id().should_be_called().will_return(None)
+        spatial.get_x_y_z_h_mat_from_cursor().should_be_called().will_return((1, 2, 3, 4, "mat"))
+        spatial.get_space_polygon_from_context_visible_objects(1, 2).should_be_called().will_return("NO POLYGONS FOUND")
+        with pytest.raises(subject.NoPolygonFound):
+            subject.add_instance_flooring_covering_from_cursor(ifc, root, spatial)
+
+
+class TestAddInstanceCeilingCoveringFromCursorNoPolygon:
+    def test_raises_no_polygon_found(self, ifc, root, covering, spatial):
+        root.get_default_container().should_be_called().will_return("container")
+        spatial.get_active_obj().should_be_called().will_return(None)
+        spatial.get_selected_objects().should_be_called().will_return([])
+        spatial.get_relating_type_id().should_be_called().will_return(None)
+        spatial.get_x_y_z_h_mat_from_cursor().should_be_called().will_return((1, 2, 3, 4, "mat"))
+        covering.get_z_from_ceiling_height().should_be_called().will_return(2.5)
+        spatial.get_space_polygon_from_context_visible_objects(1, 2).should_be_called().will_return(
+            "NO POLYGON FOR POINT"
+        )
+        with pytest.raises(subject.NoPolygonFound):
+            subject.add_instance_ceiling_covering_from_cursor(ifc, root, covering, spatial)
+
+
+class TestRegenSelectedCoveringObjectNoPolygon:
+    def test_raises_no_polygon_found(self, root, spatial):
+        root.get_default_container().should_be_called().will_return("container")
+        spatial.get_active_obj().should_be_called().will_return("active_obj")
+        spatial.get_selected_objects().should_be_called().will_return(["active_obj"])
+        spatial.get_x_y_z_h_mat_from_obj("active_obj").should_be_called().will_return((1, 2, 3, 4, "mat"))
+        spatial.get_space_polygon_from_context_visible_objects(1, 2).should_be_called().will_return("NO POLYGONS FOUND")
+        with pytest.raises(subject.NoPolygonFound):
+            subject.regen_selected_covering_object(root, spatial)


### PR DESCRIPTION
"Add Flooring From Cursor", "Add Ceiling From Cursor" and "Regen" all did **nothing, with no error**, when the cursor or active object was not inside a closed boundary polygon.

`get_space_polygon_from_context_visible_objects` reports failure by returning a string:

```python
) -> Union[shapely.Polygon, Literal["NO POLYGONS FOUND", "NO POLYGON FOR POINT"]]:
```

and all three callers simply did `if isinstance(space_polygon, str): return`.

**The sibling function proves this was an oversight rather than a contract.** `core/spatial.py`'s `generate_space`, the "Generate Space" tool, handles the identical failure by raising `SpaceGenerationError` with a descriptive message, for example "Couldn't find any polygons to form the space shape. Perhaps, RL value need to be adjusted."

The fix adds `NoPolygonFound` in `core/covering.py`, raises it in all three functions, and reports it in the three operators.

This also required creating a `covering` fixture in `test/core/bootstrap.py`, which did not exist. Core suite 393 of 393, up from a 390 baseline.

Generated with the assistance of an AI coding tool.
