### PR TITLE
ifctester: put pass/fail at the end of generated testcase names

### DIFF
--- a/src/ifctester/test/ids_doc_generator.py
+++ b/src/ifctester/test/ids_doc_generator.py
@@ -95,7 +95,7 @@ class FacetDocGenerator:
         # ifc_text = "\n".join([f"{e} /* Testcase */" if e == inst else str(e) for e in f])
         lines = ifc.wrapped_data.to_string().split("\n")[7:-3]
         ifc_text = "\n".join([f"{l} /* Testcase */" if f"#{inst.id()}=" in l else l for l in lines])
-        basename = f"{result}-" + re.sub("[^0-9a-zA-Z]", "_", name.lower())
+        basename = re.sub("[^0-9a-zA-Z]", "_", name.lower()) + f"-{result}"
 
         # Write IFC to disk
         ifc.write(os.path.join(outdir, "testcases", self.facet, f"{basename}.ifc"))
@@ -181,7 +181,7 @@ class IdsDocGenerator:
                 ifc_text += f"{newline}[{pass_or_fail}] {line}"
             else:
                 ifc_text += f"{newline}       {line}"
-        basename = f"{result}-" + re.sub("[^0-9a-zA-Z]", "_", name.lower())
+        basename = re.sub("[^0-9a-zA-Z]", "_", name.lower()) + f"-{result}"
 
         # Write IFC to disk
         ifc.write(os.path.join(outdir, "testcases", "ids", f"{basename}.ifc"))


### PR DESCRIPTION
`ids_doc_generator.py` generates the buildingSMART IDS conformance test cases from the assertions in `test_facet.py` and `test_ids.py`. Their filenames currently lead with the expected result:

```python
basename = f"{result}-" + re.sub("[^0-9a-zA-Z]", "_", name.lower())
```

so a scenario's pass and fail cases sort far apart from each other.

[buildingSMART/IDS#283](https://github.com/buildingSMART/IDS/issues/283) asks for the result at the end so the pair sorts together:

```
before   pass-nesting_may_be_indirect.ifc
after    nesting_may_be_indirect-pass.ifc
```

That issue has been open since May 2024 and is labelled "please contribute". Since the names originate here rather than in the IDS repository, this is the place to change it.

Two occurrences, lines 98 and 184. Nothing else depends on the prefix: `basename` only feeds the `.ifc` and `.ids` file writes and the generated documentation links.

The renamed files appear in the IDS repository the next time the suite is regenerated. Happy to raise the corresponding bulk rename there if maintainers want it done sooner.

Generated with the assistance of an AI coding tool.
