### PR TITLE
lint: restore black and ruff compliance on v0.9.0

### DIFF
--- a/src/bonsai/bonsai/bim/prop.py
+++ b/src/bonsai/bonsai/bim/prop.py
@@ -21,6 +21,7 @@ import os
 from typing import TYPE_CHECKING, Any, Literal, Union, assert_never, get_args
 
 import bpy
+import ifcopenshell.util.unit
 from bpy.props import (
     BoolProperty,
     CollectionProperty,
@@ -32,8 +33,6 @@ from bpy.props import (
     StringProperty,
 )
 from bpy.types import PropertyGroup
-
-import ifcopenshell.util.unit
 
 import bonsai.bim
 import bonsai.bim.handler

--- a/src/bonsai/bonsai/tool/pset.py
+++ b/src/bonsai/bonsai/tool/pset.py
@@ -293,7 +293,7 @@ class Pset(bonsai.core.tool.Pset):
         return ifcopenshell.util.unit.get_project_unit(ifc_file, f"{special_type}UNIT")
 
     @classmethod
-    def convert_attribute_unit(cls, metadata: "Attribute", new_unit_id: int, ifc_file: ifcopenshell.file) -> None:
+    def convert_attribute_unit(cls, metadata: Attribute, new_unit_id: int, ifc_file: ifcopenshell.file) -> None:
         """Rescale `metadata.float_value` in place so its physical quantity is preserved when
         switching from its current effective unit to the unit named by `new_unit_id` (0 = project
         default). No-op for non-measurable attributes or when old and new resolve to the same unit.
@@ -404,7 +404,9 @@ class Pset(bonsai.core.tool.Pset):
                 # Some real-world files (e.g. certain exporters) set Unit on properties that
                 # aren't actually measures -- ignore it there, since we only ever treat Unit as
                 # meaningful for measurable special_types (matching the UI picker's own gating).
-                own_unit = getattr(prop, "Unit", None) if cls.is_measurable_special_type(metadata.special_type) else None
+                own_unit = (
+                    getattr(prop, "Unit", None) if cls.is_measurable_special_type(metadata.special_type) else None
+                )
                 metadata.unit_id = own_unit.id() if own_unit else 0
                 metadata.unit_id_enum = str(metadata.unit_id)
                 metadata.set_value(metadata.get_value_default() if metadata.is_null else value)

--- a/src/bonsai/test/bim/test_prop.py
+++ b/src/bonsai/test/bim/test_prop.py
@@ -263,9 +263,7 @@ class TestImportPsetFromExistingWithAGenericNumericValueAndAnExplicitUnit(NewFil
         length_mm = ifcopenshell.api.unit.add_si_unit(ifc, unit_type="LENGTHUNIT", prefix="MILLI")
 
         element = ifc.createIfcWall()
-        prop = ifc.createIfcPropertySingleValue(
-            Name="Foo", NominalValue=ifc.createIfcReal(150.0), Unit=length_mm
-        )
+        prop = ifc.createIfcPropertySingleValue(Name="Foo", NominalValue=ifc.createIfcReal(150.0), Unit=length_mm)
         metadata = import_single_property(ifc, element, prop)
 
         assert metadata.special_type == "LENGTH"
@@ -291,9 +289,7 @@ class TestImportPsetFromExistingWithAStrayUnitOnANonMeasureProperty(NewFile):
         length_m = ifcopenshell.api.unit.add_si_unit(ifc, unit_type="LENGTHUNIT")
 
         element = ifc.createIfcWall()
-        prop = ifc.createIfcPropertySingleValue(
-            Name="Foo", NominalValue=ifc.createIfcLabel("Bar"), Unit=length_m
-        )
+        prop = ifc.createIfcPropertySingleValue(Name="Foo", NominalValue=ifc.createIfcLabel("Bar"), Unit=length_m)
         metadata = import_single_property(ifc, element, prop)  # must not raise
 
         assert metadata.special_type == ""

--- a/src/bonsai/test/tool/test_pset.py
+++ b/src/bonsai/test/tool/test_pset.py
@@ -69,9 +69,7 @@ class TestEditingAnOverriddenUnitPropertyRoundTrips(NewFile):
 
         element = ifc.createIfcWall()
         pset = ifcopenshell.api.pset.add_pset(ifc, product=element, name="Pset_Test")
-        prop = ifc.createIfcPropertySingleValue(
-            Name="Foo", NominalValue=ifc.createIfcLengthMeasure(2.5), Unit=length_m
-        )
+        prop = ifc.createIfcPropertySingleValue(Name="Foo", NominalValue=ifc.createIfcLengthMeasure(2.5), Unit=length_m)
         pset.HasProperties = [prop]
 
         obj = bpy.data.objects.new("Wall", None)
@@ -308,9 +306,7 @@ class TestEditPsetWithUnitOverridePicker(NewFile):
 
         element = ifc.createIfcWall()
         pset = ifcopenshell.api.pset.add_pset(ifc, product=element, name="Pset_Test")
-        prop = ifc.createIfcPropertySingleValue(
-            Name="Foo", NominalValue=ifc.createIfcLengthMeasure(2.5), Unit=length_m
-        )
+        prop = ifc.createIfcPropertySingleValue(Name="Foo", NominalValue=ifc.createIfcLengthMeasure(2.5), Unit=length_m)
         pset.HasProperties = [prop]
 
         obj = bpy.data.objects.new("Wall", None)

--- a/src/ifcopenshell-python/ifcopenshell/util/unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/unit.py
@@ -510,7 +510,11 @@ def get_project_unit(
         for unit in unit_assignment.Units or []:
             if getattr(unit, "UnitType", None) == unit_type:
                 return unit
-            if dimensional_match is None and unit.is_a("IfcDerivedUnit") and identify_unit_dimensions(unit) == unit_type:
+            if (
+                dimensional_match is None
+                and unit.is_a("IfcDerivedUnit")
+                and identify_unit_dimensions(unit) == unit_type
+            ):
                 dimensional_match = unit
         return dimensional_match
 

--- a/src/ifcopenshell-python/test/api/pset/test_edit_qto.py
+++ b/src/ifcopenshell-python/test/api/pset/test_edit_qto.py
@@ -18,7 +18,6 @@
 
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
-import ifcopenshell.api.unit
 import test.bootstrap
 
 

--- a/src/ifcopenshell-python/test/util/test_unit.py
+++ b/src/ifcopenshell-python/test/util/test_unit.py
@@ -20,8 +20,10 @@ import tempfile
 from math import pi
 from pathlib import Path
 
+import ifcpatch
 import numpy as np
 import pytest
+from ifcpatch.recipes import Ifc2Sql
 
 import ifcopenshell.api.context
 import ifcopenshell.api.georeference
@@ -31,10 +33,8 @@ import ifcopenshell.api.unit
 import ifcopenshell.util.element
 import ifcopenshell.util.geolocation
 import ifcopenshell.util.unit as subject
-import ifcpatch
 import test.bootstrap
 from ifcopenshell.util.shape_builder import ShapeBuilder
-from ifcpatch.recipes import Ifc2Sql
 
 
 class TestMmToM:
@@ -149,7 +149,9 @@ class TestGetCandidateUnits(test.bootstrap.IFC4):
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
         force = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="FORCEUNIT")
         area = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="AREAUNIT")
-        modulus = ifcopenshell.api.unit.add_derived_unit(self.file, "MODULUSOFELASTICITYUNIT", None, {force: 1, area: -1})
+        modulus = ifcopenshell.api.unit.add_derived_unit(
+            self.file, "MODULUSOFELASTICITYUNIT", None, {force: 1, area: -1}
+        )
         assert subject.get_candidate_units(self.file, "MODULUSOFELASTICITYUNIT") == [modulus]
 
     def test_userdefined_derived_unit_matched_by_dimensional_fallback(self):
@@ -288,7 +290,9 @@ class TestCalculateUnitScale(test.bootstrap.IFC4):
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
         force = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="FORCEUNIT")
         area = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="AREAUNIT", prefix="MILLI")
-        modulus = ifcopenshell.api.unit.add_derived_unit(self.file, "MODULUSOFELASTICITYUNIT", None, {force: 1, area: -1})
+        modulus = ifcopenshell.api.unit.add_derived_unit(
+            self.file, "MODULUSOFELASTICITYUNIT", None, {force: 1, area: -1}
+        )
         ifcopenshell.api.unit.assign_unit(self.file, units=[modulus])
         # AREAUNIT is a pure power of length, so its MILLI prefix is raised to
         # the length exponent (2) per #9278: (1e-3)**2 = 1e-6, inverted by the
@@ -397,7 +401,9 @@ class TestGetUnitSymbol(test.bootstrap.IFC4):
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
         force = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="FORCEUNIT")
         area = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="AREAUNIT")
-        modulus = ifcopenshell.api.unit.add_derived_unit(self.file, "MODULUSOFELASTICITYUNIT", None, {force: 1, area: -1})
+        modulus = ifcopenshell.api.unit.add_derived_unit(
+            self.file, "MODULUSOFELASTICITYUNIT", None, {force: 1, area: -1}
+        )
         assert subject.get_unit_symbol(modulus) == "N/m2"
 
     def test_unnamed_derived_unit_still_composes_a_symbol_without_crashing(self):
@@ -420,7 +426,9 @@ class TestIdentifyUnitDimensions(test.bootstrap.IFC4):
         ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")
         force = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="FORCEUNIT")
         area = ifcopenshell.api.unit.add_si_unit(self.file, unit_type="AREAUNIT")
-        modulus = ifcopenshell.api.unit.add_derived_unit(self.file, "MODULUSOFELASTICITYUNIT", None, {force: 1, area: -1})
+        modulus = ifcopenshell.api.unit.add_derived_unit(
+            self.file, "MODULUSOFELASTICITYUNIT", None, {force: 1, area: -1}
+        )
         assert subject.identify_unit_dimensions(modulus) == "PRESSUREUNIT"
 
     def test_returns_none_for_no_match(self):


### PR DESCRIPTION
`ci-lint` on `v0.9.0` has been red since 2026-08-29. Last green run was on `6dc14fa05c` (2026-08-28), first red on `1a03fd7df1` (2026-08-29). The unit-of-measure work rebased onto the branch on 2026-08-28 (`90d6d5f51a` and siblings) left five files that black would reformat and four ruff findings:

- `src/bonsai/bonsai/bim/prop.py:19` unsorted imports
- `src/bonsai/bonsai/tool/pset.py:296` quoted annotation (the file already has `from __future__ import annotations`)
- `src/ifcopenshell-python/test/api/pset/test_edit_qto.py:21` unused import
- `src/ifcopenshell-python/test/util/test_unit.py:19` unsorted imports

Every change is the mechanical output of `black` 26.5.1 and `ruff check --fix` 0.16.4, the versions `ci-lint` installs. No behaviour change.

Verified locally with those exact versions: `black --check .` reports 1843 files unchanged and `ruff check .` passes repo-wide on this branch. The seven touched files byte-compile.

Part of the `v0.9.0` CI tracking in #8870.
