### PR TITLE
Fix EPset_Drawing.BringToFront not applying to merged cut geometry

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -1725,8 +1725,12 @@ class CreateDrawing(bpy.types.Operator):
                         polygon_classes.update(polygon2_classes)
                         queue.remove((polygon2, polygon2_classes))
 
-                g = etree.Element("g")
-                path = etree.SubElement(g, "path")
+                # Must be created in the SVG namespace. Serialisation looks
+                # identical either way, but an unnamespaced <g> is invisible to
+                # the ".//svg:g" XPath queries that run later in this same
+                # session (e.g. move_elements_to_top for EPset_Drawing.BringToFront).
+                g = etree.Element("{http://www.w3.org/2000/svg}g")
+                path = etree.SubElement(g, "{http://www.w3.org/2000/svg}path")
                 d = "M" + " L".join([",".join([str(o) for o in co]) for co in polygon.exterior.coords[0:-1]]) + " Z"
                 for interior in polygon.interiors:
                     d += " M" + " L".join([",".join([str(o) for o in co]) for co in interior.coords[0:-1]]) + " Z"


### PR DESCRIPTION
Fixes #9317

`EPset_Drawing.BringToFront` only reordered *some* of an element's SVG groups. The ones it missed were the merged cut and material-layer groups — i.e. exactly the groups holding the filled, closed polygons that do the occluding — so a listed element failed to hide anything behind it.

`merge_linework_and_add_metadata` created those groups with `etree.Element("g")`, which puts them outside the SVG namespace. `move_elements_to_top` looks for them with `.//svg:g[contains(@class, '...')]`, which cannot match an unnamespaced element.

The reason this went unnoticed is that it is invisible in the written file. lxml serialises an unnamespaced `<g>` inside an SVG-default-namespace parent as plain `<g class="...">` — no `xmlns=""` — so on re-parse the element *is* SVG-namespaced. The mismatch exists only in memory, during the one session where it matters:

```python
>>> from lxml import etree
>>> root = etree.fromstring(b'<svg xmlns="http://www.w3.org/2000/svg"><g class="outer"/></svg>')
>>> group = root.find('{http://www.w3.org/2000/svg}g')
>>> g = etree.Element('g'); g.set('class', 'merged IfcSlab')
>>> group.append(g)
>>> etree.tostring(root)
b'<svg xmlns="http://www.w3.org/2000/svg"><g class="outer"><g class="merged IfcSlab"/></g></svg>'
>>> len(root.xpath('.//svg:g[contains(@class,"IfcSlab")]', namespaces={'svg': 'http://www.w3.org/2000/svg'}))
0
```

Creating the group and path in the SVG namespace leaves the serialised output byte-identical and makes them visible to the later XPath queries.

### Before / after

Test case: a section with `EPset_Drawing.BringToFront = "IfcSlab"`, where the slab passes through a wall.

Group order before — only the serializer's `projection` group (correctly namespaced) reaches the end; the two merged `IfcSlab` cut groups stay underneath the wall:

```
IfcWall material-null projection
0faNkgG_1DN9MDzCSffnKC IfcSlab cut material-null              <- should be on top
cut IfcWall material-null 1skYUSkBX1HwA9bn4RdVwu
IfcSlab layer-material-Unknown cut IfcMaterialLayer ...       <- should be on top
IfcWall cut layer-material-Framing ... IfcMaterialLayer ...   <- paints over the slab
IfcWall cut ... IfcMaterialLayer layer-material-Glazing ...   <- paints over the slab
IfcSlab material-null projection                              <- the only group that moved
```

After, all `IfcSlab` groups are moved to the end and the slab correctly occludes the wall. (The remaining sliver of wall on the far side is correct — the slab genuinely does not extend that far.)

### Not addressed here

There are two more unnamespaced `etree.Element("path")` calls in the same file (the SHAPELY `surface` fills and the `IfcSpace` pass). Nothing queries them in-memory afterwards, so they are latent rather than broken; left alone to keep this change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
