### PR TITLE
api/unit: leave derived Dimensions unset when creating IfcSIUnit

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/api/unit/assign_unit.py
+++ b/src/ifcopenshell-python/ifcopenshell/api/unit/assign_unit.py
@@ -128,10 +128,9 @@ class Usecase:
         elif unit_type == "volume":
             type_prefix = "CUBIC_"
         return self.file.createIfcSIUnit(
-            None,
-            "{}UNIT".format(unit_type.upper()),
-            ifcopenshell.util.unit.get_prefix(data["raw"]),
-            type_prefix + ifcopenshell.util.unit.get_unit_name(data["raw"]),
+            UnitType="{}UNIT".format(unit_type.upper()),
+            Prefix=ifcopenshell.util.unit.get_prefix(data["raw"]),
+            Name=type_prefix + ifcopenshell.util.unit.get_unit_name(data["raw"]),
         )
 
     def create_imperial_unit(self, unit_type: str, data: dict) -> ifcopenshell.entity_instance:
@@ -148,10 +147,8 @@ class Usecase:
             assert False, unit_type
 
         si_unit = self.file.createIfcSIUnit(
-            None,
-            "{}UNIT".format(unit_type.upper()),
-            None,
-            "{}METRE".format(name_prefix.upper() + "_" if name_prefix else ""),
+            UnitType="{}UNIT".format(unit_type.upper()),
+            Name="{}METRE".format(name_prefix.upper() + "_" if name_prefix else ""),
         )
         if data["raw"] == "INCHES":
             name = "{}inch".format(name_prefix + " " if name_prefix else "")


### PR DESCRIPTION
Two `src/ifcquery/tests/test_validate.py` tests fail on `v0.9.0` with `Attribute is derived in subtype` (run [33304472332](https://github.com/IfcOpenShell/IfcOpenShell/actions/runs/33304472332)).

`assign_unit.py` creates SI units positionally as `createIfcSIUnit(None, "LENGTHUNIT", ...)`, passing an explicit `None` for `Dimensions`, which is derived on `IfcSIUnit`. On `v0.9.0` that `None` lands in the raw slot instead of the `attribute_value_derived` sentinel, and `validate()` at `validate.py:555` flags every such unit. The STEP output is unaffected (`*` either way) and `unit.Dimensions` still resolves; only the raw slot differs.

Measured on a native `v0.9.0` build at `6f2e1aa993`, same file, three units:

| created as | raw slot passes validate |
|---|---|
| `create_entity("IfcSIUnit", UnitType=..., Name=...)` | yes |
| `createIfcSIUnit(None, "LENGTHUNIT", None, "METRE")` | no |
| `createIfcSIUnit(UnitType=..., Name=...)` | yes |

Fix here: keyword arguments that leave `Dimensions` unset in `create_metric_unit()` and `create_imperial_unit()`. RED reproduces the three `Attribute is derived in subtype` errors, GREEN `test_validate.py` 6 passed and `test/api/unit` 47 passed.

@aothms one question on the layer. The same `createIfcSIUnit(None, ...)` idiom appears in Bonsai, ifc5d, ifccityjson, ifc2ca and several test fixtures, and I have not checked whether `v0.8.0` stored the explicit `None` the same way. If you would rather the wrapper coerce a `None` written into a derived slot to the derived sentinel (or reject it), this PR becomes a tidy-up rather than the fix and I will drop it in favour of that. Otherwise I can sweep the other call sites in a follow-up.

Part of the `v0.9.0` CI tracking in #8870.
