### PR TITLE
ifcgeom: use real depth for SurfaceOfLinearExtrusion

### DIFF
--- a/src/ifcgeom/mapping/IfcSurfaceOfLinearExtrusion.cpp
+++ b/src/ifcgeom/mapping/IfcSurfaceOfLinearExtrusion.cpp
@@ -35,6 +35,6 @@ taxonomy::ptr mapping::map_impl(const IfcSchema::IfcSurfaceOfLinearExtrusion& in
 		matrix,
 		map(inst.SweptCurve()),
 		taxonomy::cast<taxonomy::direction3>(map(inst.ExtrudedDirection())),
-		std::numeric_limits<double>::infinity()
+		inst.Depth() * length_unit_
 	);
 }


### PR DESCRIPTION
Port of #8433 to `v0.9.0`. Closes #8013.

`src/ifcgeom/mapping/IfcSurfaceOfLinearExtrusion.cpp:38` passes `std::numeric_limits<double>::infinity()` as the extrusion depth instead of reading `inst.Depth()` (the value-type mapping API was renamed from `inst->` to `inst.` since `v0.8.0`, but the infinite-depth bug is unchanged). The kernel builds the prism with an infinite translation vector, so the bounding box and tessellation iterate over an unbounded domain and never terminate, which is the reported freeze on load. The sibling `src/ifcgeom/mapping/IfcExtrudedAreaSolid.cpp:28` already reads `inst.Depth() * length_unit_` for the equivalent case.

Fix: use `inst.Depth() * length_unit_`, matching the sibling mapper.

## Verified on a native arm64 Linux build of `6f2e1aa993` (v0.9.0)

Built via the arm64 Docker image described in `docker/README-arm64.md`, rebuilt all 8 `geometry_mapping_ifc*` schema targets (the change is schema-templated) and reinstalled, using the reporter's attached fixture.

RED (unpatched):
```
$ time timeout 30 IfcConvert surface_of_linear_extrusion.ifc out.obj
IfcOpenShell IfcConvert 0.9.0alpha0-6f2e1aa99
...
Parsing input file took 0 seconds

real	0m30.024s
```
(killed by the 30 s timeout, never reaches "Creating geometry")

GREEN (this branch's one-line fix applied, same targets rebuilt and reinstalled):
```
$ time timeout 30 IfcConvert surface_of_linear_extrusion.ifc out.obj
IfcOpenShell IfcConvert 0.9.0alpha0-6f2e1aa99
...
Creating geometry...
Done creating geometry (1 objects)
Conversion took 0 seconds

real	0m0.089s
```
`out.obj` is 774 bytes, a finite prism.

Kernel/flags: default `opencascade` kernel, `--kernel` not overridden. Not verified: only the `opencascade` kernel path was exercised; `cgal`/`hybrid-*` kernels were not re-run against this fixture.

Produced with AI assistance.
