### PR TITLE
Bonsai: preview drawing SVG in camera viewport

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/__init__.py
+++ b/src/bonsai/bonsai/bim/module/drawing/__init__.py
@@ -22,7 +22,7 @@ import bpy
 
 import bonsai.tool as tool
 
-from . import gizmos, handler, operator, prop, ui, workspace
+from . import decoration, gizmos, handler, operator, prop, ui, workspace
 
 classes = (
     operator.ActivateDrawing,
@@ -201,6 +201,7 @@ def register():
 
 
 def unregister():
+    decoration.SvgOverlay.uninstall()
     if not bpy.app.background:
         bpy.utils.unregister_tool(workspace.AnnotationTool)
     del bpy.types.Scene.DocProperties

--- a/src/bonsai/bonsai/bim/module/drawing/decoration.py
+++ b/src/bonsai/bonsai/bim/module/drawing/decoration.py
@@ -18,6 +18,7 @@
 
 import math
 import os
+import xml.etree.ElementTree as ET
 from collections.abc import Generator, Iterator
 from functools import cache
 from math import acos, atan, cos, degrees, pi, radians, sin
@@ -40,12 +41,127 @@ from gpu_extras.batch import batch_for_shader
 from mathutils import Matrix, Vector
 
 import bonsai.bim.module.drawing.helper as helper
+import bonsai.bim.module.drawing.svg_overlay as svg_overlay
 import bonsai.tool as tool
 from bonsai.bim.module.drawing.data import DecoratorData, DrawingsData
 from bonsai.bim.module.drawing.helper import format_distance
 from bonsai.bim.module.drawing.shaders import add_offsets, add_verts_sequence
 
 UNSPECIAL_ELEMENT_COLOR = (0.2, 0.2, 0.2, 1)  # GREY
+
+
+class SvgOverlay:
+    installed = None
+    key = None
+    drawing = None
+    batches = None
+    shader = None
+
+    @classmethod
+    def refresh(cls):
+        cls.key = cls.drawing = cls.batches = None
+        for window in bpy.context.window_manager.windows:
+            for area in window.screen.areas:
+                if area.type == "VIEW_3D":
+                    area.tag_redraw()
+
+    @classmethod
+    def install(cls):
+        if bpy.app.background:
+            return
+        if cls.installed is None:
+            cls.installed = SpaceView3D.draw_handler_add(cls.draw, (), "WINDOW", "POST_VIEW")
+        cls.refresh()
+
+    @classmethod
+    def uninstall(cls):
+        if cls.installed is not None:
+            try:
+                SpaceView3D.draw_handler_remove(cls.installed, "WINDOW")
+            except ValueError:
+                pass
+            cls.installed = None
+        cls.shader = None
+        cls.refresh()
+
+    @classmethod
+    def draw(cls):
+        # Resolve the context for each region, never the region that installed the handler.
+        context = bpy.context
+        scene, space, region_3d = context.scene, context.space_data, context.region_data
+        if not scene or not scene.DocProperties.should_draw_svg_overlay:
+            return
+        camera = scene.camera
+        if (
+            not isinstance(space, SpaceView3D)
+            or not region_3d
+            or region_3d.view_perspective != "CAMERA"
+            or camera is None
+            or camera.data.type != "ORTHO"
+            or (space.use_local_camera and space.camera != camera)
+            or not tool.Ifc.get()
+        ):
+            return
+        drawing = tool.Ifc.get_entity(camera)
+        if not drawing or not drawing.is_a("IfcAnnotation") or drawing.ObjectType != "DRAWING":
+            return
+        key = (scene.as_pointer(), camera.as_pointer())
+        if cls.key != key:
+            cls.key, cls.drawing, cls.batches = key, None, None
+            document = tool.Drawing.get_drawing_document(drawing)
+            path = tool.Drawing.get_document_uri(document) if document else None
+            if path:
+                try:
+                    cls.drawing = svg_overlay.parse_svg(Path(path).read_text(encoding="utf-8"))
+                except (OSError, UnicodeError, ET.ParseError, ValueError) as error:
+                    print(f"SVG overlay: unable to read final drawing '{path}': {error}")
+        if cls.drawing is None:
+            return
+        if cls.batches is None:
+            cls.shader = gpu.shader.from_builtin("POLYLINE_UNIFORM_COLOR")
+            groups = []
+            for stroke in cls.drawing.strokes:
+                vertices = [
+                    (*svg_overlay.paper_to_camera(point, cls.drawing.view_box, 1, 1), 0)
+                    for edge in stroke.segments
+                    for point in edge
+                ]
+                if groups and groups[-1][0][1:] == stroke[1:]:
+                    groups[-1][1].extend(vertices)
+                else:
+                    groups.append((stroke, vertices))
+            cls.batches = [
+                (stroke, batch_for_shader(cls.shader, "LINES", {"pos": vertices})) for stroke, vertices in groups
+            ]
+
+        frame = camera.data.view_frame(scene=scene)
+        left, right = min(v.x for v in frame), max(v.x for v in frame)
+        bottom, top = min(v.y for v in frame), max(v.y for v in frame)
+        depth = -(camera.data.clip_start + camera.data.clip_end) / 2
+        matrix = camera.matrix_world @ Matrix.Translation(((left + right) / 2, (bottom + top) / 2, depth))
+        matrix @= Matrix.Diagonal((right - left, top - bottom, 1, 1))
+        p0 = location_3d_to_region_2d(context.region, region_3d, matrix @ Vector((-0.5, 0, 0)))
+        p1 = location_3d_to_region_2d(context.region, region_3d, matrix @ Vector((0.5, 0, 0)))
+        if p0 is None or p1 is None:
+            return
+        pixels_per_unit = (p1 - p0).length / cls.drawing.view_box[2]
+        blend, depth_test, depth_mask = gpu.state.blend_get(), gpu.state.depth_test_get(), gpu.state.depth_mask_get()
+        try:
+            gpu.state.blend_set("ALPHA")
+            gpu.state.depth_test_set("NONE")
+            gpu.state.depth_mask_set(False)
+            with gpu.matrix.push_pop():
+                gpu.matrix.multiply_matrix(matrix)
+                cls.shader.bind()
+                cls.shader.uniform_float("viewportSize", gpu.state.viewport_get()[2:])
+                for stroke, batch in cls.batches:
+                    cls.shader.uniform_float("color", stroke.color)
+                    cls.shader.uniform_float("lineWidth", stroke.width * pixels_per_unit)
+                    batch.draw(cls.shader)
+        finally:
+            gpu.state.blend_set(blend)
+            gpu.state.depth_test_set(depth_test)
+            gpu.state.depth_mask_set(depth_mask)
 
 
 class profile_consequential:

--- a/src/bonsai/bonsai/bim/module/drawing/handler.py
+++ b/src/bonsai/bonsai/bim/module/drawing/handler.py
@@ -25,7 +25,10 @@ import bonsai.tool as tool
 
 @persistent
 def load_post(*args):
+    decoration.SvgOverlay.uninstall()
     props = tool.Drawing.get_document_props()
+    if props.should_draw_svg_overlay:
+        decoration.SvgOverlay.install()
     if props.should_draw_decorations:
         decoration.DecorationsHandler.install(bpy.context)
     else:

--- a/src/bonsai/bonsai/bim/module/drawing/operator.py
+++ b/src/bonsai/bonsai/bim/module/drawing/operator.py
@@ -68,7 +68,7 @@ import bonsai.core.geometry
 import bonsai.tool as tool
 from bonsai.bim.ifc import IfcStore
 from bonsai.bim.module.drawing.data import DecoratorData, ElementValuesData
-from bonsai.bim.module.drawing.decoration import CutDecorator
+from bonsai.bim.module.drawing.decoration import CutDecorator, SvgOverlay
 from bonsai.bim.module.drawing.prop import (
     RASTER_STYLE_PROPERTIES_EXCLUDE,
     RasterStyleProperty,
@@ -481,6 +481,9 @@ class CreateDrawing(bpy.types.Operator):
 
                 with profile("Combine SVG layers"):
                     svg_path = self.combine_svgs(context, underlay_svg, linework_svg, annotation_svg)
+
+            if self.props.should_draw_svg_overlay:
+                SvgOverlay.refresh()
 
             if self.open_viewer:
                 drawing_uri = tool.Drawing.get_document_uri(tool.Drawing.get_drawing_document(self.drawing))

--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -263,6 +263,13 @@ def update_titleblocks(self, context):
     SheetsData.data["titleblocks"] = SheetsData.titleblocks()
 
 
+def update_should_draw_svg_overlay(self, context: bpy.types.Context) -> None:
+    if self.should_draw_svg_overlay:
+        decoration.SvgOverlay.install()
+    else:
+        decoration.SvgOverlay.uninstall()
+
+
 def update_should_draw_decorations(self, context: bpy.types.Context) -> None:
     if self.should_draw_decorations:
         # TODO: design a proper text variable templating renderer
@@ -438,6 +445,14 @@ class DocProperties(PropertyGroup):
     active_sheet_index: IntProperty(name="Active Sheet Index")
     drawing_styles: CollectionProperty(name="Drawing Styles", type=DrawingStyle)
     should_draw_decorations: BoolProperty(name="Should Draw Decorations", update=update_should_draw_decorations)
+    should_draw_svg_overlay: BoolProperty(
+        name="Generated SVG Overlay",
+        description="Preview strokes from the last generated SVG in the drawing camera. "
+        "Create Drawing to refresh. Fills, text, curves and symbols are not shown",
+        default=False,
+        options={"SKIP_SAVE"},
+        update=update_should_draw_svg_overlay,
+    )
 
     if TYPE_CHECKING:
         should_use_underlay_cache: bool
@@ -464,6 +479,7 @@ class DocProperties(PropertyGroup):
         active_sheet_index: int
         drawing_styles: bpy.types.bpy_prop_collection_idprop[DrawingStyle]
         should_draw_decorations: bool
+        should_draw_svg_overlay: bool
 
     def get_active_drawing(self) -> Union[ifcopenshell.entity_instance, None]:
         drawing_id = self.active_drawing_id

--- a/src/bonsai/bonsai/bim/module/drawing/svg_overlay.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svg_overlay.py
@@ -239,7 +239,10 @@ def parse_svg(source: str) -> Drawing:
         ):
             return
         try:
-            opacity = float(inherited.get("opacity", "1")) * float(winners.get("opacity", (None, "1"))[1])
+            local_opacity = winners.get("opacity", (None, "1"))[1]
+            if local_opacity == "inherit":
+                local_opacity = "1"
+            opacity = float(inherited.get("opacity", "1")) * float(local_opacity)
             style["opacity"] = str(opacity)
             if tag in ("svg", "g", "a"):
                 for child in element:

--- a/src/bonsai/bonsai/bim/module/drawing/svg_overlay.py
+++ b/src/bonsai/bonsai/bim/module/drawing/svg_overlay.py
@@ -1,0 +1,280 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+# SPDX-License-Identifier: GPL-3.0-or-later
+# This file was generated with the assistance of an AI coding tool.
+
+"""Stroke-only preview of the final drawing SVG, independent of Blender.
+
+Supports tag/class selectors (including compounds and descendants), inherited
+stroke styles, and straight paths. Fills, curves, transforms, clipping, text,
+references and paint servers are deliberately outside this first slice.
+"""
+
+import math
+import re
+import xml.etree.ElementTree as ET
+from typing import NamedTuple
+
+Point = tuple[float, float]
+NUMBER = r"[-+]?(?:\d*\.\d+|\d+\.?\d*)(?:[eE][-+]?\d+)?"
+TOKEN = re.compile(rf"[MLHVZmlhvz]|{NUMBER}")
+SELECTOR = re.compile(r"(?:[a-zA-Z][\w-]*|\*)?(?:\.[\w-]+)*")
+DEFAULTS = {"stroke": "none", "stroke-width": "1", "stroke-opacity": "1", "stroke-dasharray": "none"}
+COLORS = {
+    "black": "000000",
+    "silver": "c0c0c0",
+    "gray": "808080",
+    "white": "ffffff",
+    "maroon": "800000",
+    "red": "ff0000",
+    "purple": "800080",
+    "fuchsia": "ff00ff",
+    "green": "008000",
+    "lime": "00ff00",
+    "olive": "808000",
+    "yellow": "ffff00",
+    "navy": "000080",
+    "blue": "0000ff",
+    "teal": "008080",
+    "aqua": "00ffff",
+    "orange": "ffa500",
+    "grey": "808080",
+}
+
+
+class Stroke(NamedTuple):
+    segments: list[tuple[Point, Point]]
+    color: tuple[float, float, float, float]
+    width: float
+
+
+class Drawing(NamedTuple):
+    view_box: tuple[float, float, float, float]
+    strokes: list[Stroke]
+
+
+def numbers(value: str) -> list[float]:
+    if re.sub(NUMBER, "", value).strip(" ,\t\r\n"):
+        raise ValueError("Unsupported SVG number")
+    result = [float(v) for v in re.findall(NUMBER, value)]
+    if not all(math.isfinite(v) for v in result):
+        raise ValueError("Non-finite SVG number")
+    return result
+
+
+def length(value: str) -> float:
+    # Bonsai's viewBox uses paper mm, with unitless (or px) CSS lengths.
+    values = numbers(value.removesuffix("px"))
+    if len(values) != 1:
+        raise ValueError("Unsupported SVG length")
+    return values[0]
+
+
+def color(value: str) -> tuple[float, float, float] | None:
+    value = value.strip().lower()
+    value = "#" + COLORS[value] if value in COLORS else value
+    if re.fullmatch(r"#[0-9a-f]{3}(?:[0-9a-f]{3})?", value):
+        digits = value[1:]
+        if len(digits) == 3:
+            digits = "".join(c * 2 for c in digits)
+        return tuple(int(digits[i : i + 2], 16) / 255 for i in (0, 2, 4))
+    if value.startswith("rgb(") and value.endswith(")"):
+        values = numbers(value[4:-1])
+        if len(values) == 3:
+            return tuple(max(0, min(255, v)) / 255 for v in values)
+    return None
+
+
+def declarations(text: str) -> dict[str, tuple[bool, str]]:
+    result = {}
+    for declaration in text.split(";"):
+        key, sep, value = declaration.partition(":")
+        key, value = key.strip().lower(), value.strip()
+        if sep and value:
+            important = bool(re.search(r"\s*!important\s*$", value, re.I))
+            value = re.sub(r"\s*!important\s*$", "", value, flags=re.I)
+            if key not in result or important or not result[key][0]:
+                result[key] = (important, value)
+    return result
+
+
+def matches(selector: list[str], ancestry: list[ET.Element]) -> bool:
+    def compound(part, element):
+        tag, *classes = part.split(".")
+        return (tag in ("", "*", element.tag.rsplit("}", 1)[-1])) and set(classes).issubset(
+            element.get("class", "").split()
+        )
+
+    if not compound(selector[-1], ancestry[-1]):
+        return False
+    index = len(ancestry) - 2
+    for part in reversed(selector[:-1]):
+        while index >= 0 and not compound(part, ancestry[index]):
+            index -= 1
+        if index < 0:
+            return False
+        index -= 1
+    return True
+
+
+def paths(data: str) -> list[list[Point]]:
+    """Reject a whole primitive if any command is unsupported, avoiding false joins."""
+    if TOKEN.sub("", data).strip(" ,\t\r\n"):
+        raise ValueError("Unsupported SVG path")
+    tokens = TOKEN.findall(data)
+    result = []
+    current = (0.0, 0.0)
+    command = None
+    index = 0
+    while index < len(tokens):
+        if tokens[index].isalpha():
+            command = tokens[index]
+            index += 1
+            if command.upper() == "Z":
+                if not result:
+                    raise ValueError("Path must start with moveto")
+                current = result[-1][0]
+                result[-1].append(current)
+                command = None
+                continue
+        if command is None or (not result and command.upper() != "M"):
+            raise ValueError("Path must start with moveto")
+        count = 2 if command.upper() in ("M", "L") else 1
+        values = numbers(" ".join(tokens[index : index + count]))
+        if len(values) != count:
+            raise ValueError("Incomplete SVG path command")
+        index += count
+        relative = command.islower()
+        x, y = current
+        if command.upper() in ("M", "L"):
+            current = (values[0] + (x if relative else 0), values[1] + (y if relative else 0))
+        elif command.upper() == "H":
+            current = (values[0] + (x if relative else 0), y)
+        else:
+            current = (x, values[0] + (y if relative else 0))
+        if command.upper() == "M":
+            result.append([current])
+            command = "l" if relative else "L"
+        else:
+            result[-1].append(current)
+    return result
+
+
+def segments(points: list[Point], dash: list[float]) -> list[tuple[Point, Point]]:
+    if not dash or sum(dash) == 0:
+        return list(zip(points, points[1:]))
+    if len(dash) % 2:
+        dash = dash * 2
+    result = []
+    index, remaining = 0, dash[0]
+    for start, end in zip(points, points[1:]):
+        distance = math.dist(start, end)
+        position = 0.0
+        while position < distance:
+            if remaining <= 0:
+                index = (index + 1) % len(dash)
+                remaining = dash[index]
+                continue
+            step = min(remaining, distance - position)
+            if index % 2 == 0:
+                result.append(
+                    tuple(
+                        tuple(a + (b - a) * fraction / distance for a, b in zip(start, end))
+                        for fraction in (position, position + step)
+                    )
+                )
+            position += step
+            remaining -= step
+    return result
+
+
+def parse_svg(source: str) -> Drawing:
+    root = ET.fromstring(source)
+    view_box = numbers(root.get("viewBox", ""))
+    if len(view_box) != 4 or min(view_box[2:]) <= 0:
+        raise ValueError("Drawing SVG needs a positive viewBox")
+    rules = []
+    for element in root.iter():
+        if element.tag.rsplit("}", 1)[-1] != "style":
+            continue
+        css = re.sub(r"/\*.*?\*/", "", "".join(element.itertext()), flags=re.S)
+        # At-rules and nested rules are outside this subset.
+        css = re.sub(r"@[^;{}]+;|@[^{}]+\{(?:[^{}]|\{[^{}]*\})*\}", "", css)
+        for selectors, body in re.findall(r"([^{}]+)\{([^{}]*)\}", css):
+            for selector in selectors.split(","):
+                parts = selector.split()
+                if not parts or not all(SELECTOR.fullmatch(part) for part in parts):
+                    continue
+                specificity = (selector.count("."), sum(part[0] not in ".*" for part in parts))
+                rules.append((parts, specificity, declarations(body)))
+
+    strokes = []
+
+    def visit(element, ancestry, inherited):
+        tag = element.tag.rsplit("}", 1)[-1]
+        if tag not in ("svg", "g", "a", "path", "line", "polyline", "polygon"):
+            return
+        if tag == "svg" and ancestry:
+            return
+        ancestry = ancestry + [element]
+        style = dict(inherited)
+        winners = {}
+        for key, value in element.attrib.items():
+            winners[key] = ((False, 0, 0, 0, -1), value)
+        for order, (selector, specificity, properties) in enumerate(rules):
+            if matches(selector, ancestry):
+                for key, (important, value) in properties.items():
+                    priority = (important, 0, *specificity, order)
+                    if key not in winners or priority >= winners[key][0]:
+                        winners[key] = (priority, value)
+        for key, (important, value) in declarations(element.get("style", "")).items():
+            priority = (important, 1, 0, 0, 0)
+            if key not in winners or priority >= winners[key][0]:
+                winners[key] = (priority, value)
+        for key, (_, value) in winners.items():
+            if value != "inherit":
+                style[key] = value
+        if style.get("display") == "none" or any(
+            style.get(key, "none") != "none" for key in ("transform", "clip-path", "mask", "filter")
+        ):
+            return
+        try:
+            opacity = float(inherited.get("opacity", "1")) * float(winners.get("opacity", (None, "1"))[1])
+            style["opacity"] = str(opacity)
+            if tag in ("svg", "g", "a"):
+                for child in element:
+                    visit(child, ancestry, style)
+                return
+            rgb = color(style["stroke"])
+            width = length(style["stroke-width"])
+            alpha = max(0, min(1, opacity * float(style["stroke-opacity"])))
+            if rgb is None or width <= 0 or alpha == 0 or style.get("visibility") in ("hidden", "collapse"):
+                return
+            if tag == "path":
+                polylines = paths(element.get("d", ""))
+            elif tag == "line":
+                polylines = [[tuple(length(element.get(f"{axis}{i}", "0")) for axis in "xy") for i in (1, 2)]]
+            else:
+                values = numbers(element.get("points", ""))
+                if len(values) % 2:
+                    return
+                points = list(zip(values[::2], values[1::2]))
+                polylines = [points + points[:1] if tag == "polygon" else points]
+            dash = [] if style["stroke-dasharray"] == "none" else numbers(style["stroke-dasharray"])
+            if any(v < 0 for v in dash):
+                dash = []
+            edges = [edge for points in polylines for edge in segments(points, dash)]
+            if edges:
+                strokes.append(Stroke(edges, (*rgb, alpha), width))
+        except (ValueError, OverflowError):
+            # An unsupported style or malformed primitive must not break the viewport.
+            return
+
+    visit(root, [], DEFAULTS)
+    return Drawing(tuple(view_box), strokes)
+
+
+def paper_to_camera(point: Point, view_box: tuple[float, float, float, float], width: float, height: float) -> Point:
+    """Invert SvgWriter's paper mapping; dimensions encode the drawing scale."""
+    x, y, w, h = view_box
+    return ((point[0] - x) / w - 0.5) * width, (0.5 - (point[1] - y) / h) * height

--- a/src/bonsai/bonsai/bim/module/drawing/ui.py
+++ b/src/bonsai/bonsai/bim/module/drawing/ui.py
@@ -306,6 +306,8 @@ class BIM_PT_drawings(Panel):
             row.operator("bim.load_drawings", text="", icon="IMPORT")
             return
 
+        self.layout.prop(self.props, "should_draw_svg_overlay")
+
         row = self.layout.row(align=True)
         row.prop(self.props, "target_view", text="")
         row.prop(self.props, "location_hint", text="")

--- a/src/bonsai/test/bim/module/drawing/test_svg_overlay.py
+++ b/src/bonsai/test/bim/module/drawing/test_svg_overlay.py
@@ -1,0 +1,146 @@
+# Bonsai - OpenBIM Blender Add-on
+# Copyright (C) 2026
+# SPDX-License-Identifier: GPL-3.0-or-later
+# This file was generated with the assistance of an AI coding tool.
+
+"""Run directly with Python/unittest, or collect with pytest; Blender is not needed."""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+# Import the pure module without executing Bonsai's Blender-dependent package initializers.
+BONSAI = Path(__file__).resolve().parents[4]
+SPEC = importlib.util.spec_from_file_location("svg_overlay", BONSAI / "bonsai/bim/module/drawing/svg_overlay.py")
+subject = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(subject)
+
+
+def drawing(body, css=""):
+    return subject.parse_svg(
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">'
+        f"<defs><style><![CDATA[{css}]]></style></defs>{body}</svg>"
+    )
+
+
+class TestSvgOverlay(unittest.TestCase):
+    def test_final_stylesheet_inheritance_and_path_override(self):
+        css = (BONSAI / "bonsai/bim/data/assets/default.css").read_text(encoding="utf-8")
+        result = drawing(
+            '<g class="projection"><g class="IfcWall">'
+            '<path d="M0,0 L10,10"/><path class="sharp" d="M0,0 L20,20"/></g></g>'
+            '<g class="cut"><path d="M0,0 L30,30"/></g>',
+            css,
+        )
+        self.assertEqual([s.width for s in result.strokes], [0.25, 0.18, 0.35])
+        self.assertEqual([s.color for s in result.strokes], [(0, 0, 0, 1), (0, 0, 0, 0.7), (0, 0, 0, 1)])
+
+    def test_cascade_specificity_order_inline_and_important(self):
+        result = drawing(
+            '<g class="cut"><path class="IfcWall thick" stroke="green" style="stroke: blue; stroke-width: 2" '
+            'd="M0 0 L1 1"/></g>',
+            ".cut .IfcWall {stroke:red} .IfcWall.thick {stroke:#123 !important;stroke-width:3} "
+            ".IfcWall.thick {stroke:#456 !important} path {stroke: white !important}",
+        )
+        self.assertEqual(result.strokes[0].color, (0x44 / 255, 0x55 / 255, 0x66 / 255, 1))
+        self.assertEqual(result.strokes[0].width, 2)
+
+    def test_child_style_beats_inherited_important(self):
+        result = drawing(
+            '<g class="cut"><line class="edge" x2="1"/></g>',
+            ".cut {stroke:red !important} .edge {stroke:blue}",
+        )
+        self.assertEqual(result.strokes[0].color, (0, 0, 1, 1))
+
+    def test_opacity_and_visibility(self):
+        result = drawing(
+            '<g stroke="red" opacity="0.5"><g opacity="0.5"><line x2="1" stroke-opacity="0.4"/></g>'
+            '<g display="none"><line x2="1"/></g><line x2="1" visibility="hidden"/></g>'
+        )
+        self.assertEqual(len(result.strokes), 1)
+        self.assertAlmostEqual(result.strokes[0].color[3], 0.1)
+
+    def test_comments_selector_lists_and_unsupported_rules(self):
+        result = drawing(
+            '<line class="edge" x2="1"/>',
+            "/* .edge {stroke:blue} */ @media print {.edge {stroke:red}} "
+            "polygon, line.edge {stroke:rgb(12, 34, 56);stroke-width:0.2px} "
+            ".edge:hover {stroke:green} g > .edge {stroke:purple}",
+        )
+        self.assertEqual(result.strokes[0].color, (12 / 255, 34 / 255, 56 / 255, 1))
+        self.assertEqual(result.strokes[0].width, 0.2)
+
+    def test_absolute_relative_repeated_and_closed_paths(self):
+        self.assertEqual(
+            subject.paths("M1 2 3 4 H5 V6 h-1 v-2 l2 1 z m10 0 2 3"),
+            [[(1, 2), (3, 4), (5, 4), (5, 6), (4, 6), (4, 4), (6, 5), (1, 2)], [(11, 2), (13, 5)]],
+        )
+
+    def test_exponents_adjacent_signs_and_subpaths(self):
+        result = subject.paths("M1e1-2.5L.5.6 M0 0L1 1")
+        self.assertEqual(result, [[(10, -2.5), (0.5, 0.6)], [(0, 0), (1, 1)]])
+        parsed = drawing('<path stroke="black" d="M0 0L1 1 M2 2L3 3"/>')
+        self.assertEqual(len(parsed.strokes[0].segments), 2)
+
+    def test_invalid_or_curved_path_is_skipped_whole(self):
+        for path in ("M0 0L1 1Q2 2 3 3", "M0 0C1 1 2 2 3 3", "M0 0A1 1 0 0 0 2 2", "M0", "L1 2", "Z", "M0 0L"):
+            with self.subTest(path=path):
+                self.assertEqual(drawing(f'<path stroke="black" d="{path}"/>').strokes, [])
+
+    def test_line_polygon_and_polyline(self):
+        result = drawing(
+            '<g stroke="black"><line x1="1" y1="2" x2="3" y2="4"/>'
+            '<polygon points="0,0 1,0 1,1"/><polyline points="0,0 1,0 1,1"/></g>'
+        )
+        self.assertEqual([len(s.segments) for s in result.strokes], [1, 3, 2])
+        self.assertEqual(result.strokes[0].segments, [((1, 2), (3, 4))])
+
+    def test_dash_phase_continues_at_corners_and_resets_at_moveto(self):
+        result = drawing('<path stroke="black" stroke-dasharray="3,2" d="M0 0H4V4 M10 0H14"/>')
+        self.assertEqual(
+            result.strokes[0].segments,
+            [((0, 0), (3, 0)), ((4, 1), (4, 4)), ((10, 0), (13, 0))],
+        )
+
+    def test_odd_and_zero_dash_arrays(self):
+        self.assertEqual(subject.segments([(0, 0), (5, 0)], [2]), [((0, 0), (2, 0)), ((4, 0), (5, 0))])
+        self.assertEqual(subject.segments([(0, 0), (5, 0)], [0, 0]), [((0, 0), (5, 0))])
+        self.assertEqual(subject.segments([(0, 0), (5, 0)], [0, 2]), [])
+
+    def test_unsupported_elements_and_transformed_subtrees_are_skipped(self):
+        result = drawing(
+            '<g stroke="black"><defs><line x2="1"/></defs><text>Text</text><use href="#symbol"/>'
+            '<g transform="translate(1,2)"><line x2="1"/></g>'
+            '<g clip-path="url(#clip)"><line x2="1"/></g><line x2="1" stroke="url(#gradient)"/>'
+            '<svg x="10" viewBox="0 0 1 1"><line x2="1"/></svg>'
+            '<line x2="2"/><polygon fill="red" stroke="none" points="0 0 1 0 1 1"/></g>'
+        )
+        self.assertEqual(len(result.strokes), 1)
+
+    def test_invalid_primitive_does_not_hide_siblings(self):
+        result = drawing('<g stroke="black"><line x2="invalid"/><line x2="1"/><path d="M0 0L1e999 1"/></g>')
+        self.assertEqual(len(result.strokes), 1)
+
+    def test_camera_mapping_matches_writer_at_different_scales(self):
+        for scale in (1 / 50, 1 / 100, 1 / 200):
+            width, height = 20, 10
+            view_box = (0, 0, width * scale * 1000, height * scale * 1000)
+            self.assertEqual(subject.paper_to_camera((0, 0), view_box, width, height), (-10, 5))
+            self.assertEqual(subject.paper_to_camera(view_box[2:], view_box, width, height), (10, -5))
+            point = ((2 + width / 2) * scale * 1000, (height / 2 - 3) * scale * 1000)
+            x, y = subject.paper_to_camera(point, view_box, width, height)
+            self.assertAlmostEqual(x, 2)
+            self.assertAlmostEqual(y, 3)
+
+    def test_portrait_and_nonzero_viewbox_origin(self):
+        self.assertEqual(subject.paper_to_camera((10, 20), (10, 20, 100, 200), 10, 20), (-5, 10))
+        self.assertEqual(subject.paper_to_camera((60, 120), (10, 20, 100, 200), 10, 20), (0, 0))
+
+    def test_invalid_viewbox(self):
+        for box in ("", "0 0 0 1", "0 0 1 -1", "0 0 1e999 1"):
+            with self.subTest(box=box), self.assertRaises(ValueError):
+                subject.parse_svg(f'<svg viewBox="{box}"/>')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/bonsai/test/bim/module/drawing/test_svg_overlay.py
+++ b/src/bonsai/test/bim/module/drawing/test_svg_overlay.py
@@ -60,6 +60,11 @@ class TestSvgOverlay(unittest.TestCase):
         self.assertEqual(len(result.strokes), 1)
         self.assertAlmostEqual(result.strokes[0].color[3], 0.1)
 
+    def test_inherit_opacity_keeps_descendants_visible(self):
+        result = drawing('<g stroke="red" opacity="0.5"><g opacity="inherit"><line x2="1"/></g></g>')
+        self.assertEqual(len(result.strokes), 1)
+        self.assertAlmostEqual(result.strokes[0].color[3], 0.5)
+
     def test_comments_selector_lists_and_unsupported_rules(self):
         result = drawing(
             '<line class="edge" x2="1"/>',


### PR DESCRIPTION
## Summary

This is a focused first slice for #6422. It adds an opt-in **Generated SVG Overlay** in the Drawings panel that reads the final combined drawing SVG and previews its straight-line publication styling directly in the active orthographic drawing camera viewport.

The overlay:
- reuses the already-generated final SVG; it does not add a second renderer or change the SVG generation pipeline;
- parses a bounded SVG/CSS subset for straight paths, lines, polylines/polygons, class/tag selectors, stroke color/width/opacity, and dash arrays;
- maps paper SVG coordinates back to the drawing camera plane and draws through Blender's `POST_VIEW` GPU path;
- caches parsed geometry and refreshes after **Create Drawing**;
- is opt-in, camera-only, and degrades safely when the final SVG is missing or contains unsupported features.

This PR deliberately does **not** attempt the complete publication preview yet. Fills, text, curves, transforms, clipping, markers/patterns, and paint servers remain outside this first bounded slice. In particular, cut/fill-color fidelity still needs a follow-up slice if this direction is accepted.

## Testing

- Focused SVG parser/mapping tests: **17 passed + 11 subtests passed**, including regression coverage for `opacity="inherit"`.
- Python compile checks passed for all 8 touched/new Python files.
- Isolated Blender 4.5.4 handler/camera-gating/cache/refresh smoke checks passed.
- Black, Ruff, and `git diff --check` passed.
- Full Bonsai suite could not be collected locally because `pytest-blender` is unavailable.

## Visual evidence

A local Windows visual harness used Blender 4.5.4 LTS with Bonsai 0.8.5-post1 and minimal integration adaptations for that older Bonsai API. The overlay/parser logic from this PR was used against a Bonsai-generated `PLAN_VIEW.svg`. These screenshots validate the stroke-overlay slice only, not fills/text/patterns or full print fidelity.

- [Overlay OFF](https://raw.githubusercontent.com/franklincg/IfcOpenShell/evidence-6422-svg-overlay/evidence/6422/overlay_OFF.png)
- [Overlay ON](https://raw.githubusercontent.com/franklincg/IfcOpenShell/evidence-6422-svg-overlay/evidence/6422/overlay_ON.png)

## AI assistance

OpenAI Codex was used to investigate, implement, test, and review this change. I reviewed the resulting patch and take responsibility for the contribution. New AI-generated files contain the repository-required disclosure.

Refs #6422
