### PR TITLE
ifcdiff: resolve elements by GlobalId with by_guid on v0.9.0

### DIFF
--- a/src/ifcdiff/ifcdiff.py
+++ b/src/ifcdiff/ifcdiff.py
@@ -152,8 +152,8 @@ class IfcDiff:
             total_diffed += 1
             if total_diffed % 250 == 0:
                 print("{}/{} diffed ...".format(total_diffed, total_same_elements), end="\r", flush=True)
-            old = self.old.by_id(global_id)
-            new = self.new.by_id(global_id)
+            old = self.old.by_guid(global_id)
+            new = self.new.by_guid(global_id)
             if should_check_attributes:
                 if self.diff_element(old, new) and self.is_shallow:
                     continue


### PR DESCRIPTION
Four of the six `src/ifcdiff/test.py` tests fail on `v0.9.0` with `TypeError: in method 'file_by_id', argument 2 of type 'int'` (run [33304472332](https://github.com/IfcOpenShell/IfcOpenShell/actions/runs/33304472332)).

`ifcdiff.py:155` calls `self.old.by_id(global_id)` with a GlobalId string. On `v0.8.0` `file.by_id()` was a Python method that dispatched strings to `by_guid()`, so this worked by accident. On `v0.9.0` `file` inherits `by_id` straight from the compiled wrapper, which is int-only, so the string raises.

Fix: call `by_guid()` at both sites, which is what the code meant.

Verified on a native `v0.9.0` build at `6f2e1aa993` (the run's head SHA): RED reproduces the identical `TypeError`, GREEN `src/ifcdiff/test.py` 6 passed.

Not a duplicate of #9296 or #9312, which target `v0.8.0` and different defects; a `v0.9.0` re-port of #9296 will need to sit on top of this line.

Part of the `v0.9.0` CI tracking in #8870.
