### PR TITLE
ifctester: prohibited attribute passes when empty

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -324,6 +324,15 @@ class Attribute(Facet):
                         names.append(k)
                         values.append(v)
 
+        if self.cardinality == "prohibited" and not self.value:
+            # "Must not exist, even if empty": an empty string or empty
+            # aggregate is still a populated attribute, only a genuinely
+            # unset (None) attribute counts as absent. Checked before the
+            # empty-value filtering below, which exists to serve REQUIRED
+            # and OPTIONAL's different definition of "populated".
+            exists = any(value is not None for value in values)
+            return AttributeResult(not exists, {"type": "PROHIBITED"})
+
         is_pass = bool(values)
         reason = None
 

--- a/src/ifctester/test/fixtures/attribute_prohibited_empty_string/attribute_prohibited_empty_string.ids
+++ b/src/ifctester/test/fixtures/attribute_prohibited_empty_string/attribute_prohibited_empty_string.ids
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Prohibited Description attribute</title>
+        <description>Description must not exist, even if empty.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must not have a Description" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <attribute cardinality="prohibited">
+                    <name>
+                        <simpleValue>Description</simpleValue>
+                    </name>
+                </attribute>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/attribute_prohibited_empty_string/fail-description_empty_string.ifc
+++ b/src/ifctester/test/fixtures/attribute_prohibited_empty_string/fail-description_empty_string.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T00:00:00',(''),(''),'IfcOpenShell 0.8.6','IfcOpenShell 0.8.6','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('08XCf5Gf1EsAang2u5CHXr',$,'Wall1','',$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/fixtures/attribute_prohibited_empty_string/pass-description_unset.ifc
+++ b/src/ifctester/test/fixtures/attribute_prohibited_empty_string/pass-description_unset.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T00:00:00',(''),(''),'IfcOpenShell 0.8.6','IfcOpenShell 0.8.6','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('08XCf5Gf1EsAang2u5CHXr',$,'Wall1',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/test_fixture_attribute_prohibited_empty_string.py
+++ b/src/ifctester/test/test_fixture_attribute_prohibited_empty_string.py
@@ -1,0 +1,55 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for a specific reported defect.
+
+buildingSMART/IDS attribute-facet.md states, for a PROHIBITED attribute
+requirement with no value given: "The attribute ... must not exist on
+applicable objects, even if empty." An attribute explicitly set to an
+empty string is still populated in the STEP file (as opposed to being
+left null), so it must fail the prohibition, not pass it silently.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "attribute_prohibited_empty_string")
+SPEC = os.path.join(FIXTURES, "attribute_prohibited_empty_string.ids")
+
+
+class TestAttributeProhibitedEmptyStringFixture:
+    def test_unset_description_passes_the_prohibition(self):
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "pass-description_unset.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is True
+        assert spec.requirements[0].status is True
+
+    def test_empty_string_description_fails_the_prohibition(self):
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "fail-description_empty_string.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+        assert spec.requirements[0].status is False


### PR DESCRIPTION
A `prohibited` attribute requirement silently passes when the attribute is present but empty.

The IDS documentation is explicit about this. `attribute-facet.md`, `property-facet.md` and `classification-facet.md` all use the same phrasing on their PROHIBITED rows: the attribute must not exist, **even if empty**.

## Cause

`Attribute.__call__` strips `None`, `""` and empty aggregates out into `non_empty_values` before deciding existence, then the prohibited branch reuses that same result:

```python
if self.cardinality == "prohibited":
    return AttributeResult(not is_pass, {"type": "PROHIBITED"})
```

That stripping is correct for REQUIRED and OPTIONAL, which define "populated" as not null. But it makes a present-but-empty attribute indistinguishable from a genuinely absent one, so inverting it turns a violation into a pass.

`Classification.__call__` does not pre-filter before its existence check (`is_pass = bool(references)`) and is already correct. It is the reference pattern here.

## Measured

| case | documented | before | after |
|---|---|---|---|
| prohibited, `Description` unset | pass | PASS | PASS |
| prohibited, `Description = ""` | **fail** | **PASS** | FAIL |
| prohibited, `LayerOn = UNKNOWN` | fail | **PASS** | FAIL |

The last row falls out for free: a LOGICAL `UNKNOWN` was being treated as absent by the same stripping.

## Scope

Deliberately limited to `Attribute`. `Property.__call__` has the identical pattern, but it is entangled with datatype and unit conversion handling, and its LOGICAL UNKNOWN behaviour is already claimed by #8161 from another contributor. Flagging it rather than touching it, so this stays a small reviewable change.

## Tests

Fixture directory `test/fixtures/attribute_prohibited_empty_string/` with an unset case and an empty-string case, and its own per-concern test file. Red before the fix (`assert True is False`), green after. Full ifctester suite 39/39.

Found while measuring [buildingSMART/IDS#402](https://github.com/buildingSMART/IDS/issues/402). Conflict-checked clean against #9203, #9205, #9250, #9261, #9263, #9268 and our PartOf recursion branch, with a control confirming the check detects real conflicts.

Produced with AI assistance.
