### PR TITLE
ifcviewer: support linking system-packaged wgpu-native and zstd

### DIFF
--- a/src/ifcviewer/CMakeLists.txt
+++ b/src/ifcviewer/CMakeLists.txt
@@ -32,13 +32,21 @@ endif()
 # everywhere a 4x4 transform shows up. Header-only, works under Emscripten.
 find_package(Eigen3 REQUIRED)
 
-# wgpu-native — fetched as a pre-built binary release from upstream.
-# Under Emscripten this whole block is skipped; the web build links
-# against Dawn's webgpu.h via the emdawnwebgpu port instead. The
+# wgpu-native — fetched as a pre-built binary release from upstream, or
+# taken from a system package via pkg-config when WGPU_NATIVE_USE_SYSTEM
+# is set. Under Emscripten this whole block is skipped; the web build
+# links against Dawn's webgpu.h via the emdawnwebgpu port instead. The
 # `wgpu_native` link target is created as an INTERFACE in that branch
 # (see the end of this block) so consumers' target_link_libraries lines
 # work uniformly.
-if(NOT EMSCRIPTEN)
+option(WGPU_NATIVE_USE_SYSTEM "Link against a system-packaged wgpu-native instead of FetchContent-ing upstream's prebuilt binary release" OFF)
+if(NOT EMSCRIPTEN AND WGPU_NATIVE_USE_SYSTEM)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(WGPU_NATIVE REQUIRED IMPORTED_TARGET wgpu-native)
+
+    add_library(wgpu_native ALIAS PkgConfig::WGPU_NATIVE)
+
+elseif(NOT EMSCRIPTEN)
 # Pin the version with WGPU_NATIVE_VERSION; bump to pull a newer release.
 set(WGPU_NATIVE_VERSION "v29.0.0.0" CACHE STRING "wgpu-native release tag")
 
@@ -244,8 +252,15 @@ if(EMSCRIPTEN)
     target_sources(IfcViewerCore PRIVATE ${ZSTD_DEC_SRC})
     target_include_directories(IfcViewerCore PRIVATE ${ZSTD_DEC_DIR})
 else()
-    find_package(zstd CONFIG REQUIRED)
-    target_link_libraries(IfcViewerCore PUBLIC zstd::libzstd_static)
+    find_package(zstd CONFIG QUIET)
+    if(TARGET zstd::libzstd_static)
+        target_link_libraries(IfcViewerCore PUBLIC zstd::libzstd_static)
+    else()
+        # No zstd CONFIG package on this system — fall back to pkg-config.
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(ZSTD REQUIRED IMPORTED_TARGET libzstd)
+        target_link_libraries(IfcViewerCore PUBLIC PkgConfig::ZSTD)
+    endif()
 endif()
 install(TARGETS IfcViewerCore EXPORT ${IFCOPENSHELL_EXPORT_TARGETS})
 
@@ -336,7 +351,12 @@ install(FILES ${IFCVIEWER_H_FILES}
 # INSTALL_RPATH is set to @executable_path/../Frameworks — together
 # they resolve at launch without depending on macdeployqt to follow
 # non-Qt @rpath references.
-if(WIN32)
+#
+# None of this applies with WGPU_NATIVE_USE_SYSTEM: the shared library
+# already lives on the system linker path, owned by its own package.
+if(WGPU_NATIVE_USE_SYSTEM)
+    # nothing to install; system package owns libwgpu_native
+elseif(WIN32)
     install(FILES "${wgpu_native_SOURCE_DIR}/lib/${_wgpu_runtime}" DESTINATION bin)
 elseif(APPLE AND BUILD_BONSAIVIEWER)
     install(FILES "${wgpu_native_SOURCE_DIR}/lib/${_wgpu_lib}"


### PR DESCRIPTION
## Summary
- Add a `WGPU_NATIVE_USE_SYSTEM` CMake option that resolves `wgpu-native` via pkg-config instead of FetchContent-ing upstream's prebuilt binary release, for distros (e.g. Fedora) that package it themselves
- Fall back to pkg-config for `zstd` when the CMake `zstd` CONFIG package isn't available
- Skip the wgpu-native runtime install step when `WGPU_NATIVE_USE_SYSTEM` is on, since the system package already owns the shared library

## Test plan
- [x] Configure with `-DWGPU_NATIVE_USE_SYSTEM=ON` on a system with a `wgpu-native` pkg-config file (e.g. Fedora) and confirm it links against the system package instead of fetching upstream's binary
- [ ] Configure without the option and confirm existing FetchContent behavior is unchanged