### PR TITLE
build: decouple OpenCascade examples from BUILD_CONVERT

### DIFF
--- a/src/ifcgeom/CMakeLists.txt
+++ b/src/ifcgeom/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
     target_link_libraries(IfcGeom plugin IfcParse ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} "Eigen3::Eigen")
 endif()
 
-if((BUILD_CONVERT OR BUILD_IFCPYTHON) AND WITH_OPENCASCADE)
+if((BUILD_CONVERT OR BUILD_IFCPYTHON OR BUILD_EXAMPLES) AND WITH_OPENCASCADE)
     add_subdirectory(serialization)
     set(IFCOPENSHELL_LIBRARIES ${IFCOPENSHELL_LIBRARIES} PARENT_SCOPE)
     set(geometry_serializer_libraries ${geometry_serializer_libraries} PARENT_SCOPE)


### PR DESCRIPTION
Port of #8478 to `v0.9.0`. Fixes #7835.

`src/ifcgeom/CMakeLists.txt:56` only adds the `serialization` subdirectory (which defines the `geometry_serializer` target) `if((BUILD_CONVERT OR BUILD_IFCPYTHON) AND WITH_OPENCASCADE)`. `src/examples/CMakeLists.txt` links `IfcOpenHouse`/`IfcAdvancedHouse` against `geometry_serializer` whenever `WITH_OPENCASCADE` is on, regardless of `BUILD_CONVERT`/`BUILD_IFCPYTHON`. So `-DBUILD_EXAMPLES=ON -DBUILD_CONVERT=OFF -DBUILD_IFCPYTHON=OFF -DWITH_OPENCASCADE=ON` configures cleanly (CMake accepts an undefined plain library name as a linker flag) but fails at compile/link time. `BUILD_EXAMPLES` now defaults to ON on `v0.9.0` (`cmake/CMakeLists.txt:93`), making this gap more visible than on `v0.8.0`.

Fix: add `BUILD_EXAMPLES` to the guard so `geometry_serializer` is built whenever Open CASCADE is enabled, independent of `BUILD_CONVERT`/`BUILD_IFCPYTHON`.

## Verified on a native arm64 Linux build of `6f2e1aa993` (v0.9.0)

Built via the arm64 Docker image described in `docker/README-arm64.md`, `cmake -S cmake -B build -DUSE_MMAP=OFF -DBUILD_EXAMPLES=ON -DBUILD_CONVERT=OFF -DBUILD_IFCPYTHON=OFF -DBUILD_IFCGEOM=ON -DWITH_CGAL=OFF -DCOLLADA_SUPPORT=OFF -DWITH_OPENCASCADE=ON ... && cmake --build build --target IfcOpenHouse`.

RED (unpatched): configure succeeds, but the build fails while compiling the example itself, because it never picked up the OpenCASCADE include dirs that would normally come in transitively through the (missing) `geometry_serializer` target:
```
[100%] Building CXX object examples/CMakeFiles/IfcOpenHouse.dir/IfcOpenHouse.cpp.o
/__w/IfcOpenShell/IfcOpenShell/src/examples/IfcOpenHouse.cpp:24:10: fatal error: TColgp_Array2OfPnt.hxx: No such file or directory
   24 | #include <TColgp_Array2OfPnt.hxx>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake: *** [Makefile:553: IfcOpenHouse] Error 2
```
(This is a slightly different manifestation than a configure-time "unknown target" error, but the same root cause: without this fix `geometry_serializer` never exists, so its OCCT include dirs never propagate to the example.)

GREEN (this branch's one-line CMake guard change applied, same configure/build repeated):
```
[100%] Building CXX object examples/CMakeFiles/IfcOpenHouse.dir/IfcOpenHouse.cpp.o
Linking CXX executable IfcOpenHouse
Built target IfcOpenHouse
```

Kernel/flags: static (non-`-shared`) `occt-7.8.1` and no CGAL (`-DWITH_CGAL=OFF`), to sidestep a `GLIBC_2.38` mismatch this arm64 build environment has against the prebuilt `*-shared` dependency cache, unrelated to this change. Not verified: `IfcAdvancedHouse` and `IfcAlignment`/`IfcSimplifiedAlignment` example targets were not individually rebuilt, only `IfcOpenHouse`, since they hit the same guard.

Produced with AI assistance.
