### PR TITLE
Bonsai: a space you just generated is hidden immediately (#9214)

### DIFF
--- a/src/bonsai/bonsai/core/spatial.py
+++ b/src/bonsai/bonsai/core/spatial.py
@@ -222,6 +222,7 @@ def generate_space(
 
     if element and element.is_a("IfcSpace"):
         spatial.set_space_representation_from_polygon(active_obj, element, space_polygon, h, polygon_is_si=True)
+        target_obj = active_obj
     else:
         if relating_type:
             name = model.generate_occurrence_name(relating_type, "IfcSpace")
@@ -235,9 +236,12 @@ def generate_space(
 
         element = ifc.get_entity(obj)
         spatial.set_space_representation_from_polygon(obj, element, space_polygon, h, polygon_is_si=True)
+        target_obj = obj
 
         if relating_type:
             spatial.assign_relating_type_to_element(ifc, type, element, relating_type)
+
+    spatial.unhide_viewport(target_obj)
 
     spatial.import_spatial_decomposition()
 
@@ -262,6 +266,7 @@ def generate_spaces_from_walls(
 
         element = ifc.get_entity(obj)
         spatial.set_space_representation_from_polygon(obj, element, poly, h, polygon_is_si=False)
+        spatial.unhide_viewport(obj)
 
 
 def toggle_space_visibility(ifc: type[tool.Ifc], spatial: type[tool.Spatial]) -> None:

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -1106,6 +1106,7 @@ class Spatial:
     def get_relating_type_id(cls): pass
     def translate_obj_to_z_location(cls, obj, z): pass
     def assign_ifcspace_class_to_obj(cls, obj): pass
+    def unhide_viewport(cls, obj): pass
     def assign_type_to_obj(cls, obj): pass
     def assign_relating_type_to_element(cls, ifc, type, element, relating_type): pass
     def toggle_spaces_visibility_wired_and_textured(cls, spaces): pass

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -1177,6 +1177,11 @@ class Spatial(bonsai.core.tool.Spatial):
         )
 
     @classmethod
+    def unhide_viewport(cls, obj: bpy.types.Object) -> None:
+        """Clear the "Disable in Viewports" flag on an object."""
+        obj.hide_viewport = False
+
+    @classmethod
     def assign_type_to_obj(cls, obj: bpy.types.Object) -> None:
         props = tool.Model.get_model_props()
         ifc_file = tool.Ifc.get()


### PR DESCRIPTION
Fixes #9214.

@dsham7 reported that creating an `IfcSpace` produces an object visible in the outliner but nothing in the viewport, with no error. His own description was accurate: *"There are no errors. Its a silent bug perhaps."*

### What is actually happening

The space is fine. Verified in headless Blender 5.2 LTS, matching his version:

```
Representation: #97=IfcProductDefinitionShape(...)
  Body / SweptSolid, 1 item (IfcExtrudedAreaSolid)
Blender object: verts 8, faces 12, correct location

obj.hide_viewport : True
obj.hide_get()    : False
```

Real geometry, in the right place. It is `hide_viewport` that hides it, and that flag also makes the object **unselectable** in the 3D view, which is why the outliner looks normal while the viewport shows and clicks nothing. That also explains why placing a space tag afterwards appears to do nothing.

### Root cause, and what this PR deliberately does not change

`tool/collector.py`'s `Collector.assign` hides every new `IfcSpace` when `BIMSpatialDecompositionProperties.is_visible` is `False`, which is the default.

**That default is deliberate and correct.** It was set in `a11f81f2ceaf` ("Fix #5701. Spaces are now invisible by default...") so that opening a model does not fill the viewport with space volumes. This PR leaves that behaviour untouched.

The bug is that the same path also fires when a user has just **explicitly asked** for a space, via "Generate Space from Cursor" or "Generate Spaces From Walls". The operator succeeds, so it reports nothing, and the thing the user asked for is hidden immediately on creation.

### The fix

A new `tool.Spatial.unhide_viewport(obj)`, called on that specific object after `generate_space` and `generate_spaces_from_walls` have built its representation. It unhides only the object just created, rather than flipping the global default.

### Verified

* Same session: `hide_viewport` is `False` immediately after `bim.generate_space`, and the space is visible and selectable.
* Save and reload: the IFC round-trips with geometry intact (8 verts, 12 faces), and a fresh `load_project` correctly re-hides spaces, preserving #5701's intended import behaviour. Toggling "Is Visible" in the Spatial Decomposition panel reveals them unchanged, so nothing is lost, only hidden by design on that path.

```
pytest test/core -o addopts=""
390 passed
```

### Not verified

The space tag half of the report was not independently tested. `hide_viewport` objects are excluded from Blender's viewport selection, so tag placement that relies on picking the space would plausibly fail for the same reason, but that is reasoning rather than a measurement and is stated as such.

Generated with the assistance of an AI coding tool.
