### PR TITLE
choco: pass subprocess commands as argument lists

### DIFF
--- a/choco/bonsai/choco_release.py
+++ b/choco/bonsai/choco_release.py
@@ -14,6 +14,7 @@ import hashlib
 import os
 import pathlib
 import re
+import shlex
 import subprocess
 from typing import NoReturn
 from urllib import request
@@ -22,7 +23,7 @@ from github import Github
 
 
 def get_repo_tag_names() -> list[str]:
-    git_return = subprocess.check_output("git tag -l", text=True)
+    git_return = subprocess.check_output(["git", "tag", "-l"], text=True)
     tag_names = [tag_name for tag_name in git_return.split("\n") if tag_name]
     print(f"{len(tag_names)} tag_names found in repo")
     return tag_names
@@ -81,7 +82,9 @@ def get_release_zip(tag: str) -> tuple[str, str]:
 
 
 def run(command: str) -> None:
-    subprocess.check_output(command)
+    # A bare string is looked up as a single executable name, so
+    # "git status" fails with FileNotFoundError. Split it first.
+    subprocess.check_output(shlex.split(command))
 
 
 start = datetime.datetime.now()
@@ -105,7 +108,7 @@ should_release = False
 target_release_tag = ""
 TARGET_OS = "windows-x64"
 
-git_status = subprocess.check_output("git status", text=True)
+git_status = subprocess.check_output(["git", "status"], text=True)
 print(git_status)
 
 for tag_name in get_repo_tag_names():


### PR DESCRIPTION
Item 2 of #8870, promised on 25 July and not delivered until now. `ci-bonsai-choco` has failed on every run since, most recently today (run 33294965528):

```
FileNotFoundError: [Errno 2] No such file or directory: 'git status'
```

`subprocess.check_output("git status", text=True)` with a bare string and no `shell=True` asks the OS to execute a file literally named `git status`. Same at line 25 (`"git tag -l"`) and in the `run()` helper used for the choco build steps.

Fix: argument lists for the two literal calls, and `shlex.split()` inside `run()` so its callers, which pass strings like `mono /opt/chocolatey/choco.exe pack --allow-unofficial`, keep working unchanged.

Verified by `py_compile`, black and ruff. Not verified by running the choco release itself, which needs the release runner. The failing step is the first `check_output` call, so it cannot get further than that today regardless.

Produced with AI assistance.