### PR TITLE
bsdd: make the include_test_dictionaries default a real boolean

### DIFF
--- a/src/bsdd/bsdd.py
+++ b/src/bsdd/bsdd.py
@@ -712,7 +712,7 @@ class Client:
         return self.get(f"api/Unit/{version}")
 
     def get_dictionary(
-        self, dictionary_uri: str = "", include_test_dictionaries: bool = "False", version: int = 1
+        self, dictionary_uri: str = "", include_test_dictionaries: bool = False, version: int = 1
     ) -> DictionaryResponseContractV1:
         """
         Get list of available Dictionaries

--- a/src/bsdd/tests/test_bsdd.py
+++ b/src/bsdd/tests/test_bsdd.py
@@ -67,3 +67,12 @@ def test_search_class():
 def test_get_properties():
     pr = client.get_properties(ifc4x3_uri, offset=0, limit=5)
     assert len(pr["properties"]) == 5
+
+
+def test_include_test_dictionaries_default_is_a_real_boolean():
+    # The default was the string "False", which is truthy, so bare calls
+    # silently sent IncludeTestDictionaries=true.
+    import inspect
+
+    default = inspect.signature(Client.get_dictionary).parameters["include_test_dictionaries"].default
+    assert default is False


### PR DESCRIPTION
The default was the string `"False"`, which is truthy, so any bare `get_dictionary()` call silently sent `IncludeTestDictionaries=true` and returned test uploads nobody asked for. Bonsai is unaffected because it always passes the preference explicitly (`tool/bsdd.py:143`); only direct library users hit it.

RED/GREEN: the new offline test asserts the signature default `is False`; on unpatched code the default is the string `'False'` and the assertion fails, on this branch it passes. Verified by inspecting both versions directly. The test is offline on purpose, since the rest of `test_bsdd.py` performs live API calls.

Found while investigating why a user's bSDD test upload was invisible in Bonsai (the answer there was the separate Load Test Dictionaries and Load Preview Dictionaries preferences, both needed for a test upload, which arrives with Preview status).
