### PR TITLE
Bonsai: draw the cell borders a schedule's spreadsheet declares

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/scheduler.py
+++ b/src/bonsai/bonsai/bim/module/drawing/scheduler.py
@@ -21,6 +21,7 @@ import re
 import string
 from pathlib import Path
 from textwrap import wrap
+from typing import Union
 
 import openpyxl
 import openpyxl.cell  # Unnecessary, bug in typeshed.
@@ -35,6 +36,32 @@ import bonsai.tool as tool
 from bonsai.bim.module.drawing.svgwriter import SvgWriter
 
 DEBUG = False
+
+# What a spreadsheet may call a cell's borders: the shorthand ruling every side
+# the same, and one key per side that departs from it.
+BORDER_KEYS = ("border", "border-left", "border-right", "border-top", "border-bottom")
+
+# Dash pattern of a border style, in multiples of the line's own width. A style
+# missing here — solid, double and the relief styles — draws as a plain line.
+BORDER_DASHES = {"dotted": (1, 1), "dashed": (3, 2)}
+
+# What each border a workbook names is worth. Excel names a weight instead of
+# measuring one, so the widths are ours: what its own rendering approximates.
+XLSX_BORDERS = {
+    "hair": ("0.25pt", None),
+    "thin": ("0.5pt", None),
+    "medium": ("1pt", None),
+    "thick": ("1.5pt", None),
+    "double": ("1pt", None),
+    "dotted": ("0.5pt", BORDER_DASHES["dotted"]),
+    "dashed": ("0.5pt", BORDER_DASHES["dashed"]),
+    "dashDot": ("0.5pt", (3, 2, 1, 2)),
+    "dashDotDot": ("0.5pt", (3, 2, 1, 2, 1, 2)),
+    "mediumDashed": ("1pt", BORDER_DASHES["dashed"]),
+    "mediumDashDot": ("1pt", (3, 2, 1, 2)),
+    "mediumDashDotDot": ("1pt", (3, 2, 1, 2, 1, 2)),
+    "slantDashDot": ("1pt", (3, 2, 1, 2)),
+}
 
 
 def col2num(col):
@@ -160,14 +187,7 @@ class Scheduler:
                 else:
                     background_color = "#ffffff"
 
-                self.svg.add(
-                    self.svg.rect(
-                        insert=(x, y),
-                        size=(width, height),
-                        style=f"fill: {background_color};",
-                        class_="border",
-                    )
-                )
+                self.draw_cell(x, y, width, height, background_color, self.get_xlsx_cell_borders(cell.border))
 
                 if not cell.value:
                     x += unmerged_width
@@ -440,15 +460,7 @@ class Scheduler:
                         col_style = self.get_style(column_styles[tdi], styles)
                         final_cell_style = cell_style or col_style
                         background_color = final_cell_style.get("background-color", "#ffffff")
-
-                        self.svg.add(
-                            self.svg.rect(
-                                insert=(x, y),
-                                size=(width, height),
-                                style=f"fill: {background_color};",
-                                class_="border",
-                            )
-                        )
+                        self.draw_cell(x, y, width, height, background_color, self.get_cell_borders(final_cell_style))
 
                         p_tags = td.getElementsByType(P)
                         text_color = final_cell_style.get("color", None)
@@ -504,6 +516,111 @@ class Scheduler:
         self.svg["height"] = "{}mm".format(total_height)
         self.svg["viewBox"] = "0 0 {} {}".format(total_width, total_height)
         self.svg.save(pretty=True)
+
+    def draw_cell(
+        self, x: float, y: float, width: float, height: float, background_color: str, borders: Union[dict, None]
+    ) -> None:
+        """Draw one cell: its background, then a line for each side it rules.
+
+        `borders` is None for a cell that rules no side, which keeps the single
+        `.border` class the stylesheet controls. One that does rule them gets
+        them drawn one by one: a rectangle carries a single stroke, a
+        spreadsheet routinely asks for four different ones.
+        """
+        if borders is None:
+            self.svg.add(
+                self.svg.rect(
+                    insert=(x, y),
+                    size=(width, height),
+                    style=f"fill: {background_color};",
+                    class_="border",
+                )
+            )
+            return
+
+        self.svg.add(
+            self.svg.rect(insert=(x, y), size=(width, height), style=f"fill: {background_color}; stroke: none;")
+        )
+        edges = {
+            "left": ((x, y), (x, y + height)),
+            "right": ((x + width, y), (x + width, y + height)),
+            "top": ((x, y), (x + width, y)),
+            "bottom": ((x, y + height), (x + width, y + height)),
+        }
+        for side, border in borders.items():
+            if border is None:
+                continue
+            border_width, color, dashes = border
+            stroke = f"stroke: {color}; stroke-width: {border_width};"
+            if dashes:
+                # Scaled by the line's own width, so a hairline dots finely.
+                stroke += " stroke-dasharray: " + ",".join(str(d * border_width) for d in dashes) + ";"
+            start, end = edges[side]
+            self.svg.add(self.svg.line(start=start, end=end, style=stroke))
+
+    def get_cell_borders(self, style: dict) -> Union[dict, None]:
+        """The border of each side, or None when the cell rules none of them and
+        the stylesheet decides.
+
+        A spreadsheet writes one `border` for a cell ruled alike on every side
+        and a `border-<side>` for each side that departs from it.
+        """
+        if not any(key in style for key in BORDER_KEYS):
+            return None
+        shorthand = self.parse_border(style.get("border"))
+        return {
+            side: self.parse_border(style[f"border-{side}"]) if f"border-{side}" in style else shorthand
+            for side in ("left", "right", "top", "bottom")
+        }
+
+    def parse_border(self, value: Union[str, None]) -> Union[tuple[float, str, Union[tuple, None]], None]:
+        """(width in mm, colour, dash pattern) of an ODF border such as
+        `0.5pt solid #ff0000`; None for a side carrying no line.
+
+        Width, style and colour may come in any order and any of them may be
+        absent, so each token is read for what it is. A border with no width is
+        no line: ODF always writes one.
+        """
+        if not value:
+            return None
+        border_width, color, dashes = None, "#000000", None
+        for token in value.split():
+            if token in ("none", "hidden"):
+                return None
+            elif token.startswith("#"):
+                color = token
+            elif token[0].isdigit() or token[0] == ".":
+                border_width = self.convert_to_mm(token)
+            elif token in BORDER_DASHES:
+                dashes = BORDER_DASHES[token]
+        if border_width is None:
+            return None
+        return border_width, color, dashes
+
+    def get_xlsx_cell_borders(self, border) -> Union[dict, None]:
+        """The border of each side of a workbook cell, or None when it rules
+        none of them.
+
+        A side openpyxl never gave a style is a side the workbook says nothing
+        about, whether it comes back as None or as a Side carrying none.
+        """
+        sides = {side: getattr(border, side, None) for side in ("left", "right", "top", "bottom")}
+        if not any(side is not None and side.style for side in sides.values()):
+            return None
+        return {name: self.parse_xlsx_border(side) for name, side in sides.items()}
+
+    def parse_xlsx_border(self, side) -> Union[tuple[float, str, Union[tuple, None]], None]:
+        """(width in mm, colour, dash pattern) of one openpyxl Side.
+
+        The colour is ARGB, and only a plain one can be read here: an indexed or
+        theme colour needs the workbook to resolve it, and draws black.
+        """
+        if side is None or not side.style:
+            return None
+        border_width, dashes = XLSX_BORDERS[side.style]
+        rgb = getattr(side.color, "rgb", None) if side.color else None
+        color = f"#{rgb[2:].lower()}" if isinstance(rgb, str) and len(rgb) == 8 else "#000000"
+        return self.convert_to_mm(border_width), color, dashes
 
     def get_style(self, style_name: str, styles: dict) -> dict:
         style = styles[style_name] if style_name else {}

--- a/src/bonsai/test/bim/module/drawing/test_scheduler.py
+++ b/src/bonsai/test/bim/module/drawing/test_scheduler.py
@@ -1,0 +1,157 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""How a schedule cell is drawn from the borders its spreadsheet declares.
+
+A cell that declares none keeps the `.border` class the stylesheet controls, so
+a document that never set borders draws as it always did. A cell that declares
+them gets one line per side, which is the only way an outline and the inner
+rules can differ. A spreadsheet says so in ODF style attributes and a workbook
+in openpyxl Sides; both arrive at draw_cell in the same shape.
+"""
+
+import pytest
+from openpyxl.styles import Border, Side
+from openpyxl.styles.colors import Color
+
+from bonsai.bim.module.drawing.scheduler import Scheduler
+
+PT = 25.4 / 72
+
+
+class FakeSvg:
+    """Collects what the scheduler draws, in order."""
+
+    def __init__(self):
+        self.items = []
+
+    def rect(self, **kwargs):
+        return ("rect", kwargs)
+
+    def line(self, **kwargs):
+        return ("line", kwargs)
+
+    def add(self, item):
+        self.items.append(item)
+
+
+@pytest.fixture
+def scheduler():
+    scheduler = Scheduler()
+    scheduler.svg = FakeSvg()
+    return scheduler
+
+
+def draw(scheduler, style):
+    background_color = style.get("background-color", "#ffffff")
+    scheduler.draw_cell(0, 0, 40, 6, background_color, scheduler.get_cell_borders(style))
+    return scheduler.svg.items
+
+
+def widths(items):
+    return [float(line["style"].split("stroke-width: ")[1].split(";")[0]) for _, line in items[1:]]
+
+
+def test_cell_without_borders_is_left_to_the_stylesheet(scheduler):
+    ((kind, cell),) = draw(scheduler, {"background-color": "#eeeeee"})
+    assert kind == "rect"
+    assert cell["class_"] == "border"
+    assert cell["style"] == "fill: #eeeeee;"
+
+
+def test_cell_that_declares_no_border_gets_no_line(scheduler):
+    assert [kind for kind, _ in draw(scheduler, {"border": "none"})] == ["rect"]
+
+
+def test_border_is_drawn_on_every_side(scheduler):
+    items = draw(scheduler, {"border": "0.5pt solid #ff0000"})
+    assert [kind for kind, _ in items] == ["rect", "line", "line", "line", "line"]
+    assert "stroke: none" in items[0][1]["style"]
+    assert [line["start"] for _, line in items[1:]] == [(0, 0), (40, 0), (0, 0), (0, 6)]
+    assert [line["end"] for _, line in items[1:]] == [(0, 6), (40, 6), (40, 0), (40, 6)]
+    for _, line in items[1:]:
+        assert "stroke: #ff0000;" in line["style"]
+    assert widths(items) == [pytest.approx(0.5 * PT)] * 4
+
+
+def test_a_side_of_its_own_departs_from_the_shorthand(scheduler):
+    items = draw(scheduler, {"border": "0.25pt solid #000000", "border-left": "1pt solid #000000"})
+    assert widths(items)[0] == pytest.approx(1 * PT)
+    assert widths(items)[1:] == [pytest.approx(0.25 * PT)] * 3
+
+
+@pytest.mark.parametrize(
+    "border,dashes",
+    [
+        ("0.5pt dashed #000000", (3, 2)),
+        ("0.5pt dotted #000000", (1, 1)),
+        ("0.5pt solid #000000", None),
+        ("0.5pt double #000000", None),
+    ],
+)
+def test_border_style_becomes_a_dash_pattern(scheduler, border, dashes):
+    _, line = draw(scheduler, {"border": border})[1]
+    if dashes is None:
+        assert "stroke-dasharray" not in line["style"]
+    else:
+        expected = ",".join(str(dash * 0.5 * PT) for dash in dashes)
+        assert f"stroke-dasharray: {expected};" in line["style"]
+
+
+@pytest.mark.parametrize("border", ["0.5pt solid #ff0000", "solid 0.5pt #ff0000", "#ff0000 0.5pt solid"])
+def test_the_three_parts_may_come_in_any_order(scheduler, border):
+    assert scheduler.parse_border(border) == (pytest.approx(0.5 * PT), "#ff0000", None)
+
+
+def test_a_border_without_a_width_is_no_line(scheduler):
+    assert scheduler.parse_border("solid #ff0000") is None
+
+
+def test_the_shorthand_stands_in_for_the_sides_left_silent(scheduler):
+    borders = scheduler.get_cell_borders({"border": "0.25pt solid #000000", "border-top": "none"})
+    assert borders["top"] is None
+    assert borders["left"] == borders["right"] == borders["bottom"]
+
+
+def test_workbook_cell_without_borders_is_left_to_the_stylesheet(scheduler):
+    assert scheduler.get_xlsx_cell_borders(Border()) is None
+
+
+def test_workbook_cell_rules_only_the_sides_it_names(scheduler):
+    border = Border(left=Side(style="thick", color="FFFF0000"), bottom=Side(style="thin"))
+    borders = scheduler.get_xlsx_cell_borders(border)
+    assert borders["left"] == (pytest.approx(1.5 * PT), "#ff0000", None)
+    assert borders["bottom"] == (pytest.approx(0.5 * PT), "#000000", None)
+    assert borders["right"] is borders["top"] is None
+
+
+@pytest.mark.parametrize(
+    "style,dashes",
+    [("dashed", (3, 2)), ("dotted", (1, 1)), ("mediumDashDot", (3, 2, 1, 2)), ("double", None)],
+)
+def test_a_workbook_border_style_becomes_a_dash_pattern(scheduler, style, dashes):
+    assert scheduler.get_xlsx_cell_borders(Border(top=Side(style=style)))["top"][2] == dashes
+
+
+def test_a_workbook_colour_that_needs_the_theme_draws_black(scheduler):
+    # openpyxl answers .rgb on a theme colour with its complaint as a string
+    # rather than raising, so the length is what tells a real ARGB from it.
+    borders = scheduler.get_xlsx_cell_borders(Border(top=Side(style="thin", color=Color(theme=1))))
+    assert borders["top"][1] == "#000000"


### PR DESCRIPTION
`schedule_ods` already collects every cell style attribute from the spreadsheet — background, font size, weight, style, color, wrap — and uses them. Borders are collected too, and discarded: every cell is drawn as a rectangle carrying one hardcoded `class_="border"` whose stroke comes from the stylesheet. `schedule_xlsx` does the same from openpyxl. A thick outline with thin inner rules, the usual look of an architectural schedule, cannot reach the drawing no matter what is set in LibreOffice or Excel.

### What changed

The inline rectangle in both branches becomes `draw_cell()`, which takes a background color and the borders **already resolved**, so it is independent of the source format. Each branch translates its own:

- `get_cell_borders()` / `parse_border()` read `.ods` style attributes;
- `get_xlsx_cell_borders()` / `parse_xlsx_border()` read openpyxl `Side` objects.

A cell that declares no border keeps the `.border` class and draws exactly as before. One that declares them gets a line per side, which a single rectangle stroke cannot express.

Width, style and color are read in any order, per the CSS `border` shorthand grammar (`<width> || <style> || <color>`), rather than assuming the order LibreOffice happens to emit. `dotted` and `dashed` become a dash pattern scaled by the line width; `double` and the relief styles draw plain.

`XLSX_BORDERS` converts Excel's fourteen named weights into widths and dash patterns. Excel names a weight instead of measuring one, so that table is a choice rather than a reading of the file, and is commented as such.

### One deliberate behaviour change

A cell that declares `border: none` now draws **no** line, where before it took the stylesheet's. This is intentional and is half the point of the change: a sheet that says a side has no border should not be given one.

Cells that declare nothing about borders are unaffected — that is the compatibility guarantee, and it covers every schedule IfcCsv writes, since it emits no cell styles at all.

### Left as it is

Adjacent cells each stroke the edge they share, so where two neighbours declare it differently the later one wins. The rectangles overlapped the same way before, with the same stroke on both sides. Spreadsheet applications resolve such conflicts by precedence, which this does not attempt.

### Testing

`src/bonsai/test/bim/module/drawing/test_scheduler.py` — 20 tests over both translators and the drawing: the untouched-cell guarantee, the `border: none` change, per-side overrides of the shorthand, token order, dash patterns, and the openpyxl side. One trap they pin down: asked for the ARGB of a theme color, openpyxl returns its own complaint *as a string* instead of raising, so the length of the value is what distinguishes a real ARGB from it.

`black` and `ruff` clean on both files.

### Notes

- Touches the same block of `schedule_ods` as #8537 (hidden columns), a few lines apart. Whichever lands second wants a trivial rebase; this change keeps the `background_color` local in place to keep the overlap as small as possible.
- Adjacent but not addressed here: #4781 (text wrap with custom CSS), #5221 (font lost when a schedule is placed on a sheet), #3586 (truncation after column widths change).
- Draft: opened for review of the approach before asking for a merge.

### AI disclosure

Per AGENTS.md: this contribution was written with the assistance of an AI coding tool, in whole — both the change to `scheduler.py` and the new test file, which carries the required header comment.
