### PR TITLE
geometry.unassign_representation: stop destroying shared geometry (#9207)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/geometry/unassign_representation.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/geometry/unassign_representation.py
@@ -46,18 +46,34 @@ class Usecase:
     def unassign_product_representation(
         self, product: ifcopenshell.entity_instance, representation: ifcopenshell.entity_instance
     ) -> None:
-        representations = list(product.Representation.Representations or [])
+        product_def = product.Representation
+        representations = list(product_def.Representations or [])
         if representation not in representations:
             return
         representations.remove(representation)
+
+        # product_def may be shared verbatim by other products (eg. some
+        # authoring tools reuse the same IfcProductDefinitionShape across
+        # occurrences, see #9207). Mutating it in place, or removing it once
+        # empty, would silently take the geometry away from every other
+        # owner too. Detach only this product onto its own definition
+        # instead, and leave the shared one untouched for its other owners.
+        if len(product_def.ShapeOfProduct) > 1:
+            if representations:
+                product.Representation = self.file.createIfcProductDefinitionShape(
+                    product_def.Name, product_def.Description, representations
+                )
+            else:
+                product.Representation = None
+            return
+
         if not representations:
-            product_def = product.Representation
             # TODO: should somehow find matching shape aspect and remove it
             # even before the last representation is removed.
             self.process_shape_aspects(product_def)
             self.file.remove(product_def)
         else:
-            product.Representation.Representations = representations
+            product_def.Representations = representations
 
     def unassign_type_representation(self) -> None:
         matching_representation_map = None

--- a/src/ifcopenshell-python/ifcopenshell/api/root/remove_product.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/root/remove_product.py
@@ -62,8 +62,10 @@ def remove_product(file: ifcopenshell.file, product: ifcopenshell.entity_instanc
     """
     representations: list[ifcopenshell.entity_instance] = []
     if product.is_a("IfcProduct"):
-        if product.Representation:
-            representations = product.Representation.Representations or []
+        # only remove representations if this product is their sole owner
+        product_def_shape = product.Representation
+        if product_def_shape and len(product_def_shape.ShapeOfProduct) == 1:
+            representations = product_def_shape.Representations or []
         else:
             representations = []
 

--- a/src/ifcopenshell-python/test/api/context/test_remove_context.py
+++ b/src/ifcopenshell-python/test/api/context/test_remove_context.py
@@ -61,6 +61,25 @@ class TestRemoveContext(test.bootstrap.IFC4):
         else:
             assert len([e for e in self.file]) == 1
 
+    def test_removing_a_context_used_by_two_products_sharing_one_shape(self):
+        # two products referencing the exact same IfcProductDefinitionShape
+        # (eg. Revit-authored files, #9207) must not crash and must not
+        # leak an orphaned representation once both are detached
+        context = self.file.createIfcGeometricRepresentationContext()
+        rep = self.file.createIfcRepresentation(ContextOfItems=context)
+        shape = self.file.createIfcProductDefinitionShape(Representations=[rep])
+        element_a = ifcopenshell.api.root.create_entity(self.file)
+        element_b = ifcopenshell.api.root.create_entity(self.file)
+        element_a.Representation = shape
+        element_b.Representation = shape
+
+        ifcopenshell.api.context.remove_context(self.file, context=context)
+
+        assert element_a.Representation is None
+        assert element_b.Representation is None
+        assert len(self.file.by_type("IfcProductDefinitionShape")) == 0
+        assert len(self.file.by_type("IfcRepresentation")) == 0
+
 
 class TestRemoveContextIFC2X3(test.bootstrap.IFC2X3, TestRemoveContext):
     pass

--- a/src/ifcopenshell-python/test/api/geometry/test_copy_representation.py
+++ b/src/ifcopenshell-python/test/api/geometry/test_copy_representation.py
@@ -116,6 +116,21 @@ class TestCopyRepresentation(test.bootstrap.IFC4):
 
         assert result is None
 
+    def test_replacing_a_target_rep_shared_with_another_product_keeps_the_sibling(self):
+        # #9207: some authoring tools reuse the same IfcProductDefinitionShape
+        # across occurrences, so replacing wall_b's rep must not destroy wall_c's
+        wall_a = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        wall_b = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        wall_c = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        self._add_body_rep(wall_a)
+        old_rep = self._add_body_rep(wall_b)
+        wall_c.Representation = wall_b.Representation
+
+        ifcopenshell.api.geometry.copy_representation(self.file, source=wall_a, target=wall_b)
+
+        assert wall_c.Representation is not None
+        assert old_rep in wall_c.Representation.Representations
+
     def test_custom_context_identifier(self):
         wall_a = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
         wall_b = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")

--- a/src/ifcopenshell-python/test/api/geometry/test_unassign_representation.py
+++ b/src/ifcopenshell-python/test/api/geometry/test_unassign_representation.py
@@ -42,6 +42,48 @@ class TestUnassignRepresentation(test.bootstrap.IFC4):
         assert len(self.file.by_type("IfcProductDefinitionShape")) == 0
         assert len(self.file.by_type("IfcShapeAspect")) == 0
 
+    def test_unassigning_the_last_representation_of_a_shape_shared_by_another_product(self):
+        # some authoring tools (eg. Revit) reuse the very same occurrence-level
+        # IfcProductDefinitionShape across multiple products (#9207)
+        representation = self.file.createIfcShapeRepresentation()
+        shape = self.file.createIfcProductDefinitionShape(Representations=[representation])
+        wall = self.file.createIfcWall(Representation=shape)
+        sibling = self.file.createIfcWall(Representation=shape)
+
+        ifcopenshell.api.geometry.unassign_representation(self.file, product=wall, representation=representation)
+
+        assert wall.Representation is None
+        # the sibling keeps the shared definition and its representation untouched
+        assert sibling.Representation == shape
+        assert representation in sibling.Representation.Representations
+        assert len(self.file.by_type("IfcProductDefinitionShape")) == 1
+        assert len(self.file.by_type("IfcShapeRepresentation")) == 1
+
+        # once the sibling is the sole owner, unassigning still cleans up the
+        # definition (unassign_representation never deletes the bare
+        # representation entity itself, matching the non-shared behaviour
+        # exercised by test_unassigning_a_product_representation above)
+        ifcopenshell.api.geometry.unassign_representation(self.file, product=sibling, representation=representation)
+        assert sibling.Representation is None
+        assert len(self.file.by_type("IfcProductDefinitionShape")) == 0
+        assert len(self.file.by_type("IfcShapeRepresentation")) == 1
+
+    def test_unassigning_one_of_several_representations_shared_by_another_product(self):
+        body = self.file.createIfcShapeRepresentation(RepresentationIdentifier="Body")
+        axis = self.file.createIfcShapeRepresentation(RepresentationIdentifier="Axis")
+        shape = self.file.createIfcProductDefinitionShape(Representations=[body, axis])
+        wall = self.file.createIfcWall(Representation=shape)
+        sibling = self.file.createIfcWall(Representation=shape)
+
+        ifcopenshell.api.geometry.unassign_representation(self.file, product=wall, representation=body)
+
+        assert list(wall.Representation.Representations) == [axis]
+        # the sibling still has both representations, unaffected by wall's detach
+        assert list(sibling.Representation.Representations) == [body, axis]
+        assert wall.Representation != sibling.Representation
+        assert len(self.file.by_type("IfcProductDefinitionShape")) == 2
+        assert len(self.file.by_type("IfcShapeRepresentation")) == 2
+
     def test_unassigning_a_type_product_representation(self):
         item = self.file.create_entity("IfcExtrudedAreaSolid")
         representation = self.file.createIfcShapeRepresentation(Items=(item,))

--- a/src/ifcopenshell-python/test/api/root/test_reassign_class.py
+++ b/src/ifcopenshell-python/test/api/root/test_reassign_class.py
@@ -196,6 +196,25 @@ class TestReassignClass(test.bootstrap.IFC4):
         assert len(self.file.by_type("IfcWallType")) == 0
         assert len(self.file.by_type("IfcSlab")) == 1
 
+    def test_reassigning_occurrence_to_type_keeps_a_sibling_sharing_its_shape(self):
+        # #9207: some authoring tools reuse the same IfcProductDefinitionShape
+        # across occurrences. switch_between_class_types unassigns every
+        # representation of `element` one at a time, so a shared shape must
+        # not be destroyed out from under the sibling that still owns it.
+        context = self.file.create_entity("IfcGeometricRepresentationContext")
+        representation = self.file.create_entity("IfcShapeRepresentation", ContextOfItems=context)
+        shape = self.file.createIfcProductDefinitionShape(Representations=[representation])
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        sibling = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element.Representation = shape
+        sibling.Representation = shape
+
+        ifcopenshell.api.root.reassign_class(self.file, product=element, ifc_class="IfcWallType")
+
+        assert sibling.Representation == shape
+        assert representation in sibling.Representation.Representations
+        assert len(self.file.by_type("IfcProductDefinitionShape")) == 1
+
 
 class TestReassignClassIFC4X3(test.bootstrap.IFC4X3, TestReassignClass):
     pass

--- a/src/ifcopenshell-python/test/api/root/test_remove_product.py
+++ b/src/ifcopenshell-python/test/api/root/test_remove_product.py
@@ -108,6 +108,39 @@ class TestRemoveProduct(test.bootstrap.IFC4):
         assert len(self.file.by_type("IfcExtrudedAreaSolid")) == 0
         assert len(self.file.by_type("IfcWall")) == 0
 
+    def test_removing_an_element_sharing_a_product_definition_shape(self):
+        # some authoring tools (eg. Revit) reuse the very same occurrence-level
+        # IfcProductDefinitionShape across multiple products (#9207)
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        ifcopenshell.api.unit.assign_unit(self.file)
+        context = ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        shape = self.file.createIfcProductDefinitionShape(
+            Representations=[
+                self.file.createIfcShapeRepresentation(
+                    ContextOfItems=context, Items=[self.file.createIfcExtrudedAreaSolid()]
+                )
+            ]
+        )
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element.Representation = shape
+        element1 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element1.Representation = shape
+
+        # removing one of the two owners must not touch the shared shape
+        ifcopenshell.api.root.remove_product(self.file, product=element)
+        assert len(self.file.by_type("IfcWall")) == 1
+        assert element1.Representation == shape
+        assert len(self.file.by_type("IfcProductDefinitionShape")) == 1
+        assert len(self.file.by_type("IfcShapeRepresentation")) == 1
+        assert len(self.file.by_type("IfcExtrudedAreaSolid")) == 1
+
+        # removing the last owner must still clean up the shape
+        ifcopenshell.api.root.remove_product(self.file, product=element1)
+        assert len(self.file.by_type("IfcWall")) == 0
+        assert len(self.file.by_type("IfcProductDefinitionShape")) == 0
+        assert len(self.file.by_type("IfcShapeRepresentation")) == 0
+        assert len(self.file.by_type("IfcExtrudedAreaSolid")) == 0
+
     def test_unassigning_but_not_removing_mapped_representations_of_an_element(self):
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
         ifcopenshell.api.unit.assign_unit(self.file)

--- a/src/ifcopenshell-python/test/api/type/test_map_type_representation.py
+++ b/src/ifcopenshell-python/test/api/type/test_map_type_representation.py
@@ -17,6 +17,7 @@
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
 import ifcopenshell.api.type
+import ifcopenshell.api.root
 import test.bootstrap
 
 
@@ -50,6 +51,32 @@ class TestMapTypeRepresentations(test.bootstrap.IFC4):
         assert rep.RepresentationType == "MappedRepresentation"
         assert rep.Items[0].MappingSource == type.RepresentationMaps[0]
         assert len(self.file.by_type("IfcShapeRepresentation")) == 2
+
+    def test_mapping_type_representations_keeps_a_sibling_sharing_the_old_shape(self):
+        # #9207: some authoring tools reuse the same IfcProductDefinitionShape
+        # across occurrences. Stripping related_object's own representations
+        # before mapping the type's must not destroy a sibling's copy.
+        context = self.file.createIfcGeometricRepresentationSubContext()
+        old_rep = self.file.createIfcShapeRepresentation(ContextOfItems=context)
+        shape = self.file.createIfcProductDefinitionShape(Representations=[old_rep])
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        sibling = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element.Representation = shape
+        sibling.Representation = shape
+
+        type = self.file.createIfcWallType(
+            RepresentationMaps=[
+                self.file.createIfcRepresentationMap(
+                    MappedRepresentation=self.file.createIfcShapeRepresentation(ContextOfItems=context)
+                )
+            ]
+        )
+        self.file.createIfcRelDefinesByType(RelatingType=type, RelatedObjects=[element])
+
+        ifcopenshell.api.type.map_type_representations(self.file, related_object=element, relating_type=type)
+
+        assert sibling.Representation is not None
+        assert old_rep in sibling.Representation.Representations
 
 
 class TestMapTypeRepresentationsIFC2X3(test.bootstrap.IFC2X3, TestMapTypeRepresentations):


### PR DESCRIPTION
Fixes #9207.

Deleting one wall silently destroys another wall's geometry when the two share an `IfcProductDefinitionShape`. @PahlawanJoey diagnosed this accurately, including identifying the shared PDS and its inverse count, and supplied a reproduction file.

### Reproduced on his file

```
wallA.Representation  #222351=IfcProductDefinitionShape($,$,(#221394,#222072))
wallB.Representation  #222351=IfcProductDefinitionShape($,$,(#221394,#222072))
same PDS? True      inverse count PDS 2

before:  wallB.Representation: None      PDS #222351 removed: True
after:   wallB.Representation: #222351=IfcProductDefinitionShape(...)
```

Saved and reloaded to confirm it survives a round trip.

### Root cause, and why the fix moved

`unassign_product_representation` in `geometry/unassign_representation.py` treats `product.Representation` as **exclusively owned**. It mutates `Representations` in place and, once that list empties, calls `self.file.remove(product_def)` directly, bypassing `remove_deep2`, which is the codebase's normal safety net for shared entities.

The first version of this PR guarded only the `root.remove_product` path into that primitive. **An audit of the other callers showed that was not enough**, so the guard now lives in the primitive itself.

### All five other callers were reproduced failing

| Caller | Symptom before |
|---|---|
| `geometry/copy_representation.py` | sibling's `Representation` silently became `None` |
| `root/reassign_class.py` (`switch_between_class_types`) | same |
| `context/remove_context.py` | **crashed** with `AttributeError: 'NoneType' object has no attribute 'Representations'`, nulled both products, and **orphaned** the `IfcShapeRepresentation` |
| `type/map_type_representations.py` | sibling's `Representation` became `None` |
| `alignment/add_vertical_layout.py` | same |

Each was demonstrated by running it, not inferred.

**And a sixth case that a per-caller guard could never have caught:** with two representations on a shared PDS, unassigning one silently removed it from the sibling as well, without the list ever reaching zero. That path never enters the "goes to zero" branch a caller-level guard would check.

That is the argument for guarding the primitive rather than each caller: callers cannot replicate `remove_product`'s "skip if shared" guard anyway, because they need to detach one specific representation from one product rather than skip the operation.

### The fix

`unassign_product_representation` now checks `len(product_def.ShapeOfProduct) > 1`. When shared, it detaches only this product onto a new `IfcProductDefinitionShape`, or `None` if nothing remains, instead of mutating or removing an entity other products still reference. Non-shared behaviour falls through to the original path unchanged.

The guard uses the typed inverse `ShapeOfProduct` rather than `get_total_inverses` deliberately: `IfcProductDefinitionShape` also has `HasShapeAspects`, so a total count reports false sharing and leaks orphans on any product with shape aspects.

`remove_context`'s collateral (both products losing the representation) is left in place, since that recipe is documented as destructive. The crash and the orphaned entity were the actual defects there, and both are fixed.

The reporter's deep-copy workaround was not adopted. Restructuring a file as a side effect of a delete would be a larger surprise than the bug.

### Tests

Both directions everywhere, since the risk of an ownership guard is trading data loss for an orphan leak: the sibling survives when shared, **and** the shape is still fully cleaned up when the last owner goes.

New regression tests in `test_unassign_representation.py` (primitive level, both directions), plus one each in `test_copy_representation.py`, `test_reassign_class.py`, `test_remove_context.py` and `test_map_type_representation.py`.

```
test/api: 1460 passed, 0 failed
```

`add_vertical_layout` has no dedicated test file; it is covered by the primitive-level tests and a manual reproduction rather than by adding a new file.

Generated with the assistance of an AI coding tool.
