### PR TITLE
ci: run on every pull request again (fixes the merge block in #9453)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,10 @@ on:
       - 'cmake/**'
       - 'test/**'
       - '.github/workflows/ci.yml'
+  # No paths filter here on purpose. A skipped workflow reports no status,
+  # so a required check would stay pending forever on any PR the filter
+  # excludes (e.g. src/bonsai only). The push filter above still applies.
   pull_request:
-    paths: *ci_paths
 
 jobs:
   activate:


### PR DESCRIPTION
Fixes the merge block reported in #9453.

`403a23a976` changed the `pull_request` trigger from having no paths filter to reusing the `push` one:

```yaml
  push:
    paths: &ci_paths
      ...
  pull_request:
    paths: *ci_paths
```

`src/bonsai/**` is not in that list, so `ci` is now skipped entirely for any pull request that touches only Bonsai. A skipped workflow reports no status at all, rather than a passing or failing one, so a required `compile-and-test` never arrives and the pull request cannot be merged. That is what #9453 hit, and it applies to every Bonsai only pull request against `v0.9.0`.

This restores the previous behaviour for pull requests and leaves the `push` filter untouched, so pushes to branches still skip the heavy build when nothing relevant changed. The anchor stays where it is, since it is still the definition used by `push`.

Two alternatives, if either is closer to the intent:

- add `src/bonsai/**` to `ci_paths`, which keeps the filter symmetric but runs the full C++ build on every Bonsai change
- keep the filter and make the required status check a job that always runs, reporting success when the heavy jobs are correctly skipped

I am happy to redo it either way. `v0.8.0` is unaffected: its `pull_request:` still has no filter.
