### PR TITLE
packaging: fail the build when runtime plugins are missing from the artifact

### DIFF
--- a/nix/package-zip-archives.py
+++ b/nix/package-zip-archives.py
@@ -11,8 +11,13 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Literal, NamedTuple
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "packaging"))
+
+import check_runtime_plugins
 
 
 class C:
@@ -338,6 +343,11 @@ def package_python_wrapper(
     if not is_platform("MAC"):
         check_runtime_dependencies(ifcopenshell_dir)
 
+    check_runtime_plugins.check(
+        [str(p.relative_to(ifcopenshell_dir)) for p in ifcopenshell_dir.rglob("*")],
+        f"staged python wrapper package '{py_version_major}'",
+    )
+
     if ARGS.no_zip:
         return
     zip_path = output_dir / f"ifcopenshell-{py_version_major}-{VERSION}-{github_sha}-{arch_suffix}.zip"
@@ -389,6 +399,11 @@ def package_executable(
             shutil.copytree(autodesk_connector_dir, connectors_dir / autodesk_connector_dir.name, symlinks=True)
 
         check_runtime_dependencies(package_dir)
+
+    check_runtime_plugins.check(
+        [str(p.relative_to(package_dir)) for p in package_dir.rglob("*")],
+        f"staged executable package '{exe}'",
+    )
 
     if ARGS.no_zip:
         return

--- a/packaging/check_runtime_plugins.py
+++ b/packaging/check_runtime_plugins.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Fail a packaging run when runtime plugins are missing from the produced artifact.
+
+IfcOpenShell 0.9 splits the toolkit into shared libraries that are loaded *by
+name* at runtime (``ifcopenshell::plugin``) instead of being linked against. A
+dependency scanner such as ``dumpbin /dependents`` or ``ldd`` therefore cannot
+see them, so a packaging step that only follows link dependencies produces an
+archive that imports and then dies with ``RuntimeError: No schema named IFC4``
+(#9423, #9431). Nothing verified the produced artifact, so the regression
+shipped in every published Windows package.
+
+The plugin families below are derived from the build definitions:
+
+    ifcopenshell_parse_schema_ifc<schema>      src/ifcparse/CMakeLists.txt
+    ifcopenshell_geometry_mapping_ifc<schema>  src/ifcgeom/mapping/CMakeLists.txt
+    ifcopenshell_geometry_writer_ifc<schema>   src/ifcgeom/serialization/schema/CMakeLists.txt
+    ifcopenshell_document_xml_ifc<schema>      src/serializers/schema_dependent/CMakeLists.txt
+    ifcopenshell_document_json_ifc<schema>     src/serializers/schema_dependent/CMakeLists.txt
+
+Each iterates ``SCHEMA_VERSIONS`` (cmake/CMakeLists.txt), whose value differs
+between builds: the WASM default is a three schema subset and a caller may pass
+its own list. The set of schemas is therefore never hardcoded here, it is read
+back out of the artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+# Plugin basenames carry no platform prefix and use underscores, see
+# decorated_basename() in src/plugin/plugin.cpp. Core shared libraries instead
+# keep the dotted `ifcopenshell.` names and the platform `lib` prefix.
+#
+# Family name -> filename prefix, one entry per per-schema plugin family.
+PER_SCHEMA_FAMILIES = {
+    "parse_schema": "ifcopenshell_parse_schema_ifc",
+    "geometry_mapping": "ifcopenshell_geometry_mapping_ifc",
+    "geometry_writer": "ifcopenshell_geometry_writer_ifc",
+    "document_xml": "ifcopenshell_document_xml_ifc",
+    "document_json": "ifcopenshell_document_json_ifc",
+}
+
+# Without these no IFC file can be opened at all, so their absence is always a bug.
+REQUIRED_FAMILIES = ("parse_schema",)
+
+LIBRARY_SUFFIXES = (".so", ".dll", ".dylib", ".pyd")
+
+
+def _basename(name: str) -> str:
+    return Path(name.replace("\\", "/")).name.lower()
+
+
+def _stem(name: str) -> str:
+    """Basename without the platform `lib` prefix and without any suffix chain."""
+    return _basename(name).removeprefix("lib").split(".", 1)[0]
+
+
+def _is_library(name: str) -> bool:
+    parts = _basename(name).split(".")[1:]
+    return any(f".{part}" in LIBRARY_SUFFIXES for part in parts)
+
+
+def classify(names: list[str]) -> dict[str, dict[str, str]]:
+    """Map each per-schema family to ``{schema: filename}`` as found in the artifact."""
+    found: dict[str, dict[str, str]] = {family: {} for family in PER_SCHEMA_FAMILIES}
+    for name in names:
+        if not _is_library(name):
+            continue
+        stem = _stem(name)
+        for family, prefix in PER_SCHEMA_FAMILIES.items():
+            if stem.startswith(prefix):
+                found[family][stem.removeprefix(prefix)] = _basename(name)
+    return found
+
+
+def needs_schema_plugins(names: list[str]) -> bool:
+    """Whether the artifact carries an IfcOpenShell core that parses IFC files.
+
+    Deliberately narrow: a package that only ships an unrelated plugin (the
+    ``svgfill`` executable bundles ``ifcopenshell_geometry_svgfill`` and nothing
+    else) never opens an IFC file and must not be failed.
+    """
+    triggers = ("ifcopenshell_document_rdb",) + tuple(PER_SCHEMA_FAMILIES.values())
+    for name in names:
+        if not _is_library(name):
+            continue
+        base = _basename(name).removeprefix("lib")
+        stem = _stem(name)
+        if stem.startswith("_ifcopenshell_wrapper"):
+            return True
+        if base.startswith(("ifcopenshell.parse", "ifcopenshell.geometry")):
+            return True
+        if stem.startswith(triggers):
+            return True
+    return False
+
+
+def _suffix_hint(found: dict[str, dict[str, str]]) -> str:
+    for filenames in found.values():
+        for filename in filenames.values():
+            if "." in filename:
+                return filename.split(".", 1)[1]
+    return "so"
+
+
+def problems(names: list[str]) -> list[str]:
+    """Return a list of readable problems, empty when the artifact is complete."""
+    if not needs_schema_plugins(names):
+        return []
+
+    found = classify(names)
+    schemas = sorted({schema for filenames in found.values() for schema in filenames})
+    suffix = _suffix_hint(found)
+    issues = []
+
+    for family in REQUIRED_FAMILIES:
+        if not found[family]:
+            issues.append(
+                f"no {PER_SCHEMA_FAMILIES[family]}* library present. These plugins are loaded by "
+                "name at runtime, so a link dependency scan cannot discover them and they have to "
+                "be collected explicitly."
+            )
+
+    for family, filenames in found.items():
+        if not filenames:
+            continue
+        missing = [schema for schema in schemas if schema not in filenames]
+        if missing:
+            expected = ", ".join(f"{PER_SCHEMA_FAMILIES[family]}{schema}.{suffix}" for schema in missing)
+            issues.append(f"{family} was built for {sorted(filenames)} but these are missing: {expected}")
+
+    return issues
+
+
+def check(names: list[str], description: str) -> None:
+    """Raise ``RuntimeError`` naming the missing files if the artifact is incomplete."""
+    issues = problems(names)
+    if issues:
+        raise RuntimeError(
+            f"{description} is missing IfcOpenShell runtime plugins:\n" + "\n".join(f"  - {issue}" for issue in issues)
+        )
+
+
+def names_in(path: Path) -> list[str]:
+    if path.is_dir():
+        return [str(item.relative_to(path)) for item in path.rglob("*") if item.is_file() or item.is_symlink()]
+    if zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as archive:
+            return archive.namelist()
+    raise RuntimeError(f"{path} is neither a directory nor a zip archive")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("paths", nargs="+", type=Path, help="Directories or zip archives to check.")
+    args = parser.parse_args()
+
+    failed = False
+    for path in args.paths:
+        try:
+            check(names_in(path), str(path))
+        except RuntimeError as error:
+            print(error, file=sys.stderr)
+            failed = True
+        else:
+            print(f"{path}: runtime plugins OK")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packaging/test_check_runtime_plugins.py
+++ b/packaging/test_check_runtime_plugins.py
@@ -1,0 +1,54 @@
+import check_runtime_plugins as guard
+import pytest
+
+SCHEMAS = ("2x3", "4", "4x1", "4x2", "4x3", "4x3_tc1", "4x3_add1", "4x3_add2")
+WRAPPER = "_ifcopenshell_wrapper.cp313-win_amd64.pyd"
+CORE = ["ifcopenshell.parse.dll", "ifcopenshell.geometry.dll", "ifcopenshell_document_rdb.dll"]
+
+
+def package(schemas=SCHEMAS, families=guard.PER_SCHEMA_FAMILIES, suffix="dll"):
+    names = [WRAPPER, *CORE, "ifcopenshell.py"]
+    for prefix in families.values():
+        names += [f"{prefix}{schema}.{suffix}" for schema in schemas]
+    return names
+
+
+def test_complete_package_passes():
+    assert guard.problems(package()) == []
+
+
+def test_reduced_schema_build_passes():
+    """WASM and custom SCHEMA_VERSIONS builds ship a subset, that is not a regression."""
+    assert guard.problems(package(schemas=("2x3", "4", "4x3_add2"))) == []
+
+
+def test_executable_package_without_geometry_writers_passes():
+    families = {k: v for k, v in guard.PER_SCHEMA_FAMILIES.items() if k != "geometry_writer"}
+    assert guard.problems(package(families=families)) == []
+
+
+def test_package_without_the_wrapper_is_not_checked():
+    assert guard.problems(["svgfill.exe", "ifcopenshell_geometry_svgfill.dll"]) == []
+
+
+def test_pre_9305_windows_package_fails():
+    """The shipped 0.9.0 win64 package: link-visible libraries only, no load-by-name plugins."""
+    issues = guard.problems([WRAPPER, *CORE])
+    assert any("ifcopenshell_parse_schema_ifc*" in issue for issue in issues)
+
+
+def test_single_missing_schema_plugin_is_named():
+    names = [n for n in package() if n != "ifcopenshell_parse_schema_ifc4x2.dll"]
+    with pytest.raises(RuntimeError, match=r"ifcopenshell_parse_schema_ifc4x2\.dll"):
+        guard.check(names, "artifact")
+
+
+def test_missing_geometry_mapping_for_a_built_schema_is_named():
+    names = [n for n in package() if n != "ifcopenshell_geometry_mapping_ifc4.dll"]
+    with pytest.raises(RuntimeError, match=r"ifcopenshell_geometry_mapping_ifc4\.dll"):
+        guard.check(names, "artifact")
+
+
+@pytest.mark.parametrize("suffix", ["so", "so.0.9.0", "dylib", "dll"])
+def test_platform_suffixes(suffix):
+    assert guard.problems(package(suffix=suffix)) == []

--- a/src/ifcopenshell-python/Makefile
+++ b/src/ifcopenshell-python/Makefile
@@ -124,6 +124,7 @@ endif
 	# wrapper (libifcopenshell.parse, ifcopenshell_document_rdb, ...). Copy
 	# them too, otherwise the wrapper fails to import. See #9364.
 	find dist/working/ifcopenshell -maxdepth 1 \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -exec cp {} dist/ifcopenshell/ \;
+	$(PYTHON) ../../packaging/check_runtime_plugins.py dist/ifcopenshell
 	rm -rf dist/working
 	$(SED) 's/version = "0.0.0"/version = "$(VERSION)"/' dist/ifcopenshell/__init__.py
 	cd dist && zip -r ifcopenshell-python-$(VERSION)-$(PYVERSION)-$(PLATFORM).zip ifcopenshell
@@ -146,6 +147,7 @@ endif
 	# wrapper (libifcopenshell.parse, ifcopenshell_document_rdb, ...). Copy
 	# them too, otherwise the wrapper fails to import. See #9364.
 	find build/botbuild/ifcopenshell -maxdepth 1 \( -name '*.so' -o -name '*.so.*' -o -name '*.dylib' -o -name '*.dll' \) -exec cp {} build/ifcopenshell/ \;
+	$(PYTHON) ../../packaging/check_runtime_plugins.py build/ifcopenshell
 	cp ../../README.md build/
 	cp pyproject.toml build/
 ifeq ($(IS_STABLE), TRUE)

--- a/win/build-all-win.py
+++ b/win/build-all-win.py
@@ -9,9 +9,14 @@ import platform
 import re
 import shutil
 import subprocess
+import sys
 import zipfile
 from pathlib import Path
 from zipfile import ZipFile
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "packaging"))
+
+import check_runtime_plugins
 
 
 def is_arm64() -> bool:
@@ -210,6 +215,20 @@ def write_zip(zip_path: Path, files: dict[str, Path], generated_files: dict[str,
             zipf.write(file, arcname=arcname)
         for arcname, contents in sorted((generated_files or {}).items()):
             zipf.writestr(arcname, contents)
+    verify_zip(zip_path, files, generated_files)
+
+
+def verify_zip(zip_path: Path, files: dict[str, Path], generated_files: dict[str, str] | None = None) -> None:
+    """Assert the archive on disk holds everything we collected and a usable plugin set."""
+    with ZipFile(zip_path) as zipf:
+        members = zipf.namelist()
+
+    expected = {Path(arcname).as_posix() for arcname in {**files, **(generated_files or {})}}
+    dropped = sorted(expected - {Path(member).as_posix() for member in members})
+    if dropped:
+        raise RuntimeError(f"{zip_path} is missing collected files: {', '.join(dropped)}")
+
+    check_runtime_plugins.check(members, str(zip_path))
 
 
 def build() -> None:


### PR DESCRIPTION
## The mechanism

IfcOpenShell 0.9 splits the toolkit into shared libraries that `ifcopenshell::plugin` loads **by name** at runtime rather than linking against. `decorated_basename()` in `src/plugin/plugin.cpp` builds the filename from a string, and `boost::dll` opens it at load time:

```cpp
std::string decorated_basename(const std::string& basename) {
    return boost::algorithm::istarts_with(basename, "ifcopenshell_") ? basename : "ifcopenshell_" + basename;
}
```

There is no import table entry for these libraries, so `dumpbin /dependents` and `ldd` cannot see them. A packaging step that collects files by following link dependencies therefore produces an archive that looks complete to the scanner and dies at import with `RuntimeError: No schema named IFC4`. Two reporters hit exactly this on published 0.9.0 Windows packages: #9423 and #9431.

The proof of mechanism is in a reporter's install: `ifcopenshell_document_rdb.dll` **is** present, because the wrapper links it directly and the scan found it, while every load-by-name schema plugin is absent.

#9305 fixed the Windows collector and #9427 fixes two more pipelines. **But nothing verified the produced artifact**, so the next regression of this class ships the same way and is discovered by users.

## The guard

`packaging/check_runtime_plugins.py` inspects a produced directory or zip archive and fails when the runtime plugin set is unusable.

The per-schema plugin families are derived from the build definitions, not guessed:

| family | defined in |
| --- | --- |
| `ifcopenshell_parse_schema_ifc<schema>` | `src/ifcparse/CMakeLists.txt` |
| `ifcopenshell_geometry_mapping_ifc<schema>` | `src/ifcgeom/mapping/CMakeLists.txt` |
| `ifcopenshell_geometry_writer_ifc<schema>` | `src/ifcgeom/serialization/schema/CMakeLists.txt` |
| `ifcopenshell_document_xml_ifc<schema>` | `src/serializers/schema_dependent/CMakeLists.txt` |
| `ifcopenshell_document_json_ifc<schema>` | `src/serializers/schema_dependent/CMakeLists.txt` |

Every one of those iterates `SCHEMA_VERSIONS`, whose value is not fixed: `cmake/CMakeLists.txt` defaults to a three schema subset for WASM and the full set otherwise, and a caller may pass their own list. So the guard never hardcodes a schema list. It reads the schema set back out of the artifact and applies two rules:

1. An artifact that carries an IFC parsing core must contain at least one `ifcopenshell_parse_schema_ifc*`. Without it no file can be opened at all.
2. A per-schema family that is present for some schemas must be present for all schemas the artifact was built with. A family that is entirely absent is not an error, only an inconsistent one is.

It stays silent for artifacts with no parsing core, so a reduced build, a WASM subset, an executable package built with `include_geometry_writers=False`, and the `svgfill` package (which bundles `ifcopenshell_geometry_svgfill` and never opens an IFC file) all pass.

## Where the guard runs, and why

Both producers and the consumer:

- **`win/build-all-win.py`** - a new `verify_zip()` runs on every archive `write_zip()` writes. It asserts both that every file the collector believed it collected is actually a member of the zip on disk, and that the plugin set is usable. This is where the shipped bug originated.
- **`nix/package-zip-archives.py`** - the staged package directory is checked before it is zipped, for both the Python wrapper and each executable.
- **`src/ifcopenshell-python/Makefile`** - the `zip` and `dist` targets check the tree assembled from the downloaded prebuilt zip. This one matters most right now: it catches a bad artifact even when that artifact was produced by an older, unfixed pipeline, which is exactly today's situation.

## Verification

Run against the real plugin set of a native aarch64 build (`build/Linux/aarch64/install/ifcopenshell/`), never a mock.

**Direction one, the complete tree passes:**

```
$ python3 packaging/check_runtime_plugins.py .../install/ifcopenshell/python-3.13.6
.../install/ifcopenshell/python-3.13.6: runtime plugins OK
exit=0
```

**Direction two, copies with plugins removed fail, naming the files:**

```
$ python3 packaging/check_runtime_plugins.py /tmp/.../ifcopenshell-no-schema /tmp/.../ifcopenshell-one-schema-dropped
/tmp/.../ifcopenshell-no-schema is missing IfcOpenShell runtime plugins:
  - no ifcopenshell_parse_schema_ifc* library present. These plugins are loaded by name at
    runtime, so a link dependency scan cannot discover them and they have to be collected explicitly.
/tmp/.../ifcopenshell-one-schema-dropped is missing IfcOpenShell runtime plugins:
  - parse_schema was built for ['2x3', '4', '4x1', '4x3', '4x3_add1', '4x3_add2', '4x3_tc1']
    but these are missing: ifcopenshell_parse_schema_ifc4x2.so
exit=1
```

**The strongest evidence: the guard rejects the package that actually shipped.** Reconstructing the file list the pre-#9305 collector produced, by applying its predicate (`name.startswith(("ifcopenshell.",))`) to the real build tree and adding `ifcopenshell_document_rdb.dll` because the wrapper links it directly:

```
Reconstructed pre-#9305 package contents:
    _ifcopenshell_wrapper.cp313-win_amd64.pyd
    ifcopenshell.geometry.dll
    ifcopenshell.geometry.writer.dll
    ifcopenshell.parse.dll
    ifcopenshell_document_rdb.dll

GUARD FAILS (expected):
reconstructed pre-#9305 win64 ifcopenshell-python zip is missing IfcOpenShell runtime plugins:
  - no ifcopenshell_parse_schema_ifc* library present. ...
```

That file list matches what the reporters found on disk, including the one plugin that survived.

**No spurious failures**, checked against the same real tree:

```
PASS: svgfill executable zip
PASS: WASM 3-schema build
PASS: executable package, geometry writers excluded
PASS: documentation-only zip
PASS: full python package
```

**The Windows call site end to end**, driving the real `verify_zip()` over zips built from the real build tree:

```
PASS: complete-python-package
FAIL: schema-plugins-not-collected      -> no ifcopenshell_parse_schema_ifc* library present
FAIL: collected-but-not-written         -> missing collected files: ifcopenshell/ifcopenshell_parse_schema_ifc4.so
```

`packaging/test_check_runtime_plugins.py` covers all of the above (11 tests). Red-green confirmed: disabling the required-family rule makes `test_pre_9305_windows_package_fails` fail.

## Not covered

- The guard checks that plugin files are *present*, not that they *load*. A plugin with an unresolvable dependency still passes here; that is what `check_runtime_dependencies()` in `nix/package-zip-archives.py` is for.
- The Windows and macOS call sites are verified by construction and by driving `verify_zip()` over real files, but not by running a full Windows or macOS packaging job.
- `pyodide/pack_wheel.py` is left to #9427, which already adds an equivalent assertion there.

Refs #9423, #9431, #9305, #9427.
