### PR TITLE
Bonsai: keep the comparison operator when a query facet round-trips

### DIFF
--- a/src/bonsai/bonsai/tool/search.py
+++ b/src/bonsai/bonsai/tool/search.py
@@ -659,7 +659,9 @@ class ImportFilterQueryTransformer(lark.Transformer):
 
     def query(self, args):
         keys, comparison, value = args
-        return {"type": "query", "name": keys, "value": f"{comparison}{value}"}
+        # The exporter reads the comparison property for query facets, so the
+        # operator must not be folded into the value (#9352).
+        return {"type": "query", "name": keys, "comparison": comparison or "=", "value": value}
 
     def comparison(self, args):
         if args[0].data == "not":

--- a/src/bonsai/test/tool/test_search_roundtrip.py
+++ b/src/bonsai/test/tool/test_search_roundtrip.py
@@ -1,0 +1,51 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026 Dion Moult <dion@thinkmoult.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+import bonsai.tool as tool
+import test.bim.bootstrap
+from bonsai.tool.search import Search as subject
+
+
+class TestFilterQueryRoundTrip(test.bim.bootstrap.NewFile):
+    """Importing a filter query into the UI facets and exporting it again must not change it."""
+
+    @pytest.mark.parametrize(
+        "query,expected",
+        [
+            ('query:"Name"!=/Test/', 'query:"Name"!=/Test/'),
+            ('query:"Name"=/Test/', 'query:"Name"=/Test/'),
+            # Unquoted values are canonically re-quoted by wrap_value; the
+            # operator and value must still survive unchanged.
+            ('query:"class"=IfcWall', 'query:"class"="IfcWall"'),
+            ("IfcWall, Name!=/Test/", "IfcWall, Name!=/Test/"),
+        ],
+    )
+    def test_round_trip_preserves_the_query(self, query, expected):
+        filter_groups = subject.get_filter_groups("search")
+        subject.import_filter_query(query, filter_groups)
+        assert subject.export_filter_query(filter_groups) == expected
+
+    def test_query_facet_comparison_lands_in_the_comparison_property(self):
+        filter_groups = subject.get_filter_groups("search")
+        subject.import_filter_query('query:"Name"!=/Test/', filter_groups)
+        ifc_filter = filter_groups[0].filters[0]
+        assert ifc_filter.type == "query"
+        assert ifc_filter.comparison == "!="
+        assert ifc_filter.value == "/Test/"


### PR DESCRIPTION
Fixes #9352.

The filter query UI is a lossy round trip, string to facets to string. `ImportFilterQueryTransformer.query()` (`tool/search.py:662`) folded the comparison operator into the value and never set the `comparison` key, while `_export_single_filter`'s query branch reads the `comparison` property. Saving or reloading a filter therefore turned `query:"Name"!=/Test/` into `query:"Name"="!=/Test/"`, silently inverting the search, exactly the reporter's screenshots. The `property` facet already sets the key correctly and the other facet types keep the operator in the value on both sides; `query` was the one mismatch, and `facet_list` already copies a `comparison` key when present, so the fix is that one line.

Verified live in headless Blender 5.2 against this branch's modules: new round-trip tests (in their own file, since `test/tool/test_search.py` does not exist yet on `v0.8.0` and #9401 adds it). RED on unpatched code fails exactly the two `!=` query cases; GREEN 5 passed. One expectation documents that unquoted values are canonically re-quoted by `wrap_value`, which is unchanged behaviour.

No overlap with #9401 (its comment/toggle work auto-merges with this; the merge-tree conflicts between the two branches are unrelated `v0.8.0` base drift in C++ alignment files neither PR touches).