### PR TITLE
sequence: implement recurrence Interval and Occurrences

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/sequence.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/sequence.py
@@ -221,6 +221,77 @@ def is_day_in_work_time(day, work_time: ifcopenshell.entity_instance) -> bool:
     return is_day_in_work_time
 
 
+def _recurrence_base_match(recurrence: ifcopenshell.entity_instance, recurrence_type: RECURRENCE_TYPE, day) -> bool:
+    """Whether `day` matches the pattern's day/week/month shape, ignoring Interval and Occurrences."""
+    if recurrence_type == "DAILY":
+        return True
+    elif recurrence_type == "WEEKLY":
+        return (day.weekday() + 1) in recurrence.WeekdayComponent
+    elif recurrence_type == "MONTHLY_BY_DAY_OF_MONTH":
+        return day.day in recurrence.DayComponent
+    elif recurrence_type == "MONTHLY_BY_POSITION":
+        return (day.weekday() + 1) in recurrence.WeekdayComponent and floor(day.day / 7) + 1 == recurrence.Position
+    elif recurrence_type == "YEARLY_BY_DAY_OF_MONTH":
+        return day.month in recurrence.MonthComponent and day.day in recurrence.DayComponent
+    elif recurrence_type == "YEARLY_BY_POSITION":
+        return (
+            day.month in recurrence.MonthComponent
+            and (day.weekday() + 1) in recurrence.WeekdayComponent
+            and floor(day.day / 7) + 1 == recurrence.Position
+        )
+    return False
+
+
+def _recurrence_cycle_index(recurrence_type: RECURRENCE_TYPE, start: datetime.date, day: datetime.date):
+    """The Nth day/week/month/year cycle `day` falls in, counted from `start`. None if before `start`."""
+    if day < start:
+        return None
+    if recurrence_type == "DAILY":
+        return (day - start).days
+    elif recurrence_type == "WEEKLY":
+        start_week = start - datetime.timedelta(days=start.weekday())
+        day_week = day - datetime.timedelta(days=day.weekday())
+        return (day_week - start_week).days // 7
+    elif recurrence_type in ("MONTHLY_BY_DAY_OF_MONTH", "MONTHLY_BY_POSITION"):
+        return (day.year - start.year) * 12 + (day.month - start.month)
+    elif recurrence_type in ("YEARLY_BY_DAY_OF_MONTH", "YEARLY_BY_POSITION"):
+        return day.year - start.year
+    return None
+
+
+def _is_recurring_day_applicable(
+    work_time: ifcopenshell.entity_instance,
+    day: datetime.date,
+    recurrence: ifcopenshell.entity_instance,
+    recurrence_type: RECURRENCE_TYPE,
+) -> bool:
+    """Interval and Occurrences handling, anchored on the work time's Start (attribute 4)."""
+    start = ifcopenshell.util.date.ifc2datetime(work_time[4])
+    if isinstance(start, datetime.datetime):
+        start = datetime.date(start.year, start.month, start.day)
+    if not _recurrence_base_match(recurrence, recurrence_type, day):
+        return False
+    cycle = _recurrence_cycle_index(recurrence_type, start, day)
+    if cycle is None:
+        return False
+    interval = recurrence.Interval or 1
+    if cycle % interval != 0:
+        return False
+    occurrences = recurrence.Occurrences
+    if not occurrences:
+        return True
+    count = 0
+    current = start
+    while current <= day:
+        current_cycle = _recurrence_cycle_index(recurrence_type, start, current)
+        if current_cycle % interval == 0 and _recurrence_base_match(recurrence, recurrence_type, current):
+            count += 1
+            if count > occurrences:
+                return False
+        current += datetime.timedelta(days=1)
+    return count <= occurrences
+
+
 def is_work_time_applicable_to_day(work_time: ifcopenshell.entity_instance, day) -> bool:
     if not is_day_in_work_time(day, work_time):
         return False
@@ -237,28 +308,37 @@ def is_work_time_applicable_to_day(work_time: ifcopenshell.entity_instance, day)
         # 4 IfcWorktime Start
         if not work_time[4]:
             return False
-        return False  # TODO
+        return _is_recurring_day_applicable(work_time, day, recurrence, recurrence_type)
     elif recurrence_type == "WEEKLY":
         if not recurrence.Interval and not recurrence.Occurrences:
             return (day.weekday() + 1) in recurrence.WeekdayComponent
         # 4 IfcWorktime Start
         if not work_time[4]:
             return False
-        return False  # TODO
+        return _is_recurring_day_applicable(work_time, day, recurrence, recurrence_type)
     elif recurrence_type == "MONTHLY_BY_DAY_OF_MONTH":
         if not recurrence.Interval and not recurrence.Occurrences:
             return day.day in recurrence.DayComponent
-        return False  # TODO
+        # 4 IfcWorktime Start
+        if not work_time[4]:
+            return False
+        return _is_recurring_day_applicable(work_time, day, recurrence, recurrence_type)
     elif recurrence_type == "MONTHLY_BY_POSITION":
         if not recurrence.Interval and not recurrence.Occurrences:
             return (day.weekday() + 1) in recurrence.WeekdayComponent and floor(day.day / 7) + 1 == recurrence[
                 "Position"
             ]
-        return False  # TODO
+        # 4 IfcWorktime Start
+        if not work_time[4]:
+            return False
+        return _is_recurring_day_applicable(work_time, day, recurrence, recurrence_type)
     elif recurrence_type == "YEARLY_BY_DAY_OF_MONTH":
         if not recurrence.Interval and not recurrence.Occurrences:
             return day.month in recurrence.MonthComponent and day.day in recurrence.DayComponent
-        return False  # TODO
+        # 4 IfcWorktime Start
+        if not work_time[4]:
+            return False
+        return _is_recurring_day_applicable(work_time, day, recurrence, recurrence_type)
     elif recurrence_type == "YEARLY_BY_POSITION":
         if not recurrence.Interval and not recurrence.Occurrences:
             return (
@@ -266,7 +346,10 @@ def is_work_time_applicable_to_day(work_time: ifcopenshell.entity_instance, day)
                 and (day.weekday() + 1) in recurrence.WeekdayComponent
                 and floor(day.day / 7) + 1 == recurrence.Position
             )
-        return False  # TODO
+        # 4 IfcWorktime Start
+        if not work_time[4]:
+            return False
+        return _is_recurring_day_applicable(work_time, day, recurrence, recurrence_type)
 
 
 def get_task_work_schedule(task: ifcopenshell.entity_instance) -> Union[ifcopenshell.entity_instance, None]:

--- a/src/ifcopenshell-python/test/util/test_sequence_recurrence_interval.py
+++ b/src/ifcopenshell-python/test/util/test_sequence_recurrence_interval.py
@@ -1,0 +1,161 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+import datetime
+
+import test.bootstrap
+import ifcopenshell.util.sequence as subject
+
+
+class TestIsWorkTimeApplicableToDayRecurrenceInterval(test.bootstrap.IFC4):
+    # All Interval/Occurrences tests anchor Start one cycle before the day
+    # under test. IfcWorkTime's own Start day is separately excluded by
+    # is_day_in_work_time's strict `>` check (a pre-existing, unrelated
+    # issue), so asserting on the Start day itself would conflate the two.
+
+    def test_daily_interval_matches_every_other_day_not_the_days_between(self):
+        recurrence = self.file.create_entity("IfcRecurrencePattern", RecurrenceType="DAILY", Interval=2)
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 2)) is False
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 3)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 4)) is False
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 5)) is True
+
+    def test_daily_neither_interval_nor_occurrences_matches_every_day(self):
+        recurrence = self.file.create_entity("IfcRecurrencePattern", RecurrenceType="DAILY")
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 2)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 3)) is True
+
+    def test_daily_occurrences_stops_matching_after_the_right_number(self):
+        recurrence = self.file.create_entity("IfcRecurrencePattern", RecurrenceType="DAILY", Occurrences=3)
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 2)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 3)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 4)) is False
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 5)) is False
+
+    def test_weekly_interval_matches_every_other_saturday_not_the_saturday_between(self):
+        # Docstring's WEEKLY example: "every other saturday".
+        recurrence = self.file.create_entity(
+            "IfcRecurrencePattern", RecurrenceType="WEEKLY", WeekdayComponent=[6], Interval=2
+        )
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-06-27")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 7, 4)) is False
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 7, 11)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 7, 18)) is False
+
+    def test_weekly_neither_interval_nor_occurrences_matches_every_saturday(self):
+        recurrence = self.file.create_entity("IfcRecurrencePattern", RecurrenceType="WEEKLY", WeekdayComponent=[6])
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-06-27")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 7, 4)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 7, 11)) is True
+
+    def test_monthly_by_day_of_month_interval_matches_docstring_example(self):
+        # The maintenance task must occur every 6 months, on the 1st.
+        recurrence = self.file.create_entity(
+            "IfcRecurrencePattern", RecurrenceType="MONTHLY_BY_DAY_OF_MONTH", DayComponent=[1], Interval=6
+        )
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 3, 1)) is False
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 7, 1)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2027, 1, 1)) is True
+
+    def test_monthly_by_day_of_month_neither_set_matches_every_month(self):
+        recurrence = self.file.create_entity(
+            "IfcRecurrencePattern", RecurrenceType="MONTHLY_BY_DAY_OF_MONTH", DayComponent=[1]
+        )
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 3, 1)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 7, 1)) is True
+
+    def test_monthly_by_position_interval_matches_every_other_month(self):
+        # Second Tuesday of every other month.
+        recurrence = self.file.create_entity(
+            "IfcRecurrencePattern",
+            RecurrenceType="MONTHLY_BY_POSITION",
+            WeekdayComponent=[2],
+            Position=2,
+            Interval=2,
+        )
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 13)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 2, 10)) is False
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 3, 10)) is True
+
+    def test_yearly_by_day_of_month_interval_matches_every_other_year(self):
+        recurrence = self.file.create_entity(
+            "IfcRecurrencePattern",
+            RecurrenceType="YEARLY_BY_DAY_OF_MONTH",
+            DayComponent=[25],
+            MonthComponent=[12],
+            Interval=2,
+        )
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 12, 25)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2027, 12, 25)) is False
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2028, 12, 25)) is True
+
+    def test_yearly_by_day_of_month_neither_set_matches_every_year(self):
+        recurrence = self.file.create_entity(
+            "IfcRecurrencePattern", RecurrenceType="YEARLY_BY_DAY_OF_MONTH", DayComponent=[25], MonthComponent=[12]
+        )
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 12, 25)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2027, 12, 25)) is True
+
+    def test_yearly_by_position_occurrences_stops_matching_after_the_right_number(self):
+        # Third Wednesday of January, for 2 occurrences.
+        recurrence = self.file.create_entity(
+            "IfcRecurrencePattern",
+            RecurrenceType="YEARLY_BY_POSITION",
+            WeekdayComponent=[3],
+            Position=3,
+            MonthComponent=[1],
+            Occurrences=2,
+        )
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 14)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2027, 1, 20)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2028, 1, 19)) is False
+
+    def test_yearly_by_position_neither_set_matches_every_year(self):
+        recurrence = self.file.create_entity(
+            "IfcRecurrencePattern",
+            RecurrenceType="YEARLY_BY_POSITION",
+            WeekdayComponent=[3],
+            Position=3,
+            MonthComponent=[1],
+        )
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence, Start="2026-01-01")
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 14)) is True
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2027, 1, 20)) is True
+
+    def test_interval_without_start_returns_false_instead_of_faking_an_anchor(self):
+        recurrence = self.file.create_entity("IfcRecurrencePattern", RecurrenceType="DAILY", Interval=2)
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence)
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 1, 2)) is False
+
+    def test_occurrences_without_start_returns_false_instead_of_faking_an_anchor(self):
+        recurrence = self.file.create_entity(
+            "IfcRecurrencePattern", RecurrenceType="MONTHLY_BY_DAY_OF_MONTH", DayComponent=[1], Occurrences=3
+        )
+        work_time = self.file.create_entity("IfcWorkTime", RecurrencePattern=recurrence)
+        assert subject.is_work_time_applicable_to_day(work_time, datetime.date(2026, 3, 1)) is False


### PR DESCRIPTION
Fixes #9134.

`is_work_time_applicable_to_day` had six branches, one per recurrence type, each shaped as `if not Interval and not Occurrences: return <matching logic>; return False  # TODO`. Setting either attribute, which is exactly what `assign_recurrence_pattern`'s own docstring documents and gives a worked example for, made the recurrence match zero days rather than fewer days. The branches have carried that TODO since May 2021 (`353281fa4d`).

Interval now counts Nth day/week/month/year cycles from the work time's Start, the anchor the DAILY and WEEKLY branches already gated on (`if not work_time[4]: return False`) but never used. Occurrences caps the total matching days counted from that same anchor. Both compose with the existing day/week/month matching, and behaviour is unchanged when neither is set. The spec says an empty interval value is regarded as 1, and that is preserved.

The semantics were verified against `assign_recurrence_pattern`'s own docstring examples, including the every-6-months and every-other-Saturday cases.

One pre-existing, separate defect was found and deliberately not touched: `MONTHLY_BY_POSITION`'s base-case `recurrence["Position"]` access raises `TypeError` on v0.8.0 independent of this change, because `entity_instance.__getitem__` only accepts int keys. The new interval path uses `recurrence.Position`, matching `YEARLY_BY_POSITION`'s convention.

14 new tests in `test/util/test_sequence_recurrence_interval.py` (its own file, named for its concern). Red-green: reverting `util/sequence.py` to v0.8.0 makes 7 of the 14 fail with `assert False is True` (every Interval/Occurrences case) while the 7 regression guards still pass, proving the fix is load-bearing and the untouched path unchanged. Full `test/api/sequence/` suite (66 tests) passes.

Known overlap: this branch edits the same `elif` chain as #9147, so whichever merges second needs a small manual rebase. Flagged rather than hidden.

Produced with AI assistance.
