### PR TITLE
docs: document drawing stylesheets and the override pattern

### DIFF
--- a/src/bonsai/bonsai/bim/data/assets/override-fine-lineweight.css
+++ b/src/bonsai/bonsai/bim/data/assets/override-fine-lineweight.css
@@ -1,0 +1,35 @@
+/*
+ * Bonsai - OpenBIM Blender Add-on
+ * Copyright (C) 2020, 2021 Dion Moult <dion@thinkmoult.com>
+ *
+ * This file is part of Bonsai.
+ *
+ * Bonsai is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bonsai is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * long with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Starter override: finer lineweight, for dense drawings where the
+ * defaults look too heavy (small-scale details, tightly packed plans).
+ * This is NOT a full stylesheet. Load it after default.css, for example:
+ *   default.css, override-fine-lineweight.css
+ * See docs/guides/drawings/styling.rst for the full guide.
+ */
+
+.cut { stroke-width: 0.25; }
+.projection { stroke-width: 0.18; }
+path.outline { stroke-width: 0.25; }
+path.boundary { stroke-width: 0.2; }
+
+/* Default plain linework annotations (grids, sketch lines) a touch finer too. */
+.PredefinedType-LINEWORK { stroke-width: 0.18; }

--- a/src/bonsai/bonsai/bim/data/assets/override-heavy-lineweight.css
+++ b/src/bonsai/bonsai/bim/data/assets/override-heavy-lineweight.css
@@ -1,0 +1,39 @@
+/*
+ * Bonsai - OpenBIM Blender Add-on
+ * Copyright (C) 2020, 2021 Dion Moult <dion@thinkmoult.com>
+ *
+ * This file is part of Bonsai.
+ *
+ * Bonsai is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bonsai is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * long with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Starter override: heavier lineweight.
+ * This is NOT a full stylesheet. Load it after default.css so the cascade
+ * only changes the rules below, for example:
+ *   default.css, override-heavy-lineweight.css
+ * See docs/guides/drawings/styling.rst for the full guide.
+ */
+
+/* Thicker cut lines (walls, slabs in section) so they read from further away. */
+.cut { stroke-width: 0.5; }
+
+/* Thicker projection lines for elements seen beyond the cut plane. */
+.projection { stroke-width: 0.35; }
+
+/* Thicker silhouette edges to match. */
+path.outline { stroke-width: 0.5; }
+
+/* Bump up the default LINEWORK weight too, so plain linework matches. */
+.PredefinedType-LINEWORK { stroke-width: 0.35; }

--- a/src/bonsai/bonsai/bim/data/assets/override-presentation-greys.css
+++ b/src/bonsai/bonsai/bim/data/assets/override-presentation-greys.css
@@ -1,0 +1,41 @@
+/*
+ * Bonsai - OpenBIM Blender Add-on
+ * Copyright (C) 2020, 2021 Dion Moult <dion@thinkmoult.com>
+ *
+ * This file is part of Bonsai.
+ *
+ * Bonsai is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Bonsai is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * long with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Starter override: softer greys for client-facing presentation drawings,
+ * with black reserved for the cut plane so it still reads as the "main"
+ * line. This is NOT a full stylesheet. Load it after default.css:
+ *   default.css, override-presentation-greys.css
+ * See docs/guides/drawings/styling.rst for the full guide.
+ */
+
+/* Keep cut lines black so the drawing still has a clear hierarchy. */
+.cut { stroke: black; }
+
+/* Grey out background/projection geometry so cut elements stand out. */
+.projection { stroke: #808080; }
+path.boundary { stroke: #808080; }
+path.crease { stroke: #a0a0a0; }
+path.sharp { stroke: #b0b0b0; }
+path.flush { stroke: #c8c8c8; }
+
+/* Grey dimension and grid linework instead of pure black. */
+.PredefinedType-DIMENSION { stroke: #606060; }
+.PredefinedType-GRID { stroke: #808080; }

--- a/src/bonsai/docs/guides/drawings/index.rst
+++ b/src/bonsai/docs/guides/drawings/index.rst
@@ -48,6 +48,16 @@ Annotating Plan Layout
 Line Work
 =========
 
+Styling Drawings
+=================
+
+Every drawing Bonsai generates is styled by a CSS stylesheet, controlling
+line weights, colours, dash patterns, text sizes and material hatches.
+See :doc:`styling` for a full guide, including how to add your own styling
+on top of the built-in defaults without editing them directly, a full
+reference of the styling classes Bonsai understands, and ready-to-use
+starter stylesheets.
+
 Annotations & Tags
 ==================
 
@@ -117,3 +127,9 @@ After mastering these basics, you may want to explore:
 
 Remember, effective drawings are key to communicating your design intent.
 Take time to explore the various options and develop a consistent style for your project documentation.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   styling

--- a/src/bonsai/docs/guides/drawings/styling.rst
+++ b/src/bonsai/docs/guides/drawings/styling.rst
@@ -1,0 +1,492 @@
+Styling drawings with stylesheets
+==================================
+
+Every 2D drawing Bonsai produces is an SVG file, and every SVG file is styled
+by a CSS stylesheet, the same technology that styles web pages. This means
+you can change how your drawings look, heavier walls, dashed hidden lines,
+grey background elements, larger dimension text, without touching the 3D
+model at all. You do not need to know CSS to use this page: copy the
+recipes below, or start from one of the ready-made files in
+``bonsai/bim/data/assets/``.
+
+This page assumes you already know how to create a drawing (see
+:doc:`index`). It does not require Inkscape, Blender scripting, or any
+programming experience.
+
+.. contents::
+   :local:
+   :depth: 1
+
+What the stylesheet is
+-----------------------
+
+Bonsai's built-in stylesheet lives at
+``bonsai/bim/data/assets/default.css``, inside the add-on. It is a plain
+text file of rules like:
+
+.. code-block:: css
+
+   .cut { fill: black; stroke: black; stroke-width: 0.35; }
+
+Each rule says: "elements tagged with this class should look like this".
+When Bonsai draws your walls, dimensions, grids and text, it tags every
+shape in the SVG with one or more classes describing what it is, whether
+it is a cut or a projection, what kind of annotation it is, what material
+it represents, and so on. The stylesheet is what turns those tags into
+actual colours, line weights and dash patterns.
+
+Where the setting lives
+------------------------
+
+Every drawing has a **Stylesheet** setting: a comma-separated list of file
+paths. When a new drawing is created, Bonsai fills this setting in from one
+of two places, in this order:
+
+1. **Project setting.** A property called ``StylesheetPath`` inside a
+   property set called ``BBIM_Documentation`` on the ``IfcProject``. This
+   pset is not built in by default, you add it yourself: select the
+   project (or any element that lets you reach the Property Sets tab),
+   add a property set named ``BBIM_Documentation``, and add a text
+   property called ``StylesheetPath``.
+2. **Add-on preferences.** If the project setting is not present, Bonsai
+   falls back to *Edit > Preferences > Add-ons > Bonsai > Drawing >
+   Default Stylesheet*.
+
+.. important::
+
+   These two settings only decide the stylesheet for **drawings you
+   create from now on**. They are copied onto the drawing once, at
+   creation time. Changing either setting later does not change drawings
+   that already exist.
+
+   To change the stylesheet path of a drawing you already created, select
+   that drawing in the *Drawings* list (Scene Properties > Drawings tab),
+   open its Property Sets, and edit the ``Stylesheet`` property inside
+   ``EPset_Drawing`` directly.
+
+The contents of the CSS file(s) themselves are **not** copied anywhere.
+Bonsai reads them fresh every time it regenerates the drawing, so editing
+a stylesheet file and regenerating the drawing is enough, you never need
+to touch the pset again just to see a styling change.
+
+The override pattern
+---------------------
+
+**Do not edit** ``default.css``. It ships with the add-on, so an update to
+Bonsai can silently overwrite your changes, and every project sharing that
+install would be affected. Instead, write your own small file with just the
+rules you want to change, and list it *after* ``default.css`` in the
+Stylesheet setting.
+
+Bonsai loads each file in the list in order and appends its rules to the
+drawing, one after another. This means normal CSS cascade rules apply:
+when two files set the same property on the same class, **the file that
+was loaded later wins**. A one-line file that only touches
+``stroke-width`` leaves everything else, colours, dashes, fonts, exactly
+as ``default.css`` defined it.
+
+Worked example: say you want heavier cut lines project-wide. Create a file
+``my-office.css`` next to your project, with just:
+
+.. code-block:: css
+
+   .cut { stroke-width: 0.5; }
+
+Then set the Stylesheet setting (project pset or add-on preferences) to:
+
+.. code-block:: text
+
+   C:\path\to\default.css, C:\path\to\my-office.css
+
+or on macOS/Linux:
+
+.. code-block:: text
+
+   /path/to/default.css, /path/to/my-office.css
+
+Every other rule in ``default.css`` still applies. Only the stroke width
+of cut elements changes.
+
+This behaviour was verified directly: a two-file stylesheet list, split on
+the comma and loaded in order, produces a drawing where the second file's
+rule visibly overrides the first for the property it sets, while any
+property the second file does not mention is inherited from the first.
+
+Three ready-to-use starting points ship alongside ``default.css`` in
+``bonsai/bim/data/assets/``:
+
+- ``override-heavy-lineweight.css``, thicker lines for drawings that need
+  to read clearly from a distance or when printed small.
+- ``override-fine-lineweight.css``, finer lines for dense, detailed
+  drawings.
+- ``override-presentation-greys.css``, greys out background and
+  projection geometry so cut elements stand out, useful for client-facing
+  presentation drawings.
+
+Copy whichever one is closest to what you want, add it after
+``default.css`` in your Stylesheet setting, and edit it to taste.
+
+Class reference
+----------------
+
+This reference was generated by reading ``default.css`` directly and
+cross-checking every selector against where Bonsai actually emits that
+class in the drawing code, so it should not drift from what the software
+does. All stroke widths below are in millimetres (see `Units`_).
+
+Geometry (cut, projection, surface)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+
+   * - Selector
+     - Controls
+   * - ``.cut``
+     - Elements sliced by the drawing's cut plane, for example a wall in
+       plan, or a slab in section. This is usually the heaviest line
+       weight in a drawing.
+   * - ``.projection``
+     - Elements seen beyond the cut plane but not cut by it, for example
+       a wall visible through a doorway.
+   * - ``.surface``
+     - Flat surface fills (used for some annotation fills).
+
+Edge classification
+^^^^^^^^^^^^^^^^^^^^
+
+These apply directly to individual ``<path>`` edges based on how sharp or
+significant that edge is in the 3D geometry (see the edge classification
+notes in ``default.css``). Because they target the ``<path>`` element
+itself, they take priority over the more general ``.projection`` rule
+above regardless of which loads first.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Selector
+     - Controls
+   * - ``path.outline``
+     - The silhouette edge of an object, its outer boundary as seen from
+       the camera. Drawn heaviest of the four.
+   * - ``path.boundary``
+     - A strong edge between two clearly different faces (for example
+       where a wall meets a roof).
+   * - ``path.crease``
+     - A moderate edge, a visible but softer change in surface direction.
+   * - ``path.sharp``
+     - A minor edge, a small but real change in direction.
+   * - ``path.flush``
+     - An edge between two faces that are nearly coplanar. Drawn
+       lightest, often barely visible.
+
+Line weights
+^^^^^^^^^^^^
+
+These only apply to plain linework annotations (``PredefinedType`` of
+``LINEWORK``), and only take effect combined with that predefined type, so
+the selector is always the pair together, for example
+``.PredefinedType-LINEWORK.thick``. You choose which one applies to a
+specific annotation object by adding the word (``fine``, ``dashed``, etc.)
+to that object's ``EPset_Annotation`` > ``Classes`` property.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Selector
+     - Stroke width
+   * - ``.PredefinedType-LINEWORK.fine``
+     - 0.18 mm (also greys the line to ``#777777``)
+   * - ``.PredefinedType-LINEWORK.thin``
+     - 0.25 mm (same as the LINEWORK default)
+   * - ``.PredefinedType-LINEWORK.medium``
+     - 0.35 mm
+   * - ``.PredefinedType-LINEWORK.thick``
+     - 0.5 mm
+   * - ``.PredefinedType-LINEWORK.strong``
+     - 1 mm
+   * - ``.PredefinedType-LINEWORK.dashed``
+     - no width change, switches the line to a dash pattern
+
+Annotation predefined types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Every annotation object has a "predefined type" (dimension, grid line,
+section marker, and so on). Bonsai tags it in the SVG as
+``PredefinedType-<TYPE>``. These are the ones ``default.css`` styles:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Selector
+     - What it is
+   * - ``.PredefinedType-LINEWORK``
+     - Generic annotation linework (see line weights above).
+   * - ``.PredefinedType-BACKGROUND``
+     - Background reference linework, drawn faint by default.
+   * - ``.PredefinedType-GRID``
+     - Structural/setting-out grid lines.
+   * - ``.PredefinedType-SECTION``
+     - Section cut lines.
+   * - ``.PredefinedType-SECTIONLEVEL``
+     - Section level markers.
+   * - ``.PredefinedType-PLANLEVEL``
+     - Plan level markers.
+   * - ``.PredefinedType-DIMENSION``
+     - Dimension lines and their arrowheads.
+   * - ``.PredefinedType-ANGLE``
+     - Angle dimensions.
+   * - ``.PredefinedType-RADIUS``
+     - Radius dimensions.
+   * - ``.PredefinedType-DIAMETER``
+     - Diameter dimensions.
+   * - ``.PredefinedType-FALL``, ``.PredefinedType-SLOPEANGLE``,
+       ``.PredefinedType-SLOPEPERCENT``, ``.PredefinedType-SLOPEFRACTION``
+     - Slope/fall callouts.
+   * - ``.PredefinedType-STAIRARROW``
+     - Stair up/down direction arrows.
+   * - ``.PredefinedType-BOUNDARY``
+     - Space/area boundary outlines.
+   * - ``.PredefinedType-SEALANT``
+     - Sealant/joint hatching.
+   * - ``.PredefinedType-FILLAREA``
+     - Filled area annotations (drawn first, underneath everything else).
+   * - ``.PredefinedType-BREAKLINE``
+     - Break lines (the zig-zag "this continues elsewhere" symbol).
+   * - ``.PredefinedType-TEXT``
+     - Plain annotation text.
+   * - ``path.PredefinedType-TEXTLEADER`` /
+       ``text.PredefinedType-TEXTLEADER``
+     - Leader lines pointing from text to an element, and their text.
+
+.. note::
+
+   ``default.css`` also defines ``.PredefinedType-STUD``,
+   ``.PredefinedType-WOOD``, ``.PredefinedType-STEEL``,
+   ``.PredefinedType-CONCRETE`` and ``.PredefinedType-PLASTERBOARD``.
+   These do not correspond to any value Bonsai currently emits for an
+   annotation's predefined type, they appear to be dead rules left over
+   from an earlier version of the styling system. Material hatching
+   today goes through the ``.material-*`` and ``.PredefinedType-*``
+   material-layer classes described below instead. Do not rely on these
+   five selectors.
+
+Text sizes
+^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+
+   * - Selector
+     - Size
+   * - ``text.small`` / ``tspan.small``
+     - 1.8 mm
+   * - ``text.regular`` / ``tspan.regular`` (the default if no size class
+       is set)
+     - 2.5 mm
+   * - ``text.large`` / ``tspan.large``
+     - 3.5 mm
+   * - ``text.header`` / ``tspan.header``
+     - 5 mm
+   * - ``text.title`` / ``tspan.title``
+     - 7 mm
+   * - ``text.GRID`` / ``tspan.GRID``
+     - 5 mm (grid bubble labels)
+
+As with line weights, you choose the size by adding the word (``large``,
+``header``, etc.) to the text object's ``EPset_Annotation`` > ``Classes``
+property.
+
+Materials
+^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+
+   * - Selector
+     - Controls
+   * - ``.material-<name>``
+     - The hatch/fill for an element whose IFC material (or material
+       layer set) is named ``<name>``. ``default.css`` ships rules for
+       ``blank``, ``diagonal1``/``2``/``3``, ``crosshatch1``/``2``/``3``,
+       ``brick``, ``earth``, ``glass``, ``liquid``, ``grass``,
+       ``honeycomb``, ``sand`` and ``concrete``, matched to a same-named
+       pattern in ``patterns.svg``. See `Case sensitivity of material
+       names`_ below, matching is exact and case-sensitive.
+   * - ``.IfcSpace``
+     - IfcSpace elements: no fill, no stroke, by default (invisible
+       unless you override it). This is an example of selecting directly
+       by IFC class rather than by annotation type.
+
+.. note::
+
+   The actual fallback class Bonsai writes when an element has no
+   material at all is ``material-null``, which has no matching rule in
+   ``default.css`` (so it falls back to whatever ``.cut``/``.projection``
+   already set). ``default.css`` separately defines a ``.material-blank``
+   rule, but nothing in the code currently emits a class called
+   ``blank``, so that rule is presently unreachable too.
+
+You are not limited to the names above. If you name an IFC material
+"Marble", Bonsai will tag the element ``material-marble`` (see `Case
+sensitivity of material names`_), and you can add your own
+``.material-marble`` rule in an override file pointing at any pattern in
+``patterns.svg`` (which has more patterns defined than ``default.css``
+uses, including ``wood``, ``steel``, several ``tile`` and ``board``
+variants) or a plain colour.
+
+Units
+------
+
+**Stroke widths** (``stroke-width``, used on lines and outlines) are
+already in millimetres of the printed drawing. A wall drawn with
+``stroke-width: 0.35`` prints as a 0.35 mm line regardless of the
+drawing's scale, this is standard technical drawing practice, where line
+weight communicates meaning (cut vs projection) rather than a literal
+model dimension.
+
+**Font sizes** (``font-size``) are written in CSS pixels, but a pixel
+here does not mean a pixel on your screen or a millimetre. Bonsai bakes a
+fixed conversion factor (about 1.65) into ``default.css`` so that a given
+class always prints at the same physical text height. ``default.css``
+documents this in a comment on every text rule, so you never need to
+calculate it yourself: pick a size from the table below, or, if you want
+a size in between, multiply your target millimetre height by 1.65 to get
+the ``font-size`` value.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Millimetres on paper
+     - ``font-size``
+   * - 1.8 mm
+     - 2.97px
+   * - 2.5 mm
+     - 4.13px
+   * - 3.5 mm
+     - 5.78px
+   * - 5 mm
+     - 8.25px
+   * - 7 mm
+     - 11.55px
+
+Recipes
+--------
+
+Each recipe below is a complete override file. Save it as its own
+``.css`` file and add it after ``default.css`` in the Stylesheet setting,
+following `The override pattern`_ above. You can combine several
+recipes in one file.
+
+Heavier cut lines
+^^^^^^^^^^^^^^^^^^
+
+Make walls and other cut elements stand out more in plan and section.
+Ships as ``override-heavy-lineweight.css``.
+
+.. code-block:: css
+
+   .cut { stroke-width: 0.5; }
+
+Grey out background elements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Push projected (uncut) geometry visually behind the cut plane. Ships as
+part of ``override-presentation-greys.css``.
+
+.. code-block:: css
+
+   .projection { stroke: #808080; }
+
+Dashed hidden lines
+^^^^^^^^^^^^^^^^^^^^
+
+If you have annotation linework marked as hidden/dashed via its
+``EPset_Annotation`` > ``Classes`` property (add the word ``dashed``),
+you can change the dash pattern itself:
+
+.. code-block:: css
+
+   .PredefinedType-LINEWORK.dashed { stroke-dasharray: 6, 3; }
+
+Larger dimension text
+^^^^^^^^^^^^^^^^^^^^^^
+
+Dimension values use whatever text size class is set on that annotation.
+To make all "regular" sized text a little bigger without touching every
+individual annotation:
+
+.. code-block:: css
+
+   text.regular, tspan.regular { font-size: 4.95px; } /* 3mm */
+
+A different hatch on concrete
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default concrete hatch is a stipple pattern. Swap it for a diagonal
+hatch instead (remember the material name match is case-sensitive, see
+below):
+
+.. code-block:: css
+
+   .material-concrete { fill: url(#diagonal2); }
+
+Hiding a category
+^^^^^^^^^^^^^^^^^^
+
+Hide all IfcSpace boundary annotations from a drawing without deleting
+them from the model:
+
+.. code-block:: css
+
+   .PredefinedType-BOUNDARY { display: none; }
+
+Troubleshooting
+-----------------
+
+A rule I added does nothing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A typo in a class name (a missing dot, wrong capitalisation, wrong dash)
+does not raise an error, CSS silently ignores any selector that matches
+nothing. Check the class reference above for the exact spelling, and
+confirm the class exists in the drawing by opening the SVG in a text
+editor and searching for ``class="`` near the element you are trying to
+style.
+
+Case sensitivity of material names
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+IFC material names are converted to a class name (``material-<name>``)
+by removing spaces and punctuation only; letters are not lowercased. A
+material named ``Concrete`` becomes ``material-Concrete``, not
+``material-concrete``, so it will not match ``default.css``'s built-in
+``.material-concrete`` rule. Either name your materials in lowercase, or
+write your override rule with the exact capitalisation of your material
+name.
+
+Nothing in my stylesheet applies, and the console shows a warning
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If a path in the Stylesheet setting does not exist on disk, Bonsai prints
+``WARNING. Couldn't find stylesheet for the drawing by the path: ...`` to
+the console and simply skips that file, it does not stop the drawing from
+generating. Open Blender's system console (*Window > Toggle System
+Console* on Windows, or run Blender from a terminal on macOS/Linux) before
+regenerating the drawing to see this warning.
+
+I changed the Stylesheet setting but nothing changed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Remember the project/preferences setting only applies to *new* drawings.
+For drawings that already exist, edit that drawing's own
+``EPset_Drawing`` > ``Stylesheet`` property (see `Where the setting
+lives`_), then regenerate the drawing.
+
+My override loads but a whole default rule seems to disappear
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You are probably repeating every property from a ``default.css`` rule
+instead of only the ones you want to change. Keep your override files
+short, list only the properties you actually want to change, and let
+everything else fall through from ``default.css``.


### PR DESCRIPTION
Bonsai styles its SVG drawings with CSS, and the system is genuinely capable. `default.css` covers cut versus projection, edge classification, named line weights, every annotation predefined type, text sizes and material hatches.

But there is currently **no documentation for any of it**. Searching `src/bonsai/docs/` for "stylesheet" returns nothing. So a BIM coordinator who wants heavier walls in plan has to discover the file exists, find it, learn CSS, and guess that the selector is `.cut`.

This adds a guide written for that person rather than for a developer.

## The thing most worth documenting

`svgwriter.py`'s `add_stylesheet()` splits the path on commas and appends each file in order:

```python
path_list = [p.strip() for p in paths.split(",")]
for path in path_list:
    ...
    self.svg.defs.add(self.svg.style(stylesheet.read()))
```

So normal CSS cascade applies and later files win. **Nobody needs to edit `default.css`.** They set the path to `default.css, my-office.css` and write three lines of their own. That reduces "learn CSS and edit a 103 line file" to "add two lines", and as far as I can tell it has never been written down anywhere.

Verified by running the real cascade logic against two files and confirming in rendered output that the second file's rule wins on a shared selector while untouched properties still inherit from the first.

## Also documented, because it costs people an afternoon

`core/drawing.py:335` bakes the resolved path onto each drawing's `EPset_Drawing` **at creation time**:

```python
"Stylesheet": drawing.get_default_drawing_resource_path("Stylesheet"),
```

Changing the project pset or the add-on preference therefore affects **future** drawings only. An existing drawing keeps the path it was created with and has to be edited directly. That is reasonable behaviour but surprising, and it is the first thing someone hits when they change the setting and nothing happens.

## What is in the guide

Where the setting lives, tracing both the `BBIM_Documentation` / `StylesheetPath` pset on `IfcProject` and the add-on preference fallback. The override pattern, front and centre. A class reference generated from `default.css` and cross-checked against what the code actually emits. A units section, since stroke widths are millimetres while font sizes are px with mm equivalents in comments. Six worked recipes for common requests. Troubleshooting, including that a mistyped class fails silently.

Plus three short starter override files, ten to twenty lines each, override-only rather than copies of the default.

## Findings along the way, reported rather than fixed

Nothing here is changed by this PR. Flagging them because they turned up while cross-checking the reference against the source.

**`.material-blank` never matches.** The code emits `material-null` (`bim/module/drawing/operator.py:1460`) and `default.css` has no rule for that class, so elements without a material fall through unstyled. Confirmed by grep: zero occurrences of `material-null` in the CSS.

**Material class names are case sensitive.** `canonicalise_class_name` (`tool/drawing.py:170`) only strips non-alphanumerics, so a material named "Concrete" yields `material-Concrete` and silently misses the `material-concrete` hatch rule. This is documented in the troubleshooting section as something to watch for, since it is a real trap regardless of whether the code changes.

**Five selectors are dead.** `.PredefinedType-STUD`, `WOOD`, `STEEL`, `CONCRETE` and `PLASTERBOARD` are not emitted anywhere in the Python or the C++.

**`sample.css` looks orphaned.** It is referenced nowhere and uses a stale vocabulary (`.hidden`, `.solid`, `.leader`) that does not match current selectors.

One thing I checked and want to correct in advance, in case it looks like a bug: `.PredefinedType-RADIUS` points at `#fall-marker-end` and `.PredefinedType-FALL` at `#radius-marker-end`, which reads as a swap. It has **no visible effect**, because both markers in `markers.svg` have byte-identical geometry (`M 0 3.5 L 0 10.5 L 10 7`). Untidy, not broken, so I have left it alone.

## Verification and its limits

The cascade was verified by executing the real `add_stylesheet()` logic and rendering the result, not by reading the code. The RST parses cleanly under docutils.

**Not verified:** end to end drawing generation inside Blender. The cascade behaviour was proven directly, but nobody has produced a real drawing with an override file through the full Bonsai pipeline. Worth someone doing before this is relied on.

Produced with AI assistance.
