### PR TITLE
sql: handle derived attributes in sqlite_entity.__getattr__

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/sql.py
+++ b/src/ifcopenshell-python/ifcopenshell/sql.py
@@ -385,8 +385,12 @@ class sqlite_entity:
         # print("*" * 100)
         # print("GETATTR", self.sqlite_wrapper.id, self.sqlite_wrapper.ifc_class, name)
 
-        INVALID, FORWARD, INVERSE = range(3)
+        INVALID, FORWARD, INVERSE, DERIVED = range(4)
         attr_cat = self.wrapped_data.get_attribute_category(name)
+        if attr_cat == DERIVED:
+            # Derived attributes aren't stored or computed for SQLite-linked
+            # files, so callers must treat None as "not available" here.
+            return None
         if attr_cat == FORWARD:
             if self.sqlite_wrapper.attribute_cache:
                 # print(self.sqlite_wrapper.ifc_class)


### PR DESCRIPTION
`test/util/test_unit.py::TestCalculateUnitScaleOnLinkedFile::test_run` fails on `v0.9.0` with `AttributeError: entity instance of type 'IfcSIUnit' has no attribute 'Dimensions'` (run [33304472332](https://github.com/IfcOpenShell/IfcOpenShell/actions/runs/33304472332)).

`sqlite_entity.__getattr__` in `ifcopenshell/sql.py:388` unpacks `get_attribute_category()` as `INVALID, FORWARD, INVERSE = range(3)` and never handles category 3, which the wrapper returns for derived attributes (`IfcParseWrapper.i:452`). Any derived attribute read on a SQLite-linked file therefore falls through to `AttributeError`. `entity_instance.py:96` already handles `DERIVED` for regular files; this brings `sql.py` in line.

Fix: add the `DERIVED` branch returning `None`, since derived attributes are neither stored nor computed for SQLite-linked files.

Verified on a native `v0.9.0` build at `6f2e1aa993`: RED reproduces the identical `AttributeError`, GREEN `test/util/test_unit.py` 59 passed.

Part of the `v0.9.0` CI tracking in #8870.
