### PR TITLE
Bonsai: scheduler: draw the cell borders a schedule's spreadsheet declares

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/scheduler.py
+++ b/src/bonsai/bonsai/bim/module/drawing/scheduler.py
@@ -21,6 +21,7 @@ import re
 import string
 from pathlib import Path
 from textwrap import wrap
+from typing import Union
 
 import openpyxl
 import openpyxl.cell  # Unnecessary, bug in typeshed.
@@ -35,6 +36,30 @@ import bonsai.tool as tool
 from bonsai.bim.module.drawing.svgwriter import SvgWriter
 
 DEBUG = False
+
+# What a spreadsheet may call a cell's borders: the shorthand ruling every side
+# the same, and one key per side that departs from it.
+BORDER_KEYS = ("border", "border-left", "border-right", "border-top", "border-bottom")
+
+# dash patterns in multiples of the line width, anything missing draws plain
+BORDER_DASHES = {"dotted": (1, 1), "dashed": (3, 2)}
+
+# xlsx names a border weight instead of measuring it, so the widths are ours
+XLSX_BORDERS = {
+    "hair": ("0.25pt", None),
+    "thin": ("0.5pt", None),
+    "medium": ("1pt", None),
+    "thick": ("1.5pt", None),
+    "double": ("1pt", None),
+    "dotted": ("0.5pt", BORDER_DASHES["dotted"]),
+    "dashed": ("0.5pt", BORDER_DASHES["dashed"]),
+    "dashDot": ("0.5pt", (3, 2, 1, 2)),
+    "dashDotDot": ("0.5pt", (3, 2, 1, 2, 1, 2)),
+    "mediumDashed": ("1pt", BORDER_DASHES["dashed"]),
+    "mediumDashDot": ("1pt", (3, 2, 1, 2)),
+    "mediumDashDotDot": ("1pt", (3, 2, 1, 2, 1, 2)),
+    "slantDashDot": ("1pt", (3, 2, 1, 2)),
+}
 
 
 def col2num(col):
@@ -160,14 +185,7 @@ class Scheduler:
                 else:
                     background_color = "#ffffff"
 
-                self.svg.add(
-                    self.svg.rect(
-                        insert=(x, y),
-                        size=(width, height),
-                        style=f"fill: {background_color};",
-                        class_="border",
-                    )
-                )
+                self.draw_cell(x, y, width, height, background_color, self.get_xlsx_cell_borders(cell.border))
 
                 if not cell.value:
                     x += unmerged_width
@@ -440,15 +458,7 @@ class Scheduler:
                         col_style = self.get_style(column_styles[tdi], styles)
                         final_cell_style = cell_style or col_style
                         background_color = final_cell_style.get("background-color", "#ffffff")
-
-                        self.svg.add(
-                            self.svg.rect(
-                                insert=(x, y),
-                                size=(width, height),
-                                style=f"fill: {background_color};",
-                                class_="border",
-                            )
-                        )
+                        self.draw_cell(x, y, width, height, background_color, self.get_cell_borders(final_cell_style))
 
                         p_tags = td.getElementsByType(P)
                         text_color = final_cell_style.get("color", None)
@@ -504,6 +514,93 @@ class Scheduler:
         self.svg["height"] = "{}mm".format(total_height)
         self.svg["viewBox"] = "0 0 {} {}".format(total_width, total_height)
         self.svg.save(pretty=True)
+
+    def draw_cell(
+        self, x: float, y: float, width: float, height: float, background_color: str, borders: Union[dict, None]
+    ) -> None:
+        """Draw a cell background, and a line for each side that has a border.
+
+        A cell with no borders of its own keeps the `.border` class, so the
+        stylesheet still styles it as it did before.
+        """
+        if borders is None:
+            self.svg.add(
+                self.svg.rect(
+                    insert=(x, y),
+                    size=(width, height),
+                    style=f"fill: {background_color};",
+                    class_="border",
+                )
+            )
+            return
+
+        self.svg.add(
+            self.svg.rect(insert=(x, y), size=(width, height), style=f"fill: {background_color}; stroke: none;")
+        )
+        edges = {
+            "left": ((x, y), (x, y + height)),
+            "right": ((x + width, y), (x + width, y + height)),
+            "top": ((x, y), (x + width, y)),
+            "bottom": ((x, y + height), (x + width, y + height)),
+        }
+        for side, border in borders.items():
+            if border is None:
+                continue
+            border_width, color, dashes = border
+            stroke = f"stroke: {color}; stroke-width: {border_width};"
+            if dashes:
+                # dashes scale with the line width, so a hairline dots finely
+                dasharray = ",".join(str(dash * border_width) for dash in dashes)
+                stroke += f" stroke-dasharray: {dasharray};"
+            start, end = edges[side]
+            self.svg.add(self.svg.line(start=start, end=end, style=stroke))
+
+    def get_cell_borders(self, style: dict) -> Union[dict, None]:
+        """Border of each side of an .ods cell, or None if it declares none."""
+        if not any(key in style for key in BORDER_KEYS):
+            return None
+        # `border` rules every side, `border-<side>` overrides one of them
+        shorthand = self.parse_border(style.get("border"))
+        return {
+            side: self.parse_border(style[f"border-{side}"]) if f"border-{side}" in style else shorthand
+            for side in ("left", "right", "top", "bottom")
+        }
+
+    def parse_border(self, value: Union[str, None]) -> Union[tuple, None]:
+        """(width in mm, color, dashes) of an .ods border, None if it has no line."""
+        if not value:
+            return None
+        # CSS shorthand: width, style and color in any order, any of them absent
+        border_width, color, dashes = None, "#000000", None
+        for token in value.split():
+            if token in ("none", "hidden"):
+                return None
+            elif token.startswith("#"):
+                color = token
+            elif token[0].isdigit() or token[0] == ".":
+                border_width = self.convert_to_mm(token)
+            elif token in BORDER_DASHES:
+                dashes = BORDER_DASHES[token]
+        if border_width is None:
+            return None
+        return border_width, color, dashes
+
+    def get_xlsx_cell_borders(self, border) -> Union[dict, None]:
+        """Border of each side of an .xlsx cell, or None if it declares none."""
+        sides = {side: getattr(border, side, None) for side in ("left", "right", "top", "bottom")}
+        if not any(side is not None and side.style for side in sides.values()):
+            return None
+        return {name: self.parse_xlsx_border(side) for name, side in sides.items()}
+
+    def parse_xlsx_border(self, side) -> Union[tuple, None]:
+        """(width in mm, color, dashes) of an openpyxl Side, None if it has no line."""
+        if side is None or not side.style:
+            return None
+        border_width, dashes = XLSX_BORDERS[side.style]
+        # NOTE: only a plain ARGB reads here, an indexed or theme color draws black
+        rgb = getattr(side.color, "rgb", None) if side.color else None
+        color = f"#{rgb[2:].lower()}" if isinstance(rgb, str) and len(rgb) == 8 else "#000000"
+        return self.convert_to_mm(border_width), color, dashes
 
     def get_style(self, style_name: str, styles: dict) -> dict:
         style = styles[style_name] if style_name else {}

--- a/src/bonsai/test/bim/module/drawing/test_scheduler.py
+++ b/src/bonsai/test/bim/module/drawing/test_scheduler.py
@@ -1,0 +1,153 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Cell borders read from a spreadsheet and drawn into the schedule SVG.
+
+A cell that declares none keeps the `.border` class the stylesheet controls, so
+schedules that never set borders are unaffected. .ods declares them in style
+attributes and .xlsx in openpyxl Sides, and both reach draw_cell alike.
+"""
+
+import pytest
+from openpyxl.styles import Border, Side
+from openpyxl.styles.colors import Color
+
+from bonsai.bim.module.drawing.scheduler import Scheduler
+
+PT = 25.4 / 72
+
+
+class FakeSvg:
+    def __init__(self):
+        self.items = []
+
+    def rect(self, **kwargs):
+        return ("rect", kwargs)
+
+    def line(self, **kwargs):
+        return ("line", kwargs)
+
+    def add(self, item):
+        self.items.append(item)
+
+
+@pytest.fixture
+def scheduler():
+    scheduler = Scheduler()
+    scheduler.svg = FakeSvg()
+    return scheduler
+
+
+def draw(scheduler, style):
+    background_color = style.get("background-color", "#ffffff")
+    scheduler.draw_cell(0, 0, 40, 6, background_color, scheduler.get_cell_borders(style))
+    return scheduler.svg.items
+
+
+def widths(items):
+    return [float(line["style"].split("stroke-width: ")[1].split(";")[0]) for _, line in items[1:]]
+
+
+def test_ods_no_borders(scheduler):
+    ((kind, cell),) = draw(scheduler, {"background-color": "#eeeeee"})
+    assert kind == "rect"
+    assert cell["class_"] == "border"
+    assert cell["style"] == "fill: #eeeeee;"
+
+
+def test_ods_border_none(scheduler):
+    assert [kind for kind, _ in draw(scheduler, {"border": "none"})] == ["rect"]
+
+
+def test_ods_border_all_sides(scheduler):
+    items = draw(scheduler, {"border": "0.5pt solid #ff0000"})
+    assert [kind for kind, _ in items] == ["rect", "line", "line", "line", "line"]
+    assert "stroke: none" in items[0][1]["style"]
+    assert [line["start"] for _, line in items[1:]] == [(0, 0), (40, 0), (0, 0), (0, 6)]
+    assert [line["end"] for _, line in items[1:]] == [(0, 6), (40, 6), (40, 0), (40, 6)]
+    for _, line in items[1:]:
+        assert "stroke: #ff0000;" in line["style"]
+    assert widths(items) == [pytest.approx(0.5 * PT)] * 4
+
+
+def test_ods_side_overrides_shorthand(scheduler):
+    items = draw(scheduler, {"border": "0.25pt solid #000000", "border-left": "1pt solid #000000"})
+    assert widths(items)[0] == pytest.approx(1 * PT)
+    assert widths(items)[1:] == [pytest.approx(0.25 * PT)] * 3
+
+
+@pytest.mark.parametrize(
+    "border,dashes",
+    [
+        ("0.5pt dashed #000000", (3, 2)),
+        ("0.5pt dotted #000000", (1, 1)),
+        ("0.5pt solid #000000", None),
+        ("0.5pt double #000000", None),
+    ],
+)
+def test_ods_border_dashes(scheduler, border, dashes):
+    _, line = draw(scheduler, {"border": border})[1]
+    if dashes is None:
+        assert "stroke-dasharray" not in line["style"]
+    else:
+        expected = ",".join(str(dash * 0.5 * PT) for dash in dashes)
+        assert f"stroke-dasharray: {expected};" in line["style"]
+
+
+@pytest.mark.parametrize("border", ["0.5pt solid #ff0000", "solid 0.5pt #ff0000", "#ff0000 0.5pt solid"])
+def test_ods_border_token_order(scheduler, border):
+    assert scheduler.parse_border(border) == (pytest.approx(0.5 * PT), "#ff0000", None)
+
+
+def test_ods_border_without_width(scheduler):
+    assert scheduler.parse_border("solid #ff0000") is None
+
+
+def test_ods_shorthand_fills_silent_sides(scheduler):
+    borders = scheduler.get_cell_borders({"border": "0.25pt solid #000000", "border-top": "none"})
+    assert borders["top"] is None
+    assert borders["left"] == borders["right"] == borders["bottom"]
+
+
+def test_xlsx_no_borders(scheduler):
+    assert scheduler.get_xlsx_cell_borders(Border()) is None
+
+
+def test_xlsx_named_sides(scheduler):
+    border = Border(left=Side(style="thick", color="FFFF0000"), bottom=Side(style="thin"))
+    borders = scheduler.get_xlsx_cell_borders(border)
+    assert borders["left"] == (pytest.approx(1.5 * PT), "#ff0000", None)
+    assert borders["bottom"] == (pytest.approx(0.5 * PT), "#000000", None)
+    assert borders["right"] is borders["top"] is None
+
+
+@pytest.mark.parametrize(
+    "style,dashes",
+    [("dashed", (3, 2)), ("dotted", (1, 1)), ("mediumDashDot", (3, 2, 1, 2)), ("double", None)],
+)
+def test_xlsx_border_dashes(scheduler, style, dashes):
+    assert scheduler.get_xlsx_cell_borders(Border(top=Side(style=style)))["top"][2] == dashes
+
+
+def test_xlsx_theme_color(scheduler):
+    # openpyxl answers .rgb on a theme color with its complaint as a string
+    # rather than raising, so the length is what tells a real ARGB from it
+    borders = scheduler.get_xlsx_cell_borders(Border(top=Side(style="thin", color=Color(theme=1))))
+    assert borders["top"][1] == "#000000"


### PR DESCRIPTION
`schedule_ods` already collects every cell style attribute from the spreadsheet — background, font size, weight, style, color, wrap — and uses them. Borders are collected too, and discarded: every cell is drawn as a rectangle carrying one hardcoded `class_="border"` whose stroke comes from the stylesheet. `schedule_xlsx` does the same from openpyxl. A thick outline with thin inner rules, the usual look of an architectural schedule, cannot reach the drawing no matter what is set in LibreOffice or Excel.

### What changed

The inline rectangle in both branches becomes `draw_cell()`, which takes a background color and the borders **already resolved**, so it is independent of the source format. Each branch translates its own:

- `get_cell_borders()` / `parse_border()` read `.ods` style attributes;
- `get_xlsx_cell_borders()` / `parse_xlsx_border()` read openpyxl `Side` objects.

A cell that declares no border keeps the `.border` class and draws exactly as before. One that declares them gets a line per side, which a single rectangle stroke cannot express.

Width, style and color are read in any order, per the CSS `border` shorthand grammar (`<width> || <style> || <color>`), rather than assuming the order LibreOffice happens to emit. `dotted` and `dashed` become a dash pattern scaled by the line width; `double` and the relief styles draw plain.

`XLSX_BORDERS` converts Excel's fourteen named weights into widths and dash patterns. Excel names a weight instead of measuring one, so that table is a choice rather than a reading of the file, and is commented as such.

### One deliberate behaviour change

A cell that declares `border: none` now draws **no** line, where before it took the stylesheet's. This is intentional and is half the point of the change: a sheet that says a side has no border should not be given one.

Cells that declare nothing about borders are unaffected — that is the compatibility guarantee, and it covers every schedule IfcCsv writes, since it emits no cell styles at all.

### Left as it is

Adjacent cells each stroke the edge they share, so where two neighbours declare it differently the later one wins. The rectangles overlapped the same way before, with the same stroke on both sides. Spreadsheet applications resolve such conflicts by precedence, which this does not attempt.

### Testing

`src/bonsai/test/bim/module/drawing/test_scheduler.py` — 20 tests over both translators and the drawing: the untouched-cell guarantee, the `border: none` change, per-side overrides of the shorthand, token order, dash patterns, and the openpyxl side. One trap they pin down: asked for the ARGB of a theme color, openpyxl returns its own complaint *as a string* instead of raising, so the length of the value is what distinguishes a real ARGB from it.

`black` and `ruff` clean on both files.

### Notes

- Touches the same block of `schedule_ods` as #8537 (hidden columns), a few lines apart. Whichever lands second wants a trivial rebase; this change keeps the `background_color` local in place to keep the overlap as small as possible.
- Adjacent but not addressed here: #4781 (text wrap with custom CSS), #5221 (font lost when a schedule is placed on a sheet), #3586 (truncation after column widths change).
- Draft: opened for review of the approach before asking for a merge.

### AI disclosure

Per AGENTS.md: this contribution was written with the assistance of an AI coding tool, in whole — both the change to `scheduler.py` and the new test file, which carries the required header comment.

