### PR TITLE
Accept an unquoted decimal in a selector value

### DIFF
--- a/src/ifcopenshell-python/docs/ifcopenshell-python/selector_syntax.rst
+++ b/src/ifcopenshell-python/docs/ifcopenshell-python/selector_syntax.rst
@@ -56,11 +56,13 @@ Filtering is typically used to select any IFC element or type.
 
     "``IfcWall, Pset_WallCommon.FireRating=2HR``", "Any 2 hour fire rated wall"
 
+    "``IfcWall, Pset_WallCommon.ThermalTransmittance=""1.5""``", "Any wall with a U-value of 1.5. Note the quotes: ``1.5`` contains a ``.``, so unquoted it is a syntax error. See `Quoting values in filters`_."
+
     "``IfcWall, IfcColumn, IfcBeam, IfcFooting, /Pset_.*Common/.LoadBearing=TRUE``", "Any load bearing structure"
 
     "``IfcElement, /Pset_.*Common/.FireRating != NULL``", "Any element with a fire rating property"
 
-    "``IfcWall, type=WT01, location=""Level 3""``", "Any walls of wall type WT01 on level 3 (we quote Level 3 since it has a space)"
+    "``IfcWall, type=WT01, location=""Level 3""``", "Any walls of wall type WT01 on level 3. We quote ``Level 3`` because it contains a space, but a space is only one of several characters that force quoting - see `Quoting values in filters`_."
 
     "``IfcElement, classification=/Pr_.*/``", "Any maintainable product according to Uniclass tables"
 
@@ -116,7 +118,7 @@ will search through all IfcTypeProducts and IfcProducts in the IFC project.
     "Classification", "Filter", "``classification{{=}}{{value}}``", "``classification=Foo`` specifies the criteria that elements must have an IfcClassificationReference with an ``Identification`` attribute with a value of ``Foo``."
     "Location", "Filter", "``location{{=}}{{value}}``", "``location=Foo`` specifies the criteria that elements must be contained directly or indirectly in a spatial element with a ``Name`` attribute with a value of ``Foo``."
     "Parent", "Filter", "``parent{{=}}{{value}}``", "``parent=Foo`` specifies the criteria that elements must be a direct or indirect child in the spatial hierarchy to an element with a ``Name`` attribute with a value of ``Foo``."
-    "Query", "Filter", "``query:{{keys}}{{=}}{{value}}``", "``query:types.count=0`` specifies the criteria that elements must have zero type occurrences. The query keys corresponds to the syntax used in the `Getting element values`_ section"
+    "Query", "Filter", "``query:{{keys}}{{=}}{{value}}``", "``query:""types.count""=0`` specifies the criteria that elements must have zero type occurrences. The query keys corresponds to the syntax used in the `Getting element values`_ section. Note that the keys are quoted: they usually contain a ``.``, which an unquoted string may not. See `Quoting values in filters`_."
 
 .. note::
 
@@ -149,8 +151,48 @@ three ways you can do so:
    :header: "Value Type", "Example", "Description"
 
     "Quoted string", "``""foo \""bar\"" baz""``", "The value must be in double quotes. The value may contain spaces, symbols, and other characters. If you need to use a double quote, you can escape it with a backslash. This is the safest, most general way to specify a value."
-    "Unquoted string", "``foobarbaz``", "For convenience, if you have a simple value which contains no spaces or special characters, you are free to specify it as an unquoted string."
+    "Unquoted string", "``foobarbaz``", "For convenience, if your value contains none of the characters listed under `Quoting values in filters`_ below, you are free to specify it as an unquoted string."
     "Regex string", "``/foo.*baz/``", "You may specify a Python-compatible regex pattern delimited by forward slashes. You can learn more about regular expressions from `Beginners Regex tutorial <https://regexone.com/>`_ and `Online Regex testing website <https://regex101.com/>`_."
+
+Quoting values in filters
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An unquoted ``{{pset}}``, ``{{prop}}``, ``{{keys}}``, or ``{{value}}`` may not
+contain any of the following characters:
+
+.. code-block::
+
+    ,  .  =  >  <  *  !  and whitespace
+
+If yours contains one of them, quote it. Every one of them except ``,`` is a
+syntax error when left unquoted. The ``,`` is the more dangerous case, because
+it does not error: it is read as the separator between two filters. So
+``Name=Foo,IfcWall`` does not look for the literal name ``Foo,IfcWall``, it
+quietly means "named ``Foo`` **and** an ``IfcWall``". Write
+``Name="Foo,IfcWall"`` to match the literal value.
+
+The ``.`` is the one most likely to catch you out. It separates a property set
+from a property, so it cannot also appear in an unquoted value, and that makes
+every decimal number a syntax error unless it is quoted:
+
+.. code-block::
+
+    Pset_WallCommon.ThermalTransmittance=1.5      # syntax error
+    Pset_WallCommon.ThermalTransmittance="1.5"    # correct
+
+Whole numbers are unaffected, which is why ``FireRating=2HR`` and
+``ThermalTransmittance>1`` are fine unquoted while ``ThermalTransmittance>1.5``
+is not. Quoting a number does not turn the check into a text comparison -
+``>``, ``>=``, ``<``, and ``<=`` still compare numerically, so
+``ThermalTransmittance>"0.9"`` does match a value of ``1.5``.
+
+.. note::
+
+    Query keys obey this same rule, and they nearly always contain a ``.``, so
+    in practice they always need quoting. Write ``query:"types.count"=0``.
+    Written as ``query:types.count=0`` it does not error, it is silently read
+    as a *property* filter looking for a ``count`` property inside a property
+    set named ``query:types``, which is not what you asked for.
 
 Getting element values
 ----------------------
@@ -235,8 +277,30 @@ do so:
    :header: "Value Type", "Example", "Description"
 
     "Quoted string", "``""foo \""bar\"" baz""``", "The value must be in double quotes. The value may contain spaces, symbols, and other characters. If you need to use a double quote, you can escape it with a backslash. This is the safest, most general way to specify a value."
-    "Unquoted string", "``foobarbaz``", "For convenience, if you have a simple value which contains no spaces or special characters, you are free to specify it as an unquoted string."
+    "Unquoted string", "``foobarbaz``", "For convenience, if your key contains none of the characters listed under `Quoting keys in value queries`_ below, you are free to specify it as an unquoted string."
     "Regex string", "``/foo.*baz/``", "You may specify a Python-compatible regex pattern delimited by forward slashes. You can learn more about regular expressions from `Beginners Regex tutorial <https://regexone.com/>`_ and `Online Regex testing website <https://regex101.com/>`_."
+
+Quoting keys in value queries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The characters that need quoting here are not the same set as in
+`Quoting values in filters`_. An unquoted key may not contain any of:
+
+.. code-block::
+
+    .  =  /  and whitespace
+
+All four are a syntax error when left unquoted, so there is no silent
+misreading to worry about in this position. The ``.`` is the key separator and
+the ``/`` delimits a regex, so a property set or property whose own name
+contains either - or a space - has to be quoted:
+
+.. code-block::
+
+    "Fire Rating Data".FireRating
+
+The remaining characters that force quoting in a filter - ``,``, ``>``, ``<``,
+``*``, and ``!`` - are accepted unquoted here.
 
 Formatting
 ----------

--- a/src/ifcopenshell-python/docs/ifcopenshell-python/selector_syntax.rst
+++ b/src/ifcopenshell-python/docs/ifcopenshell-python/selector_syntax.rst
@@ -56,7 +56,7 @@ Filtering is typically used to select any IFC element or type.
 
     "``IfcWall, Pset_WallCommon.FireRating=2HR``", "Any 2 hour fire rated wall"
 
-    "``IfcWall, Pset_WallCommon.ThermalTransmittance=""1.5""``", "Any wall with a U-value of 1.5. Note the quotes: ``1.5`` contains a ``.``, so unquoted it is a syntax error. See `Quoting values in filters`_."
+    "``IfcWall, Pset_WallCommon.ThermalTransmittance=1.5``", "Any wall with a U-value of 1.5. A decimal number is the one kind of value that may contain a ``.`` unquoted. See `Quoting values in filters`_."
 
     "``IfcWall, IfcColumn, IfcBeam, IfcFooting, /Pset_.*Common/.LoadBearing=TRUE``", "Any load bearing structure"
 
@@ -164,27 +164,31 @@ contain any of the following characters:
 
     ,  .  =  >  <  *  !  and whitespace
 
-If yours contains one of them, quote it. Every one of them except ``,`` is a
-syntax error when left unquoted. The ``,`` is the more dangerous case, because
-it does not error: it is read as the separator between two filters. So
-``Name=Foo,IfcWall`` does not look for the literal name ``Foo,IfcWall``, it
-quietly means "named ``Foo`` **and** an ``IfcWall``". Write
-``Name="Foo,IfcWall"`` to match the literal value.
+There is one exception, and it is only for a ``{{value}}``: a value that is a
+plain decimal number may contain the ``.`` unquoted, so
+``ThermalTransmittance=1.5`` is fine. A ``{{pset}}``, ``{{prop}}``, or
+``{{keys}}`` containing a ``.`` always needs quoting.
 
-The ``.`` is the one most likely to catch you out. It separates a property set
-from a property, so it cannot also appear in an unquoted value, and that makes
-every decimal number a syntax error unless it is quoted:
+Otherwise, if yours contains one of these characters, quote it. Every one of
+them except ``,`` is a syntax error when left unquoted. The ``,`` is the more
+dangerous case, because it does not error: it is read as the separator between
+two filters. So ``Name=Foo,IfcWall`` does not look for the literal name
+``Foo,IfcWall``, it quietly means "named ``Foo`` **and** an ``IfcWall``".
+Write ``Name="Foo,IfcWall"`` to match the literal value.
+
+The ``.`` still separates a property set from a property, so outside of a
+number it cannot appear in an unquoted value:
 
 .. code-block::
 
-    Pset_WallCommon.ThermalTransmittance=1.5      # syntax error
-    Pset_WallCommon.ThermalTransmittance="1.5"    # correct
+    Pset_WallCommon.ThermalTransmittance=1.5    # a number, no quotes needed
+    Pset_WallCommon.ThermalTransmittance>-.5    # signed and leading dot too
+    Name=v1.2                                   # syntax error, not a number
+    Name="v1.2"                                 # correct
 
-Whole numbers are unaffected, which is why ``FireRating=2HR`` and
-``ThermalTransmittance>1`` are fine unquoted while ``ThermalTransmittance>1.5``
-is not. Quoting a number does not turn the check into a text comparison -
-``>``, ``>=``, ``<``, and ``<=`` still compare numerically, so
-``ThermalTransmittance>"0.9"`` does match a value of ``1.5``.
+Quoting a number is still allowed and means exactly the same thing. Either way
+the check is not a text comparison - ``>``, ``>=``, ``<``, and ``<=`` compare
+numerically, so ``ThermalTransmittance>0.9`` does match a value of ``1.5``.
 
 .. note::
 

--- a/src/ifcopenshell-python/ifcopenshell/util/selector.py
+++ b/src/ifcopenshell-python/ifcopenshell/util/selector.py
@@ -66,8 +66,10 @@ filter_elements_grammar = lark.Lark("""start: filter_group
     attribute_name: /[A-Z]\\w+/
     ifc_class: /Ifc\\w+/
 
-    value: special | quoted_string | regex_string | unquoted_string
+    value: special | quoted_string | regex_string | decimal_string | unquoted_string
     unquoted_string: /[^,.=><*!\\s]+/
+    decimal_string: SIGNED_DECIMAL
+    SIGNED_DECIMAL: ["+"|"-"] (INT "." INT | "." INT)
     regex_string: "/" /[^\\/]+/ "/"
     quoted_string: ESCAPED_STRING
 
@@ -1232,6 +1234,8 @@ class FacetTransformer(lark.Transformer):
 
     def value(self, args):
         if args[0].data == "unquoted_string":
+            return args[0].children[0].value
+        elif args[0].data == "decimal_string":
             return args[0].children[0].value
         elif args[0].data == "quoted_string":
             return args[0].children[0].value[1:-1].replace('\\"', '"')

--- a/src/ifcopenshell-python/test/util/test_selector.py
+++ b/src/ifcopenshell-python/test/util/test_selector.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with IfcOpenShell.  If not, see <http://www.gnu.org/licenses/>.
 
+import lark
 import numpy as np
 import pytest
 
@@ -307,6 +308,8 @@ class TestFilterElements(test.bootstrap.IFC4):
         ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Baz": 123})
         assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz=123") == {element}
         ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Bay": 123.3})
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Bay=123.3") == {element}
+        assert subject.filter_elements(self.file, 'IfcWall, Foobar.Bay="123.3"') == {element}
         pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Pset_WallCommon")
         ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Status": ["New"]})
         assert subject.filter_elements(self.file, "IfcWall, Pset_WallCommon.Status=New") == {element}
@@ -330,6 +333,35 @@ class TestFilterElements(test.bootstrap.IFC4):
         assert subject.filter_elements(self.file, "IfcWall, Foobar.Foo*=ar") == {element}
         assert subject.filter_elements(self.file, "IfcWall, Foobar.Foo!*=ar") == {element2}
         assert subject.filter_elements(self.file, "IfcWall, Foobar.Foo*=Foo") == set()
+
+    def test_selecting_by_property_with_an_unquoted_decimal(self):
+        element = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        element2 = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcWall")
+        pset = ifcopenshell.api.pset.add_pset(self.file, product=element, name="Foobar")
+        ifcopenshell.api.pset.edit_pset(self.file, pset=pset, properties={"Baz": 1.5})
+        # A decimal needs no quotes. The pset/prop separator has already been
+        # consumed by the comparison, so a "." is unambiguous in a value.
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz=1.5") == {element}
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz>1") == {element}
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz>1.4") == {element}
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz<1.4") == set()
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz>=1.5") == {element}
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz<=1.5") == {element}
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz!=1.5") == {element2}
+        # Signed and leading dot forms.
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz>-1.5") == {element}
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz>+1.4") == {element}
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz>.5") == {element}
+        # Quoting a decimal stays legal and means exactly the same thing.
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz=1.5") == subject.filter_elements(
+            self.file, 'IfcWall, Foobar.Baz="1.5"'
+        )
+        assert subject.filter_elements(self.file, "IfcWall, Foobar.Baz>1.4") == subject.filter_elements(
+            self.file, 'IfcWall, Foobar.Baz>"1.4"'
+        )
+        # A dot in a value is still only a number. Anything else needs quotes.
+        with pytest.raises(lark.exceptions.UnexpectedInput):
+            subject.filter_elements(self.file, "IfcWall, Foobar.Baz=v1.2")
 
     def test_selecting_by_classification(self):
         project = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcProject")


### PR DESCRIPTION
Requiring quotes around a decimal in a selector value was a surprise with no
way to predict it:

```
Foobar.Baz>1      # works
Foobar.Baz>1.5    # lark.exceptions.UnexpectedCharacters
```

`>`, `>=`, `<` and `<=` are almost always used on numbers, so this is easy to
hit, and `Width>"0.2"` reads like a text comparison even though it is not.

## The change

The `.` is excluded from `unquoted_string` because it separates a pset from a
property. But by the time a value is read that separator has already been
consumed by the comparison operator, so a number is unambiguous in value
position. This adds a `decimal_string` alternative to the `value` rule only:

```
value: special | quoted_string | regex_string | decimal_string | unquoted_string
decimal_string: SIGNED_DECIMAL
SIGNED_DECIMAL: ["+"|"-"] (INT "." INT | "." INT)
```

The transformer returns the same string a quoted value would, so `=1.5` and
`="1.5"` are the same query and `compare()` does the existing type coercion.

`{{pset}}`, `{{prop}}` and query `{{keys}}` are unchanged, they still need
quoting for a `.`. Signed and leading dot forms are accepted, `1.` is not.

The change is additive. Nothing that parses today changes meaning, only inputs
that were previously a syntax error now work. Checked by parsing every example
in `selector_syntax.rst` before and after, and by confirming the bare and
quoted forms return identical sets for `=`, `!=`, `>`, `>=`, `<`, `<=` and
`*=`.

## Documentation

The first commit documents the quoting rule, which was never stated. The only
motivation the docs gave for quoting was the "Level 3" example having a space,
so nothing suggested that `ThermalTransmittance=1.5` behaved differently from
`FireRating=2HR`. The two grammars exclude different character sets, so the
element value section states its own.

That commit also fixes a bug in the docs themselves: `query:types.count=0`
does not error, it is silently parsed as a property filter for a `count`
property in a property set named `query:types`, and matches nothing. The other
query examples in the file already quote their keys.

Found during the same audit and **not** changed here: `+` is not in the
excluded set, so `Name=A+B` parses as the single value `A+B` rather than a
union of two filter groups. That looks like a separate bug.

## Testing

- `test/util/test_selector.py` — 41 passed (40 before, 1 new test).
- `test/util/` — 389 passed.
- `ifcpatch/test/test_ExtractElements.py` — 11 passed, 1 skipped.

---

This pull request is entirely AI-generated.