### PR TITLE
dev_environment.py: detect Blender's bundled Python from disk

### DIFF
--- a/src/bonsai/scripts/dev_environment.py
+++ b/src/bonsai/scripts/dev_environment.py
@@ -21,7 +21,7 @@ import subprocess
 import sys
 import urllib.request
 from pathlib import Path
-from typing import Union
+from typing import Tuple, Union
 
 available_platforms = ("win32", "darwin", "linux")
 if sys.platform not in available_platforms:
@@ -92,8 +92,34 @@ BONSAI_PATH = find_bonsai_path()
 
 # Never changed by user.
 BLENDER_VERSION_INT = tuple(map(int, BLENDER_VERSION.split(".")))
-PYTHON_VERSION = "3.13" if BLENDER_VERSION_INT >= (5, 1) else "3.11"
-PACKAGE_PATH = BLENDER_PATH / rf"extensions/.local/lib/python{PYTHON_VERSION}/site-packages"
+
+
+# PACKAGE_PATH: Path to the site-packages of the Python bundled with Blender.
+# Blender bundles a different Python per release (3.11 for 4.x, 3.13 for 5.1+), so read the
+# version off the extensions folder instead of hardcoding a mapping that needs an edit
+# every time Blender bumps it.
+def find_package_path() -> Path:
+    extensions_lib = BLENDER_PATH / "extensions/.local/lib"
+
+    def version_key(path: Path) -> Tuple[int, ...]:
+        version = path.parent.name[len("python") :]
+        try:
+            return tuple(int(part) for part in version.split("."))
+        except ValueError:
+            # Unrecognized folder name, sort it below the versions we can parse.
+            return (-1,)
+
+    candidates = sorted(extensions_lib.glob("python*/site-packages"), key=version_key)
+    if candidates:
+        # Highest version wins in case an older Blender left a folder behind.
+        return candidates[-1]
+
+    # Fallback to the known mapping so the assert in `main` can report a sensible path.
+    fallback_version = "3.13" if BLENDER_VERSION_INT >= (5, 1) else "3.11"
+    return extensions_lib / f"python{fallback_version}/site-packages"
+
+
+PACKAGE_PATH = find_package_path()
 
 
 def main() -> None:
@@ -115,6 +141,7 @@ def main() -> None:
     print(f"REPO_PATH={REPO_PATH}")
     print(f"BLENDER_PATH={BLENDER_PATH}")
     print(f"BONSAI_PATH={BONSAI_PATH}")
+    print(f"PACKAGE_PATH={PACKAGE_PATH}")
     print("-" * 10)
 
     assert REPO_PATH.exists(), f"Path '{REPO_PATH=!s}' doesn't exist, ensure variable is set correctly."


### PR DESCRIPTION
Closes #9227.

`dev_environment.py` derived the site-packages path from a hardcoded Blender→Python mapping:

```python
BLENDER_VERSION_INT = tuple(map(int, BLENDER_VERSION.split(".")))
PYTHON_VERSION = "3.13" if BLENDER_VERSION_INT >= (5, 1) else "3.11"
```

That boundary has needed a manual edit on each Blender release that bumps the interpreter — 7e1843b96 for 5.1, then d30c25010 after 5.2 fell through to 3.11 and the script aborted — and it will break again the moment Blender ships 3.14. Each time, the symptom is a new contributor unable to set up a dev environment, with an assertion that doesn't point at the cause.

The information is already on disk, so this reads it instead of predicting it: glob `extensions/.local/lib/python*/site-packages` and take the highest version. The old mapping stays as a fallback so the existing assert still reports a sensible path when nothing matches.

Sorting is on the parsed version parts rather than the raw string — plain `sorted()` puts `python3.9` above `python3.13`. Folder names that don't parse sort below the ones that do instead of raising, so an unexpected variant (e.g. a free-threaded `python3.13t` build) can't take the script down.

Also prints `PACKAGE_PATH` in the "Script settings" block. It was the one path the script asserts on but never showed.

### Testing

Loaded the module with `input` stubbed and checked the resolved path against a real install:

| Blender | Resolved | Exists |
| --- | --- | --- |
| 5.2 | `...\5.2\extensions\.local\lib\python3.13\site-packages` | yes |
| 4.5 | `...\4.5\extensions\.local\lib\python3.11\site-packages` | yes |

Sort key checked against a tree containing `python3.9`, `python3.13` and `python3.13t`: string sort picks `python3.9`, the version-part key picks `python3.13`. `black --line-length 120` reports no changes.

Windows 10, Blender 5.2 and 4.5, Bonsai installed via offline installation (`extensions/user_default/bonsai`). Not exercised on macOS or Linux, though the changed code is platform-independent — only `BLENDER_PATH`, set above it, differs per platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
