### PR TITLE
Fix silent geometry loss for sole occurrence of a typed opening

### DIFF
--- a/src/ifcgeom/mapping/mapping.cpp
+++ b/src/ifcgeom/mapping/mapping.cpp
@@ -128,6 +128,14 @@ bool mapping::reuse_ok_(const IfcSchema::IfcProduct::list::ptr& products) {
     }
 
     if (products->size() == 1) {
+        // A lone product can still disqualify reuse: if it has openings, its
+        // cut geometry is unique to it and must not be shared with a mapped
+        // representation (e.g. the sole occurrence of a type). Otherwise the
+        // occurrence's own geometry is silently skipped in favour of the
+        // shared/type-level shape. See #9348.
+        if (!settings_.get<settings::DisableOpeningSubtractions>().get() && find_openings(*products->begin())->size()) {
+            return false;
+        }
         return true;
     }
 
@@ -237,7 +245,7 @@ void mapping::get_representations(std::vector<geometry_conversion_task>& tasks, 
     for (auto representation : *representations) {
         IfcSchema::IfcRepresentationMap* rmap = nullptr;
         IfcSchema::IfcProduct::list::ptr ifcproducts = filter_products(products_represented_by(representation, rmap, false), filters);
-        
+
         if (ifcproducts->size() == 0) {
             continue;
         }


### PR DESCRIPTION
## Summary

Fixes #9348. When an `IfcOpeningElement` voids an element that is the sole occurrence of a shared/typed representation (e.g. a `MappedRepresentation` from an `IfcElementType`), the element's Body geometry silently disappeared in downstream Object-mode viewports (observed via Bonsai) — no exception, no warning/error logged, mesh ends up empty. `ifcopenshell.geom.create_shape()` called directly on the element returns correct, non-empty geometry with the opening properly subtracted, confirming the boolean/CSG kernel itself was never at fault.

Root cause: `mapping::reuse_ok_()` returned `true` for any single-product list before ever checking that product for openings. Whenever a caller's `include=` filter (or the product list naturally) narrowed down to exactly one product — the common case when editing the sole instance of a type — the size-1 fast path bypassed the `find_openings()` disqualification check entirely. `get_representations()` then treated the representation as safely shareable and processed it via the reuse/mapped path instead of computing an individual cut shape for the occurrence, and the resulting shape ended up attributed to the wrong product (or the type product, which typically has no consuming scene object downstream).

With two or more products in the list, the existing loop's `find_openings()` check ran as intended and correctly disqualified reuse — which is why this only manifests for singleton occurrences of a type and is easy to miss in testing (any file with ≥2 instances of the affected type masks it).

## Fix

Minimal, targeted change: the `products->size() == 1` fast path in `reuse_ok_()` now checks `find_openings()` on that single product before returning `true`, matching what the full loop would do for it anyway. Left the layerset/material checks out of the fast path deliberately, to avoid adding per-representation overhead to the (overwhelmingly common) non-shared, single-product case that has nothing to do with reuse.

## Testing

- Full `ifcopenshell-python` test suite: 2349 passed, 6 pre-existing/environmental failures unrelated to this change (`test_mmaped_stream`, documented as expected under this repo's `USE_MMAP=OFF` build config; 5 `mathutils`-import failures in an unrelated shape-builder test, since `mathutils` is Blender-only and unavailable to the bare test interpreter).
- Isolated before/after reproduction: on an identical minimal file (one `IfcElementType`, one occurrence, one opening), the unpatched build keys the resulting shape's geometry id to the *shared type-level representation*; the patched build keys it to the *occurrence's own representation* — matching the pattern of every other correctly-working (multi-occurrence) case.
- Confirmed end-to-end against the real-world reproduction that motivated this fix (Bonsai, a single `IfcRoofType` occurrence with an opening applied) — geometry now regenerates correctly instead of coming back empty.

## AI-generated code disclosure

This change (investigation, fix, and this PR description) was produced with the assistance of an AI coding tool, reviewed and tested by the author before submission.
