### PR TITLE
Bonsai: preserve drawing cameras per viewport

### DIFF
--- a/src/bonsai/bonsai/tool/blender.py
+++ b/src/bonsai/bonsai/tool/blender.py
@@ -146,13 +146,16 @@ class Blender(bonsai.core.tool.Blender):
 
     @classmethod
     def activate_camera(cls, obj: bpy.types.Object) -> None:
-
         area = cls.get_view3d_area()
         assert area
-        assert isinstance((space := area.spaces[0]), bpy.types.SpaceView3D)
+        assert isinstance((space := area.spaces.active), bpy.types.SpaceView3D)
         is_local_view = space.local_view is not None
 
         assert bpy.context.screen and bpy.context.scene
+        previous_camera = bpy.context.scene.camera
+        if previous_camera and previous_camera != obj:
+            # Other camera views would otherwise follow the global scene camera change.
+            cls.pin_scene_camera_to_other_viewports(previous_camera, space)
         if is_local_view:
             # Turn off local view before activating drawing, and then turn it on again.
             for a in bpy.context.screen.areas:
@@ -373,11 +376,39 @@ class Blender(bonsai.core.tool.Blender):
 
     @classmethod
     def get_view3d_area(cls) -> Union[bpy.types.Area, None]:
+        if (area := bpy.context.area) and area.type == "VIEW_3D":
+            return area
         assert (wm := bpy.context.window_manager)
         for window in wm.windows:
             for area in window.screen.areas:
                 if area.type == "VIEW_3D":
                     return area
+
+    @classmethod
+    def get_view3d_spaces(cls) -> Iterator[bpy.types.SpaceView3D]:
+        assert (wm := bpy.context.window_manager)
+        scene = bpy.context.scene
+        for window in wm.windows:
+            if window.scene != scene:
+                continue
+            for area in window.screen.areas:
+                if area.type != "VIEW_3D":
+                    continue
+                space = area.spaces.active
+                assert isinstance(space, bpy.types.SpaceView3D)
+                yield space
+
+    @classmethod
+    def pin_scene_camera_to_other_viewports(
+        cls, camera: bpy.types.Object, active_space: bpy.types.SpaceView3D
+    ) -> None:
+        for space in cls.get_view3d_spaces():
+            if space == active_space or space.use_local_camera:
+                continue
+            if not (region_3d := space.region_3d) or region_3d.view_perspective != "CAMERA":
+                continue
+            space.camera = camera
+            space.use_local_camera = True
 
     @classmethod
     def operator_idname_to_py(cls, idname: str) -> str:

--- a/src/bonsai/test/tool/test_blender.py
+++ b/src/bonsai/test/tool/test_blender.py
@@ -19,6 +19,7 @@
 # This file was modified with the assistance of an AI coding tool.
 
 import tempfile
+import types
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -58,6 +59,65 @@ class TestTransparentColor(NewFile):
         original = [1.0, 0.5, 0.25, 1.0]
         result = subject.transparent_color(original)
         assert result is not original
+
+
+class TestPinSceneCameraToOtherViewports(NewFile):
+    def test_camera_activation_pins_the_previous_camera_before_switching_scene_camera(self, monkeypatch):
+        assert bpy.context.scene
+        previous_camera = bpy.data.objects.new("Previous Camera", bpy.data.cameras.new("Previous Camera"))
+        new_camera = bpy.data.objects.new("New Camera", bpy.data.cameras.new("New Camera"))
+        bpy.context.scene.collection.objects.link(previous_camera)
+        bpy.context.scene.collection.objects.link(new_camera)
+        bpy.context.scene.camera = previous_camera
+        calls = []
+        monkeypatch.setattr(
+            subject,
+            "pin_scene_camera_to_other_viewports",
+            classmethod(lambda cls, camera, active_space: calls.append((camera, active_space))),
+        )
+
+        subject.activate_camera(new_camera)
+        subject.activate_camera(new_camera)
+
+        assert bpy.context.scene.camera == new_camera
+        assert calls == [(previous_camera, subject.get_view3d_space())]
+
+    def test_pins_only_other_camera_views_that_follow_the_scene_camera(self, monkeypatch):
+        previous_camera = object()
+        active_space = types.SimpleNamespace(
+            camera=None,
+            region_3d=types.SimpleNamespace(view_perspective="CAMERA"),
+            use_local_camera=False,
+        )
+        following_space = types.SimpleNamespace(
+            camera=None,
+            region_3d=types.SimpleNamespace(view_perspective="CAMERA"),
+            use_local_camera=False,
+        )
+        local_camera = object()
+        local_space = types.SimpleNamespace(
+            camera=local_camera,
+            region_3d=types.SimpleNamespace(view_perspective="CAMERA"),
+            use_local_camera=True,
+        )
+        perspective_space = types.SimpleNamespace(
+            camera=None,
+            region_3d=types.SimpleNamespace(view_perspective="PERSP"),
+            use_local_camera=False,
+        )
+        spaces = [active_space, following_space, local_space, perspective_space]
+        monkeypatch.setattr(subject, "get_view3d_spaces", classmethod(lambda cls: iter(spaces)))
+
+        subject.pin_scene_camera_to_other_viewports(previous_camera, active_space)
+
+        assert active_space.camera is None
+        assert active_space.use_local_camera is False
+        assert following_space.camera is previous_camera
+        assert following_space.use_local_camera is True
+        assert local_space.camera is local_camera
+        assert local_space.use_local_camera is True
+        assert perspective_space.camera is None
+        assert perspective_space.use_local_camera is False
 
 
 class TestViewportDecoratorDrawBatch(NewFile):


### PR DESCRIPTION
## Summary

This is a focused first step toward #6432: keep camera-mode 3D viewports on their current drawing camera when another viewport activates a different drawing.

Before changing `scene.camera`, Bonsai now pins other camera-perspective viewports that are still following the scene camera to the previous camera using `SpaceView3D.use_local_camera`. The viewport that invoked drawing activation is preferred as the active target, while existing user-local cameras and non-camera perspective views are left unchanged.

## Scope

This addresses the camera-switching part of #6432. Bonsai still has drawing activation paths that change object visibility and IFC representations at scene/view-layer level, so this PR does **not** claim to make all drawing state viewport-local yet. I kept this change narrow rather than mixing a broader visibility/representation redesign into the camera fix.

## Testing

- `git diff --check`
- Both changed Python files compiled successfully inside Blender 4.5 (`COMPILE_OK`).
- Added focused regression coverage for preserving the previous scene camera in other camera-mode viewports and leaving local/perspective views untouched.
- I attempted the focused Blender pytest run, but this local Blender Python does not have `pytest` installed (`ModuleNotFoundError: No module named 'pytest'`), so the repository CI remains the authoritative test run.

## AI assistance

OpenAI Codex was used to help investigate, implement, and review this change. I reviewed the resulting code and tests and take responsibility for the contribution.

Refs #6432