### PR TITLE
packaging: collect underscore-prefixed runtime plugins in every pipeline

### DIFF
--- a/nix/package-zip-archives.py
+++ b/nix/package-zip-archives.py
@@ -142,6 +142,19 @@ def is_shared_library(path: Path) -> bool:
     return name.endswith((".so", ".dylib", ".dll")) or ".so." in name
 
 
+# Runtime plug-ins are loaded by name and carry the underscore-prefixed
+# `ifcopenshell_` names without a platform library prefix (see
+# `decorated_basename()` in src/plugin/plugin.cpp and `ifcopenshell_plugin_target()`
+# in cmake/utilities.cmake), while the core shared libraries keep the dotted
+# `ifcopenshell.` names and the platform `lib` prefix. Match both conventions.
+IFC_GEOMETRY_WRITER_PREFIXES = ("ifcopenshell.geometry.writer.", "ifcopenshell_geometry_writer_")
+
+
+def is_geometry_writer(path: Path) -> bool:
+    name = path.name.removeprefix("lib")
+    return name.startswith(IFC_GEOMETRY_WRITER_PREFIXES)
+
+
 def stage_runtime_payload(install_dir: Path, dest: Path, *, include_geometry_writers: bool = True) -> None:
     """Copy all libs from `install_dir/{bin,lib,lib64}` into `dest`."""
     runtime_files = []
@@ -154,7 +167,7 @@ def stage_runtime_payload(install_dir: Path, dest: Path, *, include_geometry_wri
                 continue
             if not is_shared_library(runtime_file):
                 continue
-            if not include_geometry_writers and runtime_file.name.startswith("ifcopenshell.geometry.writer."):
+            if not include_geometry_writers and is_geometry_writer(runtime_file):
                 continue
             dest_file = dest / runtime_file.name
             # Currently there's an overlap between dependencies installations.

--- a/pyodide/pack_wheel.py
+++ b/pyodide/pack_wheel.py
@@ -103,8 +103,13 @@ class WheelBuilder:
         return f"https://s3.amazonaws.com/ifcopenshell-builds/{encoded_filename}"
 
     @staticmethod
-    def download_and_extract_so(url: str, build_dir: Path) -> tuple[Path, Path]:
-        """Download wheel from URL and extract .so and .py files."""
+    def download_and_extract_so(url: str, build_dir: Path) -> tuple[list[Path], Path]:
+        """Download wheel from URL and extract .so and .py files.
+
+        Besides `_ifcopenshell_wrapper`, the wheel bundles the underscore-prefixed
+        runtime plugins (e.g. `ifcopenshell_parse_schema_ifc4.so`) that are loaded
+        by name, so every `.so` has to be kept.
+        """
         py_wrapper_filename = "ifcopenshell_wrapper.py"
         build_dir.mkdir(parents=True, exist_ok=True)
 
@@ -124,17 +129,22 @@ class WheelBuilder:
             py_files = [f for f in zf.namelist() if f.endswith(py_wrapper_filename)]
 
             assert so_files, "No .so file found in wheel"
+            assert any(
+                Path(f).name.startswith("_ifcopenshell_wrapper") for f in so_files
+            ), "No _ifcopenshell_wrapper .so file found in wheel"
             assert py_files, f"No {py_wrapper_filename} file found in wheel"
 
-            so_file = so_files[0]
-            so_dst = build_dir / Path(so_file).name
-            so_dst.write_bytes(zf.read(so_file))
+            so_dsts = []
+            for so_file in so_files:
+                so_dst = build_dir / Path(so_file).name
+                so_dst.write_bytes(zf.read(so_file))
+                so_dsts.append(so_dst)
 
             py_file = py_files[0]
             py_dst = build_dir / Path(py_file).name
             py_dst.write_bytes(zf.read(py_file))
 
-        return so_dst, py_dst
+        return so_dsts, py_dst
 
 
 class Tools:
@@ -203,9 +213,10 @@ def main() -> None:
     print("Downloading and extracting _ifcopenshell_wrapper files...")
     makefile = REPO_ROOT / "src" / "ifcopenshell-python" / "Makefile"
     wheel_url = WheelBuilder.get_wheel_url(makefile)
-    so_file, py_file = WheelBuilder.download_and_extract_so(wheel_url, BUILD_DIR)
+    so_files, py_file = WheelBuilder.download_and_extract_so(wheel_url, BUILD_DIR)
 
-    Tools.create_symlink(IFCOPENSHELL_DIR / Path(so_file).name, so_file)
+    for so_file in so_files:
+        Tools.create_symlink(IFCOPENSHELL_DIR / so_file.name, so_file)
     Tools.create_symlink(IFCOPENSHELL_DIR / Path(py_file).name, py_file)
 
     print("Installing pyodide-build...")


### PR DESCRIPTION
## Motivation

On #9424 @aothms wrote:

> I don't want to pollute the code with so much diagnostics for broken installs which is likely a temporary situation until all the publishing pipelines and makefiles correctly copy over the shared libs.

Agreed. This PR is that work instead: an audit of every packaging path in the repo against the plug-in naming rule, and the smallest fix for each gap found. No diagnostics are added.

## The naming rule

Two conventions live side by side, and a script that matches only one of them silently drops or wrongly keeps plug-ins.

* Core shared libraries keep **dotted** names and the platform library prefix: `libifcopenshell.parse.so`, `libifcopenshell.geometry.so`, `libifcopenshell.geometry.writer.so`, `libifcopenshell.plugin.so` (`OUTPUT_NAME` in `src/ifcparse/CMakeLists.txt:39`, `src/ifcgeom/CMakeLists.txt:15`, `src/ifcgeom/serialization/CMakeLists.txt:14`, `src/plugin/CMakeLists.txt:6`).
* Runtime plug-ins loaded by name are **underscore**-prefixed and get **no** platform prefix: `ifcopenshell_parse_schema_ifc4.so`, `ifcopenshell_geometry_mapping_ifc4.so`, `ifcopenshell_geometry_kernel_opencascade.so`, `ifcopenshell_geometry_writer_ifc4.so`, the document and geometry serializers (`decorated_basename()` at `src/plugin/plugin.cpp:129`, `OUTPUT_NAME` at `src/ifcparse/CMakeLists.txt:98`, `src/ifcgeom/mapping/CMakeLists.txt:20`, `src/ifcgeom/kernels/CMakeLists.txt:37`, `src/ifcgeom/serialization/schema/CMakeLists.txt:8`, `src/serializers/CMakeLists.txt:21,48`; the missing prefix comes from `ifcopenshell_plugin_target()` at `cmake/utilities.cmake:54-56`).

The absent `lib` prefix on plug-ins is the part that is easy to miss, and it is what makes the existing filter in `nix/package-zip-archives.py` inert. Confirmed against a real Linux aarch64 install tree, which contains `ifcopenshell_parse_schema_ifc4.so` next to `libifcopenshell.parse.a`.

Getting this wrong has already shipped twice: #9301/#9305 (Windows dropped every underscore plug-in; every published 0.9.0 Windows package still lacks `ifcopenshell_parse_schema_ifc*.dll`, hence `No schema named IFC4` on import, #9423) and #9364/#9382 (the Python wheel Makefile dropped the runtime plug-ins from the wheel).

## Audit

| Pipeline | What it collects | Verdict | Evidence |
| --- | --- | --- | --- |
| `win/build-all-win.py` | `IFC_RUNTIME_PLUGIN_PREFIXES = ("ifcopenshell.", "ifcopenshell_")`, geometry writers via `IFC_GEOMETRY_WRITER_PREFIXES` with both spellings | CORRECT (canonical) | `win/build-all-win.py:61,65,166-176,291` |
| `nix/package-zip-archives.py`, Python wrapper archives | every `.so` / `.so.N` / `.dylib` / `.dll`, prefix agnostic | CORRECT | `is_shared_library` at :140-142, called from :333-336 |
| `nix/package-zip-archives.py`, executable archives | intended to skip geometry writers, matched only `ifcopenshell.geometry.writer.` | **GAP, fixed** | old :157, call site :375 |
| `nix/build-all.py` | copies the built module directory wholesale, no name filter | NOT APPLICABLE | `shutil.copytree(module_dir, dest)` at :1983 |
| `src/ifcopenshell-python/Makefile` (`zip`, `dist`) | `find ... \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \)` | CORRECT (#9382) | :126, :148 |
| `pyodide/pack_wheel.py` | took `so_files[0]` only, dropping every runtime plug-in from the repacked wheel | **GAP, fixed** | old :123-131 |
| `pyodide/split_pyodide_ifcopenshell_wheel.py` | splits every `.so` except `_ifcopenshell_wrapper`, name agnostic | CORRECT | :235-236 |
| `pyodide/order_pyodide_wheel_shared_objects.py` | orders, never selects; already knows the underscore forms | CORRECT | :37-40 |
| `pyodide/build-all-pack-wheel-local.py`, `pyodide/setup.py` | delegates to `pyodide build`; `package_data` includes `"*.so"` | CORRECT | `build-all-pack-wheel-local.py:24-35`, `setup.py:79` |
| `conda/build.sh`, `conda/build.bat`, `conda/recipe.yaml` | `ninja install`, i.e. the CMake install rules; no hand-rolled copying | NOT APPLICABLE | `build.sh:44`, `build.bat:44` |
| `src/bonsai/Makefile`, `src/bonsai/scripts/get_wheels.py` | consumes `.whl` files only, never touches shared libraries | NOT APPLICABLE | `Makefile:106-190`, `get_wheels.py:5-12` |
| `choco/bonsai/choco_release.py` | repackages a published release zip by URL and hash | NOT APPLICABLE | :156-161 |
| `.github/workflows/*` | no workflow copies libraries by name any more; the old Rocky/OSX bash was ported into `nix/package-zip-archives.py` in 13bc830 | NOT APPLICABLE | `release.yml:71` uses `make install` plus CPack |
| other `src/*/Makefile` | grep for `*.so`, `*.dylib`, `*.dll` across every `Makefile` and `*.mk` under `src/` hits only `src/ifcopenshell-python/Makefile` | NOT APPLICABLE | grep, 2 hits |

## Changes

**`nix/package-zip-archives.py`.** The writer exclusion for executable archives tested `runtime_file.name.startswith("ifcopenshell.geometry.writer.")`. On Linux and macOS, the only platforms this script runs on, that matches nothing: the core library is `libifcopenshell.geometry.writer.so` (dotted, but prefixed) and the per-schema plug-ins are `ifcopenshell_geometry_writer_ifc4.so` (unprefixed, but underscored). The exclusion has never fired, and the Linux executable archives have been shipping all of the per-schema writers. The same never-matching test existed in the bash it was ported from (`build_rocky.yml:156` before 13bc830). Replaced with `is_geometry_writer()`, which strips a leading `lib` and matches both prefixes, mirroring `IFC_GEOMETRY_WRITER_PREFIXES` in the Windows script.

This makes Linux executable archives behave like the Windows ones and like the code's stated intent: the writers ship with the Python package, not next to the executables. That is safe, because nothing in the executables loads them. `load_opencascade_geometry_ifc_writer_plugins()` is called only from `src/ifcgeom/serialization/serialization.cpp:31,43`, reached through `ifcwrap`; `IfcConvert` does not link `geometry_serializer` (`src/ifcconvert/CMakeLists.txt:4`), and its `.ifc` output path is a plain SPF dump (`src/ifcconvert/IfcConvert.cpp:647-659`). The Python archives are unaffected, they pass `include_geometry_writers=True`.

**`pyodide/pack_wheel.py`.** `download_and_extract_so()` collected the `.so` members of the downloaded wheel and then kept `so_files[0]`. The wasm wheel bundles the underscore-prefixed plug-in side modules alongside the wrapper, which is exactly why `order_pyodide_wheel_shared_objects.py` and `split_pyodide_ifcopenshell_wheel.py` exist, so the repacked wheel lost every schema plug-in and depended on zip member order to pick up the wrapper at all. It now extracts and links all of them and asserts the wrapper is among them.

## Verification

Executed, on macOS against this branch:

* Real filenames. Listed an actual Linux aarch64 install tree (`build/Linux/aarch64/install/ifcopenshell/lib64`) to confirm the on-disk spellings: 55 `ifcopenshell_*.so` plug-ins with no `lib` prefix, and `libifcopenshell.parse.a` / `libifcopenshell.geometry.writer.a` with one.
* Ran the real `stage_runtime_payload()` from this branch over a synthetic tree of 17 files covering both conventions and all four extensions. With `include_geometry_writers=True`, 17 of 17 staged. With `False`, exactly the 7 geometry-writer spellings are dropped (`.so`, `.dylib`, `.dll`, dotted and underscore) and every load-by-name plug-in survives.
* Red-green on the same harness against the pre-change file from `v0.9.0`: the old filter excludes **nothing**, staging all 6 test files including both writers.
* Ran the real `download_and_extract_so()` from this branch against a synthetic wheel containing the wrapper plus 5 plug-in `.so` members: all 6 extracted. The pre-change version returns a single `Path`, i.e. one `.so`, which is the red case.
* Lint: `black 26.5.1` clean, `ruff 0.16.4` (the pin from `requirements-tools.txt`) clean on both files.

Reasoned from the source only, not executed: every NOT APPLICABLE and CORRECT row above other than the two `nix` rows and the four `pyodide` rows. None of the packaging pipelines themselves (nix zips, pyodide, conda, Windows, choco) can be run in this environment, so no produced artifact has been inspected. In particular the behaviour change to the Linux executable archives is argued from the call graph above, not from a rebuilt archive.

Refs #9423, #9301, #9305, #9364, #9382, #9424.
