### PR TITLE
Bonsai: remove_representation handles occurrence reps mapped to a floating map (#9216)

### DIFF
--- a/src/bonsai/bonsai/core/geometry.py
+++ b/src/bonsai/bonsai/core/geometry.py
@@ -150,7 +150,15 @@ def remove_representation(
     element_type = geometry.get_element_type(element)
     data = None
     data_removed_by_switch_representation = False
-    if element_type and (geometry.is_mapped_representation(representation) or geometry.is_type_product(element)):
+    # Take the type-level branch only when the removal really is type-scoped: the
+    # object is the type itself, or the mapped rep is anchored to the type's
+    # RepresentationMaps. A mapped rep pointing at a *floating* map not owned by
+    # the type (typical of Revit imports) must be removed at the occurrence level
+    # instead -- the type branch would no-op and leave it unremovable.
+    if element_type and (
+        geometry.is_type_product(element)
+        or geometry.is_mapped_representation_of_type(representation, element_type)
+    ):
         representation = geometry.resolve_mapped_representation(representation)
         data = geometry.get_representation_data(representation)
         if data and geometry.has_data_users(data):

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -477,6 +477,7 @@ class Geometry:
     def is_box_representation(cls, representation): pass
     def is_data_supported_for_adding_representation(cls, data): pass
     def is_mapped_representation(cls, representation): pass
+    def is_mapped_representation_of_type(cls, representation, element_type): pass
     def is_type_product(cls, element): pass
     def link(cls, element, obj): pass
     def record_object_materials(cls, obj): pass

--- a/src/bonsai/bonsai/tool/geometry.py
+++ b/src/bonsai/bonsai/tool/geometry.py
@@ -1318,6 +1318,25 @@ class Geometry(bonsai.core.tool.Geometry):
         return representation.RepresentationType == "MappedRepresentation"
 
     @classmethod
+    def is_mapped_representation_of_type(
+        cls,
+        representation: ifcopenshell.entity_instance,
+        element_type: Union[ifcopenshell.entity_instance, None],
+    ) -> bool:
+        """``True`` when ``representation`` is a mapped representation whose
+        ``IfcRepresentationMap`` is one of ``element_type``'s ``RepresentationMaps``
+        -- i.e. a genuine type-anchored shared representation, as opposed to a
+        floating map not owned by the type (which Revit exports produce)."""
+        if element_type is None or representation.RepresentationType != "MappedRepresentation":
+            return False
+        if not representation.Items:
+            return False
+        item = representation.Items[0]
+        if not item.is_a("IfcMappedItem"):
+            return False
+        return item.MappingSource in (element_type.RepresentationMaps or [])
+
+    @classmethod
     def is_meshlike(cls, representation: ifcopenshell.entity_instance) -> bool:
         if ifcopenshell.util.representation.resolve_representation(representation).RepresentationType in (
             "AdvancedBrep",


### PR DESCRIPTION
Fixes #9216.

## Problem

`core.geometry.remove_representation` takes its **type-level** branch for *any* mapped representation. When the map is a **floating** `IfcRepresentationMap` not listed in the element type's `RepresentationMaps` — which Revit imports produce routinely (the `IfcTypeProduct.RepresentationMaps` is empty, yet occurrences carry `IfcMappedItem`s to a shared map) — that branch **no-ops**, so the occurrence's representation is **unremovable**:

- `unassign_representation(product=element_type, …)` finds no matching map on the type → does nothing;
- `remove_representation(resolved)` can't delete the geometry because it's still referenced by the floating map's `MappedRepresentation`.

Repro (from #9216): a Revit `IfcSanitaryTerminal` whose type has no `RepresentationMaps` — its `Model/Box/MODEL_VIEW` BoundingBox can't be removed via the panel `X` / `bpy.ops.bim.remove_representation`.

## Fix

Take the type-level branch only when the removal is genuinely type-scoped — the object is the type itself, or the mapped rep is anchored to the type (new `tool.Geometry.is_mapped_representation_of_type`, which checks the rep's `IfcRepresentationMap` is in `element_type.RepresentationMaps`). A floating mapped rep now falls through to the existing **occurrence-level** branch: it's unassigned from just that occurrence, and `remove_deep2` garbage-collects the shared map once its last user is gone.

Behaviour is unchanged for local reps and for genuinely type-anchored mapped reps (verified across all four cases: local, type-anchored mapped, floating mapped, type-product object).

## Related

This is the same `remove_representation` type branch behind #8656 (assigning a profile type with a shared mapped representation), but the opposite failure mode — #8656 *over-reaches* on a type-anchored shared map (empties siblings), this one *under-reaches* on a floating map (no-op). If the mullion maps in #8656 turn out to be floating too, this also addresses it; if they're truly type-anchored, that case needs its own handling in the profile-regeneration caller.

## Test

Verified in Blender on the #9216 model: the previously-unremovable BoundingBox on the sanitary terminal now removes; local and type-anchored removals are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
