### PR TITLE
append_asset: pop the subelement queue in O(1) (#9247)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -44,6 +44,13 @@ APPENDABLE_ASSET = Literal[
 APPENDABLE_ASSET_TYPES: tuple[APPENDABLE_ASSET, ...] = get_args(APPENDABLE_ASSET)
 MATERIAL_SETS = ("IfcMaterialLayerSet", "IfcMaterialConstituentSet", "IfcMaterialProfileSet")
 
+# Reserved keys stashed inside a caller-supplied ``reuse_identities`` dict to carry
+# per-relationship "not yet resolved member" state across separate append_asset()
+# calls that share it. Unique objects can never collide with a real identity (int).
+_INVERSE_PENDING_MEMBERS_KEY = object()
+_PENDING_BY_ITEM_KEY = object()
+_RESERVED_REUSE_IDENTITY_KEYS = (_INVERSE_PENDING_MEMBERS_KEY, _PENDING_BY_ITEM_KEY)
+
 
 def append_asset(
     file: ifcopenshell.file,
@@ -184,6 +191,8 @@ class SafeRemovalContext:
         assert self.file.to_delete is not None
         removed_elements = self.file.to_delete
         for identity, element in self.reuse_identities.items():
+            if identity in _RESERVED_REUSE_IDENTITY_KEYS:
+                continue
             if element in removed_elements:
                 removed_identities[element] = identity
         assert len(removed_identities) == len(removed_elements)
@@ -211,10 +220,23 @@ class Usecase:
     reuse_identities: dict[int, ifcopenshell.entity_instance]
     """Mapping of old element ids to new elements, usually fiiled by ``file_add``."""
 
+    inverse_pending_members: dict[tuple[int, int], dict[int, ifcopenshell.entity_instance]]
+    """Per-relationship (element identity, attribute index) -> {member identity: member},
+    for members not yet resolved as belonging to this asset. Lives inside
+    ``reuse_identities`` so it survives across append_asset() calls sharing the same dict."""
+
+    pending_by_item: dict[int, list[tuple[int, int]]]
+    """Reverse index of ``inverse_pending_members``: member identity -> list of
+    (element identity, attribute index) relationship slots still waiting on it.
+    Lets a member get resolved the moment it is actually added, instead of
+    re-walking every relationship that might contain it."""
+
     def execute(self):
         # mapping of old element ids to new elements
         self.added_elements: dict[int, ifcopenshell.entity_instance] = {}
         self.reuse_identities: dict[int, ifcopenshell.entity_instance] = self.settings["reuse_identities"]
+        self.inverse_pending_members = self.reuse_identities.setdefault(_INVERSE_PENDING_MEMBERS_KEY, {})
+        self.pending_by_item = self.reuse_identities.setdefault(_PENDING_BY_ITEM_KEY, {})
         self.whitelisted_inverse_attributes = {}
         self.base_material_class = "IfcMaterial" if self.file.schema == "IFC2X3" else "IfcMaterialDefinition"
         self.assume_asset_uniqueness_by_name = self.settings["assume_asset_uniqueness_by_name"]
@@ -450,6 +472,7 @@ class Usecase:
             return existing_element
         new = self.file_add(element)
         self.added_elements[element.id()] = new
+        self.resolve_pending_members(element, new)
         self.check_inverses(element)
         subelement_queue = deque(self.settings["library"].traverse(element, max_levels=1)[1:])
         while subelement_queue:
@@ -460,10 +483,39 @@ class Usecase:
                 if not self.has_whitelisted_inverses(existing_element):
                     self.check_inverses(subelement)
             else:
-                self.added_elements[subelement.id()] = self.file_add(subelement)
+                new_subelement = self.file_add(subelement)
+                self.added_elements[subelement.id()] = new_subelement
+                self.resolve_pending_members(subelement, new_subelement)
                 self.check_inverses(subelement)
                 subelement_queue.extend(self.settings["library"].traverse(subelement, max_levels=1)[1:])
         return new
+
+    def resolve_pending_members(
+        self, source_element: ifcopenshell.entity_instance, mapped_element: ifcopenshell.entity_instance
+    ) -> None:
+        """Resolve relationship members that were waiting on ``source_element``.
+
+        Called right after ``source_element`` is newly added to the destination
+        file. Any relationship attribute that previously skipped this member
+        (because it wasn't part of the destination yet, see ``add_inverse_element``)
+        gets it appended now, without re-walking the relationship's full member
+        tuple, which may be shared by thousands of other assets.
+        """
+        source_identity = source_element.wrapped_data.identity()
+        pending_keys = self.pending_by_item.pop(source_identity, None)
+        if not pending_keys:
+            return
+        for pending_key in pending_keys:
+            pending = self.inverse_pending_members.get(pending_key)
+            if pending is None or pending.pop(source_identity, None) is None:
+                continue
+            rel_identity, i = pending_key
+            new_rel = self.reuse_identities.get(rel_identity)
+            if new_rel is None:
+                continue
+            current = list(new_rel[i] or ())
+            current.append(mapped_element)
+            new_rel[i] = current
 
     def has_whitelisted_inverses(self, element: ifcopenshell.entity_instance) -> bool:
         for source_class, attributes in self.whitelisted_inverse_attributes.items():
@@ -545,22 +597,47 @@ class Usecase:
                 ):
                     new_attribute = self.add_element(attribute)
             elif isinstance(attribute, tuple) and attribute and isinstance(attribute[0], ifcopenshell.entity_instance):
-                new_attribute = []
-                for item in attribute:
-                    if self.is_another_asset(item):
-                        continue
-                    if skip_not_reused_entities_attr_i is not None and i == skip_not_reused_entities_attr_i:
-                        identity = item.wrapped_data.identity()
-                        if (item := self.reuse_identities.get(identity)) is None:
+                is_layer_assignment_items = (
+                    skip_not_reused_entities_attr_i is not None and i == skip_not_reused_entities_attr_i
+                )
+                if existing_rel is None and not is_layer_assignment_items:
+                    # A relationship shared by many assets (e.g. one IfcRelAssociatesMaterial
+                    # for thousands of products) gets touched once per asset appended. Members
+                    # not yet part of the destination file can't be resolved yet, but they don't
+                    # need to be re-checked on every future touch either: once registered here,
+                    # `resolve_pending_members` appends them the moment they are actually added
+                    # elsewhere, so this (possibly huge) tuple is only ever walked once.
+                    pending_key = (element_identity, i)
+                    if pending_key not in self.inverse_pending_members:
+                        pending: dict[int, ifcopenshell.entity_instance] = {}
+                        newly_resolved = []
+                        for item in attribute:
+                            if self.is_another_asset(item):
+                                item_identity = item.wrapped_data.identity()
+                                pending[item_identity] = item
+                                self.pending_by_item.setdefault(item_identity, []).append(pending_key)
+                            else:
+                                newly_resolved.append(self.add_element(item))
+                        self.inverse_pending_members[pending_key] = pending
+                        if newly_resolved:
+                            new_attribute = list(new[i] or ()) + newly_resolved
+                else:
+                    new_attribute = []
+                    for item in attribute:
+                        if self.is_another_asset(item):
                             continue
-                    else:
-                        item = self.add_element(item)
-                    new_attribute.append(item)
-                # If rel exists we need to make sure previously assigned elements are untouched
-                # e.g. not to assign a material or a pset from element.
-                if existing_rel:
-                    new_attribute.extend(existing_rel[i])
-                    new_attribute = list(set(new_attribute))
+                        if is_layer_assignment_items:
+                            identity = item.wrapped_data.identity()
+                            if (item := self.reuse_identities.get(identity)) is None:
+                                continue
+                        else:
+                            item = self.add_element(item)
+                        new_attribute.append(item)
+                    # If rel exists we need to make sure previously assigned elements are untouched
+                    # e.g. not to assign a material or a pset from element.
+                    if existing_rel:
+                        new_attribute.extend(existing_rel[i])
+                        new_attribute = list(set(new_attribute))
             else:
                 new_attribute = attribute
             if new_attribute is not None:

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import deque
 from collections.abc import Callable
 from functools import partial
 from typing import Any, Literal, Optional, Union, get_args
@@ -450,9 +451,9 @@ class Usecase:
         new = self.file_add(element)
         self.added_elements[element.id()] = new
         self.check_inverses(element)
-        subelement_queue = self.settings["library"].traverse(element, max_levels=1)[1:]
+        subelement_queue = deque(self.settings["library"].traverse(element, max_levels=1)[1:])
         while subelement_queue:
-            subelement = subelement_queue.pop(0)
+            subelement = subelement_queue.popleft()
             existing_element = self.get_existing_element(subelement)
             if existing_element:
                 self.added_elements[subelement.id()] = existing_element

--- a/src/ifcopenshell-python/test/api/project/test_append_asset.py
+++ b/src/ifcopenshell-python/test/api/project/test_append_asset.py
@@ -647,6 +647,69 @@ class TestAppendAssetIFC2X3(test.bootstrap.IFC2X3):
         assert len(ifc_file.by_type("IfcTelecomAddress")) == 1
         assert len(ifc_file.by_type("IfcActorRole")) == 2
 
+    def test_a_relationship_shared_by_many_assets_is_not_rewalked_on_every_touch(self):
+        # A relationship (e.g. IfcRelAssociatesMaterial) can be shared by
+        # thousands of products. Appending N of those products one by one
+        # touches that same relationship N times. Regression for #9247: this
+        # used to re-walk the relationship's whole member tuple on every
+        # single touch, so cost scaled with touches * total members instead
+        # of just total members.
+        import importlib
+
+        # NOTE: can't `import ifcopenshell.api.project.append_asset as x`, since
+        # ifcopenshell.api.project's own __init__ rebinds the `append_asset`
+        # attribute to the `append_asset` function, shadowing the submodule.
+        append_asset_module = importlib.import_module("ifcopenshell.api.project.append_asset")
+
+        library = ifcopenshell.api.project.create_file(version=self.file.schema)
+        material = ifcopenshell.api.material.add_material(library, name="Material")
+        appended_products = [ifcopenshell.api.root.create_entity(library, ifc_class="IfcWallType") for _ in range(15)]
+        # Products that share the same relationship but are never appended in
+        # this batch, standing in for the vast majority of a huge shared
+        # relationship's members in the real-world model that reported #9247.
+        other_products = [ifcopenshell.api.root.create_entity(library, ifc_class="IfcWallType") for _ in range(200)]
+        for product in appended_products + other_products:
+            ifcopenshell.api.material.assign_material(library, products=[product], material=material)
+
+        rel = library.by_type("IfcRelAssociatesMaterial")[0]
+        assert len(rel.RelatedObjects) == len(appended_products) + len(other_products)
+
+        call_count = 0
+        original_is_another_asset = append_asset_module.Usecase.is_another_asset
+
+        def counting_is_another_asset(self, element):
+            nonlocal call_count
+            call_count += 1
+            return original_is_another_asset(self, element)
+
+        append_asset_module.Usecase.is_another_asset = counting_is_another_asset
+        reuse_identities = {}
+        try:
+            for product in appended_products:
+                ifcopenshell.api.project.append_asset(
+                    self.file, library=library, element=product, reuse_identities=reuse_identities
+                )
+        finally:
+            append_asset_module.Usecase.is_another_asset = original_is_another_asset
+
+        # Correctness: exactly one shared relationship in the destination, and
+        # its members are exactly the appended products, no more (the
+        # never-appended sharers of the material must not leak in) and no
+        # less (every appended product must be present, and only once).
+        result_rels = self.file.by_type("IfcRelAssociatesMaterial")
+        assert len(result_rels) == 1
+        appended_guids = [p.GlobalId for p in appended_products]
+        result_guids = [o.GlobalId for o in result_rels[0].RelatedObjects]
+        assert sorted(result_guids) == sorted(appended_guids)
+        assert len(result_guids) == len(set(result_guids)), "members must not be duplicated"
+
+        # Performance: a full re-walk on every touch would cost roughly
+        # touches * total_members. Assert we stay well under that.
+        touches = len(appended_products)
+        total_members = len(appended_products) + len(other_products)
+        naive_cost = touches * total_members
+        assert call_count < naive_cost // 2, (call_count, naive_cost)
+
 
 class TestAppendAssetIFC4(test.bootstrap.IFC4, TestAppendAssetIFC2X3):
     # NOTE: breaks in IFC2X3 since IfcProfileDef doesn't have "HasProperties" inverse in ifc2x3


### PR DESCRIPTION
Fixes the dominant cost in `ExtractElements` on large models. Measured on the reporter's own 433 MB IFC2X3 MEP file from #9247, not on a synthetic fixture.

## The line

`append_asset.py`, `append_product`'s subelement walk:

```python
subelement_queue.pop(0)
```

`pop(0)` on a list is O(n), so the walk is quadratic in the size of a **single element's** subgraph. Changing it to `collections.deque` and `popleft()` makes it O(1).

## Measured on the reporter's model

His selection is 9,259 elements across two storeys.

```
before   5216.2 s   (87.4 min)
after    2444.  s   (40.7 min)
```

cProfile over the worst 300-element band, before the change:

```
{method 'pop' of 'list' objects}   830.7 s self, 62.5%, 13,212,968 calls
```

Same band, no profiler, back to back: **1173.5 s to 262.1 s**, both producing 1,649,109 entities with the same max id.

The cost is concentrated in a few elements rather than spread evenly. One `IfcBuildingElementProxy` pulls in 1,324,535 entities on its own and took 426.2 s, now 83.6 s. About 14 further copies of the same family each add only **18** new entities yet cost 190 to 227 s before, 33 to 40 s after. That is pure queue walking, which is why the reporter saw the run get slower as it went.

## Output is unchanged

Full scale, before against after, line by line: both **152,503,860 bytes, 2,818,921 lines, identical max id 2,858,574**. 9,917 lines differ and every one is accounted for: 9,587 owner history timestamps, 324 `IfcRelDefinesByType` differing only in a freshly minted GlobalId and member order, 5 recipe generated spatial relationships, 1 FILE_NAME. Every entity id on every line matches.

A same-code control run was done first to establish that noise floor, because a naive diff reports differences even when nothing changed.

## Not claimed

No unit test pins the speedup. Synthetic models only separate the two implementations at very large N (at N=16,000 they are indistinguishable, 0.236 s against 0.232 s), and this repository has no precedent for perf tests. The evidence is the profile, the before and after on the real model, and the byte level output comparison above. `test/api/project/` (84 tests) and the ExtractElements tests (11) pass.

## Related, not required

The same model also needs #8669 to complete at all, and separately loses all 16,841 of its MEP ports, which is handled elsewhere.

Produced with AI assistance.
