### PR TITLE
ifctester: fix crash on IFC2X3 material properties

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -918,6 +918,10 @@ class Property(Facet):
             return pset.HasProperties
         elif pset.is_a("IfcElementQuantity"):
             return pset.Quantities
+        elif pset.is_a("IfcExtendedMaterialProperties"):
+            # IFC2X3 subtype of IfcMaterialProperties, checked before it:
+            # it has no Properties attribute, only ExtendedProperties.
+            return pset.ExtendedProperties
         elif pset.is_a("IfcMaterialProperties") or pset.is_a("IfcProfileProperties"):
             return pset.Properties
         elif pset.is_a("IfcPreDefinedPropertySet"):

--- a/src/ifctester/test/fixtures/material_extended_properties_ifc2x3/material_extended_properties_ifc2x3.ids
+++ b/src/ifctester/test/fixtures/material_extended_properties_ifc2x3/material_extended_properties_ifc2x3.ids
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Material properties in IFC2X3</title>
+        <description>IfcMaterial must carry Pset_Foo.Bar via IfcExtendedMaterialProperties.</description>
+    </info>
+    <specifications>
+        <specification name="Materials must have Pset_Foo.Bar" ifcVersion="IFC2X3">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCMATERIAL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <property dataType="IFCLABEL">
+                    <propertySet>
+                        <simpleValue>Pset_Foo</simpleValue>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>Bar</simpleValue>
+                    </baseName>
+                </property>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/material_extended_properties_ifc2x3/material_extended_properties_ifc2x3.ifc
+++ b/src/ifctester/test/fixtures/material_extended_properties_ifc2x3/material_extended_properties_ifc2x3.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T00:00:00',(''),(''),'IfcOpenShell 0.8.6-6f3acc8','IfcOpenShell 0.8.6-6f3acc8','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCMATERIAL('Concrete');
+#3=IFCPROPERTYSINGLEVALUE('Bar',$,IFCLABEL('baz'),$);
+#4=IFCEXTENDEDMATERIALPROPERTIES(#2,(#3),$,'Pset_Foo');
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_fixture_material_extended_properties_ifc2x3.py
+++ b/src/ifctester/test/test_fixture_material_extended_properties_ifc2x3.py
@@ -1,0 +1,60 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for specific reported defects.
+
+Each test here loads a minimal .ids/.ifc pair from test/fixtures/ through
+the same entry points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestMaterialExtendedPropertiesIfc2x3Fixture:
+    def test_ifc2x3_material_property_is_checked_without_crashing(self):
+        # IfcExtendedMaterialProperties (IFC2X3) has no Properties
+        # attribute, only ExtendedProperties. A Property facet on an
+        # IFC2X3 IfcMaterial used to raise AttributeError instead of
+        # finding the property.
+        specs = ids.open(
+            os.path.join(
+                FIXTURES,
+                "material_extended_properties_ifc2x3",
+                "material_extended_properties_ifc2x3.ids",
+            )
+        )
+        ifc = ifcopenshell.open(
+            os.path.join(
+                FIXTURES,
+                "material_extended_properties_ifc2x3",
+                "material_extended_properties_ifc2x3.ifc",
+            )
+        )
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is True
+        assert spec.requirements[0].status is True


### PR DESCRIPTION
While checking IfcTester against [buildingSMART/IDS#435](https://github.com/buildingSMART/IDS/issues/435) (andyward's report that xbim misses `IfcProject` properties under IFC4 because `IfcProject` moved to the new `IfcContext` supertype), we measured IfcTester's own behaviour end to end. IfcProject is fine in both schemas; that result is reported on the issue.

Following andyward's suggestion to also check `IfcMaterialDefinition`, a real but different bug turned up: any `Property` facet on an IFC2X3 `IfcMaterial` crashes.

`IfcExtendedMaterialProperties` (IFC2X3) is a subtype of `IfcMaterialProperties`, but unlike its parent it has no `Properties` attribute, only `ExtendedProperties`. `Property.get_properties()` matched the parent class first via `is_a()` and read the wrong attribute, raising

```
AttributeError: entity instance of type 'IFC2X3.IfcExtendedMaterialProperties' has no attribute 'Properties'
```

instead of returning a verdict. Fix: check `IfcExtendedMaterialProperties` before its supertype, since `is_a()` matches supertypes and ordering decides which branch wins.

The neighbouring IFC2X3 profile-properties path was checked for the same landmine and is already excluded by design (`Property.filter` deliberately omits `IfcProfileDef` for IFC2X3), so no change there.

Fixture pair at `test/fixtures/material_extended_properties_ifc2x3/`, with its own per-fixture test file. Reproduced red against the pre-fix code with the exact `AttributeError` above, green after. 38/38 tests pass.

Verified no conflict with our open ifctester PRs #9203, #9205 and #9250 via `git merge-tree`.

Produced with AI assistance.
