### PR TITLE
Bonsai: find a sheet's drawing by path when its data-id is stale

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/sheeter.py
+++ b/src/bonsai/bonsai/bim/module/drawing/sheeter.py
@@ -24,6 +24,7 @@ import urllib.parse
 import uuid
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from typing import Union
 from xml.dom import minidom
 
 import ifcopenshell.util.geolocation
@@ -211,6 +212,46 @@ class SheetBuilder:
 
         layout_tree.write(layout_path)
 
+    def find_drawing_group(
+        self,
+        layout_root: ET.Element,
+        layout_path: str,
+        reference: ifcopenshell.entity_instance,
+    ) -> Union[ET.Element, None]:
+        """Find the <g> a drawing reference was placed into.
+
+        `data-id` is the reference's STEP id, which is only meaningful while the
+        file keeps the numbering it had when the drawing was added. Merging a
+        project - or any round trip through a tool that renumbers entities -
+        leaves every `data-id` in every layout pointing at nothing, and matching
+        on it alone then finds no group at all.
+
+        The drawing's own file is stable across that, so it is used as a
+        fallback. Layout hrefs are relative to the layout and URL-encoded, hence
+        the unquote and the join.
+        """
+        for g in layout_root.findall(f"{SVG}g"):
+            if g.attrib.get("data-id") == str(reference.id()):
+                return g
+
+        drawing_path = tool.Drawing.get_document_uri(reference)
+        if not drawing_path:
+            return None
+        wanted = os.path.normcase(os.path.normpath(drawing_path))
+        layout_dir = os.path.dirname(layout_path)
+
+        for g in layout_root.findall(f'{SVG}g[@data-type="drawing"]'):
+            foreground = g.find(f'.//{SVG}image[@data-type="foreground"]')
+            if foreground is None:
+                continue
+            href = foreground.attrib.get(f"{XLINK}href") or foreground.attrib.get("href")
+            if not href:
+                continue
+            candidate = os.path.normpath(os.path.join(layout_dir, urllib.parse.unquote(href)))
+            if os.path.normcase(candidate) == wanted:
+                return g
+        return None
+
     def remove_drawing(self, reference: ifcopenshell.entity_instance, sheet: ifcopenshell.entity_instance) -> None:
         ET.register_namespace("", "http://www.w3.org/2000/svg")
 
@@ -221,11 +262,18 @@ class SheetBuilder:
         layout_tree = ET.parse(layout_path)
         layout_root = layout_tree.getroot()
 
-        for g in layout_root.findall(f"{SVG}g"):
-            if g.attrib.get("data-id") == str(reference.id()):
-                layout_root.remove(g)
-                break
+        group = self.find_drawing_group(layout_root, layout_path, reference)
+        if group is None:
+            # Nothing to remove, so nothing to write. Rewriting the layout here
+            # would reserialise it - a changed mtime and a whole-file diff for a
+            # removal that did not happen, which is what made this hard to spot.
+            print(
+                f"WARNING. Could not find drawing #{reference.id()} in layout '{layout_path}'. "
+                "It has been removed from the sheet in the IFC, but the layout is unchanged."
+            )
+            return
 
+        layout_root.remove(group)
         layout_tree.write(layout_path)
 
     def add_document(

--- a/src/bonsai/test/tool/test_sheeter.py
+++ b/src/bonsai/test/tool/test_sheeter.py
@@ -1,0 +1,81 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026 Ryan Schultz <ryan@openingdesign.com>
+#
+# This file is part of Bonsai.
+#
+# Bonsai is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Bonsai is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Bonsai.  If not, see <http://www.gnu.org/licenses/>.
+
+import xml.etree.ElementTree as ET
+
+
+class _FakeReference:
+    def __init__(self, step_id: int):
+        self._id = step_id
+
+    def id(self) -> int:
+        return self._id
+
+
+class TestFindDrawingGroup:
+    LAYOUT = (
+        '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">'
+        '  <g data-type="drawing" data-id="{first}" data-drawing="0aaa">'
+        '    <image data-type="foreground"'
+        '           xlink:href="..%5Cdrawings%5CPLAN%20-%20LEVEL%201.svg" />'
+        "  </g>"
+        '  <g data-type="drawing" data-id="{second}" data-drawing="0bbb">'
+        '    <image data-type="foreground"'
+        '           xlink:href="..%5Cdrawings%5CSECTION%20A.svg" />'
+        "  </g>"
+        "</svg>"
+    )
+
+    def _setup(self, tmp_path, monkeypatch, first="101", second="102", drawing="PLAN - LEVEL 1.svg"):
+        import bonsai.tool as tool
+        from bonsai.bim.module.drawing import sheeter
+
+        layouts = tmp_path / "layouts"
+        layouts.mkdir()
+        layout_path = layouts / "A101 - PLANS.svg"
+        layout_path.write_text(self.LAYOUT.format(first=first, second=second))
+
+        drawing_path = str(tmp_path / "drawings" / drawing)
+        monkeypatch.setattr(tool.Drawing, "get_document_uri", lambda *a, **k: drawing_path)
+
+        root = ET.parse(str(layout_path)).getroot()
+        return sheeter.SheetBuilder(), root, str(layout_path)
+
+    def test_matches_on_data_id_when_ids_are_current(self, tmp_path, monkeypatch):
+        builder, root, layout_path = self._setup(tmp_path, monkeypatch)
+        group = builder.find_drawing_group(root, layout_path, _FakeReference(102))
+        assert group is not None
+        assert group.attrib["data-drawing"] == "0bbb"
+
+    def test_falls_back_to_the_drawing_path_when_data_id_is_stale(self, tmp_path, monkeypatch):
+        """STEP ids do not survive a re-serialisation of the IFC.
+
+        Merging a project renumbers entities, so every data-id in every layout
+        points at nothing. Matching on it alone found no group, and the drawing
+        was left on the sheet while leaving the model - silently.
+        """
+        builder, root, layout_path = self._setup(tmp_path, monkeypatch, first="3729889", second="3729890")
+        group = builder.find_drawing_group(root, layout_path, _FakeReference(101))
+        assert group is not None
+        assert group.attrib["data-drawing"] == "0aaa"
+
+    def test_returns_none_when_the_drawing_is_not_on_the_sheet(self, tmp_path, monkeypatch):
+        builder, root, layout_path = self._setup(
+            tmp_path, monkeypatch, first="3729889", second="3729890", drawing="ELEVATION - NORTH.svg"
+        )
+        assert builder.find_drawing_group(root, layout_path, _FakeReference(101)) is None


### PR DESCRIPTION
Closes #9468.

### The problem

`SheetBuilder.remove_drawing` locates a drawing's `<g>` by comparing `data-id` against the reference's STEP id:

```python
for g in layout_root.findall(f"{SVG}g"):
    if g.attrib.get("data-id") == str(reference.id()):
        layout_root.remove(g)
        break

layout_tree.write(layout_path)
```

STEP ids only mean anything while the file keeps the numbering it had when the drawing was placed. Merging a project — or any round trip that renumbers entities — leaves every `data-id` in every layout pointing at nothing.

The loop then matches nothing, and `layout_tree.write()` runs regardless. The model loses the `IfcDocumentReference` while the layout keeps the drawing, and the layout is reserialised on the way out: a changed mtime and a whole-file diff for a removal that never happened. Since the Sheets panel reads the IFC, it shows the drawing gone, so the divergence stays invisible until something built from the layout disagrees.

### The change

Look the group up by drawing path when the id lookup fails. The file a drawing points at survives renumbering; the id does not. Layout hrefs are relative to the layout and URL-encoded, so they are unquoted and joined before comparison.

Two smaller changes come with it:

- Nothing is written when no group is found. The previous unconditional write is what disguised the failure as activity.
- A warning names the layout that was left alone, instead of returning silently.

The same `<g>` already carries `data-drawing` (the drawing's GlobalId), and `update_drawing_sizes` resolves drawings through it — `remove_drawing` was the one place keyed on the unstable half of the pair. Matching on the path rather than the GlobalId keeps this self-contained: no reference-to-drawing lookup is needed, and it works on layouts written by any earlier version. Happy to switch it to a GlobalId match if you would rather add that lookup.

### Testing

Three unit tests in `src/bonsai/test/tool/test_sheeter.py`: `data-id` match when ids are current, path fallback when they are stale, and `None` when the drawing is not on that sheet.

Also exercised on a real project whose ids had been renumbered by a merge. With the id match alone, none of the sheet's references resolved to a group; with the fallback, all of them did. Removing drawings from that sheet then emptied its layout as expected, with no warnings, and the removals showed up in a downstream tool that reads layouts — which is how the divergence was noticed in the first place.
