### PR TITLE
Fix false get_total_inverses docstring claim

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/file.py
+++ b/src/ifcopenshell-python/ifcopenshell/file.py
@@ -964,13 +964,18 @@ class file:
         return set(inverses)
 
     def get_total_inverses(self, inst: ifcopenshell.entity_instance) -> int:
-        """Returns the number of entities that reference this entity
+        """Returns the number of attribute references to this entity
 
-        This is equivalent to `len(model.get_inverse(element))`, but
-        significantly faster.
+        This counts reference slots, not distinct entities, so it is NOT
+        equivalent to `len(model.get_inverse(element))`: if another entity
+        refers to `inst` through more than one of its attributes, each
+        occurrence is counted separately and the total is higher than the
+        number of distinct referencing entities. It is still significantly
+        faster than `get_inverse`, so prefer it when you only need to know
+        whether any references exist at all (e.g. comparing against 0).
 
         :param inst: The entity instance to get inverse relationships
-        :returns: The total number of references
+        :returns: The total number of attribute references (not entities)
         """
         return self.wrapped_data.get_total_inverses(inst.wrapped_data)
 


### PR DESCRIPTION
`get_total_inverses` counts attribute reference slots, not distinct entities. The docstring claimed it was equivalent to `len(get_inverse(element))`, which is false whenever one entity references another through more than one attribute.

Verified in the C++ source: `IfcParse.cpp`'s `getTotalInverses` sums the sizes of the `byref_excl_` buckets, which are keyed per `attribute_index`, and `register_inverse` pushes one entry per attribute occurrence. Confirmed at runtime: an `IfcDirection` used as both `Axis` and `RefDirection` of one `IfcAxis2Placement3D` gives `get_total_inverses == 2` while `len(get_inverse(...)) == 1`.

This matters more than a docstring usually would. That sentence is exactly what makes a `get_total_inverses(x) > len(subgraph)` containment guard look correct, and such a guard would silently leave orphaned entities behind. It nearly caused that while working on #9247.

Swept every other caller for reliance on the false equivalence. Most only test truthiness (`== 0` or `!= 0`), which is unaffected either way. `remove_deep2`'s `< 2` guard is correct by construction, since the subelement is only reached through a real traversal edge from a parent already marked for deletion. One instructive exception is `api/structural/edit_structural_connection_cs.py`, whose `== 1` checks give the right final result only because of the order in which the attributes are reassigned; not changed here, but worth knowing.

Produced with AI assistance.
