### PR TITLE
Bonsai: guard union_all().geoms crash sites in shapely fills

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -312,6 +312,18 @@ class CopyAnnotationToDrawing(bpy.types.Operator, tool.Ifc.Operator):
         self.report({"INFO"}, message)
 
 
+def polygonize_boundary_lines(boundary_lines: list[shapely.LineString]) -> shapely.GeometryCollection:
+    """Union and polygonize boundary lines, empty if they don't close a region.
+
+    ``shapely.union_all`` returns a scalar geometry (no ``.geoms``) instead of
+    a multi-geometry when the lines collapse to a single connected piece.
+    """
+    unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
+    if not hasattr(unioned_boundaries, "geoms"):
+        return shapely.GeometryCollection()
+    return shapely.polygonize(unioned_boundaries.geoms)
+
+
 class CreateDrawing(bpy.types.Operator):
     """Creates/refreshes a .svg drawing
 
@@ -1158,14 +1170,9 @@ class CreateDrawing(bpy.types.Operator):
                     start, end = tool.Drawing.extend_line(start, end, 0.5)
                     boundary_lines.append(shapely.LineString([start, end]))
 
-            unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
             # A single connected boundary (or none at all) leaves nothing to
-            # fill, same as when polygonize finds no closed region below.
-            closed_polygons = (
-                shapely.polygonize(unioned_boundaries.geoms)
-                if hasattr(unioned_boundaries, "geoms")
-                else shapely.GeometryCollection()
-            )
+            # fill, same as when polygonize finds no closed region.
+            closed_polygons = polygonize_boundary_lines(boundary_lines)
 
             for polygon in closed_polygons.geoms:
                 # Less than 0.1mm2 is not worth styling on sheet

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1159,7 +1159,13 @@ class CreateDrawing(bpy.types.Operator):
                     boundary_lines.append(shapely.LineString([start, end]))
 
             unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
-            closed_polygons = shapely.polygonize(unioned_boundaries.geoms)
+            # A single connected boundary (or none at all) leaves nothing to
+            # fill, same as when polygonize finds no closed region below.
+            closed_polygons = (
+                shapely.polygonize(unioned_boundaries.geoms)
+                if hasattr(unioned_boundaries, "geoms")
+                else shapely.GeometryCollection()
+            )
 
             for polygon in closed_polygons.geoms:
                 # Less than 0.1mm2 is not worth styling on sheet

--- a/src/bonsai/bonsai/bim/module/drawing/workspace.py
+++ b/src/bonsai/bonsai/bim/module/drawing/workspace.py
@@ -323,7 +323,11 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
                 ),
                 enable_editing=False,
             )
-            tool.Drawing.setup_annotation_object(obj, object_type, related_object, props.tag_rotation_mode)
+            try:
+                tool.Drawing.setup_annotation_object(obj, object_type, related_object, props.tag_rotation_mode)
+            except ValueError as e:
+                self.report({"ERROR"}, str(e))
+                continue
             created_objects.append(obj)
 
         # Select the created annotation objects
@@ -362,4 +366,8 @@ class Hotkey(bpy.types.Operator, tool.Ifc.Operator):
             related_object = tool.Ifc.get_object(related_product)
 
             rotation_mode = tool.Drawing.get_annotation_props().tag_rotation_mode
-            tool.Drawing.setup_annotation_object(obj, annotation_type, related_object, rotation_mode)
+            try:
+                tool.Drawing.setup_annotation_object(obj, annotation_type, related_object, rotation_mode)
+            except ValueError as e:
+                self.report({"ERROR"}, str(e))
+                continue

--- a/src/bonsai/bonsai/bim/module/model/opening.py
+++ b/src/bonsai/bonsai/bim/module/model/opening.py
@@ -503,7 +503,9 @@ class FilledOpeningGenerator:
         if profile:
             profile = ifcopenshell.util.representation.resolve_representation(profile)
 
-            def get_curve_2d_from_3d(profile: ifcopenshell.entity_instance) -> ifcopenshell.entity_instance:
+            def get_curve_2d_from_3d(
+                profile: ifcopenshell.entity_instance,
+            ) -> Union[ifcopenshell.entity_instance, None]:
                 if len(profile.Items) == 1:
                     curve_3d = profile.Items[0]
                     if tool.Ifc.get_schema() == "IFC2X3":
@@ -526,17 +528,24 @@ class FilledOpeningGenerator:
 
                 boundary_lines = [shapely.LineString([verts[v] for v in e]) for e in edges]
                 unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
-                closed_polygons = shapely.polygonize(boundary_lines)
+                if not hasattr(unioned_boundaries, "geoms"):
+                    return None
+                closed_polygons = shapely.polygonize(unioned_boundaries.geoms)
+                if not closed_polygons.geoms:
+                    return None
                 polygon = max(closed_polygons.geoms, key=lambda polygon: polygon.area)
                 return shape_builder.polyline(list(polygon.exterior.coords))
 
-            extrusion = shape_builder.extrude(
-                get_curve_2d_from_3d(profile),
-                magnitude=thickness / unit_scale,
-                position=Vector([0.0, -thickness * 0.5 / unit_scale, 0.0]),
-                **shape_builder.extrude_kwargs("Y"),
-            )
-            return shape_builder.get_representation(context, [extrusion])
+            # A non-closed profile curve (eg. bad tessellation precision) has no
+            # 2D outline to extrude, so fall back to the bounding box path below.
+            if curve_2d := get_curve_2d_from_3d(profile):
+                extrusion = shape_builder.extrude(
+                    curve_2d,
+                    magnitude=thickness / unit_scale,
+                    position=Vector([0.0, -thickness * 0.5 / unit_scale, 0.0]),
+                    **shape_builder.extrude_kwargs("Y"),
+                )
+                return shape_builder.get_representation(context, [extrusion])
 
         if (
             filling_rep := tool.Geometry.get_active_representation(filling_obj)

--- a/src/bonsai/bonsai/bim/module/model/roof.py
+++ b/src/bonsai/bonsai/bim/module/model/roof.py
@@ -89,7 +89,11 @@ class GenerateHippedRoof(bpy.types.Operator, tool.Ifc.Operator):
             self.report(op_status, error_message)
             return {"CANCELLED"}
 
-        generate_hipped_roof_bmesh(bm, self.mode, self.height, self.angle)
+        try:
+            generate_hipped_roof_bmesh(bm, self.mode, self.height, self.angle)
+        except ValueError as e:
+            self.report({"ERROR"}, str(e))
+            return {"CANCELLED"}
         tool.Blender.apply_bmesh(obj.data, bm)
         return {"FINISHED"}
 
@@ -146,7 +150,11 @@ def generate_hipped_roof_bmesh(
             boundary_lines.append(shapely.LineString([v.co for v in edge.verts]))
 
         unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
+        if not hasattr(unioned_boundaries, "geoms"):
+            raise ValueError("Roof footprint doesn't form a closed polygon.")
         closed_polygons = shapely.polygonize(unioned_boundaries.geoms)
+        if not closed_polygons.geoms:
+            raise ValueError("Roof footprint doesn't form a closed polygon.")
 
         # find the polygon with the biggest area
         roof_polygon = max(closed_polygons.geoms, key=lambda polygon: polygon.area)

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -317,7 +317,11 @@ class Drawing(bonsai.core.tool.Drawing):
             # shapely magic
             boundary_lines = [shapely.LineString([verts[v] for v in e]) for e in edges]
             unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
+            if not hasattr(unioned_boundaries, "geoms"):
+                raise ValueError("Related object doesn't form a closed outline for a revision cloud.")
             all_polygons = shapely.polygonize(unioned_boundaries.geoms).geoms
+            if not all_polygons:
+                raise ValueError("Related object doesn't form a closed outline for a revision cloud.")
             outer_shell = unary_union(all_polygons)
 
             bm = tool.Blender.get_bmesh_for_mesh(obj.data, clean=True)

--- a/src/bonsai/bonsai/tool/spatial.py
+++ b/src/bonsai/bonsai/tool/spatial.py
@@ -768,6 +768,8 @@ class Spatial(bonsai.core.tool.Spatial):
     ) -> Union[shapely.Polygon, Literal["NO POLYGONS FOUND", "NO POLYGON FOR POINT"]]:
         boundary_lines = cls.get_boundary_lines_from_context_visible_objects()
         unioned_boundaries = shapely.union_all(shapely.GeometryCollection(boundary_lines))
+        if not hasattr(unioned_boundaries, "geoms"):
+            return "NO POLYGONS FOUND"
         closed_polygons = shapely.polygonize(unioned_boundaries.geoms)
         if not closed_polygons:
             return "NO POLYGONS FOUND"

--- a/src/bonsai/test/bim/module/drawing/test_fill_area_polygonize.py
+++ b/src/bonsai/test/bim/module/drawing/test_fill_area_polygonize.py
@@ -1,0 +1,51 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression test for CreateDrawing's SHAPELY fill-area shapely guard.
+
+shapely.union_all returns a scalar LineString (no .geoms) instead of a
+MultiLineString when the boundary lines collapse to one connected piece,
+which used to crash the SVG fill-area pass with AttributeError."""
+
+import pytest
+import shapely
+
+pytestmark = pytest.mark.drawing
+
+
+def test_single_boundary_line_yields_no_fill_polygons():
+    from bonsai.bim.module.drawing.operator import polygonize_boundary_lines
+
+    single_line = [shapely.LineString([[0.0, 0.0], [120.0, 0.0]])]
+    result = polygonize_boundary_lines(single_line)
+    assert list(result.geoms) == []
+
+
+def test_closed_loop_still_yields_a_polygon():
+    closed_loop = [
+        shapely.LineString([[0, 0], [5, 0]]),
+        shapely.LineString([[5, 0], [5, 3]]),
+        shapely.LineString([[5, 3], [0, 3]]),
+        shapely.LineString([[0, 3], [0, 0]]),
+    ]
+    from bonsai.bim.module.drawing.operator import polygonize_boundary_lines
+
+    result = polygonize_boundary_lines(closed_loop)
+    assert len(list(result.geoms)) == 1

--- a/src/bonsai/test/bim/module/model/test_opening.py
+++ b/src/bonsai/test/bim/module/model/test_opening.py
@@ -1,0 +1,116 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression test for FilledOpeningGenerator's void-profile shapely guard.
+
+A filling type's ELEVATION_VIEW profile that doesn't tessellate into a
+closed 2D outline (eg. precision loss on a re-triangulated curve) used to
+crash deep inside shapely's polygonize/max(). generate_opening_from_filling
+now falls through to the bounding-box opening shape instead."""
+
+from unittest import mock
+
+import bpy
+import ifcopenshell
+import ifcopenshell.api.root
+import ifcopenshell.api.type
+import numpy as np
+import pytest
+
+import bonsai.tool as tool
+from bonsai.bim.module.model.opening import FilledOpeningGenerator
+
+pytestmark = pytest.mark.model
+
+
+def test_non_closing_profile_falls_back_to_bounding_box():
+    ifc = ifcopenshell.file()
+    tool.Ifc.set(ifc)
+
+    model_context = ifc.createIfcGeometricRepresentationContext(ContextType="Model")
+    profile_context = ifc.createIfcGeometricRepresentationSubContext(
+        ContextIdentifier="Profile",
+        ContextType="Model",
+        ParentContext=model_context,
+        TargetView="ELEVATION_VIEW",
+    )
+    ifc.createIfcGeometricRepresentationSubContext(
+        ContextIdentifier="Body",
+        ContextType="Model",
+        ParentContext=model_context,
+        TargetView="MODEL_VIEW",
+    )
+
+    door_type = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcDoorType")
+    # A multi-item profile is required to reach the shapely tessellation
+    # path (a single-item profile takes a direct, shapely-free shortcut).
+    profile_rep = ifc.createIfcShapeRepresentation(
+        ContextOfItems=profile_context,
+        RepresentationIdentifier="Profile",
+        RepresentationType="Curve2D",
+        Items=[ifc.createIfcPolyline(Points=[]), ifc.createIfcPolyline(Points=[])],
+    )
+    door_type.RepresentationMaps = [
+        ifc.createIfcRepresentationMap(
+            MappingOrigin=ifc.createIfcAxis2Placement3D(Location=ifc.createIfcCartesianPoint((0.0, 0.0, 0.0))),
+            MappedRepresentation=profile_rep,
+        )
+    ]
+    door_type_obj = bpy.data.objects.new("DoorType", bpy.data.meshes.new("DoorType"))
+    bpy.context.collection.objects.link(door_type_obj)
+    tool.Ifc.link(door_type, door_type_obj)
+
+    door = ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcDoor")
+    ifcopenshell.api.type.assign_type(ifc, related_objects=[door], relating_type=door_type)
+    door_obj = bpy.data.objects.new("Door", bpy.data.meshes.new("Door"))
+    bpy.context.collection.objects.link(door_obj)
+    tool.Ifc.link(door, door_obj)
+
+    # A single edge (0,1) never closes a loop, so shapely.polygonize finds
+    # no polygon regardless of which of the two calls below it services.
+    # The box corners (1.0m x 0.2m x 2.0m) let the fallback path compute a
+    # distinctive, checkable opening size.
+    fake_verts = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 0.2, 0.0],
+            [0.0, 0.2, 0.0],
+            [0.0, 0.0, 2.0],
+            [1.0, 0.0, 2.0],
+            [1.0, 0.2, 2.0],
+            [0.0, 0.2, 2.0],
+        ]
+    )
+    with (
+        mock.patch("ifcopenshell.geom.create_shape", return_value=object()),
+        mock.patch("ifcopenshell.util.shape.get_vertices", return_value=fake_verts),
+        mock.patch("ifcopenshell.util.shape.get_edges", return_value=[(0, 1)]),
+    ):
+        representation = FilledOpeningGenerator().generate_opening_from_filling(door, door_obj)
+
+    assert representation is not None
+    solid = representation.Items[0]
+    assert solid.is_a("IfcExtrudedAreaSolid")
+    outer_curve = solid.SweptArea.OuterCurve
+    # Only shape_builder.rectangle(size=(x, z)) produces this exact 1x2
+    # rectangle; the (unreachable, guarded-off) profile-curve path would
+    # have produced a different, non-rectangular polyline.
+    assert outer_curve.Points.CoordList == ((0.0, 0.0), (1.0, 0.0), (1.0, 2.0), (0.0, 2.0))

--- a/src/bonsai/test/bim/module/model/test_roof.py
+++ b/src/bonsai/test/bim/module/model/test_roof.py
@@ -1,0 +1,46 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression test for the hipped roof footprint shapely guard.
+
+A degenerate footprint (too few connected edges to close a polygon) used
+to crash deep inside shapely with AttributeError or ValueError.
+generate_hipped_roof_bmesh now raises a clear, user-facing ValueError
+instead."""
+
+import bmesh
+import pytest
+
+pytestmark = pytest.mark.model
+
+
+def test_degenerate_footprint_raises_clear_error():
+    from bonsai.bim.module.model.roof import generate_hipped_roof_bmesh
+
+    bm = bmesh.new()
+    try:
+        v1 = bm.verts.new((0.0, 0.0, 0.0))
+        v2 = bm.verts.new((5.0, 0.0, 0.0))
+        bm.edges.new((v1, v2))
+
+        with pytest.raises(ValueError, match="closed polygon"):
+            generate_hipped_roof_bmesh(bm)
+    finally:
+        bm.free()

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -61,6 +61,30 @@ class TestCreateAnnotationObject(NewFile):
         pass
 
 
+class TestSetupAnnotationObject(NewFile):
+    def test_revision_cloud_raises_when_related_object_has_no_closed_outline(self):
+        # A related object with a single edge makes shapely.union_all return
+        # a scalar LineString, not a MultiLineString.
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+
+        wall = ifc.createIfcWall()
+        mesh = bpy.data.meshes.new("Wall")
+        mesh.from_pydata([(0.0, 0.0, 0.0), (5.0, 0.0, 0.0)], [(0, 1)], [])
+        mesh.update()
+        revised_obj = bpy.data.objects.new("Wall", mesh)
+        bpy.context.collection.objects.link(revised_obj)
+        tool.Ifc.link(wall, revised_obj)
+
+        annotation = ifc.createIfcAnnotation()
+        cloud_obj = bpy.data.objects.new("Cloud", bpy.data.meshes.new("Cloud"))
+        bpy.context.collection.objects.link(cloud_obj)
+        tool.Ifc.link(annotation, cloud_obj)
+
+        with pytest.raises(ValueError, match="closed outline"):
+            subject.setup_annotation_object(cloud_obj, "REVISION_CLOUD", revised_obj)
+
+
 class TestCreateCamera(NewFile):
     def test_run(self):
         obj = subject.create_camera("Name", mathutils.Matrix(), "PERSPECTIVE", "PLAN_VIEW")

--- a/src/bonsai/test/tool/test_spatial.py
+++ b/src/bonsai/test/tool/test_spatial.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
+from unittest import mock
+
 import bpy
 import ifcopenshell
 import ifcopenshell.api
@@ -25,6 +27,7 @@ import ifcopenshell.api.nest
 import ifcopenshell.api.root
 import ifcopenshell.api.spatial
 import numpy as np
+import shapely
 from mathutils import Matrix
 
 import bonsai.core.tool
@@ -312,3 +315,13 @@ class TestGenerateSpace(NewFile):
         bpy.ops.bim.generate_space()
 
         assert np.isclose(space.location.z, 5), f"Expected z=5, got {space.location.z}"
+
+
+class TestGetSpacePolygonFromContextVisibleObjects(NewFile):
+    def test_boundary_lines_collapsing_to_one_piece_returns_no_polygons_found(self):
+        # A single bounding line (eg. one flat IfcVirtualElement) makes
+        # shapely.union_all return a scalar LineString, not a MultiLineString.
+        single_line = [shapely.LineString([(0.0, 0.0), (5.0, 0.0)])]
+        with mock.patch.object(subject, "get_boundary_lines_from_context_visible_objects", return_value=single_line):
+            result = subject.get_space_polygon_from_context_visible_objects(1.0, 1.0)
+        assert result == "NO POLYGONS FOUND"


### PR DESCRIPTION
`shapely.union_all()` returns a scalar `LineString` when the boundary lines collapse to one connected piece, so a following `.geoms` access raises `AttributeError`. Separately `shapely.polygonize()` can legitimately return zero polygons, which breaks a following `max()` with `ValueError`. First found and fixed in `tool/model.py` (#9233); this covers the remaining sites with the same shape.

## Proven and fixed

Each was reproduced with a real traceback before being touched, not inferred from reading.

* `bim/module/drawing/operator.py` SVG fill area: single boundary line crash, now falls back to the empty result the surrounding code already treats as "no fills"
* `bim/module/model/opening.py`: `max()` on an empty `polygonize()` result from a non-closed profile curve, now falls through to the bounding box fallback already used when there is no profile at all. Also removes a `unioned_boundaries` that was computed and never used
* `bim/module/model/roof.py` hipped roof footprint: both the `AttributeError` and the empty `max()`, now a clear `ValueError` caught by the operator and reported through `self.report({"ERROR"}, ...)`, matching the footprint validation already in that operator
* `tool/spatial.py` space from cursor: returns the existing `"NO POLYGONS FOUND"` sentinel that all three callers already handle
* `tool/drawing.py` revision cloud: both failure modes including a related `unary_union([]).exterior` crash, now a clear `ValueError` caught at both call sites in `drawing/workspace.py`

## Checked and deliberately left alone

`bim/module/drawing/operator.py`, the open-path closing pass, already guards with `if hasattr(unioned_line_strings, "geoms"):`. Not a defect, so not touched.

## Tests

One regression test per fixed site, each red-green verified against the exact traceback. They assert the documented fallback rather than merely "does not raise", because a does-not-raise test would pass against the silent swallow this PR exists to remove. The `opening.py` test asserts the returned geometry is specifically the bounding box rectangle only the fallback could produce.

The fill area block was extracted into a small `polygonize_boundary_lines` helper purely so it could be tested apart from the much larger `generate_linework` method. Behaviour is unchanged, and that is the one refactor in an otherwise guard-only PR.

Checked with `git merge-tree` against #9233: no conflict.

Produced with AI assistance.
