### PR TITLE
ifctester: apply strict XSD pattern semantics and warn on non-portable patterns

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -20,13 +20,15 @@ from __future__ import annotations
 
 import builtins
 import re
-from functools import lru_cache
+import warnings
+from functools import cache, lru_cache
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict, Union
 
 import ifcopenshell.util.classification
 import ifcopenshell.util.element
 import ifcopenshell.util.unit
+from elementpath.regex import RegexError
 from xmlschema.validators import identities
 
 if TYPE_CHECKING:
@@ -1008,6 +1010,43 @@ class Material(Facet):
         return MaterialResult(is_pass, reason)
 
 
+@cache
+def compile_xsd_pattern(pattern: str) -> re.Pattern:
+    """Compile a restriction pattern using strict XSD xs:pattern semantics."""
+    try:
+        return re.compile(
+            identities.translate_pattern(pattern, back_references=False, lazy_quantifiers=False, anchors=False)
+        )
+    except RegexError:
+        # Not expressible in strict XSD (e.g. back references), so keep the permissive translation.
+        return re.compile(identities.translate_pattern(pattern))
+
+
+@cache
+def get_pattern_portability_issues(pattern: str) -> tuple[str, ...]:
+    """List the non-XSD regex features a restriction pattern relies on."""
+    issues = []
+    try:
+        permissive = identities.translate_pattern(pattern)
+        literal_anchors = identities.translate_pattern(pattern, anchors=False)
+    except RegexError:
+        return ()
+    # With anchors=False the translation is wrapped as "^(...)$(?!\n\Z)".
+    prefix, suffix = "^(", ")$(?!\\n\\Z)"
+    if literal_anchors.startswith(prefix) and literal_anchors.endswith(suffix):
+        if literal_anchors[len(prefix) : -len(suffix)] != permissive:
+            issues.append("anchors")
+    try:
+        identities.translate_pattern(pattern, back_references=False)
+    except RegexError:
+        issues.append("back references")
+    try:
+        identities.translate_pattern(pattern, lazy_quantifiers=False)
+    except RegexError:
+        issues.append("lazy quantifiers")
+    return tuple(issues)
+
+
 class Restriction:
     def __init__(self, options=None, base="string"):
         self.base = base
@@ -1027,6 +1066,16 @@ class Restriction:
                 self.options[key] = value["@value"]
             else:
                 self.options[key] = [v["@value"] for v in value]
+        patterns = self.options.get("pattern")
+        if patterns is not None:
+            for pattern in patterns if isinstance(patterns, list) else [patterns]:
+                issues = get_pattern_portability_issues(pattern)
+                if issues:
+                    warnings.warn(
+                        f'Pattern "{pattern}" relies on regex features outside the XSD subset '
+                        f"({', '.join(issues)}) and will behave differently across IDS validators.",
+                        stacklevel=2,
+                    )
         return self
 
     def asdict(self) -> dict[str, Any]:
@@ -1064,7 +1113,7 @@ class Restriction:
                         return False
                     value = value if isinstance(value, list) else [value]
                     for pattern in value:
-                        if re.compile(identities.translate_pattern(pattern)).fullmatch(other) is None:
+                        if compile_xsd_pattern(pattern).fullmatch(other) is None:
                             return False
                 elif constraint == "length":
                     if len(str(other)) != int(value):

--- a/src/ifctester/test/test_facet.py
+++ b/src/ifctester/test/test_facet.py
@@ -18,6 +18,7 @@
 
 
 import uuid
+import warnings
 
 import ifcopenshell
 import ifcopenshell.api.aggregate
@@ -33,6 +34,7 @@ import ifcopenshell.api.type
 import ifcopenshell.api.unit
 import ifcopenshell.guid
 import ifcopenshell.util.pset
+import pytest
 
 import ifctester.facet
 import ifctester.ids
@@ -1709,6 +1711,29 @@ class TestRestriction:
         assert restriction == "AB01"
         assert restriction != "AB"
         assert restriction != "01"
+
+    def test_pattern_treats_anchors_as_literal_characters(self):
+        restriction = Restriction(options={"pattern": "^.{1,5}$"})
+        assert restriction != "AB"
+        assert restriction == "^AB$"
+
+    def test_pattern_is_implicitly_anchored(self):
+        restriction = Restriction(options={"pattern": ".{1,5}"})
+        assert restriction == "abc"
+        assert restriction != "abcdef"
+
+    def test_pattern_portability_warnings(self):
+        for pattern, feature in (
+            ("^x$", "anchors"),
+            ("(a)\\1", "back references"),
+            ("a+?", "lazy quantifiers"),
+        ):
+            with pytest.warns(UserWarning, match=feature):
+                Restriction().parse({"@base": "xs:string", "xs:pattern": {"@value": pattern}})
+        for pattern in (".{1,5}", "DT[0-9]"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                Restriction().parse({"@base": "xs:string", "xs:pattern": {"@value": pattern}})
 
     def test_filtering_using_restrictions(self):
         set_facet("restriction")


### PR DESCRIPTION
## What

IDS `xs:pattern` restrictions in ifctester were translated with xmlschema's permissive XPath defaults: `translate_pattern(pattern)` with `anchors=True, back_references=True, lazy_quantifiers=True`. Strict XSD `xs:pattern` semantics have no anchors, no back references and no lazy quantifiers, so ifctester could disagree with conformant IDS validators on the same file.

This PR:

1. Translates patterns with `back_references=False, lazy_quantifiers=False, anchors=False` in `Restriction.__eq__` (the only `translate_pattern` call site in the package), with an `functools.cache` on the compiled regex. Patterns that are not expressible in strict XSD at all (for example back references, which raise `RegexError` under the strict translator) fall back to the previous permissive translation instead of crashing.
2. Adds a portability lint: `Restriction.parse` now emits a `UserWarning` when a loaded pattern relies on non-XSD regex features (anchors, back references or lazy quantifiers). It only warns; it never changes a validation verdict on its own.

## Behaviour change, intentional

Part 1 flips verdicts for patterns that used `^` or `$` as anchors:

| Pattern | Value | Before | After (strict XSD) |
|---|---|---|---|
| `^.{1,5}$` | `AB` | pass | fail (`^` and `$` are literal characters in XSD) |
| `^.{1,5}$` | `^AB$` | fail | pass |
| `.{1,5}` | `abc` | pass | pass |
| `.{1,5}` | `abcdef` | fail | fail |

Plain patterns behave identically in both modes because ifctester already used `fullmatch`, which matches XSD's implicit whole-value anchoring. The new warning gives IDS authors the migration signal: any pattern that would change behaviour is flagged on load.

This aligns ifctester with the XSD semantics documented in buildingSMART/IDS#449, which describes exactly this divergence between validators.

## Tests

Added to `src/ifctester/test/test_facet.py` (`TestRestriction`):

- `test_pattern_treats_anchors_as_literal_characters`: `^.{1,5}$` rejects `AB` and accepts `^AB$` (fails on unpatched code, red first).
- `test_pattern_is_implicitly_anchored`: `.{1,5}` accepts `abc` and rejects `abcdef` (regression guard, passes before and after).
- `test_pattern_portability_warnings`: `^x$`, `(a)\1` and `a+?` each warn naming the feature; `.{1,5}` and `DT[0-9]` stay silent under `warnings.simplefilter("error")`.

Run with local CPython 3.11 and ifcopenshell 0.8.5 wheels, `PYTHONPATH` pointing at this branch's `src/ifctester`. The pattern logic only depends on `xmlschema`/`elementpath`, not on the 0.9 wrapper, so this is a valid check; honesty note: 7 unrelated tests in `test_facet.py`/`test_ids.py` fail identically on unmodified `v0.9.0` in this environment because the 0.8.5 wrapper lacks `entity_instance.get_attribute_category`. Before this patch: 7 failed, 30 passed. After: 7 failed (same 7), 33 passed.

`black --check` and `ruff check` (CI versions) pass on both touched files.

AI disclosure: this PR was prepared with AI assistance and reviewed by a human before submission.
