### PR TITLE
Bonsai: reduce CPU cost of the proximity snap path

### DIFF
--- a/src/bonsai/bonsai/tool/cad.py
+++ b/src/bonsai/bonsai/tool/cad.py
@@ -55,6 +55,28 @@ BISECT_TOLERANCE = 1.0e-4
 WELD_EPSILON = 1.0e-6
 
 
+# On 3-float operands np.cross/norm/dot spend more time in NumPy's dispatch
+# (normalize_axis_tuple, moveaxis) than on the arithmetic. intersect_edges_v2
+# runs thousands of times per mouse move, so it uses these instead. Results are
+# identical float64 — don't fold them back into the NumPy calls.
+def _cross3(a, b):
+    return np.array(
+        (
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0],
+        )
+    )
+
+
+def _norm3(v) -> float:
+    return (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]) ** 0.5
+
+
+def _dot3(a, b) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
 class Cad:
     @classmethod
     def get_cad_props(cls) -> BIMCadProperties:
@@ -517,19 +539,19 @@ class Cad:
         # Directions
         d1 = p1_end - p1
         d2 = p2_end - p2
-        d1 /= np.linalg.norm(d1) or 1  # equivalent of Vector.normalized() or Vector / Vector.length
-        d2 /= np.linalg.norm(d2) or 1
+        d1 /= _norm3(d1) or 1  # equivalent of Vector.normalized() or Vector / Vector.length
+        d2 /= _norm3(d2) or 1
 
-        n = np.cross(d1, d2)
+        n = _cross3(d1, d2)
 
         # if n is zero, lines are parallel
-        if abs(np.linalg.norm(n)) < 1e-6:
+        if abs(_norm3(n)) < 1e-6:
             return None, None
 
-        n2 = np.cross(d2, n)
-        c1 = p1 + (np.dot((p2 - p1), n2) / (np.dot(d1, n2))) * d1
-        n1 = np.cross(d1, n)
-        c2 = p2 + (np.dot((p1 - p2), n1) / (np.dot(d2, n1))) * d2
+        n2 = _cross3(d2, n)
+        c1 = p1 + (_dot3((p2 - p1), n2) / (_dot3(d1, n2))) * d1
+        n1 = _cross3(d1, n)
+        c2 = p2 + (_dot3((p1 - p2), n1) / (_dot3(d2, n1))) * d2
 
         if is_2d:
             return Vector(c1[:2].copy()), Vector(c2[:2].copy())

--- a/src/bonsai/bonsai/tool/raycast.py
+++ b/src/bonsai/bonsai/tool/raycast.py
@@ -1027,10 +1027,13 @@ class Raycast(bonsai.core.tool.Raycast):
             # Measure polylines
             bm = custom_bmesh
 
+        # Was copied once per vertex and twice per edge; it cannot change here.
+        matrix_world = obj.matrix_world.copy() if obj else None
+
         for vertex in bm.verts:
             v = vertex.co
-            if obj:
-                v = obj.matrix_world.copy() @ v
+            if matrix_world is not None:
+                v = matrix_world @ v
             intersection = tool.Cad.point_on_edge(v, (ray_target, loc))
             distance = (v - intersection).length
             if distance < snap_threshold:
@@ -1045,9 +1048,9 @@ class Raycast(bonsai.core.tool.Raycast):
         for edge in bm.edges:
             v1 = edge.verts[0].co
             v2 = edge.verts[1].co
-            if obj:
-                v1 = obj.matrix_world.copy() @ v1
-                v2 = obj.matrix_world.copy() @ v2
+            if matrix_world is not None:
+                v1 = matrix_world @ v1
+                v2 = matrix_world @ v2
             division_point = (v1 + v2) / 2  # TODO Make it work for different divisions
 
             intersection = tool.Cad.point_on_edge(division_point, (ray_target, loc))

--- a/src/bonsai/bonsai/tool/raycast.py
+++ b/src/bonsai/bonsai/tool/raycast.py
@@ -318,6 +318,16 @@ def _ensure_wireframe_batches(obj) -> dict[str, tuple[GPUBatch, int, list]]:
     return batches
 
 
+def edge_out_of_snap_range(midpoint_distance: float, edge_length: float, snap_threshold: float) -> bool:
+    """True when no point of an edge can lie within ``snap_threshold`` of the ray.
+
+    Every point is within half the edge length of the midpoint, so by the triangle
+    inequality none is nearer than ``midpoint_distance - edge_length / 2``. Never
+    rejects an edge that could snap.
+    """
+    return midpoint_distance - edge_length / 2 >= snap_threshold
+
+
 class Raycast(bonsai.core.tool.Raycast):
     offset = 10
     mouse_offset = (
@@ -1063,6 +1073,10 @@ class Raycast(bonsai.core.tool.Raycast):
                     "distance": distance,
                 }
                 points.append(snap_point)
+
+            # The intersection below dominates this loop and most edges fail it.
+            if edge_out_of_snap_range(distance, (v2 - v1).length, snap_threshold):
+                continue
 
             intersection = tool.Cad.intersect_edges_v2((ray_target, loc), (v1, v2))
             if intersection[0]:

--- a/src/bonsai/test/tool/test_cad.py
+++ b/src/bonsai/test/tool/test_cad.py
@@ -92,6 +92,48 @@ class TestClosestPoints(NewFile):
         assert subject.closest_points(edge1, edge2)[0] == (edge1[0], edge2[0])
 
 
+class TestIntersectEdgesV2(NewFile):
+    """Pins the closest-points results across the shapes the snap and wall-junction
+    call sites rely on, so the hot path can be optimised without changing them."""
+
+    def test_skew_lines_return_the_closest_point_on_each(self):
+        c1, c2 = subject.intersect_edges_v2((V(0, 0, 0), V(1, 0, 0)), (V(0.5, -1, 0.3), V(0.5, 1, 0.7)))
+        assert c1 is not None and c2 is not None
+        for got, want in zip(c1, V(0.5, 0, 0)):
+            assert abs(got - want) < 1e-9
+        for got, want in zip(c2, V(0.5, -0.09615385, 0.48076923)):
+            assert abs(got - want) < 1e-6
+
+    def test_crossing_lines_meet_at_the_intersection(self):
+        c1, c2 = subject.intersect_edges_v2((V(-1, 0, 0), V(1, 0, 0)), (V(0, -1, 0), V(0, 1, 0)))
+        assert c1 is not None
+        for got in c1 - c2:
+            assert abs(got) < 1e-9
+        for got, want in zip(c1, V(0, 0, 0)):
+            assert abs(got - want) < 1e-9
+
+    def test_parallel_lines_have_no_solution(self):
+        assert subject.intersect_edges_v2((V(0, 0, 0), V(1, 0, 0)), (V(0, 1, 0), V(1, 1, 0))) == (None, None)
+
+    def test_collinear_lines_have_no_solution(self):
+        assert subject.intersect_edges_v2((V(0, 0, 0), V(1, 0, 0)), (V(2, 0, 0), V(3, 0, 0))) == (None, None)
+
+    def test_2d_input_returns_2d_vectors(self):
+        c1, c2 = subject.intersect_edges_v2(
+            (Vector((-1.0, 0.0)), Vector((1.0, 0.0))), (Vector((0.0, -1.0)), Vector((0.0, 1.0)))
+        )
+        assert len(c1) == 2 and len(c2) == 2
+        for got, want in zip(c1, Vector((0.0, 0.0))):
+            assert abs(got - want) < 1e-9
+
+    def test_unnormalised_directions_do_not_change_the_result(self):
+        """Directions are normalised internally, so segment length must not matter."""
+        short = subject.intersect_edges_v2((V(0, 0, 0), V(1, 0, 0)), (V(0.5, -1, 0.3), V(0.5, 1, 0.7)))
+        long = subject.intersect_edges_v2((V(0, 0, 0), V(7, 0, 0)), (V(0.5, -1, 0.3), V(0.5, 1, 0.7)))
+        for got, want in zip(short[0], long[0]):
+            assert abs(got - want) < 1e-9
+
+
 class TestObbWorldClipPlanes(NewFile):
     def test_unit_box_at_origin_returns_axis_aligned_planes(self):
         planes = subject.obb_world_clip_planes(

--- a/src/bonsai/test/tool/test_raycast.py
+++ b/src/bonsai/test/tool/test_raycast.py
@@ -1,0 +1,74 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import random
+
+from mathutils import Vector
+from mathutils.geometry import intersect_point_line
+
+from bonsai.tool.raycast import edge_out_of_snap_range
+from test.bim.bootstrap import NewFile
+
+
+class TestEdgeOutOfSnapRange(NewFile):
+    """Guards the early-out that keeps the proximity loop off the expensive
+    line-line intersection for edges that cannot possibly snap."""
+
+    def test_far_edge_is_rejected(self):
+        # Midpoint 10 away, edge only 2 long: nothing on it gets within 9.
+        assert edge_out_of_snap_range(10.0, 2.0, 0.5) is True
+
+    def test_edge_under_the_cursor_is_kept(self):
+        assert edge_out_of_snap_range(0.01, 2.0, 0.5) is False
+
+    def test_long_edge_far_from_its_midpoint_is_kept(self):
+        """A long edge can reach the ray even when its midpoint is far away —
+        this is the case a naive midpoint-only test would wrongly discard."""
+        assert edge_out_of_snap_range(10.0, 40.0, 0.5) is False
+
+    def test_boundary_is_not_rejected(self):
+        # Bound lands exactly on the threshold; the loop's own test is strict
+        # (`distance < snap_threshold`), so rejecting here stays correct.
+        assert edge_out_of_snap_range(1.5, 1.0, 1.0) is True
+
+    def test_never_rejects_an_edge_that_could_snap(self):
+        """Random search: whenever a real point of the edge lies within the
+        threshold of the ray line, the predicate must not reject the edge."""
+        rng = random.Random(20260817)
+        ray = (Vector((0.0, 0.0, 0.0)), Vector((1.0, 0.0, 0.0)))
+        threshold = 0.5
+        checked = 0
+
+        for _ in range(3000):
+            v1 = Vector([rng.uniform(-5, 5) for _ in range(3)])
+            v2 = Vector([rng.uniform(-5, 5) for _ in range(3)])
+            midpoint = (v1 + v2) / 2
+            midpoint_distance = (midpoint - intersect_point_line(midpoint, *ray)[0]).length
+
+            if not edge_out_of_snap_range(midpoint_distance, (v2 - v1).length, threshold):
+                continue
+
+            # Predicate claims "cannot snap" — verify no sampled point does.
+            checked += 1
+            for step in range(21):
+                point = v1.lerp(v2, step / 20)
+                assert (point - intersect_point_line(point, *ray)[0]).length >= threshold
+
+        assert checked > 100, f"only {checked} edges exercised the rejection path"


### PR DESCRIPTION
## Context

The GPU snap detection that landed in `4cb6ce703`..`2b429dc60` replaces object *discovery*. `Raycast.ray_cast_by_proximity` survives it and is still the only CPU path that turns a detected object into Vertex / Edge Center / Edge snaps: `detect_snapping_points` calls it for the object under the cursor, and in plan/section views once per visible element carrying cut or fill decorator data.

These three changes reduce the cost of that function and of `Cad.intersect_edges_v2`, which it calls once per edge. They are independent of how candidates are found, so they apply equally before and after the GPU work.

## Changes

One commit each, each independently revertible:

**1. Speed up `Cad.intersect_edges_v2`.** Replace `np.cross` / `np.linalg.norm` / `np.dot` with explicit scalar arithmetic. On 3-element operands numpy spends far more time in its dispatch machinery (`normalize_axis_tuple`, `moveaxis`) than on the arithmetic itself. Float64 throughout, so results are unchanged. Also used by wall junctions in `tool/model.py`.

**2. Hoist `matrix_world` out of the proximity loops.** It was copied once per vertex and twice per edge, and cannot change while the loops run. Pure code motion: the copy is still taken, and the `obj=None` path used by the `custom_bmesh` callers is preserved.

**3. Skip the line-line intersection for edges that cannot snap.** Every point of an edge lies within half its length of its midpoint, whose distance to the ray the loop already computes for the Edge Center snap. By the triangle inequality no point can be nearer to the ray than `midpoint_distance - edge_length / 2`; once that lower bound reaches the snap threshold, `intersect_edges_v2` cannot produce a hit. The predicate never rejects an edge that could snap, so snapping results are unchanged.

## Measurements

Being explicit about what is and isn't measured:

- **3.8x on `intersect_edges_v2`** (68.95µs → 18.16µs) is a direct microbenchmark of the function and holds.
- End-to-end figures I collected earlier (per-event call count 52,113 → 1,869; ~370ms → ~70ms) were measured **before** the GPU rewrite, when `ray_cast_by_proximity` ran against every candidate object. They no longer describe the current architecture, so I am deliberately not claiming them here. What remains true regardless is that both changes strictly remove work while preserving behaviour.

Where I would expect them to still matter most is plan and section views: the cut/fill block in `detect_snapping_points` came through the rewrite unchanged and still iterates every visible mesh element with cache data, rebuilding a bmesh per object per mouse move.

## Tests

- `test/tool/test_cad.py` — 6 characterization tests for `intersect_edges_v2` (skew, crossing, parallel, collinear, 2D input, unnormalised directions), written against the previous implementation **before** the refactor, so it is verified behaviour-preserving rather than assumed to be.
- `test/tool/test_raycast.py` (new) — 5 tests for the early-out, including a randomised search over 3000 edges that samples 21 points along every rejected edge and asserts none lies within the threshold, with a guard so the test cannot pass vacuously.

`test/tool/test_cad.py test/tool/test_raycast.py` — 23 passed. `black --line-length 120` clean.

## Related

Supersedes #9004, which fixed the object-origin sort in `ray_cast_and_get_closest_to_camera_snaps`. The GPU rewrite left that function in the file but nothing calls it any more, so the heuristic it corrected is no longer on a live path. I'll close #9004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Real work comparison
Pre fix
<img width="478" height="556" alt="pre" src="https://github.com/user-attachments/assets/a71e5e7c-8a5b-434d-a2a7-9bd86e7d3590" />
After fix
<img width="648" height="606" alt="post" src="https://github.com/user-attachments/assets/feda91cb-63ad-4352-8404-ee53e6f7615d" />
