### PR TITLE
ifctester: stop dropping specification identifier

### DIFF
--- a/src/ifctester/ifctester/ids.py
+++ b/src/ifctester/ifctester/ids.py
@@ -240,6 +240,7 @@ class Specification:
 
     def parse(self, ids_dict):
         self.name = ids_dict.get("@name", "")
+        self.identifier = ids_dict.get("@identifier", None)
         self.description = ids_dict.get("@description", "")
         self.instructions = ids_dict.get("@instructions", "")
         self.minOccurs = ids_dict.get("applicability", {}).get("@minOccurs", 0)

--- a/src/ifctester/ifctester/reporter.py
+++ b/src/ifctester/ifctester/reporter.py
@@ -79,6 +79,7 @@ class Results(TypedDict):
 
 class ResultsSpecification(TypedDict):
     name: str
+    identifier: Union[str, None]
     description: str
     instructions: str
     status: bool
@@ -398,6 +399,7 @@ class Json(Reporter):
 
         return ResultsSpecification(
             name=specification.name,
+            identifier=specification.identifier,
             description=specification.description,
             instructions=specification.instructions,
             status=specification.status,

--- a/src/ifctester/test/fixtures/specification_identifier_roundtrip/specification_identifier_roundtrip.ids
+++ b/src/ifctester/test/fixtures/specification_identifier_roundtrip/specification_identifier_roundtrip.ids
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Specification identifier round-trip</title>
+        <description>The specification identifier is a short code such as SP01 and must survive parsing.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must exist" identifier="SP01" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/specification_identifier_roundtrip/specification_identifier_roundtrip.ifc
+++ b/src/ifctester/test/fixtures/specification_identifier_roundtrip/specification_identifier_roundtrip.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T00:00:00',(''),(''),'IfcOpenShell 0.8.6','IfcOpenShell 0.8.6','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('34TFeqKAv1SOmFXWFuI$ni',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('08XCf5Gf1EsAang2u5CHXr',$,'Wall1',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_fixture_specification_identifier_roundtrip.py
+++ b/src/ifctester/test/test_fixture_specification_identifier_roundtrip.py
@@ -1,0 +1,96 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for specific reported defects.
+
+Each test here loads a minimal .ids/.ifc pair from test/fixtures/ through
+the same entry points ifctester's own CLI uses (ids.open, ifcopenshell.open,
+Ids.validate), rather than exercising a facet's __call__ directly.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids, reporter
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class TestSpecificationIdentifierRoundtripFixture:
+    def test_identifier_is_parsed_from_ids_file(self):
+        # buildingSMART/IDS#339: "identifier" is the documented place for a
+        # short reference code such as "SP01". If ids.open() does not parse
+        # it, every downstream consumer silently loses a value the author
+        # explicitly provided.
+        specs = ids.open(
+            os.path.join(
+                FIXTURES,
+                "specification_identifier_roundtrip",
+                "specification_identifier_roundtrip.ids",
+            )
+        )
+        spec = specs.specifications[0]
+        assert spec.identifier == "SP01"
+
+    def test_identifier_survives_to_string_roundtrip(self):
+        path = os.path.join(
+            FIXTURES,
+            "specification_identifier_roundtrip",
+            "specification_identifier_roundtrip.ids",
+        )
+        specs = ids.open(path)
+        ifc = ifcopenshell.open(
+            os.path.join(
+                FIXTURES,
+                "specification_identifier_roundtrip",
+                "specification_identifier_roundtrip.ifc",
+            )
+        )
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is True
+
+        rewritten = ids.Ids().parse(specs.asdict())
+        assert rewritten.specifications[0].identifier == "SP01"
+        assert 'identifier="SP01"' in specs.to_string()
+
+    def test_identifier_is_not_dropped_from_json_report(self):
+        # A value the author sets on the schema must reach the structured
+        # report dict every downstream reporter (Json, Html, Ods, Bcf) is
+        # built on, not just the in-memory Specification object.
+        specs = ids.open(
+            os.path.join(
+                FIXTURES,
+                "specification_identifier_roundtrip",
+                "specification_identifier_roundtrip.ids",
+            )
+        )
+        ifc = ifcopenshell.open(
+            os.path.join(
+                FIXTURES,
+                "specification_identifier_roundtrip",
+                "specification_identifier_roundtrip.ifc",
+            )
+        )
+        specs.validate(ifc)
+        engine = reporter.Json(specs)
+        results = engine.report()
+        assert results["specifications"][0]["identifier"] == "SP01"


### PR DESCRIPTION
`Specification.parse()` read `name`, `description` and `instructions` from an `.ids` file but never read `@identifier`, even though `ids.xsd` declares it:

```xml
<xs:attribute name="identifier" type="xs:string" use="optional">
```

So a short code such as `"SP01"` was silently lost on `ids.open()`: absent from `to_string()` output, and absent from every Json, Html, Ods and Bcf report. `reporter.py` had no mention of `identifier` at all, so even a caller who fixed the parse themselves would still lose it from structured output.

That attribute exists precisely to carry a human-facing short code. [buildingSMART/IDS#339](https://github.com/buildingSMART/IDS/issues/339) is the discussion that settled what it is for, and [their PR #369](https://github.com/buildingSMART/IDS/pull/369) documented it with examples like `"SP01"` and `"Fire-001"`. An author writing one today gets it discarded.

This reads it in `Specification.parse()` and carries it through `report_specification()` into `ResultsSpecification`.

Fixture pair at `test/fixtures/specification_identifier_roundtrip/`, with its own per-concern test file covering parse, `to_string()` round trip, and the Json reporter. Red before the fix, all three failing with `assert None == 'SP01'`. Green after. Full ifctester suite 40/40.

Verified no conflict with our other open ifctester PRs #9203, #9205, #9250, #9261, #9263 and #9268 using `git merge-tree`, with a control pair confirming the check detects real conflicts.

Produced with AI assistance.
