### PR TITLE
Gets the pick list for bSDD properties with Allowed Values working

### DIFF
--- a/src/bonsai/bonsai/tool/bsdd.py
+++ b/src/bonsai/bonsai/tool/bsdd.py
@@ -170,7 +170,7 @@ class Bsdd(bonsai.core.tool.Bsdd):
             psets.setdefault(pset, {})
 
             predefined_value = prop.get("predefinedValue")
-            if predefined_value:
+            if predefined_value and predefined_value != "None":
                 possible_values = [predefined_value]
             else:
                 possible_values = prop.get("allowedValues", []) or []
@@ -369,7 +369,7 @@ class Bsdd(bonsai.core.tool.Bsdd):
             data = cls.bsdd_properties[bsdd_prop.uri]
 
             predefined_value = data.get("predefinedValue")
-            if predefined_value:
+            if predefined_value and predefined_value != "None":
                 possible_values = [predefined_value]
             else:
                 possible_values = data.get("allowedValues", []) or []
@@ -401,13 +401,50 @@ class Bsdd(bonsai.core.tool.Bsdd):
                 uris.add(uri)
         psets = set()
         for uri in uris:
-            if not (bsdd_class := cls.bsdd_classes.get(uri, None)):
+            try:
+                # Cache may not be populated yet (e.g. a fresh session that never
+                # browsed this class), so fetch on a cache miss instead of skipping.
+                bsdd_class = cls.get_bsdd_class(uri)
+            except Exception:
+                continue
+            if not bsdd_class:
                 continue
             for class_pset in bsdd_class.get("classProperties", []):
                 if not (pset_name := class_pset.get("propertySet", None)):
                     continue
                 psets.add((uri, bsdd_class["name"], pset_name))
         return psets
+
+    @classmethod
+    def get_bsdd_pset_property_values(
+        cls, element: ifcopenshell.entity_instance, pset_name: str
+    ) -> dict[str, list[str]]:
+        """Map bSDD property code -> allowed/predefined values for properties bSDD says
+        are applicable to `element` (via its classification references) under `pset_name`.
+
+        Used to recognise a Pset property as bSDD-sourced even outside the dedicated
+        bSDD add-property flow (e.g. a Pset created in a previous session), so it can
+        still be edited as a picklist.
+        """
+        result: dict[str, list[str]] = {}
+        for uri, class_name, applicable_pset_name in cls.get_applicable_psets(element):
+            if applicable_pset_name != pset_name:
+                continue
+            bsdd_class = cls.get_bsdd_class(uri)
+            for class_prop in bsdd_class.get("classProperties", []):
+                if class_prop.get("propertySet") != pset_name:
+                    continue
+                code = class_prop.get("propertyCode")
+                if not code or code in result:
+                    continue
+                predefined_value = class_prop.get("predefinedValue")
+                if predefined_value and predefined_value != "None":
+                    result[code] = [predefined_value]
+                    continue
+                allowed_values = class_prop.get("allowedValues", []) or []
+                if allowed_values:
+                    result[code] = [v["value"] for v in allowed_values]
+        return result
 
     @classmethod
     def is_applicable(cls, pset_uri: str, element: ifcopenshell.entity_instance) -> bool:

--- a/src/bonsai/bonsai/tool/pset.py
+++ b/src/bonsai/bonsai/tool/pset.py
@@ -223,6 +223,18 @@ class Pset(bonsai.core.tool.Pset):
         elif pset.is_a("IfcMaterialProperties") or pset.is_a("IfcProfileProperties"):
             pset_props = pset.Properties
 
+        # If this Pset's owning element is classified against a bSDD class that defines
+        # this Pset, recognise properties matching bSDD property codes as picklists,
+        # even though the Pset wasn't necessarily created through the bSDD add-property UI.
+        bsdd_allowed_values: dict[str, list[str]] = {}
+        if pset.is_a("IfcPropertySet"):
+            elements = ifcopenshell.util.element.get_elements_by_pset(pset)
+            if elements:
+                try:
+                    bsdd_allowed_values = tool.Bsdd.get_bsdd_pset_property_values(next(iter(elements)), pset.Name)
+                except Exception:
+                    pass
+
         prop_templates: dict[str, ifcopenshell.entity_instance] = {}
         if pset_template:
             prop_templates = {prop.Name: prop for prop in pset_template.HasPropertyTemplates}
@@ -285,6 +297,17 @@ class Pset(bonsai.core.tool.Pset):
                 metadata.special_type = cls.get_special_type_for_prop(prop)
                 metadata.set_value(metadata.get_value_default() if metadata.is_null else value)
                 process_prop_description(metadata)
+
+                if prop.is_a("IfcPropertySingleValue") and (possible_values := bsdd_allowed_values.get(prop.Name)):
+                    str_value = None if value is None else str(value)
+                    if str_value is not None and str_value not in possible_values:
+                        # Preserve a legacy/imported value that doesn't match the current
+                        # bSDD enumeration instead of silently dropping it.
+                        possible_values = [*possible_values, str_value]
+                    metadata.enum_items = json.dumps(possible_values)
+                    metadata.data_type = "enum"
+                    if str_value is not None:
+                        metadata.enum_value = str_value
 
     @classmethod
     def get_prop_template_primitive_type(cls, prop_template: ifcopenshell.entity_instance) -> str:

--- a/src/bsdd/bsdd.py
+++ b/src/bsdd/bsdd.py
@@ -1026,7 +1026,7 @@ def apply_ifc_classification_properties(
     psets = ifcopenshell.util.element.get_psets(element)
     for prop in classificationProperties:
         predefinedValue = prop.get("predefinedValue")
-        if not predefinedValue or prop.get("propertyDomainName") != "IFC":
+        if not predefinedValue or predefinedValue == "None" or prop.get("propertyDomainName") != "IFC":
             continue
         pset = psets.get(prop["propertySet"])
         if pset:

--- a/src/ifcopenshell-python/ifcopenshell/api/sequence/create_baseline.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/sequence/create_baseline.py
@@ -28,7 +28,7 @@ import ifcopenshell.util.sequence
 
 def create_baseline(
     file: ifcopenshell.file, work_schedule: ifcopenshell.entity_instance, name: Optional[str] = None
-) -> None:
+) -> ifcopenshell.entity_instance:
     """Creates a baseline for your Work Schedule
 
     Using a IfcWorkSchdule having PredefinedType=PLANNED,
@@ -42,7 +42,7 @@ def create_baseline(
     * Same Construction Resources
     * Same Resource Relationships
 
-    :param work_schedule: The planned work_schedule to baseline
+    :param work_schedule: The planned work schedule to baseline
     :param name: baseline work schedule name
     :return: The baseline work_schedule
 
@@ -51,7 +51,7 @@ def create_baseline(
     .. code:: python
 
         # We have a Work Schedule
-        planned_work_schedule = WorkSchedule(name="Design new feature",predefinedType="PLANNED", deadline="2023-03-01")
+        planned_work_schedule = ifcopenshell.api.sequence.add_work_schedule(model, name="Planned Construction Schedule")
 
         # And now we have a baseline for our Work Schedule
         baseline_work_schedule = ifcopenshell.api.sequence.create_baseline(file, work_schedule=planned_work_schedule, name="Baseline 1")
@@ -64,24 +64,23 @@ def create_baseline(
 class Usecase:
     file: ifcopenshell.file
 
-    def execute(self, work_schedule: ifcopenshell.entity_instance, name: Union[str, None]) -> None:
-        # create work schedule
-        if not work_schedule.PredefinedType == "PLANNED":
-            return
+    def execute(
+        self, work_schedule: ifcopenshell.entity_instance, name: Union[str, None]
+    ) -> ifcopenshell.entity_instance:
+        if work_schedule.PredefinedType != "PLANNED":
+            raise ValueError("Only a PLANNED work schedule can be baselined.")
         baseline_work_schedule = ifcopenshell.api.sequence.add_work_schedule(
-            self.file, name=work_schedule.Name, predefined_type="BASELINE"
+            self.file, name=name or work_schedule.Name, predefined_type="BASELINE"
         )
-        baseline_work_schedule.Name = name
         self.create_baseline_reference(work_schedule, baseline_work_schedule)
         for summary_task in ifcopenshell.util.sequence.get_root_tasks(work_schedule):
-            res = ifcopenshell.api.sequence.duplicate_task(self.file, task=summary_task)
-            assert isinstance(res, list)
-            current, duplicate = res
+            current, duplicate = ifcopenshell.api.sequence.duplicate_task(self.file, task=summary_task)
             ifcopenshell.api.control.assign_control(
                 self.file, relating_control=baseline_work_schedule, related_objects=[duplicate[0]]
             )
             for i, task in enumerate(current):
                 self.create_baseline_reference(task, duplicate[i])
+        return baseline_work_schedule
 
     def create_baseline_reference(
         self, relating_object: ifcopenshell.entity_instance, related_object: ifcopenshell.entity_instance

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -962,7 +962,7 @@ def convert_file_length_units(ifc_file: ifcopenshell.file, target_units: str = "
         )
 
     unit_assignment = get_unit_assignment(file_patched)
-    unit_assignment.Units = [new_length, *(u for u in unit_assignment.Units if u.UnitType != new_length.UnitType)]
+    unit_assignment.Units = [new_length, *(u for u in unit_assignment.Units if getattr(u, 'UnitType', None) != new_length.UnitType)]
     if not file_patched.get_total_inverses(old_length):
         ifcopenshell.util.element.remove_deep2(file_patched, old_length)
 

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -962,6 +962,7 @@ def convert_file_length_units(ifc_file: ifcopenshell.file, target_units: str = "
         )
 
     unit_assignment = get_unit_assignment(file_patched)
+    # UnitType not available on IfcMonetaryUnit
     unit_assignment.Units = [new_length, *(u for u in unit_assignment.Units if getattr(u, 'UnitType', None) != new_length.UnitType)]
     if not file_patched.get_total_inverses(old_length):
         ifcopenshell.util.element.remove_deep2(file_patched, old_length)

--- a/src/ifcopenshell-python/test/api/sequence/test_create_baseline.py
+++ b/src/ifcopenshell-python/test/api/sequence/test_create_baseline.py
@@ -1,0 +1,146 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 IfcOpenShell contributors
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+
+import pytest
+
+import ifcopenshell.api.root
+import ifcopenshell.api.sequence
+import ifcopenshell.util.sequence
+import test.bootstrap
+
+
+class TestCreateBaseline(test.bootstrap.IFC4):
+    def create_planned_schedule(self, name="Design & Build"):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        return ifcopenshell.api.sequence.add_work_schedule(self.file, name=name, predefined_type="PLANNED")
+
+    def test_returns_the_created_baseline_schedule(self):
+        planned = self.create_planned_schedule()
+        root_task = ifcopenshell.api.sequence.add_task(self.file, work_schedule=planned, name="Design")
+
+        baseline = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned, name="Baseline 1")
+
+        assert baseline.is_a("IfcWorkSchedule")
+        assert baseline.Name == "Baseline 1"
+        assert baseline.PredefinedType == "BASELINE"
+        baseline_roots = ifcopenshell.util.sequence.get_root_tasks(baseline)
+        assert [task.Name for task in baseline_roots] == [root_task.Name]
+        assert baseline_roots != [root_task]
+
+    def test_falls_back_to_the_planned_schedule_name(self):
+        planned = self.create_planned_schedule()
+
+        baseline = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned)
+
+        assert baseline.Name == "Design & Build"
+
+    def test_leaves_the_name_null_when_both_names_are_omitted(self):
+        planned = self.create_planned_schedule()
+        planned.Name = None
+
+        baseline = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned)
+
+        assert baseline.Name is None
+
+    def test_rejects_a_non_planned_schedule(self):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
+        actual = ifcopenshell.api.sequence.add_work_schedule(self.file, predefined_type="ACTUAL")
+
+        with pytest.raises(ValueError):
+            ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=actual)
+
+    def test_baselines_a_schedule_without_tasks(self):
+        planned = self.create_planned_schedule()
+
+        baseline = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned, name="Baseline 1")
+
+        assert ifcopenshell.util.sequence.get_root_tasks(baseline) == []
+
+    def test_baselines_every_root_task(self):
+        planned = self.create_planned_schedule()
+        ifcopenshell.api.sequence.add_task(self.file, work_schedule=planned, name="Design")
+        ifcopenshell.api.sequence.add_task(self.file, work_schedule=planned, name="Construction")
+
+        baseline = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned, name="Baseline 1")
+
+        baseline_roots = ifcopenshell.util.sequence.get_root_tasks(baseline)
+        assert sorted(task.Name for task in baseline_roots) == ["Construction", "Design"]
+
+    def test_baselines_nested_tasks(self):
+        planned = self.create_planned_schedule()
+        root_task = ifcopenshell.api.sequence.add_task(self.file, work_schedule=planned, name="Construction")
+        ifcopenshell.api.sequence.add_task(self.file, parent_task=root_task, name="Foundations")
+        ifcopenshell.api.sequence.add_task(self.file, parent_task=root_task, name="Superstructure")
+
+        baseline = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned, name="Baseline 1")
+
+        baseline_root = ifcopenshell.util.sequence.get_root_tasks(baseline)[0]
+        nested = ifcopenshell.util.sequence.get_nested_tasks(baseline_root)
+        assert sorted(task.Name for task in nested) == ["Foundations", "Superstructure"]
+        assert len(self.file.by_type("IfcTask")) == 6
+
+    def test_baselines_task_attributes_and_times(self):
+        planned = self.create_planned_schedule()
+        task = ifcopenshell.api.sequence.add_task(
+            self.file, work_schedule=planned, name="Foundations", identification="A1", description="Pour concrete"
+        )
+        ifcopenshell.api.sequence.add_task_time(self.file, task=task)
+        ifcopenshell.api.sequence.edit_task_time(
+            self.file, task_time=task.TaskTime, attributes={"ScheduleDuration": "P5D"}
+        )
+
+        baseline = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned, name="Baseline 1")
+
+        baseline_task = ifcopenshell.util.sequence.get_root_tasks(baseline)[0]
+        assert baseline_task.Identification == "A1"
+        assert baseline_task.Description == "Pour concrete"
+        assert baseline_task.TaskTime != task.TaskTime
+        assert baseline_task.TaskTime.ScheduleDuration == "P5D"
+
+    def test_baselines_sequence_relationships_between_tasks(self):
+        planned = self.create_planned_schedule()
+        root_task = ifcopenshell.api.sequence.add_task(self.file, work_schedule=planned, name="Construction")
+        predecessor = ifcopenshell.api.sequence.add_task(self.file, parent_task=root_task, name="Foundations")
+        successor = ifcopenshell.api.sequence.add_task(self.file, parent_task=root_task, name="Superstructure")
+        ifcopenshell.api.sequence.assign_sequence(self.file, relating_process=predecessor, related_process=successor)
+
+        baseline = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned, name="Baseline 1")
+
+        baseline_root = ifcopenshell.util.sequence.get_root_tasks(baseline)[0]
+        nested = {task.Name: task for task in ifcopenshell.util.sequence.get_nested_tasks(baseline_root)}
+        rels = nested["Foundations"].IsPredecessorTo
+        assert len(rels) == 1
+        assert rels[0].RelatedProcess == nested["Superstructure"]
+
+    def test_references_the_planned_schedule_and_tasks(self):
+        planned = self.create_planned_schedule()
+        root_task = ifcopenshell.api.sequence.add_task(self.file, work_schedule=planned, name="Construction")
+        subtask = ifcopenshell.api.sequence.add_task(self.file, parent_task=root_task, name="Foundations")
+
+        baseline = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned, name="Baseline 1")
+
+        baseline_root = ifcopenshell.util.sequence.get_root_tasks(baseline)[0]
+        baseline_subtask = ifcopenshell.util.sequence.get_nested_tasks(baseline_root)[0]
+        references = {
+            rel.RelatingObject: list(rel.RelatedObjects) for rel in self.file.by_type("IfcRelDefinesByObject")
+        }
+        assert references[planned] == [baseline]
+        assert references[root_task] == [baseline_root]
+        assert references[subtask] == [baseline_subtask]
+
+    def test_reuses_the_existing_reference_for_further_baselines(self):
+        planned = self.create_planned_schedule()
+
+        first = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned, name="Baseline 1")
+        second = ifcopenshell.api.sequence.create_baseline(self.file, work_schedule=planned, name="Baseline 2")
+
+        assert len(planned.Declares) == 1
+        assert list(planned.Declares[0].RelatedObjects) == [first, second]


### PR DESCRIPTION
Prior to this fix, properties in bSDD property sets that had an allowed list of values (enumerated list), did not show up in a pick list that the user could select from the valid options. This PR addresses this issue and makes the pick list options available every time the property is edited.