### PR TITLE
Fix operator precedence in EXPRESS aggregate initializer repetition

### DIFF
--- a/src/ifcopenshell-python/ifcopenshell/express/rule_compiler.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rule_compiler.py
@@ -632,7 +632,7 @@ def process_case_statement(context):
 
 def process_aggregate_initializer(context):
     if context.element.repetition:
-        return "([%s] * %s)" % (context.element.expression, context.element.repetition)
+        return "([%s] * (%s))" % (context.element.expression, context.element.repetition)
     else:
         return "[%s]" % ",".join(map(str, context.element.branches() if context.element else ()))
 

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4.py
@@ -11864,7 +11864,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X1.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X1.py
@@ -12021,7 +12021,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X2.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X2.py
@@ -12313,7 +12313,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3.py
@@ -13746,7 +13746,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_ADD1.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_ADD1.py
@@ -13649,7 +13649,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_ADD2.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_ADD2.py
@@ -13671,7 +13671,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC1.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC1.py
@@ -13332,7 +13332,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC2.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC2.py
@@ -13434,7 +13434,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC3.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC3.py
@@ -13548,7 +13548,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC4.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_RC4.py
@@ -13628,7 +13628,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None

--- a/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_TC1.py
+++ b/src/ifcopenshell-python/ifcopenshell/express/rules/IFC4X3_TC1.py
@@ -13605,7 +13605,7 @@ def IfcMakeArrayOfArray(lis, low1, u1, low2, u2):
         return None
     if u2 - low2 + 1 != sizeof(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
         return None
-    res = [IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * u1 - low1 + 1
+    res = ([IfcListToArray(express_getitem(lis, 1 - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE), low2, u2)] * (u1 - low1 + 1))
     for i in range(2, hiindex(lis) + 1):
         if u2 - low2 + 1 != sizeof(express_getitem(lis, i - EXPRESS_ONE_BASED_INDEXING, INDETERMINATE)):
             return None


### PR DESCRIPTION
Fixes the `TypeError: unsupported operand type(s) for -: 'list' and 'int'` reported in buildingSMART/validate#266 (https://github.com/buildingSMART/validate/issues/266).

The rule compiler emitted `[expr] * count` without parenthesizing the count expression, so `IfcMakeArrayOfArray`'s generated

```python
res = [IfcListToArray(...)] * u1 - low1 + 1
```

evaluated as `([...] * u1) - low1`, raising a TypeError. This broke the `Weights` derived attribute on `IfcRationalBSplineSurfaceWithKnots`, making the `IfcSurfaceWeightsPositive` where rule fail on valid files.

Changes:
- `rule_compiler.py`: aggregate initializer template now emits `([expr] * (count))`
- All generated `express/rules/IFC*.py` files patched accordingly (11 files with `IfcMakeArrayOfArray`)

Verified by running the patched `IfcMakeArrayOfArray` on the weights array from the issue's `#97=IfcRationalBSplineSurfaceWithKnots` instance: no TypeError, and `IfcSurfaceWeightsPositive` passes as expected.