### PR TITLE
Replace blender based space boundary generation with IFC based

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "src/svgfill/3rdparty/svgpp"]
 	path = src/svgfill/3rdparty/svgpp
 	url = https://github.com/svgpp/svgpp
+[submodule "src/ifcopenshell-python/test/IfcRelSpaceBoundary_TestFiles"]
+	path = src/ifcopenshell-python/test/IfcRelSpaceBoundary_TestFiles
+	url = https://github.com/CyrilWaechter/IfcRelSpaceBoundary_TestFiles

--- a/src/bonsai/bonsai/bim/module/boundary/operator.py
+++ b/src/bonsai/bonsai/bim/module/boundary/operator.py
@@ -719,11 +719,6 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
         if tool.Ifc.is_moved(space_obj):
             bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=space_obj)
 
-        # Don't generate boundaries for elements that already have boundaries
-        for boundary in space.BoundedBy:
-            if boundary.RelatedBuildingElement in building_elements:
-                building_elements.remove(boundary.RelatedBuildingElement)
-
         # Build shapes dict with iterator (parallel, includes space + building elements)
         include = building_elements + [space]
         tree = ifcopenshell.geom.tree()
@@ -745,13 +740,9 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
                 if not iterator.next():
                     break
 
-        # Spatially query all potential boundary elements via a 100mm extension of the space
-        building_elements = [e for e in tree.select(space, extend=0.1) if e != space]
-
-        if not building_elements:
-            return "No building elements found to create boundaries."
-
-        # Filter shapes to only include selected building elements + space
+        # Pass all building element shapes to the auto-generation function.
+        # The function performs its own spatial filtering (coplanarity + overlap),
+        # so tree-adjacency filtering is not needed here.
         filtered_shapes = {space.id(): shapes[space.id()]}
         for element in building_elements:
             if element.id() in shapes:

--- a/src/bonsai/bonsai/bim/module/boundary/operator.py
+++ b/src/bonsai/bonsai/bim/module/boundary/operator.py
@@ -18,6 +18,7 @@
 
 import logging
 import multiprocessing
+import traceback
 from math import acos, degrees, inf, pi, radians
 from typing import Optional, Union
 
@@ -38,6 +39,7 @@ import shapely.ops
 from ifcopenshell.util.shape_builder import ShapeBuilder
 from mathutils import Matrix, Vector
 
+import bonsai
 import bonsai.bim.import_ifc as import_ifc
 import bonsai.core.attribute as core
 import bonsai.core.geometry
@@ -804,12 +806,26 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
                     space_face_polygon = shapely.Polygon(
                         [tuple((space_face_matrix_i @ v).xy) for v in space_face_verts]
                     )
+                    if not space_face_polygon.is_valid:
+                        space_face_polygon = space_face_polygon.buffer(0)
 
                     space_matrix_world_i = space_obj.matrix_world.inverted()
                     face_verts = [space_matrix_world_i @ building_obj.matrix_world @ v.co.copy() for v in face.verts]
                     face_polygon = shapely.Polygon([tuple((space_face_matrix_i @ v).xy) for v in face_verts])
+                    if not face_polygon.is_valid:
+                        face_polygon = face_polygon.buffer(0)
 
-                    gross_boundary_polygon = space_face_polygon.intersection(face_polygon)
+                    try:
+                        gross_boundary_polygon = space_face_polygon.intersection(face_polygon)
+                    except shapely.errors.GEOSException:
+                        bonsai.last_error = traceback.format_exc()
+                        element_name = building_element.Name or building_element.is_a()
+                        self.report(
+                            {"ERROR"},
+                            f"Skipping invalid geometry for {element_name} (shapely topology error). "
+                            "See 'Copy Error Message To Clipboard' for details.",
+                        )
+                        continue
 
                     if type(gross_boundary_polygon) == shapely.GeometryCollection:
                         for geom in gross_boundary_polygon.geoms:

--- a/src/bonsai/bonsai/bim/module/boundary/operator.py
+++ b/src/bonsai/bonsai/bim/module/boundary/operator.py
@@ -18,8 +18,7 @@
 
 import logging
 import multiprocessing
-import traceback
-from math import acos, degrees, inf, pi, radians
+from math import inf, pi
 from typing import Optional, Union
 
 import bmesh
@@ -29,6 +28,7 @@ import ifcopenshell.api.boundary
 import ifcopenshell.api.root
 import ifcopenshell.geom
 import ifcopenshell.ifcopenshell_wrapper as W
+import ifcopenshell.util.boundary
 import ifcopenshell.util.element
 import ifcopenshell.util.placement
 import ifcopenshell.util.shape
@@ -39,7 +39,6 @@ import shapely.ops
 from ifcopenshell.util.shape_builder import ShapeBuilder
 from mathutils import Matrix, Vector
 
-import bonsai
 import bonsai.bim.import_ifc as import_ifc
 import bonsai.core.attribute as core
 import bonsai.core.geometry
@@ -697,36 +696,35 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
     def auto_generate_boundaries(
         self, space: ifcopenshell.entity_instance, space_obj: bpy.types.Object
     ) -> Union[str, list[ifcopenshell.entity_instance]]:
-        """
-        :return: list of created boundaries or a string with error description.
+        """Generate boundaries by delegating to ifcopenshell.util.boundary.
+
+        This method handles Blender-specific preprocessing (flushing moved
+        objects, building the geometry cache + spatial tree) then delegates
+        the algorithm to the Blender-independent util module.
         """
         ifc_file = tool.Ifc.get()
         props = tool.Model.get_model_props()
-        boundaries: list[ifcopenshell.entity_instance] = []
         assert isinstance(space_obj.data, bpy.types.Mesh)
 
         # Identify all potential building elements
-        # TODO: don't select everything, use AABB culling in Blender
-        building_elements = list(
-            tool.Ifc.get().by_type("IfcWall")
-            + tool.Ifc.get().by_type("IfcSlab")
-            + tool.Ifc.get().by_type("IfcVirtualElement")
-        )
+        building_elements = []
+        for ifc_class in ifcopenshell.util.boundary.BOUNDARY_ELEMENT_CLASSES:
+            building_elements.extend(ifc_file.by_type(ifc_class))
 
+        # Flush moved objects to IFC
         for building_element in building_elements:
             if obj := tool.Ifc.get_object(building_element):
                 if tool.Ifc.is_moved(obj):
                     bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=obj)
-
         if tool.Ifc.is_moved(space_obj):
             bonsai.core.geometry.edit_object_placement(tool.Ifc, tool.Geometry, tool.Surveyor, obj=space_obj)
 
-        # Don't generate boundaries of building elements that we've already got bounaries for.
+        # Don't generate boundaries for elements that already have boundaries
         for boundary in space.BoundedBy:
             if boundary.RelatedBuildingElement in building_elements:
                 building_elements.remove(boundary.RelatedBuildingElement)
 
-        # Create tree of gross shapes of all potential related building elements
+        # Build shapes dict with iterator (parallel, includes space + building elements)
         include = building_elements + [space]
         tree = ifcopenshell.geom.tree()
         shapes = {}
@@ -741,6 +739,8 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
                 shapes[shape.id] = {
                     "verts": ifcopenshell.util.shape.get_vertices(shape.geometry),
                     "faces": ifcopenshell.util.shape.get_faces(shape.geometry),
+                    "edges": ifcopenshell.util.shape.get_edges(shape.geometry),
+                    "matrix": ifcopenshell.util.shape.get_shape_matrix(shape),
                 }
                 if not iterator.next():
                     break
@@ -751,193 +751,15 @@ class AddBoundary(bpy.types.Operator, tool.Ifc.Operator):
         if not building_elements:
             return "No building elements found to create boundaries."
 
-        # Create a dissolved bmesh for the space
-        space_bm = bmesh.new()
-        space_bm.from_mesh(space_obj.data)
-        bmesh.ops.dissolve_limit(space_bm, angle_limit=pi * 2 / 360, verts=space_bm.verts[:], edges=space_bm.edges[:])
+        # Filter shapes to only include selected building elements + space
+        filtered_shapes = {space.id(): shapes[space.id()]}
+        for element in building_elements:
+            if element.id() in shapes:
+                filtered_shapes[element.id()] = shapes[element.id()]
 
-        # Create dissolved bmeshes for all boundary elements
-        building_element_bms = {}
-        for building_element in building_elements:
-            bm = bmesh.new()
-            shape = shapes[building_element.id()]
-
-            for vert in shape["verts"]:
-                bm.verts.new(Vector(vert))
-            bm.verts.ensure_lookup_table()
-
-            for face in shape["faces"]:
-                bm.faces.new([bm.verts[i] for i in face])
-            bm.verts.ensure_lookup_table()
-            bm.faces.ensure_lookup_table()
-            bm.normal_update()  # Needed so that dissolve_limit will work.
-            bmesh.ops.dissolve_limit(bm, angle_limit=radians(1), verts=bm.verts[:], edges=bm.edges[:])
-            bm.verts.ensure_lookup_table()
-            bm.faces.ensure_lookup_table()
-            building_element_bms[building_element.id()] = bm
-
-        # Compare space faces and building element faces to see if they relate to one another
-        for space_face in space_bm.faces:
-            space_face_normal = space_obj.matrix_world.to_3x3() @ space_face.normal
-            space_face_vert = space_obj.matrix_world @ space_face.verts[0].co
-            for building_element in building_elements:
-                for face in building_element_bms[building_element.id()].faces:
-                    building_obj = tool.Ifc.get_object(building_element)
-                    face_normal = building_obj.matrix_world.to_3x3() @ face.normal
-                    angle = degrees(acos(max(min(space_face_normal.dot(face_normal), 1), -1)))
-                    if tool.Cad.is_x(angle, 180, tolerance=2):
-                        pass  # Faces need to be parallel and have opposite normals to be related.
-                    elif building_element.is_a("IfcVirtualElement") and tool.Cad.is_x(angle, 0, tolerance=2):
-                        pass  # Virtual elements only need to be parallel to be related, since they are planes.
-                    else:
-                        continue
-
-                    # Both faces should be close to one another. Say within 50mm.
-                    space_vert = building_obj.matrix_world.inverted() @ space_face_vert
-                    dist = mathutils.geometry.distance_point_to_plane(space_vert, face.verts[0].co, face.normal)
-                    if abs(dist) > 0.05:
-                        continue
-
-                    # Project the building element face onto the space face
-                    space_face_verts = [v.co.copy() for v in space_face.verts]
-                    space_face_matrix = self.get_face_matrix(*[v.copy() for v in space_face_verts[0:3]])
-                    space_face_matrix_i = space_face_matrix.inverted()
-
-                    space_face_polygon = shapely.Polygon(
-                        [tuple((space_face_matrix_i @ v).xy) for v in space_face_verts]
-                    )
-                    if not space_face_polygon.is_valid:
-                        space_face_polygon = space_face_polygon.buffer(0)
-
-                    space_matrix_world_i = space_obj.matrix_world.inverted()
-                    face_verts = [space_matrix_world_i @ building_obj.matrix_world @ v.co.copy() for v in face.verts]
-                    face_polygon = shapely.Polygon([tuple((space_face_matrix_i @ v).xy) for v in face_verts])
-                    if not face_polygon.is_valid:
-                        face_polygon = face_polygon.buffer(0)
-
-                    try:
-                        gross_boundary_polygon = space_face_polygon.intersection(face_polygon)
-                    except shapely.errors.GEOSException:
-                        bonsai.last_error = traceback.format_exc()
-                        element_name = building_element.Name or building_element.is_a()
-                        self.report(
-                            {"ERROR"},
-                            f"Skipping invalid geometry for {element_name} (shapely topology error). "
-                            "See 'Copy Error Message To Clipboard' for details.",
-                        )
-                        continue
-
-                    if type(gross_boundary_polygon) == shapely.GeometryCollection:
-                        for geom in gross_boundary_polygon.geoms:
-                            if type(geom) == shapely.Polygon:
-                                gross_boundary_polygon = geom
-                                break
-
-                    if (
-                        not (isinstance(gross_boundary_polygon, shapely.Polygon) and gross_boundary_polygon.is_valid)
-                        or gross_boundary_polygon.is_empty
-                    ):
-                        continue
-
-                    # The gross boundary polygon may not be a true gross boundary since it
-                    # may have openings already removed, such as in IFC4 Reference View. So
-                    # we cheat by using the exterior boundary to mean "gross".
-                    exterior_boundary_polygon = shapely.Polygon(gross_boundary_polygon.exterior.coords)
-
-                    parent_boundary = ifcopenshell.api.root.create_entity(ifc_file, ifc_class=props.boundary_class)
-                    if building_element.is_a("IfcVirtualElement"):
-                        parent_boundary.PhysicalOrVirtualBoundary = "VIRTUAL"
-                    else:
-                        parent_boundary.PhysicalOrVirtualBoundary = "PHYSICAL"
-                    parent_boundary.InternalOrExternalBoundary = "NOTDEFINED"
-                    if building_element.is_a("IfcWall"):
-                        is_external = ifcopenshell.util.element.get_pset(
-                            building_element, "Pset_WallCommon", "IsExternal"
-                        )
-                        if is_external is True:
-                            parent_boundary.InternalOrExternalBoundary = "EXTERNAL"
-                        elif is_external is False:
-                            parent_boundary.InternalOrExternalBoundary = "INTERNAL"
-                    elif building_element.is_a("IfcSlab"):
-                        predefined_type = ifcopenshell.util.element.get_predefined_type(building_element)
-                        if predefined_type == "BASESLAB":
-                            parent_boundary.InternalOrExternalBoundary = "EXTERNAL_EARTH"
-                        else:
-                            is_external = ifcopenshell.util.element.get_pset(
-                                building_element, "Pset_SlabCommon", "IsExternal"
-                            )
-                            if is_external is True:
-                                parent_boundary.InternalOrExternalBoundary = "EXTERNAL"
-                            elif is_external is False:
-                                parent_boundary.InternalOrExternalBoundary = "INTERNAL"
-                    parent_boundary.RelatingSpace = space
-                    parent_boundary.RelatedBuildingElement = building_element
-                    parent_boundary.ConnectionGeometry = self.create_connection_geometry_from_polygon(
-                        exterior_boundary_polygon, space_face_matrix
-                    )
-                    self.set_boundary_name(parent_boundary)
-                    boundaries.append(parent_boundary)
-
-                    for rel in getattr(building_element, "HasOpenings", []):
-                        opening = rel.RelatedOpeningElement
-                        filling = opening.HasFillings[0].RelatedBuildingElement if opening.HasFillings else None
-
-                        # Create shape of opening as a dissolved BMesh
-                        settings = ifcopenshell.geom.settings()
-                        shape = ifcopenshell.geom.create_shape(settings, opening)
-                        mat = Matrix(ifcopenshell.util.shape.get_shape_matrix(shape))
-                        opening_bm = bmesh.new()
-                        verts = ifcopenshell.util.shape.get_vertices(shape.geometry)
-                        for vert in verts:
-                            opening_bm.verts.new(Vector(vert))
-                        opening_bm.verts.ensure_lookup_table()
-                        faces = ifcopenshell.util.shape.get_faces(shape.geometry)
-                        for face in faces:
-                            opening_bm.faces.new([opening_bm.verts[i] for i in face])
-                        opening_bm.verts.ensure_lookup_table()
-                        opening_bm.faces.ensure_lookup_table()
-                        opening_bm.normal_update()  # Needed so that dissolve_limit will work.
-                        bmesh.ops.dissolve_limit(
-                            opening_bm, angle_limit=radians(1), verts=opening_bm.verts[:], edges=opening_bm.edges[:]
-                        )
-                        opening_bm.verts.ensure_lookup_table()
-                        opening_bm.faces.ensure_lookup_table()
-
-                        # Get relevant faces of BMesh that can turn into boundaries
-                        opening_polygons = []
-                        for opening_face in opening_bm.faces:
-                            opening_face_normal = mat.to_3x3() @ opening_face.normal
-                            angle = degrees(acos(max(min(opening_face_normal.dot(face_normal), 1), -1)))
-                            if not tool.Cad.is_x(angle, 180, tolerance=2):
-                                continue  # Any non-parallel faces are not relevant
-                            opening_face_verts = [space_matrix_world_i @ mat @ v.co.copy() for v in opening_face.verts]
-                            polygon = shapely.Polygon([tuple((space_face_matrix_i @ v).xy) for v in opening_face_verts])
-                            opening_polygons.append(polygon)
-
-                        # Merge them all into a single opening polygon for our boundary
-                        opening_polygon = shapely.ops.unary_union(opening_polygons)
-
-                        # Only openings that are projected onto our exterior boundary are relevant.
-                        if opening_polygon.intersection(exterior_boundary_polygon).area == 0:
-                            continue
-
-                        boundary = ifcopenshell.api.root.create_entity(ifc_file, ifc_class=props.boundary_class)
-                        boundary.RelatingSpace = space
-                        boundary.RelatedBuildingElement = filling or opening
-                        boundary.ConnectionGeometry = self.create_connection_geometry_from_polygon(
-                            opening_polygon, space_face_matrix
-                        )
-                        if filling:
-                            boundary.PhysicalOrVirtualBoundary = "PHYSICAL"
-                        else:
-                            boundary.PhysicalOrVirtualBoundary = "VIRTUAL"
-                        boundary.InternalOrExternalBoundary = parent_boundary.InternalOrExternalBoundary
-                        if boundary.is_a() != "IfcRelSpaceBoundary":
-                            boundary.ParentBoundary = parent_boundary
-                        self.set_boundary_name(boundary)
-                        boundaries.append(boundary)
-
-        return boundaries
+        return ifcopenshell.util.boundary.auto_generate_boundaries(
+            ifc_file, space, filtered_shapes, props.boundary_class
+        )
 
     def create_element_boundary(
         self,

--- a/src/ifcopenshell-python/ifcopenshell/util/boundary.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/boundary.py
@@ -108,6 +108,7 @@ def auto_generate_boundaries(
         )
 
     # Compare space faces and building element faces
+    processed_fillings: set[int] = set()
     for space_ngon in space_ngons:
         space_verts_l = space_verts_local[space_ngon]
         # Normal from local verts, then transform to world via space placement
@@ -224,6 +225,7 @@ def auto_generate_boundaries(
                         parent_boundary,
                         space,
                         unit_scale,
+                        processed_fillings,
                     )
                 )
 
@@ -243,6 +245,7 @@ def _process_openings(
     parent_boundary,
     space,
     unit_scale,
+    processed_fillings: set[int],
 ):
     """Process openings and fillings for a building element.
 
@@ -251,12 +254,16 @@ def _process_openings(
     :param element_matrix: The building element placement matrix.
     :param face_matrix: The face matrix in space-local coordinates (for connection geometry).
     :param face_matrix_inv: The inverse face matrix (for 2D projection).
+    :param processed_fillings: Set of element IDs that already have opening boundaries.
     """
     boundaries = []
 
     for rel in getattr(building_element, "HasOpenings", []):
         opening = rel.RelatedOpeningElement
         filling = opening.HasFillings[0].RelatedBuildingElement if opening.HasFillings else None
+        filling_id = (filling or opening).id()
+        if filling_id in processed_fillings:
+            continue
 
         settings = ifcopenshell.geom.settings()
         try:
@@ -317,6 +324,7 @@ def _process_openings(
         if boundary.is_a() != "IfcRelSpaceBoundary":
             boundary.ParentBoundary = parent_boundary
         _set_boundary_name(boundary)
+        processed_fillings.add(filling_id)
         boundaries.append(boundary)
 
     return boundaries

--- a/src/ifcopenshell-python/ifcopenshell/util/boundary.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/boundary.py
@@ -352,8 +352,8 @@ def _assign_connection_geometry(
 ) -> None:
     """Assign connection geometry to a boundary using the existing API."""
     location = face_matrix[:3, 3]
-    axis = face_matrix[:3, 0]
-    ref_direction = face_matrix[:3, 2]
+    axis = face_matrix[:3, 2]
+    ref_direction = face_matrix[:3, 0]
 
     outer_boundary = [list(coord) for coord in polygon.exterior.coords[:-1]]
     inner_boundaries = [list(interior.coords[:-1]) for interior in polygon.interiors]

--- a/src/ifcopenshell-python/ifcopenshell/util/boundary.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/boundary.py
@@ -64,6 +64,7 @@ FULL_FACE_OFFSET_TOL = 0.25
 def _union_coplanar_face_polygon(
     space_verts_local,
     space_triangles,
+    space_triangle_normals,
     face_origin,
     face_normal,
     face_matrix_inv,
@@ -76,14 +77,15 @@ def _union_coplanar_face_polygon(
     or an opening. Unioning the raw triangles coplanar with the face restores
     those holes.
     """
+    # Vectorized coplanarity prefilter: keep only triangles whose vertices all
+    # lie within 1e-4 m (0.1 mm) of the face plane.
+    triangle_points = space_verts_local[space_triangles]
+    plane_offsets = np.abs(np.tensordot(triangle_points - face_origin, face_normal, axes=(2, 0))).max(axis=1)
     polygons = []
-    for triangle in space_triangles:
-        points = space_verts_local[triangle]
-        if _face_normal(points) is None:
+    for triangle in np.flatnonzero(plane_offsets <= 1e-4):
+        if space_triangle_normals[triangle] is None:
             continue
-        if np.abs(np.dot(points - face_origin, face_normal)).max() > 1e-4:
-            continue
-        polygon = _verts_to_polygon(points, face_matrix_inv, snap=1e-6)
+        polygon = _verts_to_polygon(space_verts_local[space_triangles[triangle]], face_matrix_inv, snap=1e-6)
         if not polygon.is_valid:
             polygon = polygon.buffer(0)
         if polygon.is_empty:
@@ -158,6 +160,11 @@ def auto_generate_boundaries(
     space_ngons = ifcopenshell.util.shape.dissolve_faces(
         space_verts_local, space_shape["faces"], space_shape["edges"], merge_coplanar=True
     )
+
+    # Per-triangle normals used to reconstruct space faces from their raw
+    # triangles (see _union_coplanar_face_polygon). Computed once instead of
+    # once per space face.
+    space_triangle_normals = [_face_normal(space_verts_local[tri]) for tri in space_shape["faces"]]
 
     # Dissolve building element meshes — verts are in element-local coords
     element_ngons = {}
@@ -262,6 +269,7 @@ def auto_generate_boundaries(
         space_face_polygon = _union_coplanar_face_polygon(
             space_verts_local,
             space_shape["faces"],
+            space_triangle_normals,
             space_verts_l[0],
             space_face_normal_local,
             face_matrix_inv,
@@ -317,7 +325,9 @@ def auto_generate_boundaries(
         # candidates are kept in order of increasing plane offset (ties broken
         # by polygon area). A candidate whose polygon is entirely covered by
         # the candidates already kept is redundant and is absorbed into the
-        # larger boundary.
+        # larger boundary. This includes coplanar candidates: e.g. wall end
+        # caps that are coplanar with the ceiling and fully covered by the
+        # slab above do not get their own boundary in the reference output.
         surviving_candidates = []
         kept_union = None
         for element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal in sorted(

--- a/src/ifcopenshell-python/ifcopenshell/util/boundary.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/boundary.py
@@ -54,16 +54,54 @@ BOUNDARY_ELEMENT_CLASSES = (
     "IfcDoor",
 )
 
-# Distance (in meters) below which an element face is considered coplanar with
-# the space face it bounds. Matches beyond this distance within the larger
-# tolerance are only kept when no coplanar element already covers the face.
-COPLANAR_TOL = 0.05
-
 # Plane offset (in meters) below which a sole bounding element is assigned the
 # full space face. Building element faces are often slightly offset from the
 # space face they bound (e.g. wall linings), so a single bounding element
 # within this offset gets the complete face rather than a clipped polygon.
-FULL_FACE_OFFSET_TOL = 0.2
+FULL_FACE_OFFSET_TOL = 0.25
+
+
+def _union_coplanar_face_polygon(
+    space_verts_local,
+    space_triangles,
+    face_origin,
+    face_normal,
+    face_matrix_inv,
+    fallback,
+):
+    """Reconstruct a space face from its raw triangles.
+
+    ``dissolve_faces`` with ``merge_coplanar=True`` drops any interior rings
+    (holes) when coplanar faces are merged, e.g. a ceiling pierced by a shaft
+    or an opening. Unioning the raw triangles coplanar with the face restores
+    those holes.
+    """
+    polygons = []
+    for triangle in space_triangles:
+        points = space_verts_local[triangle]
+        if _face_normal(points) is None:
+            continue
+        if np.abs(np.dot(points - face_origin, face_normal)).max() > 1e-4:
+            continue
+        polygon = _verts_to_polygon(points, face_matrix_inv, snap=1e-6)
+        if not polygon.is_valid:
+            polygon = polygon.buffer(0)
+        if polygon.is_empty:
+            continue
+        polygons.append(polygon)
+    if not polygons:
+        return fallback
+    union = shapely.ops.unary_union(polygons).buffer(0)
+    if isinstance(union, shapely.Polygon):
+        return union
+    if isinstance(union, shapely.MultiPolygon):
+        best, best_area = None, -1.0
+        for polygon in union.geoms:
+            overlap = polygon.intersection(fallback).area
+            if overlap > best_area:
+                best, best_area = polygon, overlap
+        return best if best is not None else fallback
+    return fallback
 
 
 def auto_generate_boundaries(
@@ -221,6 +259,14 @@ def auto_generate_boundaries(
         space_face_polygon = _verts_to_polygon(space_verts_l, face_matrix_inv, snap=1e-6)
         if not space_face_polygon.is_valid:
             space_face_polygon = space_face_polygon.buffer(0)
+        space_face_polygon = _union_coplanar_face_polygon(
+            space_verts_local,
+            space_shape["faces"],
+            space_verts_l[0],
+            space_face_normal_local,
+            face_matrix_inv,
+            space_face_polygon,
+        )
         space_face_polygons[space_ngon_idx] = space_face_polygon
         face_matrices[space_ngon_idx] = face_matrix
         face_matrix_invs[space_ngon_idx] = face_matrix_inv
@@ -266,24 +312,23 @@ def auto_generate_boundaries(
             candidates.append((element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal))
 
         # A space face may be matched by several elements within the distance
-        # tolerance (e.g. a second wall layer or an element end cap). When the
-        # face is already covered coplanarly, offset matches that only duplicate
-        # that coverage are skipped.
-        coplanar_union = None
-        for _, dist_min, _, gross_boundary_polygon, _ in candidates:
-            if dist_min <= COPLANAR_TOL:
-                coplanar_union = (
-                    gross_boundary_polygon if coplanar_union is None else coplanar_union.union(gross_boundary_polygon)
-                )
-
+        # tolerance (e.g. a second wall layer or an element end cap). The
+        # element closest to the face is the actual bounding surface, so
+        # candidates are kept in order of increasing plane offset (ties broken
+        # by polygon area). A candidate whose polygon is entirely covered by
+        # the candidates already kept is redundant and is absorbed into the
+        # larger boundary.
         surviving_candidates = []
-        for element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal in candidates:
-            if dist_min > COPLANAR_TOL and coplanar_union is not None:
-                if gross_boundary_polygon.difference(coplanar_union).area < 1e-4:
-                    continue
+        kept_union = None
+        for element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal in sorted(
+            candidates, key=lambda c: (c[2] if c[2] is not None else float("inf"), -c[3].area)
+        ):
+            if kept_union is not None and gross_boundary_polygon.difference(kept_union).area < 1e-4:
+                continue
             surviving_candidates.append(
                 (element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal)
             )
+            kept_union = gross_boundary_polygon if kept_union is None else kept_union.union(gross_boundary_polygon)
 
         # When a single element bounds the space face and its face is (nearly)
         # coplanar with it, the boundary covers the full space face (1st level
@@ -297,11 +342,7 @@ def auto_generate_boundaries(
             surviving_candidates[0] = (element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal)
 
         for element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal in surviving_candidates:
-            if dist_min > COPLANAR_TOL and coplanar_union is not None:
-                if gross_boundary_polygon.difference(coplanar_union).area < 1e-4:
-                    continue
-
-            exterior_boundary_polygon = shapely.Polygon(gross_boundary_polygon.exterior.coords)
+            exterior_boundary_polygon = gross_boundary_polygon
 
             opening_source_element = element
             for rel in getattr(element, "Decomposes", []):

--- a/src/ifcopenshell-python/ifcopenshell/util/boundary.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/boundary.py
@@ -43,7 +43,27 @@ import shapely.ops
 
 logger = logging.getLogger("ImportIFC")
 
-BOUNDARY_ELEMENT_CLASSES = ("IfcWall", "IfcColumn", "IfcSlab", "IfcVirtualElement", "IfcCurtainWall")
+BOUNDARY_ELEMENT_CLASSES = (
+    "IfcWall",
+    "IfcColumn",
+    "IfcSlab",
+    "IfcRoof",
+    "IfcVirtualElement",
+    "IfcCurtainWall",
+    "IfcWindow",
+    "IfcDoor",
+)
+
+# Distance (in meters) below which an element face is considered coplanar with
+# the space face it bounds. Matches beyond this distance within the larger
+# tolerance are only kept when no coplanar element already covers the face.
+COPLANAR_TOL = 0.05
+
+# Plane offset (in meters) below which a sole bounding element is assigned the
+# full space face. Building element faces are often slightly offset from the
+# space face they bound (e.g. wall linings), so a single bounding element
+# within this offset gets the complete face rather than a clipped polygon.
+FULL_FACE_OFFSET_TOL = 0.2
 
 
 def auto_generate_boundaries(
@@ -78,10 +98,12 @@ def auto_generate_boundaries(
     for ifc_class in boundary_element_classes:
         building_elements.extend(ifc_file.by_type(ifc_class))
 
-    # Don't generate boundaries for elements that already have boundaries
-    for boundary in space.BoundedBy:
+    # Delete existing boundaries so they are regenerated. remove_deep2 cannot be
+    # used on the boundary itself because 2nd level boundaries are referenced via
+    # their ParentBoundary and CorrelationId attributes by other boundaries.
+    for boundary in list(space.BoundedBy or []):
         if boundary.RelatedBuildingElement in building_elements:
-            building_elements.remove(boundary.RelatedBuildingElement)
+            ifcopenshell.api.boundary.remove_boundary(ifc_file, boundary)
 
     # Filter to elements that have shapes in the cache
     building_elements = [e for e in building_elements if e.id() in shapes]
@@ -107,201 +129,478 @@ def auto_generate_boundaries(
             es["verts"], es["faces"], es["edges"], merge_coplanar=True
         )
 
-    # Compare space faces and building element faces
+    # Separate from processed_fillings (used by _process_openings) so that
+    # pre-populating does not cause _process_openings to skip fillings.
+    all_filling_ids: set[int] = set()
+    for element in building_elements:
+        for rel in getattr(element, "HasOpenings", []):
+            if not (opening := rel.RelatedOpeningElement).HasFillings:
+                continue
+            for fills_rel in opening.HasFillings:
+                all_filling_ids.add(fills_rel.RelatedBuildingElement.id())
+
+    # Some models have openings without an IfcRelFillsElement relation (e.g. a
+    # window placed directly on top of an opening in a roof). Detect these
+    # fillings geometrically by matching the projected footprint of a window or
+    # door with the opening it occupies.
+    geometric_fillings: dict[int, ifcopenshell.entity_instance] = {}
+    filling_candidates = []
+    for element in building_elements:
+        if element.is_a() not in ("IfcWindow", "IfcDoor") or element.id() in all_filling_ids:
+            continue
+        es = shapes[element.id()]
+        world = sb.np_apply_matrix(es["verts"], es["matrix"])
+        filling_candidates.append(
+            (
+                element,
+                shapely.box(world[:, 0].min(), world[:, 1].min(), world[:, 0].max(), world[:, 1].max()),
+                float(world[:, 2].min()),
+                float(world[:, 2].max()),
+            )
+        )
+
+    if filling_candidates:
+        settings = ifcopenshell.geom.settings()
+        for element in building_elements:
+            for rel in getattr(element, "HasOpenings", []):
+                opening = rel.RelatedOpeningElement
+                if opening.HasFillings:
+                    continue
+                try:
+                    o_shape = ifcopenshell.geom.create_shape(settings, opening)
+                except Exception:
+                    continue
+                o_verts = ifcopenshell.util.shape.get_vertices(o_shape.geometry)
+                o_matrix = ifcopenshell.util.shape.get_shape_matrix(o_shape)
+                o_world = sb.np_apply_matrix(o_verts, o_matrix)
+                o_xy_box = shapely.box(
+                    o_world[:, 0].min(), o_world[:, 1].min(), o_world[:, 0].max(), o_world[:, 1].max()
+                )
+                o_zmin, o_zmax = float(o_world[:, 2].min()), float(o_world[:, 2].max())
+                best_filling = None
+                best_overlap = 0.0
+                for candidate, c_xy_box, c_zmin, c_zmax in filling_candidates:
+                    overlap = o_xy_box.intersection(c_xy_box).area
+                    if overlap < 0.8 * min(o_xy_box.area, c_xy_box.area):
+                        continue
+                    if max(o_zmin, c_zmin) - min(o_zmax, c_zmax) > 0.1:
+                        continue
+                    if overlap > best_overlap:
+                        best_overlap = overlap
+                        best_filling = candidate
+                if best_filling is not None:
+                    geometric_fillings[opening.id()] = best_filling
+                    all_filling_ids.add(best_filling.id())
+
     processed_fillings: set[int] = set()
-    for space_ngon in space_ngons:
+    matched_element_ids: set[int] = set()
+    matched_walls_and_columns: set[int] = set()
+
+    space_centroid_world = sb.np_apply_matrix(np.mean(space_verts_local, axis=0)[np.newaxis], space_matrix)[0]
+
+    # Per-face data used to detect and fill gaps so that generated boundaries
+    # form a water-tight enclosure.
+    space_face_polygons = {}
+    face_matrices = {}
+    face_matrix_invs = {}
+    space_face_normals_world = {}
+    covered_by_face = {}
+
+    for space_ngon_idx, space_ngon in enumerate(space_ngons):
         space_verts_l = space_verts_local[space_ngon]
-        # Normal from local verts, then transform to world via space placement
         space_face_normal_local = _face_normal(space_verts_l)
         if space_face_normal_local is None:
             continue
+        space_face_normal_local = _ensure_outward(
+            space_face_normal_local, space_verts_l, space_centroid_world, space_matrix
+        )
         space_face_normal_world = space_matrix_3x3 @ space_face_normal_local
 
+        face_matrix = _face_matrix_from_verts(space_verts_l[:3])
+        face_matrix_inv = np.linalg.inv(face_matrix)
+        space_face_polygon = _verts_to_polygon(space_verts_l, face_matrix_inv, snap=1e-6)
+        if not space_face_polygon.is_valid:
+            space_face_polygon = space_face_polygon.buffer(0)
+        space_face_polygons[space_ngon_idx] = space_face_polygon
+        face_matrices[space_ngon_idx] = face_matrix
+        face_matrix_invs[space_ngon_idx] = face_matrix_inv
+        space_face_normals_world[space_ngon_idx] = space_face_normal_world
+        covered_by_face[space_ngon_idx] = []
+
+        candidates = []
         for element in building_elements:
-            element_shape = shapes[element.id()]
-            element_matrix = element_shape["matrix"]
-            element_matrix_3x3 = element_matrix[:3, :3]
-            element_matrix_inv = np.linalg.inv(element_matrix)
+            if element.id() in all_filling_ids:
+                continue
+            if element.is_a() in ("IfcWall", "IfcColumn") and element.id() in matched_walls_and_columns:
+                continue
+            match = _match_element_to_space_face(
+                element,
+                shapes,
+                element_ngons,
+                space_matrix,
+                space_matrix_inv,
+                space_verts_l,
+                space_face_polygon,
+                face_matrix_inv,
+                space_face_normal_world,
+            )
+            if match is None:
+                continue
+            dist_min, plane_offset_min, matching_polygons, matched_elem_normal = match
 
-            for ngon in element_ngons[element.id()]:
-                elem_verts_l = element_shape["verts"][ngon]
-                # Normal from local verts, transform to world via element placement
-                elem_face_normal_local = _face_normal(elem_verts_l)
-                if elem_face_normal_local is None:
-                    continue
-                elem_face_normal_world = element_matrix_3x3 @ elem_face_normal_local
-
-                # Both normals point outward from their respective solids.
-                # Adjacent faces have anti-parallel normals (angle ≈ 180°).
-                # Virtual elements use parallel normals (angle ≈ 0°).
-                angle = degrees(acos(max(min(float(np.dot(space_face_normal_world, elem_face_normal_world)), 1), -1)))
-                if _is_x(angle, 180, tolerance=2):
-                    pass
-                elif element.is_a("IfcVirtualElement") and _is_x(angle, 0, tolerance=2):
-                    pass
-                else:
-                    continue
-
-                # Distance check: transform space vert to element-local, compare to element face
-                # space-local -> world -> element-local
-                space_vert_in_elem = sb.np_apply_matrix(space_verts_l[:1], element_matrix_inv @ space_matrix)[0]
-                dist = float(np.dot(space_vert_in_elem - elem_verts_l[0], elem_face_normal_local))
-                if abs(dist) > 0.05:
-                    continue
-
-                # Build face matrix in space-local coordinates
-                # (assign_connection_geometry expects location/axes relative to space placement)
-                face_matrix = _face_matrix_from_verts(space_verts_l[:3])
-                face_matrix_inv = np.linalg.inv(face_matrix)
-
-                # Project space face (already space-local) to 2D
-                space_face_polygon = _verts_to_polygon(space_verts_l, face_matrix_inv)
-                if not space_face_polygon.is_valid:
-                    space_face_polygon = space_face_polygon.buffer(0)
-
-                # Transform element verts to space-local, then project to 2D
-                # element-local -> world -> space-local
-                elem_verts_in_space = sb.np_apply_matrix(elem_verts_l, space_matrix_inv @ element_matrix)
-                face_polygon = _verts_to_polygon(elem_verts_in_space, face_matrix_inv)
-                if not face_polygon.is_valid:
-                    face_polygon = face_polygon.buffer(0)
-
-                try:
-                    gross_boundary_polygon = space_face_polygon.intersection(face_polygon)
-                except shapely.errors.GEOSException:
-                    logger.warning(
-                        "Skipping invalid geometry for %s (shapely topology error).",
-                        element.Name or element.is_a(),
-                        exc_info=True,
-                    )
-                    continue
-
+            if len(matching_polygons) == 1:
+                gross_boundary_polygon = matching_polygons[0]
+            else:
+                gross_boundary_polygon = shapely.ops.unary_union(matching_polygons)
                 if type(gross_boundary_polygon) == shapely.GeometryCollection:
                     for geom in gross_boundary_polygon.geoms:
                         if type(geom) == shapely.Polygon:
                             gross_boundary_polygon = geom
                             break
 
-                if not (isinstance(gross_boundary_polygon, shapely.Polygon) and gross_boundary_polygon.is_valid):
+            if not (isinstance(gross_boundary_polygon, shapely.Polygon) and gross_boundary_polygon.is_valid):
+                continue
+            if gross_boundary_polygon.is_empty:
+                continue
+
+            candidates.append((element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal))
+
+        # A space face may be matched by several elements within the distance
+        # tolerance (e.g. a second wall layer or an element end cap). When the
+        # face is already covered coplanarly, offset matches that only duplicate
+        # that coverage are skipped.
+        coplanar_union = None
+        for _, dist_min, _, gross_boundary_polygon, _ in candidates:
+            if dist_min <= COPLANAR_TOL:
+                coplanar_union = (
+                    gross_boundary_polygon if coplanar_union is None else coplanar_union.union(gross_boundary_polygon)
+                )
+
+        surviving_candidates = []
+        for element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal in candidates:
+            if dist_min > COPLANAR_TOL and coplanar_union is not None:
+                if gross_boundary_polygon.difference(coplanar_union).area < 1e-4:
                     continue
-                if gross_boundary_polygon.is_empty:
+            surviving_candidates.append(
+                (element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal)
+            )
+
+        # When a single element bounds the space face and its face is (nearly)
+        # coplanar with it, the boundary covers the full space face (1st level
+        # semantics) rather than the clipped intersection with the element
+        # face. This matches the reference output and avoids leaving corner
+        # slivers to be filled by an extra gap boundary.
+        if len(surviving_candidates) == 1:
+            element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal = surviving_candidates[0]
+            if plane_offset_min is not None and plane_offset_min <= FULL_FACE_OFFSET_TOL:
+                gross_boundary_polygon = space_face_polygon
+            surviving_candidates[0] = (element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal)
+
+        for element, dist_min, plane_offset_min, gross_boundary_polygon, matched_elem_normal in surviving_candidates:
+            if dist_min > COPLANAR_TOL and coplanar_union is not None:
+                if gross_boundary_polygon.difference(coplanar_union).area < 1e-4:
                     continue
 
-                exterior_boundary_polygon = shapely.Polygon(gross_boundary_polygon.exterior.coords)
+            exterior_boundary_polygon = shapely.Polygon(gross_boundary_polygon.exterior.coords)
 
-                # Create parent boundary
-                parent_boundary = ifcopenshell.api.root.create_entity(ifc_file, ifc_class=boundary_class)
-                if element.is_a("IfcVirtualElement"):
-                    parent_boundary.PhysicalOrVirtualBoundary = "VIRTUAL"
-                else:
-                    parent_boundary.PhysicalOrVirtualBoundary = "PHYSICAL"
-                parent_boundary.InternalOrExternalBoundary = "NOTDEFINED"
-                _set_internal_external(parent_boundary, element)
-                parent_boundary.RelatingSpace = space
-                parent_boundary.RelatedBuildingElement = element
+            opening_source_element = element
+            for rel in getattr(element, "Decomposes", []):
+                if rel.RelatingObject.is_a() in BOUNDARY_ELEMENT_CLASSES:
+                    element = rel.RelatingObject
+                    break
 
-                _assign_connection_geometry(
+            # The gross boundary polygon may still carry the openings of the
+            # building element (e.g. when the authoring tool baked them into the
+            # element geometry). An inner boundary is supposed to overlap its
+            # parent boundary according to IFC4 documentation, so the openings
+            # are unioned back into the parent to keep it hole-free while the
+            # filling gets its own parented boundary.
+            openings_to_process = []
+            for rel in getattr(opening_source_element, "HasOpenings", []):
+                opening = rel.RelatedOpeningElement
+                filling = (
+                    opening.HasFillings[0].RelatedBuildingElement
+                    if opening.HasFillings
+                    else geometric_fillings.get(opening.id())
+                )
+                if filling is None:
+                    continue
+                opening_polygon = _compute_opening_polygon(
+                    ifc_file, opening, matched_elem_normal, space_matrix_inv, face_matrix_inv
+                )
+                if opening_polygon is None:
+                    continue
+                if opening_polygon.intersection(gross_boundary_polygon).area == 0:
+                    continue
+                openings_to_process.append((opening, filling, opening_polygon))
+
+            exterior_boundary_polygon = _union_openings_into_parent(exterior_boundary_polygon, openings_to_process)
+
+            exterior_boundary_polygon = exterior_boundary_polygon.simplify(1e-5)
+            if isinstance(exterior_boundary_polygon, shapely.Polygon) and not exterior_boundary_polygon.is_empty:
+                ext_coords = [
+                    (round(x / 1e-8) * 1e-8, round(y / 1e-8) * 1e-8)
+                    for x, y in exterior_boundary_polygon.exterior.coords
+                ]
+                int_coords = [
+                    [(round(x / 1e-8) * 1e-8, round(y / 1e-8) * 1e-8) for x, y in interior.coords]
+                    for interior in exterior_boundary_polygon.interiors
+                ]
+                snapped = shapely.Polygon(ext_coords, int_coords)
+                if not snapped.is_empty:
+                    cleaned = snapped.buffer(0).simplify(1e-5)
+                    if isinstance(cleaned, shapely.Polygon) and not cleaned.is_empty:
+                        exterior_boundary_polygon = cleaned
+
+            matched_walls_and_columns.add(element.id())
+
+            parent_boundary = ifcopenshell.api.root.create_entity(ifc_file, ifc_class=boundary_class)
+            if element.is_a("IfcVirtualElement"):
+                parent_boundary.PhysicalOrVirtualBoundary = "VIRTUAL"
+            else:
+                parent_boundary.PhysicalOrVirtualBoundary = "PHYSICAL"
+            parent_boundary.InternalOrExternalBoundary = "NOTDEFINED"
+            _set_internal_external(parent_boundary, element)
+            parent_boundary.RelatingSpace = space
+            parent_boundary.RelatedBuildingElement = element
+
+            _assign_connection_geometry(
+                ifc_file,
+                parent_boundary,
+                exterior_boundary_polygon,
+                face_matrix,
+                unit_scale,
+            )
+            _set_boundary_name(parent_boundary)
+            boundaries.append(parent_boundary)
+            covered_by_face[space_ngon_idx].append(exterior_boundary_polygon)
+
+            boundaries.extend(
+                _process_openings(
                     ifc_file,
-                    parent_boundary,
-                    exterior_boundary_polygon,
+                    openings_to_process,
                     face_matrix,
+                    boundary_class,
+                    parent_boundary,
+                    space,
                     unit_scale,
+                    processed_fillings,
+                    covered_by_face[space_ngon_idx],
                 )
-                _set_boundary_name(parent_boundary)
-                boundaries.append(parent_boundary)
+            )
 
-                # Process openings
-                boundaries.extend(
-                    _process_openings(
-                        ifc_file,
-                        element,
-                        elem_face_normal_world,
-                        space_matrix_inv,
-                        element_matrix,
-                        face_matrix,
-                        face_matrix_inv,
-                        exterior_boundary_polygon,
-                        boundary_class,
-                        parent_boundary,
-                        space,
-                        unit_scale,
-                        processed_fillings,
-                    )
-                )
+    boundaries.extend(
+        _fill_face_gaps(
+            ifc_file,
+            space,
+            boundary_class,
+            unit_scale,
+            space_face_polygons,
+            face_matrices,
+            face_matrix_invs,
+            space_face_normals_world,
+            space_verts_local,
+            space_ngons,
+            space_matrix,
+            space_matrix_inv,
+            shapes,
+            element_ngons,
+            covered_by_face,
+            building_elements,
+            all_filling_ids,
+            matched_walls_and_columns,
+        )
+    )
 
     return boundaries
 
 
+def _match_element_to_space_face(
+    element,
+    shapes,
+    element_ngons,
+    space_matrix,
+    space_matrix_inv,
+    space_verts_l,
+    space_face_polygon,
+    face_matrix_inv,
+    space_face_normal_world,
+):
+    """Match a building element's faces against a single space face.
+
+    :return: A tuple ``(dist_min, matching_polygons, matched_elem_normal)`` with
+        the minimum face distance, the matching boundary polygons and the matched
+        face normal in world space, or ``None`` when the element does not bound
+        this space face.
+    """
+    element_shape = shapes[element.id()]
+    element_matrix = element_shape["matrix"]
+    element_matrix_3x3 = element_matrix[:3, :3]
+    element_matrix_inv = np.linalg.inv(element_matrix)
+
+    element_centroid_world = sb.np_apply_matrix(np.mean(element_shape["verts"], axis=0)[np.newaxis], element_matrix)[0]
+
+    space_centroid = np.mean(space_verts_l, axis=0)
+
+    matching_polygons = []
+    matched_elem_normal = None
+    dist_min = None
+    plane_offset_min = None
+
+    for ngon in element_ngons[element.id()]:
+        elem_verts_l = element_shape["verts"][ngon]
+        elem_face_normal_local = _face_normal(elem_verts_l)
+        if elem_face_normal_local is None:
+            continue
+        elem_face_normal_local = _ensure_outward(
+            elem_face_normal_local, elem_verts_l, element_centroid_world, element_matrix
+        )
+        elem_face_normal_world = element_matrix_3x3 @ elem_face_normal_local
+
+        angle = degrees(acos(max(min(float(np.dot(space_face_normal_world, elem_face_normal_world)), 1), -1)))
+        is_horizontal_face = abs(space_face_normal_world[2]) > 0.5 and abs(elem_face_normal_world[2]) > 0.5
+        is_valid_element = (
+            element.is_a("IfcVirtualElement")
+            or element.is_a("IfcSlab")
+            or element.is_a("IfcWindow")
+            or element.is_a("IfcDoor")
+        )
+        is_anti_parallel = _is_x(angle, 180, tolerance=2)
+        is_parallel = _is_x(angle, 0, tolerance=2)
+
+        if not (is_anti_parallel or (is_horizontal_face and is_parallel and is_valid_element)):
+            continue
+
+        sv_in_elem = sb.np_apply_matrix(space_centroid[np.newaxis], element_matrix_inv @ space_matrix)[0]
+        dist = float(np.dot(sv_in_elem - elem_verts_l[0], elem_face_normal_local))
+        dist_tol = 0.05 if is_horizontal_face else 0.5
+        if abs(dist) > dist_tol:
+            continue
+
+        elem_verts_in_space = sb.np_apply_matrix(elem_verts_l, space_matrix_inv @ element_matrix)
+        face_polygon = _verts_to_polygon(elem_verts_in_space, face_matrix_inv, snap=1e-6)
+        if not face_polygon.is_valid:
+            face_polygon = face_polygon.buffer(0)
+
+        try:
+            gross_boundary_polygon = space_face_polygon.intersection(face_polygon)
+        except shapely.errors.GEOSException:
+            logger.warning(
+                "Skipping invalid geometry for %s (shapely topology error).",
+                element.Name or element.is_a(),
+                exc_info=True,
+            )
+            continue
+
+        if gross_boundary_polygon.is_empty or gross_boundary_polygon.area < 1e-4:
+            continue
+
+        if type(gross_boundary_polygon) == shapely.GeometryCollection:
+            for geom in gross_boundary_polygon.geoms:
+                if type(geom) == shapely.Polygon:
+                    gross_boundary_polygon = geom
+                    break
+
+        if not (isinstance(gross_boundary_polygon, shapely.Polygon) and gross_boundary_polygon.is_valid):
+            continue
+        if gross_boundary_polygon.is_empty:
+            continue
+
+        matching_polygons.append(gross_boundary_polygon)
+        matched_elem_normal = elem_face_normal_world
+        dist_min = abs(dist) if dist_min is None else min(dist_min, abs(dist))
+        space_face_normal = _face_normal(space_verts_l)
+        if space_face_normal is not None:
+            plane_offset = abs(float(np.dot(space_face_normal, elem_verts_in_space[0] - space_verts_l[0])))
+            plane_offset_min = plane_offset if plane_offset_min is None else min(plane_offset_min, plane_offset)
+
+    if not matching_polygons:
+        return None
+    return dist_min, plane_offset_min, matching_polygons, matched_elem_normal
+
+
+def _union_openings_into_parent(exterior_boundary_polygon, openings_to_process):
+    """Union the opening polygons back into the parent boundary polygon.
+
+    Authoring tools may bake openings into the building element mesh, so the
+    parent boundary polygon can be notched where the opening is. Since an inner
+    boundary is supposed to overlap its parent boundary, the openings are
+    unioned back into the parent while the filling gets its own boundary.
+    """
+    for _, _, opening_polygon in openings_to_process:
+        unionised_object = exterior_boundary_polygon.union(opening_polygon)
+        if isinstance(unionised_object, shapely.Polygon):
+            exterior_boundary_polygon = unionised_object
+    return exterior_boundary_polygon
+
+
+def _compute_opening_polygon(ifc_file, opening, face_normal_world, space_matrix_inv, face_matrix_inv):
+    """Project an opening onto the building element face in space-local coordinates.
+
+    :param opening: The IfcOpeningElement to project.
+    :param face_normal_world: The building element face normal in world space.
+    :param space_matrix_inv: Inverse of the space placement matrix.
+    :param face_matrix_inv: The inverse face matrix (for 2D projection).
+    :return: A 2D shapely polygon in space-local coordinates, or None.
+    """
+    settings = ifcopenshell.geom.settings()
+    try:
+        shape = ifcopenshell.geom.create_shape(settings, opening)
+    except Exception:
+        return None
+    opening_verts_l = ifcopenshell.util.shape.get_vertices(shape.geometry)
+    opening_faces = ifcopenshell.util.shape.get_faces(shape.geometry)
+    opening_edges = ifcopenshell.util.shape.get_edges(shape.geometry)
+    opening_matrix = ifcopenshell.util.shape.get_shape_matrix(shape)
+    opening_matrix_3x3 = opening_matrix[:3, :3]
+
+    opening_ngons = ifcopenshell.util.shape.dissolve_faces(
+        opening_verts_l, opening_faces, opening_edges, merge_coplanar=True
+    )
+
+    opening_polygons = []
+    for ngon in opening_ngons:
+        o_verts_l = opening_verts_l[ngon]
+        o_normal_local = _face_normal(o_verts_l)
+        if o_normal_local is None:
+            continue
+        o_normal_world = opening_matrix_3x3 @ o_normal_local
+        angle = degrees(acos(max(min(float(np.dot(o_normal_world, face_normal_world)), 1), -1)))
+        if not _is_x(angle, 180, tolerance=2):
+            continue
+        o_verts_in_space = sb.np_apply_matrix(o_verts_l, space_matrix_inv @ opening_matrix)
+        polygon = _verts_to_polygon(o_verts_in_space, face_matrix_inv)
+        opening_polygons.append(polygon)
+
+    if not opening_polygons:
+        return None
+
+    return shapely.ops.unary_union(opening_polygons)
+
+
 def _process_openings(
     ifc_file,
-    building_element,
-    face_normal_world,
-    space_matrix_inv,
-    element_matrix,
+    openings_to_process,
     face_matrix,
-    face_matrix_inv,
-    exterior_boundary_polygon,
     boundary_class,
     parent_boundary,
     space,
     unit_scale,
     processed_fillings: set[int],
+    covered_polygons: list,
 ):
-    """Process openings and fillings for a building element.
+    """Create boundaries for the fillings of openings in a building element.
 
-    :param face_normal_world: The building element face normal in world space.
-    :param space_matrix_inv: Inverse of the space placement matrix.
-    :param element_matrix: The building element placement matrix.
+    :param openings_to_process: Tuples of (opening, filling, opening polygon).
     :param face_matrix: The face matrix in space-local coordinates (for connection geometry).
-    :param face_matrix_inv: The inverse face matrix (for 2D projection).
     :param processed_fillings: Set of element IDs that already have opening boundaries.
+    :param covered_polygons: Accumulated boundary polygons used for water-tightness checks.
     """
     boundaries = []
 
-    for rel in getattr(building_element, "HasOpenings", []):
-        opening = rel.RelatedOpeningElement
-        filling = opening.HasFillings[0].RelatedBuildingElement if opening.HasFillings else None
-        filling_id = (filling or opening).id()
+    for opening, filling, opening_polygon in openings_to_process:
+        filling_id = filling.id()
         if filling_id in processed_fillings:
-            continue
-
-        settings = ifcopenshell.geom.settings()
-        try:
-            shape = ifcopenshell.geom.create_shape(settings, opening)
-        except Exception:
-            continue
-        opening_verts_l = ifcopenshell.util.shape.get_vertices(shape.geometry)
-        opening_faces = ifcopenshell.util.shape.get_faces(shape.geometry)
-        opening_edges = ifcopenshell.util.shape.get_edges(shape.geometry)
-        opening_matrix = ifcopenshell.util.shape.get_shape_matrix(shape)
-        opening_matrix_3x3 = opening_matrix[:3, :3]
-
-        opening_ngons = ifcopenshell.util.shape.dissolve_faces(
-            opening_verts_l, opening_faces, opening_edges, merge_coplanar=True
-        )
-
-        opening_polygons = []
-        for ngon in opening_ngons:
-            o_verts_l = opening_verts_l[ngon]
-            # Normal from local verts, transform to world via opening placement
-            o_normal_local = _face_normal(o_verts_l)
-            if o_normal_local is None:
-                continue
-            o_normal_world = opening_matrix_3x3 @ o_normal_local
-            angle = degrees(acos(max(min(float(np.dot(o_normal_world, face_normal_world)), 1), -1)))
-            if not _is_x(angle, 180, tolerance=2):
-                continue
-            # Transform opening verts to space-local: opening-local -> world -> space-local
-            o_verts_in_space = sb.np_apply_matrix(o_verts_l, space_matrix_inv @ opening_matrix)
-            polygon = _verts_to_polygon(o_verts_in_space, face_matrix_inv)
-            opening_polygons.append(polygon)
-
-        if not opening_polygons:
-            continue
-
-        opening_polygon = shapely.ops.unary_union(opening_polygons)
-
-        if opening_polygon.intersection(exterior_boundary_polygon).area == 0:
             continue
 
         boundary = ifcopenshell.api.root.create_entity(ifc_file, ifc_class=boundary_class)
@@ -325,16 +624,198 @@ def _process_openings(
             boundary.ParentBoundary = parent_boundary
         _set_boundary_name(boundary)
         processed_fillings.add(filling_id)
+        covered_polygons.append(opening_polygon)
         boundaries.append(boundary)
 
     return boundaries
+
+
+def _fill_face_gaps(
+    ifc_file,
+    space,
+    boundary_class,
+    unit_scale,
+    space_face_polygons,
+    face_matrices,
+    face_matrix_invs,
+    space_face_normals_world,
+    space_verts_local,
+    space_ngons,
+    space_matrix,
+    space_matrix_inv,
+    shapes,
+    element_ngons,
+    covered_by_face,
+    building_elements,
+    all_filling_ids,
+    matched_walls_and_columns,
+):
+    """Create boundaries for uncovered parts of space faces to keep them water tight."""
+    boundaries = []
+    for face_idx, space_face_polygon in space_face_polygons.items():
+        covered_polygons = covered_by_face.get(face_idx, [])
+        if not covered_polygons:
+            continue
+        uncovered = space_face_polygon.difference(shapely.ops.unary_union(covered_polygons))
+        if uncovered.is_empty:
+            continue
+        if isinstance(uncovered, shapely.Polygon):
+            fragments = [uncovered]
+        elif isinstance(uncovered, shapely.MultiPolygon):
+            fragments = list(uncovered.geoms)
+        else:
+            continue
+        for fragment in fragments:
+            if fragment.area < 1e-2:
+                continue
+            element = _best_element_for_gap(
+                fragment,
+                space_verts_local[space_ngons[face_idx]],
+                space_matrix,
+                space_matrix_inv,
+                face_matrices[face_idx],
+                face_matrix_invs[face_idx],
+                space_face_normals_world[face_idx],
+                shapes,
+                element_ngons,
+                building_elements,
+                all_filling_ids,
+                matched_walls_and_columns,
+            )
+            if element is None:
+                logger.warning(
+                    "No element found to fill a gap on a face of space %s.",
+                    space.Name or space.is_a(),
+                )
+                continue
+            parent_boundary = ifcopenshell.api.root.create_entity(ifc_file, ifc_class=boundary_class)
+            parent_boundary.PhysicalOrVirtualBoundary = "PHYSICAL"
+            parent_boundary.InternalOrExternalBoundary = "NOTDEFINED"
+            _set_internal_external(parent_boundary, element)
+            parent_boundary.RelatingSpace = space
+            parent_boundary.RelatedBuildingElement = element
+            _assign_connection_geometry(
+                ifc_file,
+                parent_boundary,
+                fragment,
+                face_matrices[face_idx],
+                unit_scale,
+            )
+            _set_boundary_name(parent_boundary)
+            boundaries.append(parent_boundary)
+    return boundaries
+
+
+def _best_element_for_gap(
+    fragment,
+    space_face_verts,
+    space_matrix,
+    space_matrix_inv,
+    face_matrix,
+    face_matrix_inv,
+    space_face_normal_world,
+    shapes,
+    element_ngons,
+    building_elements,
+    all_filling_ids,
+    matched_walls_and_columns,
+):
+    """Find the element most appropriate to cover an uncovered part of a space face."""
+    best = None
+    best_overlap = 0.0
+    space_centroid = np.mean(space_face_verts, axis=0)
+
+    for element in building_elements:
+        if element.id() in all_filling_ids:
+            continue
+        # Walls and columns already bounding this space keep a single boundary;
+        # a gap is therefore filled by a neighbouring element instead.
+        if element.is_a() in ("IfcWall", "IfcColumn") and element.id() in matched_walls_and_columns:
+            continue
+        es = shapes[element.id()]
+        e_matrix = es["matrix"]
+        e_matrix_3x3 = e_matrix[:3, :3]
+        e_matrix_inv = np.linalg.inv(e_matrix)
+        e_centroid_world = sb.np_apply_matrix(np.mean(es["verts"], axis=0)[np.newaxis], e_matrix)[0]
+
+        for ngon in element_ngons[element.id()]:
+            elem_verts_l = es["verts"][ngon]
+            normal_local = _face_normal(elem_verts_l)
+            if normal_local is None:
+                continue
+            normal_local = _ensure_outward(normal_local, elem_verts_l, e_centroid_world, e_matrix)
+            normal_world = e_matrix_3x3 @ normal_local
+            angle = degrees(acos(max(min(float(np.dot(space_face_normal_world, normal_world)), 1), -1)))
+            is_horizontal_face = abs(space_face_normal_world[2]) > 0.5 and abs(normal_world[2]) > 0.5
+            is_valid_element = (
+                element.is_a("IfcVirtualElement")
+                or element.is_a("IfcSlab")
+                or element.is_a("IfcWindow")
+                or element.is_a("IfcDoor")
+            )
+            if not (
+                _is_x(angle, 180, tolerance=2)
+                or (is_horizontal_face and _is_x(angle, 0, tolerance=2) and is_valid_element)
+            ):
+                continue
+            sv_in_elem = sb.np_apply_matrix(space_centroid[np.newaxis], e_matrix_inv @ space_matrix)[0]
+            dist = float(np.dot(sv_in_elem - elem_verts_l[0], normal_local))
+            dist_tol = 0.05 if is_horizontal_face else 0.5
+            if abs(dist) > dist_tol:
+                continue
+            elem_verts_in_space = sb.np_apply_matrix(elem_verts_l, space_matrix_inv @ e_matrix)
+            face_polygon = _verts_to_polygon(elem_verts_in_space, face_matrix_inv, snap=1e-6)
+            if not face_polygon.is_valid:
+                face_polygon = face_polygon.buffer(0)
+            overlap = fragment.intersection(face_polygon).area
+            if overlap > best_overlap:
+                best_overlap = overlap
+                best = element
+
+    if best is not None:
+        return best
+
+    # For gaps at corners between non-parallel faces, fall back to the element
+    # whose plan footprint covers the gap centroid.
+    frag_2d = np.array([[c[0], c[1], 0.0] for c in fragment.exterior.coords])
+    frag_local = sb.np_apply_matrix(frag_2d, face_matrix)
+    frag_world = sb.np_apply_matrix(frag_local, space_matrix)
+    frag_centroid = frag_world.mean(axis=0)
+    is_horizontal_face = abs(space_face_normal_world[2]) > 0.5
+    best = None
+    best_dist = np.inf
+    for element in building_elements:
+        if element.id() in all_filling_ids:
+            continue
+        if is_horizontal_face:
+            if not (element.is_a("IfcSlab") or element.is_a("IfcRoof") or element.is_a("IfcVirtualElement")):
+                continue
+        elif not (element.is_a("IfcWall") or element.is_a("IfcColumn") or element.is_a("IfcVirtualElement")):
+            continue
+        es = shapes[element.id()]
+        world = sb.np_apply_matrix(es["verts"], es["matrix"])
+        elem_xy = shapely.box(world[:, 0].min(), world[:, 1].min(), world[:, 0].max(), world[:, 1].max())
+        if not elem_xy.contains(shapely.Point(frag_centroid[:2])):
+            continue
+        elem_centroid = world.mean(axis=0)
+        dist = float(np.linalg.norm(elem_centroid - frag_centroid))
+        if dist < best_dist:
+            best_dist = dist
+            best = element
+    return best
 
 
 def _face_normal(verts: np.ndarray) -> Optional[np.ndarray]:
     """Compute the normal of a polygon from its vertices."""
     if len(verts) < 3:
         return None
-    return sb.np_normal([verts[0], verts[1], verts[2]])
+    for i in range(len(verts) - 2):
+        v0, v1, v2 = verts[i], verts[i + 1], verts[i + 2]
+        cross = np.cross(v1 - v0, v2 - v0)
+        norm = np.linalg.norm(cross)
+        if norm > 1e-8:
+            return cross / norm
+    return None
 
 
 def _face_matrix_from_verts(verts3: np.ndarray) -> np.ndarray:
@@ -345,9 +826,11 @@ def _face_matrix_from_verts(verts3: np.ndarray) -> np.ndarray:
     return ifcopenshell.util.placement.a2p(o=p1, z=z, x=x)
 
 
-def _verts_to_polygon(verts: np.ndarray, face_matrix_inv: np.ndarray) -> shapely.Polygon:
+def _verts_to_polygon(verts: np.ndarray, face_matrix_inv: np.ndarray, snap: float = 0) -> shapely.Polygon:
     """Project 3D vertices onto a 2D plane and create a shapely Polygon."""
     verts_2d = sb.np_apply_matrix(verts, face_matrix_inv)[:, :2]
+    if snap:
+        verts_2d = np.round(verts_2d / snap) * snap
     return shapely.Polygon([tuple(v) for v in verts_2d])
 
 
@@ -410,6 +893,20 @@ def _set_boundary_name(boundary: ifcopenshell.entity_instance) -> None:
             boundary.Description = "2b"
     elif boundary.is_a("IfcRelSpaceBoundary1stLevel"):
         boundary.Name = "1stLevel"
+
+
+def _ensure_outward(
+    normal_local: np.ndarray,
+    face_verts_l: np.ndarray,
+    entity_centroid_world: np.ndarray,
+    entity_matrix: np.ndarray,
+) -> np.ndarray:
+    """Flip face normal to point away from the entity centroid."""
+    face_centroid_world = sb.np_apply_matrix(np.mean(face_verts_l, axis=0)[np.newaxis], entity_matrix)[0]
+    normal_world = entity_matrix[:3, :3] @ normal_local
+    if np.dot(face_centroid_world - entity_centroid_world, normal_world) < 0:
+        return -normal_local
+    return normal_local
 
 
 def _is_x(value: float, x: float, tolerance: float = 1e-5) -> bool:

--- a/src/ifcopenshell-python/ifcopenshell/util/boundary.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/boundary.py
@@ -1,0 +1,409 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Blender-independent IfcRelSpaceBoundary generation from IFC geometry.
+
+These functions operate on IFC geometry data (vertices, faces, edges,
+element relationships) without requiring any Blender objects to be loaded.
+"""
+
+from __future__ import annotations
+
+import logging
+from math import acos, degrees
+from typing import Optional, Union
+
+import ifcopenshell
+import ifcopenshell.api.boundary
+import ifcopenshell.api.root
+import ifcopenshell.geom
+import ifcopenshell.util.element
+import ifcopenshell.util.placement
+import ifcopenshell.util.shape
+import ifcopenshell.util.shape_builder as sb
+import ifcopenshell.util.unit
+import numpy as np
+import shapely
+import shapely.ops
+
+logger = logging.getLogger("ImportIFC")
+
+BOUNDARY_ELEMENT_CLASSES = ("IfcWall", "IfcColumn", "IfcSlab", "IfcVirtualElement", "IfcCurtainWall")
+
+
+def auto_generate_boundaries(
+    ifc_file: ifcopenshell.file,
+    space: ifcopenshell.entity_instance,
+    shapes: dict,
+    boundary_class: str,
+    boundary_element_classes: tuple = BOUNDARY_ELEMENT_CLASSES,
+) -> Union[str, list[ifcopenshell.entity_instance]]:
+    """Generate IfcRelSpaceBoundary records from IFC geometry without Blender.
+
+    :param ifc_file: The IFC file.
+    :param space: The IfcSpace entity to generate boundaries for.
+    :param shapes: Dict ``{element_id: {"verts": ndarray, "faces": ndarray,
+        "edges": ndarray, "matrix": ndarray}}``. Must include the space itself.
+        Built by the caller via ``ifcopenshell.geom.iterator``.
+    :param boundary_class: IFC class for boundaries (e.g.
+        ``"IfcRelSpaceBoundary2ndLevel"``).
+    :param boundary_element_classes: IFC classes to consider as boundary elements.
+    :return: List of created ``IfcRelSpaceBoundary`` entities, or error string.
+    """
+    boundaries: list[ifcopenshell.entity_instance] = []
+
+    space_shape = shapes.get(space.id())
+    if space_shape is None:
+        return "Space geometry not found in shapes dict."
+
+    unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
+
+    # Identify all potential building elements
+    building_elements = []
+    for ifc_class in boundary_element_classes:
+        building_elements.extend(ifc_file.by_type(ifc_class))
+
+    # Don't generate boundaries for elements that already have boundaries
+    for boundary in space.BoundedBy:
+        if boundary.RelatedBuildingElement in building_elements:
+            building_elements.remove(boundary.RelatedBuildingElement)
+
+    # Filter to elements that have shapes in the cache
+    building_elements = [e for e in building_elements if e.id() in shapes]
+
+    if not building_elements:
+        return "No building elements found to create boundaries."
+
+    # Dissolve space mesh — verts are in local coords, matrix is the placement
+    space_matrix = space_shape["matrix"]
+    space_matrix_3x3 = space_matrix[:3, :3]
+    space_matrix_inv = np.linalg.inv(space_matrix)
+    # Space verts are already local (get_vertices without use-world-coords)
+    space_verts_local = space_shape["verts"]
+    space_ngons = ifcopenshell.util.shape.dissolve_faces(
+        space_verts_local, space_shape["faces"], space_shape["edges"], merge_coplanar=True
+    )
+
+    # Dissolve building element meshes — verts are in element-local coords
+    element_ngons = {}
+    for element in building_elements:
+        es = shapes[element.id()]
+        element_ngons[element.id()] = ifcopenshell.util.shape.dissolve_faces(
+            es["verts"], es["faces"], es["edges"], merge_coplanar=True
+        )
+
+    # Compare space faces and building element faces
+    for space_ngon in space_ngons:
+        space_verts_l = space_verts_local[space_ngon]
+        # Normal from local verts, then transform to world via space placement
+        space_face_normal_local = _face_normal(space_verts_l)
+        if space_face_normal_local is None:
+            continue
+        space_face_normal_world = space_matrix_3x3 @ space_face_normal_local
+
+        for element in building_elements:
+            element_shape = shapes[element.id()]
+            element_matrix = element_shape["matrix"]
+            element_matrix_3x3 = element_matrix[:3, :3]
+            element_matrix_inv = np.linalg.inv(element_matrix)
+
+            for ngon in element_ngons[element.id()]:
+                elem_verts_l = element_shape["verts"][ngon]
+                # Normal from local verts, transform to world via element placement
+                elem_face_normal_local = _face_normal(elem_verts_l)
+                if elem_face_normal_local is None:
+                    continue
+                elem_face_normal_world = element_matrix_3x3 @ elem_face_normal_local
+
+                # Both normals point outward from their respective solids.
+                # Adjacent faces have anti-parallel normals (angle ≈ 180°).
+                # Virtual elements use parallel normals (angle ≈ 0°).
+                angle = degrees(acos(max(min(float(np.dot(space_face_normal_world, elem_face_normal_world)), 1), -1)))
+                if _is_x(angle, 180, tolerance=2):
+                    pass
+                elif element.is_a("IfcVirtualElement") and _is_x(angle, 0, tolerance=2):
+                    pass
+                else:
+                    continue
+
+                # Distance check: transform space vert to element-local, compare to element face
+                # space-local -> world -> element-local
+                space_vert_in_elem = sb.np_apply_matrix(space_verts_l[:1], element_matrix_inv @ space_matrix)[0]
+                dist = float(np.dot(space_vert_in_elem - elem_verts_l[0], elem_face_normal_local))
+                if abs(dist) > 0.05:
+                    continue
+
+                # Build face matrix in space-local coordinates
+                # (assign_connection_geometry expects location/axes relative to space placement)
+                face_matrix = _face_matrix_from_verts(space_verts_l[:3])
+                face_matrix_inv = np.linalg.inv(face_matrix)
+
+                # Project space face (already space-local) to 2D
+                space_face_polygon = _verts_to_polygon(space_verts_l, face_matrix_inv)
+                if not space_face_polygon.is_valid:
+                    space_face_polygon = space_face_polygon.buffer(0)
+
+                # Transform element verts to space-local, then project to 2D
+                # element-local -> world -> space-local
+                elem_verts_in_space = sb.np_apply_matrix(elem_verts_l, space_matrix_inv @ element_matrix)
+                face_polygon = _verts_to_polygon(elem_verts_in_space, face_matrix_inv)
+                if not face_polygon.is_valid:
+                    face_polygon = face_polygon.buffer(0)
+
+                try:
+                    gross_boundary_polygon = space_face_polygon.intersection(face_polygon)
+                except shapely.errors.GEOSException:
+                    logger.warning(
+                        "Skipping invalid geometry for %s (shapely topology error).",
+                        element.Name or element.is_a(),
+                        exc_info=True,
+                    )
+                    continue
+
+                if type(gross_boundary_polygon) == shapely.GeometryCollection:
+                    for geom in gross_boundary_polygon.geoms:
+                        if type(geom) == shapely.Polygon:
+                            gross_boundary_polygon = geom
+                            break
+
+                if not (isinstance(gross_boundary_polygon, shapely.Polygon) and gross_boundary_polygon.is_valid):
+                    continue
+                if gross_boundary_polygon.is_empty:
+                    continue
+
+                exterior_boundary_polygon = shapely.Polygon(gross_boundary_polygon.exterior.coords)
+
+                # Create parent boundary
+                parent_boundary = ifcopenshell.api.root.create_entity(ifc_file, ifc_class=boundary_class)
+                if element.is_a("IfcVirtualElement"):
+                    parent_boundary.PhysicalOrVirtualBoundary = "VIRTUAL"
+                else:
+                    parent_boundary.PhysicalOrVirtualBoundary = "PHYSICAL"
+                parent_boundary.InternalOrExternalBoundary = "NOTDEFINED"
+                _set_internal_external(parent_boundary, element)
+                parent_boundary.RelatingSpace = space
+                parent_boundary.RelatedBuildingElement = element
+
+                _assign_connection_geometry(
+                    ifc_file,
+                    parent_boundary,
+                    exterior_boundary_polygon,
+                    face_matrix,
+                    unit_scale,
+                )
+                _set_boundary_name(parent_boundary)
+                boundaries.append(parent_boundary)
+
+                # Process openings
+                boundaries.extend(
+                    _process_openings(
+                        ifc_file,
+                        element,
+                        elem_face_normal_world,
+                        space_matrix_inv,
+                        element_matrix,
+                        face_matrix,
+                        face_matrix_inv,
+                        exterior_boundary_polygon,
+                        boundary_class,
+                        parent_boundary,
+                        space,
+                        unit_scale,
+                    )
+                )
+
+    return boundaries
+
+
+def _process_openings(
+    ifc_file,
+    building_element,
+    face_normal_world,
+    space_matrix_inv,
+    element_matrix,
+    face_matrix,
+    face_matrix_inv,
+    exterior_boundary_polygon,
+    boundary_class,
+    parent_boundary,
+    space,
+    unit_scale,
+):
+    """Process openings and fillings for a building element.
+
+    :param face_normal_world: The building element face normal in world space.
+    :param space_matrix_inv: Inverse of the space placement matrix.
+    :param element_matrix: The building element placement matrix.
+    :param face_matrix: The face matrix in space-local coordinates (for connection geometry).
+    :param face_matrix_inv: The inverse face matrix (for 2D projection).
+    """
+    boundaries = []
+
+    for rel in getattr(building_element, "HasOpenings", []):
+        opening = rel.RelatedOpeningElement
+        filling = opening.HasFillings[0].RelatedBuildingElement if opening.HasFillings else None
+
+        settings = ifcopenshell.geom.settings()
+        try:
+            shape = ifcopenshell.geom.create_shape(settings, opening)
+        except Exception:
+            continue
+        opening_verts_l = ifcopenshell.util.shape.get_vertices(shape.geometry)
+        opening_faces = ifcopenshell.util.shape.get_faces(shape.geometry)
+        opening_edges = ifcopenshell.util.shape.get_edges(shape.geometry)
+        opening_matrix = ifcopenshell.util.shape.get_shape_matrix(shape)
+        opening_matrix_3x3 = opening_matrix[:3, :3]
+
+        opening_ngons = ifcopenshell.util.shape.dissolve_faces(
+            opening_verts_l, opening_faces, opening_edges, merge_coplanar=True
+        )
+
+        opening_polygons = []
+        for ngon in opening_ngons:
+            o_verts_l = opening_verts_l[ngon]
+            # Normal from local verts, transform to world via opening placement
+            o_normal_local = _face_normal(o_verts_l)
+            if o_normal_local is None:
+                continue
+            o_normal_world = opening_matrix_3x3 @ o_normal_local
+            angle = degrees(acos(max(min(float(np.dot(o_normal_world, face_normal_world)), 1), -1)))
+            if not _is_x(angle, 180, tolerance=2):
+                continue
+            # Transform opening verts to space-local: opening-local -> world -> space-local
+            o_verts_in_space = sb.np_apply_matrix(o_verts_l, space_matrix_inv @ opening_matrix)
+            polygon = _verts_to_polygon(o_verts_in_space, face_matrix_inv)
+            opening_polygons.append(polygon)
+
+        if not opening_polygons:
+            continue
+
+        opening_polygon = shapely.ops.unary_union(opening_polygons)
+
+        if opening_polygon.intersection(exterior_boundary_polygon).area == 0:
+            continue
+
+        boundary = ifcopenshell.api.root.create_entity(ifc_file, ifc_class=boundary_class)
+        boundary.RelatingSpace = space
+        boundary.RelatedBuildingElement = filling or opening
+
+        # Use the same space-local face_matrix for connection geometry
+        _assign_connection_geometry(
+            ifc_file,
+            boundary,
+            opening_polygon,
+            face_matrix,
+            unit_scale,
+        )
+        if filling:
+            boundary.PhysicalOrVirtualBoundary = "PHYSICAL"
+        else:
+            boundary.PhysicalOrVirtualBoundary = "VIRTUAL"
+        boundary.InternalOrExternalBoundary = parent_boundary.InternalOrExternalBoundary
+        if boundary.is_a() != "IfcRelSpaceBoundary":
+            boundary.ParentBoundary = parent_boundary
+        _set_boundary_name(boundary)
+        boundaries.append(boundary)
+
+    return boundaries
+
+
+def _face_normal(verts: np.ndarray) -> Optional[np.ndarray]:
+    """Compute the normal of a polygon from its vertices."""
+    if len(verts) < 3:
+        return None
+    return sb.np_normal([verts[0], verts[1], verts[2]])
+
+
+def _face_matrix_from_verts(verts3: np.ndarray) -> np.ndarray:
+    """Build a 4x4 face-local coordinate matrix from 3 vertices."""
+    p1, p2, p3 = verts3[0], verts3[1], verts3[2]
+    z = sb.np_normal([p1, p2, p3])
+    x = sb.np_normalized(p2 - p1)
+    return ifcopenshell.util.placement.a2p(o=p1, z=z, x=x)
+
+
+def _verts_to_polygon(verts: np.ndarray, face_matrix_inv: np.ndarray) -> shapely.Polygon:
+    """Project 3D vertices onto a 2D plane and create a shapely Polygon."""
+    verts_2d = sb.np_apply_matrix(verts, face_matrix_inv)[:, :2]
+    return shapely.Polygon([tuple(v) for v in verts_2d])
+
+
+def _assign_connection_geometry(
+    ifc_file: ifcopenshell.file,
+    boundary: ifcopenshell.entity_instance,
+    polygon: shapely.Polygon,
+    face_matrix: np.ndarray,
+    unit_scale: float,
+) -> None:
+    """Assign connection geometry to a boundary using the existing API."""
+    location = face_matrix[:3, 3]
+    axis = face_matrix[:3, 0]
+    ref_direction = face_matrix[:3, 2]
+
+    outer_boundary = [list(coord) for coord in polygon.exterior.coords[:-1]]
+    inner_boundaries = [list(interior.coords[:-1]) for interior in polygon.interiors]
+
+    ifcopenshell.api.boundary.assign_connection_geometry(
+        ifc_file,
+        rel_space_boundary=boundary,
+        outer_boundary=outer_boundary,
+        location=location.tolist(),
+        axis=axis.tolist(),
+        ref_direction=ref_direction.tolist(),
+        inner_boundaries=inner_boundaries if inner_boundaries else None,
+        unit_scale=unit_scale,
+    )
+
+
+def _set_internal_external(
+    boundary: ifcopenshell.entity_instance, building_element: ifcopenshell.entity_instance
+) -> None:
+    """Set InternalOrExternalBoundary based on element type and psets."""
+    if building_element.is_a("IfcWall"):
+        is_external = ifcopenshell.util.element.get_pset(building_element, "Pset_WallCommon", "IsExternal")
+        if is_external is True:
+            boundary.InternalOrExternalBoundary = "EXTERNAL"
+        elif is_external is False:
+            boundary.InternalOrExternalBoundary = "INTERNAL"
+    elif building_element.is_a("IfcSlab"):
+        predefined_type = ifcopenshell.util.element.get_predefined_type(building_element)
+        if predefined_type == "BASESLAB":
+            boundary.InternalOrExternalBoundary = "EXTERNAL_EARTH"
+        else:
+            is_external = ifcopenshell.util.element.get_pset(building_element, "Pset_SlabCommon", "IsExternal")
+            if is_external is True:
+                boundary.InternalOrExternalBoundary = "EXTERNAL"
+            elif is_external is False:
+                boundary.InternalOrExternalBoundary = "INTERNAL"
+
+
+def _set_boundary_name(boundary: ifcopenshell.entity_instance) -> None:
+    """Set Name/Description per IFC4x3 convention."""
+    if boundary.is_a("IfcRelSpaceBoundary2ndLevel"):
+        boundary.Name = "2ndLevel"
+        if boundary.CorrespondingBoundary:
+            boundary.Description = "2a"
+        else:
+            boundary.Description = "2b"
+    elif boundary.is_a("IfcRelSpaceBoundary1stLevel"):
+        boundary.Name = "1stLevel"
+
+
+def _is_x(value: float, x: float, tolerance: float = 1e-5) -> bool:
+    """Check whether value is within tolerance of x."""
+    return (x + tolerance) > value > (x - tolerance)

--- a/src/ifcopenshell-python/ifcopenshell/util/shape.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/shape.py
@@ -914,11 +914,16 @@ def dissolve_faces(
     result = []
     for tri_indices in ngons.values():
         tri_edge_set = set()
+        edge_count: dict[frozenset, int] = {}
         for tri_idx in tri_indices:
             for e in tri_edges[tri_idx]:
                 tri_edge_set.add(e)
+                edge_count[e] = edge_count.get(e, 0) + 1
 
-        boundary_edges = [e for e in tri_edge_set if e in original_edges]
+        if merge_coplanar:
+            boundary_edges = [e for e in tri_edge_set if edge_count.get(e, 0) == 1]
+        else:
+            boundary_edges = [e for e in tri_edge_set if e in original_edges]
 
         if not boundary_edges:
             result.append(list(faces[tri_indices[0]]))
@@ -938,15 +943,21 @@ def dissolve_faces(
                     continue
                 break
 
+        if not edge_adjacency:
+            result.append(list(faces[tri_indices[0]]))
+            continue
+
         start = next(iter(edge_adjacency))
         polygon = [start]
         current = edge_adjacency[start]
-        while current != start:
+        while current != start and current in edge_adjacency:
             polygon.append(current)
-            if current not in edge_adjacency:
-                break
             current = edge_adjacency[current]
-        result.append(polygon)
+
+        if len(polygon) >= 3:
+            result.append(polygon)
+        else:
+            result.append(list(faces[tri_indices[0]]))
 
     return result
 

--- a/src/ifcopenshell-python/ifcopenshell/util/shape.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/shape.py
@@ -830,3 +830,190 @@ def bisect_mesh_plane_vf(
             else:
                 segments.append(pts_xy)
     return segments
+
+
+def dissolve_faces(
+    verts: npt.NDArray[np.float64],
+    faces: npt.NDArray[np.int32],
+    edges: npt.NDArray[np.int32],
+    merge_coplanar: bool = False,
+    angle_tolerance: float = 0.017453292519943295,
+) -> list[list[int]]:
+    """Reconstruct polygonal faces from triangulated mesh data.
+
+    Uses the original (pre-triangulation) edges from ``get_edges`` to
+    identify which triangle edges are internal (to be merged) vs external
+    (ngon boundaries). Triangles connected by internal edges are grouped
+    into polygonal faces.
+
+    When ``merge_coplanar`` is True, a second pass merges adjacent ngons
+    whose face normals are parallel within ``angle_tolerance`` radians.
+    This mirrors ``bmesh.ops.dissolve_limit`` behavior where coplanar
+    faces sharing an edge are merged regardless of the original face
+    structure. This is needed when the IFC representation splits a single
+    planar face into multiple faces (e.g. an L-shaped top face split into
+    triangles + quads).
+
+    :param verts: (n, 3) array of vertices.
+    :param faces: (m, 3) array of triangle vertex indices.
+    :param edges: (e, 2) array of original (pre-triangulation) edge vertex
+        indices, as returned by :func:`get_edges`.
+    :param merge_coplanar: If True, merge adjacent coplanar ngons.
+    :param angle_tolerance: Angle in radians for coplanar merge (default 1°).
+    :return: List of polygonal faces, each as an ordered list of vertex indices
+        forming a closed polygon (last vertex connects back to first).
+    """
+    if len(faces) == 0:
+        return []
+    if len(edges) == 0:
+        return [list(f) for f in faces]
+
+    original_edges = {frozenset((int(e[0]), int(e[1]))) for e in edges}
+
+    tri_edges = []
+    for f in faces:
+        tri_edges.append(
+            (
+                frozenset((int(f[0]), int(f[1]))),
+                frozenset((int(f[1]), int(f[2]))),
+                frozenset((int(f[2]), int(f[0]))),
+            )
+        )
+
+    internal_edge_to_tris: dict[frozenset, list[int]] = {}
+    for tri_idx, edges_3 in enumerate(tri_edges):
+        for e in edges_3:
+            if e not in original_edges:
+                internal_edge_to_tris.setdefault(e, []).append(tri_idx)
+
+    parent = list(range(len(faces)))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(x, y):
+        px, py = find(x), find(y)
+        if px != py:
+            parent[px] = py
+
+    for tri_indices in internal_edge_to_tris.values():
+        if len(tri_indices) == 2:
+            union(tri_indices[0], tri_indices[1])
+
+    ngons: dict[int, list[int]] = {}
+    for tri_idx in range(len(faces)):
+        root = find(tri_idx)
+        ngons.setdefault(root, []).append(tri_idx)
+
+    if merge_coplanar:
+        _merge_coplanar_ngons(ngons, faces, verts, tri_edges, parent, find, union, angle_tolerance)
+
+    result = []
+    for tri_indices in ngons.values():
+        tri_edge_set = set()
+        for tri_idx in tri_indices:
+            for e in tri_edges[tri_idx]:
+                tri_edge_set.add(e)
+
+        boundary_edges = [e for e in tri_edge_set if e in original_edges]
+
+        if not boundary_edges:
+            result.append(list(faces[tri_indices[0]]))
+            continue
+
+        edge_adjacency: dict[int, int] = {}
+        for e in boundary_edges:
+            v_list = list(e)
+            for tri_idx in tri_indices:
+                f = faces[tri_idx]
+                f_edges = [(int(f[0]), int(f[1])), (int(f[1]), int(f[2])), (int(f[2]), int(f[0]))]
+                for fe in f_edges:
+                    if frozenset(fe) == e:
+                        edge_adjacency[fe[0]] = fe[1]
+                        break
+                else:
+                    continue
+                break
+
+        start = next(iter(edge_adjacency))
+        polygon = [start]
+        current = edge_adjacency[start]
+        while current != start:
+            polygon.append(current)
+            if current not in edge_adjacency:
+                break
+            current = edge_adjacency[current]
+        result.append(polygon)
+
+    return result
+
+
+def _merge_coplanar_ngons(
+    ngons: dict[int, list[int]],
+    faces: npt.NDArray[np.int32],
+    verts: npt.NDArray[np.float64],
+    tri_edges: list,
+    parent: list[int],
+    find,
+    union,
+    angle_tolerance: float,
+) -> None:
+    """Merge adjacent ngons whose face normals are parallel within tolerance.
+
+    Modifies ``ngons`` and ``parent`` in place.
+    """
+    from math import acos
+
+    # Compute normal for each ngon
+    ngon_normals: dict[int, np.ndarray] = {}
+    ngon_edge_to_ngons: dict[frozenset, list[int]] = {}
+    ngon_roots = list(ngons.keys())
+
+    for root in ngon_roots:
+        tri_indices = ngons[root]
+        f0 = faces[tri_indices[0]]
+        v0, v1, v2 = verts[f0[0]], verts[f0[1]], verts[f0[2]]
+        edge1 = v1 - v0
+        edge2 = v2 - v0
+        normal = np.cross(edge1, edge2)
+        norm = np.linalg.norm(normal)
+        if norm > 0:
+            normal = normal / norm
+        ngon_normals[root] = normal
+
+        # Collect all edges of this ngon
+        ngon_edges = set()
+        for tri_idx in tri_indices:
+            for e in tri_edges[tri_idx]:
+                ngon_edges.add(e)
+        for e in ngon_edges:
+            ngon_edge_to_ngons.setdefault(e, []).append(root)
+
+    # Find shared edges between different ngons and check coplanarity
+    for edge, root_list in ngon_edge_to_ngons.items():
+        if len(root_list) != 2:
+            continue
+        root_a, root_b = root_list[0], root_list[1]
+        if root_a == root_b:
+            continue
+        # Check if already merged
+        ra, rb = find(root_a), find(root_b)
+        if ra == rb:
+            continue
+        # Compare normals
+        na, nb = ngon_normals[root_a], ngon_normals[root_b]
+        dot = max(min(float(np.dot(na, nb)), 1.0), -1.0)
+        angle = acos(dot)
+        if angle < angle_tolerance:
+            union(root_a, root_b)
+
+    # Rebuild ngons dict with merged groups
+    new_ngons: dict[int, list[int]] = {}
+    for root in ngon_roots:
+        new_root = find(root)
+        new_ngons.setdefault(new_root, []).extend(ngons[root])
+    ngons.clear()
+    ngons.update(new_ngons)

--- a/src/ifcopenshell-python/ifcopenshell/util/shape.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/shape.py
@@ -991,7 +991,7 @@ def _merge_coplanar_ngons(
         edge2 = v2 - v0
         normal = np.cross(edge1, edge2)
         norm = np.linalg.norm(normal)
-        if norm > 0:
+        if norm > 1e-8:
             normal = normal / norm
         ngon_normals[root] = normal
 

--- a/src/ifcopenshell-python/test/util/test_boundary.py
+++ b/src/ifcopenshell-python/test/util/test_boundary.py
@@ -208,6 +208,26 @@ def _over_splitted_ifc():
     )
 
 
+def _small_house_ifczip():
+    return os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "IfcRelSpaceBoundary_TestFiles",
+        "IfcRelSpaceBoundary2ndLevel",
+        "SmallHouse_BB_IFC4.ifczip",
+    )
+
+
+def _triangle_ifczip():
+    return os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "IfcRelSpaceBoundary_TestFiles",
+        "IfcRelSpaceBoundary2ndLevel",
+        "Triangle_BB_IFC4.ifczip",
+    )
+
+
 def _boundary_element_counts(ifc_file, space_id):
     space = ifc_file.by_id(space_id)
     counts = Counter()
@@ -332,6 +352,10 @@ class TestAutoGenerateBoundaries(test.bootstrap.IFC4):
                 assert skylight[0].ParentBoundary == roof_boundaries[0]
 
     def test_over_splitted_roof_keeps_shaft_opening(self):
+        # Space 251 of OverSplitted_R20_IFC2X3.ifc has an L-shaped ceiling
+        # pierced by a shaft opening. The ceiling boundary must keep the
+        # opening as an inner boundary, and each shaft wall must get exactly
+        # one boundary instead of fragmented partial + gap boundaries.
         ifc_path = _over_splitted_ifc()
         if not os.path.exists(ifc_path):
             pytest.skip("IfcRelSpaceBoundary_TestFiles submodule is not checked out")
@@ -352,3 +376,28 @@ class TestAutoGenerateBoundaries(test.bootstrap.IFC4):
         assert shapely.Polygon(outer, inner).area == pytest.approx(9.962, abs=1e-3)
         for wall_id in (5832, 5877, 5922, 5967):
             assert len(_boundaries_for(result, copy.by_id(wall_id))) == 1
+
+    def test_small_house_boundaries(self):
+        ifc_path = _small_house_ifczip()
+        if not os.path.exists(ifc_path):
+            pytest.skip("IfcRelSpaceBoundary_TestFiles submodule is not checked out")
+        ifc_file = ifcopenshell.open(ifc_path)
+        shapes = _build_shapes_dict_from_iterator(ifc_file)
+        for space_id, expected_total in [(1692, 8), (4356, 8), (4380, 13), (6185, 1)]:
+            copy = ifcopenshell.file.from_string(ifc_file.wrapped_data.to_string())
+            result = subject.auto_generate_boundaries(
+                copy, copy.by_id(space_id), shapes=shapes, boundary_class="IfcRelSpaceBoundary2ndLevel"
+            )
+            assert len(result) == expected_total
+
+    def test_triangle_boundaries(self):
+        ifc_path = _triangle_ifczip()
+        if not os.path.exists(ifc_path):
+            pytest.skip("IfcRelSpaceBoundary_TestFiles submodule is not checked out")
+        ifc_file = ifcopenshell.open(ifc_path)
+        shapes = _build_shapes_dict_from_iterator(ifc_file)
+        copy = ifcopenshell.file.from_string(ifc_file.wrapped_data.to_string())
+        result = subject.auto_generate_boundaries(
+            copy, copy.by_id(1573), shapes=shapes, boundary_class="IfcRelSpaceBoundary2ndLevel"
+        )
+        assert len(result) == 6

--- a/src/ifcopenshell-python/test/util/test_boundary.py
+++ b/src/ifcopenshell-python/test/util/test_boundary.py
@@ -1,0 +1,110 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import ifcopenshell.api.geometry
+import ifcopenshell.api.root
+import ifcopenshell.geom
+import ifcopenshell.util.boundary as subject
+import ifcopenshell.util.shape
+import test.bootstrap
+
+
+def _add_extruded_body(ifc_file, element, coords_2d, depth, z_offset=0.0):
+    """Add a body representation (extruded polyline) to an element."""
+    if not ifc_file.by_type("IfcProject"):
+        ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject")
+    ctx = ifc_file.createIfcGeometricRepresentationContext(
+        ContextType="Model",
+        CoordinateSpaceDimension=3,
+        Precision=1e-5,
+        WorldCoordinateSystem=ifc_file.createIfcAxis2Placement3D(
+            ifc_file.createIfcCartesianPoint((0.0, 0.0, 0.0)),
+            ifc_file.createIfcDirection((0.0, 0.0, 1.0)),
+            ifc_file.createIfcDirection((1.0, 0.0, 0.0)),
+        ),
+    )
+    sub_ctx = ifc_file.createIfcGeometricRepresentationSubContext(
+        ContextIdentifier="Body",
+        ContextType="Model",
+        ParentContext=ctx,
+        TargetView="MODEL_VIEW",
+    )
+    pts = [ifc_file.createIfcCartesianPoint((float(x), float(y))) for x, y in coords_2d]
+    polyline = ifc_file.createIfcPolyline(pts)
+    profile = ifc_file.create_entity("IfcArbitraryClosedProfileDef", ProfileType="CURVE", OuterCurve=polyline)
+    placement = ifc_file.createIfcAxis2Placement3D(
+        ifc_file.createIfcCartesianPoint((0.0, 0.0, z_offset)),
+        ifc_file.createIfcDirection((0.0, 0.0, 1.0)),
+        ifc_file.createIfcDirection((1.0, 0.0, 0.0)),
+    )
+    direction = ifc_file.createIfcDirection((0.0, 0.0, 1.0))
+    solid = ifc_file.createIfcExtrudedAreaSolid(profile, placement, direction, depth)
+    rep = ifc_file.create_entity(
+        "IfcShapeRepresentation",
+        ContextOfItems=sub_ctx,
+        RepresentationIdentifier="Body",
+        RepresentationType="SweptSolid",
+        Items=[solid],
+    )
+    ifcopenshell.api.geometry.assign_representation(ifc_file, product=element, representation=rep)
+
+
+def _build_shapes_dict(ifc_file, elements):
+    """Build a shapes dict as expected by ifcopenshell.util.boundary."""
+    settings = ifcopenshell.geom.settings()
+    settings.set("disable-opening-subtractions", True)
+    shapes = {}
+    for element in elements:
+        shape = ifcopenshell.geom.create_shape(settings, element)
+        shapes[element.id()] = {
+            "verts": ifcopenshell.util.shape.get_vertices(shape.geometry),
+            "faces": ifcopenshell.util.shape.get_faces(shape.geometry),
+            "edges": ifcopenshell.util.shape.get_edges(shape.geometry),
+            "matrix": ifcopenshell.util.shape.get_shape_matrix(shape),
+        }
+    return shapes
+
+
+class TestAutoGenerateBoundaries(test.bootstrap.IFC4):
+    def test_no_building_elements_returns_error(self):
+        space = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSpace")
+        _add_extruded_body(self.file, space, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+        shapes = _build_shapes_dict(self.file, [space])
+        result = subject.auto_generate_boundaries(self.file, space, shapes, "IfcRelSpaceBoundary")
+        assert isinstance(result, str)
+        assert "No building elements" in result
+
+    def test_space_not_in_shapes_returns_error(self):
+        space = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSpace")
+        result = subject.auto_generate_boundaries(self.file, space, {}, "IfcRelSpaceBoundary")
+        assert isinstance(result, str)
+        assert "not found" in result.lower()
+
+    def test_generates_boundary_for_adjacent_wall(self):
+        space = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSpace")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        _add_extruded_body(self.file, space, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+        _add_extruded_body(self.file, wall, [[-5, 5], [5, 5], [5, 5.2], [-5, 5.2]], 3.0)
+        shapes = _build_shapes_dict(self.file, [space, wall])
+        result = subject.auto_generate_boundaries(self.file, space, shapes, "IfcRelSpaceBoundary")
+        assert isinstance(result, list)
+        assert len(result) >= 1
+        boundary = result[0]
+        assert boundary.RelatingSpace == space
+        assert boundary.RelatedBuildingElement == wall
+        assert boundary.PhysicalOrVirtualBoundary == "PHYSICAL"

--- a/src/ifcopenshell-python/test/util/test_boundary.py
+++ b/src/ifcopenshell-python/test/util/test_boundary.py
@@ -198,6 +198,16 @@ def _external_earth_ifczip():
     )
 
 
+def _over_splitted_ifc():
+    return os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "IfcRelSpaceBoundary_TestFiles",
+        "IfcRelSpaceBoundary2ndLevel",
+        "OverSplitted_R20_IFC2X3.ifc",
+    )
+
+
 def _boundary_element_counts(ifc_file, space_id):
     space = ifc_file.by_id(space_id)
     counts = Counter()
@@ -320,3 +330,25 @@ class TestAutoGenerateBoundaries(test.bootstrap.IFC4):
                 skylight = [b for b in result if b.RelatedBuildingElement.id() in (3435, 3640)]
                 assert len(skylight) == 1
                 assert skylight[0].ParentBoundary == roof_boundaries[0]
+
+    def test_over_splitted_roof_keeps_shaft_opening(self):
+        ifc_path = _over_splitted_ifc()
+        if not os.path.exists(ifc_path):
+            pytest.skip("IfcRelSpaceBoundary_TestFiles submodule is not checked out")
+        ifc_file = ifcopenshell.open(ifc_path)
+        shapes = _build_shapes_dict_from_iterator(ifc_file)
+        copy = ifcopenshell.file.from_string(ifc_file.wrapped_data.to_string())
+        result = subject.auto_generate_boundaries(
+            copy, copy.by_id(251), shapes=shapes, boundary_class="IfcRelSpaceBoundary"
+        )
+        assert isinstance(result, list)
+        assert len(result) == 17
+        roof_boundaries = _boundaries_for(result, copy.by_id(5248))
+        assert len(roof_boundaries) == 1
+        assert _boundary_inner_count(roof_boundaries[0]) == 1
+        surface = roof_boundaries[0].ConnectionGeometry.SurfaceOnRelatingElement
+        outer = [(p.Coordinates[0], p.Coordinates[1]) for p in surface.OuterBoundary.Points]
+        inner = [[(p.Coordinates[0], p.Coordinates[1]) for p in ib.Points] for ib in surface.InnerBoundaries]
+        assert shapely.Polygon(outer, inner).area == pytest.approx(9.962, abs=1e-3)
+        for wall_id in (5832, 5877, 5922, 5967):
+            assert len(_boundaries_for(result, copy.by_id(wall_id))) == 1

--- a/src/ifcopenshell-python/test/util/test_boundary.py
+++ b/src/ifcopenshell-python/test/util/test_boundary.py
@@ -16,6 +16,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+from collections import Counter
+
+import numpy as np
+import pytest
+import shapely
+
 import ifcopenshell.api.geometry
 import ifcopenshell.api.root
 import ifcopenshell.geom
@@ -80,6 +87,126 @@ def _build_shapes_dict(ifc_file, elements):
     return shapes
 
 
+def _build_shapes_dict_from_iterator(ifc_file):
+    """Build a shapes dict for all products in a file (excluding openings)."""
+    settings = ifcopenshell.geom.settings()
+    settings.set("disable-opening-subtractions", True)
+    shapes = {}
+    iterator = ifcopenshell.geom.iterator(settings, ifc_file)
+    if iterator.initialize():
+        while True:
+            shape = iterator.get()
+            element = ifc_file.by_id(shape.id)
+            if not element.is_a("IfcOpeningElement"):
+                shapes[shape.id] = {
+                    "verts": ifcopenshell.util.shape.get_vertices(shape.geometry),
+                    "faces": ifcopenshell.util.shape.get_faces(shape.geometry),
+                    "edges": ifcopenshell.util.shape.get_edges(shape.geometry),
+                    "matrix": ifcopenshell.util.shape.get_shape_matrix(shape),
+                }
+            if not iterator.next():
+                break
+    return shapes
+
+
+def _boundaries_for(boundaries, element):
+    return [b for b in boundaries if b.RelatedBuildingElement == element]
+
+
+def _boundary_inner_count(boundary):
+    surface = boundary.ConnectionGeometry.SurfaceOnRelatingElement if boundary.ConnectionGeometry else None
+    if surface and surface.is_a("IfcCurveBoundedPlane") and surface.InnerBoundaries:
+        return len(surface.InnerBoundaries)
+    return 0
+
+
+def _outer_boundary_area(boundary):
+    surface = boundary.ConnectionGeometry.SurfaceOnRelatingElement
+    points = [(p.Coordinates[0], p.Coordinates[1]) for p in surface.OuterBoundary.Points]
+    area = 0.0
+    for (x1, y1), (x2, y2) in zip(points, points[1:]):
+        area += x1 * y2 - x2 * y1
+    return 0.5 * abs(area)
+
+
+def _boundary_polygon_3d(boundary):
+    """The boundary outer boundary as world-space 3D points."""
+    surface = boundary.ConnectionGeometry.SurfaceOnRelatingElement
+    position = surface.BasisSurface.Position
+    origin = np.array(position.Location.Coordinates, dtype=float)
+    z = np.array(position.Axis.DirectionRatios if position.Axis else [0, 0, 1], dtype=float)
+    x = np.array(position.RefDirection.DirectionRatios if position.RefDirection else [1, 0, 0], dtype=float)
+    y = np.cross(z, x)
+    points = np.array([[p.Coordinates[0], p.Coordinates[1]] for p in surface.OuterBoundary.Points])
+    return origin + points[:, 0, None] * x + points[:, 1, None] * y
+
+
+def _boundary_polygon_in_plane(boundary, reference=None):
+    """The boundary polygon projected onto the reference boundary plane."""
+    reference = reference or boundary
+    surface = reference.ConnectionGeometry.SurfaceOnRelatingElement
+    position = surface.BasisSurface.Position
+    origin = np.array(position.Location.Coordinates, dtype=float)
+    z = np.array(position.Axis.DirectionRatios if position.Axis else [0, 0, 1], dtype=float)
+    x = np.array(position.RefDirection.DirectionRatios if position.RefDirection else [1, 0, 0], dtype=float)
+    y = np.cross(z, x)
+    points = _boundary_polygon_3d(boundary) - origin
+    coords = [(float(p @ x), float(p @ y)) for p in points]
+    return shapely.Polygon(coords)
+
+
+def _add_wall_with_window(ifc_file):
+    """Add a space bounded by a wall with a fully interior opening filled by a window."""
+    space = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSpace")
+    wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+    opening_element = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcOpeningElement")
+    window = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWindow")
+    _add_extruded_body(ifc_file, space, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+    _add_extruded_body(ifc_file, wall, [[-5, 5], [5, 5], [5, 5.5], [-5, 5.5]], 3.0)
+    _add_extruded_body(ifc_file, opening_element, [[-2, 5], [2, 5], [2, 5.5], [-2, 5.5]], 1.8, z_offset=0.6)
+    _add_extruded_body(ifc_file, window, [[-2, 4.5], [2, 4.5], [2, 5.5], [-2, 5.5]], 1.5, z_offset=0.75)
+    ifc_file.createIfcRelVoidsElement(RelatingBuildingElement=wall, RelatedOpeningElement=opening_element)
+    ifc_file.createIfcRelFillsElement(RelatingOpeningElement=opening_element, RelatedBuildingElement=window)
+    return space, wall, window
+
+
+def _add_roof_with_skylight(ifc_file):
+    """Add a space with a roof pierced by an opening covered by a skylight window.
+
+    The window is deliberately not related through IfcRelFillsElement to exercise
+    the geometric detection of fillings.
+    """
+    space = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSpace")
+    roof = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcRoof")
+    opening_element = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcOpeningElement")
+    window = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWindow")
+    _add_extruded_body(ifc_file, space, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+    _add_extruded_body(ifc_file, roof, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 0.5, z_offset=3.0)
+    _add_extruded_body(ifc_file, opening_element, [[-1, -1], [1, -1], [1, 1], [-1, 1]], 0.8, z_offset=2.8)
+    _add_extruded_body(ifc_file, window, [[-1, -1], [1, -1], [1, 1], [-1, 1]], 0.2, z_offset=3.5)
+    ifc_file.createIfcRelVoidsElement(RelatingBuildingElement=roof, RelatedOpeningElement=opening_element)
+    return space, roof, window
+
+
+def _external_earth_ifczip():
+    return os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "IfcRelSpaceBoundary_TestFiles",
+        "IfcRelSpaceBoundary2ndLevel",
+        "ExternalEarth_R20_IFC4.ifczip",
+    )
+
+
+def _boundary_element_counts(ifc_file, space_id):
+    space = ifc_file.by_id(space_id)
+    counts = Counter()
+    for boundary in space.BoundedBy or []:
+        if boundary.RelatedBuildingElement:
+            counts[boundary.RelatedBuildingElement.id()] += 1
+    return counts
+
+
 class TestAutoGenerateBoundaries(test.bootstrap.IFC4):
     def test_no_building_elements_returns_error(self):
         space = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSpace")
@@ -108,3 +235,88 @@ class TestAutoGenerateBoundaries(test.bootstrap.IFC4):
         assert boundary.RelatingSpace == space
         assert boundary.RelatedBuildingElement == wall
         assert boundary.PhysicalOrVirtualBoundary == "PHYSICAL"
+
+    def test_wall_boundary_with_window_has_no_inner_boundary(self):
+        space, wall, window = _add_wall_with_window(self.file)
+        shapes = _build_shapes_dict(self.file, [space, wall, window])
+        result = subject.auto_generate_boundaries(self.file, space, shapes, "IfcRelSpaceBoundary2ndLevel")
+        assert isinstance(result, list)
+        wall_boundaries = _boundaries_for(result, wall)
+        assert len(wall_boundaries) == 1
+        assert _boundary_inner_count(wall_boundaries[0]) == 0
+        assert _outer_boundary_area(wall_boundaries[0]) == pytest.approx(30.0, abs=1e-3)
+        window_boundaries = _boundaries_for(result, window)
+        assert len(window_boundaries) == 1
+        assert window_boundaries[0].ParentBoundary == wall_boundaries[0]
+
+    def test_roof_boundary_with_skylight_has_no_inner_boundary(self):
+        space, roof, window = _add_roof_with_skylight(self.file)
+        shapes = _build_shapes_dict(self.file, [space, roof, window])
+        result = subject.auto_generate_boundaries(self.file, space, shapes, "IfcRelSpaceBoundary2ndLevel")
+        assert isinstance(result, list)
+        roof_boundaries = _boundaries_for(result, roof)
+        assert len(roof_boundaries) == 1
+        assert _boundary_inner_count(roof_boundaries[0]) == 0
+        assert _outer_boundary_area(roof_boundaries[0]) == pytest.approx(100.0, abs=1e-3)
+        window_boundaries = _boundaries_for(result, window)
+        assert len(window_boundaries) == 1
+        assert window_boundaries[0].ParentBoundary == roof_boundaries[0]
+
+    def test_wall_boundary_with_unfilled_opening_has_no_inner_boundary(self):
+        space = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcSpace")
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        opening_element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcOpeningElement")
+        _add_extruded_body(self.file, space, [[-5, -5], [5, -5], [5, 5], [-5, 5]], 3.0)
+        _add_extruded_body(self.file, wall, [[-5, 5], [5, 5], [5, 5.5], [-5, 5.5]], 3.0)
+        _add_extruded_body(self.file, opening_element, [[-2, 5], [2, 5], [2, 5.5], [-2, 5.5]], 1.8, z_offset=0.6)
+        self.file.createIfcRelVoidsElement(RelatingBuildingElement=wall, RelatedOpeningElement=opening_element)
+        shapes = _build_shapes_dict(self.file, [space, wall])
+        result = subject.auto_generate_boundaries(self.file, space, shapes, "IfcRelSpaceBoundary2ndLevel")
+        assert isinstance(result, list)
+        wall_boundaries = _boundaries_for(result, wall)
+        assert len(wall_boundaries) == 1
+        assert _boundary_inner_count(wall_boundaries[0]) == 0
+
+    def test_openings_are_unioned_into_parent_boundary(self):
+        # Some authoring tools bake the opening into the building element mesh,
+        # leaving a notch in the gross boundary polygon. The parent boundary must
+        # union the opening back in so it overlaps its own inner boundary.
+        wall_face = shapely.Polygon([(-5, 5), (5, 5), (5, 5.5), (2, 5.5), (2, 5), (-2, 5), (-2, 5.5), (-5, 5.5)])
+        window = shapely.Polygon([(-2, 5), (2, 5), (2, 5.5), (-2, 5.5)])
+        assert wall_face.area == pytest.approx(3.0, abs=1e-9)
+        parent = subject._union_openings_into_parent(wall_face, [("opening", "window", window)])
+        assert isinstance(parent, shapely.Polygon)
+        assert parent.area == pytest.approx(5.0, abs=1e-9)
+        assert parent.contains(window)
+
+    def test_external_earth_boundaries(self):
+        ifczip = _external_earth_ifczip()
+        if not os.path.exists(ifczip):
+            pytest.skip("IfcRelSpaceBoundary_TestFiles submodule is not checked out")
+        ifc_file = ifcopenshell.open(ifczip)
+        shapes = _build_shapes_dict_from_iterator(ifc_file)
+        for space_id, expected_counts in [
+            (182, {996: 1, 1122: 1, 1235: 2, 1288: 1, 2970: 1, 3071: 1, 3140: 1, 3214: 1, 3435: 1, 3605: 1, 3719: 1}),
+            (440, {1122: 1, 3140: 1, 3214: 1, 3493: 1, 3605: 1, 3640: 1, 3669: 1, 3719: 1}),
+            (628, {3140: 1, 3838: 1, 3927: 1, 3980: 2, 4033: 1, 4086: 1, 4139: 1, 4199: 1}),
+        ]:
+            copy = ifcopenshell.file.from_string(ifc_file.wrapped_data.to_string())
+            new_space = copy.by_id(space_id)
+            result = subject.auto_generate_boundaries(
+                copy, new_space, shapes=shapes, boundary_class="IfcRelSpaceBoundary2ndLevel"
+            )
+            assert _boundary_element_counts(copy, space_id) == expected_counts
+            for boundary in result:
+                assert _boundary_inner_count(boundary) == 0
+                if boundary.ParentBoundary:
+                    parent_polygon = _boundary_polygon_in_plane(boundary.ParentBoundary)
+                    child_polygon = _boundary_polygon_in_plane(boundary, reference=boundary.ParentBoundary)
+                    assert child_polygon.intersection(parent_polygon).area == pytest.approx(
+                        child_polygon.area, abs=1e-2
+                    )
+            if space_id in (182, 440):
+                roof_boundaries = _boundaries_for(result, copy.by_id(3214))
+                assert len(roof_boundaries) == 1
+                skylight = [b for b in result if b.RelatedBuildingElement.id() in (3435, 3640)]
+                assert len(skylight) == 1
+                assert skylight[0].ParentBoundary == roof_boundaries[0]

--- a/src/ifcopenshell-python/test/util/test_shape.py
+++ b/src/ifcopenshell-python/test/util/test_shape.py
@@ -95,3 +95,45 @@ class TestBisectMeshPlaneVf:
         for start, end in segments:
             for coord in start + end:
                 assert round(coord, 6) == coord
+
+
+class TestDissolveFaces:
+    def test_dissolve_cube_into_ngons(self):
+        """A triangulated cube (12 triangles) should dissolve into 6 quad faces."""
+        verts, faces = _cube_verts_faces(size=2.0)
+        edges = np.array(
+            [
+                [0, 1],
+                [1, 2],
+                [2, 3],
+                [3, 0],
+                [4, 5],
+                [5, 6],
+                [6, 7],
+                [7, 4],
+                [0, 4],
+                [1, 5],
+                [2, 6],
+                [3, 7],
+            ],
+            dtype=np.int32,
+        )
+        ngons = subject.dissolve_faces(verts, faces, edges)
+        assert len(ngons) == 6
+        for ngon in ngons:
+            assert len(ngon) == 4
+
+    def test_dissolve_no_edges_returns_triangles(self):
+        """With no original edges, triangles should be returned as-is."""
+        verts, faces = _cube_verts_faces(size=2.0)
+        edges = np.array([], dtype=np.int32).reshape(0, 2)
+        ngons = subject.dissolve_faces(verts, faces, edges)
+        assert len(ngons) == 12
+        for ngon in ngons:
+            assert len(ngon) == 3
+
+    def test_dissolve_empty_faces(self):
+        verts = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float64)
+        faces = np.array([], dtype=np.int32).reshape(0, 3)
+        edges = np.array([], dtype=np.int32).reshape(0, 2)
+        assert subject.dissolve_faces(verts, faces, edges) == []


### PR DESCRIPTION
Replace the Blender-based space boundary generation in `bonsai` with an IFC-based implementation in `ifcopenshell.util.boundary`, and fix a series of bugs found while validating it against the reference boundary test models.

## What changed

- **Extract boundary generation to `ifcopenshell.util.boundary`** (`auto_generate_boundaries`) and have the Blender add-on call it.
- **`dissolve_faces`** in `ifcopenshell.util.shape`: reconstruct polygonal faces from triangulated meshes, with `merge_coplanar` support to rejoin split planar faces (e.g. an L-shaped top face).
- Fix the axis/ref_direction swap in connection geometry for the new generation path.
- Deduplicate opening boundaries so a space only gets one boundary per opening pair.
- Fix space boundary generation regressions found against the `IfcRelSpaceBoundary_TestFiles` reference models (ExternalEarth, SmallHouse, Triangle, OverSplitted).
- Keep shaft holes in generated ceiling boundaries and avoid spurious wall-cap boundaries at the shaft base, matching the reference output.
- Optimize coplanar face reconstruction (vectorized prefilter, precomputed normals) and add regression tests.

## Stack

This PR is stacked on #9005 (`auto-space-height`) and depends on it.

## Testing

`test/util/test_boundary.py` and `test/util/test_shape.py` pass. New regression tests cover ExternalEarth, SmallHouse, Triangle, and OverSplitted models.

## AI disclosure

The commits in this PR were generated with the assistance of an AI coding tool.