### PR TITLE
docker: forward IFCOS_NUM_BUILD_PROCS so -j can actually be lowered

### DIFF
--- a/docker/ifcos_env
+++ b/docker/ifcos_env
@@ -153,7 +153,7 @@ function build() {
     echo "☕ Execute the build, go make yourself a cuppa... I'll be a while"
     local BUILD_TARGET="$1"
     
-    docker exec -i -w "${WORKDIR}" -e PY_TGT="${PY_TGT}" -e BUILD_TARGET="${BUILD_TARGET}" "${NAMEPREFIX}-${UNIQUE_ID}" bash -c '
+    docker exec -i -w "${WORKDIR}" -e PY_TGT="${PY_TGT}" -e BUILD_TARGET="${BUILD_TARGET}" ${IFCOS_NUM_BUILD_PROCS:+-e IFCOS_NUM_BUILD_PROCS="${IFCOS_NUM_BUILD_PROCS}"} "${NAMEPREFIX}-${UNIQUE_ID}" bash -c '
         set -o pipefail
         CXXFLAGS="-O3" CFLAGS="-O3 ${DARWIN_C_SOURCE}" ADD_COMMIT_SHA=1 BUILD_CFG=Release uv run ./nix/build-all.py -v ${PY_TGT:+-$PY_TGT} --diskcleanup ${BUILD_TARGET} 2>&1 | tee build.log
     '


### PR DESCRIPTION
`nix/build-all.py` documents `IFCOS_NUM_BUILD_PROCS` as the way to control build parallelism:

```
- ``IFCOS_NUM_BUILD_PROCS`` - number of concurrent processes defaults to available cores + 1
```

and reads it at line 261, using it for every `make -j{N}` call. But the docker wrapper never forwarded it. `docker/ifcos_env`'s `build()` passed only `PY_TGT` and `BUILD_TARGET`, so setting `IFCOS_NUM_BUILD_PROCS` outside the container had no effect and there was no way to lower parallelism through the wrapper at all.

### Why it matters

The schema translation units are large. Each `cc1plus` peaks around 2.5 GB, so on a multi-core machine the default of `cpu_count() + 1` exceeds a typical 8 GB container ceiling and the build dies:

```
c++: fatal error: Killed signal terminated program cc1plus
```

@aothms diagnosed this precisely on #9117:

> The schemas are huge. Reduce parallelism to 1 when compiling and please try again.

That advice is correct and works. `make -j1` completes cleanly where the default OOMs. But following it through `docker/ifcos_env` was not possible without bypassing the wrapper and calling `docker exec` by hand, which is what we ended up doing.

### The change

One line, forwarding the variable only when it is set, so default behaviour is unchanged.

Verified both ways:

* unset: no `-e IFCOS_NUM_BUILD_PROCS` argument is added, `docker exec` invocation is byte-identical to before.
* set to `1`: `-e IFCOS_NUM_BUILD_PROCS=1` is added, and the container logs `running command make -j1 ifcopenshell_wrapper VERBOSE=1`.

`bash -n docker/ifcos_env` passes.

Generated with the assistance of an AI coding tool.
