### PR TITLE
ifctester: canonicalise parsed requirement order

### DIFF
--- a/src/ifctester/ifctester/ids.py
+++ b/src/ifctester/ifctester/ids.py
@@ -181,6 +181,14 @@ class Ids:
 
 
 class Specification:
+    # Canonical facet order per the Schema/ids.xsd requirementsType sequence.
+    # A requirements clause may list its facets in any other order and still
+    # validate against the XSD, because the wrapping sequence itself carries
+    # maxOccurs="unbounded" (see buildingSMART/IDS#344). We still canonicalise
+    # so that reports do not vary with how a given .ids file happened to be
+    # written.
+    FACET_ORDER = ("entity", "partOf", "classification", "attribute", "property", "material")
+
     def __init__(
         self,
         name="Unnamed",
@@ -228,7 +236,7 @@ class Specification:
                 facet_type = facet_type[0].lower() + facet_type[1:]
                 facets.setdefault(facet_type, []).append(facet.asdict(clause_type))
             # Canonicalise ordering as per XSD requirements
-            for facet_type in ("entity", "partOf", "classification", "attribute", "property", "material"):
+            for facet_type in self.FACET_ORDER:
                 if facet_type in facets:
                     results[clause_type][facet_type] = facets[facet_type]
             if clause_type == "applicability":
@@ -255,8 +263,13 @@ class Specification:
 
     def parse_clause(self, clause):
         results = []
-        for name, facets in clause.items():
-            if name not in ["entity", "attribute", "classification", "partOf", "property", "material"]:
+        # Iterate in canonical order rather than clause.items() order: a
+        # requirements clause may list its facets in any document order and
+        # still validate against the XSD (buildingSMART/IDS#344), but
+        # downstream consumers (reports, asdict()) expect a stable order.
+        for name in self.FACET_ORDER:
+            facets = clause.get(name)
+            if facets is None:
                 continue
             if not isinstance(facets, list):
                 facets = [facets]

--- a/src/ifctester/test/fixtures/requirements_facet_order/requirements_facet_order.ids
+++ b/src/ifctester/test/fixtures/requirements_facet_order/requirements_facet_order.ids
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Requirements facet order</title>
+        <description>Property is written before attribute. Schema/ids.xsd requirementsType allows this because its sequence carries maxOccurs="unbounded" (buildingSMART/IDS#344), but the reference implementation should still report facets in the canonical entity/partOf/classification/attribute/property/material order.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must have Name and a Reference" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <property dataType="IFCLABEL" cardinality="required">
+                    <propertySet>
+                        <simpleValue>Pset_WallCommon</simpleValue>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>Reference</simpleValue>
+                    </baseName>
+                </property>
+                <attribute cardinality="required">
+                    <name>
+                        <simpleValue>Name</simpleValue>
+                    </name>
+                </attribute>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/requirements_facet_order/requirements_facet_order.ifc
+++ b/src/ifctester/test/fixtures/requirements_facet_order/requirements_facet_order.ifc
@@ -1,0 +1,16 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T20:17:57',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1dJgBtUSf6dxkoeZhNQn9_',$,'P',$,$,$,$,$,$);
+#2=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#3=IFCUNITASSIGNMENT((#2));
+#4=IFCWALL('1dAVbP7Cj8Wx6o_pL9$j0K',$,'Wall1',$,$,$,$,$,$);
+#5=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('REF-001'),$);
+#6=IFCPROPERTYSET('3W6ABAoL991vYY3ZPE95WJ',$,'Pset_WallCommon',$,(#5));
+#7=IFCRELDEFINESBYPROPERTIES('1fWJIU1Ir5wPkR2n8CQybD',$,$,$,(#4),#6);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_fixture_requirements_facet_order.py
+++ b/src/ifctester/test/test_fixture_requirements_facet_order.py
@@ -1,0 +1,68 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression test for buildingSMART/IDS#344.
+
+Schema/ids.xsd's requirementsType wraps its facet elements in an
+<xs:sequence maxOccurs="unbounded">. Because the wrapping sequence itself
+repeats, a requirements clause can list its facets in any order (or even
+interleave repeats of the same facet type) and still validate against the
+XSD, even though a plain xs:sequence exists specifically "to produce the
+text version of the content in a reliable and consistent way"
+(CBenghi, buildingSMART/IDS#175).
+
+Specification.asdict() already canonicalises facet order for round-tripped
+output (see the "Canonicalise ordering as per XSD requirements" comment),
+but Specification.parse_clause() built self.requirements in raw document
+order, so a report generated straight from a parsed .ids file still varied
+with how the author happened to order the file, defeating that canonical
+ordering elsewhere in the same module.
+
+Loads a minimal .ids/.ifc pair from test/fixtures/ through the same entry
+points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestRequirementsFacetOrderFixture:
+    def test_requirements_are_reported_in_canonical_facet_order(self):
+        # The .ids file writes <property> before <attribute>, which the XSD
+        # permits (buildingSMART/IDS#344) but which is not the canonical
+        # entity/partOf/classification/attribute/property/material order.
+        specs = ids.open(os.path.join(FIXTURES, "requirements_facet_order", "requirements_facet_order.ids"))
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "requirements_facet_order", "requirements_facet_order.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+
+        assert spec.status is True
+
+        facet_order = [type(facet).__name__ for facet in spec.requirements]
+        assert facet_order == ["Attribute", "Property"], (
+            f"requirements were reported in file order {facet_order} instead of "
+            "canonical XSD order ['Attribute', 'Property']"
+        )


### PR DESCRIPTION
`Specification.parse_clause` built `self.requirements` in raw document order, so two `.ids` files expressing the same requirements in different order produced differently ordered human readable reports.

The codebase already had a canonical order in one place and not the other. `asdict()` carries an explicit comment and applies it:

```python
# Canonicalise ordering as per XSD requirements
for facet_type in ("entity", "partOf", "classification", "attribute", "property", "material"):
```

while the parser iterated `clause.items()` in whatever order the file happened to use.

This extracts that tuple into `Specification.FACET_ORDER` and makes `parse_clause` iterate it, so parsed order is canonical regardless of how the file was written. Verdicts are unaffected either way, since facets are ANDed.

Found while measuring [buildingSMART/IDS#344](https://github.com/buildingSMART/IDS/issues/344), where `requirementsType` carries `<xs:sequence maxOccurs="unbounded">` while `applicabilityType` does not, permitting cross type ordering and repeated facets. The stated reason for using `xs:sequence` there was reliable and consistent text generation, which the unstable parse order undercut. That schema question is still open upstream and this change is independent of whichever way it is resolved.

Fixture at `test/fixtures/requirements_facet_order/`, property written before attribute in the source file. Red before the fix, `['Property', 'Attribute']` in file order. Green after, `['Attribute', 'Property']` canonical. Verified through `ids.open` and `Ids.validate` rather than by calling the parser directly. Full ifctester suite 38/38.

Produced with AI assistance.
