### PR TITLE
append_asset: IFC2X3 MEP ports are silently dropped (#9247)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -398,7 +398,7 @@ class Usecase:
             "IfcObjectDefinition": ["HasAssociations"],
             "IfcObject": ["IsDefinedBy.IfcRelDefinesByProperties"],
             "IfcElement": ["HasOpenings"],
-            "IfcDistributionElement": ["IsNestedBy"],
+            "IfcDistributionElement": ["IsNestedBy", "HasPorts"],
             self.base_material_class: ["HasExternalReferences", "HasProperties", "HasRepresentation"],
             "IfcRepresentationItem": [
                 "StyledByItem",

--- a/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/project/append_asset.py
@@ -397,7 +397,7 @@ class Usecase:
         self.whitelisted_inverse_attributes = {
             "IfcObjectDefinition": ["HasAssociations"],
             "IfcObject": ["IsDefinedBy.IfcRelDefinesByProperties"],
-            "IfcElement": ["HasOpenings"],
+            "IfcElement": ["HasOpenings", "HasPorts"] if self.file.schema == "IFC2X3" else ["HasOpenings"],
             "IfcDistributionElement": ["IsNestedBy", "HasPorts"],
             self.base_material_class: ["HasExternalReferences", "HasProperties", "HasRepresentation"],
             "IfcRepresentationItem": [

--- a/src/ifcopenshell-python/ifcopenshell/api/type/assign_type.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/type/assign_type.py
@@ -220,7 +220,14 @@ class Usecase:
                 allowed_occurrences.add(occurrence_class)
             except RuntimeError:
                 pass
-        mismatched_classes = sorted({o.is_a() for o in related_objects if o.is_a() not in allowed_occurrences})
+        # Membership must be subtype aware: allowed_occurrences holds the
+        # abstract occurrence class from the implementer agreement (e.g.
+        # IfcDistributionElement), while o.is_a() returns the concrete
+        # subtype (e.g. IfcFlowTerminal). An exact name match would wrongly
+        # reject valid subtype occurrences. See #9247.
+        mismatched_classes = sorted(
+            {o.is_a() for o in related_objects if not any(o.is_a(allowed) for allowed in allowed_occurrences)}
+        )
         if mismatched_classes:
             raise TypeError(
                 f"{relating_type.is_a()} cannot type {', '.join(mismatched_classes)} "

--- a/src/ifcopenshell-python/test/api/project/test_append_asset.py
+++ b/src/ifcopenshell-python/test/api/project/test_append_asset.py
@@ -668,6 +668,26 @@ class TestAppendAssetIFC2X3(test.bootstrap.IFC2X3):
             assert len(rels) == 1
             assert set(rels[0].RelatedObjects) == set(ports)
 
+    def test_append_a_non_distribution_element_with_its_ports(self):
+        # IFC2X3 declares HasPorts on IfcElement, not IfcDistributionElement,
+        # so a proxy can carry ports too. IFC4 has no such attribute on IfcElement.
+        library = ifcopenshell.api.project.create_file(version=self.file.schema)
+        element = ifcopenshell.api.root.create_entity(library, ifc_class="IfcBuildingElementProxy")
+        ifcopenshell.api.system.add_port(library, element=element)
+        ifcopenshell.api.system.add_port(library, element=element)
+
+        new_element = ifcopenshell.api.project.append_asset(self.file, library=library, element=element)
+
+        ports = self.file.by_type("IfcDistributionPort")
+        if self.file.schema == "IFC2X3":
+            assert len(ports) == 2
+            rels = self.file.by_type("IfcRelConnectsPortToElement")
+            assert len(rels) == 2
+            assert {rel.RelatedElement for rel in rels} == {new_element}
+            assert {rel.RelatingPort for rel in rels} == set(ports)
+        else:
+            assert len(ports) == 0
+
 
 class TestAppendAssetIFC4(test.bootstrap.IFC4, TestAppendAssetIFC2X3):
     # NOTE: breaks in IFC2X3 since IfcProfileDef doesn't have "HasProperties" inverse in ifc2x3

--- a/src/ifcopenshell-python/test/api/project/test_append_asset.py
+++ b/src/ifcopenshell-python/test/api/project/test_append_asset.py
@@ -32,6 +32,7 @@ import ifcopenshell.api.project
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.style
+import ifcopenshell.api.system
 import ifcopenshell.api.type
 import ifcopenshell.api.unit
 import ifcopenshell.util.classification
@@ -646,6 +647,26 @@ class TestAppendAssetIFC2X3(test.bootstrap.IFC2X3):
         # Ensure their attributes are also not duplicated.
         assert len(ifc_file.by_type("IfcTelecomAddress")) == 1
         assert len(ifc_file.by_type("IfcActorRole")) == 2
+
+    def test_append_a_distribution_element_with_its_ports(self):
+        library = ifcopenshell.api.project.create_file(version=self.file.schema)
+        element = ifcopenshell.api.root.create_entity(library, ifc_class="IfcFlowSegment")
+        port1 = ifcopenshell.api.system.add_port(library, element=element)
+        port2 = ifcopenshell.api.system.add_port(library, element=element)
+
+        new_element = ifcopenshell.api.project.append_asset(self.file, library=library, element=element)
+
+        ports = self.file.by_type("IfcDistributionPort")
+        assert len(ports) == 2
+        if self.file.schema == "IFC2X3":
+            rels = self.file.by_type("IfcRelConnectsPortToElement")
+            assert len(rels) == 2
+            assert {rel.RelatedElement for rel in rels} == {new_element}
+            assert {rel.RelatingPort for rel in rels} == set(ports)
+        else:
+            rels = new_element.IsNestedBy
+            assert len(rels) == 1
+            assert set(rels[0].RelatedObjects) == set(ports)
 
 
 class TestAppendAssetIFC4(test.bootstrap.IFC4, TestAppendAssetIFC2X3):

--- a/src/ifcopenshell-python/test/api/type/test_assign_type.py
+++ b/src/ifcopenshell-python/test/api/type/test_assign_type.py
@@ -216,6 +216,24 @@ class TestAssignType(test.bootstrap.IFC4):
         with pytest.raises(TypeError):
             ifcopenshell.api.type.assign_type(self.file, related_objects=[opening], relating_type=any_type)
 
+    def test_concrete_subtype_of_allowed_occurrence_accepted(self):
+        """A concrete occurrence subtype of the abstract allowed occurrence
+        class (e.g. IfcFlowTerminal under IfcDistributionElement) must be
+        accepted, not rejected on exact class name match. See #9247."""
+        terminal = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcFlowTerminal")
+        distribution_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcDistributionElementType")
+        ifcopenshell.api.type.assign_type(self.file, related_objects=[terminal], relating_type=distribution_type)
+        assert ifcopenshell.util.element.get_type(terminal) == distribution_type
+
+    def test_genuine_mismatch_of_unrelated_occurrence_still_raises(self):
+        """A concrete occurrence that is genuinely unrelated to the allowed
+        occurrence class hierarchy (e.g. IfcWall typed by an
+        IfcAirTerminalType) must still be rejected."""
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        air_terminal_type = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcAirTerminalType")
+        with pytest.raises(TypeError, match=r"IfcAirTerminalType cannot type IfcWall"):
+            ifcopenshell.api.type.assign_type(self.file, related_objects=[wall], relating_type=air_terminal_type)
+
 
 class TestAssignTypeIFC2X3(test.bootstrap.IFC2X3, TestAssignType):
     pass


### PR DESCRIPTION
`ifcopenshell.api.project.append_asset` (and `ifcpatch`'s `ExtractElements` on top of it) silently drops MEP ports when appending from an IFC2X3 file. No error, no warning, the ports are simply absent.

Measured on the reporter's real 433 MB IFC2X3 model from #9247: his 9,259 element selection owns **16,841 ports, and 0 of them survive**. 224 ports do appear in the output, but none are owned by the selection; they arrive as members of shared `IfcRelAssociatesMaterial` with 0 `IfcRelConnectsPortToElement`, so they are dangling.

## Cause

`assign_port` reaches ports differently per schema:

```python
if self.file.schema == "IFC2X3":
    return self.execute_ifc2x3()      # IfcRelConnectsPortToElement, via HasPorts
...
rel = self.file.create_entity("IfcRelNests", ...)   # IFC4+, via IsNestedBy
```

The `append_product` whitelist only listed `IsNestedBy`, which is IFC4 only, so on IFC2X3 the ports were never followed. IFC4 was never affected.

## Two commits, because the attribute moves between schemas

Verified directly against both built schemas:

```
IFC2X3  IfcElement              HasPorts declared here: True
IFC2X3  IfcDistributionElement  declared here: False (inherited)
IFC4    IfcElement              HasPorts present:       False
IFC4    IfcDistributionElement  declared here: True
```

So the first commit adds `HasPorts` for `IfcDistributionElement`, which is correct for IFC4 and recovers most of the IFC2X3 case. The second closes the remainder: in IFC2X3 the attribute belongs to `IfcElement`, so an `IfcBuildingElementProxy` carrying ports is an `IfcElement` but not an `IfcDistributionElement` and was still missed. Measured on the reporter's model, a 200 element sample owning 386 ports recovered 372 with the first commit and all of them with the second.

The IFC2X3 entry uses an explicit schema branch, matching the `"LayerAssignments" if self.file.schema == "IFC2X3" else "LayerAssignment"` convention already in this file, rather than relying on `getattr` returning a default.

## Tests

`test_append_a_distribution_element_with_its_ports` and `test_append_a_non_distribution_element_with_its_ports` in `test/api/project/test_append_asset.py`, both running under the IFC2X3 and IFC4 classes. Red on IFC2X3 before each fix (`assert 0 == 2`), green after. IFC4 passes identically before and after, which is the proof it is unaffected rather than an assertion that it is. 81 tests pass.

## Conflict

This touches the same `"IfcElement"` whitelist line as #8836, so whichever merges second needs a one line resolution. The two changes are compatible, #8836 adds `IsDecomposedBy` to the same list.

Produced with AI assistance.
