### PR TITLE
geom: cache hybrid kernel component resolution to remove per-construction plugin rescans (#9371)

### DIFF
--- a/src/ifcgeom/kernel_registry.cpp
+++ b/src/ifcgeom/kernel_registry.cpp
@@ -28,6 +28,8 @@
 #include <algorithm>
 #include <cstring>
 #include <iostream>
+#include <map>
+#include <mutex>
 #include <vector>
 
 namespace ifcopenshell {
@@ -110,6 +112,11 @@ namespace {
 
 		return match;
 	}
+
+	// Component resolution scans the plugin directory and loads modules from
+	// disk, which is too expensive to repeat on every kernel construction.
+	std::mutex hybrid_component_mutex;
+	std::map<std::string, std::vector<std::string>> hybrid_component_cache;
 }
 
 void ifcopenshell::geom::kernels::kernel_registry::bind(const kernel_info& info, create_fn create, const plugin::module& module) {
@@ -149,6 +156,22 @@ std::unique_ptr<ifcopenshell::geom::kernels::abstract_kernel> ifcopenshell::geom
 	auto geometry_library_lower = boost::to_lower_copy(geometry_library);
 	auto& registry = kernel_registry_instance();
 
+	if (geometry_library_lower.rfind("hybrid-", 0) == 0) {
+		std::lock_guard<std::mutex> lock(hybrid_component_mutex);
+		auto cached = hybrid_component_cache.find(geometry_library_lower);
+		if (cached != hybrid_component_cache.end()) {
+			std::vector<std::unique_ptr<abstract_kernel>> kernels;
+			for (const auto& backend_id : cached->second) {
+				kernels.push_back(registry.create(backend_id, file, settings, logger));
+			}
+			for (auto it = kernels.begin(); it != kernels.end(); ++it) {
+				(**it).propagate_exceptions = it == kernels.begin();
+				(**it).partial_success_is_success = it == kernels.end() - 1;
+			}
+			return std::make_unique<hybrid_kernel>(geometry_library, file, settings, std::move(kernels), logger);
+		}
+	}
+
 	if (!registry.has(geometry_library_lower)) {
 		load_kernel_plugin(registry, geometry_library_lower);
 	}
@@ -157,8 +180,13 @@ std::unique_ptr<ifcopenshell::geom::kernels::abstract_kernel> ifcopenshell::geom
 	}
 
 	if (geometry_library_lower.rfind("hybrid-", 0) == 0) {
+		const auto hybrid_key = geometry_library_lower;
+
+		std::lock_guard<std::mutex> lock(hybrid_component_mutex);
+
 		geometry_library_lower = geometry_library_lower.substr(strlen("hybrid"));
 		std::vector<std::unique_ptr<abstract_kernel>> kernels;
+		std::vector<std::string> component_backend_ids;
 		while (!geometry_library_lower.empty()) {
 			if (geometry_library_lower.find("-", 0) == 0) {
 				geometry_library_lower = geometry_library_lower.substr(strlen("-"));
@@ -174,6 +202,7 @@ std::unique_ptr<ifcopenshell::geom::kernels::abstract_kernel> ifcopenshell::geom
 			}
 
 			kernels.push_back(registry.create(matched_backend_id, file, settings, logger));
+			component_backend_ids.push_back(matched_backend_id);
 			geometry_library_lower = geometry_library_lower.substr(matched_backend_id.size());
 		}
 
@@ -183,6 +212,7 @@ std::unique_ptr<ifcopenshell::geom::kernels::abstract_kernel> ifcopenshell::geom
 		}
 
 		if (!kernels.empty()) {
+			hybrid_component_cache.emplace(hybrid_key, std::move(component_backend_ids));
 			return std::make_unique<hybrid_kernel>(geometry_library, file, settings, std::move(kernels), logger);
 		}
 	}


### PR DESCRIPTION
Addresses the Bonsai-only slowdown reported in #9371: on the PGSuper bridge model, Bonsai with the Hybrid CGAL-OCC library loads in about 10 minutes while OpenCASCADE, CGAL and CGAL Simple each load in about 1 minute, and IfcConvert is fast for everyone.

## Root cause

`ifcopenshell::geom::kernels::construct()` (src/ifcgeom/kernel_registry.cpp:159) resolves a hybrid name such as `hybrid-cgal-simple-opencascade` by calling `find_kernel_match()` once per component. `find_kernel_match()` (src/ifcgeom/kernel_registry.cpp:70) creates a fresh `plugin::manager`, walks the plugin search paths and loads every `geometry_kernel_*` module from disk before matching the component name.

A named kernel pays this once: after the first load it is registered in the static registry and every later construction is a map lookup. A hybrid name is never registered, so every kernel construction (every `create_shape()` call and every iterator) repeats the full directory scan and module loading, twice for a two-component hybrid.

Measured on the model from #9371 (linux-arm64 release build): 28 to 100 ms per `find_kernel_match()` call, about 70 ms of pure overhead added to every `create_shape()` call. On Windows, where `LoadLibrary` plus antivirus scanning of the CGAL/GMP DLLs makes each load far more expensive, this scales into the reported minutes: Bonsai constructs a kernel per `create_generic_shape()` call and per iterator, while IfcConvert constructs exactly one kernel per run, which is why neither @aothms nor @RickBrice could reproduce it with IfcConvert.

## Fix

Cache the resolved component backend ids per hybrid name (30 lines in src/ifcgeom/kernel_registry.cpp). The first construction still performs the full discovery and registers the matched modules; subsequent constructions build the components straight from the registry without touching the disk. Component selection semantics are unchanged: the cache only stores the result the existing resolution already produced.

## Numbers

PGSuper_Import_Model.ifc (1.2 MB, from #9371), linux-arm64 release build at 6f2e1aa99, wall time.

Per-call paths (where the regression lives):

| Path | opencascade | hybrid before | hybrid after |
|---|---|---|---|
| `create_shape`, same IfcBeam x50, ms/call | 198.9 | 270.7 | 200.0 |
| `create_shape` over 50 products | 4.45 s | 7.81 s | 4.53 s |
| `create_shape` over 100 representations | 3.34 s | 11.00 s | 3.16 s |

Full iteration (one kernel construction, so barely affected, listed for completeness):

| Kernel | before | after |
|---|---|---|
| opencascade, 1 thread | 8.60 s | 7.93 s |
| hybrid-cgal-simple-opencascade, 1 thread | 8.21 s | 8.07 s |
| hybrid-cgal-opencascade, 1 thread | 9.08 s | 7.97 s |
| opencascade, 4 threads | 3.88 s | 3.43 s |
| hybrid-cgal-simple-opencascade, 4 threads | 3.54 s | 3.50 s |
| cgal, 1 thread | 0.05 s (0 of 322 supported) | 0.04 s |
| cgal-simple, 1 thread | 0.04 s (0 of 322 supported) | 0.03 s |

All runs convert 320 elements out of 322 tasks except the pure CGAL kernels, which reject the swept solids in this model in both builds (unchanged behaviour).

## Methodology

Instrumented `hybrid_kernel::convert` (find_openings, per-sub-kernel attempt duration) and `construct()` (load_kernel_plugin, find_kernel_match) with steady_clock timers, which isolated the cost to `find_kernel_match`: 28 to 100 ms per call, two calls per hybrid construction, on every construction. After the fix the scan appears exactly once per process; instrumentation was removed before this PR.

Tests: `test/geom` and `test_wall_opening.py` from src/ifcopenshell-python pass against the patched build (3 passed, 1 skipped).

This contribution was developed with AI assistance and human review and testing, in line with AGENTS.md.
