### PR TITLE
Rectangle mode for the polyline slab, wall and profile tools (closes #9326)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -26,7 +26,7 @@ import ifcopenshell.util.unit
 from mathutils import Vector
 
 import bonsai.tool as tool
-from bonsai.bim.module.model.decorator import PolylineDecorator
+from bonsai.bim.module.model.decorator import PolylineDecorator, ProductDecorator
 
 
 class PolylineOperator:
@@ -382,6 +382,49 @@ class PolylineOperator:
             should_round = False
         tool.Polyline.update_rectangle_polyline(self.input_ui, self.tool_state, should_round=should_round)
         tool.Blender.update_viewport()
+
+    def handle_rectangle_drawing(
+        self, context: bpy.types.Context, event: bpy.types.Event
+    ) -> Union[set[str], None]:
+        """Handle the modal events while the second corner of a rectangle is being picked.
+
+        Once the first corner is picked, the rectangle is fully defined by the current point,
+        so picking the second corner also finishes the shape, by calling the `finish` method
+        that the operator using this must implement. Returns None when the event should keep
+        being handled as a free form polyline instead.
+        """
+        if not self.tool_state.rectangle_mode or not len(self.get_polyline_points()):
+            return None
+
+        self.handle_rectangle_preview(context, event, should_round=not self.tool_state.is_input_on)
+
+        confirm_types = {"RET", "NUMPAD_ENTER", "RIGHTMOUSE"}
+        if not self.tool_state.is_input_on:
+            confirm_types.add("LEFTMOUSE")
+
+        if event.value == "RELEASE" and event.type in confirm_types:
+            if self.tool_state.is_input_on:
+                if not self.recalculate_inputs(context):
+                    return {"RUNNING_MODAL"}
+                self.handle_rectangle_preview(context, event)
+            if not tool.Polyline.is_rectangle_valid():
+                self.report({"WARNING"}, "Cannot create a rectangle with a zero length side.")
+                return {"RUNNING_MODAL"}
+            return self.finish(context)
+
+        self.handle_keyboard_input(context, event)
+
+        # There is no point to remove, so the rectangle starts over
+        if not self.tool_state.is_input_on and event.value == "RELEASE" and event.type == "BACK_SPACE":
+            tool.Polyline.clear_polyline()
+            tool.Blender.update_viewport()
+
+        cancel = self.handle_cancelation(context, event)
+        if cancel is not None:
+            ProductDecorator.uninstall()
+            return cancel
+
+        return {"RUNNING_MODAL"}
 
     def handle_snap_selection(self, context: bpy.types.Context, event: bpy.types.Event) -> None:
         if not self.tool_state.is_input_on and event.value == "PRESS" and event.type == "M":

--- a/src/bonsai/bonsai/bim/module/model/polyline.py
+++ b/src/bonsai/bonsai/bim/module/model/polyline.py
@@ -355,6 +355,34 @@ class PolylineOperator:
                 tool.Polyline.remove_last_polyline_point()
                 tool.Blender.update_viewport()
 
+    def get_polyline_points(self) -> Union[bpy.types.bpy_prop_collection, list]:
+        polyline_props = tool.Model.get_polyline_props()
+        polyline_data = polyline_props.insertion_polyline
+        return polyline_data[0].polyline_points if polyline_data else []
+
+    def set_rectangle_mode(self, value: bool) -> None:
+        """Rectangle mode is stored in the scene so that it is kept between tool invocations."""
+        self.tool_state.rectangle_mode = value
+        tool.Model.get_polyline_props().rectangle_mode = value
+
+    def handle_rectangle_mode(self, context: bpy.types.Context, event: bpy.types.Event) -> None:
+        """Toggle between drawing a free form polyline and drawing a rectangle from two opposite corners."""
+        if not self.tool_state.is_input_on and event.value == "RELEASE" and event.type == "R" and not event.shift:
+            self.set_rectangle_mode(not self.tool_state.rectangle_mode)
+            # The points already inserted don't describe a rectangle, so the shape starts over.
+            tool.Polyline.clear_polyline()
+            PolylineDecorator.update(event, self.tool_state, self.input_ui, self.snapping_points[0])
+            tool.Blender.update_viewport()
+
+    def handle_rectangle_preview(
+        self, context: bpy.types.Context, event: bpy.types.Event, should_round: bool = False
+    ) -> None:
+        """Update the provisional rectangle corners based on the first corner and the current point."""
+        if should_round and self.snapping_points[0]["type"] not in {"Plane", "Axis"}:
+            should_round = False
+        tool.Polyline.update_rectangle_polyline(self.input_ui, self.tool_state, should_round=should_round)
+        tool.Blender.update_viewport()
+
     def handle_snap_selection(self, context: bpy.types.Context, event: bpy.types.Event) -> None:
         if not self.tool_state.is_input_on and event.value == "PRESS" and event.type == "M":
             self.snapping_points = tool.Snap.modify_snapping_point_selection(

--- a/src/bonsai/bonsai/bim/module/model/profile.py
+++ b/src/bonsai/bonsai/bim/module/model/profile.py
@@ -1194,7 +1194,13 @@ class DrawPolylineProfile(bpy.types.Operator, PolylineOperator, tool.Ifc.Operato
             self.handle_mouse_move(context, event)
             return {"PASS_THROUGH"}
 
-        self.handle_instructions(context)
+        self.handle_rectangle_mode(context, event)
+
+        custom_instructions = {"Rectangle": {"icons": True, "keys": ["EVENT_R"]}}
+
+        profile_config = [f"Rectangle: {'ON' if self.tool_state.rectangle_mode else 'OFF'}"]
+
+        self.handle_instructions(context, custom_instructions, profile_config)
 
         self.handle_mouse_move(context, event, should_round=True)
 
@@ -1204,19 +1210,16 @@ class DrawPolylineProfile(bpy.types.Operator, PolylineOperator, tool.Ifc.Operato
 
         self.handle_snap_selection(context, event)
 
+        rectangle = self.handle_rectangle_drawing(context, event)
+        if rectangle is not None:
+            return rectangle
+
         if (
             not self.tool_state.is_input_on
             and event.value == "RELEASE"
             and event.type in {"RET", "NUMPAD_ENTER", "RIGHTMOUSE"}
         ):
-            self.create_profiles_from_polyline(context)
-            context.workspace.status_text_set(text=None)
-            self.tool_state.plane_method = None
-            ProductDecorator.uninstall()
-            PolylineDecorator.uninstall()
-            tool.Polyline.clear_polyline()
-            tool.Blender.update_viewport()
-            return {"FINISHED"}
+            return self.finish(context)
 
         self.handle_keyboard_input(context, event)
         self.handle_inserting_polyline(context, event)
@@ -1228,6 +1231,16 @@ class DrawPolylineProfile(bpy.types.Operator, PolylineOperator, tool.Ifc.Operato
 
         return {"RUNNING_MODAL"}
 
+    def finish(self, context):
+        self.create_profiles_from_polyline(context)
+        context.workspace.status_text_set(text=None)
+        self.tool_state.plane_method = None
+        ProductDecorator.uninstall()
+        PolylineDecorator.uninstall()
+        tool.Polyline.clear_polyline()
+        tool.Blender.update_viewport()
+        return {"FINISHED"}
+
     def invoke(self, context, event):
         return IfcStore.execute_ifc_operator(self, context, event, method="INVOKE")
 
@@ -1236,4 +1249,5 @@ class DrawPolylineProfile(bpy.types.Operator, PolylineOperator, tool.Ifc.Operato
         ProductDecorator.install(context)
         self.tool_state.use_default_container = False
         self.tool_state.plane_method = None
+        self.set_rectangle_mode(tool.Model.get_polyline_props().rectangle_mode)
         return {"RUNNING_MODAL"}

--- a/src/bonsai/bonsai/bim/module/model/prop.py
+++ b/src/bonsai/bonsai/bim/module/model/prop.py
@@ -1897,12 +1897,18 @@ class BIMPolylineProperties(PropertyGroup):
     snap_mouse_ref: bpy.props.CollectionProperty(type=SnapMousePoint)
     insertion_polyline: bpy.props.CollectionProperty(type=Polyline)
     measurement_polyline: bpy.props.CollectionProperty(type=Polyline)
+    rectangle_mode: bpy.props.BoolProperty(
+        name="Rectangle Mode",
+        description="Draw a rectangle defined by two opposite corners instead of a free form polyline",
+        default=False,
+    )
 
     if TYPE_CHECKING:
         snap_mouse_point: bpy.types.bpy_prop_collection_idprop[SnapMousePoint]
         snap_mouse_ref: bpy.types.bpy_prop_collection_idprop[SnapMousePoint]
         insertion_polyline: bpy.types.bpy_prop_collection_idprop[Polyline]
         measurement_polyline: bpy.types.bpy_prop_collection_idprop[Polyline]
+        rectangle_mode: bool
 
 
 class ProductPreviewItem(PropertyGroup):

--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -930,12 +930,18 @@ class DrawPolylineSlab(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
             props.offset_type_horizontal = items[((index + 1) % size)]
             self.set_offset(context, self.relating_type)
 
-        custom_instructions = {"Choose Axis": {"icons": True, "keys": ["EVENT_X", "EVENT_Y"]}}
+        self.handle_rectangle_mode(context, event)
+
+        custom_instructions = {
+            "Choose Axis": {"icons": True, "keys": ["EVENT_X", "EVENT_Y"]},
+            "Rectangle": {"icons": True, "keys": ["EVENT_R"]},
+        }
 
         slab_config = [
             f"Direction: {props.direction_sense}",
             f"Offset Type: {props.offset_type_horizontal}",
             f"Offset Value: {tool.Polyline.format_input_ui_units(props.offset * self.unit_scale)}",
+            f"Rectangle: {'ON' if self.tool_state.rectangle_mode else 'OFF'}",
         ]
 
         self.handle_instructions(context, custom_instructions, slab_config)
@@ -946,18 +952,44 @@ class DrawPolylineSlab(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
 
         self.handle_snap_selection(context, event)
 
+        # Once the first corner is picked, the rectangle is fully defined by the current point,
+        # so picking the second corner also finishes the slab.
+        if self.tool_state.rectangle_mode and len(self.get_polyline_points()) > 0:
+            self.handle_rectangle_preview(context, event, should_round=not self.tool_state.is_input_on)
+
+            confirm_types = {"RET", "NUMPAD_ENTER", "RIGHTMOUSE"}
+            if not self.tool_state.is_input_on:
+                confirm_types.add("LEFTMOUSE")
+
+            if event.value == "RELEASE" and event.type in confirm_types:
+                if self.tool_state.is_input_on:
+                    if not self.recalculate_inputs(context):
+                        return {"RUNNING_MODAL"}
+                    self.handle_rectangle_preview(context, event)
+                if not tool.Polyline.is_rectangle_valid():
+                    self.report({"WARNING"}, "Cannot create a rectangle with a zero length side.")
+                    return {"RUNNING_MODAL"}
+                return self.finish(context)
+
+            self.handle_keyboard_input(context, event)
+
+            if not self.tool_state.is_input_on and event.value == "RELEASE" and event.type == "BACK_SPACE":
+                tool.Polyline.clear_polyline()
+                tool.Blender.update_viewport()
+
+            cancel = self.handle_cancelation(context, event)
+            if cancel is not None:
+                ProductDecorator.uninstall()
+                return cancel
+
+            return {"RUNNING_MODAL"}
+
         if (
             not self.tool_state.is_input_on
             and event.value == "RELEASE"
             and event.type in {"RET", "NUMPAD_ENTER", "RIGHTMOUSE"}
         ):
-            self.create_slab_from_polyline(context)
-            context.workspace.status_text_set(text=None)
-            ProductDecorator.uninstall()
-            PolylineDecorator.uninstall()
-            tool.Polyline.clear_polyline()
-            tool.Blender.update_viewport()
-            return {"FINISHED"}
+            return self.finish(context)
 
         self.handle_keyboard_input(context, event)
         self.handle_inserting_polyline(context, event)
@@ -969,6 +1001,15 @@ class DrawPolylineSlab(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
 
         return {"RUNNING_MODAL"}
 
+    def finish(self, context):
+        self.create_slab_from_polyline(context)
+        context.workspace.status_text_set(text=None)
+        ProductDecorator.uninstall()
+        PolylineDecorator.uninstall()
+        tool.Polyline.clear_polyline()
+        tool.Blender.update_viewport()
+        return {"FINISHED"}
+
     def invoke(self, context, event):
         return IfcStore.execute_ifc_operator(self, context, event, method="INVOKE")
 
@@ -977,6 +1018,7 @@ class DrawPolylineSlab(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
         ProductDecorator.install(context)
         self.tool_state.use_default_container = True
         self.tool_state.plane_method = "XY"
+        self.set_rectangle_mode(tool.Model.get_polyline_props().rectangle_mode)
         self.set_offset(context, self.relating_type)
         return {"RUNNING_MODAL"}
 

--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -952,37 +952,9 @@ class DrawPolylineSlab(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
 
         self.handle_snap_selection(context, event)
 
-        # Once the first corner is picked, the rectangle is fully defined by the current point,
-        # so picking the second corner also finishes the slab.
-        if self.tool_state.rectangle_mode and len(self.get_polyline_points()) > 0:
-            self.handle_rectangle_preview(context, event, should_round=not self.tool_state.is_input_on)
-
-            confirm_types = {"RET", "NUMPAD_ENTER", "RIGHTMOUSE"}
-            if not self.tool_state.is_input_on:
-                confirm_types.add("LEFTMOUSE")
-
-            if event.value == "RELEASE" and event.type in confirm_types:
-                if self.tool_state.is_input_on:
-                    if not self.recalculate_inputs(context):
-                        return {"RUNNING_MODAL"}
-                    self.handle_rectangle_preview(context, event)
-                if not tool.Polyline.is_rectangle_valid():
-                    self.report({"WARNING"}, "Cannot create a rectangle with a zero length side.")
-                    return {"RUNNING_MODAL"}
-                return self.finish(context)
-
-            self.handle_keyboard_input(context, event)
-
-            if not self.tool_state.is_input_on and event.value == "RELEASE" and event.type == "BACK_SPACE":
-                tool.Polyline.clear_polyline()
-                tool.Blender.update_viewport()
-
-            cancel = self.handle_cancelation(context, event)
-            if cancel is not None:
-                ProductDecorator.uninstall()
-                return cancel
-
-            return {"RUNNING_MODAL"}
+        rectangle = self.handle_rectangle_drawing(context, event)
+        if rectangle is not None:
+            return rectangle
 
         if (
             not self.tool_state.is_input_on

--- a/src/bonsai/bonsai/bim/module/model/wall.py
+++ b/src/bonsai/bonsai/bim/module/model/wall.py
@@ -1097,12 +1097,18 @@ class DrawPolylineWall(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
             props.offset_type_vertical = items[((index + 1) % size)]
             self.set_offset(context, self.relating_type)
 
-        custom_instructions = {"Choose Axis": {"icons": True, "keys": ["EVENT_X", "EVENT_Y"]}}
+        self.handle_rectangle_mode(context, event)
+
+        custom_instructions = {
+            "Choose Axis": {"icons": True, "keys": ["EVENT_X", "EVENT_Y"]},
+            "Rectangle": {"icons": True, "keys": ["EVENT_R"]},
+        }
 
         wall_config = [
             f"Direction: {props.direction_sense}",
             f"Offset Type: {props.offset_type_vertical}",
             f"Offset Value: {tool.Polyline.format_input_ui_units(props.offset * self.unit_scale)}",
+            f"Rectangle: {'ON' if self.tool_state.rectangle_mode else 'OFF'}",
         ]
 
         self.handle_instructions(context, custom_instructions, wall_config)
@@ -1113,19 +1119,16 @@ class DrawPolylineWall(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
 
         self.handle_snap_selection(context, event)
 
+        rectangle = self.handle_rectangle_drawing(context, event)
+        if rectangle is not None:
+            return rectangle
+
         if (
             not self.tool_state.is_input_on
             and event.value == "RELEASE"
             and event.type in {"RET", "NUMPAD_ENTER", "RIGHTMOUSE"}
         ):
-            self.create_walls_from_polyline(context)
-            context.workspace.status_text_set(text=None)
-            self.tool_state.plane_method = None
-            ProductDecorator.uninstall()
-            PolylineDecorator.uninstall()
-            tool.Polyline.clear_polyline()
-            tool.Blender.update_viewport()
-            return {"FINISHED"}
+            return self.finish(context)
 
         self.handle_keyboard_input(context, event)
         self.handle_inserting_polyline(context, event)
@@ -1137,6 +1140,16 @@ class DrawPolylineWall(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
 
         return {"RUNNING_MODAL"}
 
+    def finish(self, context):
+        self.create_walls_from_polyline(context)
+        context.workspace.status_text_set(text=None)
+        self.tool_state.plane_method = None
+        ProductDecorator.uninstall()
+        PolylineDecorator.uninstall()
+        tool.Polyline.clear_polyline()
+        tool.Blender.update_viewport()
+        return {"FINISHED"}
+
     def invoke(self, context, event):
         return IfcStore.execute_ifc_operator(self, context, event, method="INVOKE")
 
@@ -1145,6 +1158,7 @@ class DrawPolylineWall(bpy.types.Operator, PolylineOperator, tool.Ifc.Operator):
         ProductDecorator.install(context)
         self.tool_state.use_default_container = True
         self.tool_state.plane_method = "XY"
+        self.set_rectangle_mode(tool.Model.get_polyline_props().rectangle_mode)
         self.set_offset(context, self.relating_type)
         return {"RUNNING_MODAL"}
 

--- a/src/bonsai/bonsai/tool/polyline.py
+++ b/src/bonsai/bonsai/tool/polyline.py
@@ -588,30 +588,41 @@ class Polyline(bonsai.core.tool.Polyline):
 
     @classmethod
     def get_rectangle_corners(
-        cls, first_corner: Vector, opposite_corner: Vector, round_factor: Optional[float] = None
+        cls,
+        first_corner: Vector,
+        opposite_corner: Vector,
+        round_factor: Optional[float] = None,
+        plane_method: Literal["XY", "XZ", "YZ", None] = None,
     ) -> list[Vector]:
         """Get the 4 corners of a rectangle defined by two opposite corners.
 
-        The rectangle is aligned to the custom transform orientation, when there is one.
+        The rectangle lies on the plane currently being used by the tool, defaulting to a
+        plane parallel to XY, and is aligned to the custom transform orientation, when there
+        is one. The corner that is not being defined by the mouse is always taken from the
+        first corner, so that the result is planar even when the two corners are not.
         When a round factor is provided, the sides of the rectangle are rounded to it, instead
         of rounding the diagonal that goes from the first corner to the opposite one.
         """
+        # Axes that are spanned by the rectangle. The remaining one is fixed.
+        axes = {"XY": (0, 1), "XZ": (0, 2), "YZ": (1, 2)}.get(plane_method or "XY")
+        assert axes
+
         matrix = Matrix()
         if custom_orientation := bpy.context.scene.transform_orientation_slots[0].custom_orientation:
             matrix = custom_orientation.matrix.to_4x4()
         matrix_i = matrix.inverted()
         p1 = matrix_i @ first_corner
-        p3 = matrix_i @ opposite_corner
+        opposite_corner = matrix_i @ opposite_corner
+
+        sides = [opposite_corner[axis] - p1[axis] for axis in axes]
         if round_factor:
-            p3 = Vector(
-                (
-                    p1.x + round((p3.x - p1.x) / round_factor) * round_factor,
-                    p1.y + round((p3.y - p1.y) / round_factor) * round_factor,
-                    p3.z,
-                )
-            )
-        p2 = Vector((p3.x, p1.y, p1.z))
-        p4 = Vector((p1.x, p3.y, p3.z))
+            sides = [round(side / round_factor) * round_factor for side in sides]
+
+        p2, p3, p4 = p1.copy(), p1.copy(), p1.copy()
+        p2[axes[0]] += sides[0]
+        p3[axes[0]] += sides[0]
+        p3[axes[1]] += sides[1]
+        p4[axes[1]] += sides[1]
         return [matrix @ p for p in (p1, p2, p3, p4)]
 
     @classmethod
@@ -633,7 +644,10 @@ class Polyline(bonsai.core.tool.Polyline):
         round_factor = tool.Snap.get_increment_snap_value(bpy.context) if should_round else None
         first_corner = Vector((polyline_points[0].x, polyline_points[0].y, polyline_points[0].z))
         corners = cls.get_rectangle_corners(
-            first_corner, cls.get_polyline_point_coords(input_ui, tool_state), round_factor
+            first_corner,
+            cls.get_polyline_point_coords(input_ui, tool_state),
+            round_factor,
+            tool_state.plane_method,
         )
 
         while len(polyline_points) > 1:

--- a/src/bonsai/bonsai/tool/polyline.py
+++ b/src/bonsai/bonsai/tool/polyline.py
@@ -19,7 +19,7 @@
 import math
 from dataclasses import dataclass, field
 from math import radians
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import bpy
 import ifcopenshell.util.unit
@@ -29,6 +29,9 @@ from mathutils import Matrix, Vector
 import bonsai.core.tool
 import bonsai.tool as tool
 from bonsai.bim.module.drawing.helper import format_distance
+
+if TYPE_CHECKING:
+    from bonsai.bim.module.model.prop import Polyline as PolylineProperty
 
 
 class Polyline(bonsai.core.tool.Polyline):
@@ -92,6 +95,7 @@ class Polyline(bonsai.core.tool.Polyline):
         snap_info: str = None
         mode: Literal["Mouse", "Select", "Edit", None] = None
         input_type: "Polyline.InputType" = None
+        rectangle_mode: bool = False
 
     @classmethod
     def create_input_ui(cls, input_options: list[str] = []) -> PolylineUI:
@@ -147,7 +151,7 @@ class Polyline(bonsai.core.tool.Polyline):
                 mouse_vector = Vector((mouse_point.x, mouse_point.y, mouse_point.z))
 
         second_to_last_point = None
-        if len(polyline_points) > 1:
+        if len(polyline_points) > 1 and not tool_state.rectangle_mode:
             second_to_last_point_data = polyline_points[len(polyline_points) - 2]
             second_to_last_point = Vector(
                 (second_to_last_point_data.x, second_to_last_point_data.y, second_to_last_point_data.z)
@@ -294,7 +298,7 @@ class Polyline(bonsai.core.tool.Polyline):
             else:
                 snap_vector = Vector((snap_prop.x, snap_prop.y, snap_prop.z))
 
-        if len(polyline_points) > 1:
+        if len(polyline_points) > 1 and not tool_state.rectangle_mode:
             second_to_last_point_data = polyline_points[len(polyline_points) - 2]
             second_to_last_point = Vector(
                 (second_to_last_point_data.x, second_to_last_point_data.y, second_to_last_point_data.z)
@@ -498,15 +502,14 @@ class Polyline(bonsai.core.tool.Polyline):
         )
 
     @classmethod
-    def insert_polyline_point(cls, input_ui: PolylineUI, tool_state: Optional[ToolState] = None) -> Union[str, None]:
+    def get_polyline_point_coords(cls, input_ui: PolylineUI, tool_state: ToolState) -> Vector:
+        """Get the coordinates of the point that is about to be added to the polyline."""
         x = input_ui.get_number_value("X")
         y = input_ui.get_number_value("Y")
         if input_ui.get_number_value("Z") is not None:
             z = input_ui.get_number_value("Z")
         else:
             z = 0
-        d = input_ui.get_formatted_value("D")
-        a = input_ui.get_formatted_value("A")
 
         polyline_props = tool.Model.get_polyline_props()
         snap_vertex = polyline_props.snap_mouse_point[0]
@@ -528,6 +531,17 @@ class Polyline(bonsai.core.tool.Polyline):
             y = snap_vertex.y
             z = snap_vertex.z
 
+        return Vector((x, y, z))
+
+    @classmethod
+    def insert_polyline_point(cls, input_ui: PolylineUI, tool_state: Optional[ToolState] = None) -> Union[str, None]:
+        d = input_ui.get_formatted_value("D")
+        a = input_ui.get_formatted_value("A")
+
+        assert tool_state
+        x, y, z = cls.get_polyline_point_coords(input_ui, tool_state)
+
+        polyline_props = tool.Model.get_polyline_props()
         polyline_data = polyline_props.insertion_polyline
         if not polyline_data:
             polyline_data = polyline_props.insertion_polyline.add()
@@ -560,15 +574,92 @@ class Polyline(bonsai.core.tool.Polyline):
         polyline_point.angle = a
         polyline_point.position = Vector((x, y, z))
 
-        # Add total length
+        cls.update_total_length(polyline_data)
+
+    @classmethod
+    def update_total_length(cls, polyline_data: "PolylineProperty") -> None:
         total_length = 0
-        for i, point in enumerate(polyline_points):
+        for i, point in enumerate(polyline_data.polyline_points):
             if i == 0:
                 continue
             dim = float(tool.Polyline.validate_input(point.dim, "D")[1])
             total_length += dim
-        total_length = tool.Polyline.format_input_ui_units(total_length)
-        polyline_data.total_length = total_length
+        polyline_data.total_length = tool.Polyline.format_input_ui_units(total_length)
+
+    @classmethod
+    def get_rectangle_corners(
+        cls, first_corner: Vector, opposite_corner: Vector, round_factor: Optional[float] = None
+    ) -> list[Vector]:
+        """Get the 4 corners of a rectangle defined by two opposite corners.
+
+        The rectangle is aligned to the custom transform orientation, when there is one.
+        When a round factor is provided, the sides of the rectangle are rounded to it, instead
+        of rounding the diagonal that goes from the first corner to the opposite one.
+        """
+        matrix = Matrix()
+        if custom_orientation := bpy.context.scene.transform_orientation_slots[0].custom_orientation:
+            matrix = custom_orientation.matrix.to_4x4()
+        matrix_i = matrix.inverted()
+        p1 = matrix_i @ first_corner
+        p3 = matrix_i @ opposite_corner
+        if round_factor:
+            p3 = Vector(
+                (
+                    p1.x + round((p3.x - p1.x) / round_factor) * round_factor,
+                    p1.y + round((p3.y - p1.y) / round_factor) * round_factor,
+                    p3.z,
+                )
+            )
+        p2 = Vector((p3.x, p1.y, p1.z))
+        p4 = Vector((p1.x, p3.y, p3.z))
+        return [matrix @ p for p in (p1, p2, p3, p4)]
+
+    @classmethod
+    def update_rectangle_polyline(cls, input_ui: PolylineUI, tool_state: ToolState, should_round: bool = False) -> None:
+        """Rebuild the polyline as a rectangle based on its first point and the point under the mouse.
+
+        The first point is repeated at the end so that the shape is drawn closed and so that
+        the inputs keep being calculated relative to the first corner.
+        """
+        polyline_props = tool.Model.get_polyline_props()
+        polyline_data = polyline_props.insertion_polyline
+        if not polyline_data:
+            return
+        polyline_data = polyline_data[0]
+        polyline_points = polyline_data.polyline_points
+        if not polyline_points:
+            return
+
+        round_factor = tool.Snap.get_increment_snap_value(bpy.context) if should_round else None
+        first_corner = Vector((polyline_points[0].x, polyline_points[0].y, polyline_points[0].z))
+        corners = cls.get_rectangle_corners(
+            first_corner, cls.get_polyline_point_coords(input_ui, tool_state), round_factor
+        )
+
+        while len(polyline_points) > 1:
+            polyline_points.remove(len(polyline_points) - 1)
+
+        previous_corner = corners[0]
+        for corner in corners[1:] + [corners[0]]:
+            polyline_point = polyline_points.add()
+            polyline_point.x, polyline_point.y, polyline_point.z = corner
+            polyline_point.position = corner
+            polyline_point.dim = cls.format_input_ui_units((corner - previous_corner).length)
+            polyline_point.angle = f"{90:.2f}°"
+            previous_corner = corner
+
+        cls.update_total_length(polyline_data)
+
+    @classmethod
+    def is_rectangle_valid(cls) -> bool:
+        """Check that the rectangle currently stored in the polyline has no zero length side."""
+        polyline_props = tool.Model.get_polyline_props()
+        polyline_data = polyline_props.insertion_polyline
+        polyline_points = polyline_data[0].polyline_points if polyline_data else []
+        if len(polyline_points) < 4:
+            return False
+        corners = [Vector((p.x, p.y, p.z)) for p in polyline_points[:3]]
+        return all(not tool.Cad.is_x((b - a).length, 0) for a, b in zip(corners, corners[1:]))
 
     @classmethod
     def clear_polyline(cls) -> None:

--- a/src/bonsai/test/modal/test_modal.py
+++ b/src/bonsai/test/modal/test_modal.py
@@ -405,9 +405,80 @@ def test_draw_polyline_wall(window, x, y):
     yield "FINISHED"
 
 
+def test_draw_rectangle_slab(window, x, y):
+    yield from preset_event_simulate(window, "ESC", "TAP", x, y)
+    area, region = get_area_and_region(window)
+
+    for obj in tool.Blender.get_selected_objects():
+        obj.select_set(False)
+    with bpy.context.temp_override(area=area, region=region, space_data=area.spaces[0]):
+        props = tool.Model.get_model_props()
+        ifc = tool.Ifc.get()
+        relating_type = ifc.by_type("IfcSlabType")[0]
+        props.ifc_class = "IfcSlabType"
+        props.relating_type_id = str(relating_type.id())
+
+        spatial_props = tool.Spatial.get_spatial_props()
+        spatial_props.default_container = ifc.by_type("IfcBuildingStorey")[0].id()
+
+        bpy.ops.bim.draw_polyline_slab("INVOKE_DEFAULT")
+
+    for _ in range(4):
+        yield from preset_event_simulate(window, "MOUSEMOVE", "NOTHING", x, y)
+
+    # Rectangle mode replaces the free form polyline by two opposite corners
+    yield from preset_event_simulate(window, "R", "TAP", x, y)
+    assert_msg = "Rectangle mode should be enabled"
+    assert tool.Model.get_polyline_props().rectangle_mode is True
+    _assert_pass(assert_msg)
+
+    yield from preset_event_simulate(window, "LEFTMOUSE", "TAP", x, y)
+
+    offset_x, offset_y = 300, 200
+    for _ in range(4):
+        yield from preset_event_simulate(window, "MOUSEMOVE", "NOTHING", x + offset_x, y + offset_y)
+
+    polyline_points = tool.Model.get_polyline_props().insertion_polyline[0].polyline_points
+    assert_msg = f"Rectangle preview should have 4 corners and be closed, got {len(polyline_points)} points"
+    assert len(polyline_points) == 5
+    _assert_pass(assert_msg)
+
+    # Picking the second corner is enough to create the slab
+    yield from preset_event_simulate(window, "LEFTMOUSE", "TAP", x + offset_x, y + offset_y)
+
+    obj = bpy.context.selected_objects[0]
+    element = tool.Ifc.get_entity(obj)
+    assert_msg = "Created object should be IfcSlab"
+    assert element.is_a() == "IfcSlab"
+    _assert_pass(assert_msg)
+
+    corners = []
+    for vert in obj.data.vertices:
+        co = obj.matrix_world @ vert.co
+        corner = (round(co.x, 3), round(co.y, 3))
+        if corner not in corners:
+            corners.append(corner)
+    assert_msg = f"Slab footprint should have 4 corners, got {corners}"
+    assert len(corners) == 4
+    _assert_pass(assert_msg)
+
+    xs = {corner[0] for corner in corners}
+    ys = {corner[1] for corner in corners}
+    assert_msg = f"Slab footprint should be a rectangle, got {corners}"
+    assert len(xs) == 2 and len(ys) == 2
+    _assert_pass(assert_msg)
+
+    yield "FINISHED"
+
+
 def run_tests():
     module_name = os.getenv("MODULE", "snap")
-    if module_name == "wall":
+    if module_name == "slab":
+        filepath = f"./test/files/wall.ifc"
+        bpy.ops.bim.load_project(filepath=filepath)
+        window = _get_valid_window()
+        test_queue = [lambda w=window: test_draw_rectangle_slab(w, 960, 540)]
+    elif module_name == "wall":
         filepath = f"./test/files/wall.ifc"
         bpy.ops.bim.load_project(filepath=filepath)
         window = _get_valid_window()

--- a/src/bonsai/test/modal/test_modal.py
+++ b/src/bonsai/test/modal/test_modal.py
@@ -411,6 +411,8 @@ def test_draw_rectangle_slab(window, x, y):
 
     for obj in tool.Blender.get_selected_objects():
         obj.select_set(False)
+    # Rectangle mode is kept between invocations, the operator seeds itself from the scene
+    tool.Model.get_polyline_props().rectangle_mode = False
     with bpy.context.temp_override(area=area, region=region, space_data=area.spaces[0]):
         props = tool.Model.get_model_props()
         ifc = tool.Ifc.get()
@@ -471,9 +473,102 @@ def test_draw_rectangle_slab(window, x, y):
     yield "FINISHED"
 
 
+def test_draw_rectangle_walls(window, x, y):
+    yield from preset_event_simulate(window, "ESC", "TAP", x, y)
+    area, region = get_area_and_region(window)
+
+    for obj in tool.Blender.get_selected_objects():
+        obj.select_set(False)
+    # Rectangle mode is kept between invocations, the operator seeds itself from the scene
+    tool.Model.get_polyline_props().rectangle_mode = False
+    ifc = tool.Ifc.get()
+    walls_before = len(ifc.by_type("IfcWall"))
+    with bpy.context.temp_override(area=area, region=region, space_data=area.spaces[0]):
+        props = tool.Model.get_model_props()
+        relating_type = ifc.by_type("IfcWallType")[0]
+        props.ifc_class = "IfcWallType"
+        props.relating_type_id = str(relating_type.id())
+
+        bpy.ops.bim.draw_polyline_wall("INVOKE_DEFAULT")
+
+    for _ in range(4):
+        yield from preset_event_simulate(window, "MOUSEMOVE", "NOTHING", x, y)
+
+    yield from preset_event_simulate(window, "R", "TAP", x, y)
+    yield from preset_event_simulate(window, "LEFTMOUSE", "TAP", x, y)
+
+    offset_x, offset_y = 300, 200
+    for _ in range(4):
+        yield from preset_event_simulate(window, "MOUSEMOVE", "NOTHING", x + offset_x, y + offset_y)
+    yield from preset_event_simulate(window, "LEFTMOUSE", "TAP", x + offset_x, y + offset_y)
+
+    walls = ifc.by_type("IfcWall")[walls_before:]
+    assert_msg = f"A rectangle should create 4 walls, got {len(walls)}"
+    assert len(walls) == 4, assert_msg
+    _assert_pass(assert_msg)
+
+    origins = [tuple(round(v, 3) for v in tool.Ifc.get_object(wall).matrix_world.translation[:2]) for wall in walls]
+    assert_msg = f"The 4 walls should start at the 4 corners of a rectangle, got {origins}"
+    assert len({origin[0] for origin in origins}) == 2 and len({origin[1] for origin in origins}) == 2, assert_msg
+    _assert_pass(assert_msg)
+
+    yield "FINISHED"
+
+
+def test_draw_rectangle_profiles(window, x, y):
+    yield from preset_event_simulate(window, "ESC", "TAP", x, y)
+    area, region = get_area_and_region(window)
+
+    for obj in tool.Blender.get_selected_objects():
+        obj.select_set(False)
+    # Rectangle mode is kept between invocations, the operator seeds itself from the scene
+    tool.Model.get_polyline_props().rectangle_mode = False
+    ifc = tool.Ifc.get()
+    beams_before = len(ifc.by_type("IfcBeam"))
+    with bpy.context.temp_override(area=area, region=region, space_data=area.spaces[0]):
+        props = tool.Model.get_model_props()
+        relating_type = ifc.by_type("IfcBeamType")[0]
+        props.ifc_class = "IfcBeamType"
+        props.relating_type_id = str(relating_type.id())
+
+        bpy.ops.bim.draw_polyline_profile("INVOKE_DEFAULT")
+
+    for _ in range(4):
+        yield from preset_event_simulate(window, "MOUSEMOVE", "NOTHING", x, y)
+
+    yield from preset_event_simulate(window, "R", "TAP", x, y)
+    yield from preset_event_simulate(window, "LEFTMOUSE", "TAP", x, y)
+
+    offset_x, offset_y = 300, 200
+    for _ in range(4):
+        yield from preset_event_simulate(window, "MOUSEMOVE", "NOTHING", x + offset_x, y + offset_y)
+    yield from preset_event_simulate(window, "LEFTMOUSE", "TAP", x + offset_x, y + offset_y)
+
+    beams = ifc.by_type("IfcBeam")[beams_before:]
+    assert_msg = f"A rectangle should create 4 beams, got {len(beams)}"
+    assert len(beams) == 4
+    _assert_pass(assert_msg)
+
+    elevations = {round(tool.Ifc.get_object(beam).matrix_world.translation.z, 3) for beam in beams}
+    assert_msg = f"The 4 beams should be on the same plane, got {elevations}"
+    assert len(elevations) == 1
+    _assert_pass(assert_msg)
+
+    yield "FINISHED"
+
+
 def run_tests():
     module_name = os.getenv("MODULE", "snap")
-    if module_name == "slab":
+    if module_name == "rectangle":
+        filepath = f"./test/files/wall.ifc"
+        bpy.ops.bim.load_project(filepath=filepath)
+        window = _get_valid_window()
+        test_queue = [
+            lambda w=window: test_draw_rectangle_slab(w, 960, 540),
+            lambda w=window: test_draw_rectangle_walls(w, 960, 540),
+            lambda w=window: test_draw_rectangle_profiles(w, 960, 540),
+        ]
+    elif module_name == "slab":
         filepath = f"./test/files/wall.ifc"
         bpy.ops.bim.load_project(filepath=filepath)
         window = _get_valid_window()

--- a/src/bonsai/test/tool/test_polyline.py
+++ b/src/bonsai/test/tool/test_polyline.py
@@ -101,6 +101,19 @@ class TestGetRectangleCorners(NewFile):
         corners = subject.get_rectangle_corners(Vector((0, 0, 0)), Vector((3.13, 4.79, 0)), round_factor=0.25)
         assert [tuple(c) for c in corners] == [(0, 0, 0), (3.25, 0, 0), (3.25, 4.75, 0), (0, 4.75, 0)]
 
+    def test_it_builds_the_rectangle_on_the_plane_used_by_the_tool(self):
+        corners = subject.get_rectangle_corners(Vector((0, 0, 0)), Vector((3, 0, 2)), plane_method="XZ")
+        assert [tuple(c) for c in corners] == [(0, 0, 0), (3, 0, 0), (3, 0, 2), (0, 0, 2)]
+
+        corners = subject.get_rectangle_corners(Vector((0, 0, 0)), Vector((0, 3, 2)), plane_method="YZ")
+        assert [tuple(c) for c in corners] == [(0, 0, 0), (0, 3, 0), (0, 3, 2), (0, 0, 2)]
+
+    def test_it_stays_planar_when_the_corners_are_not_on_the_same_plane(self):
+        # The profile tool can pick points anywhere in space, the rectangle is kept on the
+        # plane of the first corner.
+        corners = subject.get_rectangle_corners(Vector((0, 0, 5)), Vector((3, 4, 9)), plane_method="XY")
+        assert [tuple(c) for c in corners] == [(0, 0, 5), (3, 0, 5), (3, 4, 5), (0, 4, 5)]
+
 
 class TestUpdateRectanglePolyline(NewFile):
     def create_polyline(self, first_corner, opposite_corner):

--- a/src/bonsai/test/tool/test_polyline.py
+++ b/src/bonsai/test/tool/test_polyline.py
@@ -22,6 +22,8 @@ import ifcopenshell.api.project
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
 
+from mathutils import Vector
+
 import bonsai.core.tool
 import bonsai.tool as tool
 from bonsai.tool.polyline import Polyline as subject
@@ -84,3 +86,96 @@ class TestCalculateDistanceAndAngle(NewFile):
 
         assert input_ui.get_number_value("D") == 0
         assert input_ui.get_number_value("A") == 0
+
+
+class TestGetRectangleCorners(NewFile):
+    def test_it_returns_the_corners_of_the_rectangle(self):
+        corners = subject.get_rectangle_corners(Vector((1, 2, 3)), Vector((4, 6, 3)))
+        assert [tuple(c) for c in corners] == [(1, 2, 3), (4, 2, 3), (4, 6, 3), (1, 6, 3)]
+
+    def test_it_works_in_any_direction(self):
+        corners = subject.get_rectangle_corners(Vector((0, 0, 0)), Vector((-2, -5, 0)))
+        assert [tuple(c) for c in corners] == [(0, 0, 0), (-2, 0, 0), (-2, -5, 0), (0, -5, 0)]
+
+    def test_it_rounds_the_sides_and_not_the_diagonal(self):
+        corners = subject.get_rectangle_corners(Vector((0, 0, 0)), Vector((3.13, 4.79, 0)), round_factor=0.25)
+        assert [tuple(c) for c in corners] == [(0, 0, 0), (3.25, 0, 0), (3.25, 4.75, 0), (0, 4.75, 0)]
+
+
+class TestUpdateRectanglePolyline(NewFile):
+    def create_polyline(self, first_corner, opposite_corner):
+        polyline_props = tool.Model.get_polyline_props()
+        mouse_point = polyline_props.snap_mouse_point.add()
+        mouse_point.x, mouse_point.y, mouse_point.z = opposite_corner
+        polyline_data = polyline_props.insertion_polyline.add()
+        point = polyline_data.polyline_points.add()
+        point.x, point.y, point.z = first_corner
+        point.dim = "0"
+
+        input_ui = subject.create_input_ui(input_options=["D", "A", "X", "Y"])
+        input_ui.set_value("X", opposite_corner[0])
+        input_ui.set_value("Y", opposite_corner[1])
+        input_ui.set_value("D", (Vector(opposite_corner) - Vector(first_corner)).length)
+        input_ui.set_value("A", 0)
+
+        tool_state = subject.create_tool_state()
+        tool_state.is_input_on = False
+        tool_state.use_default_container = False
+        tool_state.plane_method = "XY"
+        tool_state.plane_origin = Vector((0, 0, 0))
+        tool_state.rectangle_mode = True
+        return polyline_data, input_ui, tool_state
+
+    def test_it_replaces_the_polyline_with_the_rectangle_corners(self):
+        polyline_data, input_ui, tool_state = self.create_polyline((0, 0, 0), (5, 3, 0))
+
+        subject.update_rectangle_polyline(input_ui, tool_state)
+
+        # The first corner is repeated at the end so that the shape is closed.
+        assert [(p.x, p.y, p.z) for p in polyline_data.polyline_points] == [
+            (0, 0, 0),
+            (5, 0, 0),
+            (5, 3, 0),
+            (0, 3, 0),
+            (0, 0, 0),
+        ]
+
+    def test_it_rebuilds_the_rectangle_instead_of_growing_the_polyline(self):
+        polyline_data, input_ui, tool_state = self.create_polyline((0, 0, 0), (5, 3, 0))
+
+        subject.update_rectangle_polyline(input_ui, tool_state)
+        input_ui.set_value("X", -2)
+        input_ui.set_value("Y", 4)
+        subject.update_rectangle_polyline(input_ui, tool_state)
+
+        assert [(p.x, p.y, p.z) for p in polyline_data.polyline_points] == [
+            (0, 0, 0),
+            (-2, 0, 0),
+            (-2, 4, 0),
+            (0, 4, 0),
+            (0, 0, 0),
+        ]
+
+    def test_it_keeps_the_side_dimensions_up_to_date(self):
+        ifc = ifcopenshell.api.project.create_file()
+        tool.Ifc.set(ifc)
+        ifcopenshell.api.root.create_entity(ifc, ifc_class="IfcProject")
+        unit = ifcopenshell.api.unit.add_si_unit(ifc, unit_type="LENGTHUNIT", prefix=None)
+        ifcopenshell.api.unit.assign_unit(ifc, [unit])
+        bpy.context.scene.unit_settings.system = "METRIC"
+        polyline_data, input_ui, tool_state = self.create_polyline((0, 0, 0), (5, 3, 0))
+
+        subject.update_rectangle_polyline(input_ui, tool_state)
+
+        assert [p.dim for p in polyline_data.polyline_points][1:] == ["5.000 m", "3.000 m", "5.000 m", "3.000 m"]
+        assert polyline_data.total_length == "16.000 m"
+
+    def test_it_detects_a_rectangle_with_a_zero_length_side(self):
+        polyline_data, input_ui, tool_state = self.create_polyline((0, 0, 0), (5, 3, 0))
+
+        subject.update_rectangle_polyline(input_ui, tool_state)
+        assert subject.is_rectangle_valid() is True
+
+        input_ui.set_value("X", 0)
+        subject.update_rectangle_polyline(input_ui, tool_state)
+        assert subject.is_rectangle_valid() is False


### PR DESCRIPTION
Closes #9326.

Adds a rectangle mode to the three polyline insertion tools. Press `R` while the tool is running to toggle it, then pick two opposite corners — the second pick completes the shape, so a rectangular slab is two clicks instead of four plus a confirmation.

| Tool | Result |
| --- | --- |
| `bim.draw_polyline_slab` | one slab with a rectangular footprint |
| `bim.draw_polyline_wall` | 4 walls, joined into a loop |
| `bim.draw_polyline_profile` | 4 members, joined into a closed frame |

The status bar shows `Rectangle: ON/OFF`, the mode is remembered between invocations so a series of rectangles doesn't need `R` every time, `Backspace` restarts the rectangle and `Esc` cancels the tool. Typed input still works: the distance/angle and X/Y inputs place the opposite corner, so an exact rectangle can be typed rather than drawn.

### Implementation notes

The provisional corners are written into `insertion_polyline` itself, with the first corner repeated at the end so the shape reads as closed. That is what lets the existing `ProductDecorator` preview, the per-side dimension labels and the total length keep working without any decorator changes, and it means walls and profiles are generated and joined by the same code path as closing a polyline by hand.

Because the polyline then holds more than one point while the second corner is still being picked, `calculate_distance_and_angle` and `calculate_x_y_and_z` skip their "second to last point" reference when `rectangle_mode` is set, so typed distance and angle stay relative to the first corner.

Two details worth a look during review:

- The rectangle spans the two axes of the tool's active plane, defaulting to a plane parallel to XY. The profile tool can draw on XZ and YZ and can pick points anywhere in space, so the coordinate of the axis the rectangle doesn't span always comes from the first corner, keeping the shape planar. It also follows the active custom transform orientation, so rectangles can be drawn square to a rotated grid.
- Increment snapping rounds the two sides of the rectangle rather than the diagonal running to the cursor. Rounding the diagonal produces sizes like 3.13 x 4.79, which defeats the purpose.

The shared modal flow lives in `PolylineOperator.handle_rectangle_drawing`, which finishes the shape through a `finish` method each of the three operators implements. Each modal gained three lines: the toggle, the instruction and status entries, and the handler call.

### Testing

- 7 new cases in `test/tool/test_polyline.py` covering the corner math, the XZ/YZ planes, the planarity rule, snapping the sides, and rebuilding the preview in place (12 pass in the file).
- Three tests in the event-simulating modal harness, `make test-modal MODULE=rectangle`, driving each of the three tools through real events: slab footprint rectangular, 4 walls at 4 corners, 4 coplanar beams.
