### PR TITLE
Bonsai: keep dimension preview visible in Item/Edit mode (#9262)

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/data.py
+++ b/src/bonsai/bonsai/bim/module/drawing/data.py
@@ -845,9 +845,12 @@ class DecoratorData:
 
         results = []
         viewport = tool.Blender.get_view3d_space()
+        # Item/Edit mode hides the original object while its items are edited.
+        # Keep decorating it so the annotation preview survives the hide.
+        editing_obj = tool.Geometry.get_geometry_props().representation_obj
 
         for obj in collection.all_objects:
-            if not obj.visible_get(viewport=viewport):
+            if not obj.visible_get(viewport=viewport) and obj is not editing_obj:
                 continue
             element = tool.Ifc.get_entity(obj)
             if not element:

--- a/src/bonsai/test/bim/module/drawing/test_decorator_data_item_mode_preview.py
+++ b/src/bonsai/test/bim/module/drawing/test_decorator_data_item_mode_preview.py
@@ -1,0 +1,117 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression guard for #9262: entering IFC Item/Edit mode must not blank
+out a dimension/line annotation's decoration (arrows, text) in the viewport.
+
+``ImportRepresentationItems._execute`` (bonsai/bim/module/geometry/operator.py)
+hides the original annotation object with ``obj.hide_set(True)`` while its
+representation items are edited, and only unhides it again in
+``Geometry.disable_item_mode``. ``DecoratorData.object_decorators`` used to
+filter candidates purely on ``obj.visible_get()``, so the hidden original
+silently dropped out of the decorated list for the whole Item/Edit mode
+session, and its arrow/text decoration disappeared from the viewport."""
+
+import bpy
+import ifcopenshell
+import ifcopenshell.api.group
+import pytest
+
+import bonsai.tool as tool
+from bonsai.bim.module.drawing.data import DecoratorData
+from bonsai.bim.module.drawing.decoration import DecorationsHandler
+from test.bim.bootstrap import NewFile
+
+pytestmark = pytest.mark.drawing
+
+
+def _create_dimension_annotation(drawing):
+    obj = tool.Drawing.create_annotation_object(drawing, "DIMENSION")
+    obj.name = "Test Dimension"
+    ifc_context = tool.Drawing.get_annotation_context(tool.Drawing.get_drawing_target_view(drawing), "DIMENSION")
+    element = tool.Drawing.run_root_assign_class(
+        obj=obj,
+        ifc_class="IfcAnnotation",
+        predefined_type="DIMENSION",
+        should_add_representation=True,
+        context=ifc_context,
+        ifc_representation_class=tool.Drawing.get_ifc_representation_class("DIMENSION"),
+    )
+    assert element
+    ifcopenshell.api.group.assign_group(
+        tool.Ifc.get(), group=tool.Drawing.get_drawing_group(drawing), products=[element]
+    )
+    tool.Collector.assign(obj)
+    return obj
+
+
+def _fake_decorations_handler():
+    # A real DecorationsHandler() calls gpu.shader.from_builtin() per decorator,
+    # which needs an initialized GPU context that headless test runs don't have.
+    # object_decorators() only reads handler.decorators, so a stand-in with the
+    # same keys is enough to exercise the visibility filtering under test.
+    return type(
+        "FakeHandler", (), {"decorators": {cls.objecttype: object() for cls in DecorationsHandler.decorators_classes}}
+    )()
+
+
+class TestObjectDecoratorsSurviveItemModeHide(NewFile):
+    def setup_dimension_drawing(self):
+        bpy.ops.bim.create_project()
+        tool.Project.save_test_project()
+        bpy.ops.bim.load_drawings()
+        bpy.ops.bim.add_drawing()
+        ifc = tool.Ifc.get()
+        drawing = next(d for d in ifc.by_type("IfcAnnotation") if d.ObjectType == "DRAWING")
+        bpy.ops.bim.activate_drawing(drawing=drawing.id())
+        return _create_dimension_annotation(drawing)
+
+    def test_hidden_representation_obj_still_gets_decorated(self):
+        obj = self.setup_dimension_drawing()
+        handler = _fake_decorations_handler()
+        DecorationsHandler.installed = True
+        try:
+            decorated = [o for o, _ in DecoratorData.object_decorators(handler)]
+            assert obj in decorated, "sanity check: a visible dimension should be decorated"
+
+            # Simulate entering IFC Item/Edit mode: the original object gets
+            # hidden while its representation items are edited (#9262).
+            gprops = tool.Geometry.get_geometry_props()
+            gprops.representation_obj = obj
+            obj.hide_set(True)
+
+            decorated = [o for o, _ in DecoratorData.object_decorators(handler)]
+            assert obj in decorated, "dimension preview must survive Item/Edit mode"
+        finally:
+            DecorationsHandler.installed = None
+            tool.Geometry.get_geometry_props().representation_obj = None
+
+    def test_unrelated_hidden_annotation_stays_excluded(self):
+        """A merely-hidden annotation (not the one being item-edited) is still filtered out."""
+        obj = self.setup_dimension_drawing()
+        obj.hide_set(True)
+
+        handler = _fake_decorations_handler()
+        DecorationsHandler.installed = True
+        try:
+            decorated = [o for o, _ in DecoratorData.object_decorators(handler)]
+            assert obj not in decorated
+        finally:
+            DecorationsHandler.installed = None


### PR DESCRIPTION
Addresses the preview half of #9262.

## Problem

Editing a dimension or line annotation blanks out its arrow and text decoration in the viewport for the whole edit session, so the user edits blind. The reporter's three screenshots show it clearly: fully decorated in IFC Object mode, bare wireframe in Item and Edit mode.

## Root cause

`ImportRepresentationItems._execute` hides the original annotation object so its individual representation items can be edited without visual overlap:

```python
props.representation_obj = obj
obj.hide_set(True)
```

`DecoratorData.object_decorators()` then filters candidates purely on visibility:

```python
for obj in collection.all_objects:
    if not obj.visible_get(viewport=viewport):
        continue
```

So the hidden-for-editing object drops out of the decorated list. This looks incidental rather than deliberate: nothing in the comments or history suggests the decoration was meant to disappear, it is a side effect of one flag serving two purposes, "hidden because the user hid it" and "hidden because we are editing it".

## Fix

Keep decorating the object currently tracked as `representation_obj`, even though it is hidden for editing.

## Scope, stated plainly

This shows the annotation as it was before editing started. It does not live-update while points are dragged, because that data only syncs back on exit. Extending decoration to the live temporary item objects is a materially bigger change, since those are not resolvable to an `IfcAnnotation` the way the dispatch expects, and it is not what the issue asks for.

The issue also asked for a hotkey to cut down clicks. **That already exists** and needs no change: Tab already cycles Object to Item to Edit (`bim.override_mode_set_edit`, bound in `geometry/__init__.py`), and @theoryshaw pointed the reporter at the Space shortcut (`bim.direct_profile_edit`) in the thread, which does it in one press. The remaining part of that half is discoverability, which is a UI question rather than a code defect.

## Testing

`test/bim/module/drawing/test_decorator_data_item_mode_preview.py` creates a real DIMENSION `IfcAnnotation` in a real drawing and simulates the Item Mode hide exactly as `ImportRepresentationItems` does. Red without the fix (`assert bpy.data.objects['IfcAnnotation/Test Dimension'] in []`), green with it. `test/bim/module/drawing` (32 tests) and `test/tool/test_drawing.py` (87 tests) unaffected.

Produced with AI assistance.
