### PR TITLE
ifctester: tolerance is missing its fixed component

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -50,14 +50,11 @@ def cast_to_value(from_value, to_value):
         pass
 
 
-# See bug 4716.
-def is_x(value, cast_value):
-    if cast_value >= 0:
-        if value < cast_value * (1.0 - 1e-6) or value > cast_value * (1.0 + 1e-6):
-            return False
-    elif value > cast_value * (1.0 - 1e-6) or value < cast_value * (1.0 + 1e-6):
-        return False
-    return True
+# See bug 4716 and IDS Documentation/ImplementersDocumentation/tolerance.md.
+def is_x(value, cast_value, tolerance=1e-6):
+    lower = cast_value - abs(cast_value) * tolerance - tolerance
+    upper = cast_value + abs(cast_value) * tolerance + tolerance
+    return lower <= value <= upper
 
 
 @lru_cache

--- a/src/ifctester/test/fixtures/tolerance_absolute_component/tolerance_absolute_component.ids
+++ b/src/ifctester/test/fixtures/tolerance_absolute_component/tolerance_absolute_component.ids
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Equality tolerance has an absolute component</title>
+        <description>Reals must be compared against v +/- (abs(v) * 1e-6 + 1e-6).</description>
+    </info>
+    <specifications>
+        <specification name="Reals are equal within the documented tolerance" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <property dataType="IFCREAL">
+                    <propertySet>
+                        <simpleValue>Foo_Bar</simpleValue>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>NearOne</simpleValue>
+                    </baseName>
+                    <value>
+                        <simpleValue>1.</simpleValue>
+                    </value>
+                </property>
+                <property dataType="IFCREAL">
+                    <propertySet>
+                        <simpleValue>Foo_Bar</simpleValue>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>NearZero</simpleValue>
+                    </baseName>
+                    <value>
+                        <simpleValue>0.</simpleValue>
+                    </value>
+                </property>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/tolerance_absolute_component/tolerance_absolute_component.ifc
+++ b/src/ifctester/test/fixtures/tolerance_absolute_component/tolerance_absolute_component.ifc
@@ -1,0 +1,15 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T00:00:00',(''),(''),'IfcOpenShell','IfcOpenShell','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('3Fu_ePwY1DZxzRl9jojPIx',$,'W',$,$,$,$,$,$);
+#3=IFCPROPERTYSINGLEVALUE('NearOne',$,IFCREAL(1.0000015),$);
+#4=IFCPROPERTYSINGLEVALUE('NearZero',$,IFCREAL(5.E-7),$);
+#5=IFCPROPERTYSET('2Fu_ePwY1DZxzRl9jojPIx',$,'Foo_Bar',$,(#3,#4));
+#6=IFCRELDEFINESBYPROPERTIES('4Fu_ePwY1DZxzRl9jojPIx',$,$,$,(#2),#5);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_fixture_tolerance_absolute_component.py
+++ b/src/ifctester/test/test_fixture_tolerance_absolute_component.py
@@ -1,0 +1,65 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression test for the absolute component of the IDS equality tolerance."""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+from ifctester.facet import is_x
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestToleranceAbsoluteComponentFixture:
+    def test_reals_within_the_documented_tolerance_pass(self):
+        # IDS tolerance.md defines the interval as
+        # (v - abs(v) * 1e-6 - 1e-6) .. (v + abs(v) * 1e-6 + 1e-6).
+        # 1.0000015 is inside the interval for 1.0 and 5e-7 is inside the
+        # interval for 0.0, which has no relative component at all.
+        directory = os.path.join(FIXTURES, "tolerance_absolute_component")
+        specs = ids.open(os.path.join(directory, "tolerance_absolute_component.ids"))
+        ifc = ifcopenshell.open(os.path.join(directory, "tolerance_absolute_component.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.requirements[0].status is True
+        assert spec.requirements[1].status is True
+        assert spec.status is True
+
+
+class TestIsX:
+    def test_zero_uses_the_absolute_tolerance(self):
+        assert is_x(0.0, 0.0)
+        assert is_x(1e-6, 0.0)
+        assert is_x(-1e-6, 0.0)
+        assert not is_x(1.1e-6, 0.0)
+        assert not is_x(-1.1e-6, 0.0)
+
+    def test_positive_and_negative_values_are_symmetric(self):
+        assert is_x(1.0000015, 1.0)
+        assert is_x(-1.0000015, -1.0)
+        assert is_x(0.9999985, 1.0)
+        assert is_x(-0.9999985, -1.0)
+        assert not is_x(1.0000021, 1.0)
+        assert not is_x(-1.0000021, -1.0)
+        assert not is_x(0.9999979, 1.0)
+        assert not is_x(-0.9999979, -1.0)


### PR DESCRIPTION
IfcTester's real-number comparison did not implement the tolerance rule that buildingSMART documents.

`Documentation/ImplementersDocumentation/tolerance.md` specifies:

```
x == v  =>  (v - abs(v) * e - e) < x < (v + abs(v) * e + e),  e = 1.0e-6
```

There is a relative component `abs(v) * e` and a fixed component `e`. `facet.py`'s `is_x` used a purely relative interval:

```python
if value < cast_value * (1.0 - 1e-6) or value > cast_value * (1.0 + 1e-6):
```

**The fixed component was missing entirely.** Two consequences:

- The accepted interval is half the documented width for every value.
- **At `v = 0` it collapses to a single point.** An IDS requiring `0.` matched only an exact binary zero, where the specification allows plus or minus 1e-6. That is the sharpest user-visible effect.

This also contradicts the formula's own author. On [buildingSMART/IDS#78](https://github.com/buildingSMART/IDS/issues/78) @aothms wrote: *"So there is a relative component and fixed component (for 0.)"*.

The fix implements the documented expression directly. Comparators stay inclusive, which is what `is_x` already did, so this takes no new position on the strict-versus-inclusive question still open in [buildingSMART/IDS#418](https://github.com/buildingSMART/IDS/issues/418). No rounding step is added, since that is exactly what is still under discussion there.

## Measured against the official conformance suite

Running all 36 cases in the IDS repository's `TestCases/tolerance/`:

```
before   22 of 36 agree   (all 14 equality boundary cases disagree)
after    34 of 36 agree
```

The 2 that still disagree are precisely the two under discussion on IDS#418, `pass-comparison_tolerance_for_floating_point_negative_one_lower_bound` and `pass-comparison_tolerance_for_floating_point_one_upper_bound`. Those fail by exactly one ULP because the decimal literal `1.000002` rounds up to its nearest double while `1 + 1e-6 + 1e-6` accumulates its roundings down, so no double-precision evaluation of the formula can pass them. Our residual disagreement is now identical to the open specification question, which is the honest resting state.

## Fixture

`test/fixtures/tolerance_absolute_component/` is a wall with `NearOne = 1.0000015` and `NearZero = 5.E-7`, both unambiguously inside the documented interval under either comparator. Red before the fix (3 failed), green after (3 passed). Suite goes 37/37 to 40/40, so no new failures, and the existing `42.0 * (1 +/- 2e-6)` tolerance tests still pass.

Produced with AI assistance.
