### PR TITLE
Fix border-half-edge bugs in `CgalShape::Triangulate()`

### DIFF
--- a/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
@@ -507,8 +507,8 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 								if ((fn2 * facet_normal) >= *smooth_treshold) {
 									normal_accum = normal_accum + fn2;
 								}
-								++vh;
 							}
+							++vh;
 						} while (vh != vh_begin);
 					}
 				}

--- a/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
+++ b/src/ifcgeom/kernels/cgal/CgalConversionResult.cpp
@@ -553,8 +553,9 @@ void ifcopenshell::geometry::CgalShape::Triangulate(ifcopenshell::geometry::Sett
 			vertexidx[i] = (int)vidx;
 			is_face_boundary[i] = setting_use_original_edges
 				? original_edges.find({ current_halfedge->vertex()->point(), current_halfedge->prev()->vertex()->point() }) != original_edges.end()
-				: facet_to_component[face] != facet_to_component[current_halfedge->opposite()->face()];
-				
+				: current_halfedge->opposite()->is_border()
+				|| facet_to_component.at(face) != facet_to_component.at(current_halfedge->opposite()->face());
+
 			++i;
 			++num_vertices;
 			++current_halfedge;


### PR DESCRIPTION
### Two bugs, both only hit on shapes with an open/border edge:

1. **Invalid iterator compare** — `facet_to_component[...]` used `operator[]`, which default-constructs a value for a border half-edge's (unmapped) facet. Comparing that against a real iterator is UB and trips MSVC's debug assert. This only ever surfaces in Debug builds. In the best case/release builds this produces smoothing artefacts near open shells. Fixed by checking `is_border()` first and switching to `.at()`. 
(See attached ifc sample file and screenshot)


2. **Circulator hang** — `++vh` was inside the `if (!vh->is_border())` block, so a border half-edge stopped the circulator from advancing, looping forever. Fixed by moving `++vh` outside the `if`.

### Testing

Re-ran on the IFC file that reproduced the assert/hang — confirmed fixed in Debug build, triangulation output unchanged on normal shapes.


[IfcSample_Asserts_CGAL.zip](https://github.com/user-attachments/files/31876226/IfcSample_Asserts_CGAL.zip)


<br><img width="476" height="407" alt="vector-iterators-incompatible-DebugAssert" src="https://github.com/user-attachments/assets/72e7370d-d4d3-4662-ad30-f3eb189da040" />

