### PR TITLE
ifctester: re-enable the minimal IDS validation test (#9430 follow-up)

### DIFF
--- a/src/ifctester/test/test_ids.py
+++ b/src/ifctester/test/test_ids.py
@@ -132,7 +132,6 @@ class TestIds:
         specs.to_xml(fn)
         os.remove(fn)
 
-    @pytest.mark.skip(reason="Re-enable when failure is investigated")
     def test_creating_a_minimal_ids_and_validating(self):
         specs = ids.Ids(title="Title")
         spec = ids.Specification(name="Name")


### PR DESCRIPTION
Follow-up to #9430, where this test was skipped with "Re-enable when failure is investigated".

The failure was investigated, and it was a real wrong verdict rather than a flaky test: `file.by_type()` returns a tuple on `v0.9.0`, while the chained facet filters guarded with `isinstance(elements, list)`. A narrowed, possibly empty result was therefore ignored and the next facet rescanned the whole model, so the prohibited specification in this test matched an `IfcSlab` that the entity facet had already excluded.

#9388 fixed that at all six filter sites and merged at 11:36 today, about half an hour before #9430 was opened, so the skip landed on a test that was already passing.

Verified rather than assumed: on a native `linux/arm64` build of `v0.9.0` at `d11440af`, where `by_type()` does return a `tuple` (checked in the same run, so the bug's precondition is present), `test_creating_a_minimal_ids_and_validating` passes. The `import pytest` stays, it is used by two other tests in this file.

Two notes on the other skips in #9430, for whoever picks them up:

- `test_package.py::TestPackageSupportedPlatforms::test_run` will keep failing on `macos64` even once builds are running again. Intel Mac builds were deliberately dropped from `build_osx.yml` in June 2026 (`45e9f763c8`), but `SUPPORTED_PLATFORMS` still lists `macos64`, so that entry needs removing rather than waiting.
- The Windows side of the same test is the subject of #9423: no Windows binary build has run since the plugin-collection fix (`65ce0f71c4`) landed, and `BUILD_COMMIT` still pins `ad113e1`, which predates it. Until a Windows build is published, every 0.9.0 Windows package is missing `ifcopenshell_parse_schema_ifc*.dll`.
