### PR TITLE
dev_environment.py: survive a locked file while symlinking

### DIFF
--- a/src/bonsai/scripts/dev_environment.py
+++ b/src/bonsai/scripts/dev_environment.py
@@ -19,6 +19,7 @@ import argparse
 import shutil
 import subprocess
 import sys
+import time
 import urllib.request
 from pathlib import Path
 from typing import Union
@@ -95,6 +96,44 @@ BLENDER_VERSION_INT = tuple(map(int, BLENDER_VERSION.split(".")))
 PYTHON_VERSION = "3.13" if BLENDER_VERSION_INT >= (5, 1) else "3.11"
 PACKAGE_PATH = BLENDER_PATH / rf"extensions/.local/lib/python{PYTHON_VERSION}/site-packages"
 
+PARTIAL_LINK_ERROR = """
+Failed while replacing '{path}'.
+
+The extension is now only partially linked and Blender won't be able to import it until
+this completes. This is usually a file lock - close Blender if it's running. An antivirus
+scan of a freshly installed extension can also hold files for a while.
+
+Re-running this script is safe and will finish the job.
+"""
+
+
+def remove_path(path: Path) -> None:
+    """Remove `path` so it can be replaced by a symlink."""
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    # Check `is_symlink` in case if it's a broken symlink.
+    elif path.is_file() or path.is_symlink():
+        path.unlink()
+
+
+def remove_path_with_retries(path: Path, attempts: int = 5, delay: float = 2.0) -> None:
+    """`remove_path`, retrying while the files are still locked by another process.
+
+    `rmtree` is only reached on the first setup, when the extension binaries have just been
+    written and an antivirus scanner may still be holding them. On Windows that surfaces as
+    PermissionError (WinError 5, not the sharing violation you might expect) and usually
+    clears within a few seconds.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            remove_path(path)
+            return
+        except PermissionError:
+            if attempt == attempts:
+                raise
+            print(f"'{path}' is locked, retrying in {delay:.0f}s ({attempt}/{attempts - 1})...")
+            time.sleep(delay)
+
 
 def main() -> None:
     global REPO_PATH
@@ -137,6 +176,8 @@ def main() -> None:
         path.unlink()
     subprocess.check_call(("git", "checkout", "--", symlinks_glob), cwd=REPO_PATH)
 
+    # Note this has to stay ahead of the symlinking below: it's the step that gets the compiled
+    # wrapper out of site-packages before that folder is deleted and replaced by a symlink.
     if args.skip_binaries:
         print("Skipping copying compiled dependencies to the repo...")
     else:
@@ -174,17 +215,13 @@ def main() -> None:
 
     for path, dest in symlinks:
         print(f"Linking {path} -> {dest}.")
-        if path.is_dir():
-            if path.is_symlink():
-                path.unlink()
-            else:
-                shutil.rmtree(path)
-        # Check `is_symlink` in case if it's a broken symlink.
-        elif path.is_file() or path.is_symlink():
-            path.unlink()
-        else:
-            pass
-        path.symlink_to(dest, dest.is_dir())
+        try:
+            remove_path_with_retries(path)
+            path.symlink_to(dest, dest.is_dir())
+        except OSError:
+            # Removal and symlinking can't be atomic, so say what state we're leaving behind.
+            print(PARTIAL_LINK_ERROR.format(path=path))
+            raise
 
     print("Download third party dependencies...")
     BONSAI_DATA = PACKAGE_PATH / "bonsai" / "bim" / "data"


### PR DESCRIPTION
Closes #9239.

Replacing a package folder with a symlink aborted on the first `PermissionError`, leaving the extension partially linked — `site-packages/ifcopenshell` had been mostly deleted but no symlink created, so Blender couldn't import it, and the `shutil` traceback said nothing about that or about the fix being "run it again".

The sharp part is *when* this happens. `rmtree` is only reachable when the target is still a real directory, i.e. the first run after installing the extension; every later run finds a symlink and takes `path.unlink()`. So the one branch with no error handling is also the one that always runs while the extension's binaries are minutes old and most likely to be held by an antivirus scanner. New contributors following the setup instructions meet it under the worst conditions, on their first attempt.

In the reported case the lock was transient and had cleared by the time it was investigated — no process held the `.pyd`, Blender wasn't running, the file wasn't read-only, and opening it exclusively for `ReadWrite` succeeded. Simply re-running the script completed it.

### Changes

- `remove_path_with_retries` retries the removal a few times before giving up, so a transient lock no longer aborts setup.
- If it still fails, print what state the extension has been left in and that re-running is safe, then re-raise. Removal and symlinking can't be made atomic, so the next best thing is saying so.
- Factored the existing removal branches into `remove_path` unchanged — same handling of real directories, directory symlinks, files, broken symlinks, and missing paths.
- Added a comment that copying the compiled wrapper has to stay ahead of the symlinking. That ordering is what kept the binaries recoverable when this aborted, and it's easy to "tidy" away.

Items 3 and 4 from #9239 (a preflight check that Blender isn't running, and clearing the read-only bit in an `onexc` handler) are deliberately left out to keep this reviewable — happy to add either if you'd like them here.

### Testing

`remove_path` and `remove_path_with_retries` were exercised directly against a temp tree, 13 assertions, all passing:

- real directory with contents removed
- directory symlink removed **and its target left intact**
- regular file removed
- broken symlink removed
- missing path is a no-op
- retries and succeeds when removal fails twice then works
- re-raises after exhausting attempts, and tries exactly `attempts` times
- the message formats with the path and states that re-running is safe

Not exercised as a full live run: pointing the script at a checkout re-links the Blender install to it, so a real end-to-end run had to happen from the actual repo rather than a test worktree. The behaviour that changed is fully covered above.

`black --line-length 120` reports no changes. Windows 10 / Blender 4.5; the changed code is platform-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
