### PR TITLE
Bonsai: fix comma-separated stylesheet paths only applying the last stylesheet

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svgwriter.py
@@ -198,7 +198,10 @@ def parse_markdown_it(text: str) -> list[dict[str, Union[str, None]]]:
 
 class SvgWriter:
     metadata: list[str]
-    resource_paths: dict[tool.Drawing.ResourceType, Union[str, None]]
+    # Resources in MULTI_PATH_RESOURCES are stored as a list of paths, other resources as a single path.
+    resource_paths: dict[tool.Drawing.ResourceType, Union[str, list[str], None]]
+    # Resources that support multiple comma-separated paths.
+    MULTI_PATH_RESOURCES = ("Stylesheet",)
 
     def __init__(
         self,
@@ -248,17 +251,28 @@ class SvgWriter:
             if not resource_path:
                 self.resource_paths[resource] = None
                 continue
-            resource_path = tool.Ifc.resolve_uri(resource_path)
-            os.makedirs(os.path.dirname(resource_path), exist_ok=True)
-            if not os.path.exists(resource_path):
-                resource_basename = os.path.basename(resource_path)
-                ootb_resource = tool.Blender.get_data_dir_path(Path("assets") / resource_basename)
-                print(
-                    f"WARNING. Couldn't find {resource} for the drawing by the path: {resource_path}. Default BBIM resource will be copied from {ootb_resource}"
-                )
-                if os.path.exists(ootb_resource):
-                    shutil.copy(ootb_resource, resource_path)
-            self.resource_paths[resource] = resource_path
+            if resource in self.MULTI_PATH_RESOURCES:
+                # Paths need to be split before they're resolved,
+                # otherwise the entire string is resolved as a single path.
+                self.resource_paths[resource] = [
+                    self.prepare_resource_path(resource, p) for p in resource_path.split(",") if p.strip()
+                ]
+                continue
+            self.resource_paths[resource] = self.prepare_resource_path(resource, resource_path)
+
+    def prepare_resource_path(self, resource: tool.Drawing.ResourceType, resource_path: str) -> str:
+        """Resolve resource path relative to the IFC file, copying the OOTB resource, if it's missing."""
+        resource_path = tool.Ifc.resolve_uri(resource_path.strip())
+        os.makedirs(os.path.dirname(resource_path), exist_ok=True)
+        if not os.path.exists(resource_path):
+            resource_basename = os.path.basename(resource_path)
+            ootb_resource = tool.Blender.get_data_dir_path(Path("assets") / resource_basename)
+            print(
+                f"WARNING. Couldn't find {resource} for the drawing by the path: {resource_path}. Default BBIM resource will be copied from {ootb_resource}"
+            )
+            if os.path.exists(ootb_resource):
+                shutil.copy(ootb_resource, resource_path)
+        return resource_path
 
     def define_boilerplate(self):
         self.add_stylesheet()
@@ -280,13 +294,17 @@ class SvgWriter:
         paths = self.resource_paths["Stylesheet"]
         if not paths:
             return
-        path_list = [p.strip() for p in paths.split(",")]
-        for path in path_list:
+        assert isinstance(paths, list)
+        # Stylesheets are concatenated in the order they're listed, so they cascade naturally.
+        css = []
+        for path in paths:
             if not os.path.exists(path):
                 print(f"WARNING. Couldn't find stylesheet for the drawing by the path: {path}")
                 continue
             with open(path, "r") as stylesheet:
-                self.svg.defs.add(self.svg.style(stylesheet.read()))
+                css.append(stylesheet.read())
+        if css:
+            self.svg.defs.add(self.svg.style("\n".join(css)))
 
     def add_markers(self):
         path = self.resource_paths["Markers"]


### PR DESCRIPTION
Closes #9410.

Follow-up to cb08191083 (#3451), which added comma-separated paths to `EPset_Drawing.Stylesheet` but only ever applied the last stylesheet in the list.

### The problem

The split on commas happened after the value had already been resolved. `setup_drawing_resource_paths()` passed the whole pset string to `tool.Ifc.resolve_uri()` as a single path, and `add_stylesheet()` only split the *resolved* result. Normalization consumes the comma, so for a value like

```
../../../../OD_Submodules/assets/default.css, ../../../../OD_Submodules/assets/life_safety.css
```

the `..` segments following `"default.css, .."` pop it back off along with `assets` and `OD_Submodules`, collapsing everything to `.../OD_Submodules/assets/life_safety.css`. No comma survives, so the split yields one entry — the last file — and since that file exists the failure is silent.

### The fix

- Split the pset value into paths *before* resolving, and resolve each entry independently. Which resources allow multiple paths is declared by `SvgWriter.MULTI_PATH_RESOURCES`, currently `Stylesheet` only; `resource_paths["Stylesheet"]` is now a list.
- The resolve + `makedirs` + OOTB-fallback-copy logic moves into `prepare_resource_path()` so each stylesheet gets the same missing-file handling as before. As a side benefit, the mangled combined path is no longer fed to `os.makedirs()`, which could create a stray directory named after it.
- `add_stylesheet()` concatenates the files in listed order into one `<style>` element instead of emitting several — same cascade, but avoids SVG-to-PDF converters that handle multiple `<style>` blocks inconsistently.

`SvgWriter.resource_paths` is only read inside `svgwriter.py`, so the str-to-list change for `Stylesheet` affects nothing else. The other four resource types keep single-path behaviour.

### Testing

Verified against real files that the old code resolves the two-path example down to `life_safety.css` alone, while the new code resolves both paths and concatenates their CSS in the listed order.
