### PR TITLE
win: collect underscore-prefixed runtime plugin DLLs in build artifacts

### DIFF
--- a/win/build-all-win.py
+++ b/win/build-all-win.py
@@ -53,6 +53,16 @@ QT_DEPLOYMENT_DLLS = {
     "vulkan-1.dll",
 }
 QT_CONF = "[Paths]\nPrefix = .\n"
+# Runtime plugins are canonically prefixed with 'ifcopenshell_' (see
+# decorated_basename() in src/plugin/plugin.cpp and the OUTPUT_NAME properties of
+# the plugin targets, e.g. 'ifcopenshell_parse_schema_ifc${schema}'), while the
+# core shared libraries keep the dotted 'ifcopenshell.' names. Match both so the
+# load-by-name plugins are not silently dropped from the archives.
+IFC_RUNTIME_PLUGIN_PREFIXES = ("ifcopenshell.", "ifcopenshell_")
+# Per-schema geometry writers ship with the Python package only, not next to the
+# executables. 'ifcopenshell.geometry.writer.' covers the core library, the
+# underscore form covers the per-schema plugins.
+IFC_GEOMETRY_WRITER_PREFIXES = ("ifcopenshell.geometry.writer.", "ifcopenshell_geometry_writer_")
 
 
 def run(command: list[str]) -> None:
@@ -153,6 +163,19 @@ def trace_runtime_dependencies(roots: set[Path], candidates: set[Path]) -> set[P
     return resolved
 
 
+def is_geometry_writer(file: Path) -> bool:
+    return file.name.startswith(IFC_GEOMETRY_WRITER_PREFIXES)
+
+
+def collect_ifc_runtime_plugins(dlls: set[Path], dependencies: set[Path]) -> set[Path]:
+    """IfcOpenShell plugins are loaded by name at runtime, so dumpbin cannot discover them."""
+    return {
+        d
+        for d in (dlls - dependencies)
+        if d.name.startswith(IFC_RUNTIME_PLUGIN_PREFIXES) and not is_geometry_writer(d)
+    }
+
+
 def is_qt_deployment_dll(file: Path) -> bool:
     name = file.name.lower()
     return name.startswith("qt") or name.startswith("d3dcompiler_") or name in QT_DEPLOYMENT_DLLS
@@ -223,11 +246,7 @@ def archive_executables() -> None:
     exes = {file for file in bin_files if file.suffix.lower() == ".exe"}
     dlls = {file for file in bin_files if file.suffix.lower() == ".dll"}
     dependencies = trace_runtime_dependencies(exes, dlls)
-    ifc_runtime_plugins = {
-        d
-        for d in (set(dlls) - dependencies)
-        if d.name.startswith("ifcopenshell.") and not d.name.startswith("ifcopenshell.geometry.writer.")
-    }
+    ifc_runtime_plugins = collect_ifc_runtime_plugins(dlls, dependencies)
     qt_deployment_files = collect_qt_deployment_files(install_dir)
 
     for file in sorted(exes):
@@ -267,12 +286,8 @@ def archive_python_package(python_version: str, python_path: Path) -> None:
     exes = {file for file in bin_files if file.suffix.lower() == ".exe"}
     dlls = {file for file in bin_files if file.suffix.lower() == ".dll"}
     dependencies = trace_runtime_dependencies(exes, dlls)
-    ifc_runtime_plugins = {
-        d
-        for d in (set(dlls) - dependencies)
-        if d.name.startswith("ifcopenshell.") and not d.name.startswith("ifcopenshell.geometry.writer.")
-    }
-    geometry_writing = {f for f in bin_files if f.name.startswith("ifcopenshell.geometry.writer.")}
+    ifc_runtime_plugins = collect_ifc_runtime_plugins(dlls, dependencies)
+    geometry_writing = {f for f in bin_files if is_geometry_writer(f)}
 
     python_version_major_minor = "".join(python_version.split(".")[:2])
     site_packages = python_path / "Lib" / "site-packages"


### PR DESCRIPTION
Fixes #9301.

### Problem

Runtime plugins are canonically underscore-prefixed: `decorated_basename()` in `src/plugin/plugin.cpp` prepends `ifcopenshell_`, and the plugin targets set `OUTPUT_NAME` to match — `ifcopenshell_parse_schema_ifc${schema}`, `ifcopenshell_geometry_mapping_ifc${schema}`, `ifcopenshell_geometry_kernel_${kernel}`, `ifcopenshell_geometry_writer_ifc${schema}`, `ifcopenshell_${plugin_output_name}` for the document/geometry serializers. Only the core shared libraries keep dotted names (`ifcopenshell.parse`, `ifcopenshell.geometry`, `ifcopenshell.geometry.writer`, `ifcopenshell.plugin`).

`win/build-all-win.py` collected runtime plugins with a dot-prefix filter, in both `archive_executables()` and `archive_python_package()`:

```python
if d.name.startswith("ifcopenshell.") and not d.name.startswith("ifcopenshell.geometry.writer.")
```

The trailing dot only matches the core libraries, so every load-by-name plugin was silently dropped from every win64 and win-arm64 zip.

The handful of underscore-named DLLs that did make it into the shipped artifacts (`ifcopenshell_document_rdb.dll`, `ifcopenshell_geometry_kernel_opencascade.dll`, and the `parse_schema` set in the BonsaiViewer zip) got there via `trace_runtime_dependencies()` as link-time dependencies, not via the plugin filter — which is also why the `geometry_mapping` plugins, loaded purely by name and invisible to dumpbin, are absent from every artifact.

On the shipped v0.9.0alpha0 win64 artifacts this means:

```
>>> ifcopenshell.file(schema="IFC4X3_ADD2")
RuntimeError: No schema named IFC4X3_ADD2
```

and, with the `parse_schema` DLLs supplied manually:

```
RuntimeError: No geometry mapping registered for ifc4x3_add2
```

linux64 and pyodide artifacts are unaffected.

### Change

Both collection sites now share one helper that accepts both prefixes, and the geometry-writer exclusion is extended to the underscore form so the per-schema writers keep their existing Python-package-only treatment.

### One question for review

`ifcopenshell_geometry_writer_ifc*.dll` stays excluded from the executable zips, which preserves current behaviour — but that exclusion predates the rename, and under the old naming `ifcopenshell.geometry.writer.` would have matched only the core library. If IfcConvert is meant to load the per-schema writers at runtime, they should be bundled with the executables too. Happy to change it either way.

### Testing

I don't have a Windows build environment to run the full script, so the filter was verified against a reconstruction of the installed `bin/` DLL set: all load-by-name plugins are now collected, the per-schema writers still route to the Python package only, and third-party DLLs are unaffected. Happy to test the resulting artifacts once CI produces them.