### PR TITLE
ifctester: gate facet filters on the presence of a population, not its type

### DIFF
--- a/src/ifctester/ifctester/facet.py
+++ b/src/ifctester/ifctester/facet.py
@@ -227,7 +227,14 @@ class Entity(Facet):
                     continue
         if self.predefinedType:
             return [r for r in results if self(r)]
-        return results
+        # `results` may come straight from ifc_file.by_type(), which is not guaranteed
+        # to be a `list` (e.g. it can be a `tuple`). Every other Facet.filter() gates
+        # on `isinstance(elements, list)` to decide whether a population has already
+        # been computed for it to narrow, versus starting a fresh, entity-type-agnostic
+        # scan of the whole model. Returning anything but a `list` here defeats that
+        # gate for the very next facet in the applicability, silently discarding this
+        # entity restriction instead of intersecting with it.
+        return list(results)
 
     def __call__(self, inst: ifcopenshell.entity_instance, logger: Optional[Logger] = None) -> EntityResult:
         is_pass = inst.is_a().upper() == self.name

--- a/src/ifctester/test/test_ids.py
+++ b/src/ifctester/test/test_ids.py
@@ -250,6 +250,32 @@ class TestIds:
         assert spec.requirements[0].failures[0]["element"] == wall
         assert spec2.requirements[0].failures[0]["element"] == wall
 
+    def test_entity_facet_without_a_predefined_type_does_not_leak_across_classes(self, monkeypatch):
+        # Regression test: Entity.filter() returns ifc_file.by_type()'s result
+        # unmodified when no predefinedType is given. That result is not guaranteed to
+        # be a `list` - some ifcopenshell builds return a `tuple` - and every other
+        # facet's filter() decides whether to narrow the population handed to it, or
+        # discard it and rescan the *entire* model, based on `isinstance(elements,
+        # list)`. A `tuple` fails that check, so the very next facet silently ignored
+        # the entity restriction and matched any class sharing the same attribute
+        # value. Force by_type() to return a tuple here so this reproduces regardless
+        # of what the local ifcopenshell build's by_type() normally returns.
+        specs = ids.Ids(title="Title")
+        spec = ids.Specification(name="Name")
+        spec.applicability.append(ids.Entity(name="IFCMATERIAL"))
+        spec.applicability.append(ids.Attribute(name="Name", value="Foo"))
+        specs.specifications.append(spec)
+
+        model = ifcopenshell.file()
+        material = model.createIfcMaterial(Name="Foo")
+        model.createIfcWall(Name="Foo")  # a different class sharing the same Name
+
+        real_by_type = model.by_type
+        monkeypatch.setattr(model, "by_type", lambda *a, **kw: tuple(real_by_type(*a, **kw)))
+
+        specs.validate(model)
+        assert set(spec.applicable_entities) == {material}
+
     def test_parsing_entities_with_no_attributes(self):
         model = ifcopenshell.file()
         wall1 = model.createIfcWall(Name="Waldo")


### PR DESCRIPTION
Entity.filter() returned ifc_file.by_type()'s result unmodified when no predefinedType was given. That result is not guaranteed to be a list (some ifcopenshell builds return a tuple), and every other facet's filter() decides whether to narrow the population handed to it, or discard it and rescan the entire model, based on isinstance(elements, list). A tuple fails that check, so the very next facet in an <ids:applicability> silently ignored the entity restriction and matched any class sharing the same attribute, classification, material, etc. value.

Observed in practice: a specification scoped to
entity(IFCMATERIAL) + attribute(Name=X) also matched an unrelated IfcTendonType that happened to share Name X with the IfcMaterial, failing the specification because the IfcTendonType lacks Pset_MaterialSteel.

Adds a regression test that forces by_type() to return a tuple so it reproduces independent of what the local ifcopenshell build normally returns.

An example is shown here:
<img width="1783" height="480" alt="IfcTester_Error" src="https://github.com/user-attachments/assets/3599ed6a-107e-4b7f-a871-36c1ca3f5a82" />

Attached are the source IFC file and the IDS. You may think the IDS is a bit weird (and it is). I am experimenting with creating an IDS that tests the outputs of a structural bridge design are retained in the IFC model as the model progresses through project development.

[PGSuper_Import_Model.ifc.txt](https://github.com/user-attachments/files/31846475/PGSuper_Import_Model.ifc.txt)

[PGSuper_Import_Model.ids.txt](https://github.com/user-attachments/files/31846496/PGSuper_Import_Model.ids.txt)
