### PR TITLE
ifctester: chained facet filters ignore tuple results on v0.9.0

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -201,7 +201,7 @@ class Entity(Facet):
     def filter(
         self, ifc_file: ifcopenshell.file, elements: Optional[list[ifcopenshell.entity_instance]] = None
     ) -> list[ifcopenshell.entity_instance]:
-        if isinstance(elements, list):
+        if isinstance(elements, (list, tuple)):
             return super().filter(ifc_file, elements)
 
         if isinstance(self.name, str):
@@ -280,7 +280,7 @@ class Attribute(Facet):
     def filter(
         self, ifc_file: ifcopenshell.file, elements: Optional[list[ifcopenshell.entity_instance]]
     ) -> list[ifcopenshell.entity_instance]:
-        if isinstance(elements, list):
+        if isinstance(elements, (list, tuple)):
             return super().filter(ifc_file, elements)
 
         results = []
@@ -415,7 +415,7 @@ class Classification(Facet):
     def filter(
         self, ifc_file: ifcopenshell.file, elements: Optional[list[ifcopenshell.entity_instance]]
     ) -> list[ifcopenshell.entity_instance]:
-        if isinstance(elements, list):
+        if isinstance(elements, (list, tuple)):
             return super().filter(ifc_file, elements)
         return ifc_file.by_type("IfcObjectDefinition")
 
@@ -480,7 +480,7 @@ class PartOf(Facet):
     def filter(
         self, ifc_file: ifcopenshell.file, elements: Optional[list[ifcopenshell.entity_instance]]
     ) -> list[ifcopenshell.entity_instance]:
-        if isinstance(elements, list):
+        if isinstance(elements, (list, tuple)):
             return super().filter(ifc_file, elements)
         return list(ifc_file)  # Lazy
 
@@ -673,7 +673,7 @@ class Property(Facet):
     def filter(
         self, ifc_file: ifcopenshell.file, elements: Optional[list[ifcopenshell.entity_instance]]
     ) -> list[ifcopenshell.entity_instance]:
-        if isinstance(elements, list):
+        if isinstance(elements, (list, tuple)):
             return super().filter(ifc_file, elements)
         if ifc_file.schema == "IFC2X3":
             return ifc_file.by_type("IfcObjectDefinition")
@@ -946,7 +946,7 @@ class Material(Facet):
     def filter(
         self, ifc_file: ifcopenshell.file, elements: Optional[list[ifcopenshell.entity_instance]]
     ) -> list[ifcopenshell.entity_instance]:
-        if isinstance(elements, list):
+        if isinstance(elements, (list, tuple)):
             return super().filter(ifc_file, elements)
         return ifc_file.by_type("IfcObjectDefinition")
 


### PR DESCRIPTION
`src/ifctester/test/test_ids.py::TestIds::test_creating_a_minimal_ids_and_validating` fails on `v0.9.0` with `assert False is True` (run [33304472332](https://github.com/IfcOpenShell/IfcOpenShell/actions/runs/33304472332)).

This is a wrong verdict, not just a broken test. Facets chain their broad-phase filters: each `filter()` either narrows the `elements` it receives or, if it received nothing usable, scans the file itself. The guard at all six sites (`Entity`, `Attribute`, `Classification`, `PartOf`, `Property`, `Material`) is `isinstance(elements, list)`. On `v0.9.0` `file.by_type()` returns a tuple, and several `filter()` methods pass that tuple straight through, so the next facet in the chain treats an already narrowed, possibly empty, result as "nothing" and rescans the whole model.

In the failing test the applicability is `IFCWALL` with `Name = Waldo`, the model holds one `IfcSlab` named Waldo and the specification is prohibited. `Entity.filter` correctly returns an empty tuple, `Attribute.filter` ignores it, finds the slab, and the prohibited spec fails against an element of the wrong class.

Fix: accept `(list, tuple)` at the six sites.

Verified on a native `v0.9.0` build at `6f2e1aa993`: RED reproduces `spec.status is False` with the slab in `applicable_entities`, GREEN `spec.status is True` and the full `src/ifctester/test` suite 37 passed.

Part of the `v0.9.0` CI tracking in #8870.
