### PR TITLE
Bonsai: report a clear error when a schedule import path is not a file (#9409)

### DIFF
--- a/src/bonsai/bonsai/bim/module/sequence/operator.py
+++ b/src/bonsai/bonsai/bim/module/sequence/operator.py
@@ -40,6 +40,30 @@ if TYPE_CHECKING:
     from bpy.stub_internal.rna_enums import OperatorReturnItems
 
 
+def validate_import_filepath(operator: bpy.types.Operator, filepath: str, description: str) -> bool:
+    """Report a readable error instead of letting the parser raise on a bad path."""
+    from ifc4d.common import InvalidInputPathError, validate_input_path
+
+    try:
+        validate_input_path(filepath, description)
+    except InvalidInputPathError as e:
+        operator.report({"ERROR"}, str(e))
+        return False
+    return True
+
+
+def validate_export_filepath(operator: bpy.types.Operator, filepath: str, description: str) -> bool:
+    """Report a readable error instead of letting the writer raise on a bad path."""
+    from ifc4d.common import InvalidOutputPathError, validate_output_path
+
+    try:
+        validate_output_path(filepath, description)
+    except InvalidOutputPathError as e:
+        operator.report({"ERROR"}, str(e))
+        return False
+    return True
+
+
 class EnableStatusFilters(bpy.types.Operator):
     bl_idname = "bim.enable_status_filters"
     bl_label = "Enable Status Filters"
@@ -837,6 +861,8 @@ class ImportWorkScheduleCSV(bpy.types.Operator, tool.Ifc.Operator, ImportHelper)
     def _execute(self, context):
         from ifc4d.csv4d2ifc import Csv2Ifc
 
+        if not validate_import_filepath(self, self.filepath, "schedule .csv file"):
+            return
         self.file = tool.Ifc.get()
         start = time.time()
         csv2ifc = Csv2Ifc()
@@ -865,6 +891,8 @@ class ImportP6(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
     def _execute(self, context):
         from ifc4d.p62ifc import P62Ifc
 
+        if not validate_import_filepath(self, self.filepath, "P6 .xml file"):
+            return
         self.file = tool.Ifc.get()
         start = time.time()
         p62ifc = P62Ifc()
@@ -894,6 +922,8 @@ class ImportP6XER(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
     def _execute(self, context):
         from ifc4d.p6xer2ifc import P6XER2Ifc
 
+        if not validate_import_filepath(self, self.filepath, "P6 .xer file"):
+            return
         self.file = tool.Ifc.get()
         start = time.time()
         p6xer2ifc = P6XER2Ifc()
@@ -923,6 +953,8 @@ class ImportPP(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
     def _execute(self, context):
         from ifc4d.pp2ifc import PP2Ifc
 
+        if not validate_import_filepath(self, self.filepath, "Powerproject .pp file"):
+            return
         self.file = tool.Ifc.get()
         start = time.time()
         pp2ifc = PP2Ifc()
@@ -952,6 +984,8 @@ class ImportMSP(bpy.types.Operator, tool.Ifc.Operator, ImportHelper):
     def _execute(self, context):
         from ifc4d.msp2ifc import MSP2Ifc
 
+        if not validate_import_filepath(self, self.filepath, "MS Project .xml file"):
+            return
         self.file = tool.Ifc.get()
         start = time.time()
         msp2ifc = MSP2Ifc()
@@ -983,11 +1017,14 @@ class ExportMSP(bpy.types.Operator, ExportHelper):
     def execute(self, context):
         from ifc4d.ifc2msp import Ifc2Msp
 
+        filepath = bpy.path.ensure_ext(self.filepath, ".xml")
+        if not validate_export_filepath(self, filepath, "MS Project .xml file"):
+            return {"CANCELLED"}
         self.file = tool.Ifc.get()
         start = time.time()
         ifc2msp = Ifc2Msp()
         ifc2msp.work_schedule = self.file.by_type("IfcWorkSchedule")[0]
-        ifc2msp.xml = bpy.path.ensure_ext(self.filepath, ".xml")
+        ifc2msp.xml = filepath
         ifc2msp.file = self.file
         ifc2msp.holiday_start_date = parser.parse(self.holiday_start_date).date()
         ifc2msp.holiday_finish_date = parser.parse(self.holiday_finish_date).date()
@@ -1017,10 +1054,13 @@ class ExportP6(bpy.types.Operator, ExportHelper):
     def execute(self, context):
         from ifc4d.ifc2p6 import Ifc2P6
 
+        filepath = bpy.path.ensure_ext(self.filepath, ".xml")
+        if not validate_export_filepath(self, filepath, "P6 .xml file"):
+            return {"CANCELLED"}
         self.file = tool.Ifc.get()
         start = time.time()
         ifc2p6 = Ifc2P6()
-        ifc2p6.xml = bpy.path.ensure_ext(self.filepath, ".xml")
+        ifc2p6.xml = filepath
         ifc2p6.file = self.file
         ifc2p6.holiday_start_date = parser.parse(self.holiday_start_date).date()
         ifc2p6.holiday_finish_date = parser.parse(self.holiday_finish_date).date()

--- a/src/ifc4d/ifc4d/common.py
+++ b/src/ifc4d/ifc4d/common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from datetime import date, datetime, timedelta
 from typing import Any, TypedDict, Union
 
@@ -8,6 +9,45 @@ import ifcopenshell.api.control
 import ifcopenshell.api.resource
 import ifcopenshell.api.sequence
 from typing_extensions import NotRequired
+
+
+class InvalidInputPathError(Exception):
+    """Raised when an input path is empty, missing, a directory, or unreadable."""
+
+
+class InvalidOutputPathError(Exception):
+    """Raised when an output path is empty, a directory, or in a missing folder."""
+
+
+def validate_input_path(path: Union[str, None], description: str = "file") -> str:
+    """Check that ``path`` points at a readable file before it is handed to a parser."""
+    if not path or not str(path).strip():
+        raise InvalidInputPathError(f"No {description} was selected.")
+    path = str(path)
+    if os.path.isdir(path):
+        raise InvalidInputPathError(f"The selected {description} is a folder, not a file: {path}")
+    if not os.path.exists(path):
+        raise InvalidInputPathError(f"The selected {description} does not exist: {path}")
+    if not os.path.isfile(path):
+        raise InvalidInputPathError(f"The selected {description} is not a file: {path}")
+    if not os.access(path, os.R_OK):
+        raise InvalidInputPathError(f"The selected {description} cannot be read: {path}")
+    return path
+
+
+def validate_output_path(path: Union[str, None], description: str = "file") -> str:
+    """Check that ``path`` can be written to before any conversion work is done."""
+    if not path or not str(path).strip():
+        raise InvalidOutputPathError(f"No {description} was selected.")
+    path = str(path)
+    if os.path.isdir(path):
+        raise InvalidOutputPathError(f"The selected {description} is a folder, not a file: {path}")
+    directory = os.path.dirname(os.path.abspath(path))
+    if not os.path.isdir(directory):
+        raise InvalidOutputPathError(f"The folder for the selected {description} does not exist: {directory}")
+    if not os.access(directory, os.W_OK):
+        raise InvalidOutputPathError(f"The folder for the selected {description} cannot be written to: {directory}")
+    return path
 
 
 class WorkSlot(TypedDict):

--- a/src/ifc4d/ifc4d/csv2ifc.py
+++ b/src/ifc4d/ifc4d/csv2ifc.py
@@ -34,6 +34,8 @@ import ifcopenshell.util.element
 import ifcopenshell.util.resource
 import isodate
 
+from .common import validate_input_path, validate_output_path
+
 SUPPORTED_COLUMN = Literal[
     "HIERARCHY",
     "TYPE",  # CREW, LABOR, EQUIPMENT, SUBCONTRACTOR, MATERIAL, PRODUCT.
@@ -94,6 +96,7 @@ class Csv2Ifc:
         self.units = {}  # TODO: never used
 
     def execute(self) -> None:
+        validate_input_path(self.csv, "resources .csv file")
         self.parse_csv()
         self.create_ifc()
 
@@ -284,6 +287,7 @@ class Ifc2Csv:
         self.inverse_resource_map = {value: key for key, value in RESOURCE_MAP.items()}
 
     def execute(self) -> None:
+        validate_output_path(self.filepath, "resources .csv file")
         with open(self.filepath, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
             writer.writerow(self.HEADER)

--- a/src/ifc4d/ifc4d/csv4d2ifc.py
+++ b/src/ifc4d/ifc4d/csv4d2ifc.py
@@ -26,6 +26,8 @@ import ifcopenshell.api.root
 import ifcopenshell.api.sequence
 import ifcopenshell.util.date
 
+from .common import validate_input_path
+
 
 class Csv2Ifc:
     def __init__(self):
@@ -38,6 +40,7 @@ class Csv2Ifc:
         self.units = {}
 
     def execute(self):
+        validate_input_path(self.csv, "schedule .csv file")
         self.parse_csv()
         self.create_ifc()
 

--- a/src/ifc4d/ifc4d/ifc2msp.py
+++ b/src/ifc4d/ifc4d/ifc2msp.py
@@ -24,6 +24,8 @@ import ifcopenshell
 import ifcopenshell.util.date
 import ifcopenshell.util.sequence
 
+from .common import validate_output_path
+
 
 class Ifc2Msp:
     def __init__(self):
@@ -45,6 +47,7 @@ class Ifc2Msp:
         self.work_schedule = None
 
     def execute(self):
+        validate_output_path(self.xml, "MS Project .xml file")
         self.root = ET.Element("Project")
         self.root.attrib["xmlns"] = "http://schemas.microsoft.com/project"
 

--- a/src/ifc4d/ifc4d/ifc2p6.py
+++ b/src/ifc4d/ifc4d/ifc2p6.py
@@ -24,6 +24,8 @@ import ifcopenshell
 import ifcopenshell.util.date
 import ifcopenshell.util.sequence
 
+from .common import validate_output_path
+
 
 class Ifc2P6:
     def __init__(self):
@@ -44,6 +46,7 @@ class Ifc2P6:
         self.holiday_finish_date = None
 
     def execute(self):
+        validate_output_path(self.xml, "P6 .xml file")
         self.root = ET.Element("APIBusinessObjects")
         self.root.attrib["xmlns"] = "http://xmlns.oracle.com/Primavera/P6Professional/V18.8/API/BusinessObjects"
         self.root.attrib["xmlns:xsi"] = "http://www.w3.org/2001/XMLSchema-instance"

--- a/src/ifc4d/ifc4d/msp2ifc.py
+++ b/src/ifc4d/ifc4d/msp2ifc.py
@@ -27,6 +27,8 @@ import ifcopenshell.api.root
 import ifcopenshell.api.sequence
 import ifcopenshell.util.date
 
+from .common import validate_input_path
+
 
 class MSP2Ifc:
     def __init__(self, optionalColumns: list[str] = []):
@@ -42,6 +44,7 @@ class MSP2Ifc:
         self.RESOURCE_TYPES_MAPPING = {"1": "LABOR", "0": "MATERIAL", "2": None}
 
     def execute(self):
+        validate_input_path(self.xml, "MS Project .xml file")
         self.parse_xml()
         self.create_ifc()
 

--- a/src/ifc4d/ifc4d/p62ifc.py
+++ b/src/ifc4d/ifc4d/p62ifc.py
@@ -19,7 +19,7 @@
 import datetime
 import xml.etree.ElementTree as ET
 
-from .common import ScheduleIfcGenerator
+from .common import ScheduleIfcGenerator, validate_input_path
 
 
 class P62Ifc:
@@ -62,6 +62,7 @@ class P62Ifc:
     def execute(self):
         import time
 
+        validate_input_path(self.xml, "P6 .xml file")
         start = time.time()
         print("Started")
         self.parse_xml()

--- a/src/ifc4d/ifc4d/p6xer2ifc.py
+++ b/src/ifc4d/ifc4d/p6xer2ifc.py
@@ -19,7 +19,7 @@
 
 from xerparser.reader import Reader
 
-from .common import ScheduleIfcGenerator
+from .common import ScheduleIfcGenerator, validate_input_path
 
 
 class P6XER2Ifc:
@@ -74,6 +74,7 @@ class P6XER2Ifc:
         }
 
     def execute(self):
+        validate_input_path(self.xer, "P6 .xer file")
         self.parse_xer()
         settings = {
             "work_plan": self.work_plan,

--- a/src/ifc4d/ifc4d/pp2ifc.py
+++ b/src/ifc4d/ifc4d/pp2ifc.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from datetime import timedelta
 from typing import Any
 
-from .common import Activity, Calendar, ScheduleIfcGenerator, WBSEntry
+from .common import Activity, Calendar, ScheduleIfcGenerator, WBSEntry, validate_input_path
 from .wpattern import AstaCalendarWorkPattern
 
 list_of_tables = [
@@ -57,6 +57,7 @@ class PP2Ifc:
         return r
 
     def execute(self) -> None:
+        validate_input_path(self.pp, "Powerproject .pp file")
         self.con = sqlite3.connect(self.pp)
         self.cur = self.con.cursor()
         self.parse_pp()

--- a/src/ifc4d/test/test_input_path_validation.py
+++ b/src/ifc4d/test/test_input_path_validation.py
@@ -1,0 +1,128 @@
+# IfcOpenShell - IFC toolkit and geometry engine
+# Copyright (C) 2026 Petru Conduraru <petru@bimvoice.com>
+#
+# This file is part of IfcOpenShell.
+#
+# IfcOpenShell is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcOpenShell is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+import os
+import tempfile
+
+import pytest
+
+from ifc4d.common import InvalidInputPathError, InvalidOutputPathError, validate_input_path, validate_output_path
+from ifc4d.csv2ifc import Csv2Ifc as ResourceCsv2Ifc
+from ifc4d.csv2ifc import Ifc2Csv
+from ifc4d.csv4d2ifc import Csv2Ifc
+from ifc4d.ifc2msp import Ifc2Msp
+from ifc4d.ifc2p6 import Ifc2P6
+from ifc4d.msp2ifc import MSP2Ifc
+from ifc4d.p62ifc import P62Ifc
+from ifc4d.p6xer2ifc import P6XER2Ifc
+from ifc4d.pp2ifc import PP2Ifc
+
+IMPORTERS = [MSP2Ifc, P62Ifc, P6XER2Ifc, PP2Ifc, Csv2Ifc]
+
+
+def make_importer(cls, path):
+    converter = cls()
+    if cls in (MSP2Ifc, P62Ifc):
+        converter.xml = path
+    elif cls is P6XER2Ifc:
+        converter.xer = path
+    elif cls is PP2Ifc:
+        converter.pp = path
+    else:
+        converter.csv = path
+    return converter
+
+
+class TestValidateInputPath:
+    def test_empty_path(self):
+        with pytest.raises(InvalidInputPathError, match="No schedule file was selected"):
+            validate_input_path("", "schedule file")
+
+    def test_none_path(self):
+        with pytest.raises(InvalidInputPathError, match="No schedule file was selected"):
+            validate_input_path(None, "schedule file")
+
+    def test_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(InvalidInputPathError, match="is a folder, not a file"):
+                validate_input_path(tmp_dir, "schedule file")
+
+    def test_missing_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(InvalidInputPathError, match="does not exist"):
+                validate_input_path(os.path.join(tmp_dir, "nope.xml"), "schedule file")
+
+    def test_existing_file_is_returned(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "schedule.xml")
+            with open(path, "w") as f:
+                f.write("")
+            assert validate_input_path(path, "schedule file") == path
+
+
+class TestImportersRejectBadPaths:
+    # The crash in #9409 was ET.parse() receiving a folder path from the file selector.
+    @pytest.mark.parametrize("cls", IMPORTERS)
+    def test_directory_is_rejected(self, cls):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(InvalidInputPathError):
+                make_importer(cls, tmp_dir).execute()
+
+    @pytest.mark.parametrize("cls", IMPORTERS)
+    def test_empty_path_is_rejected(self, cls):
+        with pytest.raises(InvalidInputPathError):
+            make_importer(cls, "").execute()
+
+    @pytest.mark.parametrize("cls", IMPORTERS)
+    def test_missing_file_is_rejected(self, cls):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(InvalidInputPathError):
+                make_importer(cls, os.path.join(tmp_dir, "missing.dat")).execute()
+
+    def test_resource_csv_importer_rejects_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(InvalidInputPathError):
+                ResourceCsv2Ifc(tmp_dir).execute()
+
+
+class TestExportersRejectBadPaths:
+    def test_msp_export_rejects_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            exporter = Ifc2Msp()
+            exporter.xml = tmp_dir
+            with pytest.raises(InvalidOutputPathError, match="is a folder, not a file"):
+                exporter.execute()
+
+    def test_p6_export_rejects_missing_folder(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            exporter = Ifc2P6()
+            exporter.xml = os.path.join(tmp_dir, "nope", "schedule.xml")
+            with pytest.raises(InvalidOutputPathError, match="does not exist"):
+                exporter.execute()
+
+    def test_resource_csv_export_rejects_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(InvalidOutputPathError):
+                Ifc2Csv(tmp_dir, None).execute()
+
+    def test_validate_output_path_accepts_new_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "schedule.xml")
+            assert validate_output_path(path, "schedule file") == path


### PR DESCRIPTION
Fixes #9409.

## Root cause

`bonsai/bim/module/sequence/operator.py:961` (`ImportMSP._execute`) hands `self.filepath` straight to `ifc4d/msp2ifc.py:45` (`MSP2Ifc.execute`), which calls `ifc4d/msp2ifc.py:49` (`parse_xml`), which calls `xml.etree.ElementTree.parse(self.xml)`. Nothing between the file selector and the parser checks that the path is a file, so a folder or an empty filename reaches `open()` and Blender shows an unhandled Python traceback.

Reproduced headless on Blender 5.2 with Bonsai from the current v0.8.0, calling `bpy.ops.bim.import_msp(filepath=<a folder>)`:

```
File ".../bonsai/bim/module/sequence/operator.py", line 961, in _execute
  msp2ifc.execute()
File ".../ifc4d/msp2ifc.py", line 45, in execute
  self.parse_xml()
File ".../ifc4d/msp2ifc.py", line 49, in parse_xml
  tree = ET.parse(self.xml)
IsADirectoryError: [Errno 21] Is a directory: '/var/folders/.../tmpwcp0m43i'
```

That is the same stack as the report. The reporter is on Windows, where a folder path with a trailing separator gives `FileNotFoundError` rather than `IsADirectoryError`, which matches the `No such file or directory: 'C:\Users\jimgr\Downloads\'` in the issue.

## Fix

`ifc4d/common.py` gains `validate_input_path` and `validate_output_path`, raising `InvalidInputPathError` / `InvalidOutputPathError` with a readable message for an empty path, a folder, a missing file, or an unreadable file. Every ifc4d importer and exporter calls the matching helper at the top of `execute()`, and the sequence import and export operators translate the exception into `self.report({"ERROR"}, ...)`, which is the reporting convention already used in that file.

## Sibling sweep

Measured behaviour of every ifc4d entry point before the fix (fresh temporary directory per case, v0.8.0 at bdc6d23):

| Entry point | folder | empty string | missing file | verdict |
| --- | --- | --- | --- | --- |
| `msp2ifc.MSP2Ifc` (`ET.parse`) | `IsADirectoryError` | `FileNotFoundError` | `FileNotFoundError` | fixed, this is #9409 |
| `p62ifc.P62Ifc` (`ET.parse`) | `IsADirectoryError` | `FileNotFoundError` | `FileNotFoundError` | fixed |
| `p6xer2ifc.P6XER2Ifc` (`xerparser.Reader`) | `IsADirectoryError` | `FileNotFoundError` | `FileNotFoundError` | fixed |
| `pp2ifc.PP2Ifc` (`sqlite3.connect`) | `OperationalError: unable to open database file` | `OperationalError: no such table: PROJECT_SUMMARY` | same, **and it created an empty sqlite database at the selected path** | fixed |
| `csv4d2ifc.Csv2Ifc` (`open`) | `IsADirectoryError` | `FileNotFoundError` | `FileNotFoundError` | fixed |
| `csv2ifc.Csv2Ifc` resources import (`open`) | `IsADirectoryError` | `FileNotFoundError` | `FileNotFoundError` | fixed |
| `ifc2msp.Ifc2Msp` (`ElementTree.write`) | output path, unchecked | output path, unchecked | output path, unchecked | fixed with `validate_output_path` |
| `ifc2p6.Ifc2P6` (`ElementTree.write`) | output path, unchecked | output path, unchecked | output path, unchecked | fixed with `validate_output_path` |
| `csv2ifc.Ifc2Csv` resources export (`open`) | `IsADirectoryError` | `FileNotFoundError` | writes | fixed with `validate_output_path` |

Operators in `bim/module/sequence/operator.py`: `ImportWorkScheduleCSV`, `ImportP6`, `ImportP6XER`, `ImportPP`, `ImportMSP` all had the same unguarded shape and now report an error and return. `ExportMSP` and `ExportP6` are guarded the same way, and the `bpy.path.ensure_ext` call moved above the check so the path that is validated is the path that is written. No other operator in that file takes a filesystem path.

`bim/module/resource/operator.py` (`ImportResources`, `ExportResources`) uses the same `ifc4d.csv2ifc` classes through `core` and `tool.Resource`, so it now gets the clearer library-level exception, but its operator layer is left alone as it is outside this module.

## RED / GREEN

RED, on v0.8.0 without this change:

```
$ python3.11 -m pytest test/test_input_path_validation.py -q
ImportError: cannot import name 'InvalidInputPathError' from 'ifc4d.common'
```

plus the measured raw exceptions in the table above, and the Blender traceback quoted at the top.

GREEN, with this change:

```
$ python3.11 -m pytest src/ifc4d/test/test_input_path_validation.py -q
25 passed in 0.58s
```

and under Blender 5.2, the same folder path now gives:

```
LIB InvalidInputPathError | The selected MS Project .xml file is a folder, not a file: /var/folders/.../tmpo458ktzz
OP directory returned=False reports=[({'ERROR'}, 'The selected MS Project .xml file is a folder, not a file: ...')]
OP empty     returned=False reports=[({'ERROR'}, 'No MS Project .xml file was selected.')]
OP missing   returned=False reports=[({'ERROR'}, 'The selected MS Project .xml file does not exist: ...')]
OP valid     returned=True reports=[]
```

black and ruff from the CI configuration pass on every changed file.

---

This change was prepared with the assistance of an AI coding tool.
