### PR TITLE
ifctester: two false passes in prohibited property checks

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import builtins
+import copy
 import re
 from functools import lru_cache
 from logging import Logger
@@ -700,6 +701,19 @@ class Property(Facet):
                 else:
                     raw_values = [v for k, v in pset_props.items() if k == self.baseName]
                 if any(v is not None for v in raw_values):
+                    return PropertyResult(False, {"type": "PROHIBITED"})
+            return PropertyResult(True, {"type": "PROHIBITED"})
+
+        if self.cardinality == "prohibited" and self.value:
+            # Each matching pset (there may be several when propertySet is a
+            # pattern) must be checked independently: reusing one shared
+            # pass flag let an earlier pset's absence or mismatch mask a
+            # later pset that actually held the prohibited value.
+            for pset_name in psets:
+                probe = copy.copy(self)
+                probe.propertySet = pset_name
+                probe.cardinality = "required"
+                if probe(inst, logger).is_pass:
                     return PropertyResult(False, {"type": "PROHIBITED"})
             return PropertyResult(True, {"type": "PROHIBITED"})
 

--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -691,6 +691,18 @@ class Property(Facet):
             all_psets = get_psets(inst)
             psets = {k: v for k, v in all_psets.items() if k == self.propertySet}
 
+        if self.cardinality == "prohibited" and not self.value:
+            # "Must not exist, even if empty": a present empty string still
+            # counts, only a genuinely unset (None) property is absent.
+            for pset_props in psets.values():
+                if isinstance(self.baseName, str):
+                    raw_values = [pset_props[self.baseName]] if self.baseName in pset_props else []
+                else:
+                    raw_values = [v for k, v in pset_props.items() if k == self.baseName]
+                if any(v is not None for v in raw_values):
+                    return PropertyResult(False, {"type": "PROHIBITED"})
+            return PropertyResult(True, {"type": "PROHIBITED"})
+
         is_pass = bool(psets)
         reason = None
 

--- a/src/ifctester/test/fixtures/property_prohibited_empty_string/fail-foo_empty_string.ifc
+++ b/src/ifctester/test/fixtures/property_prohibited_empty_string/fail-foo_empty_string.ifc
@@ -1,0 +1,14 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T00:00:00',(''),(''),'IfcOpenShell 0.8.6','IfcOpenShell 0.8.6','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('08XCf5Gf1EsAang2u5CHXr',$,'Wall1',$,$,$,$,$,$);
+#3=IFCPROPERTYSINGLEVALUE('Foo',$,IFCLABEL(''),$);
+#4=IFCPROPERTYSET('2HEubd_8H7owZECPqx6MYG',$,'Foo_Bar',$,(#3));
+#5=IFCRELDEFINESBYPROPERTIES('2Pa4HWxWr9ahtN4J8QCXoI',$,$,$,(#2),#4);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/fixtures/property_prohibited_empty_string/pass-foo_absent.ifc
+++ b/src/ifctester/test/fixtures/property_prohibited_empty_string/pass-foo_absent.ifc
@@ -1,0 +1,14 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T00:00:00',(''),(''),'IfcOpenShell 0.8.6','IfcOpenShell 0.8.6','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('08XCf5Gf1EsAang2u5CHXr',$,'Wall1',$,$,$,$,$,$);
+#3=IFCPROPERTYSINGLEVALUE('Bar',$,IFCLABEL('Baz'),$);
+#4=IFCPROPERTYSET('2HEubd_8H7owZECPqx6MYG',$,'Foo_Bar',$,(#3));
+#5=IFCRELDEFINESBYPROPERTIES('2Pa4HWxWr9ahtN4J8QCXoI',$,$,$,(#2),#4);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/fixtures/property_prohibited_empty_string/property_prohibited_empty_string.ids
+++ b/src/ifctester/test/fixtures/property_prohibited_empty_string/property_prohibited_empty_string.ids
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Prohibited Foo property</title>
+        <description>Foo must not exist in Foo_Bar, even if empty.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must not have a Foo property" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <property cardinality="prohibited">
+                    <propertySet>
+                        <simpleValue>Foo_Bar</simpleValue>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>Foo</simpleValue>
+                    </baseName>
+                </property>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/fixtures/property_prohibited_multi_pset/fail-second_pset_matches.ifc
+++ b/src/ifctester/test/fixtures/property_prohibited_multi_pset/fail-second_pset_matches.ifc
@@ -1,0 +1,16 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T00:00:00',(''),(''),'IfcOpenShell 0.8.6','IfcOpenShell 0.8.6','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('08XCf5Gf1EsAang2u5CHXr',$,'Wall1',$,$,$,$,$,$);
+#3=IFCPROPERTYSET('2HEubd_8H7owZECPqx6MYA',$,'Pset_A_NoFoo',$,());
+#4=IFCRELDEFINESBYPROPERTIES('2Pa4HWxWr9ahtN4J8QCXoA',$,$,$,(#2),#3);
+#5=IFCPROPERTYSINGLEVALUE('Foo',$,IFCLABEL('bar'),$);
+#6=IFCPROPERTYSET('2HEubd_8H7owZECPqx6MYB',$,'Pset_B_HasFoo',$,(#5));
+#7=IFCRELDEFINESBYPROPERTIES('2Pa4HWxWr9ahtN4J8QCXoB',$,$,$,(#2),#6);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/fixtures/property_prohibited_multi_pset/pass-no_pset_matches.ifc
+++ b/src/ifctester/test/fixtures/property_prohibited_multi_pset/pass-no_pset_matches.ifc
@@ -1,0 +1,16 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T00:00:00',(''),(''),'IfcOpenShell 0.8.6','IfcOpenShell 0.8.6','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1Fu_ePwY1DZxzRl9jojPIx',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('08XCf5Gf1EsAang2u5CHXr',$,'Wall1',$,$,$,$,$,$);
+#3=IFCPROPERTYSET('2HEubd_8H7owZECPqx6MYA',$,'Pset_A_NoFoo',$,());
+#4=IFCRELDEFINESBYPROPERTIES('2Pa4HWxWr9ahtN4J8QCXoA',$,$,$,(#2),#3);
+#5=IFCPROPERTYSINGLEVALUE('Foo',$,IFCLABEL('baz'),$);
+#6=IFCPROPERTYSET('2HEubd_8H7owZECPqx6MYB',$,'Pset_B_WrongVal',$,(#5));
+#7=IFCRELDEFINESBYPROPERTIES('2Pa4HWxWr9ahtN4J8QCXoB',$,$,$,(#2),#6);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/ifctester/test/fixtures/property_prohibited_multi_pset/property_prohibited_multi_pset.ids
+++ b/src/ifctester/test/fixtures/property_prohibited_multi_pset/property_prohibited_multi_pset.ids
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+    <info>
+        <title>Prohibited Foo=bar across pattern-matched property sets</title>
+        <description>No Pset_* property set may have Foo=bar.</description>
+    </info>
+    <specifications>
+        <specification name="Walls must not have Foo=bar in any Pset_* set" ifcVersion="IFC4">
+            <applicability minOccurs="0" maxOccurs="unbounded">
+                <entity>
+                    <name>
+                        <simpleValue>IFCWALL</simpleValue>
+                    </name>
+                </entity>
+            </applicability>
+            <requirements>
+                <property cardinality="prohibited">
+                    <propertySet>
+                        <xs:restriction base="xs:string">
+                            <xs:pattern value="Pset_.*"/>
+                        </xs:restriction>
+                    </propertySet>
+                    <baseName>
+                        <simpleValue>Foo</simpleValue>
+                    </baseName>
+                    <value>
+                        <simpleValue>bar</simpleValue>
+                    </value>
+                </property>
+            </requirements>
+        </specification>
+    </specifications>
+</ids>

--- a/src/ifctester/test/test_fixture_property_prohibited_empty_string.py
+++ b/src/ifctester/test/test_fixture_property_prohibited_empty_string.py
@@ -1,0 +1,84 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for a specific reported defect.
+
+buildingSMART/IDS property-facet.md states, for a PROHIBITED property
+requirement with no value given, that the property "must not exist ...
+even if empty." A property explicitly set to an empty string is still
+populated in the STEP file (as opposed to the baseName being absent from
+the pset entirely), so it must fail the prohibition, not pass it silently.
+
+This mirrors the sibling defect fixed for Attribute.__call__: the same
+existence-before-emptiness ordering is applied here for Property.__call__,
+without touching how REQUIRED and OPTIONAL treat an empty value (they
+intentionally treat it as not populated, unlike PROHIBITED).
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+from ifctester.facet import Property
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "property_prohibited_empty_string")
+SPEC = os.path.join(FIXTURES, "property_prohibited_empty_string.ids")
+
+
+class TestPropertyProhibitedEmptyStringFixture:
+    def test_absent_foo_property_passes_the_prohibition(self):
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "pass-foo_absent.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is True
+        assert spec.requirements[0].status is True
+
+    def test_empty_string_foo_property_fails_the_prohibition(self):
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "fail-foo_empty_string.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+        assert spec.requirements[0].status is False
+
+    def test_required_cardinality_still_treats_empty_string_as_no_value(self):
+        # REQUIRED and OPTIONAL legitimately treat an empty value as not
+        # populated, unlike PROHIBITED. This must stay unchanged.
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "fail-foo_empty_string.ifc"))
+        wall = ifc.by_type("IfcWall")[0]
+
+        required_facet = Property(propertySet="Foo_Bar", baseName="Foo", cardinality="required")
+        result = required_facet(wall)
+        assert result.is_pass is False
+
+    def test_optional_cardinality_still_passes_regardless_of_emptiness(self):
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "fail-foo_empty_string.ifc"))
+        wall = ifc.by_type("IfcWall")[0]
+
+        optional_facet = Property(propertySet="Foo_Bar", baseName="Foo", cardinality="optional")
+        result = optional_facet(wall)
+        assert result.is_pass is True
+
+        ifc_absent = ifcopenshell.open(os.path.join(FIXTURES, "pass-foo_absent.ifc"))
+        wall_absent = ifc_absent.by_type("IfcWall")[0]
+        result_absent = optional_facet(wall_absent)
+        assert result_absent.is_pass is True

--- a/src/ifctester/test/test_fixture_property_prohibited_multi_pset.py
+++ b/src/ifctester/test/test_fixture_property_prohibited_multi_pset.py
@@ -1,0 +1,58 @@
+# IfcTester - IDS based model auditing
+# Copyright (C) 2021-2022 Thomas Krijnen <thomas@aecgeeks.com>, Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of IfcTester.
+#
+# IfcTester is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcTester is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcTester.  If not, see <http://www.gnu.org/licenses/>.
+
+# This file was generated with the assistance of an AI coding tool.
+
+"""End-to-end regression tests for a specific reported defect.
+
+A prohibited Property requirement with a pattern-matched propertySet (e.g.
+propertySet matching several "Pset_*" sets) evaluated its matching sets with
+a single shared is_pass accumulator. An earlier set that lacked the property,
+or had a non-matching value, permanently set is_pass to False; a later set
+that actually held the prohibited value could then never flip the verdict
+back, because a value match only left is_pass unchanged rather than setting
+it. The requirement silently passed even though one of the matched sets held
+exactly the prohibited value.
+"""
+
+import os
+
+import ifcopenshell
+
+from ifctester import ids
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "property_prohibited_multi_pset")
+SPEC = os.path.join(FIXTURES, "property_prohibited_multi_pset.ids")
+
+
+class TestPropertyProhibitedMultiPsetFixture:
+    def test_no_matching_pset_has_the_value_passes_the_prohibition(self):
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "pass-no_pset_matches.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is True
+        assert spec.requirements[0].status is True
+
+    def test_a_later_matching_pset_with_the_value_fails_the_prohibition(self):
+        specs = ids.open(SPEC)
+        ifc = ifcopenshell.open(os.path.join(FIXTURES, "fail-second_pset_matches.ifc"))
+        specs.validate(ifc)
+        spec = specs.specifications[0]
+        assert spec.status is False
+        assert spec.requirements[0].status is False


### PR DESCRIPTION
Two distinct false passes in `Property.__call__`'s prohibited branch. Both let a violation report as compliant, which is the worst direction for a checker to be wrong in, since nothing prompts anyone to look again.

## 1. Present but empty looks absent

`Property.__call__` filters empty string values out before deciding whether the property exists:

```python
elif prop is not None and prop != "":
    props[pset_name][self.baseName] = prop
```

then the prohibited branch reuses that filtered result. So a property that is present but empty looks absent, and a `prohibited` requirement silently passes.

`property-facet.md` is explicit that a prohibited property must not exist **even if empty**. That filtering is correct for REQUIRED and OPTIONAL, which legitimately treat empty as not populated, and reusing it for prohibited is what inverts a violation into a pass.

This is the `Property` sibling of #9273, which fixed the same shape in `Attribute`.

## 2. Cross-pset masking when a value is required

A separate bug in the same branch, only when `value` is set. With a pattern `propertySet` matching several psets, the loop shared one `is_pass` accumulator across all of them. An earlier pset lacking the property, or holding a mismatching value, drove `is_pass` to False permanently. A later pset holding exactly the prohibited value never flipped it back, because a value match only left `is_pass` unchanged rather than setting it.

**Proven distinct rather than a restatement**: tested against this PR's own previous head, with the fix for defect 1 already in place, and it still failed identically.

Fixed by checking each matching pset independently, split cleanly on whether `self.value` is set, so the two guards together cover every prohibited case before the shared loop runs. It reuses the existing single-pset value, dataType and unit matching by probing a shallow copy rather than duplicating that logic, which leaves the main loop untouched.

## Sibling sweep

Every facet with a cardinality branch, not just this one:

| facet | existence check | affected |
|---|---|---|
| `Attribute` | filtered before check | yes, fixed in #9273 |
| `Property` | filtered before check | yes, this PR |
| `Classification` | `bool(references)`, no filtering | no, already correct |
| `PartOf` | `is not None` on relationship objects | no |
| `Material` | `is not None` from `get_material` | no |
| `Entity` | class name match, no value concept | not applicable |

`Classification` is the reference pattern: existence is checked before any filtering.

## Overlap with other open PRs

* **#8161** by @gernotluidolt: no overlap. It changes a line inside the block these guards return before.
* **#9190**: no textual conflict, but related. It fixes the same "shared accumulator masks per-pset truth" class in the `optional` branch's escape hatch. Whoever merges should know they are sibling fixes to the same method.
* **#9250**: no conflict, its change is inside the `IfcPropertyBoundedValue` handling further down.
* Clean against #9059, #9203, #9205, #9261, #9263, #9268, #9272, #9273, with a control pair confirming the check detects real conflicts.

## Tests

Two fixture directories, `property_prohibited_empty_string/` and `property_prohibited_multi_pset/`, each with its own test file. `test_facet.py` deliberately untouched, since several of our other open ifctester PRs already modify it.

Red before each fix, failing for the right reason in both cases:

```
test_empty_string_foo_property_fails_the_prohibition FAILED
E       assert True is False

test_a_later_matching_pset_with_the_value_fails_the_prohibition FAILED
E       assert True is False
```

Green after. Full ifctester suite 43/43.

Produced with AI assistance.
