### PR TITLE
ifctester: wrong-case boolean enum matches anything

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -45,6 +45,9 @@ def cast_to_value(from_value, to_value):
                 return True
             elif from_value in ("false", "0"):
                 return False
+            # An unrecognised string (e.g. wrong case) must not silently cast
+            # to True via bool(str), which is truthy for any non-empty string.
+            return None if isinstance(from_value, str) else bool(from_value)
         return builtins.__dict__[target_type](from_value)
     except ValueError:
         pass

--- a/src/ifctester/test/fixtures/enumeration_boolean_case/enumeration_boolean_case.ids
+++ b/src/ifctester/test/fixtures/enumeration_boolean_case/enumeration_boolean_case.ids
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Boolean enumeration matching is exact-case</title>
+        <description>An enumeration restriction over xs:boolean must not match a value it does not literally list.</description>
+    </info>
+    <specifications>
+        <specification name="Boolean enumeration matches only its listed literal" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <property dataType="IFCBOOLEAN">
+                    <propertySet>
+                        <simpleValue>Foo_Bar</simpleValue>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>RequiresFalse</simpleValue>
+                    </baseName>
+                    <value>
+                        <xs:restriction base="xs:boolean">
+                            <xs:enumeration value="FALSE" />
+                        </xs:restriction>
+                    </value>
+                </property>
+                <property dataType="IFCBOOLEAN">
+                    <propertySet>
+                        <simpleValue>Foo_Bar</simpleValue>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>RequiresTrueLower</simpleValue>
+                    </baseName>
+                    <value>
+                        <xs:restriction base="xs:boolean">
+                            <xs:enumeration value="true" />
+                        </xs:restriction>
+                    </value>
+                </property>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/enumeration_boolean_case/enumeration_boolean_case.ifc
+++ b/src/ifctester/test/fixtures/enumeration_boolean_case/enumeration_boolean_case.ifc
@@ -1,0 +1,15 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T00:00:00',(''),(''),'IfcOpenShell','IfcOpenShell','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('3Fu_ePwY1DZxzRl9jojPIx',$,'W',$,$,$,$,$,$);
+#3=IFCPROPERTYSINGLEVALUE('RequiresFalse',$,IFCBOOLEAN(.T.),$);
+#4=IFCPROPERTYSINGLEVALUE('RequiresTrueLower',$,IFCBOOLEAN(.T.),$);
+#5=IFCPROPERTYSET('2Fu_ePwY1DZxzRl9jojPIx',$,'Foo_Bar',$,(#3,#4));
+#6=IFCRELDEFINESBYPROPERTIES('4Fu_ePwY1DZxzRl9jojPIx',$,$,$,(#2),#5);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_fixture_enumeration_boolean_case.py
+++ b/src/ifctester/test/test_fixture_enumeration_boolean_case.py
@@ -1,0 +1,51 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression test for exact-case enumeration matching on xs:boolean.
+
+cast_to_value() falls back to bool(str) for any string it does not recognise
+as "true"/"1"/"false"/"0". bool() is truthy for any non-empty string, so an
+enumeration listing only "FALSE" incorrectly matched an actual value of True.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestEnumerationBooleanCaseFixture:
+    def test_an_unrecognised_enumeration_literal_never_matches(self):
+        directory = os.path.join(FIXTURES, "enumeration_boolean_case")
+        specs = ids.open(os.path.join(directory, "enumeration_boolean_case.ids"))
+        ifc = ifcopenshell.open(os.path.join(directory, "enumeration_boolean_case.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+
+        # The actual value is True. An enumeration of only "FALSE" must fail,
+        # not silently pass because bool("FALSE") is truthy.
+        assert spec.requirements[0].status is False
+
+        # Sanity: lowercase "true" is the recognised XSD boolean literal and
+        # must still match an actual value of True after the fix.
+        assert spec.requirements[1].status is True


### PR DESCRIPTION
`cast_to_value` silently returns `True` for any non-empty string when the target is a boolean, so a wrong-case enumeration literal matches any value.

```python
elif target_type == "bool":
    if from_value in ("true", "1"):
        return True
    elif from_value in ("false", "0"):
        return False
return builtins.__dict__[target_type](from_value)
```

`"FALSE"` misses both branches and falls through to `bool("FALSE")`, which is `True` because any non-empty string is truthy. So an IDS with `enumeration` value `"FALSE"` **passes against an actual value of `True`**.

That is a false pass in a compliance checker, which is the worst direction to be wrong in: the model violates the requirement and the report says it is fine, so nothing prompts anyone to look.

Found while measuring datatype coverage for [buildingSMART/IDS#305](https://github.com/buildingSMART/IDS/issues/305).

Fixture pair at `test/fixtures/enumeration_boolean_case/`, with its own per-concern test file. Red before the fix, green after. Full suite 38/38. Verified no conflict with our other open ifctester PRs #9203, #9205, #9250, #9261 and #9263 using `git merge-tree`, with a control pair confirming the check detects real conflicts.

Produced with AI assistance.
