### PR TITLE
serializers: emit a stable id for nested materials in XML (#5109)

### DIFF
--- a/src/serializers/schema_dependent/xml_serializer.cpp
+++ b/src/serializers/schema_dependent/xml_serializer.cpp
@@ -785,6 +785,7 @@ void POSTFIX_SCHEMA(xml_serializer)::finalize() {
 				auto ls = layerset.MaterialLayers();
 				for (auto& layer : ls) {
 					ptree subnode;
+					subnode.put("<xmlattr>.id", qualify_unrooted_instance(layer));
 					if (layer.Material()) {
                         subnode.put("<xmlattr>.Name", layer.Material());
 					}
@@ -794,6 +795,7 @@ void POSTFIX_SCHEMA(xml_serializer)::finalize() {
                 auto mats = matlist.Materials();
 				for (auto& list_material : mats) {
 					ptree subnode;
+					subnode.put("<xmlattr>.id", qualify_unrooted_instance(list_material));
                     format_entity_instance(log, mapping_, list_material, subnode, node);
 				}
 			}


### PR DESCRIPTION
Fixes #5109. Re-port of #8468 against `v0.9.0`.

## Root cause

`src/serializers/schema_dependent/xml_serializer.cpp:787-797` on `v0.9.0`: the nested `IfcMaterialLayer` subnodes (layer sets) and `IfcMaterial` subnodes (material lists) are built without an `id` attribute. The parent set already gets one from `qualify_unrooted_instance`, the children do not, so several unrooted materials come out as indistinguishable nodes with nothing to reference.

## Fix

Apply the same `qualify_unrooted_instance` scheme to the two nested subnodes (2 lines).

## Verification

Verified on a native linux/arm64 build of `v0.9.0` at 6f2e1aa99.

Fixture: an IFC4 file authored with `ifcopenshell.api`: wall `W` with an `IfcMaterialLayerSet` of two layers (Brick, Insulation), wall `W2` with an `IfcMaterialList` of the same two materials.

Command: `IfcConvert -y model.ifc out.xml`

RED (unpatched):

```xml
<IfcMaterialLayer Name="1" LayerThickness="0.10000000000000001"/>
<IfcMaterialLayer Name="1" LayerThickness="0.20000000000000001"/>
<IfcMaterial Name="Brick"/>
<IfcMaterial Name="Insulation"/>
```

GREEN (patched):

```xml
<IfcMaterialLayer id="IfcMaterialLayer_52" Name="1" LayerThickness="0.10000000000000001"/>
<IfcMaterialLayer id="IfcMaterialLayer_53" Name="1" LayerThickness="0.20000000000000001"/>
<IfcMaterial id="IfcMaterial_49" Name="Brick"/>
<IfcMaterial id="IfcMaterial_50" Name="Insulation"/>
```

Side observation, not changed here: the `Name` attribute of `IfcMaterialLayer` renders as `1` in both runs (it is filled from `layer.Material()` rather than the material name). Pre-existing on `v0.9.0`, out of scope for this PR.

This PR contains AI-generated code, generated with the assistance of an AI coding tool.
