### PR TITLE
Fixed error within the util/unit.py module in convert_file_length_units

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -962,7 +962,7 @@ def convert_file_length_units(ifc_file: ifcopenshell.file, target_units: str = "
         )
 
     unit_assignment = get_unit_assignment(file_patched)
-    unit_assignment.Units = [new_length, *(u for u in unit_assignment.Units if u.UnitType != new_length.UnitType)]
+    unit_assignment.Units = [new_length, *(u for u in unit_assignment.Units if getattr(u, 'UnitType', None) != new_length.UnitType)]
     if not file_patched.get_total_inverses(old_length):
         ifcopenshell.util.element.remove_deep2(file_patched, old_length)
 

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -962,6 +962,7 @@ def convert_file_length_units(ifc_file: ifcopenshell.file, target_units: str = "
         )
 
     unit_assignment = get_unit_assignment(file_patched)
+    # UnitType not available on IfcMonetaryUnit
     unit_assignment.Units = [new_length, *(u for u in unit_assignment.Units if getattr(u, 'UnitType', None) != new_length.UnitType)]
     if not file_patched.get_total_inverses(old_length):
         ifcopenshell.util.element.remove_deep2(file_patched, old_length)


### PR DESCRIPTION
**The Bug**
When calling _ifcopenshell.util.unit.convert_file_length_units_, the function crashes with an _AttributeError_ if the model contains an _IfcMonetaryUnit_. Because _IfcMonetaryUnit_ does not inherit the _UnitType_ attribute, the list comprehension evaluating _u.UnitType != new_length.UnitType_ fails. This exception arises in both IFC2X3 and IFC4.

**The Fix**
I implemented a minimalist change using _getattr(u, 'UnitType', None)_ within the list comprehension. This safely bypasses units that lack the _UnitType_ attribute, allowing the conversion method to execute successfully across all schemas without altering the core logic.