### PR TITLE
Bonsai: authoring walls, slabs, railings, roofs, profiles in an imported IFC crashes (#8081)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/door.py
+++ b/src/bonsai/bonsai/bim/module/model/door.py
@@ -83,6 +83,8 @@ def update_door_modifier_representation(obj: bpy.types.Object) -> None:
         },
     }
 
+    body = tool.Model.get_body_context()
+
     active_context = tool.Geometry.get_active_representation_context(obj)
 
     # ELEVATION_VIEW representation
@@ -94,7 +96,6 @@ def update_door_modifier_representation(obj: bpy.types.Object) -> None:
 
     # MODEL_VIEW representation
     # (Model/Body defined only BEFORE Plan/Body to prevent #2744)
-    body = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
     representation_data["context"] = body
     representation_data["part_of_product"] = ifcopenshell.util.representation.get_part_of_product(element, body)
     model_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)

--- a/src/bonsai/bonsai/bim/module/model/door.py
+++ b/src/bonsai/bonsai/bim/module/model/door.py
@@ -120,32 +120,28 @@ def update_door_modifier_representation(obj: bpy.types.Object) -> None:
             ifcopenshell.api.material.remove_material_set(ifc_file, material=material)
 
     # Body/PLAN_VIEW representation
-    plan_body = ifcopenshell.util.representation.get_context(ifc_file, "Plan", "Body", "PLAN_VIEW")
-    if plan_body:
-        representation_data["context"] = plan_body
-        plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
-        tool.Model.replace_object_ifc_representation(plan_body, obj, plan_representation)
+    plan_body = tool.Model.get_or_create_context("Plan", "Body", "PLAN_VIEW")
+    representation_data["context"] = plan_body
+    plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
+    tool.Model.replace_object_ifc_representation(plan_body, obj, plan_representation)
 
     # Annotation/PLAN_VIEW representation
-    plan_annotation = ifcopenshell.util.representation.get_context(ifc_file, "Plan", "Annotation", "PLAN_VIEW")
-    if plan_annotation:
-        if not sliding_door:
-            # only sliding doors have Annotation/PLAN_VIEW
-            # for other types we just check for old representation and remove it if it's there
-            old_representation = ifcopenshell.util.representation.get_representation(
-                element, "Plan", "Annotation", "PLAN_VIEW"
-            )
-            if old_representation:
-                core.remove_representation(
-                    tool.Ifc,
-                    tool.Geometry,
-                    obj=obj,
-                    representation=old_representation,
-                )
-        else:
-            representation_data["context"] = plan_annotation
-            plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
-            tool.Model.replace_object_ifc_representation(plan_annotation, obj, plan_representation)
+    # only sliding doors have Annotation/PLAN_VIEW
+    # for other types we just check for old representation and remove it if it's there
+    if sliding_door:
+        plan_annotation = tool.Model.get_or_create_context("Plan", "Annotation", "PLAN_VIEW")
+        representation_data["context"] = plan_annotation
+        plan_representation = ifcopenshell.api.geometry.add_door_representation(ifc_file, **representation_data)
+        tool.Model.replace_object_ifc_representation(plan_annotation, obj, plan_representation)
+    elif old_representation := ifcopenshell.util.representation.get_representation(
+        element, "Plan", "Annotation", "PLAN_VIEW"
+    ):
+        core.remove_representation(
+            tool.Ifc,
+            tool.Geometry,
+            obj=obj,
+            representation=old_representation,
+        )
 
     core.switch_representation(
         tool.Ifc,

--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -65,7 +65,7 @@ class DumbProfileGenerator:
         else:
             return
 
-        self.body_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
+        self.body_context = tool.Model.get_body_context()
         self.axis_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Axis", "GRAPH_VIEW")
         props = tool.Model.get_model_props()
 
@@ -315,7 +315,7 @@ class DumbProfileJoiner:
     def __init__(self):
         self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(tool.Ifc.get())
         self.axis_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Axis", "GRAPH_VIEW")
-        self.body_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
+        self.body_context = tool.Model.get_body_context()
 
     def unjoin(self, profile1: bpy.types.Object) -> None:
         element1 = tool.Ifc.get_entity(profile1)

--- a/src/bonsai/bonsai/bim/module/model/railing.py
+++ b/src/bonsai/bonsai/bim/module/model/railing.py
@@ -96,7 +96,7 @@ def update_railing_modifier_ifc_data(context: bpy.types.Context) -> None:
     )
 
     if props.railing_type == "WALL_MOUNTED_HANDRAIL":
-        body = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
+        body = tool.Model.get_body_context()
         pset_data = tool.Model.get_modeling_bbim_pset_data(bpy.context.active_object, "BBIM_Railing")
         path_data = pset_data["data_dict"]["path_data"]
         railing_path = [Vector(v) for v in path_data["verts"]]
@@ -375,7 +375,7 @@ class BIM_OT_add_railing(bpy.types.Operator, tool.Ifc.Operator):
         obj = bpy.data.objects.new("IfcRailing", mesh)
         obj.location = spawn_location
 
-        body_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
+        body_context = tool.Model.get_body_context()
         bonsai.core.root.assign_class(
             tool.Ifc,
             tool.Collector,

--- a/src/bonsai/bonsai/bim/module/model/roof.py
+++ b/src/bonsai/bonsai/bim/module/model/roof.py
@@ -24,7 +24,6 @@ import bmesh
 import bpy
 import ifcopenshell
 import ifcopenshell.api.pset
-import ifcopenshell.util.representation
 import ifcopenshell.util.unit
 import shapely
 from bpypolyskel import bpypolyskel
@@ -550,7 +549,7 @@ class BIM_OT_add_roof(bpy.types.Operator, tool.Ifc.Operator):
         obj = bpy.data.objects.new("IfcRoof", mesh)
         obj.location = spawn_location
 
-        body_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
+        body_context = tool.Model.get_body_context()
         bonsai.core.root.assign_class(
             tool.Ifc,
             tool.Collector,

--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -61,7 +61,7 @@ class DumbSlabGenerator:
         if not sum(thicknesses):
             return
 
-        self.body_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
+        self.body_context = tool.Model.get_body_context()
         self.footprint_context = ifcopenshell.util.representation.get_context(
             tool.Ifc.get(), "Plan", "FootPrint", "SKETCH_VIEW"
         )
@@ -252,7 +252,7 @@ class DumbSlabPlaner:
             return
         layer_params = tool.Model.get_material_layer_parameters(element)
         ifc_file = tool.Ifc.get()
-        body_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
+        body_context = tool.Model.get_body_context()
         obj = tool.Ifc.get_object(element)
         if not obj:
             return

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1253,7 +1253,7 @@ class DumbWallGenerator:
         if not self.layers["thickness"]:
             return
 
-        self.body_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Model", "Body", "MODEL_VIEW")
+        self.body_context = tool.Model.get_body_context()
         self.axis_context = ifcopenshell.util.representation.get_context(tool.Ifc.get(), "Plan", "Axis", "GRAPH_VIEW")
 
         props = tool.Model.get_model_props()
@@ -2686,9 +2686,7 @@ class AddPerpendicularWall(bpy.types.Operator, tool.Ifc.Operator):
         if not generator.layers["thickness"]:
             self.report({"WARNING"}, "Wall type has no layer thickness; cannot create branch wall.")
             return {"CANCELLED"}
-        generator.body_context = ifcopenshell.util.representation.get_context(
-            tool.Ifc.get(), "Model", "Body", "MODEL_VIEW"
-        )
+        generator.body_context = tool.Model.get_body_context()
         generator.axis_context = ifcopenshell.util.representation.get_context(
             tool.Ifc.get(), "Plan", "Axis", "GRAPH_VIEW"
         )

--- a/src/bonsai/bonsai/bim/module/model/window.py
+++ b/src/bonsai/bonsai/bim/module/model/window.py
@@ -86,6 +86,8 @@ def update_window_modifier_representation(context: bpy.types.Context) -> None:
         }
         representation_data["panel_properties"].append(panel_data)
 
+    body = tool.Model.get_body_context()
+
     active_context = tool.Geometry.get_active_representation_context(obj)
 
     # ELEVATION_VIEW representation
@@ -97,7 +99,6 @@ def update_window_modifier_representation(context: bpy.types.Context) -> None:
 
     # MODEL_VIEW representation
     # (Model/Body defined only BEFORE Plan/Body to prevent #2744)
-    body = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
     representation_data["context"] = body
     representation_data["part_of_product"] = ifcopenshell.util.representation.get_part_of_product(element, body)
     model_representation = ifcopenshell.api.geometry.add_window_representation(ifc_file, **representation_data)

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -39,6 +39,7 @@ from typing import (
 import bmesh
 import bpy
 import ifcopenshell
+import ifcopenshell.api.context
 import ifcopenshell.api.feature
 import ifcopenshell.api.geometry
 import ifcopenshell.api.grid
@@ -2244,6 +2245,27 @@ class Model(bonsai.core.tool.Model):
         body = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
         assert body
         cls.add_representation(obj, body)
+
+    @classmethod
+    def get_body_context(cls) -> ifcopenshell.entity_instance:
+        """Get the Model/Body/MODEL_VIEW subcontext, creating it if the file has none.
+
+        Externally authored IFCs often ship without it, and 3D body geometry
+        cannot be authored until it exists.
+        """
+        ifc_file = tool.Ifc.get()
+        if body := ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW"):
+            return body
+        model = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+        if not model:
+            model = ifcopenshell.api.context.add_context(ifc_file, context_type="Model")
+        return ifcopenshell.api.context.add_context(
+            ifc_file,
+            context_type="Model",
+            context_identifier="Body",
+            target_view="MODEL_VIEW",
+            parent=model,
+        )
 
     @classmethod
     def auto_detect_annotation_fill_area(cls, obj: bpy.types.Object, mesh: bpy.types.Mesh) -> dict | None:

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2247,25 +2247,37 @@ class Model(bonsai.core.tool.Model):
         cls.add_representation(obj, body)
 
     @classmethod
-    def get_body_context(cls) -> ifcopenshell.entity_instance:
-        """Get the Model/Body/MODEL_VIEW subcontext, creating it if the file has none.
+    def get_or_create_context(
+        cls,
+        context_type: ifcopenshell.util.representation.CONTEXT_TYPE,
+        context_identifier: ifcopenshell.util.representation.REPRESENTATION_IDENTIFIER,
+        target_view: ifcopenshell.util.representation.TARGET_VIEW,
+    ) -> ifcopenshell.entity_instance:
+        """Get a subcontext to author into, creating it if the file has none.
 
-        Externally authored IFCs often ship without it, and 3D body geometry
-        cannot be authored until it exists.
+        Externally authored IFCs often ship without the subcontexts Bonsai
+        authors into, and a representation cannot be created until they exist.
+        The parent context is created too if it is also missing.
         """
         ifc_file = tool.Ifc.get()
-        if body := ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW"):
-            return body
-        model = ifcopenshell.util.representation.get_context(ifc_file, "Model")
-        if not model:
-            model = ifcopenshell.api.context.add_context(ifc_file, context_type="Model")
+        if context := ifcopenshell.util.representation.get_context(
+            ifc_file, context_type, context_identifier, target_view
+        ):
+            return context
+        parent = ifcopenshell.util.representation.get_context(ifc_file, context_type)
+        if not parent:
+            parent = ifcopenshell.api.context.add_context(ifc_file, context_type=context_type)
         return ifcopenshell.api.context.add_context(
             ifc_file,
-            context_type="Model",
-            context_identifier="Body",
-            target_view="MODEL_VIEW",
-            parent=model,
+            context_type=context_type,
+            context_identifier=context_identifier,
+            target_view=target_view,
+            parent=parent,
         )
+
+    @classmethod
+    def get_body_context(cls) -> ifcopenshell.entity_instance:
+        return cls.get_or_create_context("Model", "Body", "MODEL_VIEW")
 
     @classmethod
     def auto_detect_annotation_fill_area(cls, obj: bpy.types.Object, mesh: bpy.types.Mesh) -> dict | None:

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -1003,6 +1003,35 @@ class TestGetBodyContext(NewFile):
         assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
 
 
+class TestGetOrCreateContext(NewFile):
+    def create_imported_file(self) -> ifcopenshell.file:
+        """An IFC as exported by other authoring tools: a Model context, no subcontexts."""
+        ifc = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="Project")
+        context = ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        context.ContextIdentifier = "Plan"
+        tool.Ifc.set(ifc)
+        return ifc
+
+    def test_creating_the_plan_body_subcontext_and_its_parent_context(self):
+        ifc = self.create_imported_file()
+        assert ifcopenshell.util.representation.get_context(ifc, "Plan") is None
+        plan_body = subject.get_or_create_context("Plan", "Body", "PLAN_VIEW")
+        assert plan_body.ContextType == "Plan"
+        assert plan_body.ContextIdentifier == "Body"
+        assert plan_body.TargetView == "PLAN_VIEW"
+        assert plan_body.ParentContext == ifcopenshell.util.representation.get_context(ifc, "Plan")
+        assert plan_body.ParentContext in ifc.by_type("IfcProject")[0].RepresentationContexts
+
+    def test_not_creating_duplicate_contexts_on_repeated_calls(self):
+        ifc = self.create_imported_file()
+        assert subject.get_or_create_context("Plan", "Body", "PLAN_VIEW") == subject.get_or_create_context(
+            "Plan", "Body", "PLAN_VIEW"
+        )
+        assert len(ifc.by_type("IfcGeometricRepresentationContext", include_subtypes=False)) == 2
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
+
+
 class TestGetSiblingOccurrenceCount(NewFile):
     """The pen-icon dispatcher's pre-edit warning depends on this count: zero
     means the edit is safe (unique geometry), non-zero means the edit will

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -31,6 +31,7 @@ import ifcopenshell.api.type
 import ifcopenshell.util.element
 import ifcopenshell.util.representation
 import ifcopenshell.util.shape_builder
+import mathutils
 import numpy as np
 from ifcopenshell.util.shape_builder import ShapeBuilder, V
 
@@ -1068,6 +1069,152 @@ class TestWindowRepresentationOnImportedFile(NewFile):
         bpy.ops.mesh.add_window()
 
         assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
+
+
+class TestWallRepresentationOnImportedFile(NewFile):
+    """wall.py mirrors the door/window crash: DumbWallGenerator and
+    AddPerpendicularWall both looked up Model/Body/MODEL_VIEW directly and
+    passed a possibly-None context into add_wall_representation, which
+    crashes on .TargetView / .ContextIdentifier."""
+
+    def strip_subcontexts(self, ifc: ifcopenshell.file) -> None:
+        for subcontext in ifc.by_type("IfcGeometricRepresentationSubContext"):
+            ifcopenshell.api.context.remove_context(ifc, context=subcontext)
+
+    def get_wall_type(self, ifc: ifcopenshell.file) -> ifcopenshell.entity_instance:
+        return next(t for t in ifc.by_type("IfcWallType") if tool.Model.get_usage_type(t) == "LAYER2")
+
+    def test_creating_a_wall_on_a_file_with_no_subcontexts(self):
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        wall_type = self.get_wall_type(ifc)
+        walls_before = {w.id() for w in ifc.by_type("IfcWall")}
+        result = bpy.ops.bim.add_occurrence(relating_type_id=wall_type.id())
+        assert result == {"FINISHED"}
+
+        wall = next(w for w in ifc.by_type("IfcWall") if w.id() not in walls_before)
+        body = ifcopenshell.util.representation.get_representation(wall, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+    def test_not_creating_duplicate_body_contexts_on_a_second_wall(self):
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        wall_type = self.get_wall_type(ifc)
+
+        bpy.ops.bim.add_occurrence(relating_type_id=wall_type.id())
+        bpy.ops.bim.add_occurrence(relating_type_id=wall_type.id())
+
+        body_subcontexts = [
+            sc
+            for sc in ifc.by_type("IfcGeometricRepresentationSubContext")
+            if sc.ContextIdentifier == "Body" and sc.TargetView == "MODEL_VIEW"
+        ]
+        assert len(body_subcontexts) == 1
+
+    def test_add_perpendicular_wall_on_a_file_with_no_subcontexts(self):
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        wall_type = self.get_wall_type(ifc)
+
+        walls_before = {w.id() for w in ifc.by_type("IfcWall")}
+        bpy.ops.bim.add_occurrence(relating_type_id=wall_type.id())
+        source_wall = next(w for w in ifc.by_type("IfcWall") if w.id() not in walls_before)
+        source_obj = tool.Ifc.get_object(source_wall)
+        tool.Blender.set_objects_selection(bpy.context, source_obj, (source_obj,))
+
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        bpy.context.scene.cursor.location = source_obj.matrix_world @ mathutils.Vector((0.5, 2.0, 0.0))
+        result = bpy.ops.bim.add_perpendicular_wall()
+        assert result == {"FINISHED"}
+
+        new_wall = next(w for w in ifc.by_type("IfcWall") if w.id() not in walls_before and w.id() != source_wall.id())
+        body = ifcopenshell.util.representation.get_representation(new_wall, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+
+class TestSlabRepresentationOnImportedFile(NewFile):
+    """slab.py mirrors the same crash in DumbSlabGenerator.generate() and in
+    DumbSlabPlaner.change_thickness() when an occurrence has no Body
+    representation of its own to fall back on."""
+
+    def strip_subcontexts(self, ifc: ifcopenshell.file) -> None:
+        for subcontext in ifc.by_type("IfcGeometricRepresentationSubContext"):
+            ifcopenshell.api.context.remove_context(ifc, context=subcontext)
+
+    def get_slab_type(self, ifc: ifcopenshell.file) -> ifcopenshell.entity_instance:
+        return next(t for t in ifc.by_type("IfcSlabType") if tool.Model.get_usage_type(t) == "LAYER3")
+
+    def test_creating_a_slab_on_a_file_with_no_subcontexts(self):
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        slab_type = self.get_slab_type(ifc)
+        slabs_before = {s.id() for s in ifc.by_type("IfcSlab")}
+        result = bpy.ops.bim.add_occurrence(relating_type_id=slab_type.id())
+        assert result == {"FINISHED"}
+
+        slab = next(s for s in ifc.by_type("IfcSlab") if s.id() not in slabs_before)
+        body = ifcopenshell.util.representation.get_representation(slab, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+    def test_not_creating_duplicate_body_contexts_on_a_second_slab(self):
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        slab_type = self.get_slab_type(ifc)
+
+        bpy.ops.bim.add_occurrence(relating_type_id=slab_type.id())
+        bpy.ops.bim.add_occurrence(relating_type_id=slab_type.id())
+
+        body_subcontexts = [
+            sc
+            for sc in ifc.by_type("IfcGeometricRepresentationSubContext")
+            if sc.ContextIdentifier == "Body" and sc.TargetView == "MODEL_VIEW"
+        ]
+        assert len(body_subcontexts) == 1
+
+    def test_change_thickness_recreates_missing_body_context(self):
+        from bonsai.bim.module.model.slab import DumbSlabPlaner
+
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        slab_type = self.get_slab_type(ifc)
+        slabs_before = {s.id() for s in ifc.by_type("IfcSlab")}
+        bpy.ops.bim.add_occurrence(relating_type_id=slab_type.id())
+        slab = next(s for s in ifc.by_type("IfcSlab") if s.id() not in slabs_before)
+
+        # Simulate an occurrence with no body representation of its own, as
+        # an externally authored import might have.
+        existing_rep = ifcopenshell.util.representation.get_representation(slab, "Model", "Body", "MODEL_VIEW")
+        assert existing_rep is not None
+        ifcopenshell.util.element.remove_deep2(ifc, existing_rep)
+        slab.Representation.Representations = tuple(r for r in slab.Representation.Representations if r != existing_rep)
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        layer_params = tool.Model.get_material_layer_parameters(slab)
+        DumbSlabPlaner().change_thickness(slab, layer_params["thickness"] * 2)
+
+        body = ifcopenshell.util.representation.get_representation(slab, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
 
 
 class TestGetSiblingOccurrenceCount(NewFile):

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -1032,6 +1032,44 @@ class TestGetOrCreateContext(NewFile):
         assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
 
 
+class TestWindowRepresentationOnImportedFile(NewFile):
+    """window.py mirrors the door crash fixed above: it looked up
+    Model/Body/MODEL_VIEW directly and passed a possibly-None context
+    into add_window_representation, which crashes on .TargetView."""
+
+    def strip_subcontexts(self, ifc: ifcopenshell.file) -> None:
+        for subcontext in ifc.by_type("IfcGeometricRepresentationSubContext"):
+            ifcopenshell.api.context.remove_context(ifc, context=subcontext)
+
+    def test_creating_a_window_on_a_file_with_no_subcontexts(self):
+        tool.Project.get_project_props().template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        result = bpy.ops.mesh.add_window()
+        assert result == {"FINISHED"}
+
+        obj = bpy.context.view_layer.objects.active
+        element = tool.Ifc.get_entity(obj)
+        body = ifcopenshell.util.representation.get_representation(element, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+    def test_not_creating_duplicate_body_contexts_on_a_second_window(self):
+        tool.Project.get_project_props().template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+
+        bpy.ops.mesh.add_window()
+        bpy.context.view_layer.objects.active = None
+        bpy.ops.mesh.add_window()
+
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
+
+
 class TestGetSiblingOccurrenceCount(NewFile):
     """The pen-icon dispatcher's pre-edit warning depends on this count: zero
     means the edit is safe (unique geometry), non-zero means the edit will

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -1217,6 +1217,72 @@ class TestSlabRepresentationOnImportedFile(NewFile):
         assert body.Items
 
 
+class TestRailingRepresentationOnImportedFile(NewFile):
+    """railing.py mirrors the same crash: BIM_OT_add_railing and the
+    WALL_MOUNTED_HANDRAIL branch of update_railing_modifier_ifc_data both
+    looked up Model/Body/MODEL_VIEW directly."""
+
+    def strip_subcontexts(self, ifc: ifcopenshell.file) -> None:
+        for subcontext in ifc.by_type("IfcGeometricRepresentationSubContext"):
+            ifcopenshell.api.context.remove_context(ifc, context=subcontext)
+
+    def test_creating_a_railing_on_a_file_with_no_subcontexts(self):
+        tool.Project.get_project_props().template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        result = bpy.ops.mesh.add_railing()
+        assert result == {"FINISHED"}
+
+        railing = ifc.by_type("IfcRailing")[0]
+        body = ifcopenshell.util.representation.get_representation(railing, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+    def test_not_creating_duplicate_body_contexts_on_a_second_railing(self):
+        tool.Project.get_project_props().template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+
+        bpy.ops.mesh.add_railing()
+        bpy.context.view_layer.objects.active = None
+        tool.Blender.set_objects_selection(bpy.context, None, ())
+        bpy.ops.mesh.add_railing()
+
+        body_subcontexts = [
+            sc
+            for sc in ifc.by_type("IfcGeometricRepresentationSubContext")
+            if sc.ContextIdentifier == "Body" and sc.TargetView == "MODEL_VIEW"
+        ]
+        assert len(body_subcontexts) == 1
+
+    def test_wall_mounted_handrail_recreates_missing_body_context(self):
+        from bonsai.bim.module.model.railing import update_railing_modifier_ifc_data
+
+        tool.Project.get_project_props().template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        bpy.ops.mesh.add_railing()
+        railing = ifc.by_type("IfcRailing")[0]
+        obj = tool.Ifc.get_object(railing)
+        tool.Blender.set_objects_selection(bpy.context, obj, (obj,))
+        props = tool.Model.get_railing_props(obj)
+        props.railing_type = "WALL_MOUNTED_HANDRAIL"
+        props.path_data = '{"edges": [[0, 1]], "verts": [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]}'
+
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        update_railing_modifier_ifc_data(bpy.context)
+
+        body = ifcopenshell.util.representation.get_representation(railing, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+
 class TestGetSiblingOccurrenceCount(NewFile):
     """The pen-icon dispatcher's pre-edit warning depends on this count: zero
     means the edit is safe (unique geometry), non-zero means the edit will

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import bpy
 import ifcopenshell
+import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.material
 import ifcopenshell.api.pset
@@ -959,6 +960,47 @@ class TestOffsetWall(NewFile):
         usage.DirectionSense = "NEGATIVE"
         subject.offset_wall(obj, "EXTERIOR")
         assert usage.OffsetFromReferenceLine == 100
+
+
+class TestGetBodyContext(NewFile):
+    def create_imported_file(self) -> ifcopenshell.file:
+        """An IFC as exported by other authoring tools: a Model context, no subcontexts."""
+        ifc = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="Project")
+        context = ifcopenshell.api.context.add_context(ifc, context_type="Model")
+        context.ContextIdentifier = "Plan"
+        tool.Ifc.set(ifc)
+        return ifc
+
+    def test_returning_the_existing_body_subcontext(self):
+        ifc = self.create_imported_file()
+        parent = ifcopenshell.util.representation.get_context(ifc, "Model")
+        body = ifcopenshell.api.context.add_context(
+            ifc, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=parent
+        )
+        assert subject.get_body_context() == body
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
+
+    def test_creating_the_body_subcontext_if_the_file_has_none(self):
+        ifc = self.create_imported_file()
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+        body = subject.get_body_context()
+        assert body.ContextType == "Model"
+        assert body.ContextIdentifier == "Body"
+        assert body.TargetView == "MODEL_VIEW"
+        assert body.ParentContext == ifcopenshell.util.representation.get_context(ifc, "Model")
+
+    def test_creating_the_model_context_if_the_file_has_none(self):
+        ifc = ifcopenshell.file()
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="Project")
+        tool.Ifc.set(ifc)
+        body = subject.get_body_context()
+        assert body.ParentContext == ifcopenshell.util.representation.get_context(ifc, "Model")
+
+    def test_not_creating_duplicates_on_repeated_calls(self):
+        ifc = self.create_imported_file()
+        assert subject.get_body_context() == subject.get_body_context()
+        assert len(ifc.by_type("IfcGeometricRepresentationSubContext")) == 1
 
 
 class TestGetSiblingOccurrenceCount(NewFile):

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -1326,6 +1326,82 @@ class TestRoofRepresentationOnImportedFile(NewFile):
         assert len(body_subcontexts) == 1
 
 
+class TestProfileRepresentationOnImportedFile(NewFile):
+    """profile.py mirrors the same crash: DumbProfileGenerator.generate()
+    and DumbProfileJoiner.unjoin() (via recreate_profile) both looked up
+    Model/Body/MODEL_VIEW directly."""
+
+    def strip_subcontexts(self, ifc: ifcopenshell.file) -> None:
+        for subcontext in ifc.by_type("IfcGeometricRepresentationSubContext"):
+            ifcopenshell.api.context.remove_context(ifc, context=subcontext)
+
+    def get_profile_type(self, ifc: ifcopenshell.file) -> ifcopenshell.entity_instance:
+        for t in ifc.by_type("IfcColumnType") + ifc.by_type("IfcBeamType") + ifc.by_type("IfcMemberType"):
+            material = ifcopenshell.util.element.get_material(t)
+            if material and material.is_a("IfcMaterialProfileSet"):
+                return t
+        assert False, "no profile-set type found in template"
+
+    def test_creating_a_profile_occurrence_on_a_file_with_no_subcontexts(self):
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        profile_type = self.get_profile_type(ifc)
+        element_class = profile_type.is_a()[:-4]
+        elems_before = {e.id() for e in ifc.by_type(element_class)}
+        result = bpy.ops.bim.add_occurrence(relating_type_id=profile_type.id())
+        assert result == {"FINISHED"}
+
+        elem = next(e for e in ifc.by_type(element_class) if e.id() not in elems_before)
+        body = ifcopenshell.util.representation.get_representation(elem, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+    def test_not_creating_duplicate_body_contexts_on_a_second_occurrence(self):
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        profile_type = self.get_profile_type(ifc)
+
+        bpy.ops.bim.add_occurrence(relating_type_id=profile_type.id())
+        bpy.context.view_layer.objects.active = None
+        tool.Blender.set_objects_selection(bpy.context, None, ())
+        bpy.ops.bim.add_occurrence(relating_type_id=profile_type.id())
+
+        body_subcontexts = [
+            sc
+            for sc in ifc.by_type("IfcGeometricRepresentationSubContext")
+            if sc.ContextIdentifier == "Body" and sc.TargetView == "MODEL_VIEW"
+        ]
+        assert len(body_subcontexts) == 1
+
+    def test_unjoin_on_a_file_with_no_subcontexts(self):
+        tool.Project.get_project_props().template_file = "IFC4 Demo Template.ifc"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        profile_type = self.get_profile_type(ifc)
+        element_class = profile_type.is_a()[:-4]
+        elems_before = {e.id() for e in ifc.by_type(element_class)}
+        bpy.ops.bim.add_occurrence(relating_type_id=profile_type.id())
+        elem = next(e for e in ifc.by_type(element_class) if e.id() not in elems_before)
+        obj = tool.Ifc.get_object(elem)
+        tool.Blender.set_objects_selection(bpy.context, obj, (obj,))
+
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        result = bpy.ops.bim.extend_profile(join_type="-")
+        assert result == {"FINISHED"}
+
+        body = ifcopenshell.util.representation.get_representation(elem, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+
 class TestGetSiblingOccurrenceCount(NewFile):
     """The pen-icon dispatcher's pre-edit warning depends on this count: zero
     means the edit is safe (unique geometry), non-zero means the edit will

--- a/src/bonsai/test/tool/test_model.py
+++ b/src/bonsai/test/tool/test_model.py
@@ -1283,6 +1283,49 @@ class TestRailingRepresentationOnImportedFile(NewFile):
         assert body.Items
 
 
+class TestRoofRepresentationOnImportedFile(NewFile):
+    """roof.py mirrors the same crash: BIM_OT_add_roof looked up
+    Model/Body/MODEL_VIEW directly and passed a possibly-None context into
+    root.assign_class, which asserts on it."""
+
+    def strip_subcontexts(self, ifc: ifcopenshell.file) -> None:
+        for subcontext in ifc.by_type("IfcGeometricRepresentationSubContext"):
+            ifcopenshell.api.context.remove_context(ifc, context=subcontext)
+
+    def test_creating_a_roof_on_a_file_with_no_subcontexts(self):
+        tool.Project.get_project_props().template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+        assert ifcopenshell.util.representation.get_context(ifc, "Model", "Body", "MODEL_VIEW") is None
+
+        result = bpy.ops.mesh.add_roof()
+        assert result == {"FINISHED"}
+
+        roof = ifc.by_type("IfcRoof")[0]
+        body = ifcopenshell.util.representation.get_representation(roof, "Model", "Body", "MODEL_VIEW")
+        assert body is not None
+        assert body.Items
+
+    def test_not_creating_duplicate_body_contexts_on_a_second_roof(self):
+        tool.Project.get_project_props().template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc = tool.Ifc.get()
+        self.strip_subcontexts(ifc)
+
+        bpy.ops.mesh.add_roof()
+        bpy.context.view_layer.objects.active = None
+        tool.Blender.set_objects_selection(bpy.context, None, ())
+        bpy.ops.mesh.add_roof()
+
+        body_subcontexts = [
+            sc
+            for sc in ifc.by_type("IfcGeometricRepresentationSubContext")
+            if sc.ContextIdentifier == "Body" and sc.TargetView == "MODEL_VIEW"
+        ]
+        assert len(body_subcontexts) == 1
+
+
 class TestGetSiblingOccurrenceCount(NewFile):
     """The pen-icon dispatcher's pre-edit warning depends on this count: zero
     means the edit is safe (unique geometry), non-zero means the edit will


### PR DESCRIPTION
**Depends on #8995 and #9201.** This is the rest of the same defect, so the diff includes their commits.

Issue #8081 was reported as an error creating a door type. It was never a door bug. **Authoring almost anything into an imported IFC that lacks a `Model/Body/MODEL_VIEW` subcontext crashes**, because `get_context(...)` returns `None` and the code downstream dereferences it. Bonsai-authored projects always create the subcontext, so none of this appears on native models. The axis is imported versus authored, not IFC4 versus IFC2X3.

Door was #8995, window was #9201. This covers the rest.

### What was fixed, all verified in headless Blender

| Site | Crash | After |
|---|---|---|
| `wall.py:1256` `DumbWallGenerator.generate` | `AttributeError: 'NoneType' object has no attribute 'ContextIdentifier'` | 8 verts / 12 polys |
| `wall.py:2690` `AddPerpendicularWall` | same, via `create_wall()` | creates exactly one Body subcontext |
| `slab.py:64` `DumbSlabGenerator.generate` | same | 8 verts / 12 polys |
| `slab.py:255` `DumbSlabPlaner.change_thickness` | same | geometry created, no crash |
| `railing.py:99` wall-mounted handrail | `AttributeError` in `add_railing_representation` | 96 verts / 180 polys |
| `railing.py:378` `BIM_OT_add_railing` | `AssertionError: Context is required for adding a representation` | 20 verts / 32 polys |
| `roof.py:553` `BIM_OT_add_roof` | same `AssertionError` | 10 verts / 16 polys |
| `profile.py:68` `DumbProfileGenerator.generate` | `ContextIdentifier` crash for columns, beams, members | 8 verts / 12 polys |
| `profile.py:318` `DumbProfileJoiner.unjoin` | same, via the unjoin operator | survives reload |

Every case was checked for real geometry, survival across save and reload, idempotency (no duplicate subcontexts on a second element), and no effect on a fresh Bonsai project.

All nine reuse `tool.Model.get_body_context()` from #8995. **No new helper was written.** The fix creates the missing subcontext as an authored project would; guarding and skipping would leave a silently bodyless element, which is worse than the crash.

### Two sites deliberately not fixed, because they are dead code

* `wall.py:1534` `DumbWallJoiner.__init__` assigns `self.body_context` and **never reads it anywhere in the class**, confirmed by a full-file grep.
* `opening.py:374` sits behind `reuse_mapped_representation`, which is hardcoded `False` at line 356 and never reassigned; only two occurrences exist in the file.

### Four sites left for a follow-up

`mep.py:543,1098,1506,1667`. All four are deep in bend, transition and obstruction fitting generation and need a real connected duct or pipe segment with profile and ports. No demo template ships one. The same pattern would almost certainly apply, but **it is not claimed as verified because it was not run**, and a fix nobody has exercised is not something to put in front of a reviewer.

### Tests

`pytest test/tool/test_model.py` → **55 passed** (41 baseline plus 14 new, across `TestWallRepresentationOnImportedFile`, `TestSlab...`, `TestRailing...`, `TestRoof...`, `TestProfile...`).
`pytest test/core` → **390 passed**. `pytest test/bim/module/model` → **530 passed**. No new failures.

Generated with the assistance of an AI coding tool.
