### PR TITLE
geom: expose a reusable kernel object to Python (prototype for #9417 discussion)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/geom/main.py
+++ b/src/ifcopenshell-python/ifcopenshell/geom/main.py
@@ -549,6 +549,63 @@ def create_shape(
     )
 
 
+class kernel:
+    """A reusable geometry kernel bound to a (geometry library, file, settings) triple.
+
+    ``ifcopenshell.geom.create_shape`` constructs a new geometry kernel on every
+    call, which repeats the backend resolution (including plugin discovery for
+    hybrid kernels) and discards the mapping and conversion caches afterwards.
+    This class performs that construction once so that converting many products
+    one by one reuses the same kernel, mapping and caches, similar to what
+    ``ifcopenshell.geom.iterator`` does internally.
+
+    The kernel is bound at construction: the settings are copied and the file
+    reference is kept, so later changes to the settings object do not affect an
+    existing kernel and instances passed to :meth:`create_shape` must belong to
+    the bound file.
+
+    Example:
+
+    .. code:: python
+
+        settings = ifcopenshell.geom.settings()
+        k = ifcopenshell.geom.kernel(settings, ifc_file, geometry_library="hybrid-cgal-simple-opencascade")
+        for product in ifc_file.by_type("IfcProduct"):
+            if product.Representation:
+                shape = k.create_shape(product)
+    """
+
+    def __init__(
+        self,
+        settings: settings,
+        file: file,
+        geometry_library: GEOMETRY_LIBRARY = "opencascade",
+        logger: Optional[ifcopenshell.logger] = None,
+    ):
+        self.settings = settings
+        self.file = file
+        self.wrapped = ifcopenshell_wrapper.geometry_kernel(
+            geometry_library, file, settings, *ifcopenshell.optional_logger_args(logger)
+        )
+
+    def create_shape(
+        self,
+        inst: entity_instance,
+        repr: Optional[entity_instance] = None,
+    ) -> Union[
+        ShapeType, ShapeElementType, ifcopenshell_wrapper.transformation, utils.shape_tuple, TopoDS.TopoDS_Shape
+    ]:
+        """Identical to :func:`create_shape` but reuses this kernel across calls.
+
+        See :func:`create_shape` for the possible return types; the settings and
+        geometry library bound at construction are used for every call.
+        """
+        return wrap_shape_creation(
+            self.settings,
+            self.wrapped.create_shape(inst, repr) if repr else self.wrapped.create_shape(inst),
+        )
+
+
 def map_shape(settings: settings, inst: entity_instance) -> ifcopenshell_wrapper.item:
     """
     Returns an interpretation of the geometry encoded as per IfcOpenShell's taxonomy layer.

--- a/src/ifcwrap/IfcGeomWrapper.i
+++ b/src/ifcwrap/IfcGeomWrapper.i
@@ -990,10 +990,7 @@ struct shape_rtti : public boost::static_visitor<PyObject*>
 		return oss.str();
 	}
 
-	static std::variant<ifcopenshell::geom::element*, ifcopenshell::geom::representation*, ifcopenshell::geom::transformation*> helper_fn_create_shape(ifcopenshell::logger& logger, const std::string& geometry_library, ifcopenshell::geom::settings& settings, const express::base& instance, const express::base& representation = express::base()) {
-		ifcopenshell::file* file = instance.file();
-
-		ifcopenshell::geom::converter kernel(ifcopenshell::geom::kernels::construct(file, geometry_library, settings, logger), file, settings, logger);
+	static std::variant<ifcopenshell::geom::element*, ifcopenshell::geom::representation*, ifcopenshell::geom::transformation*> helper_fn_create_shape_with_converter(ifcopenshell::geom::converter& kernel, ifcopenshell::geom::settings& settings, const express::base& instance, const express::base& representation) {
 		if (instance.declaration().is("IfcProduct")) {
 			if (representation && !representation.declaration().is("IfcRepresentation")) {
 				throw ifcopenshell::exception("Supplied representation not of type IfcRepresentation");
@@ -1069,6 +1066,12 @@ struct shape_rtti : public boost::static_visitor<PyObject*>
 		}
 		return std::variant<ifcopenshell::geom::element*, ifcopenshell::geom::representation*, ifcopenshell::geom::transformation*>();
 	}
+
+	static std::variant<ifcopenshell::geom::element*, ifcopenshell::geom::representation*, ifcopenshell::geom::transformation*> helper_fn_create_shape(ifcopenshell::logger& logger, const std::string& geometry_library, ifcopenshell::geom::settings& settings, const express::base& instance, const express::base& representation = express::base()) {
+		ifcopenshell::file* file = instance.file();
+		ifcopenshell::geom::converter kernel(ifcopenshell::geom::kernels::construct(file, geometry_library, settings, logger), file, settings, logger);
+		return helper_fn_create_shape_with_converter(kernel, settings, instance, representation);
+	}
 %}
 
 %typemap(out) ifcopenshell::geom::taxonomy::item::ptr {
@@ -1114,6 +1117,37 @@ ifcopenshell::geom::taxonomy::item::ptr try_upcast(PyObject* obj0, swig_type_inf
 	static std::variant<ifcopenshell::geom::element*, ifcopenshell::geom::representation*, ifcopenshell::geom::transformation*> create_shape(ifcopenshell::geom::settings& settings, const express::base& instance, const char* const geometry_library="opencascade", ifcopenshell::logger* logger = nullptr) {
 		return create_shape(settings, instance, express::base(), geometry_library, logger);
 	}
+%}
+
+%inline %{
+	// Reusable geometry kernel handle bound to a (geometry_library, file,
+	// settings) triple. Constructing it resolves the kernel once and reuses
+	// the converter, mapping and caches for every create_shape call.
+	class geometry_kernel {
+	public:
+		geometry_kernel(const std::string& geometry_library, ifcopenshell::file* file, ifcopenshell::geom::settings& settings, ifcopenshell::logger* logger = nullptr)
+			: file_(file)
+			, settings_(settings)
+			, converter_(ifcopenshell::geom::kernels::construct(file, geometry_library, settings_, ifcopenshell::logger_or_root(logger)), file, settings_, ifcopenshell::logger_or_root(logger))
+		{}
+
+		std::variant<ifcopenshell::geom::element*, ifcopenshell::geom::representation*, ifcopenshell::geom::transformation*> create_shape(const express::base& instance, const express::base& representation) {
+			if (instance.file() != file_) {
+				throw ifcopenshell::exception("Instance does not belong to the file this kernel was constructed for");
+			}
+			return helper_fn_create_shape_with_converter(converter_, settings_, instance, representation);
+		}
+
+		// Manual definition of overload without representation argument
+		std::variant<ifcopenshell::geom::element*, ifcopenshell::geom::representation*, ifcopenshell::geom::transformation*> create_shape(const express::base& instance) {
+			return create_shape(instance, express::base());
+		}
+
+	private:
+		ifcopenshell::file* file_;
+		ifcopenshell::geom::settings settings_;
+		ifcopenshell::geom::converter converter_;
+	};
 %}
 
 // @todo bring back serialization OCCT -> IFC by means of opencascade_geometry_ifc_writer_registry


### PR DESCRIPTION
Prototype requested by @aothms in the review of #9417:

> can you also prototype a solution more on the Python side for comparison: that's likely using geom.iterator instead of geom.create_shape so that the constructed kernel (not just the back-end ids) are reused. Or, also exposing the abstract_kernel instances to Python so that create_shape(settings, inst, kernel=str) can be rephrased as geom.kernel(str).create_shape(settings, inst) reusing explicitly all the lookups that you are caching in this pr.

This implements the second option: a reusable kernel object exposed to Python, so the constructed kernel (converter, mapping, caches) is reused across calls instead of only the back-end id lookups.

## Comparison

PGSuper_Import_Model.ifc, 322 products with representations (320 convert, 2 fail identically in every variant), single-threaded, arm64 Linux, v0.9.0 at b5670c4fc. ms/call = wall time of the loop divided by 322.

| Variant | opencascade | hybrid-cgal-simple-opencascade |
|---|---|---|
| (a) `create_shape` loop, v0.9.0 baseline | 23.30 ms/call (7.50 s) | 71.97 ms/call (23.18 s) |
| (b) `create_shape` loop, with #9417 id cache | 22.49 ms/call (7.24 s) | 23.08 ms/call (7.43 s) |
| (c) `geom.iterator` full pass, v0.9.0 baseline | 23.07 ms/call (7.43 s) | 22.74 ms/call (7.32 s) |
| (d) kernel object (this PR), no #9417 cache | 22.28 ms/call (7.18 s) | 23.35 ms/call (7.52 s) |
| (e) kernel object + #9417 cache | 22.33 ms/call (7.19 s) | 22.26 ms/call (7.17 s) |

One-time kernel construction, paid once per kernel object instead of once per call: ~7 ms for opencascade, ~61 to 64 ms for the hybrid (the first hybrid construction always does the full plugin discovery, with or without the #9417 cache).

Reading of the numbers:

- The baseline hybrid `create_shape` loop pays roughly 49 ms/call of kernel construction overhead on this machine.
- The kernel object removes that overhead entirely without the #9417 cache: (d) matches the iterator (c).
- The #9417 cache alone (b) also reaches parity, because the remaining per-call construction (kernel objects, converter, mapping) is only ~1 ms/call on this model. The two changes are independent and compose, (e).
- Geometry produced through the kernel object is bit-identical to `create_shape` output (asserted on verts and faces during testing).

## API

```python
settings = ifcopenshell.geom.settings()
k = ifcopenshell.geom.kernel(settings, ifc_file, geometry_library="hybrid-cgal-simple-opencascade")
for product in ifc_file.by_type("IfcProduct"):
    if product.Representation:
        shape = k.create_shape(product)          # optional second arg: representation
```

C++/SWIG side: the body of `helper_fn_create_shape` is split into `helper_fn_create_shape_with_converter(converter&, ...)` and a new wrapper-level `geometry_kernel` class holds the `converter` (which owns the `abstract_kernel` from `kernels::construct` plus the mapping and conversion caches) built once. The free `create_shape` delegates to the same shared body, so both paths stay behaviourally identical.

Binding decision: the object is bound per (geometry_library, file, settings) triple at construction. This follows what the C++ types require: `kernels::construct` takes the file, `converter` copies the settings and creates a file-bound mapping. Settings changes after construction do not affect an existing kernel, and passing an instance from another file raises (guarded explicitly, since the mapping would silently misbehave otherwise). `geom.kernel(str).create_shape(settings, inst)` as literally sketched is therefore not implementable without reconstructing per call, which is exactly the cost being avoided; the settings moved into the constructor instead, mirroring `geom.iterator`.

## Prototype-grade vs solid

- Solid: the shared conversion body (pure refactor, free `create_shape` unchanged in behaviour), the wrong-file guard, the Python class mirroring the iterator constructor signature, docstrings, black+ruff clean.
- Prototype-grade: the surface is deliberately minimal (only `create_shape`); no `map_shape` equivalent, no accessor for the underlying kernel or converter statistics, no thread-safety claim beyond what `converter` itself provides (none, same as the iterator with one thread), and the class name `geometry_kernel` on the wrapper side is up for bikeshedding.

Relationship to #9417: independent, does not include or require 697b6ecdf2. The two compose cleanly (merge-tree checked). If the kernel object is preferred as the only fix, note that plain `create_shape` callers with hybrid kernels keep the per-call scan unless #9417 (or an equivalent) also lands.

This contribution was made with AI assistance, and was reviewed and tested by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5GFJsNiEk2WfepRgT7miN
