### PR TITLE
api: five removal functions write empty aggregates

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/grid/remove_grid_axis.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/grid/remove_grid_axis.py
@@ -22,7 +22,12 @@ import ifcopenshell.util.element
 def remove_grid_axis(file: ifcopenshell.file, axis: ifcopenshell.entity_instance) -> None:
     """Removes a grid axis from a grid
 
+    UAxes and VAxes must have at least one axis, so removing the last one
+    raises a ValueError instead of leaving the grid schema-invalid. WAxes is
+    optional, so removing the last W axis simply unsets it.
+
     :param axis: The IfcGridAxis you want to remove.
+    :raises ValueError: If axis is the last remaining U or V axis.
     :return: None
 
     Example:
@@ -41,6 +46,13 @@ def remove_grid_axis(file: ifcopenshell.file, axis: ifcopenshell.entity_instance
         # Let's remove it!
         ifcopenshell.api.grid.remove_grid_axis(model, axis=axis_2)
     """
+    grid = next(i for i in file.get_inverse(axis) if i.is_a("IfcGrid"))
+    for uvw_axes in ("UAxes", "VAxes"):
+        axes = getattr(grid, uvw_axes) or ()
+        if axis in axes and len(axes) == 1:
+            raise ValueError(f"Cannot remove the last axis in IfcGrid.{uvw_axes}, it is a mandatory attribute")
+
     axis_curve = axis.AxisCurve
     file.remove(axis)
-    ifcopenshell.util.element.remove_deep2(file, axis_curve)
+    if axis_curve:
+        ifcopenshell.util.element.remove_deep2(file, axis_curve)

--- a/src/ifcopenshell-python/ifcopenshell/api/material/remove_layer.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/material/remove_layer.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+import ifcopenshell.api.material
 import ifcopenshell.util.element
 
 
@@ -23,8 +24,9 @@ def remove_layer(
 ) -> None:
     """Removes a layer from a layer set
 
-    Note that it is invalid to have zero items in a set, so you should leave
-    at least one layer to ensure a valid IFC dataset.
+    It is invalid to have zero items in a layer set. If you remove the last
+    layer, the entire IfcMaterialLayerSet is removed instead, following the
+    same convention as ifcopenshell.api.material.remove_material_set.
 
     :param layer: The IfcMaterialLayer entity you want to remove
     :param should_remove_material: If true, materials with no users will be removed
@@ -55,6 +57,10 @@ def remove_layer(
         ifcopenshell.api.material.remove_layer(model, layer=layer3)
     """
     material = layer.Material
-    file.remove(layer)
+    layer_set = next(i for i in file.get_inverse(layer) if i.is_a("IfcMaterialLayerSet"))
+    if len(layer_set.MaterialLayers) == 1:
+        ifcopenshell.api.material.remove_material_set(file, material=layer_set)
+    else:
+        file.remove(layer)
     if material and should_remove_material:
         ifcopenshell.util.element.remove_deep2(file, material)

--- a/src/ifcopenshell-python/ifcopenshell/api/material/remove_list_item.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/material/remove_list_item.py
@@ -17,6 +17,7 @@
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
 import ifcopenshell
+import ifcopenshell.api.material
 
 
 def remove_list_item(
@@ -24,8 +25,9 @@ def remove_list_item(
 ) -> None:
     """Removes an item in an material list
 
-    Note that it is invalid to have zero items in a list, so you should leave
-    at least one item to ensure a valid IFC dataset.
+    It is invalid to have zero items in a material list. If you remove the
+    last item, the entire IfcMaterialList is removed instead, following the
+    same convention as ifcopenshell.api.material.remove_material_set.
 
     :param material_list: The IfcMaterialList entity you want to remove an
         item from.
@@ -53,4 +55,7 @@ def remove_list_item(
     """
     materials = list(material_list.Materials)
     materials.pop(material_index)
-    material_list.Materials = materials
+    if materials:
+        material_list.Materials = materials
+    else:
+        ifcopenshell.api.material.remove_material_set(file, material=material_list)

--- a/src/ifcopenshell-python/ifcopenshell/api/material/remove_profile.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/material/remove_profile.py
@@ -17,6 +17,7 @@
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import ifcopenshell.api.material
 import ifcopenshell.util.element
 
 
@@ -28,8 +29,10 @@ def remove_profile(
 ) -> None:
     """Removes a profile item from a profile set
 
-    Note that it is invalid to have zero items in a set, so you should leave
-    at least one profile to ensure a valid IFC dataset.
+    It is invalid to have zero items in a profile set. If you remove the
+    last profile, the entire IfcMaterialProfileSet is removed instead,
+    following the same convention as
+    ifcopenshell.api.material.remove_material_set.
 
     :param profile: The IfcMaterialProfile entity you want to remove
     :param should_remove_profile_def: If true, profile defs with no users will be removed
@@ -71,7 +74,11 @@ def remove_profile(
     for attribute in profile:
         if isinstance(attribute, ifcopenshell.entity_instance):
             subelements.add(attribute)
-    file.remove(profile)
+    profile_set = next(i for i in file.get_inverse(profile) if i.is_a("IfcMaterialProfileSet"))
+    if len(profile_set.MaterialProfiles) == 1:
+        ifcopenshell.api.material.remove_material_set(file, material=profile_set)
+    else:
+        file.remove(profile)
     for subelement in subelements:
         if subelement.is_a("IfcMaterial") and not should_remove_material:
             continue

--- a/src/ifcopenshell-python/ifcopenshell/api/root/remove_product.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/root/remove_product.py
@@ -19,7 +19,6 @@
 import ifcopenshell.api.boundary
 import ifcopenshell.api.feature
 import ifcopenshell.api.geometry
-import ifcopenshell.api.grid
 import ifcopenshell.api.material
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
@@ -91,8 +90,13 @@ def remove_product(file: ifcopenshell.file, product: ifcopenshell.entity_instanc
         ifcopenshell.api.feature.remove_feature(file, feature=opening.RelatedOpeningElement)
 
     if product.is_a("IfcGrid"):
+        # Not ifcopenshell.api.grid.remove_grid_axis: the grid itself is
+        # being removed below, so the last-U/V-axis guard does not apply.
         for axis in product.UAxes + product.VAxes + (product.WAxes or ()):
-            ifcopenshell.api.grid.remove_grid_axis(file, axis=axis)
+            axis_curve = axis.AxisCurve
+            file.remove(axis)
+            if axis_curve:
+                ifcopenshell.util.element.remove_deep2(file, axis_curve)
 
     def element_exists(element_id):
         try:

--- a/src/ifcopenshell-python/ifcopenshell/api/style/add_surface_style.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/style/add_surface_style.py
@@ -20,6 +20,7 @@ from typing import Any, Literal, Optional
 
 import ifcopenshell
 import ifcopenshell.api.style
+from ifcopenshell.api.style.remove_surface_style import _remove_surface_style_item
 
 SURFACE_STYLE_TYPES = Literal[
     "IfcSurfaceStyleShading",
@@ -135,7 +136,9 @@ def add_surface_style(
         select_class = "IfcSurfaceStyleShading"
     duplicate_items = [s for s in styles if s.is_a(select_class)]
     for duplicate_item in duplicate_items:
-        ifcopenshell.api.style.remove_surface_style(file, style=duplicate_item)
+        # Not ifcopenshell.api.style.remove_surface_style: a new item is
+        # appended below, so the last-item guard does not apply here.
+        _remove_surface_style_item(file, style=duplicate_item)
 
     styles = list(style.Styles or [])
     styles.append(style_item)

--- a/src/ifcopenshell-python/ifcopenshell/api/style/remove_style.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/style/remove_style.py
@@ -18,8 +18,8 @@
 
 from collections.abc import Iterable
 
-import ifcopenshell.api.style
 import ifcopenshell.util.element
+from ifcopenshell.api.style.remove_surface_style import _remove_surface_style_item
 
 
 def remove_style(file: ifcopenshell.file, style: ifcopenshell.entity_instance) -> None:
@@ -54,8 +54,11 @@ class Usecase:
         self.purge_inverses(style)
         ifc_class = style.is_a()
         if ifc_class == "IfcSurfaceStyle":
+            # Not ifcopenshell.api.style.remove_surface_style: the
+            # IfcSurfaceStyle itself is removed below, so the
+            # last-item guard does not apply here.
             for style_ in style.Styles:
-                ifcopenshell.api.style.remove_surface_style(self.file, style=style_)
+                _remove_surface_style_item(self.file, style=style_)
         elif ifc_class == "IfcFillAreaStyle":
             for style_ in style.FillStyles:
                 ifcopenshell.util.element.remove_deep2(

--- a/src/ifcopenshell-python/ifcopenshell/api/style/remove_surface_style.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/style/remove_surface_style.py
@@ -23,7 +23,14 @@ import ifcopenshell.util.element
 def remove_surface_style(file: ifcopenshell.file, style: ifcopenshell.entity_instance) -> None:
     """Removes a presentation item from a presentation style
 
+    It is invalid for IfcSurfaceStyle.Styles to have zero items. If style is
+    the last remaining item, this raises instead of leaving the parent
+    schema-invalid. Use ifcopenshell.api.style.remove_style to remove the
+    whole IfcSurfaceStyle.
+
     :param style: The IfcPresentationItem to remove.
+    :raises ValueError: If style is the last remaining item of its
+        IfcSurfaceStyle.
     :return: None
 
     Example:
@@ -43,7 +50,16 @@ def remove_surface_style(file: ifcopenshell.file, style: ifcopenshell.entity_ins
         # Remove the shading item
         ifcopenshell.api.style.remove_surface_style(model, style=shading)
     """
+    parent = next((i for i in file.get_inverse(style) if i.is_a("IfcSurfaceStyle")), None)
+    if parent and len(parent.Styles) == 1:
+        raise ValueError(
+            "Cannot remove the last item of IfcSurfaceStyle.Styles, it is a mandatory "
+            "attribute. Use ifcopenshell.api.style.remove_style to remove the whole style."
+        )
+    _remove_surface_style_item(file, style)
 
+
+def _remove_surface_style_item(file: ifcopenshell.file, style: ifcopenshell.entity_instance) -> None:
     to_delete = set()
     if style.is_a("IfcSurfaceStyleWithTextures"):
         textures = style.Textures

--- a/src/ifcopenshell-python/test/api/grid/test_remove_grid_axis.py
+++ b/src/ifcopenshell-python/test/api/grid/test_remove_grid_axis.py
@@ -16,11 +16,29 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
+
 import ifcopenshell.api.grid
 import test.bootstrap
 
 
 class TestRemoveGridAxis(test.bootstrap.IFC4):
+    def test_removing_the_last_u_axis_raises(self):
+        grid = self.file.createIfcGrid()
+        axis = ifcopenshell.api.grid.create_grid_axis(self.file, axis_tag="A", uvw_axes="UAxes", grid=grid)
+        axis.AxisCurve = self.file.createIfcPolyline([self.file.createIfcCartesianPoint((0.0, 0.0, 0.0))])
+        with pytest.raises(ValueError):
+            ifcopenshell.api.grid.remove_grid_axis(self.file, axis=axis)
+        assert grid.UAxes == (axis,)
+
+    def test_removing_the_last_v_axis_raises(self):
+        grid = self.file.createIfcGrid()
+        axis = ifcopenshell.api.grid.create_grid_axis(self.file, axis_tag="1", uvw_axes="VAxes", grid=grid)
+        axis.AxisCurve = self.file.createIfcPolyline([self.file.createIfcCartesianPoint((0.0, 0.0, 0.0))])
+        with pytest.raises(ValueError):
+            ifcopenshell.api.grid.remove_grid_axis(self.file, axis=axis)
+        assert grid.VAxes == (axis,)
+
     def test_removing_an_axis_removes_its_curve(self):
         grid = self.file.createIfcGrid()
         axis = ifcopenshell.api.grid.create_grid_axis(

--- a/src/ifcopenshell-python/test/api/material/test_remove_layer.py
+++ b/src/ifcopenshell-python/test/api/material/test_remove_layer.py
@@ -1,0 +1,45 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.material
+import test.bootstrap
+
+
+class TestRemoveLayerIFC2X3(test.bootstrap.IFC2X3):
+    def test_removing_a_non_last_layer(self):
+        material_set = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialLayerSet")
+        material = ifcopenshell.api.material.add_material(self.file)
+        layer1 = ifcopenshell.api.material.add_layer(self.file, layer_set=material_set, material=material)
+        layer2 = ifcopenshell.api.material.add_layer(self.file, layer_set=material_set, material=material)
+        ifcopenshell.api.material.remove_layer(self.file, layer=layer2)
+        assert material_set.MaterialLayers == (layer1,)
+
+    def test_removing_the_last_layer_removes_the_whole_set(self):
+        material_set = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialLayerSet")
+        material = ifcopenshell.api.material.add_material(self.file)
+        layer = ifcopenshell.api.material.add_layer(self.file, layer_set=material_set, material=material)
+        ifcopenshell.api.material.remove_layer(self.file, layer=layer)
+        assert len(self.file.by_type("IfcMaterialLayerSet")) == 0
+        assert len(self.file.by_type("IfcMaterialLayer")) == 0
+        assert len(self.file.by_type("IfcMaterial")) == 1
+
+
+class TestRemoveLayerIFC4(test.bootstrap.IFC4, TestRemoveLayerIFC2X3):
+    pass

--- a/src/ifcopenshell-python/test/api/material/test_remove_list_item.py
+++ b/src/ifcopenshell-python/test/api/material/test_remove_list_item.py
@@ -1,0 +1,45 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.material
+import test.bootstrap
+
+
+class TestRemoveListItemIFC2X3(test.bootstrap.IFC2X3):
+    def test_removing_a_non_last_item(self):
+        material_list = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialList")
+        material1 = ifcopenshell.api.material.add_material(self.file)
+        material2 = ifcopenshell.api.material.add_material(self.file)
+        ifcopenshell.api.material.add_list_item(self.file, material_list=material_list, material=material1)
+        ifcopenshell.api.material.add_list_item(self.file, material_list=material_list, material=material2)
+        ifcopenshell.api.material.remove_list_item(self.file, material_list=material_list, material_index=1)
+        assert material_list.Materials == (material1,)
+
+    def test_removing_the_last_item_removes_the_whole_list(self):
+        material_list = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialList")
+        material = ifcopenshell.api.material.add_material(self.file)
+        ifcopenshell.api.material.add_list_item(self.file, material_list=material_list, material=material)
+        ifcopenshell.api.material.remove_list_item(self.file, material_list=material_list, material_index=0)
+        assert len(self.file.by_type("IfcMaterialList")) == 0
+        assert len(self.file.by_type("IfcMaterial")) == 1
+
+
+class TestRemoveListItemIFC4(test.bootstrap.IFC4, TestRemoveListItemIFC2X3):
+    pass

--- a/src/ifcopenshell-python/test/api/material/test_remove_profile.py
+++ b/src/ifcopenshell-python/test/api/material/test_remove_profile.py
@@ -1,0 +1,50 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import ifcopenshell.api.material
+import test.bootstrap
+
+
+class TestRemoveProfile(test.bootstrap.IFC4):
+    # IfcMaterialProfileSet does not exist in IFC2X3.
+    def test_removing_a_non_last_profile(self):
+        profile_set = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialProfileSet")
+        material = ifcopenshell.api.material.add_material(self.file)
+        profile_def = self.file.create_entity("IfcArbitraryClosedProfileDef", ProfileType="AREA")
+        profile1 = ifcopenshell.api.material.add_profile(
+            self.file, profile_set=profile_set, material=material, profile=profile_def
+        )
+        profile2 = ifcopenshell.api.material.add_profile(
+            self.file, profile_set=profile_set, material=material, profile=profile_def
+        )
+        ifcopenshell.api.material.remove_profile(self.file, profile=profile2)
+        assert profile_set.MaterialProfiles == (profile1,)
+
+    def test_removing_the_last_profile_removes_the_whole_set(self):
+        profile_set = ifcopenshell.api.material.add_material_set(self.file, set_type="IfcMaterialProfileSet")
+        material = ifcopenshell.api.material.add_material(self.file)
+        profile_def = self.file.create_entity("IfcArbitraryClosedProfileDef", ProfileType="AREA")
+        profile = ifcopenshell.api.material.add_profile(
+            self.file, profile_set=profile_set, material=material, profile=profile_def
+        )
+        ifcopenshell.api.material.remove_profile(self.file, profile=profile)
+        assert len(self.file.by_type("IfcMaterialProfileSet")) == 0
+        assert len(self.file.by_type("IfcMaterialProfile")) == 0
+        assert len(self.file.by_type("IfcMaterial")) == 1

--- a/src/ifcopenshell-python/test/api/style/test_remove_surface_style.py
+++ b/src/ifcopenshell-python/test/api/style/test_remove_surface_style.py
@@ -17,6 +17,8 @@
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import pytest
+
 import ifcopenshell.api.style
 import test.bootstrap
 
@@ -26,6 +28,13 @@ class TestRemoveSurfaceStyleIFC2X3(test.bootstrap.IFC2X3):
         style = self.file.createIfcSurfaceStyleShading(SurfaceColour=self.file.createIfcColourRgb(None, 1, 1, 1))
         ifcopenshell.api.style.remove_surface_style(self.file, style=style)
         assert len(list(self.file)) == 0
+
+    def test_removing_the_last_item_of_a_surface_style_raises(self):
+        shading = self.file.createIfcSurfaceStyleShading(SurfaceColour=self.file.createIfcColourRgb(None, 1, 1, 1))
+        surface_style = self.file.createIfcSurfaceStyle(Side="BOTH", Styles=[shading])
+        with pytest.raises(ValueError):
+            ifcopenshell.api.style.remove_surface_style(self.file, style=shading)
+        assert surface_style.Styles == (shading,)
 
     def test_removing_a_texture_style(self):
         texture = self.file.createIfcImageTexture()


### PR DESCRIPTION
Fixes #9165.

Five `ifcopenshell.api` removal functions left a schema-invalid empty aggregate when the last member was removed. Confirmed against the schema (`optional=False`, `list [1:?]` or `set [1:5]`) on IFC2X3, IFC4 and IFC4X3_ADD2, and by running each function and validating the result.

- `material.remove_layer`, `remove_profile`, `remove_list_item`: when the item being removed is the last one, the whole owning set is now removed instead, by delegating to `material.remove_material_set`. That function already handles unassigning products correctly first, avoiding the invalid `IfcRelAssociatesMaterial.RelatingMaterial = None` state a naive cascade delete would produce.
- `grid.remove_grid_axis`: raises `ValueError` when asked to remove the last U or V axis, since those are mandatory and deleting the whole `IfcGrid` is a bigger decision than a single-axis removal should make silently. `WAxes` is optional and was already self-healing.
- `style.remove_surface_style`: raises `ValueError` when removing the last item of an `IfcSurfaceStyle`, pointing callers at `style.remove_style`, which already owns deleting the parent.

A sixth candidate was checked and deliberately left alone: `IfcGrid.WAxes` is `optional=True` and already nulls itself through `file.remove`'s inverse cleanup, so it is not a defect.

Two internal callers relied on the old silent-empty behaviour and needed updating to call the underlying implementation directly: `root.remove_product` (tearing down a whole `IfcGrid` axis by axis) and `style.add_surface_style` (swapping a duplicate item before appending the new one). Both were caught by their existing tests failing against the new guards, and both keep those tests passing now.

Also fixed while touching those lines: `remove_grid_axis` crashed with `AttributeError` when `AxisCurve` was unset, a pre-existing gap unrelated to schema validity.

Each fix has a regression test, verified red then green: reverting each guard individually makes the new assertions fail (`assert 1 == 0`, `DID NOT RAISE ValueError`); restoring turns them green. Full material/grid/style/root suite: 306 passed. The 2 deselected tests are the pre-existing, documented segfault of #2046, reproduced identically on unmodified v0.8.0.

Produced with AI assistance.
