### PR TITLE
bsdd: dist target ships only one of three modules

### DIFF
--- a/src/bsdd/Makefile
+++ b/src/bsdd/Makefile
@@ -18,6 +18,7 @@
 
 PACKAGE_NAME:=bsdd.py
 IS_MODULE:=true
+EXTRA_MODULES:=bsdd_json.py type_hints.py
 include ../common.mk
 
 .PHONY: test

--- a/src/common.mk
+++ b/src/common.mk
@@ -27,6 +27,9 @@ dist:
 	mkdir -p build
 	mkdir -p dist
 	cp -r $(PACKAGE_NAME) build/
+ifdef EXTRA_MODULES
+	cp -r $(EXTRA_MODULES) build/
+endif
 	cp pyproject.toml build/
 	if [ -f README.md ]; then cp README.md build/; fi
 ifeq ($(IS_STABLE), TRUE)


### PR DESCRIPTION
Fixes #7468.

The `dist` target in `src/common.mk` copies only `$(PACKAGE_NAME)` into the isolated build directory:

```make
cp -r $(PACKAGE_NAME) build/
```

so `bsdd_json.py` and `type_hints.py` never shipped, even though `src/bsdd/pyproject.toml` has declared all three as `py-modules` since #7145. The published `bsdd-0.8.5` wheel, uploaded well after that declaration landed, still contains only `bsdd.py`.

`bsdd` is the only package in the repository with more than one entry in `py-modules`, which is why nothing else hits this.

Added an opt-in `EXTRA_MODULES` hook to `common.mk` (empty by default, so every other package using the shared Makefile is unaffected) and set it in `src/bsdd/Makefile`.

Verified through the exact path CI uses, `make dist IS_STABLE=TRUE`, with the before case taken from a real `v0.8.0` worktree rather than a hand revert:

```
before   "file bsdd_json.py (for module bsdd_json) not found"
         wheel contains only bsdd.py
after    wheel contains bsdd.py, bsdd_json.py, type_hints.py
```

Installed the built wheel into a scratch venv and confirmed all three modules import.

Note for the record: we commented on #7468 on 2026-07-05 saying the `pyproject.toml` declaration meant this was fixed in tree. That was wrong. The declaration was never the problem, and the release cut afterwards still shipped one module.

Produced with AI assistance.
