### PR TITLE
Bonsai: grid axis label truncation and duplicate axis objects (#9232)

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -514,6 +514,9 @@ class IfcImporter:
         self, axes: list[ifcopenshell.entity_instance], grid_obj: bpy.types.Object, grid_placement: MatrixType
     ) -> None:
         for axis in axes:
+            # A single IfcGridAxis can be shared by multiple IfcGrids.
+            if tool.Ifc.get_object(axis):
+                continue
             shape = tool.Loader.create_generic_shape(axis.AxisCurve)
             mesh = self.create_mesh(axis, shape)
             obj = bpy.data.objects.new(tool.Loader.get_name(axis), mesh)

--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -18,6 +18,7 @@
 
 import math
 import os
+import re
 from collections.abc import Generator, Iterator
 from functools import cache
 from math import acos, atan, cos, degrees, pi, radians, sin
@@ -1476,7 +1477,11 @@ class GridDecorator(BaseDecorator):
         p0 = location_3d_to_region_2d(region, region3d, v0)
         p1 = location_3d_to_region_2d(region, region3d, v1)
         dir = Vector((1, 0))
-        text = obj.name.split("/")[1].split(".")[0]
+        element = tool.Ifc.get_entity(obj)
+        axis_tag = getattr(element, "AxisTag", None) if element else None
+        if axis_tag is None:
+            axis_tag = re.sub(r"\.\d{3}$", "", obj.name.split("/")[1])
+        text = axis_tag
         if p0:
             self.draw_label(context, text, p0, dir, vcenter=True, gap=0)
         if p1:

--- a/src/bonsai/bonsai/bim/module/spatial/decorator.py
+++ b/src/bonsai/bonsai/bim/module/spatial/decorator.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
+
 import blf
 import gpu
 from bpy_extras.view3d_utils import location_3d_to_region_2d
@@ -49,7 +51,11 @@ class GridDecorator(tool.Blender.ViewportDecorator):
             if obj.select_get() and context.mode != "OBJECT":
                 continue
 
-            tag = obj.name.split("/")[-1].split(".")[0]
+            element = tool.Ifc.get_entity(obj)
+            axis_tag = getattr(element, "AxisTag", None) if element else None
+            if axis_tag is None:
+                axis_tag = re.sub(r"\.\d{3}$", "", obj.name.split("/")[-1])
+            tag = axis_tag
             matrix_world = obj.matrix_world
             v1 = matrix_world @ obj.data.vertices[0].co
             v2 = matrix_world @ obj.data.vertices[1].co

--- a/src/bonsai/test/bim/module/drawing/test_grid_decorator.py
+++ b/src/bonsai/test/bim/module/drawing/test_grid_decorator.py
@@ -1,0 +1,125 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression tests for #9232: the viewport GridDecorator truncated
+IfcGridAxis.AxisTag at the first dot (e.g. "a.1" -> "a"), because it derived
+the label text by splitting the Blender object's display name instead of
+reading AxisTag from the linked IFC entity.
+
+``GridDecorator`` is built with ``__new__`` (skipping ``BaseDecorator.__init__``)
+so these tests never touch ``gpu.shader.from_builtin``, which requires a
+live GPU context that isn't guaranteed under every Blender test runner.
+``draw_label`` and the region-projection helper are stubbed so only the
+text-derivation logic under test executes."""
+
+import types
+from unittest.mock import Mock
+
+import bpy
+import pytest
+
+pytestmark = pytest.mark.drawing
+
+
+@pytest.fixture(autouse=True)
+def _require_real_bpy():
+    if not isinstance(bpy, types.ModuleType) or hasattr(bpy, "_mock_name"):
+        pytest.skip("requires real Blender (bpy is mocked or absent)")
+
+
+def _rendered_text(obj, monkeypatch, element=None):
+    """Call the real (patched) GridDecorator.draw_labels and return the
+    text it asked draw_label to render (both endpoints always get the
+    same text, so a single string is returned)."""
+    from mathutils import Vector
+
+    import bonsai.bim.module.drawing.decoration as decoration
+    import bonsai.tool as tool
+
+    monkeypatch.setattr(decoration, "location_3d_to_region_2d", lambda region, region3d, v: Vector((0.0, 0.0)))
+    monkeypatch.setattr(tool.Ifc, "get_entity", lambda o: element)
+
+    captured = []
+    decorator = decoration.GridDecorator.__new__(decoration.GridDecorator)
+    decorator.draw_label = lambda context, text, *a, **kw: captured.append(text)
+
+    context = Mock(region=object(), region_data=object())
+    verts = [Vector((0, 0, 0)), Vector((1, 0, 0))]
+    decorator.draw_labels(context, obj, verts)
+
+    assert len(captured) == 2
+    assert captured[0] == captured[1]
+    return captured[0]
+
+
+def _fake_obj(name):
+    # Mock's constructor special-cases the ``name`` kwarg for its own repr,
+    # so the ``.name`` attribute has to be assigned after construction.
+    obj = Mock(spec=["name"])
+    obj.name = name
+    return obj
+
+
+def test_dotted_axis_tag_renders_in_full_from_the_ifc_entity(monkeypatch):
+    element = Mock(AxisTag="a.1")
+    text = _rendered_text(_fake_obj("IfcGridAxis/a.1"), monkeypatch, element=element)
+    assert text == "a.1"
+
+
+@pytest.mark.parametrize("tag", ["a.A", "a.B", "a.C", "b.1", "b.C"])
+def test_letter_and_numeric_suffixes_render_in_full(monkeypatch, tag):
+    element = Mock(AxisTag=tag)
+    text = _rendered_text(_fake_obj(f"IfcGridAxis/{tag}"), monkeypatch, element=element)
+    assert text == tag
+
+
+def test_object_name_is_never_consulted_when_the_entity_is_reachable(monkeypatch):
+    # The Blender object name is a red herring here (looks pre-truncated);
+    # the element's AxisTag must still win.
+    element = Mock(AxisTag="a.1")
+    text = _rendered_text(_fake_obj("IfcGridAxis/a"), monkeypatch, element=element)
+    assert text == "a.1"
+
+
+def test_missing_element_falls_back_to_object_name_untouched(monkeypatch):
+    # No linked IFC entity: fall back to the object name. A dotted tag with
+    # no real Blender duplicate suffix must be left exactly as-is.
+    text = _rendered_text(_fake_obj("IfcGridAxis/a.1"), monkeypatch, element=None)
+    assert text == "a.1"
+
+
+def test_missing_element_fallback_strips_only_a_real_blender_suffix(monkeypatch):
+    # Blender appended ".001" for a name collision; the fallback must strip
+    # only that trailing suffix, not the axis tag's own dot.
+    text = _rendered_text(_fake_obj("IfcGridAxis/a.1.001"), monkeypatch, element=None)
+    assert text == "a.1"
+
+
+def test_missing_element_fallback_does_not_strip_a_single_digit_suffix(monkeypatch):
+    # A single trailing digit is legitimate axis-tag content, not a
+    # Blender-generated ".001"-style duplicate suffix.
+    text = _rendered_text(_fake_obj("IfcGridAxis/a.5"), monkeypatch, element=None)
+    assert text == "a.5"
+
+
+def test_element_with_falsy_axis_tag_falls_back_to_object_name(monkeypatch):
+    element = Mock(AxisTag=None)
+    text = _rendered_text(_fake_obj("IfcGridAxis/a.1"), monkeypatch, element=element)
+    assert text == "a.1"

--- a/src/bonsai/test/bim/module/spatial/__init__.py
+++ b/src/bonsai/test/bim/module/spatial/__init__.py
@@ -1,0 +1,17 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.

--- a/src/bonsai/test/bim/module/spatial/test_grid_decorator.py
+++ b/src/bonsai/test/bim/module/spatial/test_grid_decorator.py
@@ -1,0 +1,119 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression tests for #9232: this is the Spatial module's own
+``GridDecorator`` (distinct from ``bonsai.bim.module.drawing.decoration``'s
+``GridDecorator``), which draws the always-on grid axis labels installed by
+``tool.Root.reload_grid_decorator()`` on every project load. It carried the
+exact same bug: the label text was split off the Blender object's display
+name at the first dot instead of read from the linked IfcGridAxis entity.
+
+``GridDecorator`` is built with ``__new__`` (skipping ``ViewportDecorator``
+init) so these tests never touch a live GPU/blf backend."""
+
+import types
+from unittest.mock import Mock
+
+import bpy
+import pytest
+
+pytestmark = pytest.mark.spatial
+
+
+@pytest.fixture(autouse=True)
+def _require_real_bpy():
+    if not isinstance(bpy, types.ModuleType) or hasattr(bpy, "_mock_name"):
+        pytest.skip("requires real Blender (bpy is mocked or absent)")
+
+
+def _fake_obj(name):
+    from mathutils import Vector
+
+    obj = Mock(spec=["name", "visible_get", "select_get", "matrix_world", "data"])
+    obj.name = name
+    obj.visible_get.return_value = True
+    obj.select_get.return_value = False
+    obj.matrix_world = __import__("mathutils").Matrix.Identity(4)
+    obj.data = Mock(vertices=[Mock(co=Vector((0, 0, 0))), Mock(co=Vector((1, 0, 0)))])
+    return obj
+
+
+def _drawn_labels(obj, monkeypatch, element=None):
+    from types import SimpleNamespace
+
+    from mathutils import Vector
+
+    import bonsai.bim.module.spatial.decorator as spatial_decoration
+    import bonsai.tool as tool
+
+    monkeypatch.setattr(spatial_decoration, "location_3d_to_region_2d", lambda region, region3d, v: Vector((0, 0)))
+    monkeypatch.setattr(tool.Ifc, "get_entity", lambda o: element)
+    monkeypatch.setattr(
+        tool.Blender,
+        "get_addon_preferences",
+        staticmethod(
+            lambda: SimpleNamespace(
+                decorator_color_selected=(1, 1, 1, 1),
+                decorator_color_unselected=(1, 1, 1, 1),
+                decorator_color_special=(1, 1, 1, 1),
+            )
+        ),
+    )
+    monkeypatch.setattr(tool.Blender, "is_addon_enabled", staticmethod(lambda: True))
+    monkeypatch.setattr(
+        tool.Spatial, "get_grid_props", staticmethod(lambda: SimpleNamespace(grid_axes=[SimpleNamespace(obj=obj)]))
+    )
+
+    import blf
+
+    drawn = []
+    monkeypatch.setattr(blf, "draw", lambda font_id, text: drawn.append(text))
+    monkeypatch.setattr(blf, "dimensions", lambda font_id, text: (10.0, 10.0))
+
+    decorator = spatial_decoration.GridDecorator.__new__(spatial_decoration.GridDecorator)
+    context = SimpleNamespace(region=object(), region_data=object(), mode="OBJECT")
+    decorator.draw_text(context)
+
+    assert len(drawn) == 2
+    assert drawn[0] == drawn[1]
+    return drawn[0]
+
+
+def test_dotted_axis_tag_renders_in_full_from_the_ifc_entity(monkeypatch):
+    element = Mock(AxisTag="a.1")
+    text = _drawn_labels(_fake_obj("IfcGridAxis/a.1"), monkeypatch, element=element)
+    assert text == "a.1"
+
+
+@pytest.mark.parametrize("tag", ["a.A", "b.C", "b.5"])
+def test_letter_and_numeric_suffixes_render_in_full(monkeypatch, tag):
+    element = Mock(AxisTag=tag)
+    text = _drawn_labels(_fake_obj(f"IfcGridAxis/{tag}"), monkeypatch, element=element)
+    assert text == tag
+
+
+def test_missing_element_fallback_strips_only_a_real_blender_suffix(monkeypatch):
+    text = _drawn_labels(_fake_obj("IfcGridAxis/a.1.001"), monkeypatch, element=None)
+    assert text == "a.1"
+
+
+def test_missing_element_fallback_does_not_strip_a_single_digit_suffix(monkeypatch):
+    text = _drawn_labels(_fake_obj("IfcGridAxis/a.5"), monkeypatch, element=None)
+    assert text == "a.5"


### PR DESCRIPTION
Fixes #9232.

Grid axis decorations truncate `IfcGridAxis.AxisTag` at the first dot, so `a.1` renders as `a`. @PahlawanJoey diagnosed this correctly and supplied a test model.

### The offending line

`bim/module/drawing/decoration.py`, `GridDecorator.draw_labels`:

```python
text = obj.name.split("/")[1].split(".")[0]
```

`"IfcGridAxis/a.1"` splits on `/` to `"a.1"`, then on `.` to `"a"`.

### There were two decorators, not one

`bim/module/spatial/decorator.py:52` has its **own** `GridDecorator` with the same shape:

```python
tag = obj.name.split("/")[-1].split(".")[0]
```

It is installed unconditionally on every project load via `tool.Root.reload_grid_decorator()`, called from `bim.load_project`. Confirmed live against Joey's file that it truncates independently, so fixing only the drawing module would have left the bug visible in practice.

Both now read `AxisTag` from `tool.Ifc.get_entity(obj)`, falling back to stripping a genuine trailing Blender duplicate suffix (`\.\d{3}$`) only if the entity is unreachable. Reading the authoritative value beats parsing a display name.

### Drawings are not affected

Checked rather than assumed. `svgwriter.py:479` uses `axis_tag = tool.Ifc.get_entity(obj).Name`, and `tool/drawing.py:2047` and `:2111` write `element.Name = axis.AxisTag or "-"`. The annotation entity's `Name` comes straight from `AxisTag` and is read straight back, with no splitting on that path. So this was viewport only.

### Verified against the reporter's own file

Loaded `Testmodel.ifc` (tags `a.1` to `a.5`, `a.A` to `a.C`, `b.1` to `b.5`, `b.A` to `b.C`) in a real headless Blender 5.2 session with a GPU context. Both decorators reproduced the truncation to `a` and `b` before the fix, and rendered every tag in full after.

### Same shape elsewhere, enumerated not fixed

* `bim/handler.py:110` — `element.AxisTag = object_name.split("/")[1]`, unbounded, would truncate a tag renamed to contain a `/`. Write-back path, different from this bug.
* `tool/root.py:200-203` — `get_object_name()` already attempts the "smarter split" (`if "." in obj.name and obj.name.split(".")[-1].isnumeric()`), and **still misfires on a tag ending in a bare digit**, so `a.1` becomes `a`. Used in the Blender to IFC authoring path rather than display, so it is not what Joey hit, but it is the same trap.
* `bim/module/geometry/decorator.py:138` — handles dots, would break on an embedded `/`. Not exercised live.

Correct and left alone: `bim/handler.py:103`, `tool/root.py:465`, `bim/module/void/operator.py:218` (splits then rejoins with `/`).

### Tests

`test/bim/module/drawing/test_grid_decorator.py` (11 tests) and `test/bim/module/spatial/test_grid_decorator.py` (6 tests, new package). All pass against the fix and **all fail against the unfixed code**, checked both ways.

`test/bim/module/drawing` 41 passed, `test/bim/module/spatial` 6 passed, `test/core` 390 passed with one pre-existing unrelated error in `TestCopyClass`.

### Second commit: duplicate objects for shared grid axes on import

While verifying against Joey's model this PR also fixes a separate defect in the same file, kept as its own commit so the two can be reviewed independently.

His model shares 16 `IfcGridAxis` entities across 29 `IfcGrid` entities, which is valid IFC since an axis is a positioning construct with no rule tying it to one grid. `create_grid_axes()` in `bim/import_ifc.py` creates a new Blender object unconditionally for every occurrence of an axis across every referencing grid:

```python
for axis in axes:
    shape = tool.Loader.create_generic_shape(axis.AxisCurve)
    mesh = self.create_mesh(axis, shape)
    obj = bpy.data.objects.new(tool.Loader.get_name(axis), mesh)
```

Measured on his file:

| | before | after |
|---|---|---|
| objects created | **230** | 16 |
| orphaned (no collection, no IFC element) | **214** | 0 |

`IfcStore.link_element` does detect the collision and unlinks the previous object, but that object was already created and never entered a collection, so it is left as an orphaned object and mesh datablock. The fix skips creation when `tool.Ifc.get_object(axis)` already returns an object.

**An honest limitation.** A Blender object has one `matrix_world`, and his 29 grids are the same 16-axis layout repeated at different storey elevations. So one shared axis object can only sit at one elevation. That was already true before this change, where whichever grid was processed last silently won and the rest became orphans. This makes it deterministic, first grid wins, and removes the waste. Displaying the axes at every floor would require multiple objects again, which is the defect being fixed here, so that is left alone.

Verified: a normal single-grid model still imports 1:1 with no orphans, and saving and reloading his file leaves entity counts identical (247,964 both ways) with no `IFCGRID` or `IFCGRIDAXIS` differences.

Generated with the assistance of an AI coding tool.

