### PR TITLE
Bonsai: drawing a slab with an empty polyline crashes (#9426)

### DIFF
--- a/src/bonsai/bonsai/bim/module/model/slab.py
+++ b/src/bonsai/bonsai/bim/module/model/slab.py
@@ -93,11 +93,11 @@ class DumbSlabGenerator:
         polyline_props = tool.Model.get_polyline_props()
         polyline_data = polyline_props.insertion_polyline
         polyline_points = polyline_data[0].polyline_points if polyline_data else []
+        if len(polyline_points) <= 2:
+            return
+
         self.location = Vector((polyline_points[0].x, polyline_points[0].y, self.container_obj.location.z))
         self.polyline = [tuple(Vector((p.x, p.y, 0.0)) - self.location) for p in polyline_points]
-
-        if len(self.polyline) <= 2:
-            return
 
         # Always assume a closed polyline
         if self.polyline[0] != self.polyline[-1]:
@@ -115,11 +115,11 @@ class DumbSlabGenerator:
         poly = tool.Model.get_polygons_from_wall_axis(walls)
         polyline_points = [tuple([v for v in c]) for c in poly.exterior.coords]
 
+        if len(polyline_points) <= 2:
+            return
+
         self.location = Vector((polyline_points[0][0], polyline_points[0][1], self.container_obj.location.z))
         self.polyline = [tuple(Vector((p[0], p[1], 0.0)) - self.location) for p in polyline_points]
-
-        if len(self.polyline) <= 2:
-            return
 
         # Always assume a closed polyline
         if self.polyline[0] != self.polyline[-1]:

--- a/src/bonsai/test/bim/module/model/test_slab_empty_polyline.py
+++ b/src/bonsai/test/bim/module/model/test_slab_empty_polyline.py
@@ -1,0 +1,65 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+#
+# This file was generated with the assistance of an AI coding tool.
+
+"""Regression contract for #9426: finishing the polyline slab tool without
+enough points must end quietly instead of raising IndexError.
+
+``DumbSlabGenerator`` needs a live IFC file and a relating type to construct,
+so the tests call ``derive_from_polyline`` as a plain function against a stub
+``self``. That is the exact code path the traceback in #9426 names, and the
+too-few-points guard has to fire before any indexing for these to pass."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.model
+
+
+class _Point:
+    def __init__(self, x, y, z=0.0):
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+def _polyline_props(points=None):
+    """Mimic the polyline props: an empty ``insertion_polyline`` collection
+    when nothing was drawn, otherwise a single entry holding the points."""
+    if points is None:
+        return SimpleNamespace(insertion_polyline=[])
+    return SimpleNamespace(insertion_polyline=[SimpleNamespace(polyline_points=points)])
+
+
+def _derive(points):
+    from bonsai.bim.module.model.slab import DumbSlabGenerator
+
+    generator = SimpleNamespace(container_obj=None, location=None, polyline=None)
+    with patch("bonsai.tool.Model.get_polyline_props", return_value=_polyline_props(points)):
+        return DumbSlabGenerator.derive_from_polyline(generator)
+
+
+def test_empty_polyline_returns_without_creating_a_slab():
+    assert _derive(None) is None
+
+
+def test_polyline_with_two_points_returns_without_creating_a_slab():
+    assert _derive([_Point(0.0, 0.0), _Point(1.0, 0.0)]) is None


### PR DESCRIPTION
Fixes #9426.

## Root cause

`DumbSlabGenerator.derive_from_polyline` in `src/bonsai/bonsai/bim/module/model/slab.py` starts by tolerating a missing polyline and then immediately indexes the empty list it just built:

```python
polyline_points = polyline_data[0].polyline_points if polyline_data else []
self.location = Vector((polyline_points[0].x, polyline_points[0].y, self.container_obj.location.z))   # slab.py:96
self.polyline = [tuple(Vector((p.x, p.y, 0.0)) - self.location) for p in polyline_points]

if len(self.polyline) <= 2:   # slab.py:98, too late
    return
```

The `<= 2` guard is the right guard, it is just placed one statement after the line that raises. `len(self.polyline)` is always `len(polyline_points)`, so the guard can move up without changing any behaviour that used to work.

## How the user gets there

`DrawPolylineSlab._modal` (`slab.py:944`) treats `RET`, `NUMPAD_ENTER` and `RIGHTMOUSE` as "finish", and calls `create_slab_from_polyline` (`slab.py:871`) directly. Nothing on that path inserts a point first, and `tool.Polyline.clear_polyline()` empties `insertion_polyline` entirely. So pressing Enter or right-clicking before any point has been placed reaches `derive_from_polyline` with `insertion_polyline` empty, `polyline_points` becomes `[]`, and `[0]` raises `IndexError: list index out of range`, which is exactly the traceback in the report.

## The fix

Move the existing guard above the indexing, in both `derive_from_polyline` and `derive_from_walls`. The operator now ends with no traceback, the same silent return the function already performed for one and two points, which is also the surrounding convention (`create_slab_from_polyline` already handles a falsy generator result with a bare `return`).

## Sibling sweep

The same "index the first point" shape appears in six other places in `bim/module/model/`. Each was traced to its caller before deciding.

| Site | Can the list be empty or short? | Verdict |
| --- | --- | --- |
| `slab.py:96` `derive_from_polyline` | Yes, finishing the modal with no points placed | Fixed, guard moved before the indexing |
| `slab.py:118` `derive_from_walls` | No. `AddSlabFromWalls._execute` returns early on `if not walls`, and `shapely.Polygon` needs at least three coordinates to build a ring, so `poly.exterior.coords` has at least four entries whenever this line runs | Guard moved for symmetry, behaviour unchanged |
| `profile.py:93` | No, the index sits inside `if len(polyline_points) > 3:` | Already guarded, untouched |
| `wall.py:1287` | No, same `if len(polyline_points) > 3:` guard | Already guarded, untouched |
| `wall.py:1312` `derive_from_slab` | No. The points come from an existing slab's `SweptArea.OuterCurve`, which cannot have fewer than three coordinates and still be a slab profile | Untouched |
| `polyline.py:313` | No, the index sits inside `if len(polyline_points) > 2:` | Already guarded, untouched |
| `product.py:197` | No. `DrawOccurrence.create_occurrence` calls `tool.Polyline.insert_polyline_point` on the line immediately above, which creates the `insertion_polyline` entry and appends a point. Its two early returns both require a non-empty point list already | Untouched |
| `decorator.py:436` | No, `calculate_measurement_x_y_and_z` returns on `len(self.polyline_points) == 0` | Already guarded, untouched |

Only `slab.py` is changed, and only by reordering statements.

## Red, then green

A direct unit test of the generator is possible because `derive_from_polyline` only reads `tool.Model.get_polyline_props()` and `self`, so the test calls it as a plain function against a stub `self`, which is the exact frame from the traceback. Test added at `src/bonsai/test/bim/module/model/test_slab_empty_polyline.py`.

Headless Blender 5.2, running the new test file against the unpatched code as installed (`derive_from_polyline` there is byte identical to the `v0.8.0` version):

```
FAILED test/bim/module/model/test_slab_empty_polyline.py::test_empty_polyline_returns_without_creating_a_slab - IndexError: list index out of range
FAILED test/bim/module/model/test_slab_empty_polyline.py::test_polyline_with_two_points_returns_without_creating_a_slab - AttributeError: 'NoneType' object has no attribute 'location'
2 failed in 0.51s
```

Both failures land on `slab.py:96`, the line the issue names. With the patched module loaded in the same Blender session:

```
BEFORE (unpatched) / empty:      IndexError: list index out of range  -> FAIL
BEFORE (unpatched) / two points: AttributeError: 'NoneType' object has no attribute 'location'  -> FAIL
AFTER (patched) / empty:         returned None  -> PASS
AFTER (patched) / two points:    returned None  -> PASS
```

The second case is worth noting: with one or two points the old code also crashed before reaching its own guard, because `self.container_obj` is `None` when there is no default container. Moving the guard up removes that ordering problem too.

`black` and `ruff` clean on both files.
