### PR TITLE
ifcdiff: compare container and aggregate by GlobalId, not by instance

### DIFF
--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -325,11 +325,17 @@ class IfcDiff:
                     self.change_register.setdefault(new.GlobalId, {}).update({"properties_changed": diff})
                     return True
             elif relationship == "container":
-                if ifcopenshell.util.element.get_container(old) != ifcopenshell.util.element.get_container(new):
+                # Compare by GlobalId, not by instance: the two containers belong to
+                # different files, and instances from different files are never equal.
+                old_container = ifcopenshell.util.element.get_container(old)
+                new_container = ifcopenshell.util.element.get_container(new)
+                if getattr(old_container, "GlobalId", None) != getattr(new_container, "GlobalId", None):
                     self.change_register.setdefault(new.GlobalId, {}).update({"container_changed": True})
                     return True
             elif relationship == "aggregate":
-                if ifcopenshell.util.element.get_aggregate(old) != ifcopenshell.util.element.get_aggregate(new):
+                old_aggregate = ifcopenshell.util.element.get_aggregate(old)
+                new_aggregate = ifcopenshell.util.element.get_aggregate(new)
+                if getattr(old_aggregate, "GlobalId", None) != getattr(new_aggregate, "GlobalId", None):
                     self.change_register.setdefault(new.GlobalId, {}).update({"aggregate_changed": True})
                     return True
             elif relationship == "classification":

--- a/src/ifcdiff/test.py
+++ b/src/ifcdiff/test.py
@@ -21,10 +21,12 @@ import os
 import tempfile
 
 import ifcopenshell
+import ifcopenshell.api.aggregate
 import ifcopenshell.api.context
 import ifcopenshell.api.geometry
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
+import ifcopenshell.api.spatial
 import ifcopenshell.api.unit
 import ifcopenshell.util.representation
 
@@ -39,6 +41,19 @@ def setup_project() -> ifcopenshell.file:
     model = ifcopenshell.api.context.add_context(ifc_file, "Model")
     ifcopenshell.api.context.add_context(ifc_file, "Model", "Body", "MODEL_VIEW", parent=model)
     return ifc_file
+
+
+def setup_spatial_tree(ifc_file: ifcopenshell.file) -> tuple[ifcopenshell.entity_instance, ...]:
+    """Aggregate a Project > Site > Building > (Level 1, Level 2) tree."""
+    project = ifc_file.by_type("IfcProject")[0]
+    site = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcSite", name="Site")
+    building = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuilding", name="Building")
+    level_1 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey", name="Level 1")
+    level_2 = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcBuildingStorey", name="Level 2")
+    ifcopenshell.api.aggregate.assign_object(ifc_file, products=[site], relating_object=project)
+    ifcopenshell.api.aggregate.assign_object(ifc_file, products=[building], relating_object=site)
+    ifcopenshell.api.aggregate.assign_object(ifc_file, products=[level_1, level_2], relating_object=building)
+    return site, building, level_1, level_2
 
 
 class TestIfcDiff:
@@ -121,6 +136,48 @@ class TestIfcDiff:
             with open(output) as f:
                 results = json.load(f)
             assert "Pset_WallCommon" in str(results["changed"][wall.GlobalId]["properties_changed"])
+
+    def test_unchanged_container_is_not_a_change(self):
+        # Regression test for #4110: the container check compared the entity
+        # instances returned by get_container. They belong to two different
+        # ifcopenshell.file objects and so never compare equal, meaning every
+        # contained element was reported as changed even when it had not moved.
+        ifc_file = setup_project()
+        _, _, level_1, _ = setup_spatial_tree(ifc_file)
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=level_1)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {}
+
+    def test_unchanged_aggregate_is_not_a_change(self):
+        # Regression test for #4110, the same defect on the aggregate check.
+        ifc_file = setup_project()
+        setup_spatial_tree(ifc_file)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["aggregate"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {}
+
+    def test_changed_container(self):
+        ifc_file = setup_project()
+        _, _, level_1, level_2 = setup_spatial_tree(ifc_file)
+        wall = ifcopenshell.api.root.create_entity(ifc_file, ifc_class="IfcWall", name="Foo")
+        ifcopenshell.api.spatial.assign_container(ifc_file, products=[wall], relating_structure=level_1)
+
+        new_file = ifc_file.from_string(ifc_file.to_string())
+        ifcopenshell.api.spatial.assign_container(
+            new_file, products=[new_file.by_id(wall.id())], relating_structure=new_file.by_id(level_2.id())
+        )
+
+        ifc_diff = ifcdiff.IfcDiff(ifc_file, new_file, relationships=["container"])
+        ifc_diff.diff()
+        assert ifc_diff.change_register == {wall.GlobalId: {"container_changed": True}}
 
     def test_changed_geometry(self):
         ifc_file = setup_project()


### PR DESCRIPTION
Running IfcDiff with `relationships=["container", "aggregate"]` on a model and an identical copy of it reports every element that has a container or an aggregate as changed. On a small IFC4 model with 8 spatial and physical elements, all 8 come back with `{"container_changed": True}` or `{"aggregate_changed": True}`, and the register is exactly the same as the one you get when a wall genuinely moves to another storey. A real move ends up indistinguishable from no change at all.

The cause is in `diff_element_relationships`: it compares the `entity_instance` objects returned by `get_container` and `get_aggregate`, but the old and new instances belong to two different `ifcopenshell.file` objects, and instance equality is identity within a single file, so the comparison is unequal even when nothing moved.

The fix compares the GlobalIds instead, with a `None` fallback so an added or removed container is still reported. This is what the `type` branch a few lines above already does. The register value stays `True`, so the output shape and the shallow-return behaviour are unchanged.

Repro (Project > Site > Building > two storeys, 4 walls contained in Level 1, copied via `to_string`/`from_string`):

| | before | after |
|---|---|---|
| identical models | 8 changed | 0 changed |
| one wall recontained to Level 2 | 8 changed | 1 changed (the moved wall) |

Three tests added to `src/ifcdiff/test.py` in the existing `setup_project()` style: `test_unchanged_container_is_not_a_change`, `test_unchanged_aggregate_is_not_a_change`, `test_changed_container`. `pytest -p no:pytest-blender test.py` is 2 failed / 7 passed before the change and 9 passed after. black and ruff at line-length 120 are clean.

This is the container/aggregate part of #4110. I'm aware #8294 and #8249 proposed the same fix and were closed by their author in favour of #9296, which is still a draft and bundles this with six other ifcdiff changes, including turning `container_changed` into a dict of old and new ids, which changes the output shape for anything reading `change_register` or the exported JSON (Bonsai's diff panel included). This PR is deliberately just the two-line behaviour fix with no shape change. If #9296 lands first this becomes redundant and I'll close it.
