### PR TITLE
Bonsai: void loop that encloses no area crashes (#9230), or is silently lost (#8983)

### DIFF
--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2361,8 +2361,10 @@ class Model(bonsai.core.tool.Model):
                 if group_index in v[deform_layer]:
                     return group_index
 
-        # Convert all loops into IFC curves
+        # Convert all loops into IFC curves. `closed_curves` marks curves
+        # authored as a genuinely closed loop (or a circle, always closed).
         curves: list[ifcopenshell.entity_instance] = []
+        closed_curves: set[ifcopenshell.entity_instance] = set()
         for loop in loops:
 
             if len(loop) == 1 and all([is_in_group(v, "IFCCIRCLE") for v in loop[0].verts]):
@@ -2374,6 +2376,7 @@ class Model(bonsai.core.tool.Model):
                 curves.append(
                     tmp.createIfcCircle(tmp.createIfcAxis2Placement2D(tmp.createIfcCartesianPoint(list(mid))), radius)
                 )
+                closed_curves.add(curves[-1])
             else:
                 loop_verts: list[bmesh.types.BMVert] = []
                 for i, edge in enumerate(loop):
@@ -2449,6 +2452,8 @@ class Model(bonsai.core.tool.Model):
                         coord_list.append(coord_list[0])
                     points = tmp.createIfcCartesianPointList2D(coord_list)
                     curves.append(tmp.createIfcIndexedPolyCurve(points))
+                if is_closed:
+                    closed_curves.add(curves[-1])
 
         # Sort IFC curves into either closed, or closed with void profile defs
         profile_defs: list[ifcopenshell.entity_instance] = []
@@ -2465,12 +2470,16 @@ class Model(bonsai.core.tool.Model):
             edges = ifcopenshell.util.shape.get_edges(geometry)
             boundary_lines = [shapely.LineString([v[e[0]], v[e[1]]]) for e in edges]
             unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
-            if not hasattr(unioned_boundaries, "geoms"):
-                continue
-            closed_polygons = shapely.polygonize(unioned_boundaries.geoms)
-            for polygon in closed_polygons.geoms:
-                polygons[curve] = polygon
-                break
+            # A curve authored as closed must resolve to exactly one polygon;
+            # if not, fail loudly instead of dropping or guessing (#8983).
+            if hasattr(unioned_boundaries, "geoms"):
+                closed_polygons = list(shapely.polygonize(unioned_boundaries.geoms).geoms)
+            else:
+                closed_polygons = []
+            if len(closed_polygons) == 1:
+                polygons[curve] = closed_polygons[0]
+            elif curve in closed_curves:
+                return (False, "INVALID_LOOP")
 
         # Check for contains properly (IFC doesn't allow common boundary points)
         outer_inner = {}

--- a/src/bonsai/bonsai/tool/model.py
+++ b/src/bonsai/bonsai/tool/model.py
@@ -2465,6 +2465,8 @@ class Model(bonsai.core.tool.Model):
             edges = ifcopenshell.util.shape.get_edges(geometry)
             boundary_lines = [shapely.LineString([v[e[0]], v[e[1]]]) for e in edges]
             unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
+            if not hasattr(unioned_boundaries, "geoms"):
+                continue
             closed_polygons = shapely.polygonize(unioned_boundaries.geoms)
             for polygon in closed_polygons.geoms:
                 polygons[curve] = polygon
@@ -2481,9 +2483,11 @@ class Model(bonsai.core.tool.Model):
                     outer_inner.setdefault(curve, []).append(curve2)
                     inner_outer.setdefault(curve2, []).append(curve)
 
-        # Odd-even rule for nested curves
-        nested_level = {c: len(inner_outer[c]) if c in inner_outer else 0 for c in curves}
-        for curve in sorted(curves, key=lambda c: nested_level[c]):
+        # Odd-even rule for nested curves. Only curves that actually resolved to a
+        # polygon above are candidates: a curve outside `polygons` traced no closed
+        # area and must not be promoted to its own outer profile.
+        nested_level = {c: len(inner_outer[c]) if c in inner_outer else 0 for c in polygons}
+        for curve in sorted(polygons, key=lambda c: nested_level[c]):
             level = nested_level[curve]
             if level % 2 == 0:
                 if curve in outer_inner:

--- a/src/bonsai/test/bim/module/model/test_auto_detect_profiles_open_loop.py
+++ b/src/bonsai/test/bim/module/model/test_auto_detect_profiles_open_loop.py
@@ -1,0 +1,127 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression tests for #9230: editing a void crashed with
+``AttributeError: 'LineString' object has no attribute 'geoms'``.
+
+``shapely.union_all()`` returns a scalar ``LineString``, not a
+``MultiLineString``, whenever the dissolved boundary collapses to a single
+connected piece -- only multi-part geometries expose ``.geoms``. A curve
+with no enclosed area (the simplest case: one still-open edge, which slips
+past the ``UNCLOSED_LOOP`` sanity check whenever the mesh has no
+IFCARCINDEX/IFCCIRCLE vertex groups at all, since that check is gated
+behind ``if deform_layer:``) unions to exactly that scalar LineString.
+
+A prior fix attempt that only guarded the ``.geoms`` access without also
+excluding the curve from the odd/even nesting loop further down would have
+traded the crash for a worse bug: the loop unconditionally wraps every
+curve at nesting level 0 in ``IfcArbitraryClosedProfileDef``, so an open,
+never-polygonised curve would silently become a bogus "closed" profile
+instead of being dropped."""
+
+import bmesh
+import bpy
+import ifcopenshell
+import ifcopenshell.api.root
+import ifcopenshell.api.unit
+import pytest
+
+import bonsai.tool as tool
+from bonsai.bim.ifc import IfcStore
+
+pytestmark = pytest.mark.model
+
+
+@pytest.fixture
+def ifc_file():
+    ifc = ifcopenshell.file(schema="IFC4")
+    ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject", name="P")
+    ifcopenshell.api.unit.assign_unit(ifc)
+    previous = IfcStore.file
+    IfcStore.file = ifc
+    try:
+        yield ifc
+    finally:
+        IfcStore.file = previous
+
+
+def _mesh_obj(name, verts, edges):
+    mesh = bpy.data.meshes.new(name)
+    obj = bpy.data.objects.new(name, mesh)
+    bm = bmesh.new()
+    bm_verts = [bm.verts.new(v) for v in verts]
+    bm.verts.ensure_lookup_table()
+    for a, b in edges:
+        bm.edges.new((bm_verts[a], bm_verts[b]))
+    bm.to_mesh(mesh)
+    bm.free()
+    return obj, mesh
+
+
+def test_open_edge_without_groups_does_not_crash(ifc_file):
+    # One unclosed edge, no vertex groups: the UNCLOSED_LOOP sanity check
+    # is skipped (it is gated behind `if deform_layer:`), so this reaches
+    # the shapely union as the crash-triggering single LineString.
+    obj, mesh = _mesh_obj("open_edge", [(0, 0, 0), (1, 0.2, 0)], [(0, 1)])
+    result = tool.Model.auto_detect_profiles(obj, mesh)
+    assert result is None
+
+
+def test_closed_triangle_still_detected(ifc_file):
+    obj, mesh = _mesh_obj(
+        "closed_triangle",
+        [(0, -1, 0), (1, 0, 0), (0, 1, 0)],
+        [(0, 1), (1, 2), (2, 0)],
+    )
+    result = tool.Model.auto_detect_profiles(obj, mesh)
+    assert isinstance(result, dict)
+    assert result["profile_def"].is_a("IfcArbitraryClosedProfileDef")
+
+
+def test_valid_boundary_survives_stray_unclosed_edge(ifc_file):
+    # A real closed square plus an unrelated stray open edge in the same
+    # mesh (e.g. leftover geometry from an aborted arc edit). The square
+    # must still be detected; the stray edge must not corrupt or block it.
+    obj, mesh = _mesh_obj(
+        "square_plus_stray_edge",
+        [
+            (-1, -1, 0),
+            (1, -1, 0),
+            (1, 1, 0),
+            (-1, 1, 0),
+            (5, 5, 0),
+            (6, 5.2, 0),
+        ],
+        [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5)],
+    )
+    result = tool.Model.auto_detect_profiles(obj, mesh)
+    assert isinstance(result, dict)
+    assert result["profile_def"].is_a("IfcArbitraryClosedProfileDef")
+
+
+def test_void_with_hole_still_detected(ifc_file):
+    outer = [(-1, -1, 0), (1, -1, 0), (1, 1, 0), (-1, 1, 0)]
+    inner = [(-0.25, -0.25, 0), (0.25, -0.25, 0), (0.25, 0.25, 0), (-0.25, 0.25, 0)]
+    verts = outer + inner
+    edges = [(0, 1), (1, 2), (2, 3), (3, 0), (4, 5), (5, 6), (6, 7), (7, 4)]
+    obj, mesh = _mesh_obj("void_with_hole", verts, edges)
+    result = tool.Model.auto_detect_profiles(obj, mesh)
+    assert isinstance(result, dict)
+    assert result["profile_def"].is_a("IfcArbitraryProfileDefWithVoids")

--- a/src/bonsai/test/bim/module/model/test_auto_detect_profiles_open_loop.py
+++ b/src/bonsai/test/bim/module/model/test_auto_detect_profiles_open_loop.py
@@ -18,23 +18,36 @@
 #
 # This file was generated with the assistance of an AI coding tool.
 
-"""Regression tests for #9230: editing a void crashed with
-``AttributeError: 'LineString' object has no attribute 'geoms'``.
+"""Regression tests for #9230 and #8983: two symptoms of the same missing
+guard in ``auto_detect_profiles()`` -- a curve whose loop doesn't resolve to
+exactly one simple polygon must not be silently promoted, dropped, or
+arbitrarily resolved.
 
-``shapely.union_all()`` returns a scalar ``LineString``, not a
-``MultiLineString``, whenever the dissolved boundary collapses to a single
-connected piece -- only multi-part geometries expose ``.geoms``. A curve
-with no enclosed area (the simplest case: one still-open edge, which slips
-past the ``UNCLOSED_LOOP`` sanity check whenever the mesh has no
-IFCARCINDEX/IFCCIRCLE vertex groups at all, since that check is gated
-behind ``if deform_layer:``) unions to exactly that scalar LineString.
+#9230: editing a void crashed with ``AttributeError: 'LineString' object
+has no attribute 'geoms'``. ``shapely.union_all()`` returns a scalar
+``LineString``, not a ``MultiLineString``, whenever the dissolved boundary
+collapses to a single connected piece -- only multi-part geometries expose
+``.geoms``. A curve with no enclosed area (the simplest case: one still-open
+edge, which slips past the ``UNCLOSED_LOOP`` sanity check whenever the mesh
+has no IFCARCINDEX/IFCCIRCLE vertex groups at all, since that check is
+gated behind ``if deform_layer:``) unions to exactly that scalar LineString.
 
 A prior fix attempt that only guarded the ``.geoms`` access without also
 excluding the curve from the odd/even nesting loop further down would have
 traded the crash for a worse bug: the loop unconditionally wraps every
 curve at nesting level 0 in ``IfcArbitraryClosedProfileDef``, so an open,
 never-polygonised curve would silently become a bogus "closed" profile
-instead of being dropped."""
+instead of being dropped.
+
+#8983: a curve that IS authored as a closed loop (e.g. a void boundary),
+but is degenerate (collinear points, encloses zero area), also fails to
+polygonise -- but unlike a stray open edge, it was clearly meant to enclose
+an area. Silently dropping it (matching the #9230 fix's tolerance for
+open, never-closed stray geometry) would quietly turn a boundary-with-void
+into a boundary-without-void, with nothing shown to the user. `curves` that
+were authored closed (or a circle, always closed) must resolve to exactly
+one polygon or surface ``(False, "INVALID_LOOP")``; only curves that were
+never closed to begin with are tolerated and skipped."""
 
 import bmesh
 import bpy
@@ -125,3 +138,31 @@ def test_void_with_hole_still_detected(ifc_file):
     result = tool.Model.auto_detect_profiles(obj, mesh)
     assert isinstance(result, dict)
     assert result["profile_def"].is_a("IfcArbitraryProfileDefWithVoids")
+
+
+def test_degenerate_closed_void_loop_surfaces_a_failure(ifc_file):
+    # #8983: a genuine 10x10 outer square, plus a "void" that IS a closed
+    # loop (3 collinear points along y=4, closing back on itself) but
+    # encloses zero area. Unlike the stray open edge above, this loop was
+    # authored closed, so it must not be silently dropped.
+    verts = [
+        (0, 0, 0),
+        (10, 0, 0),
+        (10, 10, 0),
+        (0, 10, 0),
+        (4, 4, 0),
+        (5, 4, 0),
+        (6, 4, 0),
+    ]
+    edges = [
+        (0, 1),
+        (1, 2),
+        (2, 3),
+        (3, 0),
+        (4, 5),
+        (5, 6),
+        (6, 4),
+    ]
+    obj, mesh = _mesh_obj("degenerate_closed_void", verts, edges)
+    result = tool.Model.auto_detect_profiles(obj, mesh)
+    assert result == (False, "INVALID_LOOP"), result


### PR DESCRIPTION
Fixes #9230. Fixes #8983.

Both are the same missing guard in `auto_detect_profiles()`: a curve whose triangulated boundary does not resolve to exactly one simple polygon was not handled safely.

## What the original fix on this branch did, and what it missed

It stopped the crash (`AttributeError: 'LineString' object has no attribute 'geoms'`, #9230) by skipping a curve whose union collapsed to a scalar `LineString`, and by restricting the odd/even nesting loop to curves that actually resolved. **That stopped the crash but left #8983 open**, exactly as its own commit message admitted. A curve authored as a closed loop, meaning a real void boundary or a circle, that failed to polygonise for any reason still vanished silently.

The two red runs show it clearly. Same input, an outer square with a degenerate void loop:

```
unpatched      the void becomes a bogus 2-member IfcCompositeProfileDef
this branch    the outer square is correct and THE VOID IS SIMPLY GONE
```

So the first fix changed the shape of the bug without removing it.

## What changed now

`closed_curves` tracks which curves were authored genuinely closed, or are circles, which always are. Only those must resolve to exactly one polygon. If one does not, `auto_detect_profiles()` returns `(False, "INVALID_LOOP")`, the convention already used for `CIRCLE`, `3POINT_ARC` and `UNCLOSED_LOOP`, which `edit_representation_item` already turns into an "INVALID PROFILE" popup.

This distinction is load-bearing rather than cosmetic. A naive "fail on any unresolved curve" would break this branch's own `test_valid_boundary_survives_stray_unclosed_edge`, which deliberately asserts that a valid square survives a stray open edge elsewhere in the mesh. Debris that was never closed is still tolerated and skipped, and that test passes unchanged.

## Verification

Live in Blender 5.2.0 LTS through `bonsai.tool.Model.auto_detect_profiles()` for both symptoms. Red-green for both against this branch:

* fully unpatched: 3 failures, including #9230's `AttributeError` at two sites and #8983's wrong composite
* this branch before the new commit: 1 failure, the silent drop, proving the two defects are distinct

The #8983 regression case is folded into the existing `test_auto_detect_profiles_open_loop.py` beside the #9230 tests. All 5 pass. The 4 original tests are unchanged.

## Related, not fixed here

The same unguarded `union_all().geoms` shape appears in `bim/module/drawing/operator.py`, `bim/module/model/opening.py`, `bim/module/model/roof.py`, `tool/spatial.py` and `tool/drawing.py`. Two of those also call `max()` on a possibly empty result, which raises `ValueError`. Handled separately so this PR stays reviewable.

Produced with AI assistance.
