### PR TITLE
ifcparse: guard express::base::as<T>() on unresolved references

### DIFF
--- a/src/ifcparse/express.h
+++ b/src/ifcparse/express.h
@@ -132,6 +132,11 @@ class IFC_PARSE_API base {
 
     template <class T>
     T as() const {
+        if (!*this) {
+            // Unresolved or malformed attribute reference (e.g. a step-id
+            // that never resolved to an instance). Never dereference it.
+            return T{};
+        }
         if constexpr (std::is_same_v<entity, T>) {
             if (declaration().as_entity() != nullptr) {
                 return T(data_weak());


### PR DESCRIPTION
Fixes #6032.

`express::base::as<T>()` dereferences the underlying instance before checking it is valid. For a malformed file whose attribute reference never resolved to an instance, that is a null dereference and a segfault, before any downstream guard can run.

## Root cause

`src/ifcgeom/mapping/IfcHalfSpaceSolid.cpp:26` already has the right defensive code:

```cpp
auto plane = surface.as<IfcSchema::IfcPlane>();
if (!plane) { ... log and skip ... }
```

but `as<T>()` at `src/ifcparse/express.h:134` calls `declaration()` unconditionally first, and `declaration()` is `return *data()->declaration();`. With an unresolved reference `data()` is null, so the crash happens inside `as<T>()` and the guard is never reached. brunopostle's backtrace shows exactly that chain.

## Fix

Five lines at the top of `as<T>()`: if `*this` is falsy, return a default-constructed `T` before touching `declaration()`. `express::base` already defines `operator bool()` for this purpose (line 75).

This is fixed at the class layer deliberately. `.as<...>()` is called unguarded against attribute values in **29 files under `src/ifcgeom/mapping/`, 150 call sites**. A fix scoped to `IfcHalfSpaceSolid.cpp` alone would have left the identical crash reachable through `IfcBooleanResult`, `IfcFace`, `IfcManifoldSolidBrep`, `IfcTrimmedCurve` and the rest. With this change, every existing `if (!x)` guard after an `as<>()` call now actually works.

No behaviour change for valid input: a resolved reference is truthy and takes the existing path unchanged.

## Verification

On a real compiled `v0.9.0` (`1a6336bd20`, built with the repo's docker toolchain).

RED, unpatched, on the reporter's `segfault_207013_3099.ifc`:

```
$ IfcConvert segfault_207013_3099.ifc out.obj
Segmentation fault    (exit 139)
```

GREEN, patched:

```
$ IfcConvert segfault_207013_3099.ifc out.obj
Done creating geometry (38 objects)
[error] Instance reference #1607 used by instance #1604 ... not found
[error] [UNS016] Unsupported BaseSurface:
[error] [GEO326] Failed to convert: #1708=IfcHalfSpaceSolid(#1707,.F.)
exit 0
```

All 9 fuzzed files from the original `invalid-stepid.zip`: 8 convert cleanly, 1 fails with a proper `SYN001` parse error. No segfaults.

`test_ifcopenshell_parse` (12 assertions) and `test_ifcopenshell_geometry` (30 assertions) both pass against the patched build.

## Context

We previously commented on #6032 that it was fixed, twice. Those checks ran on v0.8.x, where the parser tolerated the bad reference. The v0.9.0 boundary rewrite reintroduced the crash in `as<T>()`. That mistake is acknowledged on the issue.

Produced with AI assistance.
