### PR TITLE
ifcgeom: fall back when convert_openings cleanly fails

### DIFF
--- a/src/ifcgeom/converter.cpp
+++ b/src/ifcgeom/converter.cpp
@@ -198,8 +198,10 @@ ifcopenshell::geom::native_element* ifcopenshell::geom::converter::create_brep_f
 
 			if (opening_items.empty()) {
 				opened_shapes = shapes;
-			} else {
-				kernel_->convert_openings(product, opening_items, shapes, *place, opened_shapes);
+			} else if (!kernel_->convert_openings(product, opening_items, shapes, *place, opened_shapes)) {
+				// A clean `false` return is a failure just like a thrown exception.
+				logger_.message(ifcopenshell::logger::LOG_ERROR, "GEO", 34, "Error processing openings for:", product);
+				caught_error = true;
 			}
 		} catch (const std::exception& e) {
 			logger_.message(ifcopenshell::logger::LOG_ERROR, "GEO", 33, std::string("Error processing openings for: ") + e.what() + ":", product);


### PR DESCRIPTION
Port of #8814 to `v0.9.0`. Fixes #5880.

`src/ifcgeom/converter.cpp:202` (`create_brep_for_representation_and_product`) called `kernel_->convert_openings(product, opening_items, shapes, *place, opened_shapes)` without checking its return value (still `bool`, `abstract_kernel.h:136`). When every candidate kernel *cleanly* rejects the opening-cut operands (CGAL's Nef conversion refusing self-intersecting geometry, logged as GEO094 rather than thrown), the resulting empty `opened_shapes` silently overwrote the product's valid unopened solid, with no error and no fallback. That matches the reporter's description exactly.

Fix: check the return value; a clean `false` is now logged (`GEO034`, `logger_.message`, renamed from `logger_.Message` since `v0.8.0`) and sets `caught_error = true`, routing through the same fallback-to-unopened-geometry guard that already protects the thrown-exception path.

## Verified on a native arm64 Linux build of `6f2e1aa993` (v0.9.0)

Built a full standalone `IfcConvert` (static, non-`-shared` `occt-7.8.1` and `cgal-v5.6.3`/`gmp-6.3.0`/`mpfr-6.3.0`, to sidestep a `GLIBC_2.38` mismatch this arm64 build environment has against the prebuilt `*-shared` dependency cache) against the reporter's attached `MessedUpWindow_simplified.ifc`.

RED (unpatched):
```
$ IfcConvert MessedUpWindow_simplified.ifc out.obj --kernel cgal
...
Creating geometry...
Done creating geometry (1 objects)

Log:
[error] [GEO094] ... Conversion to Nef will fail. Self-intersecting geometry:
#228882=IfcWindow(...)

Conversion took 0 seconds
```
`out.obj` has 0 vertices, window geometry silently vanishes, no GEO034.

GREEN (this branch's 4-line fix applied, same rebuild):
```
$ IfcConvert MessedUpWindow_simplified.ifc out.obj --kernel cgal
...
Log:
[error] [GEO094] ... Conversion to Nef will fail. Self-intersecting geometry:
#228882=IfcWindow(...)
[error] [GEO034] ... Error processing openings for:
#228882=IfcWindow(...)

Conversion took 0 seconds
```
`out.obj` now has 268 vertices, matching the original `v0.8.0` PR's reported before/after numbers for this exact fixture and kernel. The window falls back to the unopened solid instead of vanishing.

Kernel/flags: `--kernel cgal`. Not verified on `v0.9.0` in this pass: `--kernel hybrid-cgal-opencascade` and `hybrid-cgal-simple-opencascade` (the original PR's table also exercised these), and the `test/input/*.ifc` regression sweep the original PR ran on `v0.8.0`.

Produced with AI assistance.
