### PR TITLE
ifctester webapp: reorder facets within applicability and requirements

### DIFF
--- a/src/ifctester/webapp/src/modules/api/ids.svelte.ts
+++ b/src/ifctester/webapp/src/modules/api/ids.svelte.ts
@@ -268,6 +268,23 @@ export async function deleteFacet(
     list.splice(facetId, 1);
 }
 
+export function moveFacet(
+    docId: string,
+    specId: number,
+    clause: "applicability" | "requirements",
+    facet: "entity" | "attribute" | "classification" | "partOf" | "property" | "material",
+    facetId: number,
+    direction: -1 | 1
+) {
+    const spec = Module.documents[docId].specifications.specification[specId];
+    const list = (spec[clause] as Record<string, unknown> | undefined)?.[facet] as Facet[] | undefined;
+    if (!list) return;
+    const target = facetId + direction;
+    if (facetId < 0 || facetId >= list.length || target < 0 || target >= list.length) return;
+    const [moved] = list.splice(facetId, 1);
+    list.splice(target, 0, moved);
+}
+
 export function getSpecUsage(spec?: Specification | null): IdsCardinality {
     if (!spec?.applicability) return 'required';
     const minOccurs = spec.applicability["@minOccurs"] as number | undefined;

--- a/src/ifctester/webapp/src/pages/Home/ApplicabilityPanel.svelte
+++ b/src/ifctester/webapp/src/pages/Home/ApplicabilityPanel.svelte
@@ -31,13 +31,26 @@
     
     async function removeFacet(facetType: FacetType, facetIndex: number) {
         if (!activeSpecification || !documentState || !IDS.Module.activeDocument) return;
-        
+
         await IDS.deleteFacet(
-            IDS.Module.activeDocument, 
+            IDS.Module.activeDocument,
             documentState.activeSpecification ?? 0,
-            "applicability", 
+            "applicability",
             facetType,
             facetIndex
+        );
+    }
+
+    function moveFacet(facetType: FacetType, facetIndex: number, direction: -1 | 1) {
+        if (!activeSpecification || !documentState || !IDS.Module.activeDocument) return;
+
+        IDS.moveFacet(
+            IDS.Module.activeDocument,
+            documentState.activeSpecification ?? 0,
+            "applicability",
+            facetType,
+            facetIndex,
+            direction
         );
     }
 
@@ -66,9 +79,11 @@
                         bind:facet={facets[index]} 
                         {facetType} 
                         specification={activeSpecification}
-                        activeTab="applicability" 
-                        {removeFacet} 
+                        activeTab="applicability"
+                        {removeFacet}
+                        {moveFacet}
                         {index}
+                        listLength={facets.length}
                     />
                 {/each}
             {/each}

--- a/src/ifctester/webapp/src/pages/Home/FacetEditor.svelte
+++ b/src/ifctester/webapp/src/pages/Home/FacetEditor.svelte
@@ -15,14 +15,18 @@
         facetType,
         activeTab,
         removeFacet,
+        moveFacet,
         index,
+        listLength,
         specification
     }: {
         facet: Facet;
         facetType: FacetType;
         activeTab: "applicability" | "requirements";
         removeFacet: (facetType: FacetType, facetIndex: number) => void | Promise<void>;
+        moveFacet: (facetType: FacetType, facetIndex: number, direction: -1 | 1) => void;
         index: number;
+        listLength: number;
         specification: Specification;
     } = $props();
 
@@ -41,6 +45,16 @@
     <div class="restriction-header">
         <span class="restriction-type">{facetType.toUpperCase()}</span>
         <span class="restriction-name">{@html stringifyFacet(activeTab, facet, facetType, specification)}</span>
+        <button class="btn-move" onclick={() => moveFacet(facetType, index, -1)} disabled={index === 0} aria-label={`Move ${facetType} facet up`} title="Move up (within {facetType.toUpperCase()} facets)">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="18,15 12,9 6,15"></polyline>
+            </svg>
+        </button>
+        <button class="btn-move" onclick={() => moveFacet(facetType, index, 1)} disabled={index === listLength - 1} aria-label={`Move ${facetType} facet down`} title="Move down (within {facetType.toUpperCase()} facets)">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="6,9 12,15 18,9"></polyline>
+            </svg>
+        </button>
         <button class="btn-delete" onclick={() => removeFacet(facetType, index)} aria-label="Delete Restriction">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M18 6L6 18M6 6l12 12"></path>
@@ -97,3 +111,28 @@
         {/if}
     </div>
 </div>
+
+<style>
+    .btn-move {
+        padding: 5px;
+        border-radius: 50px;
+        border: 1px solid #ffffff26;
+        color: #b0b0b0;
+        background: none;
+        cursor: pointer;
+        transition: background-color 200ms;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .btn-move:hover:not(:disabled) {
+        background: #ffffff12;
+        color: white;
+    }
+
+    .btn-move:disabled {
+        opacity: 0.35;
+        cursor: default;
+    }
+</style>

--- a/src/ifctester/webapp/src/pages/Home/RequirementsPanel.svelte
+++ b/src/ifctester/webapp/src/pages/Home/RequirementsPanel.svelte
@@ -31,13 +31,26 @@
     
     async function removeFacet(facetType: FacetType, facetIndex: number) {
         if (!activeSpecification || !documentState || !IDS.Module.activeDocument) return;
-        
+
         await IDS.deleteFacet(
-            IDS.Module.activeDocument, 
+            IDS.Module.activeDocument,
             documentState.activeSpecification ?? 0,
             "requirements",
             facetType,
             facetIndex
+        );
+    }
+
+    function moveFacet(facetType: FacetType, facetIndex: number, direction: -1 | 1) {
+        if (!activeSpecification || !documentState || !IDS.Module.activeDocument) return;
+
+        IDS.moveFacet(
+            IDS.Module.activeDocument,
+            documentState.activeSpecification ?? 0,
+            "requirements",
+            facetType,
+            facetIndex,
+            direction
         );
     }
 
@@ -63,9 +76,11 @@
                         bind:facet={facets[index]} 
                         {facetType} 
                         specification={activeSpecification}
-                        activeTab="requirements" 
-                        {removeFacet} 
+                        activeTab="requirements"
+                        {removeFacet}
+                        {moveFacet}
                         {index}
+                        listLength={facets.length}
                     />
                 {/each}
             {/each}


### PR DESCRIPTION
## What

Lets the user change the order of facets in the specification editor, in both the Applicability and Requirements panels, with up/down buttons on each facet card (no new npm dependency; no drag library).

The buttons call a new `moveFacet` action in `src/modules/api/ids.svelte.ts` that splices the facet within its list in the underlying IDS document model, so save/export emits the facets in the new order. Moves are bounds-checked and never cross between applicability and requirements.

## Scope constraint (important)

Reordering is limited to facets of the same type within one clause (for example among several PROPERTY facets). This is not a UI shortcut but a data model fact, verified in code:

* The webapp document model groups facets by type key (`requirements.property: [...]`, `requirements.material: [...]`), so an interleaved cross-type order cannot even be represented.
* ifctester's `Specification.asdict` canonicalises the type groups "as per XSD requirements" into the fixed sequence entity, partOf, classification, attribute, property, material before encoding, so a cross-type order would not survive export either.

Order within one type group does round-trip: each group's array maps to repeated XML elements in array order. The up/down buttons are disabled at the boundaries of the facet's own type group, and their tooltips say "within PROPERTY facets" etc. to make the constraint visible.

## Files

* `src/modules/api/ids.svelte.ts`: `moveFacet(docId, specId, clause, facetType, index, direction)`
* `src/pages/Home/FacetEditor.svelte`: up/down buttons in the facet card header
* `src/pages/Home/ApplicabilityPanel.svelte`, `src/pages/Home/RequirementsPanel.svelte`: wire the action and the list length for bounds

## Verification (honest labels)

Build-verified: `npm run build`, `tsc --noEmit`, `svelte-check` (0 errors, 0 warnings, same as the unmodified branch) and `biome lint` all pass.

Untested: the buttons have not been clicked in a browser, and an export after reordering has not been diffed by hand. This is why the PR is a draft.

## Manual test steps

1. From `src/ifctester`, run `make webapp-dev` (stages Pyodide, the wasm wheel and the ifctester wheel into `webapp/public/`, then runs `npm install` and `npm run dev`). If the assets are already staged, `npm run dev` from `src/ifctester/webapp` is enough. (`serve.py` only serves a prebuilt `dist/`.)
2. Create a new IDS document and a specification.
3. In Requirements, add three Property facets and give them distinct Base Names (P1, P2, P3).
4. Each facet card header now shows up and down chevrons next to the delete button. On P1 the up button is disabled; on P3 the down button is disabled.
5. Click the down button on P1; expect the order to become P2, P1, P3 and all field values to stay with their cards.
6. Edit a field on the moved card to confirm editing still targets the right facet.
7. Add a Material facet; its up/down buttons only move it among Material facets (there is just one, so both are disabled), and it cannot be moved into the Property group.
8. Export the document (File > Export or the download action) and check the emitted XML: the property elements appear as P2, P1, P3.
9. Repeat steps 3 to 5 in the Applicability panel with two Entity facets.

Drafted with AI assistance (Claude) under my direction and review.
