### PR TITLE
Isolate load_post steps from each other's errors

### DIFF
--- a/src/bonsai/bonsai/bim/handler.py
+++ b/src/bonsai/bonsai/bim/handler.py
@@ -19,6 +19,7 @@
 # This file was modified with the assistance of an AI coding tool.
 
 import os
+import traceback
 import weakref
 from collections.abc import Callable
 from typing import Union
@@ -572,8 +573,21 @@ def _install_viewport_overlays() -> None:
         install_decorator_cache_handlers()
 
 
+def _run_load_post_step(name: str, step: Callable[[], None]) -> None:
+    """Run one ``load_post`` step in isolation.
+
+    Steps are independent UI/session setup. A failure in one (e.g. a stale
+    cache or a msgbus quirk) must not silently skip the steps after it -
+    notably the BIM workspace restore. See #9329."""
+    try:
+        step()
+    except Exception:
+        print(f"WARNING. load_post step '{name}' failed:")
+        traceback.print_exc()
+
+
 @persistent
 def load_post(scene):
-    _apply_save_file_invariants(scene)
-    _apply_user_preferences()
-    _install_viewport_overlays()
+    _run_load_post_step("apply_save_file_invariants", lambda: _apply_save_file_invariants(scene))
+    _run_load_post_step("apply_user_preferences", _apply_user_preferences)
+    _run_load_post_step("install_viewport_overlays", _install_viewport_overlays)

--- a/src/bonsai/test/bim/test_load_post_step_isolation.py
+++ b/src/bonsai/test/bim/test_load_post_step_isolation.py
@@ -1,0 +1,111 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Forward-compat AST contract for ``handler.load_post`` step isolation.
+
+Pins #9329: ``load_post`` used to call ``_apply_save_file_invariants``,
+``_apply_user_preferences`` (BIM workspace restore) and
+``_install_viewport_overlays`` back to back. An exception raised by the
+first call aborted the function, so the BIM workspace was silently never
+re-added after a session reset (e.g. ``bim.load_project`` with "Should
+Start Fresh Session", which calls ``wm.read_homefile``). Each step must
+run isolated so a failure in one cannot swallow the ones after it."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.contract_guard
+
+HANDLER_PATH = Path(__file__).parent.parent.parent / "bonsai" / "bim" / "handler.py"
+
+# The steps load_post must run, in order, each isolated from the others'
+# exceptions. If a step's implementation is renamed, update this list.
+EXPECTED_STEPS = (
+    "_apply_save_file_invariants",
+    "_apply_user_preferences",
+    "_install_viewport_overlays",
+)
+
+
+def _function_node(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name!r} not found in {HANDLER_PATH.name}")
+
+
+@pytest.fixture(scope="module")
+def handler_tree() -> ast.Module:
+    return ast.parse(HANDLER_PATH.read_text(encoding="utf-8"))
+
+
+def _referenced_names(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name):
+            names.add(sub.id)
+    return names
+
+
+def _called_name(call: ast.Call) -> str | None:
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return call.func.attr
+    return None
+
+
+def test_load_post_runs_no_step_unguarded(handler_tree: ast.Module) -> None:
+    """``load_post``'s top-level statements must never be a bare, direct call
+    to one of the setup steps - each call must go through an isolating
+    helper so one step's exception cannot prevent the next from running.
+    (A step may still appear nested inside the helper call's arguments,
+    e.g. wrapped in a lambda - only the outermost call matters here.)"""
+    fn = _function_node(handler_tree, "load_post")
+    bare_calls = []
+    for stmt in fn.body:
+        call = None
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            call = stmt.value
+        if call is None:
+            continue
+        called = _called_name(call)
+        if called in EXPECTED_STEPS:
+            bare_calls.append(called)
+    if bare_calls:
+        pytest.fail(
+            f"load_post calls {bare_calls} directly at the top level, unguarded. "
+            "A failure in one step will silently skip the rest (including the BIM "
+            "workspace restore in _apply_user_preferences). Route every step through "
+            "an isolating try/except helper. See #9329."
+        )
+
+
+def test_load_post_still_invokes_every_expected_step(handler_tree: ast.Module) -> None:
+    """Whatever isolation mechanism is used, load_post must still reference
+    every step it's responsible for - the isolation must not have silently
+    dropped one instead of wrapping it."""
+    fn = _function_node(handler_tree, "load_post")
+    referenced = _referenced_names(fn)
+    missing = [name for name in EXPECTED_STEPS if name not in referenced]
+    if missing:
+        pytest.fail(f"load_post no longer references step(s) {missing}. See #9329.")


### PR DESCRIPTION
Related to #9329. **This does not claim to fix that issue**, see the honesty section below.

## What this changes

`load_post` ran three independent setup steps back to back with no isolation:

```python
_apply_save_file_invariants(scene)
_apply_user_preferences()      # <- restores the BIM workspace
_install_viewport_overlays()
```

An exception anywhere in the first call silently prevents the BIM workspace restore from ever running. Blender swallows handler exceptions quietly, so there is no traceback for the user and no visible failure, just a missing workspace.

Each step now runs through a helper that catches and prints a warning plus traceback, so one failing step cannot skip the others.

## Why this is relevant to #9329

Opening a model calls `bpy.ops.wm.read_homefile()` (`bim/module/project/operator.py:1124`), which replaces Blender's workspace set. Bonsai relies on `_apply_user_preferences()` in `load_post` to put the BIM workspace back (`bim/handler.py:471-484`). If anything before it throws, the workspace stays gone, which is exactly the reported symptom, including the absence of any error output.

## Honesty about what is and is not proven

**I did not reproduce the reported bug**, and I did not identify which exception fires in the field.

I diffed the entire `read_homefile` to `load_post` to workspace-restore chain between `v0.8.0` and `v0.9.0`. `handler.py`, `bim/__init__.py` (registration and handler order), the relevant parts of `LoadProject`, `tool.Parametric.on_load_post`, and `data/workspace.blend` are all identical between the branches. So the regression is not visible in this chain, and I cannot say why it appears on 0.9 specifically.

There is no compiled v0.9.0 wrapper available in my environment, so I could not run `bpy.ops.bim.load_project_elements()` or drive a real v0.9.0 session. A simulation of the sequence against the real `workspace.blend` on Blender 5.2.0 worked correctly, meaning the append and reactivate mechanism itself is not broken in isolation.

So: this is a structural fix for a failure mode that matches the report exactly, and it is worth having on its own merits, but it is not a confirmed fix for #9329. If someone can reproduce with a console open, the new warning should name the failing step, which would identify the real trigger.

## Test

`src/bonsai/test/bim/test_load_post_step_isolation.py`, an AST contract test in the same style as the existing `test_handler_forward_compat.py`, so it needs no compiled wrapper. It asserts the three steps are not called bare from `load_post` and that all three are still invoked. Red against current `v0.9.0`, green after.

## Related, not changed

The same "first exception kills the rest" shape exists one level down in `tool.Parametric.on_load_post` (`bonsai/tool/parametric.py:291-299`), where `heal_stale_edit_flags()`, `discard_pending_previews(scene)` and `wall_offset_gizmos.clear_caches()` run unguarded in sequence. Left alone to keep this change to one thing.

black and ruff clean.

Produced with AI assistance.
