### PR TITLE
CAD Join: keep the side of the edge you clicked, and remove edges in between

### DIFF
--- a/src/bonsai/bonsai/bim/module/cad/__init__.py
+++ b/src/bonsai/bonsai/bim/module/cad/__init__.py
@@ -30,6 +30,8 @@ classes = (
     operator.CadFillet,
     operator.CadMitre,
     operator.CadOffset,
+    operator.CadSelect,
+    operator.CadSelectBox,
     operator.CadTrimExtend,
     prop.BIMCadProperties,
     workspace.CadHotkey,
@@ -41,6 +43,10 @@ def register():
         bpy.utils.register_tool(workspace.CadTool, after={"builtin.transform"}, separator=True, group=False)
     bpy.types.Scene.BIMCadProperties = bpy.props.PointerProperty(type=prop.BIMCadProperties)
 
+    # Clicks remembered for joining describe geometry that an undo rolls back.
+    bpy.app.handlers.undo_post.append(operator.clear_clicked_ends)
+    bpy.app.handlers.redo_post.append(operator.clear_clicked_ends)
+
     workspace.load_custom_icons()
 
 
@@ -48,5 +54,9 @@ def unregister():
     if not bpy.app.background:
         bpy.utils.unregister_tool(workspace.CadTool)
     del bpy.types.Scene.BIMCadProperties
+
+    for handlers in (bpy.app.handlers.undo_post, bpy.app.handlers.redo_post):
+        if operator.clear_clicked_ends in handlers:
+            handlers.remove(operator.clear_clicked_ends)
 
     workspace.unload_custom_icons()

--- a/src/bonsai/bonsai/bim/module/cad/operator.py
+++ b/src/bonsai/bonsai/bim/module/cad/operator.py
@@ -34,6 +34,268 @@ messages = {
 }
 
 
+# How far along each edge the user last clicked, keyed by the edge's two vertex
+# indices. Joining two edges is ambiguous - either side of each edge may be kept
+# - so the side that was clicked is the one kept. This is resolved at the moment
+# of the click, while Blender can still say which edge was picked and the pointer
+# is still on it: by the time the hotkey is pressed the mouse has moved on, and
+# the geometry shifts during the join, so a remembered screen position would no
+# longer mean anything.
+clicked_ends: dict[tuple[int, int], float] = {}
+MAX_CLICKED_ENDS = 32
+
+# A click that drags even slightly is routed to box select instead, which is
+# modal - the selection only exists once the drag ends, long after we could ask
+# what it picked. So the press position is parked here and resolved later, at
+# join time, against whichever selected edge it landed on.
+pending_presses: list[tuple[int, int]] = []
+MAX_PENDING_PRESSES = 8
+# How close a press has to land to an edge (in pixels) to count as picking it.
+PRESS_TOLERANCE = 50
+
+
+def edge_key(edge) -> tuple[int, int]:
+    a, b = edge.verts
+    return (a.index, b.index) if a.index < b.index else (b.index, a.index)
+
+
+def active_tool() -> str:
+    try:
+        return bpy.context.workspace.tools.from_space_view3d_mode(bpy.context.mode, create=False).idname
+    except Exception:
+        return ""
+
+
+def deselect_edit_meshes() -> None:
+    """Drop the edit-mode selection, so nothing stays selected without a click on it."""
+    try:
+        objects = list(getattr(bpy.context, "objects_in_mode", None) or [])
+        if not objects and bpy.context.active_object:
+            objects = [bpy.context.active_object]
+        for obj in objects:
+            if obj.type != "MESH" or obj.mode != "EDIT":
+                continue
+            bm = bmesh.from_edit_mesh(obj.data)
+            for sequence in (bm.verts, bm.edges, bm.faces):
+                for element in sequence:
+                    element.select = False
+            bm.select_history.clear()
+            bmesh.update_edit_mesh(obj.data)
+        for area in bpy.context.screen.areas:
+            if area.type == "VIEW_3D":
+                area.tag_redraw()
+    except Exception:
+        pass
+
+
+@bpy.app.handlers.persistent
+def clear_clicked_ends(*args) -> None:
+    """Forget the clicks - and the selection - once undo rolls the geometry back.
+
+    Undo restores the selection along with the geometry, which would leave both
+    edges looking ready to join while the clicks describing them are gone. The
+    join would then run on an edge nobody picked and quietly fall back to the
+    longest side. Clearing both keeps them honest: after an undo you pick the two
+    edges again, and picking them is what records which side to keep.
+    """
+    clicked_ends.clear()
+    pending_presses.clear()
+    # Only while the CAD tool is driving. Undo has no business wiping the
+    # selection for anyone else working in edit mode.
+    if active_tool() == "bim.cad_tool":
+        deselect_edit_meshes()
+
+
+def project_edge(region, rv3d, matrix_world, edge):
+    """Both ends of an edge in screen space, or None if either is behind the camera."""
+    projected = []
+    for vert in edge.verts:
+        co_2d = bpy_extras.view3d_utils.location_3d_to_region_2d(region, rv3d, matrix_world @ vert.co)
+        if co_2d is None:
+            return None
+        projected.append((co_2d, vert))
+    return projected
+
+
+def record_clicked_end(context, region, rv3d, pos: tuple[int, int]) -> None:
+    """Remember how far along the edge just clicked the pointer landed."""
+    obj = context.active_object
+    if not obj or obj.type != "MESH" or obj.mode != "EDIT":
+        return
+
+    bm = bmesh.from_edit_mesh(obj.data)
+    bm.verts.index_update()
+    edge = bm.select_history.active
+    if not isinstance(edge, bmesh.types.BMEdge):
+        # Clicking empty space, or picking a vert or face, tells us nothing.
+        return
+    projected = project_edge(region, rv3d, obj.matrix_world, edge)
+    if not projected:
+        return
+
+    # Measured from the lower-numbered vertex, to match how the join reads it.
+    # This is a screen-space percentage, which equals the real one in orthographic
+    # views and is close enough in perspective except right at the intersection.
+    (a_2d, a), (b_2d, b) = projected
+    if a.index > b.index:
+        a_2d, b_2d = b_2d, a_2d
+    _, percent = mathutils.geometry.intersect_point_line(Vector(pos), a_2d, b_2d)
+
+    if len(clicked_ends) >= MAX_CLICKED_ENDS:
+        clicked_ends.clear()
+    clicked_ends[edge_key(edge)] = min(max(percent, 0.0), 1.0)
+
+
+def resolve_pending_press(context, obj, edge) -> float | None:
+    """Fall back to a drag's press position for an edge that got no proper click."""
+    region = context.region
+    rv3d = context.region_data
+    if not pending_presses or region is None or region.type != "WINDOW" or rv3d is None:
+        return None
+
+    projected = project_edge(region, rv3d, obj.matrix_world, edge)
+    if not projected:
+        return None
+    (a_2d, a), (b_2d, b) = projected
+    if a.index > b.index:  # Measured from the lower-numbered vertex, as elsewhere.
+        a_2d, b_2d = b_2d, a_2d
+
+    # Newest press first - the most recent drag is the one that selected this.
+    for pos in reversed(pending_presses):
+        press = Vector(pos)
+        _, percent = mathutils.geometry.intersect_point_line(press, a_2d, b_2d)
+        percent = min(max(percent, 0.0), 1.0)
+        if (a_2d.lerp(b_2d, percent) - press).length > PRESS_TOLERANCE:
+            continue
+        return percent
+    return None
+
+
+def remove_chain_between(bm, edge_a, edge_b, clicked_percents) -> int:
+    """Delete whatever edges sit between the two being joined, and return how many.
+
+    Without this the in-between edges aren't removed, they're merely dragged along
+    by the vertices the join moves, leaving a spike hanging off the new corner.
+    """
+    # On a closed loop both routes between the two edges can be the same number of
+    # edges, so which one is "between" them cannot be settled by length. The answer
+    # is the route attached to the ends the join is about to throw away.
+    p1, p2 = [vert.co for vert in edge_a.verts]
+    p3, p4 = [vert.co for vert in edge_b.verts]
+    intersection = tool.Cad.get_intersection([p1, p2], [p3, p4])
+    if intersection is None:
+        return 0
+
+    discard_a = tool.Cad.vert_idx_to_move(intersection, edge_a, clicked_percents)
+    discard_b = tool.Cad.vert_idx_to_move(intersection, edge_b, clicked_percents)
+    bm.verts.ensure_lookup_table()
+    chain = tool.Cad.get_chain_between(
+        edge_a, edge_b, start=bm.verts[discard_a], goal=bm.verts[discard_b]
+    )
+    if not chain:
+        return 0
+
+    # Interior vertices of the chain belong to nothing else, so deleting them
+    # takes their edges with them and leaves nothing floating. The vertices the
+    # two joined edges own are never touched - the join still needs them.
+    kept = set(edge_a.verts) | set(edge_b.verts)
+    interior = {vert for edge in chain for vert in edge.verts} - kept
+    if interior:
+        bmesh.ops.delete(bm, geom=list(interior), context="VERTS")
+    # A single edge spanning the two joined edges has no interior vertex, so it
+    # survives the step above and has to go explicitly.
+    remaining = [edge for edge in chain if edge.is_valid]
+    if remaining:
+        bmesh.ops.delete(bm, geom=remaining, context="EDGES")
+
+    bm.verts.ensure_lookup_table()
+    bm.edges.ensure_lookup_table()
+    bm.verts.index_update()
+    bm.edges.index_update()
+    return len(chain)
+
+
+def get_clicked_percents(context, obj, edges) -> dict:
+    """How far along each edge the user clicked, keyed by the edge itself.
+
+    Keyed by edge rather than by vertex indices so it stays valid after the chain
+    between the two edges is removed, which renumbers vertices.
+    """
+    percents = {}
+    for edge in edges:
+        percent = clicked_ends.get(edge_key(edge))
+        if percent is None:
+            percent = resolve_pending_press(context, obj, edge)
+        if percent is not None:
+            percents[edge] = percent
+    return percents
+
+
+class CadSelect(bpy.types.Operator):
+    bl_idname = "bim.cad_select"
+    bl_label = "CAD Select"
+    bl_description = "Select, remembering where you clicked so joins keep the end you picked"
+    bl_options = {"INTERNAL"}
+
+    # Mirrors the properties the default selection keymap sets on view3d.select.
+    # SKIP_SAVE so a shift-click's toggle=True can't leak into the next click.
+    deselect_all: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
+    toggle: bpy.props.BoolProperty(default=False, options={"SKIP_SAVE"})
+
+    def invoke(self, context, event):
+        region = context.region
+        rv3d = context.region_data
+        # Region coords, derived from the (always absolute) window coords.
+        pos = (event.mouse_x - region.x, event.mouse_y - region.y) if region else None
+        # Every mode property is passed explicitly. Leaving any of them out lets
+        # it keep whatever value it last had, which silently turns a plain click
+        # into an extending one and leaves the previous selection in place.
+        result = bpy.ops.view3d.select(
+            "INVOKE_DEFAULT",
+            extend=False,
+            deselect=False,
+            toggle=self.toggle,
+            deselect_all=self.deselect_all,
+            center=False,
+            enumerate=False,
+            object=False,
+        )
+        # Only after the selection has happened do we know which edge was picked.
+        if pos and region.type == "WINDOW" and rv3d:
+            record_clicked_end(context, region, rv3d, pos)
+        return result
+
+
+class CadSelectBox(bpy.types.Operator):
+    bl_idname = "bim.cad_select_box"
+    bl_label = "CAD Box Select"
+    bl_description = "Box select, remembering where the drag started so joins keep the end you picked"
+    bl_options = {"INTERNAL"}
+
+    # Mirrors the property the default selection keymap sets on view3d.select_box.
+    mode: bpy.props.EnumProperty(
+        items=[
+            ("SET", "Set", ""),
+            ("ADD", "Extend", ""),
+            ("SUB", "Subtract", ""),
+            ("AND", "Intersect", ""),
+        ],
+        default="SET",
+        options={"SKIP_SAVE"},
+    )
+
+    def invoke(self, context, event):
+        region = context.region
+        # A drag this short is a click the user fumbled, and the press position
+        # is the closest thing to the click they meant to make. Box select is
+        # modal, so the answer has to wait until the join asks for it.
+        if region and region.type == "WINDOW":
+            pos = (event.mouse_x - region.x, event.mouse_y - region.y)
+            pending_presses.append(pos)
+            del pending_presses[:-MAX_PENDING_PRESSES]
+        return bpy.ops.view3d.select_box("INVOKE_DEFAULT", mode=self.mode)
+
+
 class CadTrimExtend(bpy.types.Operator):
     bl_idname = "bim.cad_trim_extend"
     bl_label = "CAD Trim / Extend"
@@ -65,7 +327,8 @@ class CadTrimExtend(bpy.types.Operator):
         edges = [e for e in bm.edges if e.select and not e.hide]
 
         if len(edges) == 2:
-            message = tool.Cad.do_vtx_if_appropriate(bm, edges, mode="T")
+            clicked_percents = get_clicked_percents(context, obj, edges)
+            message = tool.Cad.do_vtx_if_appropriate(bm, edges, mode="T", clicked_percents=clicked_percents)
             if isinstance(message, set):
                 msg = messages.get(message.pop())
                 return self.cancel_message(msg)
@@ -111,7 +374,11 @@ class CadMitre(bpy.types.Operator):
         edges = [e for e in bm.edges if e.select and not e.hide]
 
         if len(edges) == 2:
-            message = tool.Cad.do_vtx_if_appropriate(bm, edges, mode="V")
+            # Resolved before anything is deleted, and keyed by edge so it stays
+            # valid once removing the chain renumbers the vertices.
+            clicked_percents = get_clicked_percents(context, obj, edges)
+            remove_chain_between(bm, edges[0], edges[1], clicked_percents)
+            message = tool.Cad.do_vtx_if_appropriate(bm, edges, mode="V", clicked_percents=clicked_percents)
             if isinstance(message, set):
                 msg = messages.get(message.pop())
                 return self.cancel_message(msg)

--- a/src/bonsai/bonsai/bim/module/cad/workspace.py
+++ b/src/bonsai/bonsai/bim/module/cad/workspace.py
@@ -57,7 +57,13 @@ class CadTool(WorkSpaceTool):
     bl_description = "Gives you CAD authoring related superpowers"
     bl_icon = os.path.join(os.path.dirname(__file__), "ops.authoring.cad")
     bl_widget = None
-    bl_keymap = tool.Blender.get_default_selection_keypmap() + (
+    # bim.cad_select records where each click lands so that Join and Extend can
+    # keep the end of the edge the user clicked on. bim.cad_select_box covers the
+    # same ground for a click that drags slightly, which Blender routes to box
+    # select instead - otherwise those selections arrive with no click recorded.
+    bl_keymap = tool.Blender.get_default_selection_keypmap(
+        select_operator="bim.cad_select", box_select_operator="bim.cad_select_box"
+    ) + (
         ("bim.cad_hotkey", {"type": "C", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_C")]}),
         ("bim.cad_hotkey", {"type": "E", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_E")]}),
         ("bim.cad_hotkey", {"type": "F", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_F")]}),

--- a/src/bonsai/bonsai/bim/module/cad/workspace.py
+++ b/src/bonsai/bonsai/bim/module/cad/workspace.py
@@ -57,13 +57,17 @@ class CadTool(WorkSpaceTool):
     bl_description = "Gives you CAD authoring related superpowers"
     bl_icon = os.path.join(os.path.dirname(__file__), "ops.authoring.cad")
     bl_widget = None
-    # bim.cad_select records where each click lands so that Join and Extend can
-    # keep the end of the edge the user clicked on. bim.cad_select_box covers the
-    # same ground for a click that drags slightly, which Blender routes to box
-    # select instead - otherwise those selections arrive with no click recorded.
-    bl_keymap = tool.Blender.get_default_selection_keypmap(
-        select_operator="bim.cad_select", box_select_operator="bim.cad_select_box"
-    ) + (
+    # bim.cad_select records where each click lands so that Join and Extend can keep
+    # the end of the edge the user clicked on. bim.cad_select_box covers the same
+    # ground for a click that drags slightly, which Blender routes to box select
+    # instead - otherwise those selections arrive with no click recorded.
+    #
+    # Read back by tool.Blender.get_tool_select_operators, so that rebuilding the
+    # keymap for the Cross Select preference keeps these rather than substituting
+    # the generic pair. With Cross Select on, bim.cross_select handles the click and
+    # records it itself, and these are not used.
+    bim_select_operators = ("bim.cad_select", "bim.cad_select_box")
+    bl_keymap = tool.Blender.get_default_selection_keypmap(*bim_select_operators) + (
         ("bim.cad_hotkey", {"type": "C", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_C")]}),
         ("bim.cad_hotkey", {"type": "E", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_E")]}),
         ("bim.cad_hotkey", {"type": "F", "value": "PRESS", "shift": True}, {"properties": [("hotkey", "S_F")]}),

--- a/src/bonsai/bonsai/bim/module/model/workspace.py
+++ b/src/bonsai/bonsai/bim/module/model/workspace.py
@@ -1929,6 +1929,23 @@ class CrossSelect(bpy.types.Operator):
             )
         except Exception:
             pass
+        self._record_cad_click(context, event)
+
+    @staticmethod
+    def _record_cad_click(context, event) -> None:
+        """Tell the CAD tools where this click landed.
+
+        When Cross Select is on it owns every LEFTMOUSE press, so bim.cad_select is
+        not in any keymap and the CAD tool would otherwise see no clicks at all -
+        leaving Join unable to tell which end of an edge was picked. Only clicks are
+        reported; a drag is a box select and picks no particular end.
+        """
+        from bonsai.bim.module.cad.operator import record_clicked_end
+
+        region = context.region
+        rv3d = context.region_data
+        if region and region.type == "WINDOW" and rv3d:
+            record_clicked_end(context, region, rv3d, (event.mouse_region_x, event.mouse_region_y))
 
 
 custom_icon_previews = None

--- a/src/bonsai/bonsai/core/tool.py
+++ b/src/bonsai/bonsai/core/tool.py
@@ -93,7 +93,7 @@ class Blender:
     def create_ifc_object(cls, ifc_class: str, name: Optional[str] = None, data=None): pass
     def get_active_object(cls): pass
     def get_bmesh_for_mesh(cls, mesh, clean=False): pass
-    def get_default_selection_keypmap(cls): pass
+    def get_default_selection_keypmap(cls, select_operator: str = "view3d.select", box_select_operator: str = "view3d.select_box"): pass
     def get_name(cls, ifc_class, name): pass
     def get_obj_ifc_definition_id(cls, obj=None, obj_type=None, context=None): pass
     def get_object_bounding_box(cls, obj): pass

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -843,7 +843,19 @@ class Blender(bonsai.core.tool.Blender):
     # Length of the selection block in bl_keymap, keyed by the operator idname of its
     # first entry.  Used to locate and replace the selection block during a rebuild
     # while preserving any pre-selection or post-selection entries the tool declares.
-    _SELECTION_PREFIX_LENGTHS = {"bim.cross_select": 4, "view3d.select_box": 6}
+    # bim.cad_select_box is the CAD tool's wrapper - see bim_select_operators below.
+    _SELECTION_PREFIX_LENGTHS = {"bim.cross_select": 4, "view3d.select_box": 6, "bim.cad_select_box": 6}
+
+    @classmethod
+    def get_tool_select_operators(cls, tool_cls) -> tuple[str, str]:
+        """The (click, drag) selection operators a tool wants in its keymap.
+
+        A tool declares ``bim_select_operators`` when it needs to know more about a
+        click than plain selection reports - the CAD tool records which end of an
+        edge was clicked so Join can keep that side. Everything else gets Blender's
+        native pair.
+        """
+        return getattr(tool_cls, "bim_select_operators", ("view3d.select", "view3d.select_box"))
 
     @classmethod
     def _iter_selection_tools(cls):
@@ -893,10 +905,10 @@ class Blender(bonsai.core.tool.Blender):
         """
         if bpy.app.background:
             return
-        selection_keymap = tuple(cls.get_default_selection_keypmap())
         tools = list(cls._iter_selection_tools())
         if not tools:
             return
+        selection_keymap = tuple(cls.get_default_selection_keypmap(*cls.get_tool_select_operators(tools[0][0])))
 
         desired_op = selection_keymap[0][0] if selection_keymap else None
         current = tuple(tools[0][0].bl_keymap)
@@ -917,7 +929,10 @@ class Blender(bonsai.core.tool.Blender):
                 pass
         for tool_cls, after, separator, group in tools:
             pre, post = pre_post[tool_cls]
-            tool_cls.bl_keymap = pre + selection_keymap + post
+            # Rebuilt per tool, so a tool that wraps selection keeps its wrappers
+            # instead of being handed the generic pair.
+            tool_keymap = tuple(cls.get_default_selection_keypmap(*cls.get_tool_select_operators(tool_cls)))
+            tool_cls.bl_keymap = pre + tool_keymap + post
             bpy.utils.register_tool(tool_cls, after=after, separator=separator, group=group)
 
     KEY_MODIFIERS = {

--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -753,31 +753,40 @@ class Blender(bonsai.core.tool.Blender):
                             pass
 
     @classmethod
-    def get_native_selection_keymap(cls) -> tuple:
-        """Blender's default click + box selection keymap (used when Cross Select is off)."""
+    def get_native_selection_keymap(
+        cls, select_operator: str = "view3d.select", box_select_operator: str = "view3d.select_box"
+    ) -> tuple:
+        """Blender's default click + box selection keymap (used when Cross Select is off).
+
+        :param select_operator: Operator to use for click selection. Tools that need
+            to know where the user clicked can pass a wrapper around ``view3d.select``.
+        :param box_select_operator: Operator to use for drag selection. A click that
+            drags even slightly comes here instead of ``select_operator``, so a tool
+            that wraps one usually needs to wrap both.
+        """
         # Data from blender_default.py (GPL v2): the items of km_3d_view_tool_select_box()
         # and km_3d_view_tool_select(select_mouse="LEFTMOUSE"). See git history for the
         # console snippet to regenerate these if Blender's defaults ever change.
         return (
-            ("view3d.select_box", {"type": "LEFTMOUSE", "value": "CLICK_DRAG"}, None),
+            (box_select_operator, {"type": "LEFTMOUSE", "value": "CLICK_DRAG"}, None),
             (
-                "view3d.select_box",
+                box_select_operator,
                 {"type": "LEFTMOUSE", "value": "CLICK_DRAG", "shift": True},
                 {"properties": [("mode", "ADD")]},
             ),
             (
-                "view3d.select_box",
+                box_select_operator,
                 {"type": "LEFTMOUSE", "value": "CLICK_DRAG", "ctrl": True},
                 {"properties": [("mode", "SUB")]},
             ),
             (
-                "view3d.select_box",
+                box_select_operator,
                 {"type": "LEFTMOUSE", "value": "CLICK_DRAG", "shift": True, "ctrl": True},
                 {"properties": [("mode", "AND")]},
             ),
-            ("view3d.select", {"type": "LEFTMOUSE", "value": "PRESS"}, {"properties": [("deselect_all", True)]}),
+            (select_operator, {"type": "LEFTMOUSE", "value": "PRESS"}, {"properties": [("deselect_all", True)]}),
             (
-                "view3d.select",
+                select_operator,
                 {"type": "LEFTMOUSE", "value": "PRESS", "shift": True},
                 {"properties": [("toggle", True)]},
             ),
@@ -813,15 +822,23 @@ class Blender(bonsai.core.tool.Blender):
             return True
 
     @classmethod
-    def get_default_selection_keypmap(cls) -> tuple:
+    def get_default_selection_keypmap(
+        cls, select_operator: str = "view3d.select", box_select_operator: str = "view3d.select_box"
+    ) -> tuple:
         """Selection keymap shared by every Bonsai tool.
 
         Returns the Cross Select keymap when the add-on preference is enabled, otherwise
         Blender's native selection keymap. ``bl_keymap`` is evaluated once when the tool
         classes are imported, so toggling the preference re-applies the keymap live via
         :meth:`apply_cross_select_preference`.
+
+        :param select_operator: Operator to use for click selection. Tools that need
+            to know where the user clicked can pass a wrapper around ``view3d.select``.
+        :param box_select_operator: Operator to use for drag selection.
         """
-        return cls.get_cross_select_keymap() if cls.is_cross_select_enabled() else cls.get_native_selection_keymap()
+        if cls.is_cross_select_enabled():
+            return cls.get_cross_select_keymap()
+        return cls.get_native_selection_keymap(select_operator, box_select_operator)
 
     # Length of the selection block in bl_keymap, keyed by the operator idname of its
     # first entry.  Used to locate and replace the selection block during a rebuild

--- a/src/bonsai/bonsai/tool/cad.py
+++ b/src/bonsai/bonsai/tool/cad.py
@@ -559,16 +559,100 @@ class Cad:
         return bm
 
     @classmethod
-    def perform_t(cls, bm, pt, target, edge, pts, vertex_indices):
-        cl_vert = cls.closest_idx(pt, bm.edges[edge.index])
+    def get_chain_between(cls, edge_a, edge_b, start=None, goal=None) -> list:
+        """
+        > edge_a, edge_b:   bmesh edges
+        > start:            vertex of `edge_a` to walk from, or both of them
+        > goal:             vertex of `edge_b` to walk to, or either of them
+        < returns:          the edges of the shortest path linking them, excluding
+                            themselves, or an empty list if they aren't linked
+
+        Joining two edges of a chain leaves whatever sat between them stranded -
+        dragged along by the moved vertices instead of removed. These are the
+        edges that have to go for the join to produce a clean corner.
+
+        On a closed loop there are two routes between any pair of edges, and they
+        can be the same length, so `start` and `goal` pin down which one is meant:
+        the route hanging off the ends the join is about to discard.
+        """
+        goal = {goal} if goal is not None else set(edge_b.verts)
+        starts = [start] if start is not None else list(edge_a.verts)
+        # How each vertex was reached: {vertex: (edge walked, previous vertex)}.
+        came_from = {vert: None for vert in starts}
+        frontier = list(starts)
+
+        while frontier:
+            next_frontier = []
+            for vert in frontier:
+                if vert in goal:
+                    path = []
+                    while came_from[vert] is not None:
+                        edge, vert = came_from[vert]
+                        path.append(edge)
+                    return path
+                for edge in vert.link_edges:
+                    if edge is edge_a or edge is edge_b:
+                        continue
+                    other = edge.other_vert(vert)
+                    if other is None or other in came_from:
+                        continue
+                    came_from[other] = (edge, vert)
+                    next_frontier.append(other)
+            frontier = next_frontier
+        return []
+
+    @classmethod
+    def vert_idx_to_move(cls, pt, e, clicked_percents=None):
+        """
+        > pt:                 vector, the intersection point the edge is joined at
+        > e:                  bmesh edge
+        > clicked_percents:   optional {bmesh edge: percent} of where along each
+                              edge the user clicked, measured from its lower-numbered
+                              vertex. Keyed by the edge itself, not by vertex indices,
+                              because removing the chain between the two edges
+                              renumbers vertices while leaving the edges intact.
+        < returns:            index of the vertex of `e` that should be moved to `pt`
+
+        By default the vertex closest to `pt` is moved, which always keeps the
+        longest side of the edge. When `pt` falls inside the edge both sides are
+        equally valid, so the side the user clicked on is kept instead.
+
+        The intersection is what divides the edge into the two sides on offer, so
+        that - not the edge's midpoint - is what a click has to be compared
+        against. Keeping the nearer endpoint instead splits the edge in the wrong
+        place, and picks the wrong side for any click between the two.
+        """
+        v1, v2 = e.verts
+        low, high = (v1, v2) if v1.index < v2.index else (v2, v1)
+        percent = cls.edge_percent(pt, (low.co, high.co))
+
+        clicked = clicked_percents.get(e) if clicked_percents else None
+        if clicked is None:
+            return cls.closest_idx(pt, e)
+
+        # Only meaningful when pt splits the edge - if pt is off the end then
+        # the edge has to be extended and there is only one vertex to move.
+        if not cls.is_point_on_edge(pt, (v1.co, v2.co)):
+            return cls.closest_idx(pt, e)
+
+        keep, move = (low, high) if clicked < percent else (high, low)
+
+        # Never collapse the edge to nothing if pt sits on the vertex we'd keep.
+        if (keep.co - pt).length < VTX_PRECISION:
+            return cls.closest_idx(pt, e)
+        return move.index
+
+    @classmethod
+    def perform_t(cls, bm, pt, target, edge, pts, vertex_indices, clicked_percents=None):
+        cl_vert = cls.vert_idx_to_move(pt, bm.edges[edge.index], clicked_percents)
         bm.verts[cl_vert].co = pt
         bm.edges.index_update()
         return bm
 
     @classmethod
-    def perform_v(cls, bm, pt, target, edge, pts, vertex_indices):
-        bm = cls.perform_t(bm, pt, target, edge, pts, vertex_indices)
-        bm = cls.perform_t(bm, pt, edge, target, pts, vertex_indices)
+    def perform_v(cls, bm, pt, target, edge, pts, vertex_indices, clicked_percents=None):
+        bm = cls.perform_t(bm, pt, target, edge, pts, vertex_indices, clicked_percents)
+        bm = cls.perform_t(bm, pt, edge, target, pts, vertex_indices, clicked_percents)
         return bm
 
     @classmethod
@@ -576,7 +660,7 @@ class Cad:
         return [edges[0], edges[1]] if bm.select_history.active == edges[0] else [edges[1], edges[0]]
 
     @classmethod
-    def do_vtx_if_appropriate(cls, bm, edges, mode):
+    def do_vtx_if_appropriate(cls, bm, edges, mode, clicked_percents=None):
         vertex_indices = cls.get_vert_indices_from_bmedges(edges)
 
         # test 1, are there shared vers? if so return non-viable
@@ -597,9 +681,9 @@ class Cad:
         edges = cls.prioritise_active_edge(bm, edges)
         # point must lie on an edge or the virtual extension of an edge
         if mode == "T":
-            bm = cls.perform_t(bm, point, edges[0], edges[1], (p1, p2, p3, p4), vertex_indices)
+            bm = cls.perform_t(bm, point, edges[0], edges[1], (p1, p2, p3, p4), vertex_indices, clicked_percents)
         elif mode == "V":
-            bm = cls.perform_v(bm, point, edges[0], edges[1], (p1, p2, p3, p4), vertex_indices)
+            bm = cls.perform_v(bm, point, edges[0], edges[1], (p1, p2, p3, p4), vertex_indices, clicked_percents)
         return bm
 
     @classmethod


### PR DESCRIPTION
Closes #9314

> [!IMPORTANT]
> Stacked on #8153 — this PR targets `cross_select_integration`, so the diff shows only its own two commits. **#8153 needs to merge first.** GitHub will retarget this to `v0.9.0` automatically when it does.

## What this does

Joining two crossing edges is ambiguous: the intersection divides each edge into two pieces and either could be the one kept. Join always kept the **longest** piece, so the shorter one was unreachable.

Now **the piece you clicked is the piece that survives** — click near the end you want to keep, and the rest is trimmed back to the intersection. This matches how joining and filleting work in most CAD packages, where the portions you select are the portions retained.

Join also **removes the chain of edges between the two being joined**. Previously those weren't removed at all, just dragged along by the vertices the join moved, leaving a spike hanging off the new corner.

## Notes for review

**Clicks are captured as they happen.** `bim.cad_select` / `bim.cad_select_box` wrap the CAD tool's selection keymap and record how far along the edge the pointer landed. Reading the mouse when the hotkey is pressed does not work — it has moved on by then — and a remembered screen position goes stale, because the geometry itself shifts during the join.

**The edge is split at the intersection, not at its midpoint.** The two differ, and splitting at the midpoint picks the wrong side for any click between them. Where the intersection falls beyond the end of an edge, the edge has to be *extended* to reach the joint and there is only one sensible outcome, so the click is ignored there.

**The chain is found between the two ends the join discards.** On a closed loop both routes between two edges can be the same number of edges, so shortest-path alone picks arbitrarily and can delete the wrong side.

**Undo clears the selection as well as the remembered clicks.** Undo restores the selection along with the geometry, which would otherwise leave both edges looking ready to join while the clicks describing them were gone — and the join would quietly fall back to the longest side. Scoped to when the CAD tool is active.

## Two incidental fixes to selection

Both fall out of wrapping `view3d.select`, and are worth keeping regardless of this feature:

- **Every mode property is now passed explicitly.** Omitting any let it keep whatever value it last held, silently turning a plain click into an extending one and leaving the previous selection in place.
- **`view3d.select_box` is wrapped too.** A click that drags even slightly is routed there rather than to click-select, and would otherwise arrive with no click recorded.

## Interaction with #8153

The second commit exists because Cross Select routes every `LEFTMOUSE` press through `bim.cross_select` and drops `view3d.select` from the tool keymaps entirely. Without it, Cross Select being enabled — the default — means the CAD tool sees no clicks at all and Join silently reverts to keeping the longest side.

`bim.cross_select` now reports its single clicks to the CAD tools. Only clicks; a drag is a box select and picks no particular end. Rebuilding the keymap for the preference toggle also had to stop handing every tool the generic selection pair, so tools can declare their own via `bim_select_operators`.

## Known characteristic

The side you click is only as easy to hit as it is big on screen, so a short piece at a low zoom is a small target — zooming in makes the intended side easier to click. This is inherent to "what you click is what you keep" rather than a defect, but worth knowing.

## Testing

Manually tested in Blender during development, with Cross Select **off**: joining with the click on either side of the intersection, undoing and re-picking, and joining across a chain of intermediate edges.

Two things have **not** been exercised since and are worth a look:

- the second commit's path, i.e. joining with Cross Select **on**, where `bim.cross_select` records the click instead of `bim.cad_select`
- toggling the Cross Select preference with the CAD tool active, which rebuilds its keymap

Not covered by automated tests.
