### PR TITLE
[AI-generated, unverified] ifcparse: stop scanning the whole inverse index when deleting an instance

### DIFF
--- a/src/ifcparse/parse.cpp
+++ b/src/ifcparse/parse.cpp
@@ -2940,7 +2940,7 @@ void file::process_deletion_(const express::base& entity) {
     // entity being deleted are not deleted themselves.
     if (!references.empty()) {
         for (auto& related_instance : references) {
-            if (std::find(batch_deletion_ids_.begin(), batch_deletion_ids_.end(), related_instance.id()) != batch_deletion_ids_.end()) {
+            if (batch_deletion_ids_.get<1>().count((int)related_instance.id()) != 0) {
                 continue;
             }
 
@@ -3021,7 +3021,20 @@ void ifcopenshell::impl::in_memory_file_storage::process_deletion_inverse(const 
 
     // Delete inverses into entity
     byref_excl_.erase(id);
-    byref_excl_.remove_source(id);
+
+    // Delete the records the entity contributed through its own attributes.
+    // Walking the attributes mirrors build_inverses_, so every record with
+    // this source is covered without scanning the whole index for it.
+    const auto* decl = entity.declaration().as_entity();
+    if (decl == nullptr) {
+        return;
+    }
+    std::function<void(const express::base&, int)> fn = [this, id, decl](const express::base& attr, int idx) {
+        if (attr.declaration().as_entity() != nullptr) {
+            byref_excl_.remove(attr.id(), id, (uint16_t)decl->index_in_schema(), idx);
+        }
+    };
+    apply_individual_instance_visitor(entity).apply(fn);
 }
 
 namespace {

--- a/src/ifcparse/storage.h
+++ b/src/ifcparse/storage.h
@@ -444,27 +444,6 @@ namespace ifcopenshell {
                 return true;
             }
 
-            // Nothing indexes records by source, so this walks the whole index.
-            void remove_source(uint32_t source_id) {
-                sort();
-                for (auto& record : base_) {
-                    if (!is_dead(record) && record.source_id == source_id) {
-                        kill(record);
-                    }
-                }
-                for (auto it = delta_.begin(); it != delta_.end();) {
-                    auto& records = it->second;
-                    auto removed = std::remove_if(records.begin(), records.end(), [source_id](const inverse_record& record) {
-                        return record.source_id == source_id;
-                    });
-                    delta_size_ -= (size_t)std::distance(removed, records.end());
-                    records.erase(removed, records.end());
-                    it = records.empty() ? delta_.erase(it) : std::next(it);
-                }
-                compact_if_tombstones_dominate();
-                invalidate_materialized();
-            }
-
             // Finalizes bulk loading. Subsequent add() calls go to the delta.
             void sort() const {
                 if (!sorted_) {

--- a/src/ifcparse/tests/test_ifcopenshell_parse.cpp
+++ b/src/ifcparse/tests/test_ifcopenshell_parse.cpp
@@ -165,3 +165,80 @@ TEST_CASE("Inverse lookups stay consistent across interleaved adds, removals and
     }
     CHECK(referencing_ids(target) == std::vector<int>{(int)trimmed.id()});
 }
+
+TEST_CASE("Deleting an instance unregisters the records its own attributes contributed", "[ifcparse]") {
+    ifcopenshell::file file(ifcopenshell::schema_by_name("IFC4"));
+    const auto* point_declaration = file.schema()->declaration_by_name("IfcCartesianPoint");
+    const auto* polyline_declaration = file.schema()->declaration_by_name("IfcPolyline");
+    const auto* trimmed_curve_declaration = file.schema()->declaration_by_name("IfcTrimmedCurve");
+
+    auto target = file.create(point_declaration);
+    auto second = file.create(point_declaration);
+
+    // A reference registered before the first lookup lands in the base tier,
+    // one registered after it in the delta.
+    auto base_referencer = file.create(polyline_declaration);
+    base_referencer.set_attribute_value(0, std::vector<express::base>{target, target});
+    REQUIRE(file.instances_by_reference(target.id()).size() == 2);
+    auto delta_referencer = file.create(polyline_declaration);
+    delta_referencer.set_attribute_value(0, std::vector<express::base>{target, second});
+    REQUIRE(file.instances_by_reference(target.id()).size() == 3);
+
+    // Duplicate references in one aggregate contribute two records; deleting
+    // the source must drop both.
+    file.remove_entity(base_referencer);
+    CHECK(file.instances_by_reference(target.id()).size() == 1);
+
+    // Referencing the same instance through two attributes contributes a
+    // record per attribute; deleting the source must drop them all.
+    auto trimmed = file.create(trimmed_curve_declaration);
+    trimmed.set_attribute_value(1, std::vector<express::base>{second});
+    trimmed.set_attribute_value(2, std::vector<express::base>{second});
+    CHECK(file.instances_by_reference(second.id()).size() == 3);
+    file.remove_entity(trimmed);
+    CHECK(file.instances_by_reference(second.id()).size() == 1);
+
+    // Deleting the target first prunes it out of the source's attribute, so
+    // deleting the source afterwards finds nothing left to unregister.
+    file.remove_entity(target);
+    file.remove_entity(delta_referencer);
+    CHECK(file.instances_by_reference(second.id()).empty());
+    CHECK(file.get_total_inverses(second.id()) == 0);
+}
+
+TEST_CASE("Batch deletion prunes surviving referencers and leaves no stale records", "[ifcparse]") {
+    ifcopenshell::file file(ifcopenshell::schema_by_name("IFC4"));
+    const auto* point_declaration = file.schema()->declaration_by_name("IfcCartesianPoint");
+    const auto* polyline_declaration = file.schema()->declaration_by_name("IfcPolyline");
+
+    auto kept_point = file.create(point_declaration);
+    std::vector<express::base> doomed_points;
+    for (int i = 0; i < 50; ++i) {
+        doomed_points.push_back(file.create(point_declaration));
+    }
+
+    // The survivor references every doomed point plus the kept one; a doomed
+    // referencer references the kept point.
+    auto survivor = file.create(polyline_declaration);
+    auto survivor_points = doomed_points;
+    survivor_points.push_back(kept_point);
+    survivor.set_attribute_value(0, survivor_points);
+    auto doomed_referencer = file.create(polyline_declaration);
+    doomed_referencer.set_attribute_value(0, std::vector<express::base>{kept_point});
+    REQUIRE(file.instances_by_reference(kept_point.id()).size() == 2);
+
+    file.batch();
+    for (auto& point : doomed_points) {
+        file.remove_entity(point);
+    }
+    file.remove_entity(doomed_referencer);
+    file.unbatch();
+
+    CHECK((std::vector<express::base>)survivor.get_attribute_value(0) == std::vector<express::base>{kept_point});
+    CHECK(file.instances_by_reference(kept_point.id()).size() == 1);
+    CHECK(file.get_total_inverses(kept_point.id()) == 1);
+    for (auto& point : doomed_points) {
+        CHECK(file.instances_by_reference(point.id()).empty());
+    }
+    CHECK(file.instances_by_reference(doomed_referencer.id()).empty());
+}


### PR DESCRIPTION
> **This PR was written entirely by an AI coding tool (Claude Code) and has not been verified by a human.** The maintainer who opened it has not reviewed the code, the design, or the benchmark methodology. Treat every claim below as unverified until a person has checked it.

**Stacked on #9460** (base branch is `inverse-index-delta`): the change relies on the targeted `inverse_index::remove()` that PR introduced. If #9460 is superseded by a different index design, this PR needs reworking on top of it — the idea (unregister through the deleted instance's own attributes rather than scanning for its source id) carries over to any layout.

## Problem

#9460 fixed the lookup side of the inverse index but left deletion alone: `file.remove()` still walks the entire index once per deleted instance, so bulk deletion on a large file is quadratic. This is the dominant remaining cost of `file.remove` / `root.remove_product` loops on big models.

## Cause

Two linear scans per deletion:

- `process_deletion_inverse()` called `inverse_index::remove_source()`, which visits every record in the file's index (base and delta tiers) to find the ones whose source is the deleted instance — O(R) per deletion for R references in the file. The class comment said it itself: "Nothing indexes records by source, so this walks the whole index."
- The batch-mode check in `process_deletion_()` ("is this referencing instance also being deleted?") was a linear `std::find` over the *sequenced* view of `batch_deletion_ids_` — a boost multi_index that already carries an `ordered_unique` view the lookup never used. O(b) per referencing instance makes batch deletion of b instances quadratic.

## Change

- The records a deleted instance contributed to the index are exactly the entity references in its own attributes. `process_deletion_inverse()` now walks them with `apply_individual_instance_visitor` — the same visitor `build_inverses_()` uses for registration, so coverage is symmetric by construction (duplicate members of one aggregate contribute and remove one record each; a reference through two attributes contributes and removes two) — and removes each record with the targeted `inverse_index::remove()` (binary search on the base tier, bucket lookup on the delta). `remove_source()` has no callers left and is deleted.
- The batch membership check uses the ordered view (`get<1>().count()`), O(log b).

References *into* the deleted instance were already handled by the targeted `erase(id)`; that path is unchanged.

## Verification

- Two new Catch2 cases in `src/ifcparse/tests/test_ifcopenshell_parse.cpp`: duplicate references within one aggregate, the same source referencing a target through two attributes, records in base vs delta tier, deleting the target before the source (the walk then finds already-pruned attributes), and a batch deletion where a survivor references 50 doomed instances plus a kept one while a doomed referencer references the kept one. All 7 parse test cases pass (713 assertions).
- Python, same sets as #9460: `test_file.py`, `test_file_inverse.py`, `test_entity_instance.py`, `test_file_gc.py`, `test_parse.py`, `test/api/root`, `test/api/pset`, `test/api/project`: 360 passed, 24 skipped. The whole `test/api` tree plus `test_open.py`, `test_stream.py`, `test_global_id_updates.py`, `test_guid.py`, `test_instance_string_formatting.py`, `test_express_aggregate_bounds.py`: 1818 passed, 7 skipped.
- Benchmark, 155 MB IFC4 model (201k `IfcRoot`), Python 3.13 source-tree Release build, this branch's parent (`inverse-index-delta`, f05b7b84a) as "before":

  | scenario | before | after |
  |---|---|---|
  | `file.remove` per call, 300 `IfcPropertySet` | 3.15 ms | 0.17 ms |
  | batched `file.remove` per call, 2000 `IfcPropertySet` | 3.34 ms | 0.17 ms |
  | `root.remove_product` per call, 100 walls | 332 ms | 131 ms |

  The remaining `remove_product` cost is Python-side API logic and attribute rewrites of large shared aggregates, not the index.

Not covered here, noted for later: the `entity_file_map_` full scan per deletion in `process_deletion_()` (only populated by `file::add()` from another file, so it doesn't show in these scenarios), and rewriting only the referencing attributes named by the inverse records instead of scanning every attribute of every referencer.

Not tested: the RocksDB storage backend (its `process_deletion_inverse` is untouched), Windows/macOS builds, and Bonsai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNrXDmR88wKPCYwGE21SyH
