### PR TITLE
IfcGeomTree: keep clash_intersection_many result order

### DIFF
--- a/src/ifcgeom/kernels/opencascade/tree.h
+++ b/src/ifcgeom/kernels/opencascade/tree.h
@@ -1085,6 +1085,12 @@ namespace ifcopenshell::geom {
                                 is_manifold = true;
                                 clash intersection = test_intersection(task.b, task.a, tolerance, check_all);
                                 if (intersection.clash_type != -1) {
+                                    // test_intersection() was called with the arguments swapped in
+                                    // order to test whether task.b protrudes into task.a, so it
+                                    // reports .a and .b in swapped order. Restore the canonical
+                                    // order so that result.a always refers to an element of set_a
+                                    // and result.b to an element of set_b.
+                                    std::swap(intersection.a, intersection.b);
                                     // Replace the clash result if any of these criteria apply:
                                     // - We don't have a clash yet
                                     // - Our previous clash is piercing, and our new one is a protrusion


### PR DESCRIPTION
Port of #8424 to `v0.9.0`. Closes #5357.

`clash_intersection_many` runs a protrusion pass that calls `test_intersection(task.b, task.a, ...)` with its arguments swapped (protrusion is directional, this pass tests whether the set_b element protrudes into the set_a element). `test_intersection` always stamps its first argument as `.a` and second as `.b`, so when this pass produces the adopted result, `result.a` comes out as a set_b element instead of a set_a element. On `v0.9.0` this code moved from `IfcGeomTree.h` into `src/ifcgeom/kernels/opencascade/tree.h:1086-1087` inside the templated `tree_backend<T>::clash_intersection_many`, but the swapped call is byte-identical to the `v0.8.0` bug.

Fix: swap `intersection.a`/`intersection.b` back to canonical order right after the directional call (`src/ifcgeom/kernels/opencascade/tree.h`), so `result.a` always refers to a set_a element and `result.b` to a set_b element. `distance` and `clash_type` are unaffected.

## Verified on a native arm64 Linux build of `6f2e1aa993` (v0.9.0)

Built via the arm64 Docker image described in `docker/README-arm64.md`. Authored a small IFC in-process (`ifcopenshell.api`): a 10x1x3 m `IfcWall` at the origin containing a 1x0.5x1 m `IfcSpace` fully embedded inside it, then ran `tree.clash_intersection_many([wall], [space])` via the "opencascade.trianglebvh" tree backend.

RED (unpatched `tree.h`, rebuilt `geometry_tree_opencascade_trianglebvh`/`brep` + `ifcopenshell_wrapper`, reinstalled):
```
n_results=1
a= IfcSpace Space b= IfcWall Wall clash_type= 0
RED: order flipped, a=IfcSpace b=IfcWall
```

GREEN (this branch's one-line swap applied, same targets rebuilt and reinstalled):
```
n_results=1
a= IfcWall Wall b= IfcSpace Space clash_type= 0
GREEN: a=Wall, b=Space (correct order)
```

Not verified: the Python-side `ifcquery/clash.py` caller mentioned in the original PR body was not re-checked on `v0.9.0` in this pass; only the C++ kernel behavior above was exercised.

Produced with AI assistance.
