### PR TITLE
ifc5d: evaluate IfcEarthworksCut quantities against the host, not the subtraction solid (#9376)

### DIFF
--- a/src/bonsai/bonsai/bim/module/qto/calculator.py
+++ b/src/bonsai/bonsai/bim/module/qto/calculator.py
@@ -647,6 +647,39 @@ def get_void_intersection_mesh(o: bpy.types.Object) -> Optional[bpy.types.Mesh]:
         delete_mesh(gross_mesh)
 
 
+# Per-take-off-run memo for the void intersection, keyed by object name.
+# One BOOLEAN evaluation serves all four quantities of an element; the qto
+# engine clears it at the start of every calculate() run.
+_void_result_cache: dict[str, Union[tuple[float, "VectorTuple"], None]] = {}
+
+
+def clear_void_cache() -> None:
+    _void_result_cache.clear()
+
+
+def _get_void_result(o: bpy.types.Object) -> Union[tuple[float, "VectorTuple"], None]:
+    """(volume, extents) of the host intersection, or None if o voids nothing."""
+    key = o.name
+    if key in _void_result_cache:
+        return _void_result_cache[key]
+    mesh = get_void_intersection_mesh(o)
+    if mesh is None:
+        result = None
+    else:
+        bm = get_bmesh_from_mesh(mesh)
+        volume = bm.calc_volume()
+        bm.free()
+        if not mesh.vertices:
+            extents = (0.0, 0.0, 0.0)
+        else:
+            coords = [v.co for v in mesh.vertices]
+            extents = tuple(max(c[i] for c in coords) - min(c[i] for c in coords) for i in range(3))
+        delete_mesh(mesh)
+        result = (volume, extents)
+    _void_result_cache[key] = result
+    return result
+
+
 def get_void_volume(o: bpy.types.Object) -> float:
     """Calculate the volume actually removed from the host voided by this element.
 
@@ -657,14 +690,10 @@ def get_void_volume(o: bpy.types.Object) -> float:
     :param o: Blender object
     :return float: volume
     """
-    mesh = get_void_intersection_mesh(o)
-    if mesh is None:
+    result = _get_void_result(o)
+    if result is None:
         return get_net_volume(o)
-    bm = get_bmesh_from_mesh(mesh)
-    volume = bm.calc_volume()
-    bm.free()
-    delete_mesh(mesh)
-    return volume
+    return result[0]
 
 
 def get_void_extents(o: bpy.types.Object) -> Optional[VectorTuple]:
@@ -673,16 +702,10 @@ def get_void_extents(o: bpy.types.Object) -> Optional[VectorTuple]:
     :param o: Blender object
     :return: (x, y, z) extents, or None if the element voids nothing
     """
-    mesh = get_void_intersection_mesh(o)
-    if mesh is None:
+    result = _get_void_result(o)
+    if result is None:
         return None
-    if not mesh.vertices:
-        extents = (0.0, 0.0, 0.0)
-    else:
-        coords = [v.co for v in mesh.vertices]
-        extents = tuple(max(c[i] for c in coords) - min(c[i] for c in coords) for i in range(3))
-    delete_mesh(mesh)
-    return extents
+    return result[1]
 
 
 def get_void_length(o: bpy.types.Object) -> float:

--- a/src/bonsai/bonsai/bim/module/qto/calculator.py
+++ b/src/bonsai/bonsai/bim/module/qto/calculator.py
@@ -611,6 +611,125 @@ def has_openings(obj: bpy.types.Object) -> list[ifcopenshell.entity_instance]:
     return [o for o in ifcopenshell.util.element.get_openings(element)]
 
 
+def get_void_intersection_mesh(o: bpy.types.Object) -> Optional[bpy.types.Mesh]:
+    """Boolean-intersect a voiding feature element with its host's gross geometry.
+
+    :param o: Blender object of an IfcFeatureElementSubtraction (e.g. IfcEarthworksCut)
+    :return: World-space intersection mesh (the caller must delete it), or None
+        if the element voids nothing or the host has no Blender object
+    """
+    element = tool.Ifc.get_entity(o)
+    if not element:
+        return None
+    rels = getattr(element, "VoidsElements", None)
+    if not rels:
+        return None
+    host = rels[0].RelatingBuildingElement
+    host_obj = tool.Ifc.get_object(host)
+    if not isinstance(host_obj, bpy.types.Object):
+        return None
+    gross_mesh = get_gross_element_mesh(host)
+    temp_host = bpy.data.objects.new("QtoVoidHost", gross_mesh)
+    bpy.context.scene.collection.objects.link(temp_host)
+    try:
+        temp_host.matrix_world = host_obj.matrix_world.copy()
+        modifier = temp_host.modifiers.new("QtoVoidIntersection", "BOOLEAN")
+        assert isinstance(modifier, bpy.types.BooleanModifier)
+        modifier.operation = "INTERSECT"
+        modifier.solver = "EXACT"
+        modifier.object = o
+        depsgraph = bpy.context.evaluated_depsgraph_get()
+        mesh = bpy.data.meshes.new_from_object(temp_host.evaluated_get(depsgraph))
+        mesh.transform(temp_host.matrix_world)
+        return mesh
+    finally:
+        delete_obj(temp_host)
+        delete_mesh(gross_mesh)
+
+
+def get_void_volume(o: bpy.types.Object) -> float:
+    """Calculate the volume actually removed from the host voided by this element.
+
+    Subtraction solids are deliberately oversized, so the element's own volume
+    overstates the removed material. Falls back to the element's own net volume
+    when it voids nothing.
+
+    :param o: Blender object
+    :return float: volume
+    """
+    mesh = get_void_intersection_mesh(o)
+    if mesh is None:
+        return get_net_volume(o)
+    bm = get_bmesh_from_mesh(mesh)
+    volume = bm.calc_volume()
+    bm.free()
+    delete_mesh(mesh)
+    return volume
+
+
+def get_void_extents(o: bpy.types.Object) -> Optional[VectorTuple]:
+    """Calculate the world-axis extents of the material removed from the voided host.
+
+    :param o: Blender object
+    :return: (x, y, z) extents, or None if the element voids nothing
+    """
+    mesh = get_void_intersection_mesh(o)
+    if mesh is None:
+        return None
+    if not mesh.vertices:
+        extents = (0.0, 0.0, 0.0)
+    else:
+        coords = [v.co for v in mesh.vertices]
+        extents = tuple(max(c[i] for c in coords) - min(c[i] for c in coords) for i in range(3))
+    delete_mesh(mesh)
+    return extents
+
+
+def get_void_length(o: bpy.types.Object) -> float:
+    """Calculate the length of the material actually removed from the voided host.
+
+    The larger horizontal extent of the intersection with the host's gross
+    geometry. Falls back to the element's own length when it voids nothing.
+
+    :param o: Blender object
+    :return float: length
+    """
+    extents = get_void_extents(o)
+    if extents is None:
+        return get_length(o)
+    return max(extents[0], extents[1])
+
+
+def get_void_width(o: bpy.types.Object) -> float:
+    """Calculate the width of the material actually removed from the voided host.
+
+    The smaller horizontal extent of the intersection with the host's gross
+    geometry. Falls back to the element's own width when it voids nothing.
+
+    :param o: Blender object
+    :return float: width
+    """
+    extents = get_void_extents(o)
+    if extents is None:
+        return get_width(o)
+    return min(extents[0], extents[1])
+
+
+def get_void_height(o: bpy.types.Object) -> float:
+    """Calculate the height (e.g. excavation depth) of the material actually removed from the voided host.
+
+    The vertical extent of the intersection with the host's gross geometry.
+    Falls back to the element's own height when it voids nothing.
+
+    :param o: Blender object
+    :return float: height
+    """
+    extents = get_void_extents(o)
+    if extents is None:
+        return get_height(o)
+    return extents[2]
+
+
 def get_obj_decompositions(obj: bpy.types.Object) -> set[ifcopenshell.entity_instance]:
     element = tool.Ifc.get_entity(obj)
     assert element

--- a/src/bonsai/test/tool/test_qto.py
+++ b/src/bonsai/test/tool/test_qto.py
@@ -24,6 +24,7 @@ import ifcopenshell.api.cost
 import ifcopenshell.api.pset
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
+import ifcopenshell.guid
 import ifcopenshell.util.pset
 
 import bonsai.bim.import_ifc as import_ifc
@@ -218,3 +219,65 @@ class TestGetRelatedCostItemQuantities(test.bim.bootstrap.NewFile):
         assert subject.get_related_cost_item_quantities(wall)[0]["quantity_name"] == "NetVolume"
         assert subject.get_related_cost_item_quantities(wall)[0]["quantity_value"] == 42
         assert subject.get_related_cost_item_quantities(wall)[0]["quantity_type"] == "IfcQuantityVolume"
+
+
+class TestGetCalculatedVoidQuantities(test.bim.bootstrap.NewFile):
+    def test_earthworks_cut_quantities_measure_the_removed_material(self):
+        # The subtraction solid is deliberately oversized, so quantities must be
+        # evaluated against the voided host, not the solid itself (#9376).
+        import logging
+
+        import ifc5d.qto
+
+        self.ifc = ifcopenshell.file(schema="IFC4X3")
+        tool.Ifc.set(self.ifc)
+        ifcopenshell.api.root.create_entity(self.ifc, ifc_class="IfcProject", name="My Project")
+        ifcopenshell.api.unit.assign_unit(
+            self.ifc,
+            length={"is_metric": True, "raw": "METERS"},
+            area={"is_metric": True, "raw": "SQUARE_METERS"},
+            volume={"is_metric": True, "raw": "CUBIC_METERS"},
+        )
+        ifc_import_settings = import_ifc.IfcImportSettings.factory(
+            bpy.context, tool.Ifc.get_path(), logging.getLogger("ImportIFC")
+        )
+        ifc_importer = import_ifc.IfcImporter(ifc_import_settings)
+        ifc_importer.file = self.ifc
+        ifc_importer.create_project()
+        context = ifcopenshell.api.context.add_context(self.ifc, context_type="Model")
+
+        # Host box spanning z 0..2, cut box spanning z 1..3: only a 2x2x1 slab
+        # of the host is actually removed, while the solid itself is 2x2x2.
+        bpy.ops.mesh.primitive_cube_add(location=(0.0, 0.0, 1.0), size=2)
+        host_obj = bpy.context.active_object
+        host = bonsai.core.root.assign_class(
+            tool.Ifc, tool.Collector, tool.Root, obj=host_obj, ifc_class="IfcGeographicElement", context=context
+        )
+        bpy.ops.mesh.primitive_cube_add(location=(0.0, 0.0, 2.0), size=2)
+        cut_obj = bpy.context.active_object
+        cut = bonsai.core.root.assign_class(
+            tool.Ifc, tool.Collector, tool.Root, obj=cut_obj, ifc_class="IfcEarthworksCut", context=context
+        )
+        self.ifc.createIfcRelVoidsElement(ifcopenshell.guid.new(), None, None, None, host, cut)
+
+        rules = {
+            "calculators": {
+                "Blender": {
+                    "IfcEarthworksCut": {
+                        "Qto_EarthworksCutBaseQuantities": {
+                            "Depth": "get_void_height",
+                            "Length": "get_void_length",
+                            "UndisturbedVolume": "get_void_volume",
+                            "Width": "get_void_width",
+                        }
+                    },
+                }
+            }
+        }
+        results = ifc5d.qto.quantify(self.ifc, {cut}, rules)
+        quantities = {k: round(v, 3) for k, v in results[cut]["Qto_EarthworksCutBaseQuantities"].items()}
+
+        assert quantities["UndisturbedVolume"] == 4.0
+        assert quantities["Depth"] == 1.0
+        assert quantities["Length"] == 2.0
+        assert quantities["Width"] == 2.0

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json
@@ -265,12 +265,12 @@
             },
             "IfcEarthworksCut": {
                 "Qto_EarthworksCutBaseQuantities": {
-                    "Depth": "net_get_z",
-                    "Length": "net_get_x",
+                    "Depth": "net_get_void_z",
+                    "Length": "net_get_void_x",
                     "LooseVolume": null,
-                    "UndisturbedVolume": "net_get_volume",
+                    "UndisturbedVolume": "net_get_void_volume",
                     "Weight": null,
-                    "Width": "net_get_y"
+                    "Width": "net_get_void_y"
                 }
             },
             "IfcEarthworksFill": {

--- a/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
+++ b/src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json
@@ -265,12 +265,12 @@
             },
             "IfcEarthworksCut": {
                 "Qto_EarthworksCutBaseQuantities": {
-                    "Depth": "get_height",
-                    "Length": "get_length",
+                    "Depth": "get_void_height",
+                    "Length": "get_void_length",
                     "LooseVolume": null,
-                    "UndisturbedVolume": "get_net_volume",
+                    "UndisturbedVolume": "get_void_volume",
                     "Weight": null,
-                    "Width": "get_width"
+                    "Width": "get_void_width"
                 }
             },
             "IfcEarthworksFill": {

--- a/src/ifc5d/ifc5d/qto.py
+++ b/src/ifc5d/ifc5d/qto.py
@@ -26,6 +26,8 @@ from collections import defaultdict
 from collections.abc import Iterable
 from typing import Any, Literal, NamedTuple, Union, get_args
 
+import numpy as np
+
 import ifcopenshell
 import ifcopenshell.api.pset
 import ifcopenshell.geom
@@ -292,6 +294,21 @@ class IfcOpenShell(QtoCalculator):
             "The covering's thickness: the side area axis for AXIS2 (e.g. wall finishes), "
             "otherwise the local Z depth (e.g. floor or ceiling finishes)",
         ),
+        "get_void_x": Function(
+            "IfcLengthMeasure",
+            "Void X",
+            "The X extent of the material actually removed from the host voided by this element",
+        ),
+        "get_void_y": Function(
+            "IfcLengthMeasure",
+            "Void Y",
+            "The Y extent of the material actually removed from the host voided by this element",
+        ),
+        "get_void_z": Function(
+            "IfcLengthMeasure",
+            "Void Z",
+            "The Z extent (e.g. excavation depth) of the material actually removed from the host voided by this element",
+        ),
         # IfcAreaMeasure
         "get_area": Function("IfcAreaMeasure", "Area", "The total surface area of the element"),
         "get_covering_area": Function(
@@ -330,6 +347,11 @@ class IfcOpenShell(QtoCalculator):
         ),
         # IfcVolumeMeasure
         "get_volume": Function("IfcVolumeMeasure", "Volume", "Calculates the volume of a manifold shape"),
+        "get_void_volume": Function(
+            "IfcVolumeMeasure",
+            "Void Volume",
+            "The volume of the material actually removed from the host voided by this element",
+        ),
         # IfcMassMeasure
         "get_weight": Function(
             "IfcMassMeasure",
@@ -357,6 +379,10 @@ class IfcOpenShell(QtoCalculator):
     internal_functions = (
         "get_segment_length",
         "get_weight",
+        "get_void_x",
+        "get_void_y",
+        "get_void_z",
+        "get_void_volume",
         "get_opening_width",
         "get_opening_height",
         "get_opening_depth",
@@ -373,6 +399,7 @@ class IfcOpenShell(QtoCalculator):
         cls.gross_settings.set("disable-opening-subtractions", True)
         cls.net_settings = ifcopenshell.geom.settings()
         cls.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
+        cls._void_shape_cache = {}
 
         gross_qtos: QtosFormulas = {}
         net_qtos: QtosFormulas = {}
@@ -430,6 +457,11 @@ class IfcOpenShell(QtoCalculator):
                             elif formula.startswith("get_opening_"):
                                 value = cls.get_opening_quantity(geometry, formula)
                                 value = cls.unit_converter.convert(value, IfcOpenShell.raw_functions[formula].measure)
+                            elif formula.startswith("get_void_"):
+                                value = cls.get_void_quantity(element, geometry, formula)
+                                if value is None:
+                                    continue
+                                value = cls.unit_converter.convert(value, cls.raw_functions[formula].measure)
                             elif formula in cls.footing_functions:
                                 value = getattr(cls, formula)(element, geometry)
                                 if value is None:
@@ -448,6 +480,8 @@ class IfcOpenShell(QtoCalculator):
                             results[element][name][quantity] = value
                     if not iterator.next():
                         break
+
+        cls._void_shape_cache = {}
 
     @staticmethod
     def create_iterators(
@@ -492,6 +526,66 @@ class IfcOpenShell(QtoCalculator):
         if is_horizontal:
             return ifcopenshell.util.shape.get_footprint_area(geometry)
         return ifcopenshell.util.shape.get_side_area(geometry)
+
+    @classmethod
+    def _create_void_shape(cls, element, settings):
+        key = (element.id(), settings is cls.gross_settings)
+        if key not in cls._void_shape_cache:
+            try:
+                cls._void_shape_cache[key] = ifcopenshell.geom.create_shape(settings, element)
+            except RuntimeError:
+                cls._void_shape_cache[key] = None
+        return cls._void_shape_cache[key]
+
+    @classmethod
+    def get_void_quantity(
+        cls, element: ifcopenshell.entity_instance, geometry: ifcopenshell.geom.ShapeType, formula: str
+    ) -> Union[float, None]:
+        """Get a dimension or the volume of the material actually removed from the voided host.
+
+        Subtraction solids are deliberately modelled oversized, so the feature's
+        own shape systematically overstates what is excavated from the host (#9376).
+        The volume is the host's gross volume minus its net volume, which is exact
+        when this feature is the host's only void; with several voids it cannot be
+        attributed to one feature, so ``None`` is returned rather than a wrong
+        number. Dimensions are the extents of the world-space bounding box
+        intersection between the feature and the host's gross shape, exact for
+        axis-aligned box cuts and an upper bound otherwise. An element that voids
+        nothing is measured on its own shape.
+
+        :param element: IFC element entity.
+        :param geometry: The element's own geometry output.
+        :param formula: One of the ``get_void_*`` internal function names.
+        :return: The quantity in SI units, or ``None`` if it cannot be derived.
+        """
+        rels = getattr(element, "VoidsElements", None)
+        if not rels:
+            if formula == "get_void_volume":
+                return ifcopenshell.util.shape.get_volume(geometry)
+            return getattr(ifcopenshell.util.shape, f"get_{formula[-1]}")(geometry)
+        host = rels[0].RelatingBuildingElement
+        if formula == "get_void_volume":
+            if len(host.HasOpenings) != 1:
+                return None
+            gross_shape = cls._create_void_shape(host, cls.gross_settings)
+            net_shape = cls._create_void_shape(host, cls.net_settings)
+            if gross_shape is None or net_shape is None:
+                return None
+            gross_volume = ifcopenshell.util.shape.get_volume(gross_shape.geometry)
+            net_volume = ifcopenshell.util.shape.get_volume(net_shape.geometry)
+            return gross_volume - net_volume
+        host_shape = cls._create_void_shape(host, cls.gross_settings)
+        cut_shape = cls._create_void_shape(element, cls.net_settings)
+        if host_shape is None or cut_shape is None:
+            return None
+        cut_verts = ifcopenshell.util.shape.get_shape_vertices(cut_shape, cut_shape.geometry)
+        host_verts = ifcopenshell.util.shape.get_shape_vertices(host_shape, host_shape.geometry)
+        if not len(cut_verts) or not len(host_verts):
+            return None
+        lower = np.maximum(cut_verts.min(axis=0), host_verts.min(axis=0))
+        upper = np.minimum(cut_verts.max(axis=0), host_verts.max(axis=0))
+        extents = np.maximum(upper - lower, 0.0)
+        return float(extents["xyz".index(formula[-1])])
 
     @classmethod
     def get_segment_length(cls, element: ifcopenshell.entity_instance) -> Union[float, None]:
@@ -677,6 +771,9 @@ class Blender(QtoCalculator):
         "get_footing_height": Function("IfcLengthMeasure", "Height", ""),
         "get_footing_length": Function("IfcLengthMeasure", "Length", ""),
         "get_footing_width": Function("IfcLengthMeasure", "Width", ""),
+        "get_void_height": Function("IfcLengthMeasure", "Void Height", ""),
+        "get_void_length": Function("IfcLengthMeasure", "Void Length", ""),
+        "get_void_width": Function("IfcLengthMeasure", "Void Width", ""),
         # IfcAreaMeasure
         "get_covering_gross_area": Function("IfcAreaMeasure", "Covering Gross Area", ""),
         "get_covering_net_area": Function("IfcAreaMeasure", "Covering Net Area", ""),
@@ -700,6 +797,7 @@ class Blender(QtoCalculator):
         "get_gross_volume": Function("IfcVolumeMeasure", "Gross Volume", ""),
         "get_net_volume": Function("IfcVolumeMeasure", "Net Volume", ""),
         "get_space_net_volume": Function("IfcVolumeMeasure", "Space Net Volume", ""),
+        "get_void_volume": Function("IfcVolumeMeasure", "Void Volume", ""),
         # IfcMassMeasure
         "get_gross_weight": Function("IfcMassMeasure", "Gross Weight", ""),
         "get_net_weight": Function("IfcMassMeasure", "Net Weight", ""),

--- a/src/ifc5d/ifc5d/qto.py
+++ b/src/ifc5d/ifc5d/qto.py
@@ -827,6 +827,7 @@ class Blender(QtoCalculator):
         import bonsai.bim.module.qto.calculator as calculator
         import bonsai.tool as tool
 
+        calculator.clear_void_cache()
         unit_converter = SI2ProjectUnitConverter(ifc_file)
         formula_functions: dict[str, types.FunctionType] = {}
 

--- a/src/ifc5d/test/test_qto.py
+++ b/src/ifc5d/test/test_qto.py
@@ -20,6 +20,7 @@
 
 import ifcopenshell
 import ifcopenshell.api.context
+import ifcopenshell.guid
 import ifcopenshell.api.root
 import ifcopenshell.api.unit
 import pytest
@@ -90,3 +91,80 @@ class TestOpeningQuantities:
         assert quantities["Depth"] == pytest.approx(0.3)
         assert quantities["Area"] == pytest.approx(0.5)
         assert quantities["Volume"] == pytest.approx(0.15)
+
+
+class TestEarthworksCutQuantities:
+    """Quantities must measure the material removed from the host, not the oversized subtraction solid (#9376)."""
+
+    def setup_method(self):
+        self.file = ifcopenshell.file(schema="IFC4X3")
+        ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject", name="Test")
+        f = self.file
+        units = [
+            f.createIfcSIUnit(None, "LENGTHUNIT", None, "METRE"),
+            f.createIfcSIUnit(None, "AREAUNIT", None, "SQUARE_METRE"),
+            f.createIfcSIUnit(None, "VOLUMEUNIT", None, "CUBIC_METRE"),
+        ]
+        ifcopenshell.api.unit.assign_unit(self.file, units=units)
+        model = ifcopenshell.api.context.add_context(self.file, context_type="Model")
+        self.body = ifcopenshell.api.context.add_context(
+            self.file, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=model
+        )
+
+    def create_box(self, ifc_class: str, size_x: float, size_y: float, size_z: float, origin):
+        """An axis-aligned box spanning origin .. origin + size on each axis."""
+        f = self.file
+        element = ifcopenshell.api.root.create_entity(f, ifc_class=ifc_class)
+        element.ObjectPlacement = f.createIfcLocalPlacement(
+            None, f.createIfcAxis2Placement3D(f.createIfcCartesianPoint((0.0, 0.0, 0.0)), None, None)
+        )
+        profile = f.createIfcRectangleProfileDef("AREA", None, None, size_x, size_y)
+        position = f.createIfcAxis2Placement3D(
+            f.createIfcCartesianPoint((origin[0] + size_x / 2, origin[1] + size_y / 2, origin[2])), None, None
+        )
+        solid = f.createIfcExtrudedAreaSolid(profile, position, f.createIfcDirection((0.0, 0.0, 1.0)), size_z)
+        rep = f.createIfcShapeRepresentation(self.body, "Body", "SweptSolid", [solid])
+        element.Representation = f.createIfcProductDefinitionShape(None, None, [rep])
+        return element
+
+    def void(self, host, cut):
+        self.file.createIfcRelVoidsElement(ifcopenshell.guid.new(), None, None, None, host, cut)
+
+    def quantify(self, cut) -> dict[str, float]:
+        rules = ifc5d.qto.rules["IFC4X3QtoBaseQuantities"]
+        results = ifc5d.qto.quantify(self.file, {cut}, rules)
+        return results[cut]["Qto_EarthworksCutBaseQuantities"]
+
+    def test_cut_voiding_a_host(self):
+        # Host terrain 10 x 10 x 2; the 2 x 2 x 3 subtraction solid is oversized,
+        # protruding 2m above the host top, so only 2 x 2 x 1 is actually removed.
+        host = self.create_box("IfcGeographicElement", 10.0, 10.0, 2.0, (0.0, 0.0, 0.0))
+        cut = self.create_box("IfcEarthworksCut", 2.0, 2.0, 3.0, (4.0, 4.0, 1.0))
+        self.void(host, cut)
+        quantities = self.quantify(cut)
+        assert quantities["UndisturbedVolume"] == pytest.approx(4.0)
+        assert quantities["Depth"] == pytest.approx(1.0)
+        assert quantities["Length"] == pytest.approx(2.0)
+        assert quantities["Width"] == pytest.approx(2.0)
+
+    def test_cut_on_host_with_several_voids_omits_the_volume(self):
+        # Gross minus net cannot attribute the removed material to one particular
+        # void, so no volume is written rather than a wrong one.
+        host = self.create_box("IfcGeographicElement", 10.0, 10.0, 2.0, (0.0, 0.0, 0.0))
+        cut = self.create_box("IfcEarthworksCut", 2.0, 2.0, 3.0, (4.0, 4.0, 1.0))
+        other = self.create_box("IfcEarthworksCut", 1.0, 1.0, 3.0, (1.0, 1.0, 1.0))
+        self.void(host, cut)
+        self.void(host, other)
+        quantities = self.quantify(cut)
+        assert "UndisturbedVolume" not in quantities
+        assert quantities["Depth"] == pytest.approx(1.0)
+        assert quantities["Length"] == pytest.approx(2.0)
+        assert quantities["Width"] == pytest.approx(2.0)
+
+    def test_cut_voiding_nothing_measures_its_own_shape(self):
+        cut = self.create_box("IfcEarthworksCut", 2.0, 2.0, 3.0, (4.0, 4.0, 1.0))
+        quantities = self.quantify(cut)
+        assert quantities["UndisturbedVolume"] == pytest.approx(12.0)
+        assert quantities["Depth"] == pytest.approx(3.0)
+        assert quantities["Length"] == pytest.approx(2.0)
+        assert quantities["Width"] == pytest.approx(2.0)


### PR DESCRIPTION
Fixes #9376.

## Root cause

`Qto_EarthworksCutBaseQuantities` for an `IfcEarthworksCut` was calculated on the cut's own subtraction solid:

- `src/ifc5d/ifc5d/IFC4X3QtoBaseQuantitiesBlender.json` line 266: `UndisturbedVolume: get_net_volume`, `Depth: get_height`, `Length: get_length`, `Width: get_width` (all measure the cut's own mesh / bounding box).
- `src/ifc5d/ifc5d/IFC4X3QtoBaseQuantities.json` line 266: the same mapping with `net_get_volume` / `net_get_z` / `net_get_x` / `net_get_y`.

Subtraction solids are deliberately modelled oversized so they reliably pierce the host, so these numbers systematically overstate the excavation. We introduced this mapping ourselves in d506f5df1e (PR #8409, for #6325); the volume of the tool is simply not the volume of the hole, and this PR corrects that.

## Measured on the reporter's model (Test_Grundstueck3.ifc, terrain 10x10x5 m with one BASE_EXCAVATION cut)

Before (both engines):

- UndisturbedVolume = 8.0 m3, Depth = 2.0 m (the solid's own size)

After:

- Blender engine: UndisturbedVolume = 4.083818435668947 m3, Depth = 1.0209546089172363 m, Length = 2.0 m, Width = 2.0 m
- IfcOpenShell engine: UndisturbedVolume = 4.083818048238754 m3, Depth = 1.0209545120596886 m, Length = 2.0 m, Width = 2.0 m

The reporter's expected values are 4.084 m3 and 1.02 m; the two engines agree with each other to within 4e-7 m3, and the host's gross volume (500.0) minus net volume (495.916) gives the same 4.0838 m3.

## What was done

Blender engine (`src/bonsai/bonsai/bim/module/qto/calculator.py`): new `get_void_volume`, `get_void_length`, `get_void_width`, `get_void_height` boolean-intersect (BOOLEAN modifier, INTERSECT, EXACT solver) the voiding feature with its host's gross geometry (openings not applied) in world space, and measure the intersection's volume and extents. An element that voids nothing falls back to the previous own-shape behaviour, so nothing changes for standalone cuts.

IfcOpenShell engine (`src/ifc5d/ifc5d/qto.py`): new internal functions `net_get_void_volume` and `net_get_void_x/y/z`. There is no boolean machinery in this engine, so:

- Volume is the host's gross volume minus its net volume, which is exact when this feature is the host's only void. When the host has several voids the difference cannot be attributed to one feature, so the quantity is omitted rather than written wrongly (the reporter explicitly preferred a missing value over a wrong one; the Blender engine still writes it since the boolean is per feature).
- Dimensions are the extents of the world-space bounding box intersection between the feature and the host's gross shape: exact for axis-aligned box cuts like the reported model, an upper bound otherwise, and never worse than the previous tool-bbox values.

`IfcEarthworksFill` was checked and left untouched: it is an `IfcBuiltElement` (verified against the IFC4X3_ADD2 schema), modelled as its own solid rather than a voiding feature, so `CompactedVolume: get_net_volume` is already conceptually correct for it.

## Tests

- `src/ifc5d/test/test_qto.py`: `TestEarthworksCutQuantities` covers the single-void case (oversized cut, expects the removed 4.0 m3 / 1.0 m instead of the solid's 12.0 m3 / 3.0 m), the several-voids case (volume omitted, dimensions still clamped), and a cut voiding nothing (own-shape behaviour preserved). 5 passed on the branch; with the engine changes reverted to origin/v0.8.0 the new tests fail (2 failed), so they do capture the bug.
- `src/bonsai/test/tool/test_qto.py`: `TestGetCalculatedVoidQuantities` builds a host and a protruding cut in Blender, links them with `IfcRelVoidsElement` and asserts the Blender engine's boolean result (4.0 m3, depth 1.0). Run headless under Blender 5.2 together with the existing `TestGetCalculatedObjectQuantities` (4 passed; the same run fails with the engine changes reverted).
- Existing opening quantity tests in `src/ifc5d/test/test_qto.py` still pass.

Lint: CI-exact black and ruff clean on all touched files.

*This contribution was made with the assistance of an AI coding tool operated by Petru Conduraru.*
