### PR TITLE
Bonsai: wall side areas wrong for baked openings and Y-oriented walls (#9235, #9237)

### DIFF
--- a/src/bonsai/bonsai/bim/module/qto/calculator.py
+++ b/src/bonsai/bonsai/bim/module/qto/calculator.py
@@ -815,13 +815,56 @@ def get_lateral_area(
     return area + total_opening_area
 
 
+def get_side_void_area(obj: bpy.types.Object) -> float:
+    """Total area of holes enclosed by the object's Y-facing mesh faces.
+
+    Openings can be baked directly into the body tessellation (e.g. an
+    IfcIndexedPolygonalFaceWithVoids) rather than modelled as an
+    IfcOpeningElement relationship. Such holes leave no trace in
+    ifcopenshell.util.element.get_openings, but they do leave a real gap
+    in the mesh. Projecting the Y-facing faces onto the XZ plane and
+    unioning them exposes that gap as an interior ring, so its area can be
+    recovered exactly instead of guessed from a bounding box.
+
+    Returns 0 if no such enclosed hole is found, which is also the correct
+    answer for a solid wall of any (including non-rectangular) outline.
+    """
+    assert isinstance(obj.data, bpy.types.Mesh)
+    odata = obj.data
+    shapely_polygons = []
+    for polygon in odata.polygons:
+        if polygon.normal.y == 0:
+            continue
+        polygon_tuples = []
+        for loop_index in polygon.loop_indices:
+            loop = odata.loops[loop_index]
+            co = odata.vertices[loop.vertex_index].co
+            polygon_tuples.append((co.x, co.z))
+        try:
+            shapely_polygon = Polygon(polygon_tuples)
+        except Exception:
+            continue
+        if shapely_polygon.is_valid and not shapely_polygon.is_empty:
+            shapely_polygons.append(shapely_polygon)
+
+    if not shapely_polygons:
+        return 0.0
+
+    union = unary_union(shapely_polygons)
+    parts = union.geoms if hasattr(union, "geoms") else [union]
+
+    void_area = 0.0
+    for part in parts:
+        for interior in getattr(part, "interiors", []):
+            void_area += Polygon(interior).area
+    return void_area
+
+
 def get_gross_side_area(obj: bpy.types.Object) -> float:
-    if not has_openings(obj):
-        return get_net_side_area(obj)
+    if has_openings(obj):
+        return get_lateral_area(obj, exclude_end_areas=True, subtract_openings=False, main_axis="x") / 2
 
-    gross_side_area = get_lateral_area(obj, exclude_end_areas=True, subtract_openings=False, main_axis="x") / 2
-
-    return gross_side_area
+    return get_net_side_area(obj) + get_side_void_area(obj)
 
 
 def get_net_side_area(obj: bpy.types.Object) -> float:

--- a/src/bonsai/bonsai/bim/module/qto/calculator.py
+++ b/src/bonsai/bonsai/bim/module/qto/calculator.py
@@ -770,7 +770,8 @@ def get_lateral_area(
     :param bool exclude_side_areas: , defaults to False
     :param int angle_z1: Angle measured from the positive z-axis to the normal-vector of the area. Openings with a normal_vector lower than this value will be ignored, defaults to 45
     :param int angle_z2: Angle measured from the positive z-axis to the normal-vector of the area. Openings with a normal_vector greater than this value will be ignored, defaults to 135
-    :param str main_axis: set main axis, for example a wall must have x main axis default 'x'
+    :param str main_axis: force the main (length) axis to "x", "y" or "z" instead of guessing
+        it from the object's bounding box. Defaults to "", which uses the guess.
     :return float: Lateral Area
     """
 
@@ -778,21 +779,21 @@ def get_lateral_area(
     y_axis = [0, 1, 0]
     z_axis = [0, 0, 1]
 
-    main_axis_guess = get_object_main_axis(obj)
-    if main_axis_guess == "x" or main_axis == "x":
+    resolved_axis: AxisType = main_axis if main_axis in ("x", "y", "z") else get_object_main_axis(obj)
+    if resolved_axis == "x":
         main_axis_v = x_axis
         side_axis = y_axis
         top_axis = z_axis
-    elif main_axis_guess == "z":
+    elif resolved_axis == "z":
         main_axis_v = z_axis
         side_axis = x_axis
         top_axis = y_axis
-    elif main_axis_guess == "y":
+    elif resolved_axis == "y":
         main_axis_v = y_axis
-        side_axis = z_axis
-        top_axis = x_axis
+        side_axis = x_axis
+        top_axis = z_axis
     else:
-        assert_never(main_axis_guess)
+        assert_never(resolved_axis)
 
     area = 0
     total_opening_area = 0 if subtract_openings else get_opening_area(obj, angle_z1=angle_z1, angle_z2=angle_z2)
@@ -815,31 +816,50 @@ def get_lateral_area(
     return area + total_opening_area
 
 
-def get_side_void_area(obj: bpy.types.Object) -> float:
-    """Total area of holes enclosed by the object's Y-facing mesh faces.
+def get_elevation_main_axis(obj: bpy.types.Object) -> Literal["x", "y"]:
+    """The horizontal axis a wall-like element runs along: "x" or "y".
+
+    Compares only the local X and Y bounding box extents, unlike
+    get_object_main_axis which also compares Z. Wall-like elements (walls,
+    AXIS2 coverings, vertical openings) are always vertical, so Z is the
+    height axis regardless of how long or short the element is; including
+    it in the comparison would wrongly pick "z" for an element that is
+    taller than it is wide, such as a typical door or window opening.
+    """
+    return "x" if get_x(obj) >= get_y(obj) else "y"
+
+
+def get_side_void_area(obj: bpy.types.Object, main_axis: Literal["x", "y"] = "x") -> float:
+    """Total area of holes enclosed by the object's elevational mesh faces.
 
     Openings can be baked directly into the body tessellation (e.g. an
     IfcIndexedPolygonalFaceWithVoids) rather than modelled as an
     IfcOpeningElement relationship. Such holes leave no trace in
     ifcopenshell.util.element.get_openings, but they do leave a real gap
-    in the mesh. Projecting the Y-facing faces onto the XZ plane and
-    unioning them exposes that gap as an interior ring, so its area can be
-    recovered exactly instead of guessed from a bounding box.
+    in the mesh. Projecting the elevational faces onto the plane spanned by
+    the length axis and Z, and unioning them, exposes that gap as an
+    interior ring, so its area can be recovered exactly instead of guessed
+    from a bounding box.
+
+    :param main_axis: the wall's length axis, as returned by
+        get_elevation_main_axis. The elevational faces are the ones normal
+        to the other horizontal axis.
 
     Returns 0 if no such enclosed hole is found, which is also the correct
     answer for a solid wall of any (including non-rectangular) outline.
     """
     assert isinstance(obj.data, bpy.types.Mesh)
     odata = obj.data
+    side_axis = "y" if main_axis == "x" else "x"
     shapely_polygons = []
     for polygon in odata.polygons:
-        if polygon.normal.y == 0:
+        if getattr(polygon.normal, side_axis) == 0:
             continue
         polygon_tuples = []
         for loop_index in polygon.loop_indices:
             loop = odata.loops[loop_index]
             co = odata.vertices[loop.vertex_index].co
-            polygon_tuples.append((co.x, co.z))
+            polygon_tuples.append((getattr(co, main_axis), co.z))
         try:
             shapely_polygon = Polygon(polygon_tuples)
         except Exception:
@@ -861,14 +881,16 @@ def get_side_void_area(obj: bpy.types.Object) -> float:
 
 
 def get_gross_side_area(obj: bpy.types.Object) -> float:
+    main_axis = get_elevation_main_axis(obj)
     if has_openings(obj):
-        return get_lateral_area(obj, exclude_end_areas=True, subtract_openings=False, main_axis="x") / 2
+        return get_lateral_area(obj, exclude_end_areas=True, subtract_openings=False, main_axis=main_axis) / 2
 
-    return get_net_side_area(obj) + get_side_void_area(obj)
+    return get_net_side_area(obj) + get_side_void_area(obj, main_axis)
 
 
 def get_net_side_area(obj: bpy.types.Object) -> float:
-    net_side_area = get_lateral_area(obj, exclude_end_areas=True, main_axis="x") / 2
+    main_axis = get_elevation_main_axis(obj)
+    net_side_area = get_lateral_area(obj, exclude_end_areas=True, main_axis=main_axis) / 2
     return net_side_area
 
 

--- a/src/bonsai/test/tool/test_qto.py
+++ b/src/bonsai/test/tool/test_qto.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+import bmesh
 import bpy
 import ifcopenshell
 import ifcopenshell.api
@@ -27,6 +28,7 @@ import ifcopenshell.api.unit
 import ifcopenshell.util.pset
 
 import bonsai.bim.import_ifc as import_ifc
+import bonsai.bim.module.qto.calculator as calculator
 import bonsai.core.root
 import bonsai.core.tool
 import bonsai.tool as tool
@@ -179,6 +181,153 @@ class TestGetCalculatedObjectQuantities(test.bim.bootstrap.NewFile):
         assert quantities["NetSideArea"] == 43.056
         assert quantities["GrossVolume"] == 282.517
         assert quantities["NetVolume"] == 282.517
+
+
+class TestGetGrossSideAreaWithoutOpeningRelationship(test.bim.bootstrap.NewFile):
+    """Regression tests for #9235.
+
+    An opening can be baked directly into the body tessellation (e.g. an
+    IfcIndexedPolygonalFaceWithVoids) instead of being modelled as an
+    IfcOpeningElement related via IfcRelVoidsElement. has_openings() only
+    sees the relationship, so it is blind to this case.
+    """
+
+    def setup_file(self):
+        import logging
+
+        self.ifc = ifcopenshell.file()
+        tool.Ifc.set(self.ifc)
+        ifcopenshell.api.root.create_entity(self.ifc, ifc_class="IfcProject", name="My Project")
+        ifc_import_settings = import_ifc.IfcImportSettings.factory(
+            bpy.context, tool.Ifc.get_path(), logging.getLogger("ImportIFC")
+        )
+        ifc_importer = import_ifc.IfcImporter(ifc_import_settings)
+        ifc_importer.file = self.ifc
+        ifc_importer.create_project()
+        ifcopenshell.api.unit.assign_unit(
+            self.ifc,
+            length={"is_metric": True, "raw": "METERS"},
+            area={"is_metric": True, "raw": "SQUARE_METERS"},
+            volume={"is_metric": True, "raw": "CUBIC_METERS"},
+        )
+
+    def make_wall(self, mesh: bpy.types.Mesh) -> bpy.types.Object:
+        context = ifcopenshell.api.context.add_context(self.ifc, context_type="Model")
+        obj = bpy.data.objects.new("Wall", mesh)
+        bpy.context.scene.collection.objects.link(obj)
+        bpy.context.view_layer.objects.active = obj
+        obj.select_set(True)
+        bonsai.core.root.assign_class(
+            tool.Ifc,
+            tool.Collector,
+            tool.Root,
+            obj=obj,
+            ifc_class="IfcWall",
+            predefined_type="NOTDEFINED",
+            context=context,
+        )
+        return obj
+
+    def build_wall_with_baked_hole(
+        self, length: float, height: float, thickness: float, hole_size: float
+    ) -> bpy.types.Mesh:
+        """A rectangular wall with a square hole cut straight into the mesh.
+
+        No IfcOpeningElement is involved: the hole is a topological gap in
+        the body geometry itself, like an opening baked into an
+        IfcIndexedPolygonalFaceWithVoids.
+        """
+        cx, cz = length / 2, height / 2
+        outer = [(0, 0), (length, 0), (length, height), (0, height)]
+        h = hole_size / 2
+        inner = [(cx - h, cz - h), (cx + h, cz - h), (cx + h, cz + h), (cx - h, cz + h)]
+
+        mesh = bpy.data.meshes.new("WallWithBakedHole")
+        bm = bmesh.new()
+
+        def make_ring(y: float):
+            outer_v = [bm.verts.new((x, y, z)) for x, z in outer]
+            inner_v = [bm.verts.new((x, y, z)) for x, z in inner]
+            return outer_v, inner_v
+
+        outer_front, inner_front = make_ring(0.0)
+        outer_back, inner_back = make_ring(thickness)
+        bm.verts.ensure_lookup_table()
+
+        n = 4
+        for i in range(n):
+            j = (i + 1) % n
+            bm.faces.new([outer_front[i], outer_front[j], inner_front[j], inner_front[i]])
+        for i in range(n):
+            j = (i + 1) % n
+            bm.faces.new([outer_back[j], outer_back[i], inner_back[i], inner_back[j]])
+        for i in range(n):
+            j = (i + 1) % n
+            bm.faces.new([outer_front[i], outer_front[j], outer_back[j], outer_back[i]])
+        for i in range(n):
+            j = (i + 1) % n
+            bm.faces.new([inner_front[j], inner_front[i], inner_back[i], inner_back[j]])
+
+        bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
+        bm.to_mesh(mesh)
+        bm.free()
+        return mesh
+
+    def build_gable_wall(
+        self, length: float, eave_height: float, ridge_height: float, thickness: float
+    ) -> bpy.types.Mesh:
+        """A gable-shaped wall (pentagon profile), no openings at all.
+
+        Its bounding box is taller than the wall itself, so a fallback that
+        substitutes the bounding box for GrossSideArea would overstate it.
+        """
+        profile = [
+            (0.0, 0.0),
+            (length, 0.0),
+            (length, eave_height),
+            (length / 2, ridge_height),
+            (0.0, eave_height),
+        ]
+
+        mesh = bpy.data.meshes.new("GableWall")
+        bm = bmesh.new()
+        verts_front = [bm.verts.new((x, 0.0, z)) for x, z in profile]
+        verts_back = [bm.verts.new((x, thickness, z)) for x, z in profile]
+        bm.verts.ensure_lookup_table()
+
+        bm.faces.new(verts_front[::-1])
+        bm.faces.new(verts_back)
+        n = len(profile)
+        for i in range(n):
+            j = (i + 1) % n
+            bm.faces.new([verts_front[i], verts_front[j], verts_back[j], verts_back[i]])
+
+        bmesh.ops.recalc_face_normals(bm, faces=bm.faces[:])
+        bm.to_mesh(mesh)
+        bm.free()
+        return mesh
+
+    def test_baked_opening_is_recovered(self):
+        self.setup_file()
+        length, height, thickness, hole = 4.0, 3.0, 0.2, 1.0
+        obj = self.make_wall(self.build_wall_with_baked_hole(length, height, thickness, hole))
+
+        assert calculator.has_openings(obj) == []
+        assert round(calculator.get_net_side_area(obj), 3) == round(length * height - hole * hole, 3)
+        assert round(calculator.get_gross_side_area(obj), 3) == round(length * height, 3)
+
+    def test_non_rectangular_wall_without_openings_is_not_overstated(self):
+        self.setup_file()
+        length, eave_height, ridge_height, thickness = 6.0, 2.0, 4.0, 0.3
+        obj = self.make_wall(self.build_gable_wall(length, eave_height, ridge_height, thickness))
+
+        true_area = length * eave_height + 0.5 * length * (ridge_height - eave_height)
+        bbox_area = calculator.get_side_area(obj)  # what a bounding-box fallback would return
+
+        assert calculator.has_openings(obj) == []
+        assert round(calculator.get_net_side_area(obj), 3) == round(true_area, 3)
+        assert round(calculator.get_gross_side_area(obj), 3) == round(true_area, 3)
+        assert bbox_area > true_area + 1  # the bounding box would have overstated this wall
 
 
 class TestGetBaseQto(test.bim.bootstrap.NewFile):

--- a/src/bonsai/test/tool/test_qto.py
+++ b/src/bonsai/test/tool/test_qto.py
@@ -229,25 +229,37 @@ class TestGetGrossSideAreaWithoutOpeningRelationship(test.bim.bootstrap.NewFile)
         return obj
 
     def build_wall_with_baked_hole(
-        self, length: float, height: float, thickness: float, hole_size: float
+        self,
+        length: float,
+        height: float,
+        thickness: float,
+        hole_size: float,
+        main_axis: str = "x",
     ) -> bpy.types.Mesh:
         """A rectangular wall with a square hole cut straight into the mesh.
 
         No IfcOpeningElement is involved: the hole is a topological gap in
         the body geometry itself, like an opening baked into an
         IfcIndexedPolygonalFaceWithVoids.
+
+        :param main_axis: which local axis the wall runs along ("x" or "y").
+            The thickness always runs along the other horizontal axis, and
+            height is always along Z. #9237 was Bonsai only handling "x".
         """
         cx, cz = length / 2, height / 2
         outer = [(0, 0), (length, 0), (length, height), (0, height)]
         h = hole_size / 2
         inner = [(cx - h, cz - h), (cx + h, cz - h), (cx + h, cz + h), (cx - h, cz + h)]
 
+        def point(along_main: float, along_thickness: float, z: float) -> tuple[float, float, float]:
+            return (along_main, along_thickness, z) if main_axis == "x" else (along_thickness, along_main, z)
+
         mesh = bpy.data.meshes.new("WallWithBakedHole")
         bm = bmesh.new()
 
-        def make_ring(y: float):
-            outer_v = [bm.verts.new((x, y, z)) for x, z in outer]
-            inner_v = [bm.verts.new((x, y, z)) for x, z in inner]
+        def make_ring(thickness_pos: float):
+            outer_v = [bm.verts.new(point(x, thickness_pos, z)) for x, z in outer]
+            inner_v = [bm.verts.new(point(x, thickness_pos, z)) for x, z in inner]
             return outer_v, inner_v
 
         outer_front, inner_front = make_ring(0.0)
@@ -315,6 +327,33 @@ class TestGetGrossSideAreaWithoutOpeningRelationship(test.bim.bootstrap.NewFile)
         assert calculator.has_openings(obj) == []
         assert round(calculator.get_net_side_area(obj), 3) == round(length * height - hole * hole, 3)
         assert round(calculator.get_gross_side_area(obj), 3) == round(length * height, 3)
+
+    def test_y_oriented_wall_baked_opening_is_recovered(self):
+        """Regression test for #9237.
+
+        A wall whose length runs along local Y (thickness along X) used to
+        report its end face instead of its elevation face, because
+        get_net_side_area/get_gross_side_area hardcoded main_axis="x".
+        """
+        self.setup_file()
+        length, height, thickness, hole = 4.0, 3.0, 0.2, 1.0
+        obj = self.make_wall(self.build_wall_with_baked_hole(length, height, thickness, hole, main_axis="y"))
+
+        assert calculator.get_x(obj) < calculator.get_y(obj)
+        assert calculator.has_openings(obj) == []
+        assert round(calculator.get_net_side_area(obj), 3) == round(length * height - hole * hole, 3)
+        assert round(calculator.get_gross_side_area(obj), 3) == round(length * height, 3)
+
+    def test_x_and_y_oriented_walls_agree(self):
+        """The same wall, modelled with its length along local X or local Y,
+        must report the same NetSideArea and GrossSideArea (#9237)."""
+        self.setup_file()
+        length, height, thickness, hole = 4.0, 3.0, 0.2, 1.0
+        obj_x = self.make_wall(self.build_wall_with_baked_hole(length, height, thickness, hole, main_axis="x"))
+        obj_y = self.make_wall(self.build_wall_with_baked_hole(length, height, thickness, hole, main_axis="y"))
+
+        assert round(calculator.get_net_side_area(obj_x), 3) == round(calculator.get_net_side_area(obj_y), 3)
+        assert round(calculator.get_gross_side_area(obj_x), 3) == round(calculator.get_gross_side_area(obj_y), 3)
 
     def test_non_rectangular_wall_without_openings_is_not_overstated(self):
         self.setup_file()


### PR DESCRIPTION
Fixes #9235.

`GrossSideArea` equals `NetSideArea` whenever a wall's openings are baked into its tessellation rather than modelled as `IfcOpeningElement`. @PahlawanJoey diagnosed this precisely, measured his whole model, and cross-checked against Solibri.

```python
def get_gross_side_area(obj):
    if not has_openings(obj):          # only sees IfcRelVoidsElement
        return get_net_side_area(obj)  # Gross becomes Net
```

On his model: 120 walls, only **4** with `HasOpenings`, and his named wall `0P6UZIU3HDXOpp9cgjZsYR` reports 9.808 for both, where Solibri reports 20.08 and 9.81.

### Why the obvious fix was not taken

Joey proposed falling back to the bounding-box elevation, `max(x*z, y*z)`, which matches Solibri on this model. **That regresses non-rectangular walls, which was measured rather than assumed.**

On a hand-built gable wall with no openings and a true elevation area of 18.0 m2, the bounding-box fallback returns **24.0 m2, 33% too high**. A bounding box cannot distinguish a rectangular wall with a hole from a non-rectangular wall without one.

### What this does instead

The openings are recoverable from the geometry. Joey's file contains 44 `IfcIndexedPolygonalFaceWithVoids`, and his named wall uses two of them.

Rather than reading those interior loops directly, which only works for that one representation type, this works from the tessellated mesh topology, which is general: project the wall's Y-facing faces onto the XZ plane, union them with Shapely, and add the area of any resulting **interior ring** to the already-correct `NetSideArea`.

A genuine hole produces an interior ring. A non-rectangular outline does not. So:

| case | net | gross |
|---|---|---|
| wall with a hole cut into the mesh | 11.0 | **12.0** |
| gable wall, no openings | 18.0 | **18.0**, unchanged |
| Joey's wall `0P6UZIU3HDXOpp9cgjZsYR` | 9.808 | matches Solibri |

Returning `net + void_area` is also monotonically safe: gross can never come out **below** net, which a naive "replace net with the projected outline" approach does for foreshortened or curved faces.

### A crash fixed along the way

`get_projected_area` raises `'MultiPolygon' object has no attribute 'interiors'` whenever a wall's projected faces are not a single connected polygon. That affects **12 of the 156 walls** in Joey's file. It was previously unused, so the crash was latent. The new `get_side_void_area` handles both `Polygon` and `MultiPolygon`.

### Verification

Whole-model sweep of Joey's file, all 156 walls including `IfcWallStandardCase`: **0 exceptions, 0 cases of gross below net**, 0.12s.

`test/tool/test_qto.py` adds `TestGetGrossSideAreaWithoutOpeningRelationship`, covering both the baked-opening recovery and the gable no-regression case. All 12 tests pass under real headless Blender.

Generated with the assistance of an AI coding tool.


---

## Second commit: the same functions used the wrong axis for Y-oriented walls (#9237)

@PahlawanJoey found a second defect in these functions, and it turned out the fix above shared it.

`get_net_side_area` and `get_gross_side_area` both call `get_lateral_area(..., main_axis="x")`, hardcoding the wall's length to local X. For a wall whose length runs along **Y**, they measure the **end face** instead of the elevation.

**And the fix in the first commit had the same assumption.** `get_side_void_area` filters `polygon.normal.y == 0` and projects `(co.x, co.z)`, so on a Y-oriented wall it inspected the wrong faces and always returned a void of zero. The baked-opening recovery silently did nothing for those walls.

### Every hardcoded-axis site

* `get_net_side_area` and `get_gross_side_area`, both forcing `main_axis="x"`
* `get_lateral_area`'s dispatch, `if main_axis_guess == "x" or main_axis == "x":`, where the existing bbox-based guess was always overridden
* `get_lateral_area`'s `"y"` branch was itself wrong: `side_axis = z_axis; top_axis = x_axis` rather than mirroring the `"x"` branch. Walls are vertical, so Z stays the height reference whichever horizontal axis is longer
* `get_side_void_area` from the first commit

Axis selection now compares only the local X and Y extents. `get_object_main_axis` compares all three, which would wrongly pick Z for a door taller than it is wide.

### Measured on the reporter's file

His six named GlobalIds, before: Net = Gross ≈ 1.149, matching his report. After: **Net 4.2437, Gross 9.5987**, matching Solibri's 4.24 and 9.60. Cross-checked by manual projection: net face 4.2437 plus void 5.355 equals 9.598, which is L × H.

Across all 120 walls in the file, 108 X-oriented and 12 Y-oriented: **the X-oriented walls change by at most 4.8e-8**, float noise. All 12 Y-oriented walls now report the corrected figures. The 42 X-oriented walls with detected baked-opening voids are unaffected, so the first commit's behaviour still holds.

### Not handled, stated plainly

A wall running at 45 degrees to both local axes reports 6.30 m² against a true 12.0 m². **That is unchanged by this commit** and was equally wrong before, being a limitation of axis-aligned face classification rather than of the axis choice.

`get_opening_area` also hardcodes `main_axis="x"`, against an opening's own OBB. Same defect class, left alone because the reporter's file contains no Y-oriented wall with a formal `IfcRelVoidsElement` opening to verify against.

### Tests

`test_y_oriented_wall_baked_opening_is_recovered` and `test_x_and_y_oriented_walls_agree`, generalising the first commit's wall builder to build along either axis. All 14 tests in `test/tool/test_qto.py` pass.
