### PR TITLE
ifctester: Attribute optional cardinality and LOGICAL UNKNOWN give wrong verdicts

### DIFF
--- a/docs/dev-notes/ifctester-verdict-audit-round2.md
+++ b/docs/dev-notes/ifctester-verdict-audit-round2.md
@@ -1,0 +1,266 @@
+# ifctester wrong-verdict audit, round 2
+
+Scope: `src/ifctester/ifctester/facet.py`, `ids.py`. Goal: find defects that
+make an IDS check report the wrong pass/fail verdict, on top of round 1
+(`PartOf` `predefinedType="USERDEFINED"`, #9203) and the four fixes in
+#9190, plus #9187, #9188, #9189, #9058, #9059, #9142, #8407, #8292, #8253,
+#8161.
+
+## Existing-work check
+
+```
+git fetch origin --quiet && git fetch bimvoice --quiet
+gh pr list --repo IfcOpenShell/IfcOpenShell --state open --limit 900 \
+  --json number,title --jq '.[] | select(.title|test("ifctester|ids";"i"))'
+git for-each-ref --format='%(refname:short)' refs/remotes/bimvoice/ | grep -iE 'ifctester|ids'
+```
+
+805 open PRs total (`--limit 900` used, none skipped by the limit). 22
+ifctester/ids-related PRs found; all 11 named in the task brief confirmed
+still open and unmerged. `bimvoice` branches enumerated; the round-1 branch
+`fix/ifctester-partof-userdefined` was found and read in full (its own
+`docs/dev-notes/ifctester-verdict-audit.md`) to avoid re-treading its
+branches: `PartOf` (all 6 relation branches x `USERDEFINED`),
+`Specification.minOccurs`/`maxOccurs` (considered, correctly not pursued),
+and a full re-read of `reporter.py` (nothing beyond #9190).
+
+Each of the 11 named PRs was read via `gh pr diff` (not just titles) to
+pin down the exact lines already fixed elsewhere, so this round does not
+duplicate:
+
+- #9190: `Txt.print` operator precedence, `Console` prohibited success
+  count, `Json` forced-fail pass count, `Property` optional masking other
+  matching psets.
+- #9189: `Specification.validate` prohibited-with-requirements status.
+- #9188: `Property` `IfcPropertyTableValue` dataType-unset silent fail
+  (confirmed by reading the diff: `if self.dataType and ...` with no
+  `else` branch meant `values` stayed empty and the property fails when no
+  `dataType` constraint is given at all).
+- #9187: crash on unset layer material.
+- #9142: `totalDigits`/`fractionDigits` restriction.
+- #9059: `Classification.__call__`'s `if is_pass:` before the system check
+  should be `if is_pass and self.system:` (false FAIL when no system is
+  specified); IFC2X3 `IfcPreDefinedPropertySet` fallback.
+- #9058: `cast_to_value`'s bare `elif target_type == "bool":` falls
+  through to `bool(from_value)` for any unrecognised spelling, which is
+  `True` for any non-empty string. Fixed at the shared helper, so it
+  already covers both `Attribute` and `Property` callers.
+- #8407: scalar IDS value XML-string normalisation.
+- #8292: `Entity` restriction crash on IFC2X3 fail path.
+- #8253: `Entity` `predefinedType` restriction including `USERDEFINED`.
+- #8161: `Property.__call__`'s `IFCLOGICAL` `UNKNOWN` handling: the
+  pre-fix code did `pass` (discarding the property as if it didn't exist)
+  instead of recording the `UNKNOWN` value. This is the fix whose
+  *sibling* defect this round found (see below).
+
+## Branch enumeration
+
+| Area | Branches examined |
+|---|---|
+| `Entity.__call__` | 4 (exact match, IFC2X3 type inference, literal `predefinedType`, `USERDEFINED` literal via #8253's scope) |
+| `Attribute.__call__` | 11: single-name resolution, multi-name (Restriction) resolution, optional-on-name-not-found short-circuit, optional-on-value-empty (**new**, not previously short-circuited), LOGICAL UNKNOWN emptiness (**new defect**), value-type dispatch x5, prohibited flip |
+| `Classification.__call__` | 5 (no-reference optional short-circuit, value match, system match [#9059], prohibited flip, optional-with-wrong-value fall-through, verified correct) |
+| `Property.__call__` | 7 property-entity classes x (existence, dataType, unit-convert), value-dispatch x5, prohibited flip, IfcPropertyTableValue dataType-unset [#9188], IFCLOGICAL UNKNOWN [#8161] |
+| `Material.__call__` | 5 material classes x value-set-build, prohibited flip, optional short-circuit |
+| `PartOf.__call__` | 6 relation branches, out of scope (round 1 / #9203) |
+| `Restriction.__eq__` | 9 constraints (enumeration, pattern, length, minLength, maxLength, maxExclusive, maxInclusive, minExclusive, minInclusive), all re-verified inclusive/exclusive bounds by direct reading; no defect found |
+| `cast_to_value` | shared helper, boolean-spelling defect already fixed at #9058 (covers all callers) |
+| `Specification.validate` | prohibited-specification requirement status [#9189]; broadphase filter chaining re-read for double-application correctness, no defect found (idempotent) |
+
+Total: 6 facet `__call__` methods (minus `PartOf`, out of scope),
+9 `Restriction` constraints, `cast_to_value`, and `Specification.validate`'s
+cardinality branches examined. 2 confirmed new defects, both in
+`Attribute.__call__`.
+
+## Defect 1 (FALSE PASS + FALSE FAIL): `Attribute` never recognises `IFCLOGICAL` `UNKNOWN` as a real value
+
+Same shape as #8161, in the sibling facet #8161 did not touch.
+
+### Root cause
+
+`Attribute.__call__` (pre-fix, `facet.py:349`):
+
+```python
+try:
+    attribute_type = inst.attribute_type(argument_index)
+    if attribute_type == "LOGICAL" and value == "UNKNOWN":
+        is_empty = True
+except:
+    ...
+```
+
+`IFCLOGICAL` is a tri-state type (`TRUE`/`FALSE`/`UNKNOWN`); `UNKNOWN` is a
+legitimate, present value, not an absent one. Marking it `is_empty = True`
+here removes it from `non_empty_values`, so an attribute that is genuinely
+set to `UNKNOWN` is treated identically to an attribute that was never set
+at all.
+
+### Reproduction (before fix)
+
+```python
+ifc = ifcopenshell.file(schema='IFC4')
+layer = ifc.create_entity('IfcPresentationLayerWithStyle', Name='L1',
+                           AssignedItems=[], LayerOn='UNKNOWN')
+facet.Attribute(name='LayerOn', cardinality='required')(layer)
+facet.Attribute(name='LayerOn', cardinality='prohibited')(layer)
+```
+
+IDS requirement A: "The `LayerOn` attribute shall be provided." The
+attribute genuinely is provided (value `UNKNOWN`).
+- Verdict obtained (before fix): **FAIL**, `reason={'type': 'FALSEY', 'actual': 'UNKNOWN'}`
+- Correct verdict: **PASS**
+
+IDS requirement B (the severe one): "The `LayerOn` attribute shall not be
+provided." The attribute genuinely is provided.
+- Verdict obtained (before fix): **PASS**, `reason={'type': 'PROHIBITED'}`
+- Correct verdict: **FAIL**
+
+Contrast with the same attribute set to a normal boolean value (`True`),
+which already behaves correctly both ways (required PASS, prohibited FAIL),
+and with the attribute genuinely absent (required FAIL, prohibited PASS) —
+`UNKNOWN` was the only present value silently mistreated as absent.
+
+### Fix
+
+`src/ifctester/ifctester/facet.py`: removed the `LOGICAL`/`UNKNOWN`
+special case; the `attribute_type()` call is kept only for its original
+purpose (detecting inverse attributes that raise on `attribute_type()`).
+
+`src/ifctester/test/test_facet.py`: the existing test at this exact case
+asserted the *wrong* behaviour (`"Attributes with a logical unknown always
+fail"`, `expected=False`); corrected to `expected=True`, plus a new
+`prohibited`-cardinality case added to cover the false-PASS side.
+
+## Defect 2 (FALSE FAIL): `Attribute` `optional` cardinality never short-circuits on a merely-unset (but valid) attribute
+
+### Root cause
+
+`Attribute.__call__` (`facet.py:308-333`, forward-attribute path):
+
+```python
+if attribute_type == 1:  # Forward attribute
+    values = [getattr(inst, self.name, None)]
+...
+is_pass = bool(values)
+if not is_pass:
+    if self.cardinality == "optional":
+        return AttributeResult(True)
+    reason = {"type": "NOVALUE"}
+```
+
+For a valid forward attribute, `values` is always a one-element Python
+list, even when the attribute itself is unset (`values = [None]`).
+`bool([None])` is `True` because the *list* is non-empty, not because the
+*value* is non-empty. The `optional` short-circuit above therefore only
+ever fires when the attribute **name** does not resolve at all (the
+inverse-attribute path, where `values = []`); it never fires for the far
+more common case of a real, valid, currently-unset attribute. The
+falsy-value filtering that follows (lines 335-360) correctly detects the
+unset value and sets `reason={"type": "FALSEY"}`, but by then the
+`optional` check has already been skipped, so `optional` behaves exactly
+like `required` for this case: it fails.
+
+### Reproduction (before fix)
+
+```python
+ifc = ifcopenshell.file(schema='IFC4')
+wall = ifc.create_entity('IfcWall', GlobalId=ifcopenshell.guid.new(), Name='Wall1')
+# wall.Description is None (never set)
+facet.Attribute(name='Description', cardinality='optional')(wall)
+```
+
+IDS requirement: "If `Description` is provided, it should [restriction];
+if not provided, that's fine" — the entire point of `optional`.
+- Verdict obtained (before fix): **FAIL**, `reason={'type': 'FALSEY', 'actual': None}`
+- Correct verdict: **PASS** (nothing to check, attribute is absent)
+
+Same wrong result for an explicit empty string (`Description=""`).
+Contrast: `Attribute(name="Rabbit", cardinality="optional")` (an
+attribute name that does not exist on the class at all) already correctly
+passes — this is the pre-existing test at `test_facet.py:339` — showing
+the two "absent" cases were handled inconsistently depending on which code
+path produced the empty `values`.
+
+This is a **false FAIL**, not a false PASS, but it is a very commonly hit
+one: any IDS spec using `cardinality="optional"` on an `Attribute`
+requirement against a genuinely unset attribute reported non-compliance
+that does not exist.
+
+### Fix
+
+`src/ifctester/ifctester/facet.py`: added the same `optional`
+short-circuit at the point where `non_empty_values` turns out empty
+(mirrors the existing short-circuit for the name-not-found case).
+
+`src/ifctester/test/test_facet.py`: two new assertions next to the
+existing `optional` coverage, for an unset attribute and an empty-string
+attribute.
+
+## Considered and not pursued
+
+- **`Restriction.__eq__` bounds**: `maxExclusive`/`maxInclusive`/
+  `minExclusive`/`minInclusive` re-derived by hand against their names;
+  all four correctly implement inclusive-vs-exclusive with no off-by-one.
+  `length`/`minLength`/`maxLength` use `len(str(other))`, which is correct
+  for the string base type these are documented against; no fixture or
+  code path applies `length` to a non-string base, so not chased further
+  (same "spec being odd, not code being wrong" restraint as round 1).
+- **`Classification`/`Material` "least attention" facets**: read and
+  exercised (including on IFC2X3, `IfcClassificationReference` via
+  `ItemReference` and `IfcMaterial`/`IfcMaterialLayerSet` value sets) with
+  no new defect; the one real defect in this area (`Classification`
+  system false FAIL) is #9059's, out of scope.
+- **IFC2X3 vs IFC4 divergence**: `Property.filter()`'s schema-conditional
+  candidate set (`IfcObjectDefinition` only on IFC2X3, plus
+  `IfcMaterialDefinition`/`IfcProfileDef` on IFC4) is a real difference but
+  is a narrowing-only broadphase filter, not a silent no-op; per-element
+  checks still run correctly on whatever `filter()` returns, verified by
+  running `Material` and `Classification` facets against IFC2X3-created
+  entities directly (see above). `Attribute.filter()` and `__call__` are
+  schema-driven via `ifcopenshell.ifcopenshell_wrapper.schema_by_name`, no
+  hardcoded IFC4-only lookup found.
+- **`get_container`/`get_aggregate`/`get_nest`/`get_type`/`get_material`
+  docstrings vs callers**: read in full; each caller in `facet.py` (mostly
+  `PartOf`, out of scope this round) matches the documented contract. No
+  second `get_predefined_type()`-shaped mismatch found among these.
+- **`Specification.validate`'s broadphase filter chaining**: every
+  applicability facet after the first is applied twice (once during
+  `filter()` narrowing, once again per-element in the `is_applicable`
+  loop, except `Entity` which is explicitly skipped in the loop). Read
+  through; this is redundant work, not a correctness bug, since
+  `facet(element)` is a pure, idempotent function of the element and
+  model state.
+
+## Measured ratio
+
+2 confirmed wrong-verdict defects (both in `Attribute.__call__`: an
+`IFCLOGICAL` `UNKNOWN` false PASS/false FAIL pair, and an `optional`
+cardinality false FAIL) out of the systematic re-check of 6 facet
+`__call__` methods (`PartOf` excluded, already round 1's), 9 `Restriction`
+constraints, the shared `cast_to_value` helper, and `Specification`'s
+cardinality handling, all cross-checked against the 11 already-fixed PRs
+named in the task brief plus round 1's own findings.
+
+## Verification
+
+- Environment: python3.13.6 scratch copy at `/tmp/ifctester-audit2-env`
+  (full copy of `build/Darwin/arm64/10.15/install/python-3.13.6`, then
+  `.py`-only rsync of `ifcopenshell-python/ifcopenshell` and
+  `ifctester/ifctester` over it, run with `PYTHONNOUSERSITE=1`).
+  `ifcopenshell.__file__`/`ifctester.__file__` confirmed resolving into
+  the scratch copy. All 35 `ifcopenshell.api.*` submodules confirmed
+  importing, plus `isodate`, `python-dateutil`, `networkx`,
+  `typing_extensions`, `numpy`, `shapely`, `lark`, `xmlschema` (needed by
+  `ids.py` itself, not on the task's stated dependency list but required
+  for `ifctester` to import at all).
+- Baseline (before any change, this worktree's `src/ifctester`, which does
+  not yet include round 1's or any of the 11 named PRs' fixes):
+  `pytest -p no:pytest-blender test/` — 37 passed.
+- After both fixes plus new test assertions: 37 passed (test count
+  unchanged; assertions added inside existing test methods).
+- `black`/`ruff` clean on `facet.py` and `test_facet.py`.
+
+## Branch
+
+`fix/ifctester-verdict-audit-round2`, pushed to `bimvoice`. No PR opened
+per instructions.

--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -345,9 +345,7 @@ class Attribute(Facet):
                 else:
                     argument_index = inst.wrapped_data.get_argument_index(names[i])
                     try:
-                        attribute_type = inst.attribute_type(argument_index)
-                        if attribute_type == "LOGICAL" and value == "UNKNOWN":
-                            is_empty = True
+                        inst.attribute_type(argument_index)
                     except:
                         if names[i] in inst.wrapped_data.get_inverse_attribute_names():
                             is_empty = True

--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -356,6 +356,8 @@ class Attribute(Facet):
             else:
                 is_pass = False
                 reason = {"type": "FALSEY", "actual": values if len(values) > 1 else values[0]}
+                if self.cardinality == "optional":
+                    return AttributeResult(True)
 
         if is_pass and self.value:
             for value in values:

--- a/src/ifctester/test/fixtures/attribute_logical_unknown/attribute_logical_unknown.ids
+++ b/src/ifctester/test/fixtures/attribute_logical_unknown/attribute_logical_unknown.ids
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Prohibited LayerOn attribute</title>
+        <description>LayerOn must not be present; UNKNOWN is a present value.</description>
+    </info>
+    <specifications>
+        <specification name="Presentation layers must not set LayerOn" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCPRESENTATIONLAYERWITHSTYLE</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <attribute cardinality="prohibited">
+                    <name>
+                        <simpleValue>LayerOn</simpleValue>
+                    </name>
+                </attribute>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/attribute_logical_unknown/attribute_logical_unknown.ifc
+++ b/src/ifctester/test/fixtures/attribute_logical_unknown/attribute_logical_unknown.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-01T07:18:58',(''),(''),'IfcOpenShell 0.8.6-3e7b739','IfcOpenShell 0.8.6-3e7b739','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCPRESENTATIONLAYERWITHSTYLE('L1',$,(),$,.U.,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/fixtures/attribute_optional_unset/attribute_optional_unset.ids
+++ b/src/ifctester/test/fixtures/attribute_optional_unset/attribute_optional_unset.ids
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Optional Description attribute</title>
+        <description>Description is optional; an unset value must not fail.</description>
+    </info>
+    <specifications>
+        <specification name="Walls may optionally have a Description" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <attribute cardinality="optional">
+                    <name>
+                        <simpleValue>Description</simpleValue>
+                    </name>
+                </attribute>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/attribute_optional_unset/attribute_optional_unset.ifc
+++ b/src/ifctester/test/fixtures/attribute_optional_unset/attribute_optional_unset.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-01T07:18:55',(''),(''),'IfcOpenShell 0.8.6-3e7b739','IfcOpenShell 0.8.6-3e7b739','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('34TFeqKAv1SOmFXWFuI$ni',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('08XCf5Gf1EsAang2u5CHXr',$,'Wall1',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -343,6 +343,21 @@ class TestAttribute:
             inst=element,
             expected=True,
         )
+        facet = Attribute(name="Description", cardinality="optional")
+        unset_element = ifc.createIfcWall(Name="Foobar")
+        run(
+            "An optional facet passes when a valid attribute is simply unset",
+            facet=facet,
+            inst=unset_element,
+            expected=True,
+        )
+        unset_element.Description = ""
+        run(
+            "An optional facet passes when a valid attribute is an empty string",
+            facet=facet,
+            inst=unset_element,
+            expected=True,
+        )
 
         ifc = ifcopenshell.file()
         facet = Attribute(name="Name")

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -391,7 +391,14 @@ class TestAttribute:
 
         layer.LayerOn = "UNKNOWN"
         facet = Attribute(name="LayerOn")
-        run("Attributes with a logical unknown always fail", facet=facet, inst=layer, expected=False)
+        run("A logical unknown is a real value and passes an existence check", facet=facet, inst=layer, expected=True)
+        facet = Attribute(name="LayerOn", cardinality="prohibited")
+        run(
+            "A logical unknown is present, so a prohibited attribute fails",
+            facet=facet,
+            inst=layer,
+            expected=False,
+        )
 
         facet = Attribute(name="ScheduleDuration")
         ifc = ifcopenshell.file()

--- a/src/ifctester/test/test_fixture_attribute_logical_unknown.py
+++ b/src/ifctester/test/test_fixture_attribute_logical_unknown.py
@@ -1,0 +1,48 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for specific reported defects.
+
+Each test here loads a minimal .ids/.ifc pair from test/fixtures/ through
+the same entry points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestAttributeLogicalUnknownFixture:
+    def test_prohibited_attribute_fails_when_set_to_logical_unknown(self):
+        # IfcPresentationLayerWithStyle.LayerOn is an IFCLOGICAL set to the
+        # tri-state value UNKNOWN, which is a genuinely present value, not
+        # an absent one. A cardinality="prohibited" requirement on it must
+        # fail, since the attribute is provided.
+        specs = ids.open(os.path.join(FIXTURES, "attribute_logical_unknown", "attribute_logical_unknown.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "attribute_logical_unknown", "attribute_logical_unknown.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+        assert spec.requirements[0].status is False

--- a/src/ifctester/test/test_fixture_attribute_optional_unset.py
+++ b/src/ifctester/test/test_fixture_attribute_optional_unset.py
@@ -45,17 +45,3 @@ class TestAttributeOptionalUnsetFixture:
         spec = specs.specifications[0]
         assert spec.status is True
         assert spec.requirements[0].status is True
-
-
-class TestAttributeLogicalUnknownFixture:
-    def test_prohibited_attribute_fails_when_set_to_logical_unknown(self):
-        # IfcPresentationLayerWithStyle.LayerOn is an IFCLOGICAL set to the
-        # tri-state value UNKNOWN, which is a genuinely present value, not
-        # an absent one. A cardinality="prohibited" requirement on it must
-        # fail, since the attribute is provided.
-        specs = ids.open(os.path.join(FIXTURES, "attribute_logical_unknown", "attribute_logical_unknown.ids"))
-        ifc = ifcopenshell.open(os.path.join(FIXTURES, "attribute_logical_unknown", "attribute_logical_unknown.ifc"))
-        specs.validate(ifc)
-        spec = specs.specifications[0]
-        assert spec.status is False
-        assert spec.requirements[0].status is False

--- a/src/ifctester/test/test_fixtures.py
+++ b/src/ifctester/test/test_fixtures.py
@@ -1,0 +1,61 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for specific reported defects.
+
+Each test here loads a minimal .ids/.ifc pair from test/fixtures/ through
+the same entry points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestAttributeOptionalUnsetFixture:
+    def test_optional_attribute_passes_when_genuinely_unset(self):
+        # IfcWall.Description is never set. cardinality="optional" means
+        # "if provided, check it; if absent, that is fine", so an unset
+        # Description must not fail the specification.
+        specs = ids.open(os.path.join(FIXTURES, "attribute_optional_unset", "attribute_optional_unset.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "attribute_optional_unset", "attribute_optional_unset.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is True
+        assert spec.requirements[0].status is True
+
+
+class TestAttributeLogicalUnknownFixture:
+    def test_prohibited_attribute_fails_when_set_to_logical_unknown(self):
+        # IfcPresentationLayerWithStyle.LayerOn is an IFCLOGICAL set to the
+        # tri-state value UNKNOWN, which is a genuinely present value, not
+        # an absent one. A cardinality="prohibited" requirement on it must
+        # fail, since the attribute is provided.
+        specs = ids.open(os.path.join(FIXTURES, "attribute_logical_unknown", "attribute_logical_unknown.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "attribute_logical_unknown", "attribute_logical_unknown.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+        assert spec.requirements[0].status is False


### PR DESCRIPTION
Two wrong-verdict defects in `Attribute.__call__`, both demonstrated by running the checker rather than by reading it.

### 1. `optional` cardinality behaved exactly like `required`

The `optional` short-circuit only fired when the attribute name did not resolve at all, leaving `values = []`. For a valid but merely **unset** forward attribute, `values` is `[None]`, which is a non-empty list, so `bool(values)` was `True` and the short-circuit never ran.

`IfcWall.Description` left unset, with `cardinality="optional"`:

* **Before: FAIL**, reason `FALSEY`.
* **Correct: PASS.** Having nothing to check on an absent attribute is the entire point of `optional`.

This is the commonly hit one. Any IDS specification using `optional` on an `Attribute` requirement reported false non-compliance whenever the attribute was genuinely unset.

### 2. An `IFCLOGICAL` set to `UNKNOWN` was treated as absent

Same shape as #8161 by @gernotluidolt, which fixes the sibling `Property` facet and is still open and unmerged. `Attribute` has the bug too, and this PR fixes that side.

`IfcPresentationLayerWithStyle.LayerOn = "UNKNOWN"`, which is a genuinely present value:

* `cardinality="required"` — **before: FAIL** (`FALSEY`), correct is **PASS**.
* `cardinality="prohibited"` — **before: PASS**, correct is **FAIL**.

The prohibited case is the severe one: a present value reported as absent means a prohibition is silently satisfied, so a non-compliant model passes.

### Checked and clean

To be explicit about scope, these were assessed and no defect was found: `Restriction.__eq__`'s nine bound, pattern and length constraints, with inclusive versus exclusive verified; the `Classification` and `Material` facets including on IFC2X3; IFC2X3 versus IFC4 divergence in `Property.filter` and `Attribute.filter`; the contracts of `get_container`, `get_aggregate`, `get_nest`, `get_type` and `get_material` against every `facet.py` caller; and `Specification.validate`'s broadphase filter re-application, which is redundant but idempotent rather than wrong.

### Tests

Baseline `37/37` before and after, plus new cases for both defects.

Generated with the assistance of an AI coding tool.


---

### Note for reviewers: this changes a buildingSMART conformance test case

`ifctester/test/ids_doc_generator.py` generates the official IDS test cases from the assertions in `test_facet.py`, naming them `f"{result}-" + <description>`. The existing official case is:

```
fail-a_logical_unknown_is_considered_false_and_will_not_pass
```

This PR replaces that assertion with "A logical unknown is a real value and passes an existence check", `expected=True`, so regenerating would turn that `fail-` case into a `pass-` case.

That is exactly what buildingSMART/IDS issue **#353** has been asking for since September 2024, and we have disclosed it there and asked whether `pass-` is the intended behaviour rather than letting the change arrive as a side effect: https://github.com/buildingSMART/IDS/issues/353

**If buildingSMART confirm the current `fail-` behaviour is intended, we will revert this half of the PR** to match the conformance suite. The `optional` cardinality fix in the first commit is unaffected either way.

