### PR TITLE
Draw reference image

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -482,6 +482,7 @@ class CreateDrawing(bpy.types.Operator):
 
                 with profile("Combine SVG layers"):
                     svg_path = self.combine_svgs(context, underlay_svg, linework_svg, annotation_svg)
+                    self.generate_reference_images(svg_path)
 
             if self.open_viewer:
                 drawing_uri = tool.Drawing.get_document_uri(tool.Drawing.get_drawing_document(self.drawing))
@@ -550,6 +551,75 @@ class CreateDrawing(bpy.types.Operator):
                         outfile.write(line)
             outfile.write("</svg>")
         return svg_path
+
+    def generate_reference_images(self, svg_path: str) -> None:
+        """Embed reference image annotations into the printed drawing SVG.
+
+        Reference images are textured planes that the linework serializer does
+        not emit, so they are added here as SVG image elements below all
+        linework. The source PNG is copied next to the drawing so the SVG keeps
+        its alpha transparency.
+        """
+        reference_images = [
+            element
+            for element in tool.Drawing.get_drawing_elements(self.camera_element)
+            if tool.Drawing.is_reference_image(element)
+        ]
+        if not reference_images:
+            return
+
+        drawing_dir = os.path.dirname(svg_path)
+        assets_dir = os.path.join(drawing_dir, "assets")
+
+        try:
+            root = etree.parse(svg_path).getroot()
+        except etree.XMLSyntaxError:
+            return
+
+        images = []
+        for element in reference_images:
+            obj = tool.Ifc.get_object(element)
+            if not obj:
+                continue
+            rect = self.svg_writer.get_image_rect(obj)
+            if rect is None:
+                continue
+            texture = tool.Drawing.get_reference_image_texture(element)
+            if not texture or texture.is_a("IfcBlobTexture"):
+                continue
+            image_url = getattr(texture, "URLReference", None) or getattr(texture, "UrlReference", None)
+            if not image_url:
+                continue
+            source_path = Path(tool.Ifc.resolve_uri(image_url))
+            if not source_path.is_file():
+                continue
+
+            os.makedirs(assets_dir, exist_ok=True)
+            target_path = os.path.join(assets_dir, f"{element.GlobalId}-{source_path.name}")
+            if not os.path.exists(target_path) or not os.path.samefile(source_path, target_path):
+                shutil.copyfile(source_path, target_path)
+            href = os.path.relpath(target_path, drawing_dir)
+
+            x, y, width, height = rect
+            image = etree.SubElement(root, "{http://www.w3.org/2000/svg}image")
+            image.set("{http://www.w3.org/1999/xlink}href", href)
+            image.set("x", str(x))
+            image.set("y", str(y))
+            image.set("width", str(width))
+            image.set("height", str(height))
+            image.set("preserveAspectRatio", "none")
+            image.set("class", "IfcAnnotation")
+            image.set("{http://www.ifcopenshell.org/ns}guid", element.GlobalId)
+            images.append(image)
+
+        if not images:
+            return
+
+        for image in reversed(images):
+            root.insert(0, image)
+
+        with open(svg_path, "wb") as svg:
+            svg.write(etree.tostring(root))
 
     def generate_underlay(self, context: bpy.types.Context) -> Union[str, None]:
         if not ifcopenshell.util.element.get_pset(self.drawing, "EPset_Drawing", "HasUnderlay"):

--- a/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
@@ -1690,6 +1690,31 @@ class SvgWriter:
             self.camera_projection,
         )
 
+    def get_image_rect(self, obj: bpy.types.Object) -> Union[tuple[float, float, float, float], None]:
+        """Project a reference image plane into SVG coordinates.
+
+        Returns the axis-aligned bounding rectangle (x, y, width, height) in
+        SVG units, or None when the projection is degenerate (e.g. the image
+        plane is edge-on to the camera).
+        """
+        if obj.type != "MESH" or not obj.data.vertices:
+            return None
+
+        offset = Vector([self.raw_width, self.raw_height]) / 2
+        projected_points = [
+            (offset + self.project_point_onto_camera(obj.matrix_world @ vertex.co).xy * Vector((1, -1)))
+            * self.svg_scale
+            for vertex in obj.data.vertices
+        ]
+
+        xs = [p.x for p in projected_points]
+        ys = [p.y for p in projected_points]
+        width = max(xs) - min(xs)
+        height = max(ys) - min(ys)
+        if width < 1e-6 or height < 1e-6:
+            return None
+        return (min(xs), min(ys), width, height)
+
     def get_spline_points(self, spline: bpy.types.Spline) -> Union[SplineBezierPoints, SplinePoints]:
         return spline.bezier_points if spline.bezier_points else spline.points
 

--- a/src/bonsai/bonsai/tool/drawing.py
+++ b/src/bonsai/bonsai/tool/drawing.py
@@ -414,6 +414,27 @@ class Drawing(bonsai.core.tool.Drawing):
         return applicable_occurrence.split("/", 1)[1]
 
     @classmethod
+    def is_reference_image(cls, element: ifcopenshell.entity_instance) -> bool:
+        return cls.is_annotation_object_type(element, "IMAGE")
+
+    @classmethod
+    def get_reference_image_texture(
+        cls, element: ifcopenshell.entity_instance
+    ) -> Union[ifcopenshell.entity_instance, None]:
+        """Return the first image texture of a reference image annotation.
+
+        The texture lives on an IfcSurfaceStyleWithTextures assigned to the
+        element's body representation.
+        """
+        for style in ifcopenshell.util.element.get_styles(element):
+            for surface_style in getattr(style, "Styles", None) or []:
+                if surface_style.is_a("IfcSurfaceStyleWithTextures"):
+                    for texture in surface_style.Textures or []:
+                        if texture.is_a("IfcImageTexture") or texture.is_a("IfcBlobTexture"):
+                            return texture
+        return None
+
+    @classmethod
     def get_annotation_representation(
         cls, element: ifcopenshell.entity_instance
     ) -> Union[ifcopenshell.entity_instance, None]:

--- a/src/bonsai/test/bim/feature/drawing.feature
+++ b/src/bonsai/test/bim/feature/drawing.feature
@@ -436,3 +436,17 @@ Scenario: Add reference image
     When I press "bim.add_reference_image(filepath='{cwd}/test/files/image.jpg', x_length=1, y_length=0.565)"
     Then the object "IfcAnnotation/image" exists
     And the object "IfcAnnotation/image" dimensions are "1.0,0.565,0."
+
+Scenario: Print reference image into drawing
+    Given an empty IFC project
+    And I save IFC project
+    When I press "bim.add_reference_image(filepath='{cwd}/test/files/image.jpg', x_length=1, y_length=0.565)"
+    And I look at the "Drawings" panel
+    And I click "IMPORT"
+    And I click "ADD"
+    And I press "bim.toggle_target_view(option='EXPAND', target_view='PLAN_VIEW')"
+    And I select the "PLAN_VIEW" item in the "BIM_UL_drawinglist" list
+    And I click "VIEW_CAMERA_UNSELECTED" in the row where I see "PLAN_VIEW" in the "1st" list
+    And the variable "assigned" is "tool.Ifc.run('group.assign_group', group=tool.Drawing.get_drawing_group([e for e in tool.Ifc.get().by_type('IfcAnnotation') if e.ObjectType == 'DRAWING'][0]), products=[e for e in tool.Ifc.get().by_type('IfcAnnotation') if ifcopenshell.util.element.get_predefined_type(e) == 'IMAGE'])"
+    Then I click "OUTPUT"
+    And the file "{ifc_dir}/drawings/PLAN_VIEW.svg" should contain "<image"

--- a/src/bonsai/test/tool/test_drawing.py
+++ b/src/bonsai/test/tool/test_drawing.py
@@ -1104,6 +1104,60 @@ class TestAddReferenceImage(NewFile):
         assert len(uv_node.outputs["Generated"].links[:]) == 1
 
 
+class TestIsReferenceImage(NewFile):
+    def test_run(self):
+        ifc = ifcopenshell.file()
+        tool.Ifc.set(ifc)
+        image = ifc.createIfcAnnotation(ObjectType="IMAGE")
+        text = ifc.createIfcAnnotation(ObjectType="TEXT")
+        assert subject.is_reference_image(image) is True
+        assert subject.is_reference_image(text) is False
+
+
+class TestGetReferenceImageTexture(NewFile):
+    def test_run(self):
+        props = tool.Project.get_project_props()
+        props.template_file = "0"
+        bpy.ops.bim.create_project()
+        ifc_path = Path("test/files/temp/test.ifc").absolute()
+        bpy.ops.bim.save_project(filepath=str(ifc_path), should_save_as=True)
+
+        filepath = Path("test/files/image.jpg").absolute()
+        bpy.ops.bim.add_reference_image(filepath=str(filepath), x_length=1, y_length=1)
+
+        obj = bpy.data.objects["IfcAnnotation/image"]
+        element = tool.Ifc.get_entity(obj)
+        texture = subject.get_reference_image_texture(element)
+        assert texture
+        assert texture.is_a("IfcImageTexture")
+        assert texture.URLReference
+
+
+class TestSvgWriterGetImageRect(NewFile):
+    def test_run(self):
+        from bonsai.bim.module.drawing import svgwriter
+
+        camera = subject.create_camera("Camera", mathutils.Matrix(), "PERSPECTIVE", "PLAN_VIEW")
+        writer = svgwriter.SvgWriter(
+            camera_width=2.0,
+            camera_height=2.0,
+            camera=camera,
+            camera_projection=(camera.matrix_world.to_quaternion() @ Vector((0, 0, -1))),
+            scale=1 / 100,
+        )
+
+        mesh = bpy.data.meshes.new("plane")
+        mesh.from_pydata(
+            [(-1.0, -1.0, 0.0), (1.0, -1.0, 0.0), (1.0, 1.0, 0.0), (-1.0, 1.0, 0.0)],
+            [],
+            [[0, 1, 2, 3]],
+        )
+        mesh.update()
+        obj = bpy.data.objects.new("plane", mesh)
+
+        assert writer.get_image_rect(obj) == pytest.approx((0.0, 0.0, 20.0, 20.0))
+
+
 class TestIsDrawingActive(NewFile):
     def test_no_active_camera(self):
         bpy.context.scene.camera = None


### PR DESCRIPTION
This is a followup up of https://community.osarch.org/discussion/comment/30028#Comment_30028 

Here the reference Image IFCannotation is exported to vsg draw as an image tag (at the bottom of the svg items).

It will allow to have the ifc reference image in the draw file in order to print it.

Cheers!
