### PR TITLE
Fix to_string() on eof marker token

### DIFF
--- a/src/ifcparse/parse.cpp
+++ b/src/ifcparse/parse.cpp
@@ -536,19 +536,34 @@ boost::dynamic_bitset<> token::as_binary() {
 }
 
 std::string token::to_string() {
-    std::string result;
-    if (type == Token_OPERATOR || type == Token_BOOL) {
-		result.push_back(value_char);
-    } else if (type == Token_INT) {
-        result = std::to_string(value_int);
-    } else if (type == Token_FLOAT) {
+    switch (type) {
+    case Token_OPERATOR:
+    case Token_BOOL:
+        return std::string(1, value_char);
+
+    case Token_INT:
+        return std::to_string(value_int);
+
+    case Token_IDENTIFIER:
+        return "#" + std::to_string(value_int);
+
+    case Token_FLOAT: {
         std::ostringstream oss;
         oss << std::setprecision(15) << value_double;
-        result = oss.str();
-	} else {
-        return as_string();
+        return oss.str();
     }
-    return result;
+
+    case Token_STRING:
+    case Token_ENUMERATION:
+    case Token_BINARY:
+    case Token_KEYWORD:
+        return as_string();
+
+    case Token_NONE:
+        throw invalid_token_exception(start_pos, "", "");
+    }
+
+    throw exception("Unknown token type");
 }
 
 std::string ifcopenshell::encode_spf_string(const std::string& value) {

--- a/src/ifcparse/tests/test_ifcopenshell_parse.cpp
+++ b/src/ifcparse/tests/test_ifcopenshell_parse.cpp
@@ -1,8 +1,11 @@
 // This file was generated with the assistance of an AI coding tool.
 
 #include <catch2/catch_test_macros.hpp>
+#include <ifcparse/exception.h>
 #include <ifcparse/file.h>
 #include <ifcparse/parse.h>
+#include <cstdint>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -95,4 +98,35 @@ TEST_CASE("Aggregate inverse updates preserve reference multiplicity", "[ifcpars
     CHECK(inverse_count(segment_b) == 0);
     CHECK(inverse_count(segment_c) == 2);
     CHECK(inverse_count(segment_d) == 1);
+}
+
+TEST_CASE("Tokens without a string representation do not recurse in to_string()", "[ifcparse]") {
+    // to_string() used to delegate to as_string() for every token type it did
+    // not handle explicitly, while as_string() builds its exception message
+    // with to_string(). An EOF marker or an instance name therefore recursed
+    // between the two until the stack was exhausted.
+    ifcopenshell::token eof;
+    REQUIRE(eof.type == ifcopenshell::token::Token_NONE);
+    CHECK_THROWS_AS(eof.to_string(), ifcopenshell::invalid_token_exception);
+    CHECK_THROWS_AS(eof.as_string(), ifcopenshell::invalid_token_exception);
+
+    ifcopenshell::token identifier(0, ifcopenshell::token::Token_IDENTIFIER, (int64_t)123);
+    CHECK(identifier.to_string() == "#123");
+    CHECK_THROWS_AS(identifier.as_string(), ifcopenshell::invalid_token_exception);
+}
+
+TEST_CASE("Files that contain no tokens are rejected rather than crashing", "[ifcparse]") {
+    // The header parser asks the lexer for a keyword before checking for EOF,
+    // so input that lexes to zero tokens reaches token::as_string() on the EOF
+    // marker. Parsing must fail cleanly instead of overflowing the stack.
+    const std::vector<std::string> inputs{" ", "\r\n\t  ", "/* only a comment */"};
+
+    for (const auto& contents : inputs) {
+        INFO("input: " << contents);
+        ifcopenshell::logger log;
+        std::istringstream input(contents);
+        ifcopenshell::file file(input, (int)contents.size(), log);
+
+        CHECK(file.good().value() != ifcopenshell::file_open_status::SUCCESS);
+    }
 }


### PR DESCRIPTION
Following a bug report from: Kamal Sentassi (Security Electronic Service) "1-byte DoS: infinite mutual recursion in IfcOpenShell's token::as_string()/to_string()"

```
[error] [2026-09-09 14:04:01] token  at offset 0 invalid
[error] [2026-09-09 14:04:01] No support for file schema encountered ()
[error] [SYN001] [2026-09-09 14:04:01] Unable to parse input file 'poc_1byte_space.ifc'
```