### PR TITLE
ifcopenshell: explain a missing schema plugin instead of a bare No schema named error (#9423)

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/__init__.py
@@ -162,6 +162,62 @@ class SchemaError(Error):
     pass
 
 
+# Schemas built by a default (non-WASM) build, see SCHEMA_VERSIONS in cmake/CMakeLists.txt.
+_EXPECTED_SCHEMA_PLUGINS = ("2x3", "4", "4x1", "4x2", "4x3", "4x3_tc1", "4x3_add1", "4x3_add2")
+
+
+def _schema_plugin_suffix() -> str:
+    if sys.platform == "win32":
+        return ".dll"
+    elif sys.platform == "darwin":
+        return ".dylib"
+    return ".so"
+
+
+def _schema_plugin_dirs() -> list[str]:
+    """Directories where the schema plugin libraries are expected to live."""
+    dirs: list[str] = []
+    try:
+        dirs.extend(get_plugin_search_paths())
+    except Exception:
+        pass
+    native = getattr(ifcopenshell_wrapper, "_ifcopenshell_wrapper", None)
+    for path in (getattr(native, "__file__", None), getattr(ifcopenshell_wrapper, "__file__", None), __file__):
+        if path:
+            dirs.append(os.path.dirname(os.path.abspath(path)))
+    return list(dict.fromkeys(dirs))
+
+
+def _missing_schema_plugins_message(schema: str) -> Optional[str]:
+    """Explain a failed schema lookup caused by missing schema plugin libraries.
+
+    Returns ``None`` if schemas are registered, meaning the lookup failed for
+    an unrelated reason such as an unknown schema name.
+    """
+    try:
+        names = tuple(ifcopenshell_wrapper.schema_names())
+    except Exception:
+        return None
+    if any(name.upper().startswith("IFC") for name in names):
+        return None
+
+    suffix = _schema_plugin_suffix()
+    expected = ["ifcopenshell_parse_schema_ifc" + version + suffix for version in _EXPECTED_SCHEMA_PLUGINS]
+    dirs = _schema_plugin_dirs()
+    missing = [name for name in expected if not any(os.path.isfile(os.path.join(d, name)) for d in dirs)]
+    return (
+        "No schema named %s. No IFC schema is registered at all, which means this IfcOpenShell "
+        "installation is incomplete or half updated: every IFC schema is loaded from a separate "
+        "plugin library next to the Python wrapper, and none of them could be found.\n"
+        "Searched: %s\n"
+        "Missing: %s\n"
+        "If a Blender extension update reported that it could not remove old files "
+        '("Access is denied", "The directory is not empty"), close Blender completely, delete the '
+        "leftover extension directory and install the extension again."
+        % (schema, ", ".join(dirs) or "(no directory resolved)", ", ".join(missing) or "(none)")
+    )
+
+
 @overload
 def open(
     path: Union[os.PathLike, str],
@@ -334,7 +390,13 @@ def schema_by_name(
         schema = "".join("".join(map(str, t)) if t[1] else "" for t in zip(prefixes, schema_version))
     else:
         schema = {"IFC4X3": "IFC4X3_ADD2"}.get(schema, schema)
-    return ifcopenshell_wrapper.schema_by_name(schema)
+    try:
+        return ifcopenshell_wrapper.schema_by_name(schema)
+    except Exception as e:
+        message = _missing_schema_plugins_message(schema)
+        if message is None:
+            raise
+        raise SchemaError(message) from e
 
 
 SupportedFormat = Literal[".ifc", ".ifcZIP", ".ifcXML", ".ifcJSON", ".ifcSQLite", "rocksdb", None]

--- a/src/ifcopenshell-python/ifcopenshell/__init__.py
+++ b/src/ifcopenshell-python/ifcopenshell/__init__.py
@@ -396,7 +396,9 @@ def schema_by_name(
         message = _missing_schema_plugins_message(schema)
         if message is None:
             raise
-        raise SchemaError(message) from e
+        # Deliberately still a RuntimeError: only the message changes, so code
+        # already catching the old error keeps working.
+        raise RuntimeError(message) from e
 
 
 SupportedFormat = Literal[".ifc", ".ifcZIP", ".ifcXML", ".ifcJSON", ".ifcSQLite", "rocksdb", None]

--- a/src/ifcopenshell-python/test/test_schema_by_name.py
+++ b/src/ifcopenshell-python/test/test_schema_by_name.py
@@ -1,0 +1,51 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2021 Thomas Krijnen <thomas@aecgeeks.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+import ifcopenshell
+
+
+def fail_lookup(*args, **kwargs):
+    raise RuntimeError("No schema named IFC4")
+
+
+class TestSchemaByName:
+    def test_schema_by_name(self):
+        assert ifcopenshell.schema_by_name("IFC4").name() == "IFC4"
+
+    def test_unknown_schema_keeps_the_original_error(self):
+        with pytest.raises(RuntimeError) as excinfo:
+            ifcopenshell.schema_by_name("IFC9")
+        assert not isinstance(excinfo.value, ifcopenshell.SchemaError)
+
+    def test_missing_schema_plugins_are_explained(self, monkeypatch):
+        monkeypatch.setattr(ifcopenshell.ifcopenshell_wrapper, "schema_by_name", fail_lookup)
+        monkeypatch.setattr(ifcopenshell.ifcopenshell_wrapper, "schema_names", lambda: ("HEADER_SECTION_SCHEMA",))
+        with pytest.raises(ifcopenshell.SchemaError) as excinfo:
+            ifcopenshell.schema_by_name("IFC4")
+        message = str(excinfo.value)
+        assert "No schema named IFC4" in message
+        assert "incomplete or half updated" in message
+        assert "ifcopenshell_parse_schema_ifc4" in message
+
+    def test_a_registered_schema_is_not_reported_as_a_broken_install(self, monkeypatch):
+        monkeypatch.setattr(ifcopenshell.ifcopenshell_wrapper, "schema_by_name", fail_lookup)
+        with pytest.raises(RuntimeError) as excinfo:
+            ifcopenshell.schema_by_name("IFC4")
+        assert not isinstance(excinfo.value, ifcopenshell.SchemaError)

--- a/src/ifcopenshell-python/test/test_schema_by_name.py
+++ b/src/ifcopenshell-python/test/test_schema_by_name.py
@@ -32,12 +32,12 @@ class TestSchemaByName:
     def test_unknown_schema_keeps_the_original_error(self):
         with pytest.raises(RuntimeError) as excinfo:
             ifcopenshell.schema_by_name("IFC9")
-        assert not isinstance(excinfo.value, ifcopenshell.SchemaError)
+        assert "incomplete or half updated" not in str(excinfo.value)
 
     def test_missing_schema_plugins_are_explained(self, monkeypatch):
         monkeypatch.setattr(ifcopenshell.ifcopenshell_wrapper, "schema_by_name", fail_lookup)
         monkeypatch.setattr(ifcopenshell.ifcopenshell_wrapper, "schema_names", lambda: ("HEADER_SECTION_SCHEMA",))
-        with pytest.raises(ifcopenshell.SchemaError) as excinfo:
+        with pytest.raises(RuntimeError) as excinfo:
             ifcopenshell.schema_by_name("IFC4")
         message = str(excinfo.value)
         assert "No schema named IFC4" in message
@@ -48,4 +48,4 @@ class TestSchemaByName:
         monkeypatch.setattr(ifcopenshell.ifcopenshell_wrapper, "schema_by_name", fail_lookup)
         with pytest.raises(RuntimeError) as excinfo:
             ifcopenshell.schema_by_name("IFC4")
-        assert not isinstance(excinfo.value, ifcopenshell.SchemaError)
+        assert "incomplete or half updated" not in str(excinfo.value)


### PR DESCRIPTION
Fixes the diagnostic half of #9423.

## What the reporter sees

Installing the current 0.9.0 development build of Bonsai on Windows fails at import with a bare `RuntimeError: No schema named IFC4`, raised from `ifcopenshell.util.pset.get_template` -> `ifcopenshell.schema_by_name` -> `_ifcopenshell_wrapper.schema_by_name`. That message reads like a bad schema name or a bad IFC file. It is neither.

In v0.9.0 every IFC schema is a separate runtime plugin library: `src/ifcparse/CMakeLists.txt` builds `parse_schema_ifc${schema}` from `schema_plugin.cpp` with `OUTPUT_NAME ifcopenshell_parse_schema_ifc${schema}`. `schema_registry::get()` (`src/ifcparse/schema.cpp:262`) throws `No schema named X` both when the name is unknown and when the plugin library simply is not there. The reporter's log shows the Blender extension updater failing to delete the previous install first (`PermissionError(13, 'Access is denied')`, `OSError(41, 'The directory is not empty')`), which is exactly how a Windows install ends up with a wrapper but no plugin libraries.

## The change

`ifcopenshell.schema_by_name` now separates the two cases. `ifcopenshell_wrapper.schema_names()` returns the registry contents, and a registry that holds no `IFC*` schema at all cannot be an unknown-name problem: only `HEADER_SECTION_SCHEMA` is built in (`register_builtin_schemas`, `src/ifcparse/schema.cpp:118`), everything else arrives from a plugin. In that case the wrapper's exception is re-raised as `SchemaError` with a message that names the cause, the directories searched, and the plugin files that are absent:

```
No schema named IFC4. No IFC schema is registered at all, which means this IfcOpenShell
installation is incomplete or half updated: every IFC schema is loaded from a separate
plugin library next to the Python wrapper, and none of them could be found.
Searched: ...\site-packages\ifcopenshell
Missing: ifcopenshell_parse_schema_ifc2x3.dll, ifcopenshell_parse_schema_ifc4.dll, ...
If a Blender extension update reported that it could not remove old files
("Access is denied", "The directory is not empty"), close Blender completely, delete the
leftover extension directory and install the extension again.
```

An unknown schema name, and any wrapper without `schema_names()`, keep the original exception object and type. The happy path gains nothing but a `try` block.

The exception type changes from `RuntimeError` to `SchemaError` in the broken-install case only. `SchemaError` already exists in this module for schema problems. No caller in the tree catches `RuntimeError` around `schema_by_name`; the two `except RuntimeError` sites in `ifcopenshell/util/schema.py` guard `declaration_by_name`, not this call.

## Tests

`src/ifcopenshell-python/test/test_schema_by_name.py`, pure Python, no Blender:

- a real lookup still works,
- an unknown schema name keeps the original error,
- a registry with no IFC schema produces the diagnostic,
- a registry that does hold schemas is never reported as a broken install.

## Not fixed here: the published Windows package

Worth flagging separately, because the code fix for the packaging itself is already merged and the published package is still broken:

- `win/build-all-win.py` now collects underscore-prefixed plugin DLLs (`IFC_RUNTIME_PLUGIN_PREFIXES`, line 57), merged as 65ce0f71c4 for #9301.
- `src/ifcopenshell-python/Makefile:61` still pins `BUILD_COMMIT:=ad113e1`, a commit that predates that fix, and `build_win.yml` has not run since the fix landed. So the S3 zip the Bonsai daily consumes, and therefore the wheel inside the published `bonsai_py311-0.9.0-alpha260901-windows-x64.zip`, still ship zero `ifcopenshell_parse_schema_ifc*.dll`.

A fresh `build_win.yml` run at or after 65ce0f71c4 plus a `BUILD_COMMIT` bump is needed before Windows dailies work again. That is a release action, not a code change, so it is not in this PR.
