### PR TITLE
ifctester: install setuptools for the no-isolation wheel build

### DIFF
--- a/src/ifctester/Makefile
+++ b/src/ifctester/Makefile
@@ -100,7 +100,7 @@ else
 	$(SED) 's/version = "0.0.0"/version = "$(VERSION_DAILY)"/' $(WEBAPP_IFCTESTER_BUILD_DIR)/pyproject.toml
 	$(SED) 's/version = "0.0.0"/version = "$(VERSION_DAILY)"/' $(WEBAPP_IFCTESTER_BUILD_DIR)/$(PACKAGE_NAME)/__init__.py
 endif
-	cd $(WEBAPP_IFCTESTER_BUILD_DIR) && $(PYTHON) -m venv env --system-site-packages && . env/$(VENV_ACTIVATE) && python -m pip install build && python -m build --wheel --no-isolation
+	cd $(WEBAPP_IFCTESTER_BUILD_DIR) && $(PYTHON) -m venv env --system-site-packages && . env/$(VENV_ACTIVATE) && python -m pip install build "setuptools>=61" && python -m build --wheel --no-isolation
 	mkdir -p $(WEBAPP_GENERATED_DIR)
 	wheel=$$(basename $(WEBAPP_IFCTESTER_BUILD_DIR)/dist/$(PACKAGE_NAME)-*.whl); \
 	cp "$(WEBAPP_IFCTESTER_BUILD_DIR)/dist/$$wheel" "$(WEBAPP_GENERATED_DIR)/$$wheel"; \


### PR DESCRIPTION
`ci-ifctester-org` has failed on every run since 19 August (run 32269233851) at `webapp-stage-ifctester-wheel`:

```
ERROR Missing dependencies:
	setuptools>=61.0
make: *** [Makefile:98: webapp-stage-ifctester-wheel] Error 1
```

The target creates a venv with `--system-site-packages`, installs only `build`, then runs `python -m build --wheel --no-isolation`. `--no-isolation` means the build backend must already be importable, and the runner's system Python no longer ships `setuptools`, so the backend is missing.

Fix: install `"setuptools>=61"` next to `build`. One line.

Not verified by running the workflow, since it publishes to a separate repo with a bot token. The error names the exact missing package and the fix installs it.

Produced with AI assistance.