### PR TITLE
Fix #8603: drawing underlay renders the previously active drawing's objects

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -387,9 +387,12 @@ class CreateDrawing(bpy.types.Operator):
 
         active_drawing_id = tool.Blender.get_ifc_definition_id(context.scene.camera)
         original_drawing_id = None
+        original_cache_setting = self.props.should_use_underlay_cache
         if self.print_all:
             original_drawing_id = active_drawing_id
             drawings_to_print = [d.ifc_definition_id for d in self.props.drawings if d.is_selected and d.is_drawing]
+            # Every drawing in the batch must be re-rendered, restored once the batch ends.
+            self.props.should_use_underlay_cache = False
         else:
             drawings_to_print = [active_drawing_id]
 
@@ -397,8 +400,6 @@ class CreateDrawing(bpy.types.Operator):
             self.drawing_index = drawing_i
             if self.print_all:
                 bpy.ops.bim.activate_drawing(drawing=drawing_id, should_view_from_camera=False)
-                original_cache_setting = self.props.should_use_underlay_cache
-                self.props.should_use_underlay_cache = False
 
                 # Force Blender to process all pending operations
                 for area in context.screen.areas:
@@ -490,6 +491,7 @@ class CreateDrawing(bpy.types.Operator):
             self.report({"INFO"}, f"{len(drawings_to_print)} drawings created...")
         if self.print_all:
             assert original_drawing_id is not None
+            self.props.should_use_underlay_cache = original_cache_setting
             bpy.ops.bim.activate_drawing(drawing=original_drawing_id, should_view_from_camera=False)
         return {"FINISHED"}
 

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -2363,21 +2363,17 @@ class Blender(bonsai.core.tool.Blender):
 
     @classmethod
     def sync_render_visibility(cls):
-        # Doing bpy.ops.object.hide_render_clear_all() or
-        # bpy.ops.object.isolate_type_render() is extremely slow.
-        # Hopefully this doesn't crash on Windows, it doesn't crash on Linux.
-        should_hides = [0 if obj.visible_get() else 1 for obj in bpy.data.objects]
-        should_hides = np.fromiter(should_hides, dtype=np.uint8, count=len(should_hides))
-        bpy.data.objects.foreach_set("hide_render", should_hides)
-        return  # Otherwise...
-        # for obj in bpy.data.objects:
-        #     if not obj.data:
-        #         continue
-        #     # For speed, check equality prior to change to prevent needless updates
-        #     if (is_visible := obj.visible_get()) and obj.hide_render is True:
-        #         obj.hide_render = False
-        #     elif not is_visible and obj.hide_render is False:
-        #         obj.hide_render = True
+        # Do NOT use bpy.data.objects.foreach_set("hide_render", ...) here. It writes the
+        # DNA directly and skips the RNA update, so nothing tags the depsgraph and the
+        # *evaluated* visibility stays a render behind - drawing underlays then render the
+        # previously active drawing's objects with the current drawing's camera. See #8603.
+        # bpy.ops.object.hide_render_clear_all() / isolate_type_render() are also out, they
+        # are extremely slow. Assigning through RNA tags each object correctly, and the
+        # equality check keeps it cheap by only writing objects that actually change.
+        for obj in bpy.data.objects:
+            should_hide = not obj.visible_get()
+            if obj.hide_render != should_hide:
+                obj.hide_render = should_hide
 
     @classmethod
     def hide_objects(cls, objs):


### PR DESCRIPTION
Fixes #8603.

### The bug

A drawing created after a *different* drawing was created earlier in the session gets an underlay showing the **previous drawing's objects**, rendered with the **current drawing's camera**. A ROOF plan rendered after a 1ST FLOOR plan comes out as the floor plan seen from the roof camera — the roof is simply absent, so you see down to the slab. The first drawing of a session is always correct.

### Root cause

`Blender.sync_render_visibility` wrote `hide_render` with `bpy.data.objects.foreach_set(...)`. `foreach_set` writes the DNA directly and skips the RNA update, so **nothing tags the depsgraph** — the evaluated visibility stays a render behind and `bpy.ops.render.render()` draws the previous drawing's object set. The camera is unaffected, since camera changes go through normal RNA assignment.

This is why it resisted diagnosis: `visible_get()`, `obj.hide_render` and `context.visible_objects` all read the DNA we had just written, so every python readback reports correct state. Instrumenting right up to the `render.render()` call showed the correct camera *and* the correct 276-object renderable set — and it still rendered the other drawing.

It also explains why the previously attempted workarounds all failed (`use_persistent_data = False`, `view_layer.update()`, `evaluated_depsgraph_get()`, `frame_set()`, warm-up renders, toggling the render engine): they flush or rebuild, but nothing re-tags objects that were never marked dirty.

### The fix

Assign `hide_render` through RNA so each object is tagged, with an equality check so only objects that actually change are written.

Cost on a 3041-object model: **0.65s** for the first drawing (2982 changes), **0.06s** for the next (248 changes). Note the `visible_get()` scan still runs over every object, exactly as before — that part is unchanged.

### Verification

Tested on a real model (Highland Haven), on both `bpy.ops.bim.create_drawing` and SHIFT+click `print_all` batches.

Both underlays render at the same 246 px/m, so aligning them on camera position and pixel-diffing is a direct measure of "is this the other drawing's image":

| | before | after |
|---|---|---|
| ROOF underlay vs 1ST FLOOR underlay, aligned | **0.99%** of pixels differ | **67%** differ |
| topmost building object at render time | `IfcWall/Wall.079` (floor plan) | `IfcRoof/Roof.007` |

Controlled A/B: the renderable fingerprint going into the render was byte-identical between the failing and passing runs (`n=276 md5=c819482e421d`), same camera, same clip band. The only variable changed was `foreach_set` → RNA assignment, and the output flipped from wrong to correct.

### Second commit

Unrelated bug noticed in the same code path: `CreateDrawing` saves `should_use_underlay_cache` into a local that is never read again — and does it *inside* the loop, so each drawing overwrites it. Any batch print left the user's underlay cache setting disabled until they toggled it back by hand. Hoisted the save/disable out of the loop and restored the value alongside the existing active-drawing restore.

### Note on the previous diagnosis

The original issue attributed this to `bpy.ops.render.render()` carrying state across calls under EEVEE-Next and suggested an upstream Blender report. That was wrong — see https://github.com/IfcOpenShell/IfcOpenShell/issues/8603#issuecomment-5302565495. In particular, re-running a single drawing does **not** fix it (the rerun produces a pixel-identical wrong image), and the visible-object sets were never identical. Draft PR #8900 restructures `print_all` into a modal operator on that basis; it does not address this, since the failure reproduces across two separate operator invocations with a full event loop in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
