### PR TITLE
ifcdiff: six silent under-reporting defects

### DIFF
--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -41,7 +41,17 @@ from orderly_set import StableSet
 __version__ = version = "0.0.0"
 
 
-RELATIONSHIP_TYPE = Literal["geometry", "attributes", "type", "property", "container", "aggregate", "classification"]
+RELATIONSHIP_TYPE = Literal[
+    "geometry",
+    "attributes",
+    "type",
+    "property",
+    "container",
+    "aggregate",
+    "classification",
+    "material",
+    "placement",
+]
 
 
 class IfcDiff:
@@ -162,7 +172,7 @@ class IfcDiff:
                     continue
             if should_check_geometry:
                 # Option 1: check everything heuristically using the iterator (seems faster)
-                if ifcopenshell.util.representation.get_representation(new, "Model", "Body", "MODEL_VIEW"):
+                if self.has_body_representation(new):
                     potential_old_changes.append(old)
                     potential_new_changes.append(new)
                 # Option 2: check first using Python, then fallback to iterator (twice as slow)
@@ -190,7 +200,7 @@ class IfcDiff:
                 del new_shapes[global_id]
                 diff = DeepDiff(old_shape, new_shape, math_epsilon=1e-5)
                 if diff:
-                    self.change_register.setdefault(global_id, {}).update({"geometry_changed": True})
+                    self.change_register.setdefault(global_id, {}).update({"geometry_changed": diff})
                     continue
 
             for global_id in new_shapes.keys():
@@ -199,6 +209,25 @@ class IfcDiff:
         print(" - {} item(s) were changed".format(len(self.change_register.keys())))
 
         logging.disable(logging.NOTSET)
+
+    def has_body_representation(self, element: ifcopenshell.entity_instance) -> bool:
+        # Mirrors get_settings()'s body_contexts fallback: some BIM programs
+        # (e.g. the INFRA sample in #7392-style diffs) put Body items directly
+        # under IfcGeometricRepresentationContext without a MODEL_VIEW
+        # subcontext, so a strict get_representation(..., "MODEL_VIEW") match
+        # would silently skip them.
+        representation = getattr(element, "Representation", None)
+        if not representation:
+            return False
+        for r in representation.Representations:
+            if r.RepresentationIdentifier not in ("Body", "Facetation"):
+                continue
+            context = r.ContextOfItems
+            if context.is_a("IfcGeometricRepresentationSubContext"):
+                return True
+            if context.is_a("IfcGeometricRepresentationContext") and context.ContextType == "Model":
+                return True
+        return False
 
     def summarise_shapes(
         self, ifc: ifcopenshell.file, elements: list[ifcopenshell.entity_instance]
@@ -280,33 +309,74 @@ class IfcDiff:
             return contexts[0].Precision or 1e-4
         return 1e-4
 
+    def get_comparable_attributes(self, element: ifcopenshell.entity_instance) -> dict[str, Any]:
+        # "id" is the STEP entity number, which shifts on every re-save. "type"
+        # duplicates is_a(), which is separately reported as class_changed.
+        # OwnerHistory and other entity-valued/list attributes change on every
+        # save and aren't meaningfully diffable by value, so they're excluded.
+        return {
+            k: v
+            for k, v in element.get_info().items()
+            if k not in ("id", "type") and not isinstance(v, (ifcopenshell.entity_instance, tuple))
+        }
+
     def diff_element(self, old, new):
+        changed = False
+
+        if old.is_a() != new.is_a():
+            self.change_register.setdefault(new.GlobalId, {}).update(
+                {"class_changed": {"old_class": old.is_a(), "new_class": new.is_a()}}
+            )
+            changed = True
+
         diff = DeepDiff(
-            [a for a in old if not isinstance(a, (ifcopenshell.entity_instance, tuple))],
-            [a for a in new if not isinstance(a, (ifcopenshell.entity_instance, tuple))],
+            self.get_comparable_attributes(old),
+            self.get_comparable_attributes(new),
             math_epsilon=self.precision,
             ignore_string_type_changes=True,
             ignore_numeric_type_changes=True,
         )
-        if diff and new.GlobalId:
-            self.change_register.setdefault(new.GlobalId, {}).update({"attributes_changed": True})
+        if diff:
+            self.change_register.setdefault(new.GlobalId, {}).update({"attributes_changed": diff})
+            changed = True
+
+        if changed and new.GlobalId:
             return True
 
     def diff_element_relationships(self, old, new):
         if not self.relationships:
             return
+        found = False
         for relationship in self.relationships:
             if relationship == "type":
                 old_type = ifcopenshell.util.element.get_type(old)
                 new_type = ifcopenshell.util.element.get_type(new)
                 if old_type is not None and new_type is not None:
                     if old_type.GlobalId != new_type.GlobalId:
-                        self.change_register.setdefault(new.GlobalId, {}).update({"type_changed": True})
-                        return True
+                        self.change_register.setdefault(new.GlobalId, {}).update(
+                            {
+                                "type_changed": {
+                                    "old_type": old_type.GlobalId,
+                                    "new_type": new_type.GlobalId,
+                                }
+                            }
+                        )
+                        found = True
+                        if self.is_shallow:
+                            return True
                 elif old_type != new_type:
                     # one of the types is None while the other is not None
-                    self.change_register.setdefault(new.GlobalId, {}).update({"type_changed": True})
-                    return True
+                    self.change_register.setdefault(new.GlobalId, {}).update(
+                        {
+                            "type_changed": {
+                                "old_type": old_type.GlobalId if old_type else None,
+                                "new_type": new_type.GlobalId if new_type else None,
+                            }
+                        }
+                    )
+                    found = True
+                    if self.is_shallow:
+                        return True
             elif relationship == "property":
                 old_psets = ifcopenshell.util.element.get_psets(old)
                 new_psets = ifcopenshell.util.element.get_psets(new)
@@ -317,29 +387,91 @@ class IfcDiff:
                         math_epsilon=self.precision,
                         ignore_string_type_changes=True,
                         ignore_numeric_type_changes=True,
-                        exclude_regex_paths=[r".*id$"],
+                        exclude_regex_paths=[r"\['id'\]$"],
                     )
                 except:
                     diff = True
                 if diff and new.GlobalId:
                     self.change_register.setdefault(new.GlobalId, {}).update({"properties_changed": diff})
-                    return True
+                    found = True
+                    if self.is_shallow:
+                        return True
             elif relationship == "container":
-                if ifcopenshell.util.element.get_container(old) != ifcopenshell.util.element.get_container(new):
-                    self.change_register.setdefault(new.GlobalId, {}).update({"container_changed": True})
-                    return True
+                old_container = ifcopenshell.util.element.get_container(old)
+                new_container = ifcopenshell.util.element.get_container(new)
+                # old_container and new_container come from two different
+                # ifcopenshell.file objects, so they are never == even when
+                # unchanged. Compare by GlobalId instead of by identity.
+                old_container_id = old_container.GlobalId if old_container else None
+                new_container_id = new_container.GlobalId if new_container else None
+                if old_container_id != new_container_id:
+                    self.change_register.setdefault(new.GlobalId, {}).update(
+                        {
+                            "container_changed": {
+                                "old_container": old_container_id,
+                                "new_container": new_container_id,
+                            }
+                        }
+                    )
+                    found = True
+                    if self.is_shallow:
+                        return True
             elif relationship == "aggregate":
-                if ifcopenshell.util.element.get_aggregate(old) != ifcopenshell.util.element.get_aggregate(new):
-                    self.change_register.setdefault(new.GlobalId, {}).update({"aggregate_changed": True})
-                    return True
+                old_aggregate = ifcopenshell.util.element.get_aggregate(old)
+                new_aggregate = ifcopenshell.util.element.get_aggregate(new)
+                old_aggregate_id = old_aggregate.GlobalId if old_aggregate else None
+                new_aggregate_id = new_aggregate.GlobalId if new_aggregate else None
+                if old_aggregate_id != new_aggregate_id:
+                    self.change_register.setdefault(new.GlobalId, {}).update(
+                        {
+                            "aggregate_changed": {
+                                "old_aggregate": old_aggregate_id,
+                                "new_aggregate": new_aggregate_id,
+                            }
+                        }
+                    )
+                    found = True
+                    if self.is_shallow:
+                        return True
             elif relationship == "classification":
                 old_id = "ItemReference" if self.old.schema == "IFC2X3" else "Identification"
                 new_id = "ItemReference" if self.new.schema == "IFC2X3" else "Identification"
                 old_refs = [getattr(r, old_id) for r in ifcopenshell.util.classification.get_references(old)]
                 new_refs = [getattr(r, new_id) for r in ifcopenshell.util.classification.get_references(new)]
                 if old_refs != new_refs:
-                    self.change_register.setdefault(new.GlobalId, {}).update({"classification_changed": True})
-                    return True
+                    self.change_register.setdefault(new.GlobalId, {}).update(
+                        {"classification_changed": {"old_references": old_refs, "new_references": new_refs}}
+                    )
+                    found = True
+                    if self.is_shallow:
+                        return True
+            elif relationship == "material":
+                # get_materials() resolves layer sets, profile sets, constituent
+                # sets, set usages, and material lists down to their individual
+                # IfcMaterial entities, so this covers all material relationship
+                # shapes, not just a directly assigned IfcMaterial.
+                old_materials = sorted(m.Name for m in ifcopenshell.util.element.get_materials(old) if m.Name)
+                new_materials = sorted(m.Name for m in ifcopenshell.util.element.get_materials(new) if m.Name)
+                if old_materials != new_materials:
+                    self.change_register.setdefault(new.GlobalId, {}).update(
+                        {"material_changed": {"old_materials": old_materials, "new_materials": new_materials}}
+                    )
+                    found = True
+                    if self.is_shallow:
+                        return True
+            elif relationship == "placement":
+                old_matrix = ifcopenshell.util.placement.get_local_placement(old.ObjectPlacement)
+                new_matrix = ifcopenshell.util.placement.get_local_placement(new.ObjectPlacement)
+                moved = float(np.linalg.norm(old_matrix[:3, 3] - new_matrix[:3, 3]))
+                rotated = not np.allclose(old_matrix[:3, :3], new_matrix[:3, :3], atol=1e-2)
+                if moved > self.precision or rotated:
+                    self.change_register.setdefault(new.GlobalId, {}).update(
+                        {"placement_changed": {"moved": moved, "rotated": rotated}}
+                    )
+                    found = True
+                    if self.is_shallow:
+                        return True
+        return found or None
 
     def diff_element_basic_geometry(self, old, new):
         old_placement = ifcopenshell.util.placement.get_local_placement(old.ObjectPlacement)
@@ -439,7 +571,7 @@ if __name__ == "__main__":
         type=str,
         help=(
             'A list of space-separated relationships, chosen from "attributes", "geometry", '
-            '"type", "property", "container", "aggregate", "classification". '
+            '"type", "property", "container", "aggregate", "classification", "material", "placement". '
             'Defaults to "attributes geometry" when omitted.'
         ),
         default="",

--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -397,42 +397,13 @@ class IfcDiff:
                     if self.is_shallow:
                         return True
             elif relationship == "container":
-                old_container = ifcopenshell.util.element.get_container(old)
-                new_container = ifcopenshell.util.element.get_container(new)
-                # old_container and new_container come from two different
-                # ifcopenshell.file objects, so they are never == even when
-                # unchanged. Compare by GlobalId instead of by identity.
-                old_container_id = old_container.GlobalId if old_container else None
-                new_container_id = new_container.GlobalId if new_container else None
-                if old_container_id != new_container_id:
-                    self.change_register.setdefault(new.GlobalId, {}).update(
-                        {
-                            "container_changed": {
-                                "old_container": old_container_id,
-                                "new_container": new_container_id,
-                            }
-                        }
-                    )
-                    found = True
-                    if self.is_shallow:
-                        return True
+                if ifcopenshell.util.element.get_container(old) != ifcopenshell.util.element.get_container(new):
+                    self.change_register.setdefault(new.GlobalId, {}).update({"container_changed": True})
+                    return True
             elif relationship == "aggregate":
-                old_aggregate = ifcopenshell.util.element.get_aggregate(old)
-                new_aggregate = ifcopenshell.util.element.get_aggregate(new)
-                old_aggregate_id = old_aggregate.GlobalId if old_aggregate else None
-                new_aggregate_id = new_aggregate.GlobalId if new_aggregate else None
-                if old_aggregate_id != new_aggregate_id:
-                    self.change_register.setdefault(new.GlobalId, {}).update(
-                        {
-                            "aggregate_changed": {
-                                "old_aggregate": old_aggregate_id,
-                                "new_aggregate": new_aggregate_id,
-                            }
-                        }
-                    )
-                    found = True
-                    if self.is_shallow:
-                        return True
+                if ifcopenshell.util.element.get_aggregate(old) != ifcopenshell.util.element.get_aggregate(new):
+                    self.change_register.setdefault(new.GlobalId, {}).update({"aggregate_changed": True})
+                    return True
             elif relationship == "classification":
                 old_id = "ItemReference" if self.old.schema == "IFC2X3" else "Identification"
                 new_id = "ItemReference" if self.new.schema == "IFC2X3" else "Identification"

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -21,14 +21,25 @@ import os
 import tempfile
 
 import ifcopenshell
+import ifcopenshell.api.aggregate
 import ifcopenshell.api.context
 import ifcopenshell.api.geometry
+import ifcopenshell.api.material
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
+import ifcopenshell.api.spatial
 import ifcopenshell.api.unit
+import ifcopenshell.util.element
+import ifcopenshell.util.placement
 import ifcopenshell.util.representation
+import numpy as np
+import pytest
 
 import ifcdiff
+
+SAMPLE_MODEL_DIR = "/Users/petruc/dev/sample models/012"
+SAMPLE_MODEL_OLD = os.path.join(SAMPLE_MODEL_DIR, "PCERT_PRA-bSI-L-INFRA-3E-ARL_version1.ifc")
+SAMPLE_MODEL_NEW = os.path.join(SAMPLE_MODEL_DIR, "PCERT_PRA-bSI-L-INFRA-3E-ARL_version2.ifc")
 
 
 def setup_project() -> ifcopenshell.file:
@@ -80,7 +91,9 @@ class TestIfcDiff:
         ifc_diff.diff()
         assert ifc_diff.added_elements == set()
         assert ifc_diff.deleted_elements == set()
-        assert ifc_diff.change_register == {wall.GlobalId: {"attributes_changed": True}}
+        changes = ifc_diff.change_register[wall.GlobalId]["attributes_changed"]
+        assert changes["values_changed"]["root['Name']"]["old_value"] == "Foo"
+        assert changes["values_changed"]["root['Name']"]["new_value"] == "Bar"
 
     def test_changed_predefined_type_is_caught_by_default(self):
         # Regression test for #8214: a plain diff (no relationships specified)
@@ -97,7 +110,9 @@ class TestIfcDiff:
         ifc_diff.diff()
         assert ifc_diff.added_elements == set()
         assert ifc_diff.deleted_elements == set()
-        assert ifc_diff.change_register == {wall.GlobalId: {"attributes_changed": True}}
+        changes = ifc_diff.change_register[wall.GlobalId]["attributes_changed"]
+        assert changes["values_changed"]["root['PredefinedType']"]["old_value"] == "SOLIDWALL"
+        assert changes["values_changed"]["root['PredefinedType']"]["new_value"] == "NOTDEFINED"
 
     def test_property_diff_exports_to_json(self):
         # Regression test for #8905: comparing "property" relationships makes
@@ -138,4 +153,306 @@ class TestIfcDiff:
         ifc_diff.diff()
         assert ifc_diff.added_elements == set()
         assert ifc_diff.deleted_elements == set()
-        assert ifc_diff.change_register == {wall.GlobalId: {"geometry_changed": True}}
+        assert ifc_diff.change_register[wall.GlobalId]["geometry_changed"]
+
+    def test_class_change_is_detected(self):
+        # Regression test: a reclassified element (same GlobalId, different
+        # is_a()) with no other attribute differences was previously reported
+        # as unchanged, since diff_element only compared attribute values.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        global_id = wall.GlobalId
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        ifcopenshell.api.root.remove_product(new_file, new_file.by_id(wall.id()))
+        slab = ifcopenshell.api.root.create_entity(new_file, ifc_class="IfcSlab", name="Foo")
+        slab.GlobalId = global_id
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["attributes", "geometry", "property", "type"])
+        ifc_diff.diff()
+        assert ifc_diff.added_elements == set()
+        assert ifc_diff.deleted_elements == set()
+        assert ifc_diff.change_register == {
+            global_id: {"class_changed": {"old_class": "IfcWall", "new_class": "IfcSlab"}}
+        }
+
+    def test_property_diff_excludes_step_id_bookkeeping_key(self):
+        # Regression test: the exclude_regex_paths pattern for the pset "id"
+        # bookkeeping key was r".*id$", which never matches a DeepDiff path
+        # like root['Pset_WallCommon']['id'] because the path ends with "]".
+        # A pset re-saved with a different STEP entity number (but otherwise
+        # identical properties) was falsely reported as changed.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        pset = ifcopenshell.api.pset.add_pset(ifc_file, product=wall, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties={"FireRating": "2HR"})
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        for rel in list(wall_new.IsDefinedBy):
+            pset_def = rel.RelatingPropertyDefinition
+            if pset_def.Name == "Pset_WallCommon":
+                ifcopenshell.api.pset.remove_pset(new_file, product=wall_new, pset=pset_def)
+        # shift STEP numbering so the recreated pset gets a different "id"
+        dummy = ifcopenshell.api.root.create_entity(new_file, ifc_class="IfcWall", name="Dummy")
+        ifcopenshell.api.root.remove_product(new_file, dummy)
+        new_pset = ifcopenshell.api.pset.add_pset(new_file, product=wall_new, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(new_file, pset=new_pset, properties={"FireRating": "2HR"})
+        assert pset.id() != new_pset.id()
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["property"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {}
+
+    def test_property_diff_still_detects_real_change_despite_id_exclusion(self):
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        pset = ifcopenshell.api.pset.add_pset(ifc_file, product=wall, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties={"FireRating": "2HR"})
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        for rel in list(wall_new.IsDefinedBy):
+            pset_def = rel.RelatingPropertyDefinition
+            if pset_def.Name == "Pset_WallCommon":
+                ifcopenshell.api.pset.remove_pset(new_file, product=wall_new, pset=pset_def)
+        dummy = ifcopenshell.api.root.create_entity(new_file, ifc_class="IfcWall", name="Dummy")
+        ifcopenshell.api.root.remove_product(new_file, dummy)
+        new_pset = ifcopenshell.api.pset.add_pset(new_file, product=wall_new, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(new_file, pset=new_pset, properties={"FireRating": "1HR"})
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["property"])
+        ifc_diff.diff()
+        changed = ifc_diff.change_register[wall.GlobalId]["properties_changed"]
+        assert changed["values_changed"]["root['Pset_WallCommon']['FireRating']"]["old_value"] == "2HR"
+        assert changed["values_changed"]["root['Pset_WallCommon']['FireRating']"]["new_value"] == "1HR"
+        assert "id" not in str(changed)
+
+    def test_attributes_changed_includes_diff_detail(self):
+        # Regression test: attributes_changed used to be a bare True even
+        # though a full DeepDiff was computed and then discarded, and it
+        # compared positional attribute lists, so paths were root[N] instead
+        # of the attribute name.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        wall.PredefinedType = "SOLIDWALL"
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        new_file.by_id(wall.id()).PredefinedType = None
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["attributes"])
+        ifc_diff.diff()
+        changed = ifc_diff.change_register[wall.GlobalId]["attributes_changed"]
+        assert changed["type_changes"]["root['PredefinedType']"]["old_value"] == "SOLIDWALL"
+        assert changed["type_changes"]["root['PredefinedType']"]["new_value"] is None
+
+    def test_is_shallow_true_reports_only_first_relationship_change(self):
+        # Documents the current default: is_shallow=True keeps the historical
+        # "first difference only" behaviour for speed.
+        ifc_file = setup_project()
+        storey1 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
+        storey2 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=storey1)
+        pset = ifcopenshell.api.pset.add_pset(ifc_file, product=wall, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties={"FireRating": "2HR"})
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        storey2_new = new_file.by_id(storey2.id())
+        ifcopenshell.api.spatial.assign_container(new_file, products=[wall_new], relating_structure=storey2_new)
+        new_pset = ifcopenshell.util.element.get_psets(wall_new)["Pset_WallCommon"]
+        pset_new = new_file.by_id(new_pset["id"])
+        ifcopenshell.api.pset.edit_pset(new_file, pset=pset_new, properties={"FireRating": "1HR"})
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container", "property"], is_shallow=True)
+        ifc_diff.diff()
+        assert len(ifc_diff.change_register[wall.GlobalId]) == 1
+
+    def test_is_shallow_false_accumulates_multiple_relationship_changes(self):
+        # Regression test: diff_element_relationships returned as soon as any
+        # one relationship in the loop differed, unconditionally, even when
+        # is_shallow=False. So container+property changes on the same
+        # element only ever reported the first relationship checked.
+        ifc_file = setup_project()
+        storey1 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
+        storey2 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=storey1)
+        pset = ifcopenshell.api.pset.add_pset(ifc_file, product=wall, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties={"FireRating": "2HR"})
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        storey2_new = new_file.by_id(storey2.id())
+        ifcopenshell.api.spatial.assign_container(new_file, products=[wall_new], relating_structure=storey2_new)
+        new_pset = ifcopenshell.util.element.get_psets(wall_new)["Pset_WallCommon"]
+        pset_new = new_file.by_id(new_pset["id"])
+        ifcopenshell.api.pset.edit_pset(new_file, pset=pset_new, properties={"FireRating": "1HR"})
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container", "property"], is_shallow=False)
+        ifc_diff.diff()
+        changes = ifc_diff.change_register[wall.GlobalId]
+        assert "container_changed" in changes
+        assert "properties_changed" in changes
+
+    def test_container_changed_compares_by_global_id_not_identity(self):
+        # Regression test: old_container and new_container come from two
+        # different ifcopenshell.file objects, so comparing them directly
+        # with != is always true, even when the container is unchanged.
+        ifc_file = setup_project()
+        storey = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=storey)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {}
+
+    def test_aggregate_changed_compares_by_global_id_not_identity(self):
+        ifc_file = setup_project()
+        assembly = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcElementAssembly")
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
+        ifcopenshell.api.aggregate.assign_object(ifc_file, products=[wall], relating_object=assembly)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["aggregate"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {}
+
+    def test_material_change_is_detected(self):
+        # Regression test: there was no "material" relationship at all, so a
+        # material reassignment (e.g. Soil1 -> topsoil) was invisible.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        material_a = ifcopenshell.api.material.add_material(ifc_file, name="Soil1")
+        ifcopenshell.api.material.assign_material(ifc_file, products=[wall], material=material_a)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        material_b = ifcopenshell.api.material.add_material(new_file, name="topsoil")
+        ifcopenshell.api.material.assign_material(new_file, products=[wall_new], material=material_b)
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["material"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {
+            wall.GlobalId: {"material_changed": {"old_materials": ["Soil1"], "new_materials": ["topsoil"]}}
+        }
+
+    def test_material_change_through_layer_set_is_detected(self):
+        # get_materials() should resolve a layer set down to its individual
+        # materials, not just compare the layer set entity itself.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        material_set = ifcopenshell.api.material.add_material_set(ifc_file, set_type="IfcMaterialLayerSet")
+        material_a = ifcopenshell.api.material.add_material(ifc_file, name="Concrete")
+        ifcopenshell.api.material.add_layer(ifc_file, layer_set=material_set, material=material_a)
+        ifcopenshell.api.material.assign_material(
+            ifc_file, products=[wall], type="IfcMaterialLayerSet", material=material_set
+        )
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        new_layer = new_file.by_type("IfcMaterialLayer")[0]
+        material_b = ifcopenshell.api.material.add_material(new_file, name="Brick")
+        new_layer.Material = material_b
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["material"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {
+            wall.GlobalId: {"material_changed": {"old_materials": ["Concrete"], "new_materials": ["Brick"]}}
+        }
+
+    def test_unmoved_placement_is_not_reported(self):
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["placement"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {}
+
+    def test_placement_change_is_detected(self):
+        # Regression test: ifcdiff never compared object placement at all, so
+        # a moved or rotated element whose attributes, properties, and mesh
+        # were unchanged was reported as unchanged.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        matrix = np.eye(4)
+        matrix[0, 3] = 1.0  # 1 metre, is_si=True converts to the project's mm units
+        ifcopenshell.api.geometry.edit_object_placement(new_file, product=wall_new, matrix=matrix)
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["placement"])
+        ifc_diff.diff()
+        changed = ifc_diff.change_register[wall.GlobalId]["placement_changed"]
+        assert changed["moved"] == pytest.approx(1000.0)
+        assert changed["rotated"] is False
+
+
+class TestIfcDiffRealSamplePair:
+    @pytest.mark.skipif(
+        not os.path.exists(SAMPLE_MODEL_OLD) or not os.path.exists(SAMPLE_MODEL_NEW),
+        reason="Real sample IFC pair not available on this machine",
+    )
+    def test_real_sample_pair_ground_truth(self):
+        # Regression test using a real revision pair that exercises class
+        # change, attribute change, geometry change, material change, and
+        # placement change together. Ground truth established independently
+        # of ifcdiff: 1 added, 2 deleted, 26 modified.
+        old = ifcopenshell.open(SAMPLE_MODEL_OLD)
+        new = ifcopenshell.open(SAMPLE_MODEL_NEW)
+
+        ifc_diff = ifcdiff.IfcDiff(
+            old,
+            new,
+            relationships=[
+                "attributes",
+                "geometry",
+                "property",
+                "type",
+                "container",
+                "aggregate",
+                "classification",
+                "material",
+                "placement",
+            ],
+            is_shallow=False,
+        )
+        ifc_diff.diff()
+
+        assert len(ifc_diff.added_elements) == 1
+        assert len(ifc_diff.deleted_elements) == 2
+        assert len(ifc_diff.change_register) == 26
+
+        reclassified = {
+            "3pUQsWUqb8deDoLZ6CIIET",
+            "0zGSqxrLf0ngxWk8EXkozt",
+            "0yVWtUza9BkBPidcrOmhrJ",
+            "3pzBWeief4XhSr5Lnykkbq",
+        }
+        for global_id in reclassified:
+            assert ifc_diff.change_register[global_id]["class_changed"] == {
+                "old_class": "IfcBuildingElementProxy",
+                "new_class": "IfcGeographicElement",
+            }
+
+        # the one reclassified element that also has genuinely changed
+        # geometry (316 to 200 vertices, i.e. 948 to 600 flat floats)
+        geometry_change = ifc_diff.change_register["3pzBWeief4XhSr5Lnykkbq"]["geometry_changed"]
+        assert geometry_change["values_changed"]["root['total_verts']"]["old_value"] == 948
+        assert geometry_change["values_changed"]["root['total_verts']"]["new_value"] == 600
+
+        for global_id in ("2eGMeS8JXEqPOIXktx3T6F", "3$Tc0Y2BH1KhfYOdLzGw$7"):
+            material_change = ifc_diff.change_register[global_id]["material_changed"]
+            assert material_change["old_materials"] == ["Soil1"]
+            assert material_change["new_materials"] == ["topsoil"]
+
+        placement_change = ifc_diff.change_register["23sFQGRy90RxVbRHD9iSE2"]["placement_changed"]
+        assert placement_change["moved"] == pytest.approx(40000.0, abs=1.0)
+        assert placement_change["rotated"] is True

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -37,10 +37,6 @@ import pytest
 
 import ifcdiff
 
-SAMPLE_MODEL_DIR = "/Users/petruc/dev/sample models/012"
-SAMPLE_MODEL_OLD = os.path.join(SAMPLE_MODEL_DIR, "PCERT_PRA-bSI-L-INFRA-3E-ARL_version1.ifc")
-SAMPLE_MODEL_NEW = os.path.join(SAMPLE_MODEL_DIR, "PCERT_PRA-bSI-L-INFRA-3E-ARL_version2.ifc")
-
 
 def setup_project() -> ifcopenshell.file:
     ifc_file = ifcopenshell.file(schema="IFC4")
@@ -371,69 +367,25 @@ class TestIfcDiff:
         assert changed["moved"] == pytest.approx(1000.0)
         assert changed["rotated"] is False
 
+    def test_geometry_change_detected_without_model_view_subcontext(self):
+        # Regression test: some BIM programs place Body items directly under
+        # the top-level IfcGeometricRepresentationContext instead of a
+        # MODEL_VIEW subcontext. The old strict get_representation(...,
+        # "MODEL_VIEW") lookup silently skipped such elements, so their
+        # geometry was never queued for comparison at all.
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        model_context = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+        body_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", "Body", "MODEL_VIEW")
+        representation = ifcopenshell.api.geometry.add_slab_representation(ifc_file, body_context, depth=0.2)
+        # simulate the BIM program's non-conformant output: no subcontext
+        representation.ContextOfItems = model_context
+        ifcopenshell.api.geometry.assign_representation(ifc_file, wall, representation)
 
-class TestIfcDiffRealSamplePair:
-    @pytest.mark.skipif(
-        not os.path.exists(SAMPLE_MODEL_OLD) or not os.path.exists(SAMPLE_MODEL_NEW),
-        reason="Real sample IFC pair not available on this machine",
-    )
-    def test_real_sample_pair_ground_truth(self):
-        # Regression test using a real revision pair that exercises class
-        # change, attribute change, geometry change, material change, and
-        # placement change together. Ground truth established independently
-        # of ifcdiff: 1 added, 2 deleted, 26 modified.
-        # "container" and "aggregate" are deliberately excluded: the
-        # comparison here still compares get_container()/get_aggregate()
-        # results by instance identity across two different
-        # ifcopenshell.file objects, which are never equal, so every element
-        # with a container/aggregate would be falsely flagged. That fix is
-        # left to PR #9312 rather than duplicated here.
-        old = ifcopenshell.open(SAMPLE_MODEL_OLD)
-        new = ifcopenshell.open(SAMPLE_MODEL_NEW)
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        extrusion = new_file.by_type("IfcExtrudedAreaSolid")[0]
+        extrusion.Depth = 500.0
 
-        ifc_diff = ifcdiff.IfcDiff(
-            old,
-            new,
-            relationships=[
-                "attributes",
-                "geometry",
-                "property",
-                "type",
-                "classification",
-                "material",
-                "placement",
-            ],
-            is_shallow=False,
-        )
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["geometry"])
         ifc_diff.diff()
-
-        assert len(ifc_diff.added_elements) == 1
-        assert len(ifc_diff.deleted_elements) == 2
-        assert len(ifc_diff.change_register) == 26
-
-        reclassified = {
-            "3pUQsWUqb8deDoLZ6CIIET",
-            "0zGSqxrLf0ngxWk8EXkozt",
-            "0yVWtUza9BkBPidcrOmhrJ",
-            "3pzBWeief4XhSr5Lnykkbq",
-        }
-        for global_id in reclassified:
-            assert ifc_diff.change_register[global_id]["class_changed"] == {
-                "old_class": "IfcBuildingElementProxy",
-                "new_class": "IfcGeographicElement",
-            }
-
-        # the one reclassified element that also has genuinely changed
-        # geometry (316 to 200 vertices, i.e. 948 to 600 flat floats)
-        geometry_change = ifc_diff.change_register["3pzBWeief4XhSr5Lnykkbq"]["geometry_changed"]
-        assert geometry_change["values_changed"]["root['total_verts']"]["old_value"] == 948
-        assert geometry_change["values_changed"]["root['total_verts']"]["new_value"] == 600
-
-        for global_id in ("2eGMeS8JXEqPOIXktx3T6F", "3$Tc0Y2BH1KhfYOdLzGw$7"):
-            material_change = ifc_diff.change_register[global_id]["material_changed"]
-            assert material_change["old_materials"] == ["Soil1"]
-            assert material_change["new_materials"] == ["topsoil"]
-
-        placement_change = ifc_diff.change_register["23sFQGRy90RxVbRHD9iSE2"]["placement_changed"]
-        assert placement_change["moved"] == pytest.approx(40000.0, abs=1.0)
-        assert placement_change["rotated"] is True
+        assert ifc_diff.change_register[wall.GlobalId]["geometry_changed"]

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -272,56 +272,33 @@ class TestIfcDiff:
     def test_is_shallow_false_accumulates_multiple_relationship_changes(self):
         # Regression test: diff_element_relationships returned as soon as any
         # one relationship in the loop differed, unconditionally, even when
-        # is_shallow=False. So container+property changes on the same
+        # is_shallow=False. So material+property changes on the same
         # element only ever reported the first relationship checked.
+        # NOTE: "container" is deliberately not used here. The
+        # container/aggregate GlobalId-comparison fix (and its is_shallow
+        # accumulation behaviour) is left to PR #9312 to avoid duplicating
+        # that fix; see the removed old_container/old_aggregate handling
+        # below.
         ifc_file = setup_project()
-        storey1 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
-        storey2 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
         wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
-        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=storey1)
+        material_a = ifcopenshell.api.material.add_material(ifc_file, name="Soil1")
+        ifcopenshell.api.material.assign_material(ifc_file, products=[wall], material=material_a)
         pset = ifcopenshell.api.pset.add_pset(ifc_file, product=wall, name="Pset_WallCommon")
         ifcopenshell.api.pset.edit_pset(ifc_file, pset=pset, properties={"FireRating": "2HR"})
 
         new_file = ifc_file.from_string(ifc_file.to_string())
         wall_new = new_file.by_id(wall.id())
-        storey2_new = new_file.by_id(storey2.id())
-        ifcopenshell.api.spatial.assign_container(new_file, products=[wall_new], relating_structure=storey2_new)
+        material_b = ifcopenshell.api.material.add_material(new_file, name="topsoil")
+        ifcopenshell.api.material.assign_material(new_file, products=[wall_new], material=material_b)
         new_pset = ifcopenshell.util.element.get_psets(wall_new)["Pset_WallCommon"]
         pset_new = new_file.by_id(new_pset["id"])
         ifcopenshell.api.pset.edit_pset(new_file, pset=pset_new, properties={"FireRating": "1HR"})
 
-        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container", "property"], is_shallow=False)
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["material", "property"], is_shallow=False)
         ifc_diff.diff()
         changes = ifc_diff.change_register[wall.GlobalId]
-        assert "container_changed" in changes
+        assert "material_changed" in changes
         assert "properties_changed" in changes
-
-    def test_container_changed_compares_by_global_id_not_identity(self):
-        # Regression test: old_container and new_container come from two
-        # different ifcopenshell.file objects, so comparing them directly
-        # with != is always true, even when the container is unchanged.
-        ifc_file = setup_project()
-        storey = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey")
-        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
-        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=storey)
-
-        new_file = ifc_file.from_string(ifc_file.to_string())
-
-        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container"])
-        ifc_diff.diff()
-        assert ifc_diff.change_register == {}
-
-    def test_aggregate_changed_compares_by_global_id_not_identity(self):
-        ifc_file = setup_project()
-        assembly = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcElementAssembly")
-        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall")
-        ifcopenshell.api.aggregate.assign_object(ifc_file, products=[wall], relating_object=assembly)
-
-        new_file = ifc_file.from_string(ifc_file.to_string())
-
-        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["aggregate"])
-        ifc_diff.diff()
-        assert ifc_diff.change_register == {}
 
     def test_material_change_is_detected(self):
         # Regression test: there was no "material" relationship at all, so a
@@ -405,6 +382,12 @@ class TestIfcDiffRealSamplePair:
         # change, attribute change, geometry change, material change, and
         # placement change together. Ground truth established independently
         # of ifcdiff: 1 added, 2 deleted, 26 modified.
+        # "container" and "aggregate" are deliberately excluded: the
+        # comparison here still compares get_container()/get_aggregate()
+        # results by instance identity across two different
+        # ifcopenshell.file objects, which are never equal, so every element
+        # with a container/aggregate would be falsely flagged. That fix is
+        # left to PR #9312 rather than duplicated here.
         old = ifcopenshell.open(SAMPLE_MODEL_OLD)
         new = ifcopenshell.open(SAMPLE_MODEL_NEW)
 
@@ -416,8 +399,6 @@ class TestIfcDiffRealSamplePair:
                 "geometry",
                 "property",
                 "type",
-                "container",
-                "aggregate",
                 "classification",
                 "material",
                 "placement",


### PR DESCRIPTION
Six defects in `src/ifcdiff/ifcdiff.py`, each causing a revision comparison to silently under-report. Found by comparing two real IFC revisions against three independent implementations and chasing every disagreement.

**Scope note.** This originally carried a seventh fix, for `get_container()` and `get_aggregate()` being compared as entity instances across two different `ifcopenshell.file` objects, which are never equal, so every contained element was falsely reported as changed. @ProductOfAmerica has since fixed that independently and more narrowly in #9312. I have dropped it from here so the two do not conflict, and confirmed with `git merge-tree` that this branch and #9312 now merge cleanly. That defect is fixed by #9312, not by this PR, and the `container` and `aggregate` code paths here are byte identical to `v0.8.0`.

## The defects

**1. Class changes are never detected.** Same GlobalId, `IfcWall` becomes `IfcSlab`, and with every relationship enabled the result is `changed=0`. `diff_element` compares attribute values and never compares `is_a()`. Now reported as `class_changed` with old and new class names.

**2. Placement is never compared.** A moved or rotated object whose attributes, mesh and properties are unchanged reads as unchanged. On the test pair this hid a re-georeferencing: an `IfcSite` moved from `(0, 40000, 0)` at 60 degrees to the origin at 0 degrees, entirely unreported. Added as its own `placement` relationship rather than folded into `geometry`, because `IfcSite` has no `Representation` at all and is structurally invisible to the mesh pipeline. Compares the composed world transform, tolerance gated by `self.precision`.

**3. Material changes are never detected.** No `material` branch existed and it was absent from `RELATIONSHIP_TYPE`. Added, resolving through layer sets, profile sets, constituent sets, usages and material lists, and comparing resolved names rather than entity references, since references renumber on every save.

**4. The `id` exclusion regex never matches.** The property branch already tried to exclude the bookkeeping key with `exclude_regex_paths=[r".*id$"]`, but the real DeepDiff path is `root['Pset_Foo']['id']`, which ends in `']`. So the intended filter silently did nothing and every re-saved file reported false property changes whose only difference was a STEP entity number. Fixed to `r"\['id'\]$"`.

**5. Attribute detail was computed then discarded.** `diff_element` built a full DeepDiff and stored `{"attributes_changed": True}`, throwing the detail away, and compared positional lists so names were lost anyway. Now compares name keyed dicts and keeps the diff, so the output says which attribute changed:

```json
"attributes_changed": {"type_changes": {"root['PredefinedType']":
  {"old_value": "USERDEFINED", "new_value": null}}}
```

**6. `is_shallow=False` never worked.** Each relationship branch returned unconditionally, so even asking for full accumulation only ever reported the first change type found. The default stays `True`, deliberately: it is a documented speed tradeoff and consumers may rely on the output shape.

**7. Geometry was never queued on some files.** The check required a `MODEL_VIEW` subcontext; models placing Body items directly under the base `IfcGeometricRepresentationContext` never reached geometry diffing at all, regardless of settings.

(Numbered one to seven for readability; six are fixed here, since the container and aggregate defect moved to #9312.)

## Tests

17 tests in `src/ifcdiff/test.py`, all built programmatically with `ifcopenshell.api` so they run anywhere with no sample files. Each defect above has a test that fails without its fix.

Worth flagging one thing found while making the suite portable: defect 7 previously had **no portable coverage at all**. Every other test uses a helper that creates a proper `MODEL_VIEW` subcontext, so none of them ever reached the fallback branch the fix adds; it was only exercised by a local sample file. `test_geometry_change_detected_without_model_view_subcontext` now covers it, verified red against pre-fix `ifcdiff.py` with a `KeyError` and green after.

An earlier revision of this branch included a test reading two 900KB IFC files from a hardcoded local path, skipped when absent. That has been removed rather than committed, on size and redistribution grounds. The consequence is that coverage is now unit level rather than integration level against real project data, which is the right trade for reviewability but is a real reduction and worth stating.

black and ruff clean.

## Conflicts

Checked with `git merge-tree --write-tree` against #9312 and against our other open branches, with a control pair confirming the check detects real conflicts rather than passing everything. Clean.

Produced with AI assistance.
