### PR TITLE
Release per-storey HLR data after drawing

### DIFF
--- a/src/serializers/svg_serializer.cpp
+++ b/src/serializers/svg_serializer.cpp
@@ -2430,8 +2430,12 @@ void svg_serializer::finalize() {
 		addTextAnnotations(p.first);
 	}
 
-	for (auto& p : storey_hlr) {
-		draw_hlr(drawing_metadata[{p.first, ""}].pln_3d, { p.first, "" });
+	// Each entry holds that storey's shapes and its HLR engine, which are not
+	// referenced again once the drawing has been emitted. Releasing them here
+	// keeps peak memory at one storey rather than the whole model.
+	for (auto it = storey_hlr.begin(); it != storey_hlr.end();) {
+		draw_hlr(drawing_metadata[{it->first, ""}].pln_3d, { it->first, "" });
+		it = storey_hlr.erase(it);
 	}
 
 	auto m = resize();


### PR DESCRIPTION
The SVG serializer emits one drawing per building storey, iterating `storey_hlr` in `finalize()`. Each entry is an `hlr_engine` holding that storey's shapes in `items_`, its `large_ortho_faces_`, its classified edge shapes and an OCCT HLR engine — but entries are never released, so peak memory is the projection input for the entire model even though the drawings are produced one at a time.

`storey_hlr` has three uses: the insert in `write(const geometry_data&)`, the lookup at the top of `draw_hlr`, and this loop. Nothing reads it afterwards, so each entry can be erased once its drawing has been emitted. Peak then tracks one storey plus the accumulated output paths, which are much smaller than the input BReps.

This frees data that has no remaining reader, so the emitted SVG is unchanged.

Not formatted with `clang-format`: `svg_serializer.cpp` is tab-indented throughout while `.clang-format` specifies LLVM/4-space, so running it would rewrite the whole file. The change follows the surrounding style instead.

---

This change was generated with the assistance of an AI coding tool. It is the result of static reading of the serializer; I have not built or profiled it.