### PR TITLE
Set VERSION and SOVERSION on geometry_serializer

### DIFF
--- a/src/ifcgeom/serialization/CMakeLists.txt
+++ b/src/ifcgeom/serialization/CMakeLists.txt
@@ -16,6 +16,9 @@ set_target_properties(geometry_serializer PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${geometry_serialization_plugin_runtime_dir}"
     LIBRARY_OUTPUT_DIRECTORY "${geometry_serialization_plugin_runtime_dir}"
 )
+if (NOT CREATE_BUNDLE)
+    set_target_properties(geometry_serializer PROPERTIES VERSION "${PROJECT_VERSION}" SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
+endif()
 target_link_libraries(geometry_serializer plugin IfcGeom IfcParse ${OpenCASCADE_LIBRARIES})
 if(NOT WASM_BUILD)
     target_link_libraries(geometry_serializer geometry_kernel_opencascade)


### PR DESCRIPTION
Fixes point 2 of #9328.

`geometry_serializer`, which produces `libifcopenshell.geometry.writer`, was the only one of the four core shared libraries without a `VERSION`/`SOVERSION` block, so it installed as a single unversioned `.so` with no SONAME and no symlink chain. Its siblings all have one, guarded the same way:

- `src/ifcgeom/CMakeLists.txt:26-28` (`IfcGeom`)
- `src/ifcparse/CMakeLists.txt:58-60` (`IfcParse`)
- `src/plugin/CMakeLists.txt:13-17` (`plugin`)

This adds the matching block so it gets the same `.so` -> `.so.0.9` -> `.so.0.9.0` chain.

## On the other two points in the issue

Neither looks like a defect, so nothing here changes them.

**Dotted names are intentional.** Only the dlopen-loaded plugin artifacts (kernels, schema mappings, per-schema writers) were switched to underscores in `a441757080`. The four core libraries keep dots by design: `OUTPUT_NAME "ifcopenshell.geometry"` at `src/ifcgeom/CMakeLists.txt:15`, and the same pattern for parse, plugin and geometry.writer.

**The 0.8.6 SONAME looks like a stale build.** `VERSION` on `v0.9.0` reads `0.9.0alpha0`, bumped in `7a1dcd07c8` on 10 August, and `cmake/CMakeLists.txt:39-42` extracts `0.9.0` from it into `PROJECT_VERSION_MAJOR`/`MINOR`. The reported build has the underscore plugin naming from 9 August but not the version bump from 10 August, so it appears to come from that window. A fresh build should already report `0.9`.

## Verification

Real `cmake` configure and generate against the repo, then inspection of the generated output. The `geometry_serializer` link line now carries the same version flags as `IfcGeom`, and the install rule now creates the three-step symlink chain where it previously installed only the bare library.

Scope honesty: this was verified by configure and generate on macOS, not by a full compile, and not on Linux. The `VERSION`/`SOVERSION` machinery is platform independent and drives the same symlink logic, but I have not built the `.so` itself.

Produced with AI assistance.
