### PR TITLE
Bonsai: clear stale linked element queries on unload

### DIFF
--- a/src/bonsai/bonsai/bim/module/project/operator.py
+++ b/src/bonsai/bonsai/bim/module/project/operator.py
@@ -1504,8 +1504,12 @@ class UnloadLink(bpy.types.Operator, tool.Ifc.Operator):
         link_index: int
 
     def _execute(self, context):
-        link = tool.Project.get_project_props().links[self.link_index]
+        props = tool.Project.get_project_props()
+        link = props.links[self.link_index]
         if obj := tool.Project.get_link_empty_handle(link):
+            if props.queried_obj_root == obj:
+                tool.Project.Link.deselect_queried_linked_element()
+                LinksData.linked_data = {}
             collection = obj.instance_collection
             library = collection.library
             tool.Ifc.unlink(obj=obj)

--- a/src/bonsai/test/tool/test_project.py
+++ b/src/bonsai/test/tool/test_project.py
@@ -35,6 +35,7 @@ from ifcpatch.recipes import Ifc2Sql
 
 import bonsai.core.tool
 import bonsai.tool as tool
+from bonsai.bim.module.project.data import LinksData
 from bonsai.tool.project import Project as subject
 from test.bim.bootstrap import NewFile
 
@@ -336,6 +337,65 @@ class TestLoadLinkedModels(NewFile):
             subject.load_linked_models_from_ifc()
             assert len(props.links) == 1
             assert props.links[0].query == ""
+
+
+class TestUnloadLink(NewFile):
+    @staticmethod
+    def create_link(name: str) -> tuple[bpy.types.Object, bpy.types.Object]:
+        collection = bpy.data.collections.new(f"IfcProject/{name}")
+        chunk = bpy.data.objects.new("Chunk", bpy.data.meshes.new(f"{name} Mesh"))
+        collection.objects.link(chunk)
+
+        handle = bpy.data.objects.new(f"IfcProject/{name}", None)
+        handle.instance_type = "COLLECTION"
+        handle.instance_collection = collection
+        bpy.context.scene.collection.objects.link(handle)
+
+        link = tool.Project.get_project_props().links.add()
+        link.name = name
+        link.empty_handle = handle
+        link.is_loaded = True
+        return handle, chunk
+
+    @staticmethod
+    def query_linked_element(handle: bpy.types.Object, chunk: bpy.types.Object, guid: str) -> None:
+        props = tool.Project.get_project_props()
+        props.queried_obj = chunk
+        props.queried_obj_root = handle
+        props.queried_guid = guid
+        for field in subject.Link.SelectedGeometry._fields:
+            chunk[field] = []
+        LinksData.linked_data = {
+            "attributes": {"GlobalId": guid},
+            "properties": [],
+            "type_properties": [],
+        }
+
+    def test_unloading_the_queried_link_clears_queried_element_state(self):
+        handle, chunk = self.create_link("queried.ifc")
+        self.query_linked_element(handle, chunk, "queried-guid")
+
+        bpy.ops.bim.unload_link(link_index=0)
+
+        props = tool.Project.get_project_props()
+        assert props.queried_obj is None
+        assert props.queried_obj_root is None
+        assert props.queried_guid == ""
+        assert LinksData.linked_data == {}
+
+    def test_unloading_another_link_preserves_queried_element_state(self):
+        queried_handle, queried_chunk = self.create_link("queried.ifc")
+        self.create_link("other.ifc")
+        self.query_linked_element(queried_handle, queried_chunk, "queried-guid")
+
+        bpy.ops.bim.unload_link(link_index=1)
+
+        props = tool.Project.get_project_props()
+        assert props.queried_obj == queried_chunk
+        assert props.queried_obj_root == queried_handle
+        assert props.queried_guid == "queried-guid"
+        assert LinksData.linked_data["attributes"]["GlobalId"] == "queried-guid"
+        LinksData.linked_data = {}
 
 
 class TestCalculateLinkMatrix(NewFile):


### PR DESCRIPTION
## Summary

- Clear queried linked-element state when unloading the link that supplied it.
- Preserve valid queried-element state when unloading a different link.
- Add regression coverage for both behaviours.

Fixes #9322.

## Root cause

`UnloadLink` removed the linked geometry but did not clear the associated queried-object properties or cached `LinksData.linked_data`. The Links panel could therefore continue displaying the identity of an element from an unloaded link. Reloading a link inherited the same problem because it uses the unload lifecycle internally.

## User impact

After **Unload Link** or **Reload Link**, the Links panel no longer presents stale element identification. Query data belonging to another loaded link remains intact.

## Validation

- Manual reproduction confirmed with Bonsai `0.8.6-alpha260808` (`0a51ebd`), Blender 5.1.2 and Debian Linux.
- Patch based on `bonsai-0.8.6-alpha2608132105` (`1af5cc9`).
- `git diff --check`: passed.
- Python compilation check: passed.
- Local Black check on the two changed files: passed unchanged.
- Ruff check: passed.
- GitHub Actions `ci/compile-and-test`: passed.
- The Blender regression tests were not run locally because the full `pytest-blender` development environment was unavailable.

## CI baseline note

The GitHub Actions `ci-lint/lint-formatting` job currently fails because `psf/black@stable` installed Black 26.5.1 and flagged these three pre-existing files from the unchanged `v0.8.0` base:

- `src/ifcopenshell-python/test/api/alignment/test_create.py`
- `src/ifcopenshell-python/ifcopenshell/util/unit.py`
- `src/ifcopenshell-python/test/api/alignment/test_referent_names.py`

None of these files is modified by this PR. Syntax checking, Ruff and both `ty` checks within the lint job passed. No unrelated formatting changes have been added to this patch.

## AI assistance disclosure

The diagnosis, patch, regression tests and pull-request text were developed with OpenAI Codex/ChatGPT under the contributor's direction. The contributor reviewed the changes and performed the reported manual validation.
