### PR TITLE
ifcpatch: guard Tag getattr for non-product type objects

### DIFF
--- a/src/ifcpatch/ifcpatch/recipes/MergeDuplicateTypes.py
+++ b/src/ifcpatch/ifcpatch/recipes/MergeDuplicateTypes.py
@@ -25,7 +25,9 @@ import ifcopenshell.util.element
 
 
 class Patcher:
-    def __init__(self, file: ifcopenshell.file, logger: Logger, attribute: str = "Tag", should_merge_null: bool = False):
+    def __init__(
+        self, file: ifcopenshell.file, logger: Logger, attribute: str = "Tag", should_merge_null: bool = False
+    ):
         """Merge duplicate element types via the Tag or another attribute
 
         Revit is notorious for creating many duplicate element types. Element
@@ -84,7 +86,8 @@ class Patcher:
     def patch(self):
         keys: dict[Any, ifcopenshell.entity_instance] = {}
         for element_type in self.file.by_type("IfcTypeObject"):
-            attribute_value = getattr(element_type, self.attribute)
+            # Not every subtype has this attribute, e.g. IfcTypeProcess.
+            attribute_value = getattr(element_type, self.attribute, None)
             if not attribute_value and not self.should_merge_null:
                 continue
             # Include the IFC class in the key so that only types of the same

--- a/src/ifcpatch/test/test_MergeDuplicateTypes.py
+++ b/src/ifcpatch/test/test_MergeDuplicateTypes.py
@@ -113,3 +113,14 @@ class TestMergeDuplicateTypes(test.bootstrap.IFC4):
 
 class TestMergeDuplicateTypesIFC2X3(test.bootstrap.IFC2X3, TestMergeDuplicateTypes):
     pass
+
+
+class TestMergeDuplicateTypesMissingAttribute(test.bootstrap.IFC4):
+    def test_types_without_the_merge_attribute_are_not_crashed_on(self):
+        # IfcTypeProcess (unlike IfcTypeProduct) has no Tag attribute at
+        # all. IfcTypeProcess is IFC4-only, so this is not shared with the
+        # IFC2X3 test class above.
+        event_type1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcEventType")
+        event_type2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcEventType")
+        output = ifcpatch.execute({"file": self.file, "recipe": "MergeDuplicateTypes", "arguments": []})
+        assert len(output.by_type("IfcEventType")) == 2


### PR DESCRIPTION
Offered on top of your branch rather than against v0.8.0, since we would otherwise both be editing the same `getattr` line.

`MergeDuplicateTypes` iterates `by_type("IfcTypeObject")` and reads the chosen attribute unguarded:

```python
attribute_value = getattr(element_type, self.attribute)
```

`IfcTypeObject` includes `IfcTypeProcess` and `IfcTypeResource`, and **neither has a `Tag` attribute**; only `IfcTypeProduct` does. Confirmed by introspection with `declaration_by_name(...).all_attributes()` rather than from memory.

Reproduced by running the recipe against two `IfcEventType` entities, `IfcEventType` being a concrete `IfcTypeProcess`:

```
AttributeError: entity instance of type 'IFC4.IfcEventType' has no attribute 'Tag'
```

The fix is a default on the `getattr`, so a type without the attribute is skipped rather than aborting the whole run.

### Why this is separate from your change

Your PR reworks the merge key for cross-class safety, which is a different concern and does not touch this dereference. A note elsewhere in our own tree had recorded this defect as already covered by your PR; that turned out to be wrong when we read the diff, which is why it is offered here.

### Tests

`TestMergeDuplicateTypesMissingAttribute` added to `test_MergeDuplicateTypes.py`, kept out of the shared IFC4/IFC2X3 base class because `IfcTypeProcess` does not exist in IFC2X3.

7 of 9 pass. The 2 failures, `test_not_merging_different_classes` in both schemas, are **pre-existing on your branch** and unrelated to this change, confirmed by stashing the diff and re-running: `TypeError: IfcTypeProduct cannot type IfcAnnotation`, from a stricter `assign_type` occurrence check.

Generated with the assistance of an AI coding tool.
