### PR TITLE
Bonsai: stop pset panels crashing on a stale or absent definition id

### DIFF
--- a/src/bonsai/bonsai/bim/module/pset/data.py
+++ b/src/bonsai/bonsai/bim/module/pset/data.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any
+from typing import Any, Union
 
 import bpy
 import ifcopenshell
@@ -50,7 +50,13 @@ def refresh():
 
 class Data:
     @classmethod
-    def psetqtos(cls, element: ifcopenshell.entity_instance, psets_only: bool = False, qtos_only: bool = False):
+    def psetqtos(
+        cls, element: Union[ifcopenshell.entity_instance, None], psets_only: bool = False, qtos_only: bool = False
+    ):
+        # A stale or absent ifc_definition_id resolves to None; render no psets
+        # instead of aborting every panel draw that shares this data class.
+        if element is None:
+            return []
         ifc_file = tool.Ifc.get()
         results = []
         psetqtos = ifcopenshell.util.element.get_psets(
@@ -185,7 +191,7 @@ class MaterialPsetsData(Data):
 
         cls.data = {
             "ifc_definition_id": ifc_definition_id,
-            "psets": cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id)),
+            "psets": cls.psetqtos(tool.Ifc.get_entity_by_id(ifc_definition_id)),
             "pset_name": cls.pset_name(),
         }
         cls.is_loaded = True
@@ -195,7 +201,9 @@ class MaterialPsetsData(Data):
         props = tool.Material.get_material_props()
         if material := props.active_material:
             if material.ifc_definition_id:
-                material = tool.Ifc.get().by_id(material.ifc_definition_id)
+                material = tool.Ifc.get_entity_by_id(material.ifc_definition_id)
+                if material is None:
+                    return []
                 category = getattr(material, "Category", None) or None
                 psets = bonsai.bim.schema.ifc.psetqto.get_applicable(
                     props.material_type, category, pset_only=True, schema=tool.Ifc.get_schema()
@@ -219,7 +227,7 @@ class MaterialSetItemPsetsData(Data):
         assert obj
         ifc_definition_id = tool.Material.get_object_material_props(obj).active_material_set_item_id
         if ifc_definition_id:
-            psets = cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id))
+            psets = cls.psetqtos(tool.Ifc.get_entity_by_id(ifc_definition_id))
         cls.data = {"psets": psets}
         cls.is_loaded = True
 
@@ -233,7 +241,7 @@ class TaskQtosData(Data):
         wprops = tool.Sequence.get_work_schedule_props()
         tprops = tool.Sequence.get_task_tree_props()
         ifc_definition_id = tprops.tasks[wprops.active_task_index].ifc_definition_id
-        cls.data = {"qtos": cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id), qtos_only=True)}
+        cls.data = {"qtos": cls.psetqtos(tool.Ifc.get_entity_by_id(ifc_definition_id), qtos_only=True)}
         cls.is_loaded = True
 
 
@@ -246,7 +254,7 @@ class ResourceQtosData(Data):
         active_resource = tool.Resource.get_resource_props().active_resource
         assert active_resource
         ifc_definition_id = active_resource.ifc_definition_id
-        cls.data = {"qtos": cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id), qtos_only=True)}
+        cls.data = {"qtos": cls.psetqtos(tool.Ifc.get_entity_by_id(ifc_definition_id), qtos_only=True)}
         cls.is_loaded = True
 
 
@@ -259,7 +267,7 @@ class ResourcePsetsData(Data):
         active_resource = tool.Resource.get_resource_props().active_resource
         assert active_resource
         ifc_definition_id = active_resource.ifc_definition_id
-        cls.data = {"psets": cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id), psets_only=True)}
+        cls.data = {"psets": cls.psetqtos(tool.Ifc.get_entity_by_id(ifc_definition_id), psets_only=True)}
         cls.is_loaded = True
 
 
@@ -298,7 +306,7 @@ class ProfilePsetsData(Data):
         active_profile = tool.Profile.get_active_profile_ui()
         if active_profile:
             ifc_definition_id = active_profile.ifc_definition_id
-            psets_data = cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id), psets_only=True)
+            psets_data = cls.psetqtos(tool.Ifc.get_entity_by_id(ifc_definition_id), psets_only=True)
         else:
             ifc_definition_id = 0
             psets_data = []
@@ -318,7 +326,7 @@ class WorkSchedulePsetsData(Data):
     def load(cls):
         props = tool.Sequence.get_work_schedule_props()
         ifc_definition_id = props.active_work_schedule_id
-        cls.data = {"psets": cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id), psets_only=True)}
+        cls.data = {"psets": cls.psetqtos(tool.Ifc.get_entity_by_id(ifc_definition_id), psets_only=True)}
         cls.is_loaded = True
 
 
@@ -332,7 +340,7 @@ class ZonePsetsData(Data):
         assert (active_zone := props.active_zone)
         ifc_definition_id = active_zone.ifc_definition_id
         cls.data = {
-            "psets": (cls.psetqtos(tool.Ifc.get().by_id(ifc_definition_id), psets_only=True)),
+            "psets": (cls.psetqtos(tool.Ifc.get_entity_by_id(ifc_definition_id), psets_only=True)),
         }
         cls.is_loaded = True
 

--- a/src/bonsai/bonsai/tool/ifc.py
+++ b/src/bonsai/bonsai/tool/ifc.py
@@ -165,6 +165,8 @@ class Ifc(bonsai.core.tool.Ifc):
     @classmethod
     def get_entity_by_id(cls, entity_id: int) -> Union[ifcopenshell.entity_instance, None]:
         """useful to check whether entity_id is still exists in IFC"""
+        if not entity_id:
+            return None
         ifc_file = tool.Ifc.get()
         try:
             return ifc_file.by_id(entity_id)

--- a/src/bonsai/test/tool/test_ifc.py
+++ b/src/bonsai/test/tool/test_ifc.py
@@ -343,3 +343,30 @@ class TestUri(test.bim.bootstrap.NewFile):
 
             rel_path = "../" + link_name
             assert subject.normalize_path(rel_path) == rel_path
+
+
+class TestGetEntityById(test.bim.bootstrap.NewFile):
+    def test_returns_the_instance_for_a_live_id(self):
+        ifc = ifcopenshell.file()
+        subject.set(ifc)
+        wall = ifc.createIfcWall()
+        assert subject.get_entity_by_id(wall.id()) == wall
+
+    def test_returns_none_for_a_removed_id(self):
+        ifc = ifcopenshell.file()
+        subject.set(ifc)
+        wall = ifc.createIfcWall()
+        wall_id = wall.id()
+        ifc.remove(wall)
+        assert subject.get_entity_by_id(wall_id) is None
+
+    def test_returns_none_for_an_id_never_allocated(self):
+        ifc = ifcopenshell.file()
+        subject.set(ifc)
+        assert subject.get_entity_by_id(99999) is None
+
+    def test_returns_none_for_a_falsy_id(self):
+        ifc = ifcopenshell.file()
+        subject.set(ifc)
+        assert subject.get_entity_by_id(0) is None
+        assert subject.get_entity_by_id(None) is None


### PR DESCRIPTION
Fixes #9373.

**What the reporter hit.** Deleting a wall while its material was active in the Materials panel leaves `props.active_material.ifc_definition_id` pointing at a removed instance. `MaterialPsetsData.load()` (`pset/data.py:188`) feeds that id straight into `file.by_id()`, which raises `RuntimeError: Instance #8788 not found` on every redraw, and the whole properties panel stops drawing. The reporter's traceback matches this line for line.

**The same shape, eight more times.** `pset/data.py` has eight data classes using the raw `tool.Ifc.get().by_id(ifc_definition_id)` idiom (material set items, task and resource qtos, resource and work schedule psets, profiles, zones), all one stale id away from the same panel-killing crash. The two Group classes already resolve through `tool.Ifc.get_entity_by_id()`, but still crash one call later: `get_psets(None)` dereferences `element.file`. And `by_id(None)` returns `None` silently while `by_id(0)` raises, so the "no active material" path was crossing that inconsistency on every load.

**Fix, guarded once at the choke points:**
- `Data.psetqtos()` renders no psets for a `None` element instead of aborting the draw.
- `tool.Ifc.get_entity_by_id()` also returns `None` for a falsy id.
- The eight raw call sites route through `get_entity_by_id()`, matching the Group classes.
- `MaterialPsetsData.pset_name()` guards its own stale lookup.

**Verified live**, headless Blender 5.2 via `runpytest.py`: `test/tool/test_ifc.py` 30 passed, of which 4 are new `TestGetEntityById` cases (live id, removed id, never-allocated id, falsy id). The removed-id case is the reporter's scenario at the helper level. The panel redraw loop itself is not covered by the test harness; the RED evidence for that is the reporter's traceback.

The reporter's second error (`KeyError: 'mode'` after restarting Blender) is a different, already-fixed bug: `ViewportData.load()` was left half-loaded by an earlier exception, fixed by `1961cd905e` (2026-05-28). If their build predates it, updating picks it up.
