### PR TITLE
ifcgeom: IfcProjectLibrary breaks unit detection (#9294)

### DIFF
--- a/src/ifcgeom/mapping/mapping.cpp
+++ b/src/ifcgeom/mapping/mapping.cpp
@@ -823,18 +823,47 @@ void mapping::initialize_units_() {
     angle_unit_ = -1.;
     length_unit_name_ = "METER";
     
+    IfcSchema::IfcUnitAssignment* unit_assignment = nullptr;
+
 #ifdef SCHEMA_HAS_IfcContext
-    auto projects = file_->instances_by_type<IfcSchema::IfcContext>();
+    // IfcProjectLibrary is also an IfcContext, so a file with a project and one
+    // or more libraries legitimately has more than one IfcContext instance.
+    // Prefer the unique IfcProject, then fall back to a unique IfcContext (this
+    // is what makes library-only files resolve), then to a context that is the
+    // only one carrying units.
+    auto ifc_projects = file_->instances_by_type<IfcSchema::IfcProject>();
+    if (ifc_projects->size() == 1) {
+        unit_assignment = (*ifc_projects->begin())->UnitsInContext();
+    } else {
+        auto contexts = file_->instances_by_type<IfcSchema::IfcContext>();
+        if (contexts->size() == 1) {
+            unit_assignment = (*contexts->begin())->UnitsInContext();
+        } else {
+            IfcSchema::IfcContext* context_with_units = nullptr;
+            for (auto it = contexts->begin(); it != contexts->end(); ++it) {
+                if ((*it)->UnitsInContext() != nullptr) {
+                    if (context_with_units != nullptr) {
+                        context_with_units = nullptr;
+                        break;
+                    }
+                    context_with_units = *it;
+                }
+            }
+            if (context_with_units != nullptr) {
+                unit_assignment = context_with_units->UnitsInContext();
+            } else {
+                logger_.Warning("GEO", 308, "Not a single project or context in file");
+            }
+        }
+    }
 #else
     auto projects = file_->instances_by_type<IfcSchema::IfcProject>();
-#endif
-    IfcSchema::IfcUnitAssignment* unit_assignment = nullptr;
     if (projects->size() == 1) {
-        auto* project = *projects->begin();
-        unit_assignment = project->UnitsInContext();
+        unit_assignment = (*projects->begin())->UnitsInContext();
     } else {
         logger_.Warning("GEO", 308, "Not a single project or context in file");
     }
+#endif
     if (unit_assignment == nullptr) {
         logger_.Warning("GEO", 309, "Unable to detect unit information");
         return;

--- a/src/ifcopenshell-python/test/test_create_shape.py
+++ b/src/ifcopenshell-python/test/test_create_shape.py
@@ -9,11 +9,13 @@ import pytest
 
 import ifcopenshell
 import ifcopenshell.api.context
+import ifcopenshell.api.geometry
 import ifcopenshell.api.owner.settings
 import ifcopenshell.api.project
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
 import ifcopenshell.geom
+import ifcopenshell.guid
 import ifcopenshell.ifcopenshell_wrapper as W
 import ifcopenshell.util.shape
 import test.bootstrap
@@ -192,6 +194,68 @@ class TestAssignObject:
 
         # even though there are only 12 unique vertices as the cubes are touching
         assert len(set(vs)) == 12
+
+
+class TestUnitsWithProjectLibrary(test.bootstrap.IFC4X3):
+    """https://github.com/IfcOpenShell/IfcOpenShell/issues/9294
+
+    IfcProjectLibrary is also an IfcContext, so a file with a project and a
+    library legitimately has more than one IfcContext instance. The geometry
+    kernel used to require exactly one IfcContext to resolve units, so any
+    such file silently lost unit detection and read every length 1000x too
+    large for a millimetre project.
+    """
+
+    def build(self, library=None):
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject", name="P")
+        mm = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="LENGTHUNIT", prefix="MILLI")
+        ifcopenshell.api.unit.assign_unit(self.file, units=[mm])
+        parent = ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        body = ifcopenshell.api.context.add_context(
+            self.file,
+            context_type="Model",
+            context_identifier="Body",
+            target_view="MODEL_VIEW",
+            parent=parent,
+        )
+        wall = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall", name="W")
+        representation = ifcopenshell.api.geometry.add_wall_representation(
+            self.file, context=body, length=5.0, height=3.0, thickness=0.2
+        )
+        ifcopenshell.api.geometry.assign_representation(self.file, product=wall, representation=representation)
+
+        project = self.file.by_type("IfcProject")[0]
+        if library == "bare":
+            self.file.create_entity("IfcProjectLibrary", GlobalId=ifcopenshell.guid.new())
+        elif library == "shares_units":
+            self.file.create_entity(
+                "IfcProjectLibrary",
+                GlobalId=ifcopenshell.guid.new(),
+                UnitsInContext=project.UnitsInContext,
+            )
+        return wall
+
+    def wall_x_extent(self, wall):
+        settings = ifcopenshell.geom.settings()
+        iterator = ifcopenshell.geom.iterator(settings, self.file, include=[wall])
+        assert iterator.initialize()
+        shape = iterator.get()
+        xs = shape.geometry.verts[0::3]
+        return max(xs) - min(xs)
+
+    def test_no_library(self):
+        wall = self.build(library=None)
+        assert self.wall_x_extent(wall) == pytest.approx(5.0)
+
+    def test_bare_library(self):
+        wall = self.build(library="bare")
+        assert len(self.file.by_type("IfcContext")) == 2
+        assert self.wall_x_extent(wall) == pytest.approx(5.0)
+
+    def test_library_sharing_units(self):
+        wall = self.build(library="shares_units")
+        assert len(self.file.by_type("IfcContext")) == 2
+        assert self.wall_x_extent(wall) == pytest.approx(5.0)
 
 
 def test_iterator():


### PR DESCRIPTION
Fixes #9294.

## The bug

`mapping::initialize_units_()` resolves the file's length unit by requiring **exactly one `IfcContext`**:

```cpp
auto projects = file_->instances_by_type<IfcSchema::IfcContext>();
...
if (projects->size() == 1) { ... } else { warn }
```

`instances_by_type` includes subtypes, and `IfcProjectLibrary` is an `IfcContext`. So any file where a project declares a library, which is what the class exists for, has two instances, takes the else branch, and loses unit detection entirely.

Both consequences are silent:

- **Wrong scale.** The length unit falls back to 1.0, so a millimetre model comes out of the iterator 1000 times too large.
- **Slow shape creation.** @joepaddock-uk measured 0.42 s to 57.42 s on a real 1846-product model differing by two entities. I have not reproduced that timing myself, so it is reported rather than confirmed here; the scale defect below is measured.

The Python side is unaffected, since `ifcopenshell.util.unit.calculate_unit_scale` resolves through `by_type("IfcProject")[0]`. So the two halves of the library currently disagree on the same file.

## The fix

Prefer the unique `IfcProject`; fall back to a unique `IfcContext`; then to a context that is the only one carrying units; otherwise warn as before.

Backward compatible: every file that resolves today resolves to the same context afterwards. The second branch is load-bearing and I verified it explicitly, since it is what keeps library-only files working:

```
only context = IfcProject          wall x-extent = 5.0   units READ
only context = IfcProjectLibrary   wall x-extent = 5.0   units READ
```

Both hold before and after the change. The `#ifdef SCHEMA_HAS_IfcContext` structure and the IFC2X3 path are unchanged.

## Verification

Built the C++ through `docker/ifcos_env` and ran the reporter's self-contained reproduction against both an unpatched and a patched build.

Before:

```
IfcProjectLibrary  IfcContext    wall length   expected 5.0
none                        1            5.0
bare                        2         5000.0
shares units                2         5000.0
shares contexts             2         5000.0
own units                   2         5000.0
```

After:

```
none                        1            5.0
bare                        2            5.0
shares units                2            5.0
shares contexts             2            5.0
own units                   2            5.0
```

## Tests

`TestUnitsWithProjectLibrary` in `src/ifcopenshell-python/test/test_create_shape.py`, following the existing `test_iterator` pattern in that file.

- Red on the unpatched build: 2 failed, 1 passed, both library variants returning 5000.0
- Green on the patched build: 11 passed across the file, no regressions

Produced with AI assistance.
