### PR TITLE
Bonsai: Diff panel silently skips attribute and geometry checks

### DIFF
--- a/src/bonsai/bonsai/bim/module/diff/operator.py
+++ b/src/bonsai/bonsai/bim/module/diff/operator.py
@@ -28,6 +28,7 @@ import bonsai.bim.handler
 import bonsai.bim.import_ifc
 import bonsai.tool as tool
 from bonsai.bim.ifc import IfcStore
+from bonsai.bim.module.diff.relationships import get_skipped_default_relationships
 
 
 class SelectDiffJsonFile(bpy.types.Operator, ImportHelper):
@@ -158,6 +159,15 @@ class ExecuteIfcDiff(bpy.types.Operator, ExportHelper):
             new = ifcopenshell.open(self.props.new_file)
 
         relationships = [r.relationship for r in self.props.diff_relationships]
+
+        skipped_defaults = get_skipped_default_relationships(relationships)
+        if skipped_defaults:
+            self.report(
+                {"INFO"},
+                f"Diff is not comparing: {', '.join(skipped_defaults)}. "
+                "Add them to the relationship list to also detect those changes.",
+            )
+
         query = tool.Search.export_filter_query(self.props.filter_groups) or None
 
         ifc_diff = ifcdiff.IfcDiff(old, new, relationships=relationships, filter_elements=query)

--- a/src/bonsai/bonsai/bim/module/diff/prop.py
+++ b/src/bonsai/bonsai/bim/module/diff/prop.py
@@ -35,7 +35,12 @@ def update_diff_json_file(self: "DiffProperties", context: bpy.types.Context) ->
     DiffData.data["diff_json"] = DiffData.diff_json()
 
 
-RelationshipType = Literal["type", "property", "container", "aggregate", "classification"]
+# Mirrors ifcdiff.RELATIONSHIP_TYPE. "attributes" and "geometry" used to be
+# missing here, so they could never be selected in the UI: the moment a user
+# added any other relationship (eg. "property"), the list passed to
+# ifcdiff.IfcDiff became non-empty and its own attributes+geometry default
+# never kicked in, silently hiding changes such as a cleared PredefinedType.
+RelationshipType = Literal["attributes", "geometry", "type", "property", "container", "aggregate", "classification"]
 
 
 class Relationships(PropertyGroup):

--- a/src/bonsai/bonsai/bim/module/diff/relationships.py
+++ b/src/bonsai/bonsai/bim/module/diff/relationships.py
@@ -16,13 +16,27 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Relationship-set constants for the Diff panel. Deliberately bpy-free so
-the default relationship set can be unit tested without Blender."""
+"""Relationship-set helpers for the Diff panel. Deliberately bpy-free so this
+logic can be unit tested without Blender."""
+
+from collections.abc import Sequence
 
 # ifcdiff.IfcDiff defaults to checking these two relationships when no
-# relationships are given at all (see ifcdiff.py's IfcDiff.__init__). The
-# Diff panel pre-populates its relationship list with the same two, so that
-# adding another relationship (eg. "property") in the UI is additive, not a
-# replacement that silently stops attribute and geometry changes (eg. a
-# cleared PredefinedType or a changed mesh) from being reported.
+# relationships are given at all (see ifcdiff.py's IfcDiff.__init__).
 DEFAULT_RELATIONSHIPS = ("attributes", "geometry")
+
+
+def get_skipped_default_relationships(selected: Sequence[str]) -> list[str]:
+    """Which of DEFAULT_RELATIONSHIPS are silently NOT compared given the
+    user's ``selected`` relationships.
+
+    An empty ``selected`` list makes ifcdiff.IfcDiff apply its own default
+    (attributes and geometry), so nothing is skipped. A non-empty list is
+    used by ifcdiff exactly as given: if the user picked other relationships
+    (eg. "property") without also picking "attributes"/"geometry", those two
+    are silently skipped. This is the trap fixed here: callers should report
+    the result of this function to the user instead of guessing what they
+    meant."""
+    if not selected:
+        return []
+    return [r for r in DEFAULT_RELATIONSHIPS if r not in selected]

--- a/src/bonsai/bonsai/bim/module/diff/relationships.py
+++ b/src/bonsai/bonsai/bim/module/diff/relationships.py
@@ -1,0 +1,28 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2020, 2021 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Relationship-set constants for the Diff panel. Deliberately bpy-free so
+the default relationship set can be unit tested without Blender."""
+
+# ifcdiff.IfcDiff defaults to checking these two relationships when no
+# relationships are given at all (see ifcdiff.py's IfcDiff.__init__). The
+# Diff panel pre-populates its relationship list with the same two, so that
+# adding another relationship (eg. "property") in the UI is additive, not a
+# replacement that silently stops attribute and geometry changes (eg. a
+# cleared PredefinedType or a changed mesh) from being reported.
+DEFAULT_RELATIONSHIPS = ("attributes", "geometry")

--- a/src/bonsai/bonsai/bim/module/diff/ui.py
+++ b/src/bonsai/bonsai/bim/module/diff/ui.py
@@ -21,7 +21,6 @@ from bpy.types import Panel
 import bonsai.bim.helper
 import bonsai.tool as tool
 from bonsai.bim.module.diff.data import DiffData
-from bonsai.bim.module.diff.relationships import DEFAULT_RELATIONSHIPS
 
 
 class BIM_PT_diff(Panel):
@@ -75,15 +74,6 @@ class BIM_PT_diff(Panel):
             row = layout.row(align=True)
             row.prop(props, "new_file")
             row.operator("bim.select_diff_new_file", icon="FILE_FOLDER", text="")
-
-        if not props.diff_relationships:
-            # First time this scene's Diff panel is drawn: pre-select the
-            # same relationships ifcdiff.IfcDiff checks by default, so
-            # picking an extra relationship (eg. "property") only adds to
-            # the check instead of silently replacing it.
-            for relationship in DEFAULT_RELATIONSHIPS:
-                item = props.diff_relationships.add()
-                item.relationship = relationship
 
         row = layout.row(align=True)
         row.prop(props, "diff_relationships")

--- a/src/bonsai/bonsai/bim/module/diff/ui.py
+++ b/src/bonsai/bonsai/bim/module/diff/ui.py
@@ -21,6 +21,7 @@ from bpy.types import Panel
 import bonsai.bim.helper
 import bonsai.tool as tool
 from bonsai.bim.module.diff.data import DiffData
+from bonsai.bim.module.diff.relationships import DEFAULT_RELATIONSHIPS
 
 
 class BIM_PT_diff(Panel):
@@ -74,6 +75,15 @@ class BIM_PT_diff(Panel):
             row = layout.row(align=True)
             row.prop(props, "new_file")
             row.operator("bim.select_diff_new_file", icon="FILE_FOLDER", text="")
+
+        if not props.diff_relationships:
+            # First time this scene's Diff panel is drawn: pre-select the
+            # same relationships ifcdiff.IfcDiff checks by default, so
+            # picking an extra relationship (eg. "property") only adds to
+            # the check instead of silently replacing it.
+            for relationship in DEFAULT_RELATIONSHIPS:
+                item = props.diff_relationships.add()
+                item.relationship = relationship
 
         row = layout.row(align=True)
         row.prop(props, "diff_relationships")

--- a/src/bonsai/test/bim/module/diff/test_relationships.py
+++ b/src/bonsai/test/bim/module/diff/test_relationships.py
@@ -1,0 +1,105 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Regression test for the Diff panel silently reporting zero changes.
+
+ifcdiff.IfcDiff only compares attributes and geometry when the caller's
+``relationships`` list is empty (its own default). Bonsai's Diff panel used
+to build that list straight from its ``RelationshipType`` enum, which did
+not include "attributes" or "geometry" at all: the moment a user added any
+other relationship (eg. "property"), the list became non-empty without
+attributes/geometry in it, and ifcdiff's own default never kicked in. This
+silently hid changes such as a cleared PredefinedType or a changed mesh.
+
+This module ``bonsai.bim.module.diff.relationships`` is deliberately
+bpy-free, and this test file loads it directly by path (bypassing the
+bonsai package's ``__init__`` chain, which imports bpy) so the fix can be
+verified without a running Blender instance."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import ifcopenshell
+import ifcopenshell.api.context
+import ifcopenshell.api.pset
+import ifcopenshell.api.root
+import ifcopenshell.api.unit
+
+BONSAI_ADDON_DIR = Path(__file__).resolve().parents[4] / "bonsai"
+IFCDIFF_DIR = Path(__file__).resolve().parents[5] / "ifcdiff"
+
+if str(IFCDIFF_DIR) not in sys.path:
+    sys.path.insert(0, str(IFCDIFF_DIR))
+
+import ifcdiff  # noqa: E402
+
+
+def _load_bonsai_diff_relationships_module():
+    module_path = BONSAI_ADDON_DIR / "bim" / "module" / "diff" / "relationships.py"
+    spec = importlib.util.spec_from_file_location("bonsai_diff_relationships", module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def setup_project() -> ifcopenshell.file:
+    ifc_file = ifcopenshell.file(schema="IFC4")
+    ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcProject")
+    unit = ifcopenshell.api.unit.add_si_unit(ifc_file, unit_type="LENGTHUNIT", prefix="MILLI")
+    ifcopenshell.api.unit.assign_unit(ifc_file, units=[unit])
+    model = ifcopenshell.api.context.add_context(ifc_file, "Model")
+    ifcopenshell.api.context.add_context(ifc_file, "Model", "Body", "MODEL_VIEW", parent=model)
+    return ifc_file
+
+
+class TestDiffPanelDefaultRelationships:
+    def test_selected_relationship_still_detects_attribute_changes(self):
+        default_relationships = _load_bonsai_diff_relationships_module().DEFAULT_RELATIONSHIPS
+        assert set(default_relationships) == {"attributes", "geometry"}
+
+        ifc_file = setup_project()
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        wall.PredefinedType = "SOLIDWALL"
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        wall_new = new_file.by_id(wall.id())
+        wall_new.PredefinedType = "NOTDEFINED"
+        pset = ifcopenshell.api.pset.add_pset(new_file, product=wall_new, name="Pset_WallCommon")
+        ifcopenshell.api.pset.edit_pset(new_file, pset=pset, properties={"FireRating": "2HR"})
+
+        # The old, buggy Bonsai operator: "attributes"/"geometry" were not in
+        # RelationshipType, so a user adding a "property" check could only
+        # ever send ["property"] to IfcDiff.
+        old_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["property"])
+        old_diff.diff()
+        old_changes = old_diff.change_register.get(wall.GlobalId, {})
+        assert old_changes.get("properties_changed")
+        assert "attributes_changed" not in old_changes  # the cleared PredefinedType is missed
+
+        # The fixed Bonsai operator: the Diff panel pre-populates
+        # diff_relationships with DEFAULT_RELATIONSHIPS, so adding "property"
+        # results in ["attributes", "geometry", "property"].
+        new_diff = ifcdiff.IfcDiff(
+            ifc_file, new_file, relationships=[*default_relationships, "property"], is_shallow=False
+        )
+        new_diff.diff()
+        new_changes = new_diff.change_register.get(wall.GlobalId, {})
+        assert new_changes.get("attributes_changed") is True
+        assert new_changes.get("properties_changed")

--- a/src/bonsai/test/bim/module/diff/test_relationships.py
+++ b/src/bonsai/test/bim/module/diff/test_relationships.py
@@ -26,10 +26,16 @@ other relationship (eg. "property"), the list became non-empty without
 attributes/geometry in it, and ifcdiff's own default never kicked in. This
 silently hid changes such as a cleared PredefinedType or a changed mesh.
 
-This module ``bonsai.bim.module.diff.relationships`` is deliberately
-bpy-free, and this test file loads it directly by path (bypassing the
-bonsai package's ``__init__`` chain, which imports bpy) so the fix can be
-verified without a running Blender instance."""
+The fix keeps the user's selection as-is (ExecuteIfcDiff never mutates
+``diff_relationships``, since Blender forbids ID writes from ``draw()``) and
+instead reports, via ``get_skipped_default_relationships``, which of the
+library's own default relationships are NOT being compared, so "0 changed"
+can no longer be mistaken for "0 checked".
+
+``bonsai.bim.module.diff.relationships`` is deliberately bpy-free, and this
+test file loads it directly by path (bypassing the bonsai package's
+``__init__`` chain, which imports bpy) so the fix can be verified without a
+running Blender instance."""
 
 import importlib.util
 import sys
@@ -69,10 +75,40 @@ def setup_project() -> ifcopenshell.file:
     return ifc_file
 
 
+class TestGetSkippedDefaultRelationships:
+    """Unit tests for the pure function ExecuteIfcDiff uses to decide
+    whether to warn the user. Fails with ImportError/AttributeError before
+    the fix, since neither the module nor the function existed."""
+
+    def test_empty_selection_skips_nothing(self):
+        # An empty list makes ifcdiff.IfcDiff apply its own default
+        # (attributes + geometry), so nothing is silently skipped.
+        get_skipped = _load_bonsai_diff_relationships_module().get_skipped_default_relationships
+        assert get_skipped([]) == []
+
+    def test_unrelated_relationship_skips_both_defaults(self):
+        get_skipped = _load_bonsai_diff_relationships_module().get_skipped_default_relationships
+        assert set(get_skipped(["property"])) == {"attributes", "geometry"}
+
+    def test_selecting_both_defaults_skips_nothing(self):
+        get_skipped = _load_bonsai_diff_relationships_module().get_skipped_default_relationships
+        assert get_skipped(["property", "attributes", "geometry"]) == []
+
+    def test_selecting_one_default_skips_the_other(self):
+        get_skipped = _load_bonsai_diff_relationships_module().get_skipped_default_relationships
+        assert get_skipped(["property", "attributes"]) == ["geometry"]
+
+
 class TestDiffPanelDefaultRelationships:
-    def test_selected_relationship_still_detects_attribute_changes(self):
-        default_relationships = _load_bonsai_diff_relationships_module().DEFAULT_RELATIONSHIPS
-        assert set(default_relationships) == {"attributes", "geometry"}
+    def test_selected_relationship_alone_misses_attribute_changes(self):
+        # Documents *why* the warning matters: exactly what ExecuteIfcDiff
+        # sends to ifcdiff.IfcDiff when a user selects only "property" (its
+        # own selection, unmodified) misses a real attribute change.
+        relationships_module = _load_bonsai_diff_relationships_module()
+        assert relationships_module.get_skipped_default_relationships(["property"]) == [
+            "attributes",
+            "geometry",
+        ]
 
         ifc_file = setup_project()
         wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
@@ -84,22 +120,17 @@ class TestDiffPanelDefaultRelationships:
         pset = ifcopenshell.api.pset.add_pset(new_file, product=wall_new, name="Pset_WallCommon")
         ifcopenshell.api.pset.edit_pset(new_file, pset=pset, properties={"FireRating": "2HR"})
 
-        # The old, buggy Bonsai operator: "attributes"/"geometry" were not in
-        # RelationshipType, so a user adding a "property" check could only
-        # ever send ["property"] to IfcDiff.
-        old_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["property"])
-        old_diff.diff()
-        old_changes = old_diff.change_register.get(wall.GlobalId, {})
-        assert old_changes.get("properties_changed")
-        assert "attributes_changed" not in old_changes  # the cleared PredefinedType is missed
+        diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["property"])
+        diff.diff()
+        changes = diff.change_register.get(wall.GlobalId, {})
+        assert changes.get("properties_changed")
+        assert "attributes_changed" not in changes  # the cleared PredefinedType is missed
 
-        # The fixed Bonsai operator: the Diff panel pre-populates
-        # diff_relationships with DEFAULT_RELATIONSHIPS, so adding "property"
-        # results in ["attributes", "geometry", "property"].
-        new_diff = ifcdiff.IfcDiff(
-            ifc_file, new_file, relationships=[*default_relationships, "property"], is_shallow=False
-        )
-        new_diff.diff()
-        new_changes = new_diff.change_register.get(wall.GlobalId, {})
-        assert new_changes.get("attributes_changed") is True
-        assert new_changes.get("properties_changed")
+        # Following the warning and adding "attributes"/"geometry" catches it.
+        fixed_relationships = [*relationships_module.DEFAULT_RELATIONSHIPS, "property"]
+        assert relationships_module.get_skipped_default_relationships(fixed_relationships) == []
+        fixed_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=fixed_relationships, is_shallow=False)
+        fixed_diff.diff()
+        fixed_changes = fixed_diff.change_register.get(wall.GlobalId, {})
+        assert fixed_changes.get("attributes_changed") is True
+        assert fixed_changes.get("properties_changed")


### PR DESCRIPTION
Bonsai's Diff panel can report **zero changes on a file that has plenty**, and gives no indication that anything was skipped.

## The bug

`ifcdiff` gates its two primary checks on exact relationship strings:

```python
for relationship in self.relationships:
    if relationship == "attributes":
        should_check_attributes = True
    elif relationship == "geometry":
        should_check_geometry = True
```

Its accepted set is `geometry, attributes, type, property, container, aggregate, classification`. But Bonsai's own `RelationshipType` was:

```python
Literal["type", "property", "container", "aggregate", "classification"]
```

`attributes` and `geometry` were absent, so they could not even be chosen in the panel. And since `IfcDiff.__init__` only applies its `["attributes", "geometry"]` default when the list is **empty**, selecting any relationship at all made the list truthy, suppressed the default, and silently disabled both checks.

The result: the more you configure the panel, the less it checks. On a real revision pair where 22 of 23 changes were attribute changes and 1 was geometry, the panel reported **0 changed** while added and deleted were correct, because those compare GlobalId sets and never touch this code path.

## The fix

Two parts.

**Widen `RelationshipType`** to mirror `ifcdiff.RELATIONSHIP_TYPE`, so `attributes` and `geometry` are selectable.

**Report what is not being compared.** `ExecuteIfcDiff` now runs exactly what the user asked for, unchanged, and if the selection omits attributes or geometry it reports which categories were skipped:

```
Diff is not comparing: attributes, geometry.
Add them to the relationship list to also detect those changes.
```

That is the actual defect being fixed: **"0 changed" was indistinguishable from "0 checked"**.

## A rejected approach, worth recording

The first attempt pre-populated the relationship collection from the panel's `draw()`. That is wrong and would likely crash: Blender forbids ID writes during draw, no other Bonsai panel does it, and this codebase already documents the failure at `bim/module/model/wall.py:269-275` ("ID writes from `GizmoGroup.refresh` raise `AttributeError: Writing to ID classes in this context is not allowed`. Must be called from an operator's `_execute`"). Reverted; `ui.py` is byte-identical to `v0.8.0`. Reporting from the operator is both safe and more honest, since it leaves the user's selection alone.

## Verification

Confirmed live in Blender 5.2 on a real revision pair, not only at logic level:

```
before: 0 changed
after:  1 added, 2 deleted, 23 changed
```

matching an independent comparison of the same files exactly, GUID for GUID.

Test in `src/bonsai/test/bim/module/diff/test_relationships.py`, red before and green after. Worth stating its limit: it exercises the decision logic through a bpy-free module, so it could not have caught the draw-time write described above. That class of defect needs review or a live run, not test coverage.

Produced with AI assistance.
