### PR TITLE
ifcwrap: keep the derived marker when None is assigned to a derived attribute

### DIFF
--- a/src/ifcwrap/IfcParseWrapper.i
+++ b/src/ifcwrap/IfcParseWrapper.i
@@ -623,6 +623,12 @@ private:
 			// @nb we don't check anymore if the attribute is optional here, because it should be
 			// possible to go back to the state at construction time.
 			// bool is_optional = $self->declaration().as_entity()->attribute_by_index(i)->optional();
+			// A derived attribute keeps its derived marker, as at construction time.
+			auto* ent = $self->declaration().as_entity();
+			if (ent && i < ent->derived().size() && ent->derived()[i]) {
+				self->set_attribute_value(i, ifcopenshell::derived{});
+				return;
+			}
 			self->set_attribute_value(i, blank{});
 			return;
 		}


### PR DESCRIPTION
Replaces #9389, following @aothms's direction there: fix the wrapper, not the API.

**What changed between 0.8 and 0.9.** `set_attribute_value_py` (`IfcParseWrapper.i:621`) turns every Python `None` into `blank{}` without checking whether the target slot is derived. A derived slot is initialised with the derived marker by `populate_derived_()` at construction, so assigning `None` to it afterwards replaces the marker with a real null. The STEP output is unaffected (`*` either way) and `unit.Dimensions` still resolves; only the raw slot differs, which is what `validate()` reads at `validate.py:555`.

Measured, same four-unit file on both sides:

| created as | 0.8.5 wheel | `v0.9.0` at `6f2e1aa993` | this branch |
|---|---|---|---|
| `create_entity("IfcSIUnit", UnitType=..., Name=...)` | `*`, valid | `*`, valid | `*`, valid |
| `createIfcSIUnit(None, "LENGTHUNIT", None, "METRE")` | `*`, valid | `*`, **flagged** | `*`, valid |
| `createIfcSIUnit(UnitType=..., Name=...)` | `*`, valid | `*`, valid | `*`, valid |
| `createIfcSIUnit(Dimensions=None, UnitType=..., Name=...)` | `*`, valid | `*`, **flagged** | `*`, valid |

So both the positional and the keyword `None` regressed, and the pervasive `createIfcSIUnit(None, ...)` idiom in Bonsai, ifc5d, ifccityjson and ifc2ca is affected without any of those call sites changing.

**Fix.** When the value is `None` and `declaration().as_entity()->derived()[i]` is set, store `ifcopenshell::derived{}` (the same call `populate_derived_()` makes) instead of `blank{}`. Six lines, no API or test changes.

Verified on a native `linux/arm64` build of `v0.9.0`: RED on `6f2e1aa993` flags instances 2 and 4; GREEN on this branch flags none of the four, `src/ifcquery/tests/test_validate.py` 6 passed, `test/api/unit` plus `test/test_validate.py` 85 passed, `test/util/test_unit.py` 58 passed with the one remaining failure being the `sql.py` case that #9387 fixes.

Part of the `v0.9.0` CI tracking in #8870 (the two `src/ifcquery/tests/test_validate.py` failures).
