### PR TITLE
Bonsai: bSDD search crashes on dictionaries without referenceCode (#9034)

### DIFF
--- a/src/bonsai/bonsai/bim/module/classification/operator.py
+++ b/src/bonsai/bonsai/bim/module/classification/operator.py
@@ -423,7 +423,7 @@ class AddClassificationReferenceFromBSDD(bpy.types.Operator, tool.Ifc.Operator):
                 tool.Ifc.get(),
                 products=[element],
                 classification=classification,
-                identification=bsdd_classification.reference_code,
+                identification=bsdd_classification.reference_code or None,
                 name=bsdd_classification.name,
             )
             reference.Location = bsdd_classification.uri

--- a/src/bonsai/bonsai/tool/bsdd.py
+++ b/src/bonsai/bonsai/tool/bsdd.py
@@ -232,11 +232,16 @@ class Bsdd(bonsai.core.tool.Bsdd):
                 )
                 dictionary_name = response.get("name", "")
                 dictionary_namespace_uri = response.get("uri", "")
-                for _class in sorted(response.get("classes", []), key=lambda c: c["referenceCode"]):
+                # Classes without a referenceCode sort after those with one.
+                classes = sorted(
+                    response.get("classes", []),
+                    key=lambda c: (c.get("referenceCode") is None, c.get("referenceCode", "")),
+                )
+                for _class in classes:
                     prop = bprops.classifications.add()
-                    prop.name = _class["name"]
-                    prop.reference_code = _class["referenceCode"]
-                    prop.uri = _class["uri"]
+                    prop.name = _class.get("name", "")
+                    prop.reference_code = _class.get("referenceCode", "")
+                    prop.uri = _class.get("uri", "")
                     prop.dictionary_name = dictionary_name
                     prop.dictionary_namespace_uri = dictionary_namespace_uri
 

--- a/src/bonsai/test/core/test_bsdd_search_class.py
+++ b/src/bonsai/test/core/test_bsdd_search_class.py
@@ -1,0 +1,143 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file was generated with the assistance of an AI coding tool.
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Regression test for #9034: bSDD KeyError: 'referenceCode'.
+
+bonsai.tool.bsdd.Bsdd is a Blender-facing tool and normally requires bpy.
+This test runs it against a stubbed bpy and a stubbed bonsai.tool package
+(instead of the real Blender-dependent one) so that Bsdd.search_class's
+response-parsing logic can be exercised with a canned bSDD payload, offline
+and without a real Blender session. This mirrors the technique
+bonsai/__init__.py already uses to support running test/core without bpy.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+BONSAI_SRC = Path(__file__).resolve().parents[2] / "bonsai"
+
+
+class _FakeClassificationProps:
+    classification_source = "BSDD"
+
+
+class _FakeClassification:
+    @classmethod
+    def get_classification_props(cls):
+        return _FakeClassificationProps()
+
+
+class _FakeClassificationItem:
+    def __init__(self):
+        self.name = ""
+        self.reference_code = ""
+        self.uri = ""
+        self.dictionary_name = ""
+        self.dictionary_namespace_uri = ""
+
+
+class _FakeCollection(list):
+    def add(self):
+        item = _FakeClassificationItem()
+        self.append(item)
+        return item
+
+
+class _FakeDictionary:
+    def __init__(self, uri, is_active=True):
+        self.uri = uri
+        self.is_active = is_active
+
+
+class _FakeBsddProps:
+    def __init__(self, dictionary_uri):
+        self.dictionaries = [_FakeDictionary(dictionary_uri)]
+        self.classifications = _FakeCollection()
+
+
+class _FakeClient:
+    def __init__(self, response):
+        self.response = response
+
+    def get_classes(self, **kwargs):
+        return self.response
+
+
+@pytest.fixture
+def bsdd_tool(monkeypatch):
+    """Loads the real bonsai/tool/bsdd.py with bpy and bonsai.tool stubbed out."""
+    monkeypatch.setitem(sys.modules, "bpy", types.ModuleType("bpy"))
+
+    fake_tool_pkg = types.ModuleType("bonsai.tool")
+    fake_tool_pkg.Classification = _FakeClassification
+    monkeypatch.setitem(sys.modules, "bonsai.tool", fake_tool_pkg)
+
+    import bonsai
+
+    monkeypatch.setattr(bonsai, "tool", fake_tool_pkg, raising=False)
+
+    spec = importlib.util.spec_from_file_location("bonsai.tool.bsdd_under_test", BONSAI_SRC / "tool" / "bsdd.py")
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "bonsai.tool.bsdd_under_test", module)
+    spec.loader.exec_module(module)
+    return module.Bsdd
+
+
+DICT_URI = "https://identifier.buildingsmart.org/uri/nl-sfb/nl-sfb/2005"
+
+
+def _search(bsdd_tool, classes):
+    props = _FakeBsddProps(DICT_URI)
+    bsdd_tool.get_bsdd_props = classmethod(lambda cls: props)
+    bsdd_tool.client = _FakeClient({"name": "NL-SfB", "uri": DICT_URI, "classes": classes})
+    bsdd_tool.search_class("grond", None, should_paginate=False)
+    return list(props.classifications)
+
+
+@pytest.mark.bsdd
+class TestSearchClass:
+    def test_classes_without_reference_code_do_not_crash(self, bsdd_tool):
+        classes = _search(
+            bsdd_tool,
+            [
+                {"name": "(11) Grond", "referenceCode": "11", "uri": DICT_URI + "/class/11"},
+                {"name": "Uncoded class", "uri": DICT_URI + "/class/uncoded"},
+            ],
+        )
+        by_name = {c.name: c for c in classes}
+        assert by_name["(11) Grond"].reference_code == "11"
+        assert by_name["Uncoded class"].reference_code == ""
+        # entries with a referenceCode still sort before those without one.
+        assert [c.name for c in classes] == ["(11) Grond", "Uncoded class"]
+
+    def test_classes_with_reference_code_sort_as_before(self, bsdd_tool):
+        classes = _search(
+            bsdd_tool,
+            [
+                {"name": "Beton", "referenceCode": "22", "uri": DICT_URI + "/class/22"},
+                {"name": "Grond", "referenceCode": "11", "uri": DICT_URI + "/class/11"},
+            ],
+        )
+        assert [c.reference_code for c in classes] == ["11", "22"]
+        assert [c.name for c in classes] == ["Grond", "Beton"]


### PR DESCRIPTION
Fixes #9034.

Searching bSDD for a classification crashes when the dictionary's classes have no `referenceCode`:

```
File ".../bonsai/tool/bsdd.py", line 235, in search_class
KeyError: 'referenceCode'
```

@Moult hit this with NL-SfB.

### Confirmed against the live API

One query to bSDD for "grond" in NL-SfB 2005 returns **27 of 27 classes with no `referenceCode` key at all**. They carry `code` instead:

```json
{"uri": ".../class/11.1", "code": "11.1", "name": "(11.1) bodemvoorzieningen; grond"}
```

This is expected rather than anomalous: `src/bsdd/bsdd.py`'s own `ClassListItemContractV1` marks `referenceCode`, `name` and `uri` all `NotRequired[str]`. The code subscripts all three directly.

```python
for _class in sorted(response.get("classes", []), key=lambda c: c["referenceCode"]):
    prop.name = _class["name"]
    prop.reference_code = _class["referenceCode"]
    prop.uri = _class["uri"]
```

### Why this is not simply a `.get()` with an empty default

`referenceCode` is used for two things, not one. It is the sort key, and it is stored into `prop.reference_code`, which later reaches `classification/operator.py:426` as `identification=bsdd_classification.reference_code` and becomes **`IfcClassificationReference.Identification`**.

So defaulting it to `""` all the way through would write an empty-string `Identification` onto a real IFC entity, which is worse than the crash because it looks like data. `ifcopenshell.api.classification.add_reference` already declares `identification: Optional[str] = None`, so the correct value for "absent" is `None`, not `""`.

The fix therefore does both:

* guards the three subscripts, and sorts codeless classes after coded ones with `(c.get("referenceCode") is None, c.get("referenceCode", ""))`
* passes `reference_code or None` at the operator, so an absent code leaves `Identification` unset rather than empty

### The same assumption elsewhere, enumerated not fixed

Every one of these subscripts a bSDD response field the contracts mark `NotRequired`:

* `create_dictionaries()` line 112 and `get_dictionaries()` line 150, `["status"]`
* `import_classes()` line 303 `["classes"]`, line 304 `["name"]` and `["uri"]`
* `import_class_properties()` lines 322 and 327 `["uri"]`, line 325 `["propertyCode"]`
* `import_properties()` line 340 `["properties"]`, lines 342-344 `["name"]`, `["code"]`, `["uri"]`
* `import_selected_properties()` `["dataType"]`

Already safe: `get_class_properties()`, `get_applicable_psets()`, and `import_class_properties()`'s `["name"]` (contract-required) and `["propertySet"]` (guarded by a preceding check).

Left alone here to keep this PR to the reported crash, but they are the same defect waiting on a different dictionary.

### Tests

`test/core/test_bsdd_search_class.py`, two cases: a mixed coded and uncoded payload matching the real NL-SfB shape, and a regression check that normal dictionaries still sort as before. Both confirmed **red on the unfixed code** first.

```
pytest -p no:pytest-blender test/core
392 passed
```

Note PR #9081 also concerns bSDD but touches `src/bsdd/bsdd.py`'s `apply_ifc_classification_properties`, a different file and a different subscript. No overlap.

Generated with the assistance of an AI coding tool.
