### PR TITLE
fix(cgal): bound conic segments by mesher-angular-deflection

### DIFF
--- a/src/bonsai/test/bim/feature/model.feature
+++ b/src/bonsai/test/bim/feature/model.feature
@@ -822,7 +822,7 @@ Scenario: Create a MEP transition
     And the object "IfcDuctSegment/RectSegment" is at "0,0,0"
     And the object "IfcDuctSegment/RectSegment" dimensions are "0.4,0.2,2.370096"
     And the object "IfcDuctSegment/CircleSegment" is at "3.1299,0,0"
-    And the object "IfcDuctSegment/CircleSegment" dimensions are "0.1000, 0.09927, 2.370096"
+    And the object "IfcDuctSegment/CircleSegment" dimensions are "0.098547, 0.099271, 2.370096"
     And the object "IfcDuctFitting/DuctFitting" is at "2.370096, 0.0000, 0.0000"
     And the object "IfcDuctFitting/DuctFitting" dimensions are "0.4000, 0.2000, 0.759807"
 

--- a/src/bonsai/test/bim/feature/model.feature
+++ b/src/bonsai/test/bim/feature/model.feature
@@ -822,7 +822,7 @@ Scenario: Create a MEP transition
     And the object "IfcDuctSegment/RectSegment" is at "0,0,0"
     And the object "IfcDuctSegment/RectSegment" dimensions are "0.4,0.2,2.370096"
     And the object "IfcDuctSegment/CircleSegment" is at "3.1299,0,0"
-    And the object "IfcDuctSegment/CircleSegment" dimensions are "0.098547, 0.099271, 2.370096"
+    And the object "IfcDuctSegment/CircleSegment" dimensions are approximately "0.1, 0.1, 2.370096"
     And the object "IfcDuctFitting/DuctFitting" is at "2.370096, 0.0000, 0.0000"
     And the object "IfcDuctFitting/DuctFitting" dimensions are "0.4000, 0.2000, 0.759807"
 

--- a/src/bonsai/test/bim/test_feature.py
+++ b/src/bonsai/test/bim/test_feature.py
@@ -1806,6 +1806,34 @@ def the_object_name_dimensions_are_dimensions(name, dimensions):
         assert is_x(number, expected_dimensions[i]), f"Expected {expected_dimensions} but got {actual_dimensions}"
 
 
+# An inscribed tessellation is never wider than the profile it approximates, so
+# the slack is one sided: short of nominal is fine, over nominal is not.
+DIMENSION_RELATIVE_TOLERANCE = 0.05
+
+
+@then(parsers.parse('the object "{name}" dimensions are approximately "{dimensions}"'))
+def the_object_name_dimensions_are_approximately_dimensions(name, dimensions):
+    """Assert nominal dimensions without pinning the mesher's tessellation.
+
+    Bonsai meshes with mesher-angular-deflection 0.5, so a conforming full
+    circle turns at most 0.5 rad per chord and needs at least
+    ceil(2 * pi / 0.5) = 13 of them. The bounding box of a polygon with that
+    many chords inscribed in a circle is at least 2r * cos(pi / 13), 97.1% of
+    the nominal diameter, whatever the phase the mesher starts sampling at.
+    5% accepts every tessellation that honours the setting, with headroom, and
+    the upper bound stays exact because an inscribed profile cannot overshoot.
+    """
+    actual_dimensions = list(the_object_name_exists(name).dimensions)
+    expected_dimensions = [float(co) for co in dimensions.split(",")]
+    assert len(actual_dimensions) == len(
+        expected_dimensions
+    ), f"Expected {len(expected_dimensions)} dimensions but got {actual_dimensions}"
+    for actual, expected in zip(actual_dimensions, expected_dimensions):
+        lower = expected - abs(expected) * DIMENSION_RELATIVE_TOLERANCE - 1e-5
+        upper = expected + 1e-5
+        assert lower <= actual <= upper, f"Expected approximately {expected_dimensions} but got {actual_dimensions}"
+
+
 @then(parsers.parse('the object "{name}" top right corner is at "{location}"'))
 def the_object_name_top_right_corner_is_at_location(name, location):
     obj = the_object_name_exists(name)

--- a/src/ifcgeom/conversion_settings.h
+++ b/src/ifcgeom/conversion_settings.h
@@ -346,7 +346,7 @@ namespace ifcopenshell {
 
 			struct CircleSegments : public SettingBase<CircleSegments, int> {
 				static constexpr const char* const name = "circle-segments";
-				static constexpr const char* const description = "Number of segments to approximate full circles in the CGAL kernel. When 0 (the default) the segment count is derived from mesher-linear-deflection instead, so curves stay within the deflection tolerance regardless of radius.";
+				static constexpr const char* const description = "Number of segments to approximate full circles in the CGAL kernel. When 0 (the default) the segment count is derived from mesher-linear-deflection and mesher-angular-deflection instead, whichever is stricter, so curves stay within tolerance regardless of radius.";
 				static constexpr int defaultvalue = 0;
 			};
 

--- a/src/ifcgeom/kernels/cgal/cgal_kernel.cpp
+++ b/src/ifcgeom/kernels/cgal/cgal_kernel.cpp
@@ -441,11 +441,13 @@ namespace {
 			// CircleSegments controls how conics (circles, ellipses, arcs) are approximated
 			// in the CGAL kernel. Two modes, one or the other:
 			//  - CircleSegments == 0 (the default): the segment count is derived from
-			//    MesherLinearDeflection, so the chord deviation stays within the mesher's
-			//    linear deflection regardless of radius. This matches the deflection based
-			//    meshing the OpenCascade kernel already does and fixes issue #8051, where
-			//    large radius arcs (curved curtain wall mullions) collapsed to straight chords
-			//    because a fixed segment count is radius agnostic.
+			//    MesherLinearDeflection and MesherAngularDeflection, whichever is stricter,
+			//    matching the deflection based meshing the OpenCascade kernel already does
+			//    and fixing issue #8051, where large radius arcs (curved curtain wall
+			//    mullions) collapsed to straight chords because a fixed segment count is
+			//    radius agnostic. The angular bound is what keeps small radii from
+			//    collapsing: chord deviation scales with radius, so a linear tolerance alone
+			//    lets a small circle degenerate into a triangle.
 			//  - CircleSegments > 0: it is used directly as the number of segments for a full
 			//    circle, giving deterministic, radius independent output.
 			int num_segments;
@@ -455,14 +457,19 @@ namespace {
 			} else {
 				const double radius = conic_radius(t);
 				const double deflection = settings_.get<settings::MesherLinearDeflection>().get();
+				const double angular_deflection = settings_.get<settings::MesherAngularDeflection>().get();
+				// Widest turn a single chord may span, in radians.
+				double max_segment_angle = M_PI / 2.;
 				if (deflection > 0. && radius > deflection) {
-					const double max_segment_angle = 2.0 * std::acos(1.0 - deflection / radius);
-					num_segments = (int)std::ceil(span / max_segment_angle);
-				} else {
-					// Radius within the deflection tolerance (or no deflection set): a chord per
-					// quarter turn already keeps the deviation within tolerance.
-					num_segments = (int)std::ceil(span / (M_PI / 2.));
+					const double linear_bound = 2.0 * std::acos(1.0 - deflection / radius);
+					if (linear_bound > 0. && linear_bound < max_segment_angle) {
+						max_segment_angle = linear_bound;
+					}
 				}
+				if (angular_deflection > 0. && angular_deflection < max_segment_angle) {
+					max_segment_angle = angular_deflection;
+				}
+				num_segments = (int)std::ceil(span / max_segment_angle);
 			}
 			if (num_segments < 1) {
 				num_segments = 1;

--- a/src/ifcopenshell-python/docs/ifcconvert/usage.rst
+++ b/src/ifcopenshell-python/docs/ifcconvert/usage.rst
@@ -313,8 +313,9 @@ CLI Manual
       --circle-segments arg (= 0)           Number of segments to approximate full
                                             circles in the CGAL kernel. When 0 (the
                                             default) the segment count is derived from
-                                            mesher-linear-deflection instead, so curves
-                                            stay within the deflection tolerance
+                                            mesher-linear-deflection and
+                                            mesher-angular-deflection instead, whichever
+                                            is stricter, so curves stay within tolerance
                                             regardless of radius.
       --cgal-smooth-angle-degrees arg (= -1)
                                             Angle in degrees under which adjacent 

--- a/src/ifcopenshell-python/docs/ifcopenshell/geometry_settings.rst
+++ b/src/ifcopenshell-python/docs/ifcopenshell/geometry_settings.rst
@@ -231,7 +231,7 @@ circle-segments
 | INT  | ``--circle-segments`` | 0       |
 +------+-----------------------+---------+
 
-Number of segments to approximate full circles in the CGAL kernel. When 0 (the default) the segment count is derived from mesher-linear-deflection instead, so curves stay within the deflection tolerance regardless of radius.
+Number of segments to approximate full circles in the CGAL kernel. When 0 (the default) the segment count is derived from mesher-linear-deflection and mesher-angular-deflection instead, whichever is stricter, so curves stay within tolerance regardless of radius.
 
 context-identifiers
 ^^^^^^^^^^^^^^^^^^^

--- a/src/ifcopenshell-python/test/geom/test_cgal_conic_segments.py
+++ b/src/ifcopenshell-python/test/geom/test_cgal_conic_segments.py
@@ -1,0 +1,88 @@
+"""Segment counts for conics in the CGAL kernel.
+
+Guards against small radii collapsing to a triangle when circle-segments is 0
+and the segment count is derived from the deflection settings.
+"""
+
+import math
+
+import pytest
+
+import ifcopenshell
+import ifcopenshell.geom
+
+# Values Bonsai passes for interactive viewport quality.
+BONSAI_LINEAR_DEFLECTION = 0.05
+BONSAI_ANGULAR_DEFLECTION = 0.5
+
+kernels = [
+    pytest.param(
+        kernel,
+        marks=pytest.mark.skipif(
+            not ifcopenshell.geom.has_geometry_library(kernel),
+            reason=f"{kernel} geometry kernel is unavailable",
+        ),
+    )
+    for kernel in ("cgal", "cgal-simple")
+]
+
+
+def circular_extrusion(radius: float) -> tuple[ifcopenshell.file, ifcopenshell.entity_instance]:
+    f = ifcopenshell.file(schema="IFC4")
+    context = f.create_entity("IfcGeometricRepresentationContext")
+    solid = f.create_entity(
+        "IfcExtrudedAreaSolid",
+        SweptArea=f.create_entity("IfcCircleProfileDef", ProfileType="AREA", Radius=radius),
+        Position=f.create_entity(
+            "IfcAxis2Placement3D",
+            Location=f.create_entity("IfcCartesianPoint", Coordinates=(0.0, 0.0, 0.0)),
+        ),
+        ExtrudedDirection=f.create_entity("IfcDirection", DirectionRatios=(0.0, 0.0, 1.0)),
+        Depth=1.0,
+    )
+    representation = f.create_entity(
+        "IfcShapeRepresentation",
+        ContextOfItems=context,
+        RepresentationIdentifier="Body",
+        RepresentationType="SweptSolid",
+        Items=[solid],
+    )
+    element = f.create_entity(
+        "IfcBuildingElementProxy",
+        GlobalId=ifcopenshell.guid.new(),
+        Representation=f.create_entity("IfcProductDefinitionShape", Representations=[representation]),
+    )
+    return f, element
+
+
+def segments_per_section(radius: float, kernel: str, circle_segments: int = 0) -> int:
+    _, element = circular_extrusion(radius)
+    settings = ifcopenshell.geom.settings()
+    settings.set("mesher-linear-deflection", BONSAI_LINEAR_DEFLECTION)
+    settings.set("mesher-angular-deflection", BONSAI_ANGULAR_DEFLECTION)
+    settings.set("circle-segments", circle_segments)
+    settings.set("weld-vertices", True)
+    shape = ifcopenshell.geom.create_shape(settings, element, geometry_library=kernel)
+    verts = shape.geometry.verts
+    return sum(1 for i in range(len(verts) // 3) if round(verts[i * 3 + 2], 6) == 0.0)
+
+
+@pytest.mark.parametrize("kernel", kernels)
+@pytest.mark.parametrize("radius", [0.05, 0.1, 0.5, 1.0, 5.0])
+def test_angular_deflection_bounds_small_radii(kernel: str, radius: float) -> None:
+    """A full circle never turns more than mesher-angular-deflection per chord."""
+    segments = segments_per_section(radius, kernel)
+    assert segments >= math.ceil(2 * math.pi / BONSAI_ANGULAR_DEFLECTION)
+
+
+@pytest.mark.parametrize("kernel", kernels)
+def test_linear_deflection_still_drives_large_radii(kernel: str) -> None:
+    """Large radii keep the finer, linear deflection driven count (issue #8051)."""
+    assert segments_per_section(5.0, kernel) > segments_per_section(0.5, kernel)
+
+
+@pytest.mark.parametrize("kernel", kernels)
+def test_explicit_circle_segments_is_radius_independent(kernel: str) -> None:
+    """A non zero circle-segments is used verbatim, whatever the radius."""
+    for radius in (0.05, 0.5, 5.0):
+        assert segments_per_section(radius, kernel, circle_segments=16) == 16


### PR DESCRIPTION
## What our commit changed

`c57da082a5` ("Make CGAL circle-segments 0-default deflection-driven (rework #8368)") changed `circle-segments` to default to `0`. With `0`, `evaluate_conic` in `src/ifcgeom/kernels/cgal/cgal_kernel.cpp` no longer uses a fixed segment count and instead derives one from `mesher-linear-deflection`:

```
radius > deflection  ->  n = ceil(span / (2 * acos(1 - deflection / radius)))
otherwise            ->  n = ceil(span / (pi / 2))            i.e. 4 for a full circle
```

Chord deviation scales with radius, so a linear tolerance on its own places no lower bound on the segment count. For any radius at or below the deflection, every polygon is "within tolerance" and the count collapses.

Bonsai sets `mesher-linear-deflection` to `0.05` and `mesher-angular-deflection` to `0.5` (`src/bonsai/bonsai/bim/import_ifc.py:1352-1353`, applied in `tool/geometry.py:1169` and `tool/loader.py:723`) and never sets `circle-segments`, so the `0` default applies. At those settings small circles degenerate.

## Measured, before and after

`IfcCircleProfileDef` extruded 1.0, vertices counted per circular cross section, `mesher-linear-deflection` 0.05, `mesher-angular-deflection` 0.5. Native aarch64 build of `v0.9.0`, measured through the build's own interpreter. `cgal` and `cgal-simple` agree on every row.

| radius | before c57da082a5 | on v0.9.0 today | with this PR | `circle-segments=16` |
|---|---|---|---|---|
| 0.05 | 16 | **4** | 13 | 16 |
| 0.1  | 16 | **3** | 13 | 16 |
| 0.5  | 16 | **7** | 13 | 16 |
| 1.0  | 16 | **10** | 13 | 16 |
| 5.0  | 23 | 23 | 23 | 16 |

The "on v0.9.0 today", "with this PR" and "`circle-segments=16`" columns are direct measurements. The "before" column is the same two measured quantities combined by the pre-`c57da082a5` expression, which was `max(fixed count, deflection floor)`.

A radius 0.1 circle rendering as a triangle is not a defensible output for any tolerance setting.

## Why this layer

The fix belongs in the kernel, not in what Bonsai passes.

`mesher-angular-deflection` already exists, already defaults to `0.5`, and is already passed by Bonsai. The OpenCascade kernel honours it; the CGAL kernel silently ignored it. Bounding the per-chord turn by the angular tolerance as well, and taking whichever of the two tolerances is stricter, is what the setting is for and is what OpenCascade does with the same inputs. Changing Bonsai instead would leave every other CGAL consumer with the same collapse.

The angular bound can only lower the maximum segment angle, so it can only raise the segment count. Deflection driven output can never come out coarser than it does today.

What `c57da082a5` set out to do is preserved:

- radius aware output for #8051 is unchanged, since the linear bound still wins wherever it is stricter (radius 5.0 stays at 23, radius 50.0 at 71, radius 100.0 at 100 at Bonsai settings);
- default `ifcconvert` settings (`mesher-linear-deflection` 0.001) are dominated by the linear bound and are bit for bit unchanged (16, 23, 50, 71, 158, 497 for the radii above plus 50.0);
- a non zero `circle-segments` is still used verbatim as a fixed, radius independent count.

Simply restoring the fixed default of 16 would reintroduce #8051, so that is not the fix.

## Test

`src/ifcopenshell-python/test/geom/test_cgal_conic_segments.py` asserts a full circle never turns more than `mesher-angular-deflection` per chord, that large radii keep the finer linear driven count, and that an explicit `circle-segments` stays radius independent. Red and green were both run against the native build:

- against unpatched `v0.9.0`: 8 failed, 6 passed
- with this PR: 14 passed

## Acknowledgement

This corrects a regression we introduced ourselves in `c57da082a5`. Every circle and arc authored in Bonsai at typical element radii has been coarser than it was before that commit.

## Folded in: the MEP transition expectation

`src/bonsai/test/bim/feature/model.feature` "Create a MEP transition" asserts the bounding box of the default circular duct segment, an `IfcCircleProfileDef` of radius 0.05 (`FLOW_SEGMENT_CIRCULAR`, `default_diameter = 0.1`, `src/bonsai/bonsai/bim/module/root/operator.py:734-742`). That is not a property of the model, it is a property of one tessellation, and it has moved twice:

1. It was baked as `0.1000, 0.09927` against **OpenCascade**, which approximates the profile with 26 chords whose extreme vertices sit at +-83.08 degrees: 2r in X, 2r*cos(pi/26) in Y. Bonsai has not defaulted to OpenCascade since `a32c4ae694`; the default geometry library is `hybrid-cgal-simple-opencascade` (`src/bonsai/bonsai/bim/module/project/prop.py:356-365`), so the mesh comes from CGAL.
2. On `v0.9.0` today the CGAL kernel gives this radius **4 segments**, which happen to land on both axes and hand back an exact 0.1 x 0.1. The expectation was therefore already failing on Y, for a reason unrelated to accuracy.
3. With the angular bound in this PR the profile settles at **13 segments**, so the box becomes 0.098547 x 0.099271.

An earlier revision of this PR simply moved the constant from the OpenCascade number to the CGAL one. @aothms was right to object: that repeats the coupling between tessellation detail and user-facing expectation that produced the failure in the first place, only with a different magic number. What the scenario is actually about is that a circular duct of nominal diameter 0.1 gets created with the right length.

So the constant is gone. `src/bonsai/test/bim/test_feature.py` gains an approximate predicate next to the exact one:

```gherkin
And the object "IfcDuctSegment/CircleSegment" dimensions are approximately "0.1, 0.1, 2.370096"
```

The `RectSegment` and `DuctFitting` lines keep the exact step. A box has no tessellation error, and the `RectSegment` line pins the same 2.370096 extrusion length to `1e-5`.

**The tolerance is derived from the mesher settings, not chosen by taste.** Bonsai passes `mesher-angular-deflection` 0.5 (`src/bonsai/bonsai/bim/module/project/prop.py:378`), so a conforming full circle turns at most 0.5 rad per chord and needs at least `ceil(2*pi/0.5) = 13` of them. A polygon of 13 or more chords inscribed in a circle has a bounding box of at least `2r*cos(pi/13)`, **97.094%** of the nominal diameter, at any phase the mesher starts sampling from. A 5% band accepts that with headroom.

**The band is one sided.** An inscribed polygon is never wider than the profile it approximates, so an extent may fall short of nominal by up to 5% but may not exceed it beyond the same `1e-5` the exact step uses. That keeps the upper bound exact on every axis, including the extrusion length, rather than silently relaxing an assertion that was previously tight in both directions.

`is_x` (`src/bonsai/test/bim/test_feature.py:326`) is an absolute epsilon equality helper, used by three call sites and by `vectors_are_equal`. What this step needs is a relative, one sided band, so the comparison lives in the new step rather than as a new parameter on `is_x`, and no existing caller is touched.

The predicate was exercised directly, outside Blender, against the measured and analytic extents for radius 0.05 (nominal diameter 0.1):

| input | source | result |
|---|---|---|
| 0.098547091, 0.099270887 | measured, 13 segment CGAL, this PR | accept |
| 0.100000000, 0.099270887 | measured, 26 segment OpenCascade | accept |
| 0.100000000, 0.100000000 | exact circle | accept |
| 0.097094182, 0.097094182 | `2r*cos(pi/13)`, worst case for any conforming tessellation | accept |
| 0.090450850, 0.095105652 | 5 segments | reject |
| 0.100000000, 0.086602540 | 6 segments | reject |
| 0.075000000, 0.086602540 | 3 segments, the collapse this PR fixes at radius 0.1 | reject |
| 0.105, 0.105 | oversized | reject |

Worth stating plainly, since it bears on what this assertion is and is not for: at **this** radius the pre-fix output was 4 segments landing exactly on both axes, so it measures 0.1 x 0.1 and the approximate predicate accepts it, exactly as the exact predicate accepted it in X. A bounding box was never a tessellation quality guard. That job belongs to `src/ifcopenshell-python/test/geom/test_cgal_conic_segments.py`, which asserts segment counts directly, and it is where the red and green for this PR were run.

This is carried here rather than in a separate PR so the kernel change and the expectation it moves land together. The measurements above come from the native aarch64 build with this PR applied, and the predicate was unit tested against them; the Blender scenario itself was not executed in this environment.
