### PR TITLE
sequence: assign_product is quadratic on fan-in (#9253)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/assign_product.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/assign_product.py
@@ -64,14 +64,14 @@ def assign_product(
         # Let's construct that wall!
         ifcopenshell.api.sequence.assign_product(model, relating_product=wall, related_object=task)
     """
-    if related_object.HasAssignments:
-        for assignment in related_object.HasAssignments:
-            if assignment.is_a("IfcRelAssignsToProduct") and assignment.RelatingProduct == relating_product:
-                return assignment
+    # ReferencedBy is the product's own IfcRelAssignsToProduct set, so it does
+    # not grow with the number of products already assigned to related_object.
+    referenced_by_all: tuple[ifcopenshell.entity_instance, ...] = relating_product.ReferencedBy
+    for assignment in referenced_by_all:
+        if related_object in assignment.RelatedObjects:
+            return assignment
 
-    referenced_by = None
-    if relating_product.ReferencedBy:
-        referenced_by = relating_product.ReferencedBy[0]
+    referenced_by = referenced_by_all[0] if referenced_by_all else None
 
     if referenced_by:
         related_objects = list(referenced_by.RelatedObjects)

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/unassign_product.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/unassign_product.py
@@ -56,8 +56,10 @@ def unassign_product(
         # Change our mind.
         ifcopenshell.api.sequence.unassign_product(relating_product=wall, related_object=task)
     """
-    for rel in related_object.HasAssignments or []:
-        if not rel.is_a("IfcRelAssignsToProduct") or rel.RelatingProduct != relating_product:
+    # Scan the product's own IfcRelAssignsToProduct set, not the process's
+    # whole assignment set, which grows with every product assigned to it.
+    for rel in relating_product.ReferencedBy or []:
+        if related_object not in rel.RelatedObjects:
             continue
         if len(rel.RelatedObjects) == 1:
             history = rel.OwnerHistory

--- a/src/ifcopenshell-python/test/api/sequence/test_assign_product.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_assign_product.py
@@ -16,8 +16,27 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import ifcopenshell
 import ifcopenshell.api.sequence
 import test.bootstrap
+
+
+def count_attribute_reads(func):
+    """Number of entity attribute reads performed by func."""
+    original = ifcopenshell.entity_instance.__getattr__
+    reads = 0
+
+    def counting(instance, name):
+        nonlocal reads
+        reads += 1
+        return original(instance, name)
+
+    ifcopenshell.entity_instance.__getattr__ = counting
+    try:
+        func()
+    finally:
+        ifcopenshell.entity_instance.__getattr__ = original
+    return reads
 
 
 class TestAssignProduct(test.bootstrap.IFC4):
@@ -33,9 +52,53 @@ class TestAssignProduct(test.bootstrap.IFC4):
     def test_not_assigning_twice(self):
         wall = self.file.createIfcWall()
         task = self.file.createIfcTask()
-        ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
-        ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
+        rel = ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
+        again = ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
+        assert again == rel
         assert wall.ReferencedBy[0].RelatedObjects == (task,)
+        assert len(self.file.by_type("IfcRelAssignsToProduct")) == 1
+
+    def test_not_assigning_twice_when_the_task_already_has_other_products(self):
+        task = self.file.createIfcTask()
+        walls = [self.file.createIfcWall() for _ in range(3)]
+        rels = [
+            ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
+            for wall in walls
+        ]
+        for wall, rel in zip(walls, rels):
+            assert (
+                ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task) == rel
+            )
+        assert len(self.file.by_type("IfcRelAssignsToProduct")) == 3
+        for wall in walls:
+            assert wall.ReferencedBy[0].RelatedObjects == (task,)
+
+    def test_not_assigning_twice_when_the_product_already_has_other_tasks(self):
+        wall = self.file.createIfcWall()
+        task = self.file.createIfcTask()
+        task2 = self.file.createIfcTask()
+        rel = ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
+        assert ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task2) == rel
+        assert ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task) == rel
+        assert wall.ReferencedBy[0].RelatedObjects == (task, task2)
+        assert len(self.file.by_type("IfcRelAssignsToProduct")) == 1
+
+    def test_cost_does_not_grow_with_the_products_already_assigned_to_the_task(self):
+        task = self.file.createIfcTask()
+        walls = [self.file.createIfcWall() for _ in range(22)]
+
+        def assign(wall):
+            return lambda: ifcopenshell.api.sequence.assign_product(
+                self.file, relating_product=wall, related_object=task
+            )
+
+        for wall in walls[:10]:
+            assign(wall)()
+        early = count_attribute_reads(assign(walls[10]))
+        for wall in walls[11:21]:
+            assign(wall)()
+        late = count_attribute_reads(assign(walls[21]))
+        assert early == late
 
 
 class TestAssignProductIFC2X3(test.bootstrap.IFC2X3, TestAssignProduct):

--- a/src/ifcopenshell-python/test/api/sequence/test_unassign_product.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_unassign_product.py
@@ -18,6 +18,7 @@
 
 import ifcopenshell.api.sequence
 import test.bootstrap
+from test.api.sequence.test_assign_product import count_attribute_reads
 
 
 class TestUnassignProduct(test.bootstrap.IFC4):
@@ -27,6 +28,52 @@ class TestUnassignProduct(test.bootstrap.IFC4):
         ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
         ifcopenshell.api.sequence.unassign_product(self.file, relating_product=wall, related_object=task)
         assert len(self.file.by_type("IfcRelAssignsToProduct")) == 0
+
+    def test_unassigning_one_of_many_products_on_the_same_task(self):
+        task = self.file.createIfcTask()
+        walls = [self.file.createIfcWall() for _ in range(3)]
+        for wall in walls:
+            ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
+        ifcopenshell.api.sequence.unassign_product(self.file, relating_product=walls[1], related_object=task)
+        assert not walls[1].ReferencedBy
+        assert walls[0].ReferencedBy[0].RelatedObjects == (task,)
+        assert walls[2].ReferencedBy[0].RelatedObjects == (task,)
+        assert len(self.file.by_type("IfcRelAssignsToProduct")) == 2
+
+    def test_unassigning_keeps_the_other_tasks_on_the_product(self):
+        wall = self.file.createIfcWall()
+        task = self.file.createIfcTask()
+        task2 = self.file.createIfcTask()
+        ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
+        ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task2)
+        ifcopenshell.api.sequence.unassign_product(self.file, relating_product=wall, related_object=task)
+        assert wall.ReferencedBy[0].RelatedObjects == (task2,)
+        assert len(self.file.by_type("IfcRelAssignsToProduct")) == 1
+
+    def test_unassigning_an_unassigned_product_does_nothing(self):
+        wall = self.file.createIfcWall()
+        task = self.file.createIfcTask()
+        task2 = self.file.createIfcTask()
+        ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
+        ifcopenshell.api.sequence.unassign_product(self.file, relating_product=wall, related_object=task2)
+        assert wall.ReferencedBy[0].RelatedObjects == (task,)
+
+    def test_cost_does_not_grow_with_the_products_assigned_to_the_task(self):
+        task = self.file.createIfcTask()
+        walls = [self.file.createIfcWall() for _ in range(22)]
+        for wall in walls:
+            ifcopenshell.api.sequence.assign_product(self.file, relating_product=wall, related_object=task)
+
+        def unassign(wall):
+            return lambda: ifcopenshell.api.sequence.unassign_product(
+                self.file, relating_product=wall, related_object=task
+            )
+
+        late = count_attribute_reads(unassign(walls[21]))
+        for wall in walls[11:21]:
+            unassign(wall)()
+        early = count_attribute_reads(unassign(walls[10]))
+        assert early == late
 
 
 class TestUnassignProductIFC2X3(test.bootstrap.IFC2X3, TestUnassignProduct):


### PR DESCRIPTION
`sequence.assign_product` and `sequence.unassign_product` located the existing relationship by scanning `related_object.HasAssignments`. That inverse holds every product already assigned to the process, so assigning N products to one task cost O(N^2).

Reported with measurements, a root cause analysis and a standalone repro script by @PahlawanJoey in #9253. On a real 4D schedule, a fan-in of a couple of thousand products onto one task is the normal case, not an edge case.

The same relationship is reachable from `relating_product.ReferencedBy`, which holds only that product's own `IfcRelAssignsToProduct` set and does not grow with the fan-in. `structural.assign_product` already resolves it this way, so this makes the sequence pair consistent with its existing sibling. The lookup is equivalent, not merely similar: both sides select the `IfcRelAssignsToProduct` whose `RelatingProduct` is the product and whose `RelatedObjects` contain the process. `ReferencedBy` is present on every type `RelatingProduct` can hold in IFC2X3, IFC4 and IFC4X3_ADD2.

The redundant second `HasAssignments` read goes away with it, so the inverse is read once per call instead of twice. `unassign_product` had the identical defect and is fixed alongside; Bonsai's `unassign_products` loops over it the same way `assign_products` does.

Measured, assigning N products to one task:

| products | before | per call | after | per call |
|---|---|---|---|---|
| 250 | 0.105s | 0.419ms | 0.005s | 0.020ms |
| 1000 | 1.599s | 1.599ms | 0.019s | 0.019ms |
| 2000 | 6.519s | 3.260ms | 0.040s | 0.020ms |

Per-call cost is flat, verified to N=16000. The reporter's acceptance script now exits 0.

Tests assert the invariant without wall-clock timing, by counting attribute reads: the work done by the last assignment equals the work done by the first. Reverting the source makes them fail `assert 13 == 24` and `assert 14 == 25` on both IFC4 and IFC2X3. Separate tests pin the no-duplicate guard, including re-assignment when the task already holds other products and when the product already holds other tasks; those pass before and after, confirming the lookup change is behaviour-preserving.

The documented example in `code_examples.rst` writes this loop the obvious way and is now linear as written, so it needs no change.

Fixes #9253

Produced with AI assistance.
