### PR TITLE
Bonsai: fix stale MEP transition test expectation baked against the OpenCascade mesher

### DIFF
--- a/src/bonsai/test/bim/feature/model.feature
+++ b/src/bonsai/test/bim/feature/model.feature
@@ -822,7 +822,7 @@ Scenario: Create a MEP transition
     And the object "IfcDuctSegment/RectSegment" is at "0,0,0"
     And the object "IfcDuctSegment/RectSegment" dimensions are "0.4,0.2,2.370096"
     And the object "IfcDuctSegment/CircleSegment" is at "3.1299,0,0"
-    And the object "IfcDuctSegment/CircleSegment" dimensions are "0.1000, 0.09927, 2.370096"
+    And the object "IfcDuctSegment/CircleSegment" dimensions are "0.1000, 0.1000, 2.370096"
     And the object "IfcDuctFitting/DuctFitting" is at "2.370096, 0.0000, 0.0000"
     And the object "IfcDuctFitting/DuctFitting" dimensions are "0.4000, 0.2000, 0.759807"
 


### PR DESCRIPTION
## What fails

`src/bonsai/test/bim/test_feature.py::test_create_a_mep_transition` fails in `ci-bonsai-daily`:

```
AssertionError: Expected [0.1, 0.09927, 2.370096]
             but got [0.10000000149011612, 0.10000000149011612, 2.370096206665039]
```

Failing step, `src/bonsai/test/bim/feature/model.feature:825`:

```
And the object "IfcDuctSegment/CircleSegment" dimensions are "0.1000, 0.09927, 2.370096"
```

It is not new and it is not specific to this branch. The same assertion, with the same two numbers, fails in the `ci-bonsai-daily` run on `v0.9.0` (run 33646630922, 2026-09-02) and in the `ci-bonsai-daily` run on `v0.8.0` (run 33538637069, 2026-09-01).

## Why the expectation is wrong

The scenario adds a `Circular Distribution Segment` type. That template creates the profile in `src/bonsai/bonsai/bim/module/root/operator.py` (`FLOW_SEGMENT_CIRCULAR`) as an `IfcCircleProfileDef` with `default_diameter = 0.1`, so `Radius = 0.05`. The exact bounding box of that profile is therefore 0.1 by 0.1, and no inscribed polygonal approximation of it can be wider than that in either axis.

`0.09927` is not a property of the model, it is a property of one tessellation. The OpenCascade kernel approximates that circle with 26 chords. With vertices at multiples of 360/26 = 13.846 degrees, the extreme vertices in Y sit at plus or minus 83.08 degrees, so:

* X extent: vertices land exactly on 0 and 180 degrees, so 2r = 0.1
* Y extent: 2r * cos(pi/26) = 0.1 * 0.9927089 = 0.0992709, which is the `0.09927` in the feature file

Bonsai does not load geometry with OpenCascade by default. `BIMProjectProperties.geometry_library` has defaulted to `hybrid-cgal-simple-opencascade` since a32c4ae694 (2024-10-11), so the mesh is produced by the CGAL kernel, which places vertices on both axes and reports the exact analytic bounding box, 0.1 by 0.1.

Measured, not reasoned. With the `ifcopenshell` shipped inside Bonsai, an `IfcExtrudedAreaSolid` over an `IfcCircleProfileDef` of `Radius = 0.05`, using the deflection values Bonsai passes (`mesher-linear-deflection` 0.05, `mesher-angular-deflection` 0.5):

```
cgal-simple   32 verts   X 0.1   Y 0.1
cgal          32 verts   X 0.1   Y 0.1
opencascade   52 verts   X 0.1   Y 0.09927088740980541
```

The OpenCascade figure reproduces the stale expectation to all quoted digits, and the CGAL figures reproduce what CI reports. The expectation was baked against a kernel Bonsai stopped defaulting to in 2024; the geometry, the transition maths and the Z length (2.370096) are all unaffected.

## The change

One line: the Y expectation becomes the true diameter of the profile.

```
-    And the object "IfcDuctSegment/CircleSegment" dimensions are "0.1000, 0.09927, 2.370096"
+    And the object "IfcDuctSegment/CircleSegment" dimensions are "0.1000, 0.1000, 2.370096"
```

This is not a loosened tolerance. `is_x` still compares to 1e-5; the new expected value is the analytically exact bounding box of the profile rather than the artefact of one mesher.

## What was executed and what was reasoned

* Executed: the three-kernel measurement above, on this machine, with the `ifcopenshell` bundled in the installed Bonsai extension.
* Executed: the current CI logs for both branches, quoted above.
* Not executed: the Blender feature test itself. `pytest_bdd` is not installed under the Blender used here (`ImportError: No module named 'pytest_bdd'`), so `test_feature.py` cannot be collected locally. The scenario stops at the failing step, so the steps after line 825 have not run in CI either; they assert the fitting bounding box (0.4 by 0.2), which is driven by the rectangular profile and is insensitive to circle tessellation.

## Note for maintainers

`v0.8.0` carries the identical line and the identical failure, so it needs the same one line change or a cherry pick.

Separately, and not addressed here: on `v0.9.0` the CGAL kernel derives the conic segment count from `mesher-linear-deflection` when `circle-segments` is 0 (the current default). Bonsai passes a deliberately coarse `mesher-linear-deflection` of 0.05, which for a radius of 0.05 yields four segments, and around seven for a radius of 0.5, where the previous fixed default gave 16. That is a mesh quality question rather than a test failure, since the bounding box is unchanged, and it is being looked at on its own.
