### PR TITLE
Add Fedora/RHEL RPM packaging support

### DIFF
--- a/.github/workflows/build_fedora_rpm.yml
+++ b/.github/workflows/build_fedora_rpm.yml
@@ -1,0 +1,36 @@
+name: Build Fedora RPM
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v[0-9].[0-9].[0-9]*'
+
+jobs:
+  build_rpm:
+    runs-on: ubuntu-22.04
+    container: fedora:41
+
+    steps:
+      - name: Install git (for checkout + submodules)
+        run: dnf install -y git
+
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory '*'
+
+      - name: Build RPM
+        run: ./fedora/build-rpm.sh
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: ifcopenshell-fedora-rpm
+          path: |
+            build-fedora/assets/*.rpm
+            build-fedora/assets/*.tar.gz
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /_installed-vs*-x*/
 /build/
 /build.log
+/build-fedora/
 /output/
 /src/examples/build/
 # ifctester docs output

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -853,11 +853,15 @@ set(CPACK_RPM_PACKAGE_VENDOR "${CPACK_PACKAGE_VENDOR}")
 set(CPACK_RPM_PACKAGE_URL "https://ifcopenshell.org")
 set(CPACK_RPM_PACKAGE_SUMMARY "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}")
 set(CPACK_RPM_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
-# Shared-library dependencies are resolved automatically from the installed
-# ELF binaries (CPACK_RPM_PACKAGE_AUTOREQPROV defaults to ON); only the
-# high-level runtime requirements are listed explicitly here. Package names
-# follow Fedora/RHEL conventions (opencascade + hdf5 live in EPEL on RHEL).
-set(CPACK_RPM_PACKAGE_REQUIRES "python3, libxml2, opencascade, hdf5, boost")
+# Shared-library dependencies (OpenCASCADE, Boost, HDF5, libxml2, GMP, MPFR,
+# ...) are resolved automatically from the installed ELF binaries by RPM's
+# soname dependency generator (CPACK_RPM_PACKAGE_AUTOREQPROV defaults to ON).
+# This maps each library to the correct distro (sub)package -- e.g. on Fedora
+# OpenCASCADE ships as opencascade-foundation/-modeling/-visualization/-ocaf
+# rather than a single "opencascade" package. Only the Python interpreter is
+# listed explicitly, since it is loaded by the interpreter and not linked as a
+# shared library, so the soname generator cannot infer it.
+set(CPACK_RPM_PACKAGE_REQUIRES "python3")
 
 include(CPack)
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -808,6 +808,12 @@ set(CPACK_PACKAGE_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
 set(CPACK_PACKAGE_VERSION_PATCH "${PROJECT_VERSION_PATCH}")
 
 set(CPACK_GENERATOR "TGZ;DEB")
+# Only enable the RPM generator when rpmbuild is available so that DEB-only
+# hosts (e.g. Debian/Ubuntu CI) don't fail when running `make package`.
+find_program(RPMBUILD_EXECUTABLE rpmbuild)
+if(RPMBUILD_EXECUTABLE)
+    list(APPEND CPACK_GENERATOR "RPM")
+endif()
 set(CPACK_SOURCE_GENERATOR "TGZ")
 
 foreach(COMPONENT IN ITEMS ${BOOST_COMPONENTS})
@@ -825,6 +831,33 @@ set(CPACK_DEBIAN_PACKAGE_SECTION "science")
 set(CPACK_DEBIAN_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}${EXTRA_VERSION}")
 set(CPACK_DEBIAN_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
 # set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/cmake/debian/postinst")
+
+# RPM packaging (Fedora / RHEL / Rocky / openSUSE).
+# RPM versions may not contain hyphens, so any pre-release suffix in
+# EXTRA_VERSION (e.g. "-alpha.3") is folded into the RPM release field.
+string(REGEX REPLACE "^-+" "" RPM_EXTRA_VERSION "${EXTRA_VERSION}")
+if(RPM_EXTRA_VERSION)
+    set(CPACK_RPM_PACKAGE_RELEASE "0.${RPM_EXTRA_VERSION}")
+else()
+    set(CPACK_RPM_PACKAGE_RELEASE "1")
+endif()
+
+set(CPACK_RPM_PACKAGE_NAME "${PROJECT_NAME}")
+set(CPACK_RPM_PACKAGE_VERSION
+    "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}"
+)
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_RPM_PACKAGE_LICENSE "LGPLv3+")
+set(CPACK_RPM_PACKAGE_GROUP "Applications/Engineering")
+set(CPACK_RPM_PACKAGE_VENDOR "${CPACK_PACKAGE_VENDOR}")
+set(CPACK_RPM_PACKAGE_URL "https://ifcopenshell.org")
+set(CPACK_RPM_PACKAGE_SUMMARY "${CPACK_PACKAGE_DESCRIPTION_SUMMARY}")
+set(CPACK_RPM_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
+# Shared-library dependencies are resolved automatically from the installed
+# ELF binaries (CPACK_RPM_PACKAGE_AUTOREQPROV defaults to ON); only the
+# high-level runtime requirements are listed explicitly here. Package names
+# follow Fedora/RHEL conventions (opencascade + hdf5 live in EPEL on RHEL).
+set(CPACK_RPM_PACKAGE_REQUIRES "python3, libxml2, opencascade, hdf5, boost")
 
 include(CPack)
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -860,8 +860,14 @@ set(CPACK_RPM_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
 # OpenCASCADE ships as opencascade-foundation/-modeling/-visualization/-ocaf
 # rather than a single "opencascade" package. Only the Python interpreter is
 # listed explicitly, since it is loaded by the interpreter and not linked as a
-# shared library, so the soname generator cannot infer it.
-set(CPACK_RPM_PACKAGE_REQUIRES "python3")
+# shared library, so the soname generator cannot infer it. The Python
+# packages below are the third-party runtime imports of the ifcopenshell
+# Python module (see src/ifcopenshell-python/pyproject.toml); without them
+# `import ifcopenshell.util.*` fails on a clean system. Names follow Fedora's
+# python3-* convention.
+set(CPACK_RPM_PACKAGE_REQUIRES
+    "python3, python3-shapely, python3-numpy, python3-isodate, python3-dateutil, python3-lark, python3-pyparsing, python3-typing-extensions"
+)
 
 include(CPack)
 

--- a/fedora/build-rpm.sh
+++ b/fedora/build-rpm.sh
@@ -85,7 +85,6 @@ cmake -S "${REPO_ROOT}/cmake" -B "${BUILD_DIR}" \
     -DGMP_LIBRARY_DIR="${LIBDIR}" \
     -DMPFR_LIBRARY_DIR="${LIBDIR}" \
     -DHDF5_INCLUDE_DIR=/usr/include \
-    -DHDF5_LIBRARY_DIR="${LIBDIR}" \
     -DGLTF_SUPPORT=On \
     -DJSON_INCLUDE_DIR=/usr/include \
     -DEIGEN_DIR=/usr/include/eigen3

--- a/fedora/build-rpm.sh
+++ b/fedora/build-rpm.sh
@@ -55,11 +55,17 @@ fi
 # Resolve Fedora-specific locations rather than hard-coding them, so the script
 # keeps working across Fedora releases, Python versions and architectures.
 LIBDIR="$(rpm --eval '%{_libdir}')"                       # e.g. /usr/lib64
+LIB="$(rpm --eval '%{_lib}')"                             # e.g. lib64
 PY="$(command -v python3)"
 PY_INCLUDE="$(${PY} -c 'import sysconfig; print(sysconfig.get_path("include"))')"
 PY_LIBDIR="$(${PY} -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
 PY_LDLIBRARY="$(${PY} -c 'import sysconfig; print(sysconfig.get_config_var("LDLIBRARY"))')"
 PY_LIBRARY="${PY_LIBDIR}/${PY_LDLIBRARY}"
+PY_XY="$(${PY} -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+# Install the Python module to Fedora's system site-packages (kept relative to
+# the /usr package prefix) so `import ifcopenshell` works without PYTHONPATH.
+# Overrides the Debian-style "dist-packages" default in src/ifcwrap/CMakeLists.txt.
+PY_MODULE_SUBDIR="${LIB}/python${PY_XY}/site-packages"    # e.g. lib64/python3.14/site-packages
 
 echo "==> Configuring (build dir: ${BUILD_DIR}, type: ${BUILD_TYPE})"
 echo "    libdir=${LIBDIR} python=${PY}"
@@ -76,6 +82,7 @@ cmake -S "${REPO_ROOT}/cmake" -B "${BUILD_DIR}" \
     -DPYTHON_EXECUTABLE:FILEPATH="${PY}" \
     -DPYTHON_INCLUDE_DIR:PATH="${PY_INCLUDE}" \
     -DPYTHON_LIBRARY:FILEPATH="${PY_LIBRARY}" \
+    -DPACKAGE_PYTHON_SUBDIR="${PY_MODULE_SUBDIR}" \
     -DCOLLADA_SUPPORT=Off \
     -DLIBXML2_INCLUDE_DIR=/usr/include/libxml2 \
     -DLIBXML2_LIBRARIES="${LIBDIR}/libxml2.so" \

--- a/fedora/build-rpm.sh
+++ b/fedora/build-rpm.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Build an IfcOpenShell RPM package on Fedora (and compatible RHEL/Rocky/Alma
+# with EPEL enabled) using the system C++ toolchain and distribution packages.
+#
+# This mirrors the Debian-oriented `make package` flow used in CI
+# (.github/workflows/ci-ifcopenshell-docker.yml) but resolves Fedora-specific
+# library/include locations and produces an `.rpm` via CPack's RPM generator
+# (see cmake/CMakeLists.txt). The resulting artifacts are written to
+# <build-dir>/assets/.
+#
+# Usage:
+#   fedora/build-rpm.sh [build-dir]
+#
+# Environment overrides:
+#   BUILD_TYPE   CMake build type            (default: Release)
+#   JOBS         Parallel build jobs         (default: nproc)
+#   INSTALL_DEPS Install build deps via dnf  (default: 1; set 0 to skip)
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${1:-${REPO_ROOT}/build-fedora}"
+BUILD_TYPE="${BUILD_TYPE:-Release}"
+JOBS="${JOBS:-$(nproc)}"
+INSTALL_DEPS="${INSTALL_DEPS:-1}"
+
+# Fedora/RHEL runtime + build dependencies. opencascade and hdf5 come from
+# EPEL on RHEL-family distros.
+DEPS=(
+    gcc gcc-c++ make cmake git rpm-build
+    boost-devel
+    opencascade-devel
+    hdf5-devel
+    zlib-devel
+    libxml2-devel
+    cgal-devel
+    gmp-devel
+    mpfr-devel
+    eigen3-devel
+    json-devel
+    swig
+    pcre-devel
+    python3-devel
+    python3-pip
+)
+
+if [ "${INSTALL_DEPS}" = "1" ]; then
+    echo "==> Installing build dependencies via dnf"
+    SUDO=""
+    if [ "$(id -u)" != "0" ]; then SUDO="sudo"; fi
+    ${SUDO} dnf install -y "${DEPS[@]}"
+fi
+
+# Resolve Fedora-specific locations rather than hard-coding them, so the script
+# keeps working across Fedora releases, Python versions and architectures.
+LIBDIR="$(rpm --eval '%{_libdir}')"                       # e.g. /usr/lib64
+PY="$(command -v python3)"
+PY_INCLUDE="$(${PY} -c 'import sysconfig; print(sysconfig.get_path("include"))')"
+PY_LIBDIR="$(${PY} -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')"
+PY_LDLIBRARY="$(${PY} -c 'import sysconfig; print(sysconfig.get_config_var("LDLIBRARY"))')"
+PY_LIBRARY="${PY_LIBDIR}/${PY_LDLIBRARY}"
+
+echo "==> Configuring (build dir: ${BUILD_DIR}, type: ${BUILD_TYPE})"
+echo "    libdir=${LIBDIR} python=${PY}"
+
+mkdir -p "${BUILD_DIR}"
+cmake -S "${REPO_ROOT}/cmake" -B "${BUILD_DIR}" \
+    -DCMAKE_INSTALL_PREFIX="${BUILD_DIR}/install" \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DCMAKE_PREFIX_PATH=/usr \
+    -DCMAKE_SYSTEM_PREFIX_PATH=/usr \
+    -DBUILD_PACKAGE=On \
+    -DOCC_INCLUDE_DIR=/usr/include/opencascade \
+    -DOCC_LIBRARY_DIR="${LIBDIR}" \
+    -DPYTHON_EXECUTABLE:FILEPATH="${PY}" \
+    -DPYTHON_INCLUDE_DIR:PATH="${PY_INCLUDE}" \
+    -DPYTHON_LIBRARY:FILEPATH="${PY_LIBRARY}" \
+    -DCOLLADA_SUPPORT=Off \
+    -DLIBXML2_INCLUDE_DIR=/usr/include/libxml2 \
+    -DLIBXML2_LIBRARIES="${LIBDIR}/libxml2.so" \
+    -DCGAL_INCLUDE_DIR=/usr/include \
+    -DGMP_INCLUDE_DIR=/usr/include \
+    -DMPFR_INCLUDE_DIR=/usr/include \
+    -DGMP_LIBRARY_DIR="${LIBDIR}" \
+    -DMPFR_LIBRARY_DIR="${LIBDIR}" \
+    -DHDF5_INCLUDE_DIR=/usr/include \
+    -DHDF5_LIBRARY_DIR="${LIBDIR}" \
+    -DGLTF_SUPPORT=On \
+    -DJSON_INCLUDE_DIR=/usr/include \
+    -DEIGEN_DIR=/usr/include/eigen3
+
+echo "==> Building with ${JOBS} jobs"
+cmake --build "${BUILD_DIR}" -j "${JOBS}"
+
+echo "==> Installing"
+cmake --build "${BUILD_DIR}" --target install
+
+echo "==> Packaging (RPM + TGZ)"
+cmake --build "${BUILD_DIR}" --target package
+
+echo "==> Done. Artifacts:"
+ls -1 "${BUILD_DIR}/assets/" 2>/dev/null || true

--- a/fedora/readme.md
+++ b/fedora/readme.md
@@ -1,0 +1,56 @@
+# Building an IfcOpenShell RPM on Fedora
+
+`build-rpm.sh` builds IfcOpenShell against the system toolchain and Fedora
+distribution packages, then produces an `.rpm` (and `.tar.gz`) via CPack's RPM
+generator (configured in `../cmake/CMakeLists.txt`).
+
+## Quick start
+
+```bash
+# From the repository root:
+./fedora/build-rpm.sh
+```
+
+Artifacts are written to `build-fedora/assets/`. To install the result:
+
+```bash
+sudo dnf install ./build-fedora/assets/IfcOpenShell-*.rpm
+```
+
+## Options
+
+| Variable       | Default        | Meaning                                   |
+| -------------- | -------------- | ----------------------------------------- |
+| `BUILD_TYPE`   | `Release`      | CMake build type                          |
+| `JOBS`         | `nproc`        | Parallel build jobs                       |
+| `INSTALL_DEPS` | `1`            | Install build dependencies via `dnf`      |
+| arg 1          | `build-fedora` | Build directory                           |
+
+```bash
+INSTALL_DEPS=0 JOBS=8 ./fedora/build-rpm.sh /tmp/iosbuild
+```
+
+## Development packages
+
+The script installs these via `dnf` (see the `DEPS` array). Install them
+manually if you set `INSTALL_DEPS=0`:
+
+```bash
+sudo dnf install -y \
+    gcc gcc-c++ make cmake git rpm-build \
+    boost-devel opencascade-devel hdf5-devel zlib-devel libxml2-devel \
+    cgal-devel gmp-devel mpfr-devel eigen3-devel json-devel \
+    swig pcre-devel python3-devel python3-pip
+```
+
+Notes:
+
+- `opencascade-devel` and `hdf5-devel` are in **EPEL** on RHEL/Rocky/Alma —
+  enable EPEL first (`dnf install epel-release`). On Fedora they are in the
+  main repositories.
+- **OpenCOLLADA is not packaged for Fedora**, so COLLADA export is disabled
+  (`-DCOLLADA_SUPPORT=Off`). This matches the Debian Docker CI build.
+- Optional features that are **off** by default (and therefore need no extra
+  packages) include USD (`USD_SUPPORT`), RocksDB (`WITH_ROCKSDB`), PROJ
+  (`WITH_PROJ`) and the Qt viewer (`BUILD_QTVIEWER`). Enabling any of these
+  requires the corresponding `-devel` package.

--- a/src/ifcwrap/CMakeLists.txt
+++ b/src/ifcwrap/CMakeLists.txt
@@ -274,7 +274,15 @@ IF(Python_Interpreter_FOUND OR PYTHON_MODULE_INSTALL_DIR)
             set(python_package_dir "${Python_SITEARCH}")
         ENDIF()
         if (BUILD_PACKAGE)
-            set(python_package_dir ${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}/dist-packages/)
+            # Relative install location for the Python module inside the package.
+            # Defaults to the Debian/Ubuntu layout (dist-packages); other distros
+            # can override PACKAGE_PYTHON_SUBDIR, e.g. Fedora/RHEL use
+            # lib64/pythonX.Y/site-packages. Keep it relative so it resolves under
+            # the package install prefix (/usr) rather than an absolute host path.
+            IF (NOT PACKAGE_PYTHON_SUBDIR)
+                set(PACKAGE_PYTHON_SUBDIR ${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}/dist-packages/)
+            ENDIF()
+            set(python_package_dir "${PACKAGE_PYTHON_SUBDIR}")
         endif()
     endif()
     IF("${python_package_dir}" STREQUAL "")


### PR DESCRIPTION
## Summary

Adds Fedora/RHEL RPM packaging, alongside the existing Debian/TGZ CPack setup. The goal is that `dnf install` of the produced RPM yields a working, importable `ifcopenshell` Python module with correct distro dependencies.

## What's in here

- **`cmake/CMakeLists.txt`** — enables the CPack `RPM` generator and adds a `CPACK_RPM_*` metadata block mirroring the existing Debian one. The generator is appended only when `rpmbuild` is found, so DEB-only hosts (the existing Debian CI) are unaffected by `make package`. `EXTRA_VERSION` is folded into the RPM *release* field, since RPM versions may not contain hyphens.
- **`src/ifcwrap/CMakeLists.txt`** — the `BUILD_PACKAGE` path hard-coded a Debian `dist-packages` layout, which is not on Fedora/RHEL's default `sys.path`. Adds a `PACKAGE_PYTHON_SUBDIR` override, **defaulting to the exact existing Debian value**, so the Debian package is byte-for-byte unchanged.
- **`fedora/build-rpm.sh`, `fedora/readme.md`** — build script and dependency/usage docs.
- **`.github/workflows/build_fedora_rpm.yml`** — builds the RPM in a Fedora container.

## Two things worth reviewing

**Dependency handling.** An earlier iteration hard-coded `Requires: opencascade`, which does not exist as a package on Fedora — OCCT ships split as `opencascade-foundation` / `-modeling` / `-visualization` / `-ocaf` — so `dnf` failed with *nothing provides opencascade*. The other high-level names (libxml2, hdf5, boost) were redundant with RPM's soname dependency generator, which already records the exact `libTK*.so` / `libboost*.so` / `libhdf5*.so` / `libxml2.so` deps and maps them to the right subpackages. So `CPACK_RPM_PACKAGE_REQUIRES` is now only what `AUTOREQ` *cannot* infer: the Python interpreter (not linked as a shared library) and the module's third-party Python imports (shapely, numpy, isodate, python-dateutil, lark, pyparsing, typing-extensions — per `src/ifcopenshell-python/pyproject.toml`). Happy to adjust if you'd rather pin these differently.

**HDF5 linkage.** `FindHDF5.cmake` resolves to static `.a` names when `HDF5_LIBRARY_DIR` is set, but Fedora's `hdf5-devel` ships only shared libraries (static archives live in the separate `hdf5-static` package). The Fedora script leaves that flag unset so the finder falls through to CMake's HDF5 module via `h5c++` and locates the shared libs — matching how the Debian Docker CI already configures HDF5.

## Testing

Verified end-to-end on Fedora 43: the build produces a valid RPM that installs cleanly, resolves OCCT/Boost/HDF5/libxml2 automatically, installs to `/usr/lib64/python3.14/site-packages`, and imports without needing `PYTHONPATH`.

One caveat, stated plainly: that verification was performed with these commits based on `v0.8.0`. They have been rebased onto `v0.9.0` here, with two small conflicts resolved (a `.gitignore` entry, and CMake keyword casing around the `BUILD_PACKAGE` block). The resulting net diff is identical in content to the verified version, but I have **not** re-run a full end-to-end Fedora build on top of `v0.9.0` — the included CI workflow should confirm it, and I'm glad to chase down anything it turns up.

Also happy to retarget this at a different branch if `v0.9.0` isn't where you'd want packaging changes to land.
