### PR TITLE
Fix double free of section HLR state

### DIFF
--- a/src/serializers/svg_serializer.cpp
+++ b/src/serializers/svg_serializer.cpp
@@ -2523,11 +2523,8 @@ void svg_serializer::finalize() {
 				write(e);
 			}
 
-			if (use_hlr) {
-				const auto& section = boost::get<vertical_section>(sd);
-				const auto& ax = section.plane.Position();
-
-				draw_hlr(ax, { express::base{}, drawing_name });
+			if (use_hlr && pln) {
+				draw_hlr(pln->Position(), { express::base{}, drawing_name });
 			}
 
 			addTextAnnotations({express::base{}, drawing_name});
@@ -2588,6 +2585,7 @@ void svg_serializer::finalize() {
 			resetScale();
 
 			delete hlr;
+			hlr = nullptr;
 		}
 	}
 


### PR DESCRIPTION
In the deferred section loop in `svg_serializer::finalize()`, `hlr` is allocated only when both `use_hlr` and `pln` are set, but `delete hlr` runs at the end of every iteration and the pointer is never reset.

### Reachability

Narrower than "double free" on its own suggests, so worth stating plainly.

`deferred_section_data_` only ever receives `vertical_section` entries — `horizontal_plan` is pushed to `section_data_` instead — so the `sd.which() != 2` paths cannot be reached through this loop as it is populated today. The path that *is* open is `addDrawing(..., include_projection=false)`: `use_hlr` becomes false, nothing is allocated, and the iteration still runs `delete hlr`.

`hlr` is initialised to `nullptr` in the constructor (`svg_serializer.h:665`), so the first such iteration is a harmless no-op delete. The double free needs two: a projected section allocates and deletes, leaving the pointer dangling, and a following non-projected entry deletes it a second time.

Nothing in Bonsai calls `addDrawing` today — the only occurrence in the tree is a commented example in `ifcopenshell/draw.py` — so this is latent through the public C++ API rather than a crash users are currently hitting.

### The guard mismatch

`use_hlr` is initialised `true` and only assigned inside `if (sd.which() == 2)`, so a variant holding something other than a `vertical_section` would reach `boost::get<vertical_section>` on the wrong alternative, and a vertical section with a null `pln` would reach `*hlr` on a null pointer in `draw_hlr`. Neither is reachable through `deferred_section_data_` as populated today, but the existing `// @todo do we have always have pln here?` sits directly above the allocation, so guarding the call the way the allocation is guarded removes the trap rather than leaving it to the caller.

This guards the call the way the allocation is guarded, and nulls the pointer after `delete`.

`pln` already points at `section.plane`, so `pln->Position()` is the same expression the removed lines built — behaviour on the path that previously worked is unchanged.

Not formatted with `clang-format`: `svg_serializer.cpp` is tab-indented throughout while `.clang-format` specifies LLVM/4-space, so running it would rewrite the whole file. The change follows the surrounding style instead.

---

This change was generated with the assistance of an AI coding tool. It is the result of static reading of the serializer; I have not built or profiled it.
