### PR TITLE
Bonsai: warn when geometry creation silently fails

### DIFF
--- a/src/bonsai/bonsai/bim/import_ifc.py
+++ b/src/bonsai/bonsai/bim/import_ifc.py
@@ -751,6 +751,15 @@ class IfcImporter:
             if not iterator.next():
                 break
         print("Done creating geometry")
+        missing = {p for p in products if p.Representation} - results
+        if missing:
+            sample = ", ".join(f"#{p.id()}={p.is_a()}" for p in list(missing)[:5])
+            self.ifc_import_settings.logger.error(
+                "Failed to generate geometry for %d element(s) (e.g. %s) using Geometry Library '%s'",
+                len(missing),
+                sample,
+                self.ifc_import_settings.geometry_library,
+            )
         return results
 
     def create_structural_items(self):

--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -806,13 +806,19 @@ class Loader(bonsai.core.tool.Loader):
     ) -> Union[ifcopenshell.geom.ShapeElementType, None]:
         context_settings = cls.settings.gross_context_settings if is_gross else cls.settings.context_settings
         geometry_library = tool.Project.get_project_props().geometry_library
+        error: Optional[Exception] = None
         for settings in context_settings:
             try:
                 result = ifcopenshell.geom.create_shape(settings, element, geometry_library=geometry_library)
                 if result:
                     return result
-            except:
-                pass
+            except Exception as e:
+                error = e
+        if error is not None:
+            print(
+                f"WARNING. Failed to create geometry for {element} using Geometry Library "
+                f"'{geometry_library}': {error}"
+            )
 
     @classmethod
     def create_point_cloud_mesh(cls, representation: ifcopenshell.entity_instance) -> Union[bpy.types.Mesh, None]:

--- a/src/bonsai/test/bim/test_import_ifc.py
+++ b/src/bonsai/test/bim/test_import_ifc.py
@@ -1,0 +1,93 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from unittest import mock
+
+import bpy
+import ifcopenshell
+import ifcopenshell.geom
+import ifcopenshell.guid
+import ifcopenshell.util.representation
+from ifcopenshell.util.shape_builder import ShapeBuilder, V
+
+import bonsai.bim.import_ifc as import_ifc
+import bonsai.tool as tool
+from test.bim.bootstrap import NewFile
+
+
+class FakeIterator:
+    """Stands in for ifcopenshell.geom.iterator so a silently-skipped element
+    can be simulated without depending on a specific geometry kernel bug."""
+
+    def __init__(self, shapes):
+        self.shapes = shapes
+        self.index = 0
+
+    def initialize(self):
+        return True
+
+    def progress(self):
+        return 100
+
+    def set_cache(self, cache):
+        pass
+
+    def get(self):
+        return self.shapes[self.index] if self.index < len(self.shapes) else None
+
+    def next(self):
+        self.index += 1
+        return self.index < len(self.shapes)
+
+
+class TestCreateProducts(NewFile):
+    def test_warns_about_elements_the_iterator_silently_dropped(self, caplog):
+        bpy.ops.bim.create_project()
+        ifc_file = tool.Ifc.get()
+
+        body_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
+        builder = ShapeBuilder(ifc_file)
+        curve = builder.rectangle(size=V(1.0, 1.0))
+        profile = ifc_file.createIfcArbitraryClosedProfileDef(ProfileType="AREA", OuterCurve=curve)
+        solid = builder.extrude(profile, magnitude=1.0)
+        rep = ifc_file.createIfcShapeRepresentation(
+            ContextOfItems=body_context, RepresentationIdentifier="Body", RepresentationType="SweptSolid", Items=[solid]
+        )
+        pds = ifc_file.createIfcProductDefinitionShape(Representations=[rep])
+        wall_ok = ifc_file.createIfcWall(GlobalId=ifcopenshell.guid.new(), Representation=pds)
+        wall_dropped = ifc_file.createIfcWall(GlobalId=ifcopenshell.guid.new(), Representation=pds)
+
+        settings = ifcopenshell.geom.settings()
+        real_shape = ifcopenshell.geom.create_shape(settings, wall_ok)
+        assert real_shape.id == wall_ok.id()
+
+        import_settings = import_ifc.IfcImportSettings.factory(bpy.context, None, logging.getLogger("ImportIFC"))
+        import_settings.geometry_library = "cgal"
+        importer = import_ifc.IfcImporter(import_settings)
+        importer.file = ifc_file
+
+        fake_iterator = FakeIterator([real_shape, None])
+        with mock.patch("ifcopenshell.geom.iterator", return_value=fake_iterator):
+            with caplog.at_level(logging.ERROR, logger="ImportIFC"):
+                results = importer.create_products({wall_ok, wall_dropped}, settings)
+
+        assert results == {wall_ok}
+        messages = " ".join(record.message for record in caplog.records)
+        assert f"#{wall_dropped.id()}={wall_dropped.is_a()}" in messages
+        assert "cgal" in messages

--- a/src/bonsai/test/tool/test_loader.py
+++ b/src/bonsai/test/tool/test_loader.py
@@ -18,12 +18,15 @@
 
 import json
 from pathlib import Path
+from unittest import mock
 
 import bmesh
 import bpy
 import ifcopenshell
 import ifcopenshell.api.library
 import ifcopenshell.api.style
+import ifcopenshell.geom
+import ifcopenshell.guid
 import ifcopenshell.util.schema
 import numpy as np
 from ifcopenshell.util.shape_builder import ShapeBuilder
@@ -602,3 +605,22 @@ class TestCreatePointCloudMesh(NewFile):
         assert len(mesh.vertices) == 1
         verts = np.array([v.co for v in mesh.vertices])
         assert np.allclose(verts, np.array([np.array(c) for c in coords3d]))
+
+
+class TestCreateGenericShape(NewFile):
+    def test_warns_and_returns_none_when_the_kernel_fails_for_every_context(self, capsys):
+        bpy.ops.bim.create_project()
+        tool.Loader.load_settings()
+        ifc_file = tool.Ifc.get()
+        wall = ifc_file.createIfcWall(GlobalId=ifcopenshell.guid.new())
+
+        def always_fail(*args, **kwargs):
+            raise RuntimeError("Failed to process shape")
+
+        with mock.patch("ifcopenshell.geom.create_shape", side_effect=always_fail):
+            result = subject.create_generic_shape(wall)
+
+        assert result is None
+        output = capsys.readouterr().out
+        assert f"#{wall.id()}={wall.is_a()}" in output
+        assert "Failed to process shape" in output


### PR DESCRIPTION
`tool.Loader.create_generic_shape` swallowed every `ifcopenshell.geom` failure with a bare `except: pass` (which also catches `KeyboardInterrupt` and `SystemExit`), and `IfcImporter.create_products` had no branch for a falsy `iterator.get()`. An element whose shape could not be built for any reason just never appeared in the scene, with nothing printed or logged anywhere to say why.

Both sites now report the failing element and the active Geometry Library instead of failing silently. Import still completes either way; this only adds a diagnostic.

The two sites report differently on purpose. `create_generic_shape` is only called for grids, grid axes, annotations, spatial elements and element types, never in the main per-product loop, so it prints one warning per genuine failure, matching the `print(f"WARNING. ...")` convention already used throughout this class. `create_products` is the main per-product import loop, so it logs one aggregated error after the loop naming the count and a sample of dropped elements, matching the `logger.error` convention this same class already uses for the identical shape-came-back-falsy case in `create_element_type`, rather than flooding the log on a file with many failures.

This is a diagnostics-only change. It is not a fix for any specific reported symptom and does not close any issue.

Tests: `test/tool/test_loader.py::TestCreateGenericShape` and `test/bim/test_import_ifc.py::TestCreateProducts` (new file, none existed for `import_ifc.py`). Both assert the warning is actually emitted and names the element, not merely that nothing raised. Verified red before the fix (`assert '#63=IfcWall' in ''`), green after, live in headless Blender 5.2.

Produced with AI assistance.
