### PR TITLE
Bonsai: creating a window in an imported IFC crashes (#8081)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/door.py
+++ b/src/bonsai/bonsai/bim/module/model/door.py
@@ -83,6 +83,8 @@ def update_door_modifier_representation(obj: bpy.types.Object) -> None:
         },
     }
 
+    body = tool.Model.get_body_context()
+
     active_context = tool.Geometry.get_active_representation_context(obj)
 
     # ELEVATION_VIEW representation
@@ -94,7 +96,6 @@ def update_door_modifier_representation(obj: bpy.types.Object) -> None:
 
     # MODEL_VIEW representation
     # (Model/Body defined only BEFORE Plan/Body to prevent #2744)
-    body = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
     representation_data["context"] = body
     representation_data["part_of_product"] = ifcopenshell.util.representation.get_part_of_product(element, body)
     model_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)

--- a/src/bonsai/bonsai/bim/module/model/door.py
+++ b/src/bonsai/bonsai/bim/module/model/door.py
@@ -120,32 +120,28 @@ def update_door_modifier_representation(obj: bpy.types.Object) -> None:
             ifcopenshell.api.material.remove_material_set(ifc_file, material=material)
 
     # Body/PLAN_VIEW representation
-    plan_body = ifcopenshell.util.representation.get_context(ifc_file, "Plan", "Body", "PLAN_VIEW")
-    if plan_body:
-        representation_data["context"] = plan_body
-        plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
-        tool.Model.replace_object_ifc_representation(plan_body, obj, plan_representation)
+    plan_body = tool.Model.get_or_create_context("Plan", "Body", "PLAN_VIEW")
+    representation_data["context"] = plan_body
+    plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
+    tool.Model.replace_object_ifc_representation(plan_body, obj, plan_representation)
 
     # Annotation/PLAN_VIEW representation
-    plan_annotation = ifcopenshell.util.representation.get_context(ifc_file, "Plan", "Annotation", "PLAN_VIEW")
-    if plan_annotation:
-        if not sliding_door:
-            # only sliding doors have Annotation/PLAN_VIEW
-            # for other types we just check for old representation and remove it if it's there
-            old_representation = ifcopenshell.util.representation.get_representation(
-                element, "Plan", "Annotation", "PLAN_VIEW"
-            )
-            if old_representation:
-                core.remove_representation(
-                    tool.Ifc,
-                    tool.Geometry,
-                    obj=obj,
-                    representation=old_representation,
-                )
-        else:
-            representation_data["context"] = plan_annotation
-            plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
-            tool.Model.replace_object_ifc_representation(plan_annotation, obj, plan_representation)
+    # only sliding doors have Annotation/PLAN_VIEW
+    # for other types we just check for old representation and remove it if it's there
+    if sliding_door:
+        plan_annotation = tool.Model.get_or_create_context("Plan", "Annotation", "PLAN_VIEW")
+        representation_data["context"] = plan_annotation
+        plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
+        tool.Model.replace_object_ifc_representation(plan_annotation, obj, plan_representation)
+    elif old_representation := ifcopenshell.util.representation.get_representation(
+        element, "Plan", "Annotation", "PLAN_VIEW"
+    ):
+        core.remove_representation(
+            tool.Ifc,
+            tool.Geometry,
+            obj=obj,
+            representation=old_representation,
+        )
 
     core.switch_representation(
         tool.Ifc,

--- a/src/bonsai/bonsai/bim/module/model/window.py
+++ b/src/bonsai/bonsai/bim/module/model/window.py
@@ -86,6 +86,8 @@ def update_window_modifier_representation(context: bpy.types.Context) -> None:
         }
         representation_data["panel_properties"].append(panel_data)
 
+    body = tool.Model.get_body_context()
+
     active_context = tool.Geometry.get_active_representation_context(obj)
 
     # ELEVATION_VIEW representation
@@ -97,7 +99,6 @@ def update_window_modifier_representation(context: bpy.types.Context) -> None:
 
     # MODEL_VIEW representation
     # (Model/Body defined only BEFORE Plan/Body to prevent #2744)
-    body = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
     representation_data["context"] = body
     representation_data["part_of_product"] = ifcopenshell.util.representation.get_part_of_product(element, body)
     model_representation = ifcopenshell.api.geometry.add_window_representation(ifc_file, **representation_data)

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -39,6 +39,7 @@ from typing import (
 import bmesh
 import bpy
 import ifcopenshell
+import ifcopenshell.api.context
 import ifcopenshell.api.feature
 import ifcopenshell.api.geometry
 import ifcopenshell.api.grid
@@ -2244,6 +2245,27 @@ class Model(bonsai.core.tool.Model):
         body = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
         assert body
         cls.add_representation(obj, body)
+
+    @classmethod
+    def get_body_context(cls) -> ifcopenshell.entity_instance:
+        """Get the Model/Body/MODEL_VIEW subcontext, creating it if the file has none.
+
+        Externally authored IFCs often ship without it, and 3D body geometry
+        cannot be authored until it exists.
+        """
+        ifc_file = tool.Ifc.get()
+        if body := ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW"):
+            return body
+        model = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+        if not model:
+            model = ifcopenshell.api.context.add_context(ifc_file, context_type="Model")
+        return ifcopenshell.api.context.add_context(
+            ifc_file,
+            context_type="Model",
+            context_identifier="Body",
+            target_view="MODEL_VIEW",
+            parent=model,
+        )
 
     @classmethod
     def auto_detect_annotation_fill_area(cls, obj: bpy.types.Object, mesh: bpy.types.Mesh) -> dict | None:

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2247,25 +2247,37 @@ class Model(bonsai.core.tool.Model):
         cls.add_representation(obj, body)
 
     @classmethod
-    def get_body_context(cls) -> ifcopenshell.entity_instance:
-        """Get the Model/Body/MODEL_VIEW subcontext, creating it if the file has none.
+    def get_or_create_context(
+        cls,
+        context_type: ifcopenshell.util.representation.CONTEXT_TYPE,
+        context_identifier: ifcopenshell.util.representation.REPRESENTATION_IDENTIFIER,
+        target_view: ifcopenshell.util.representation.TARGET_VIEW,
+    ) -> ifcopenshell.entity_instance:
+        """Get a subcontext to author into, creating it if the file has none.
 
-        Externally authored IFCs often ship without it, and 3D body geometry
-        cannot be authored until it exists.
+        Externally authored IFCs often ship without the subcontexts Bonsai
+        authors into, and a representation cannot be created until they exist.
+        The parent context is created too if it is also missing.
         """
         ifc_file = tool.Ifc.get()
-        if body := ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW"):
-            return body
-        model = ifcopenshell.util.representation.get_context(ifc_file, "Model")
-        if not model:
-            model = ifcopenshell.api.context.add_context(ifc_file, context_type="Model")
+        if context := ifcopenshell.util.representation.get_context(
+            ifc_file, context_type, context_identifier, target_view
+        ):
+            return context
+        parent = ifcopenshell.util.representation.get_context(ifc_file, context_type)
+        if not parent:
+            parent = ifcopenshell.api.context.add_context(ifc_file, context_type=context_type)
         return ifcopenshell.api.context.add_context(
             ifc_file,
-            context_type="Model",
-            context_identifier="Body",
-            target_view="MODEL_VIEW",
-            parent=model,
+            context_type=context_type,
+            context_identifier=context_identifier,
+            target_view=target_view,
+            parent=parent,
         )
+
+    @classmethod
+    def get_body_context(cls) -> ifcopenshell.entity_instance:
+        return cls.get_or_create_context("Model", "Body", "MODEL_VIEW")
 
     @classmethod
     def auto_detect_annotation_fill_area(cls, obj: bpy.types.Object, mesh: bpy.types.Mesh) -> dict | None:

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -1003,6 +1003,35 @@ class TestGetBodyContext(NewFile):
         assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
 
 
+class TestGetOrCreateContext(NewFile):
+    def create_imported_file(self) -> ifcopenshell.file:
+        """An IFC as exported by other authoring tools: a Model context, no subcontexts."""
+        ifc = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="Project")
+        context = ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        context.ContextIdentifier = "Plan"
+        tool.Ifc.set(ifc)
+        return ifc
+
+    def test_creating_the_plan_body_subcontext_and_its_parent_context(self):
+        ifc = self.create_imported_file()
+        assert ifcopenshell.util.representation.get_context(ifc, "Plan") is None
+        plan_body = subject.get_or_create_context("Plan", "Body", "PLAN_VIEW")
+        assert plan_body.ContextType == "Plan"
+        assert plan_body.ContextIdentifier == "Body"
+        assert plan_body.TargetView == "PLAN_VIEW"
+        assert plan_body.ParentContext == ifcopenshell.util.representation.get_context(ifc, "Plan")
+        assert plan_body.ParentContext in ifc.by_type("IfcProject")[0].RepresentationContexts
+
+    def test_not_creating_duplicate_contexts_on_repeated_calls(self):
+        ifc = self.create_imported_file()
+        assert subject.get_or_create_context("Plan", "Body", "PLAN_VIEW") == subject.get_or_create_context(
+            "Plan", "Body", "PLAN_VIEW"
+        )
+        assert len(ifc.by_type("IfcGeometricRepresentationContext", include_subtypes=False)) == 2
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
+
+
 class TestGetSiblingOccurrenceCount(NewFile):
     """The pen-icon dispatcher's pre-edit warning depends on this count: zero
     means the edit is safe (unique geometry), non-zero means the edit will

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -1032,6 +1032,44 @@ class TestGetOrCreateContext(NewFile):
         assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
 
 
+class TestWindowRepresentationOnImportedFile(NewFile):
+    """window.py mirrors the door crash fixed above: it looked up
+    Model/Body/MODEL_VIEW directly and passed a possibly-None context
+    into add_window_representation, which crashes on .TargetView."""
+
+    def strip_subcontexts(self, ifc: ifcopenshell.file) -> None:
+        for subcontext in ifc.by_type("IfcGeometricRepresentationSubContext"):
+            ifcopenshell.api.context.remove_context(ifc, context=subcontext)
+
+    def test_creating_a_window_on_a_file_with_no_subcontexts(self):
+        tool.Project.get_project_props().template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        result = bpy.ops.mesh.add_window()
+        assert result == {"FINISHED"}
+
+        obj = bpy.context.view_layer.objects.active
+        element = tool.Ifc.get_entity(obj)
+        body = ifcopenshell.util.representation.get_representation(element, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+    def test_not_creating_duplicate_body_contexts_on_a_second_window(self):
+        tool.Project.get_project_props().template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+
+        bpy.ops.mesh.add_window()
+        bpy.context.view_layer.objects.active = None
+        bpy.ops.mesh.add_window()
+
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
+
+
 class TestGetSiblingOccurrenceCount(NewFile):
     """The pen-icon dispatcher's pre-edit warning depends on this count: zero
     means the edit is safe (unique geometry), non-zero means the edit will

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import bpy
 import ifcopenshell
+import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.material
 import ifcopenshell.api.pset
@@ -959,6 +960,47 @@ class TestOffsetWall(NewFile):
         usage.DirectionSense = "NEGATIVE"
         subject.offset_wall(obj, "EXTERIOR")
         assert usage.OffsetFromReferenceLine == 100
+
+
+class TestGetBodyContext(NewFile):
+    def create_imported_file(self) -> ifcopenshell.file:
+        """An IFC as exported by other authoring tools: a Model context, no subcontexts."""
+        ifc = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="Project")
+        context = ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        context.ContextIdentifier = "Plan"
+        tool.Ifc.set(ifc)
+        return ifc
+
+    def test_returning_the_existing_body_subcontext(self):
+        ifc = self.create_imported_file()
+        parent = ifcopenshell.util.representation.get_context(ifc, "Model")
+        body = ifcopenshell.api.context.add_context(
+            ifc, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=parent
+        )
+        assert subject.get_body_context() == body
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
+
+    def test_creating_the_body_subcontext_if_the_file_has_none(self):
+        ifc = self.create_imported_file()
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+        body = subject.get_body_context()
+        assert body.ContextType == "Model"
+        assert body.ContextIdentifier == "Body"
+        assert body.TargetView == "MODEL_VIEW"
+        assert body.ParentContext == ifcopenshell.util.representation.get_context(ifc, "Model")
+
+    def test_creating_the_model_context_if_the_file_has_none(self):
+        ifc = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="Project")
+        tool.Ifc.set(ifc)
+        body = subject.get_body_context()
+        assert body.ParentContext == ifcopenshell.util.representation.get_context(ifc, "Model")
+
+    def test_not_creating_duplicates_on_repeated_calls(self):
+        ifc = self.create_imported_file()
+        assert subject.get_body_context() == subject.get_body_context()
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
 
 
 class TestGetSiblingOccurrenceCount(NewFile):


### PR DESCRIPTION
**Depends on #8995.** This is the window half of the same defect; the diff here includes #8995's commits.

Issue #8081 was reported as an error when creating a door type, but it was never a door bug. Authoring any element into an **imported** IFC that has no `Model/Body/MODEL_VIEW` subcontext crashes, because `get_context(...)` returns `None` and the `add_*_representation` API then dereferences `.TargetView` on it. Bonsai-authored projects always create the subcontext, so this never shows up on native models. The axis is imported versus authored, not IFC4 versus IFC2X3.

`bim/module/model/window.py` has the same unguarded lookup #8995 fixed in `door.py`:

```
File ".../bonsai/bim/module/model/window.py", line 103, in update_window_modifier_representation
    model_representation = ifcopenshell.api.geometry.add_window_representation(ifc_file, **representation_data)
File ".../ifcopenshell/api/geometry/add_window_representation.py", line 437, in execute
    if self.settings["context"].TargetView == "ELEVATION_VIEW":
AttributeError: 'NoneType' object has no attribute 'TargetView'
```

This reuses #8995's existing `tool.Model.get_body_context()` rather than adding a second helper, so the missing subcontext is **created** as an authored project would have it. Guarding and skipping would leave a silently bodyless window, which is worse than the crash.

### Verified in headless Blender

* Before: the traceback above, reproduced on a context-stripped file.
* After: window created with real geometry, **56 verts / 108 polys**.
* Saved and reloaded: **56 verts / 108 polys**, unchanged.
* Idempotent: a second window leaves exactly one `Model/Body/MODEL_VIEW` subcontext.
* Fresh Bonsai project unaffected: 14 contexts before and after.

Tests added in `src/bonsai/test/tool/test_model.py` alongside #8995's, exercising the real `bpy.ops.mesh.add_window()` operator. Both were confirmed to **fail** against the pre-fix file with the exact traceback above, so they are testing what they claim to.

### The wider picture, not fixed here

Door and window are two of seventeen. The same unguarded lookup exists at `railing.py` (2 sites), `opening.py`, `profile.py` (2), `wall.py` (3), `roof.py`, `mep.py` (4) and `slab.py` (2). Two sites are already guarded, `opening.py` with an `assert` and `wall.py` with an explicit `None` check, which suggests the guard is the intended convention and the rest are omissions.

Happy to extend this PR to cover them, or to follow up separately, whichever is easier to review.

Generated with the assistance of an AI coding tool.
