### PR TITLE
Blend alpha channel in diffuse mode

### DIFF
--- a/src/bonsai/bonsai/tool/loader.py
+++ b/src/bonsai/bonsai/tool/loader.py
@@ -456,8 +456,9 @@ class Loader(bonsai.core.tool.Loader):
                     node.location = bsdf.location - Vector((400, 0))
                     node.image = image
                     blender_material.node_tree.links.new(node.outputs[0], bsdf.inputs["Base Color"])
-                    # leave it to default(OPAQUE) when no Transparency defined
-                    if transparency := rendering_style.get("Transparency", None):
+                    # Enable transparency when the image itself has an alpha channel,
+                    # even if the style's uniform Transparency is 0.0 (e.g. reference images).
+                    if image.channels == 4:
                         blender_material.node_tree.links.new(node.outputs[1], bsdf.inputs["Alpha"])
                         blender_material.blend_method = "BLEND"
 


### PR DESCRIPTION
See discussion https://community.osarch.org/discussion/3583/blend-alpha-channel-in-material-for-material-preview-rendered-modes/p1?new=1

The old condition testing was too broad since Transparency is a uniform surface attribute, not the texture's alpha. 

A reference image has Transparency: 0.0 (falsy, so it was treated as "not defined") while its actual transparency is per-pixel alpha in the PNG. 

This can be very useful when you use reference images as top view of terrain but you want to have transparent areas where buildings expand below the ground. 
<img width="2071" height="1911" alt="image" src="https://github.com/user-attachments/assets/b24aeaf5-8fde-49cc-b31e-edf42e095fb3" />

Gating on image.channels == 4 wires alpha only for images that really have it, and keeps opaque RGB images on OPAQUE as before.

Cheers!
