### PR TITLE
ifctester webapp: Pattern Playground with real ifctester verdicts

### DIFF
--- a/src/ifctester/webapp/public/worker/api.py
+++ b/src/ifctester/webapp/public/worker/api.py
@@ -3,6 +3,7 @@ import ifcopenshell.util.attribute
 import ifcopenshell.util.pset
 from xmlschema.validators.exceptions import XMLSchemaValidationError
 
+from ifctester.facet import Restriction
 from ifctester.ids import Ids, IdsXmlValidationError, get_schema
 
 # https://github.com/buildingSMART/IDS/blob/9914d568c7ac037acd97e58a0d16e9f93c3e3416/Schema/ids.xsd#L232
@@ -181,6 +182,19 @@ def get_standard_classification_systems():
         "Uniformat": {"source": "UniFormat", "tokens": ["."]},
         "VMSW": {"source": "VMSW", "tokens": ["."]},
     }
+
+
+def test_pattern(pattern, values):
+    """Test an XSD pattern against sample values using ifctester's restriction logic."""
+
+    restriction = Restriction(options={"pattern": pattern})
+    results = []
+    for value in values:
+        try:
+            results.append(bool(restriction == value))
+        except Exception as e:
+            return {"error": str(e), "results": []}
+    return {"error": None, "results": results}
 
 
 def ids_from_xml_string(xml: str, validate: bool = False) -> Ids:

--- a/src/ifctester/webapp/src/components/PatternPlayground.svelte
+++ b/src/ifctester/webapp/src/components/PatternPlayground.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+    import * as Dialog from "$lib/components/ui/dialog";
+    import { testPattern } from "$src/modules/api/api.svelte";
+
+    let {
+        open = $bindable(false),
+        initialPattern = ""
+    }: {
+        open?: boolean;
+        initialPattern?: string;
+    } = $props();
+
+    let pattern = $state("");
+    let valuesText = $state("");
+    let results = $state<{ value: string; passes: boolean }[]>([]);
+    let patternError = $state<string | null>(null);
+    let isChecking = $state(false);
+    let requestToken = 0;
+
+    let hasAnchors = $derived(pattern.includes("^") || pattern.includes("$"));
+    let sampleValues = $derived(valuesText.split("\n").filter((value) => value !== ""));
+
+    // Seed the pattern from the editor each time the dialog is opened
+    $effect(() => {
+        if (open) pattern = initialPattern;
+    });
+
+    // Debounced live evaluation through ifctester in the Pyodide worker
+    $effect(() => {
+        if (!open) return;
+        const currentPattern = pattern;
+        const currentValues = sampleValues;
+
+        if (currentPattern === "" || currentValues.length === 0) {
+            requestToken++;
+            results = [];
+            patternError = null;
+            isChecking = false;
+            return;
+        }
+
+        const token = ++requestToken;
+        const timer = setTimeout(async () => {
+            isChecking = true;
+            try {
+                const response = await testPattern(currentPattern, currentValues);
+                if (token !== requestToken) return;
+                patternError = response.error;
+                results = response.error
+                    ? []
+                    : currentValues.map((value, index) => ({ value, passes: response.results[index] }));
+            } catch (err) {
+                if (token !== requestToken) return;
+                patternError = err instanceof Error ? err.message : String(err);
+                results = [];
+            } finally {
+                if (token === requestToken) isChecking = false;
+            }
+        }, 300);
+
+        return () => clearTimeout(timer);
+    });
+</script>
+
+<Dialog.Root bind:open={open}>
+    <Dialog.Content class="sm:max-w-[550px]">
+        <Dialog.Header>
+            <Dialog.Title>Pattern Playground</Dialog.Title>
+            <Dialog.Description>
+                Patterns are checked by ifctester itself, so the verdicts match a real IDS audit.
+            </Dialog.Description>
+        </Dialog.Header>
+        <div class="playground">
+            <div class="form-group">
+                <label for="playground-pattern">XSD Pattern</label>
+                <input
+                    class="form-input"
+                    id="playground-pattern"
+                    type="text"
+                    bind:value={pattern}
+                    placeholder="e.g., DT[0-9]{2}"
+                >
+                <p class="hint">Note: IDS patterns must match the whole value, not just a part of it.</p>
+                {#if hasAnchors}
+                    <p class="warning">
+                        Warning: ^ and $ anchors are not part of IDS pattern syntax (XSD regex) and behave
+                        differently across validators. Remove them; patterns already match the whole value.
+                    </p>
+                {/if}
+                {#if patternError}
+                    <p class="pattern-error">Invalid pattern: {patternError}</p>
+                {/if}
+            </div>
+            <div class="form-group">
+                <label for="playground-values">Sample Values (one per line)</label>
+                <textarea
+                    class="form-input"
+                    id="playground-values"
+                    rows="4"
+                    bind:value={valuesText}
+                    placeholder="DT01&#10;DT1"
+                ></textarea>
+            </div>
+            {#if results.length > 0 && !patternError}
+                <ul class="results" class:checking={isChecking}>
+                    {#each results as result}
+                        <li class="result-item">
+                            <span class="verdict {result.passes ? 'pass' : 'fail'}">
+                                {result.passes ? 'PASS' : 'FAIL'}
+                            </span>
+                            <span class="result-value">{result.value}</span>
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
+        </div>
+        <Dialog.Footer>
+            <Dialog.Close asChild>
+                <button class="btn">Close</button>
+            </Dialog.Close>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>
+
+<style>
+    .playground {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+    }
+
+    .hint {
+        font-size: 12px;
+        color: #999;
+        margin: 4px 0 0;
+    }
+
+    .warning {
+        font-size: 12px;
+        color: #e8a33d;
+        margin: 4px 0 0;
+    }
+
+    .pattern-error {
+        font-size: 12px;
+        color: #e05d5d;
+        margin: 4px 0 0;
+    }
+
+    .results {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        max-height: 200px;
+        overflow-y: auto;
+    }
+
+    .results.checking {
+        opacity: 0.6;
+    }
+
+    .result-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .verdict {
+        font-size: 11px;
+        font-weight: 600;
+        padding: 2px 8px;
+        border-radius: 4px;
+        min-width: 44px;
+        text-align: center;
+    }
+
+    .verdict.pass {
+        background: #1f4d2e;
+        color: #7fdc9a;
+    }
+
+    .verdict.fail {
+        background: #542125;
+        color: #f0868c;
+    }
+
+    .result-value {
+        font-family: monospace;
+        font-size: 13px;
+        word-break: break-all;
+    }
+</style>

--- a/src/ifctester/webapp/src/modules/api/api.svelte.ts
+++ b/src/ifctester/webapp/src/modules/api/api.svelte.ts
@@ -103,6 +103,10 @@ export async function getApplicablePsets(schema: string, entity: string, predefi
     return await wasm.getApplicablePsets(schema, entity, predefinedType);
 }
 
+export async function testPattern(pattern: string, values: string[]) {
+    return await wasm.testPattern(pattern, values) as { error: string | null; results: boolean[] };
+}
+
 export function getEntityClasses() {
     return Autocompletions.entityClasses;
 }

--- a/src/ifctester/webapp/src/modules/wasm/index.ts
+++ b/src/ifctester/webapp/src/modules/wasm/index.ts
@@ -181,6 +181,13 @@ class WASMModule extends EventEmitter {
     }
 
     /**
+     * Test an XSD pattern against sample values using ifctester's restriction logic
+     */
+    async testPattern(pattern: string, values: string[]) {
+        return this._apiCall('testPattern', pattern, values);
+    }
+
+    /**
      * Load an IFC file. Returns a unique ID for the loaded file.
      */
     async loadIfc(ifcData: number[] | Uint8Array | ArrayBuffer) {
@@ -313,6 +320,7 @@ export const {
     getApplicablePsets,
     getMaterialCategories,
     getStandardClassificationSystems,
+    testPattern,
     loadIfc,
     unloadIfc,
     auditIfc,

--- a/src/ifctester/webapp/src/modules/wasm/worker/api.ts
+++ b/src/ifctester/webapp/src/modules/wasm/worker/api.ts
@@ -82,6 +82,19 @@ export async function getStandardClassificationSystems() {
     return result.toJs({ dict_converter: Object.fromEntries });
 }
 
+export async function testPattern(pattern: string, values: string[]) {
+    // JSON.stringify twice: the inner call encodes the payload, the outer call
+    // produces a quoted literal that is safe to embed in the Python source.
+    const payload = JSON.stringify(JSON.stringify({ pattern, values }));
+    const result = await pyodide.runPythonAsync(`
+        import json
+        from api import test_pattern
+        payload = json.loads(${payload})
+        json.dumps(test_pattern(payload["pattern"], payload["values"]))
+    `);
+    return JSON.parse(result) as { error: string | null; results: boolean[] };
+}
+
 export async function loadIfc(ifcData: number[] | Uint8Array | ArrayBuffer) {
     const ifc_id = id();
     const path = `/tmp/${encodeURIComponent(ifc_id)}.ifc`;
@@ -140,6 +153,7 @@ export const API = {
     "getApplicablePsets": getApplicablePsets,
     "getMaterialCategories": getMaterialCategories,
     "getStandardClassificationSystems": getStandardClassificationSystems,
+    "testPattern": testPattern,
     "loadIfc": loadIfc,
     "unloadIfc": unloadIfc,
     "auditIfc": auditIfc

--- a/src/ifctester/webapp/src/pages/Home/RestrictionEditor.svelte
+++ b/src/ifctester/webapp/src/pages/Home/RestrictionEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import Svelecte from 'svelecte';
+    import PatternPlayground from '$src/components/PatternPlayground.svelte';
     import {
         getApplicablePsets,
         getClassificationSystems,
@@ -441,6 +442,7 @@
         setFieldValue({ 'restriction': restriction });
     };
 
+    let isPlaygroundOpen = $state(false);
     let restrictionType = $state(getRestrictionType());
     let hasUserSelectedType = $state(false);
     let lastFacetRef = $state(facet);
@@ -582,7 +584,11 @@
                 </div>
             
             {:else if restrictionType === 'Pattern'}
-                <input class="form-input" type="text" bind:value={() => getPatternValue(), (v) => setPatternValue(v)} placeholder="Enter regex pattern (e.g., DT[0-9]{2})" aria-label={`${label} pattern`}>
+                <div class="pattern-controls">
+                    <input class="form-input" type="text" bind:value={() => getPatternValue(), (v) => setPatternValue(v)} placeholder="Enter regex pattern (e.g., DT[0-9]{2})" aria-label={`${label} pattern`}>
+                    <button class="btn-test" type="button" onclick={() => isPlaygroundOpen = true}>Test</button>
+                </div>
+                <PatternPlayground bind:open={isPlaygroundOpen} initialPattern={getPatternValue()} />
             
             {:else if restrictionType === 'Range'}
                 {@const range = getRangeValues()}
@@ -707,6 +713,30 @@
     }
 
     .btn-add:hover {
+        background: #007bff;
+        color: white;
+    }
+
+    .pattern-controls {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+    }
+
+    .pattern-controls .form-input {
+        flex: 1;
+    }
+
+    .btn-test {
+        background: none;
+        border: 1px solid #007bff;
+        border-radius: 4px;
+        color: #007bff;
+        padding: 8px 12px;
+        cursor: pointer;
+    }
+
+    .btn-test:hover {
         background: #007bff;
         color: white;
     }


### PR DESCRIPTION
## What

Adds a Pattern Playground to the ifctester webapp: a dialog where you type an XSD pattern and sample values (one per line) and see live PASS/FAIL verdicts per value.

The verdicts do not come from a JavaScript regex. They come from ifctester's own `Restriction` logic (`re.compile(identities.translate_pattern(pattern)).fullmatch(value)`) running in the Pyodide worker, via a new `test_pattern(pattern, values)` entry point in `public/worker/api.py`. That way the playground agrees with a real IDS audit, including XSD whole-value matching semantics that differ from JS regex.

UI details:

* A "Test" button next to every Pattern restriction input opens the dialog, seeded with the current pattern.
* Input is debounced (300 ms), and stale responses are discarded.
* An invalid pattern shows the Python regex error inline.
* A permanent note explains that IDS patterns must match the whole value.
* If the pattern contains `^` or `$`, a warning explains that anchors are not part of IDS pattern syntax and behave differently across validators.

The pattern and values are passed into Python as a JSON payload rather than interpolated into the code string, so backslashes and quotes in patterns are safe.

## Files

* `public/worker/api.py`: new `test_pattern` using `ifctester.facet.Restriction`
* `src/modules/wasm/worker/api.ts`, `src/modules/wasm/index.ts`, `src/modules/api/api.svelte.ts`: `testPattern` wired through the existing worker message protocol
* `src/components/PatternPlayground.svelte`: the dialog (bits-ui Dialog, same as the About dialog)
* `src/pages/Home/RestrictionEditor.svelte`: the Test button in the Pattern branch

## Verification (honest labels)

Logic-verified (real ifctester, CPython 3.11, outside Pyodide): `test_pattern(".{1,5}", ["AB", "ABCDEFGH"])` returns `{error: None, results: [True, False]}`; `test_pattern("[unclosed", ["AB"])` returns the regex error string; `\d+` gives `[True, False]` for `123` / `12a`.

Build-verified: `npm ci` (clean), `npm run build`, `tsc --noEmit`, `svelte-check` (0 errors, 0 warnings, same as the unmodified branch) and `biome lint` (the repo's `npm run check` linter; note that `biome check` formatting fails on unmodified files too, so it is not a usable gate here) all pass.

Untested: the dialog has not been clicked in a browser; the worker round trip has not been exercised inside Pyodide. This is why the PR is a draft.

## Manual test steps

1. From `src/ifctester`, run `make webapp-dev` (downloads Pyodide and the ifcopenshell wasm wheel into `webapp/public/`, stages the ifctester wheel into `public/worker/generated/`, then runs `npm install` and `npm run dev`). If those assets are already staged, `npm run dev` from `src/ifctester/webapp` is enough; the Vite dev server serves `public/` at the root, including the modified `worker/api.py`. (`serve.py` only serves a prebuilt `dist/`, so use it only after `npm run build`.)
2. Open the app, create a new IDS document and a specification.
3. In Requirements, click Create Facet, pick Attribute.
4. In the Value field, change the restriction type dropdown from Simple to Pattern.
5. A "Test" button appears next to the pattern input. Click it.
6. Type `.{1,5}` as the pattern and, in the sample values box, `AB` on one line and `ABCDEFGH` on another.
7. Expect PASS for `AB` and FAIL for `ABCDEFGH` after a short debounce (the worker must be initialised; the splash screen must have finished).
8. Type `[unclosed` as the pattern; expect an inline "Invalid pattern" error.
9. Type `^DT[0-9]{2}$`; expect the anchor warning to appear.
10. Close the dialog; the pattern in the editor is unchanged (the playground is a sandbox, it does not write back).

Drafted with AI assistance (Claude) under my direction and review.
