### PR TITLE
Ship the split shared libraries in the Python wheel

### DIFF
--- a/src/ifcopenshell-python/Makefile
+++ b/src/ifcopenshell-python/Makefile
@@ -120,6 +120,10 @@ endif
 	cd dist/working && wget $(IOS_URL)
 	cd dist/working && unzip ifcopenshell-python*
 	cp -r dist/working/ifcopenshell/*ifcopenshell_wrapper* dist/ifcopenshell/
+	# v0.9.0 splits IfcOpenShell into shared libraries loaded from next to the
+	# wrapper (libifcopenshell.parse, ifcopenshell_document_rdb, ...). Copy
+	# them too, otherwise the wrapper fails to import. See #9364.
+	find dist/working/ifcopenshell -maxdepth 1 \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -exec cp {} dist/ifcopenshell/ \;
 	rm -rf dist/working
 	$(SED) 's/version = "0.0.0"/version = "$(VERSION)"/' dist/ifcopenshell/__init__.py
 	cd dist && zip -r ifcopenshell-python-$(VERSION)-$(PYVERSION)-$(PLATFORM).zip ifcopenshell
@@ -138,6 +142,10 @@ endif
 	mkdir build/botbuild
 	cd build/botbuild && wget $(IOS_URL) && unzip ifcopenshell-python*
 	cp -r build/botbuild/ifcopenshell/*ifcopenshell_wrapper* build/ifcopenshell/
+	# v0.9.0 splits IfcOpenShell into shared libraries loaded from next to the
+	# wrapper (libifcopenshell.parse, ifcopenshell_document_rdb, ...). Copy
+	# them too, otherwise the wrapper fails to import. See #9364.
+	find build/botbuild/ifcopenshell -maxdepth 1 \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -exec cp {} build/ifcopenshell/ \;
 	cp ../../README.md build/
 	cp pyproject.toml build/
 ifeq ($(IS_STABLE), TRUE)


### PR DESCRIPTION
Fixes #9364.

Every `0.9.0` alpha build published to the unstable channel since 25 August fails to load on all three platforms:

```
ImportError: dlopen(.../_ifcopenshell_wrapper.cpython-313-darwin.so):
  Library not loaded: @rpath/ifcopenshell_document_rdb.dylib
FATAL ERROR: Unable to load Bonsai
```

## Root cause

`src/ifcopenshell-python/Makefile` builds the wheel by downloading the prebuilt zip from S3 and copying the compiled wrapper out of it:

```make
cp -r build/botbuild/ifcopenshell/*ifcopenshell_wrapper* build/ifcopenshell/
```

That glob matches exactly two files, `_ifcopenshell_wrapper.*.so` and `ifcopenshell_wrapper.py`. It was correct while the wrapper was a single monolithic binary.

`d9f218eacf` (25 August) bumped the pin from `0.8.6-e333c1c` to `0.9.0alpha0-ad113e1`. That build is the v0.9.0 split architecture: the S3 zip for `ad113e1` contains the wrapper **plus about sixty shared libraries** it links against at runtime (`libifcopenshell.parse`, `ifcopenshell_document_rdb`, the per-schema `ifcopenshell_geometry_mapping_*`, the kernels, the writers). None of them match `*ifcopenshell_wrapper*`, so none reach the wheel. The wrapper ships alone and cannot load.

Confirmed by downloading the `ad113e1` zips: `macosm164` has 60 `.dylib`, `linux64` has 62 `.so`, `win64` has 6 `.dll` plus the `.pyd`. The published wheels each contain exactly one native file.

## Fix

After the existing wrapper copy, also copy every shared library from the top level of the unpacked zip, in both the `zip` and `dist` targets:

```make
find build/botbuild/ifcopenshell -maxdepth 1 \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -exec cp {} build/ifcopenshell/ \;
```

`pyproject.toml` already has `package-data "*" = ["*.*"]`, so once the files are in `build/ifcopenshell/` they are included in the wheel with no other change. The loader already searches the wrapper's own directory (the failing traceback lists that path first), so no rpath change is needed.

`make -n dist` on the patched Makefile emits the expected recipe.

## Scope honesty

I have not run the CI build itself. Verification is: the exact glob is the only copy step, the S3 zips demonstrably contain the libraries, the wheels demonstrably do not, and the patched recipe parses. The wheels will grow accordingly, roughly to the size of the S3 zip on each platform, which is the cost of shipping the libraries at all.

A less blunt alternative would be to install only the libraries the wrapper actually links, but the plugin libraries are `dlopen`ed by name at runtime rather than linked, so a static list would be fragile. Copying everything the build produced is the safe default; trimming can come later if size matters.

Produced with AI assistance.
