### PR TITLE
Build shared in the docker dev environment

### DIFF
--- a/docker/ifcos_env
+++ b/docker/ifcos_env
@@ -155,7 +155,7 @@ function build() {
     
     docker exec -i -w "${WORKDIR}" -e PY_TGT="${PY_TGT}" -e BUILD_TARGET="${BUILD_TARGET}" "${NAMEPREFIX}-${UNIQUE_ID}" bash -c '
         set -o pipefail
-        CXXFLAGS="-O3" CFLAGS="-O3 ${DARWIN_C_SOURCE}" ADD_COMMIT_SHA=1 BUILD_CFG=Release uv run ./nix/build-all.py -v ${PY_TGT:+-$PY_TGT} --diskcleanup ${BUILD_TARGET} 2>&1 | tee build.log
+        CXXFLAGS="-O3" CFLAGS="-O3 ${DARWIN_C_SOURCE}" ADD_COMMIT_SHA=1 BUILD_CFG=Release uv run ./nix/build-all.py -v ${PY_TGT:+-$PY_TGT} --diskcleanup --ifcopenshell-shared ${BUILD_TARGET} 2>&1 | tee build.log
     '
     echo "🎒 Pack Dependencies"
     docker exec -i -w "${WORKDIR}" "${NAMEPREFIX}-${UNIQUE_ID}" bash -c '


### PR DESCRIPTION
`docker/README.md` tells developers to build with `./ifcos_env build`, which invokes `build-all.py` without `--ifcopenshell-shared`. Both CI workflows pass that flag:

- `.github/workflows/build_rocky.yml`
- `.github/workflows/build_osx.yml`

so the configuration CI builds and ships is not the one the documented developer workflow produces.

The difference is not cosmetic. Defaulting to static links a private copy of OCCT into every serializer plugin, each built `-fvisibility=hidden` so the copies are not interposable. Shapes created in `ifcopenshell_geometry_kernel_opencascade.so` then fail handle downcasts against the SVG plugin's own OCCT instance, and `IfcConvert model.ifc out.svg` aborts with `Standard_NoSuchObject` on nearly every element. OBJ and GLB output from the same binary is fine, because those serializers consume triangulated output and never cross the boundary, so the failure presents as an SVG or model problem rather than a build one.

Full diagnosis and backtrace in #9398.

To check whether a given build is affected:

```
readelf -d <install>/lib64/ifcopenshell_geometry_svg.so | grep -c "NEEDED.*libTK"
```

0 means the plugin carries its own static OCCT; a correct build reports 48.

This PR changes one line so the developer build matches CI. It does not attempt to make the fully static configuration work; if that configuration is meant to be supported, this is a workaround and #9398 is the real bug.

---

This change was generated with the assistance of an AI coding tool.
