### PR TITLE
build: force-exclude generated files so the pre-commit hook matches CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = '''
     src/.*.pyi?$
     |nix/.*.pyi?$
 '''
-extend-exclude = '''
+force-exclude = '''
     src/ifcopenshell-python/ifcopenshell/express/rules/*
     |src/ifcopenshell-python/ifcopenshell/express/express_parser.py
     |src/ifcopenshell-python/ifcopenshell/mvd/*


### PR DESCRIPTION
`black`'s `exclude` and `extend-exclude` only apply while black is **walking a directory**. They are ignored when a file is named explicitly on the command line. `force-exclude` applies in both cases. This is documented black behaviour, and it is measurable here:

```
$ black --check src/ifcopenshell-python/ifcopenshell/express/
All done! 15 files would be left unchanged.

$ black --check src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3.py
Oh no! 1 file would be reformatted.
```

Same files, same config, opposite answers.

### Why it matters

The repository's `pre-commit` hook builds its file list from `git diff --cached --name-only` and passes those paths to black explicitly. So the generated `express/rules/*.py` and `express_parser.py` files are checked despite being deliberately excluded, and **any commit whose diff includes them fails the hook**.

That happens on every merge of an older branch into `v0.8.0`, because upstream `98aa2c635e` ("Rerun express-related codegen") regenerated those files. It blocked three PR conflict resolutions today, and the only ways past it were to bypass the hook or to reformat about 600 lines of intentionally-excluded generated code into an unrelated PR. Neither is acceptable.

**CI is unaffected**, since `psf/black@stable` runs in directory mode. This is a local-hook-only false positive, which is why it has gone unnoticed.

### The change

One word, `extend-exclude` to `force-exclude`. Verified after the change:

```
$ black --check .../express/rules/IFC4X3.py     # explicit path
No Python files are present to be formatted. Nothing to do

$ black --check .../express/                     # directory
All done! 15 files would be left unchanged.

$ black --check .../ifcopenshell/util/element.py # a normal file, still checked
All done! 1 file would be left unchanged.
```

Both modes now agree, and ordinary source files are still linted.

Generated with the assistance of an AI coding tool.
