### PR TITLE
Bonsai: reload external styles from .blend in update_current_style

### DIFF
--- a/src/bonsai/bonsai/bim/module/style/operator.py
+++ b/src/bonsai/bonsai/bim/module/style/operator.py
@@ -209,7 +209,8 @@ class UpdateCurrentStyle(bpy.types.Operator):
     bl_idname = "bim.update_current_style"
     bl_label = "Update Current Style"
     bl_description = (
-        "Update style for all selected objects according to current style type\n(Shading/External).\n\n"
+        "Update style for all selected objects according to current style type\n(Shading/External).\n"
+        + "External styles are reloaded from their .blend file.\n\n"
         + "SHIFT+CLICK to update ALL styles in the .ifc file to current style type"
     )
     bl_options = {"REGISTER", "UNDO"}
@@ -232,6 +233,11 @@ class UpdateCurrentStyle(bpy.types.Operator):
         if self.update_all:
             sprops = tool.Style.get_style_props()
             sprops.active_style_type = current_style_type
+            if current_style_type == "External":
+                for mat in bpy.data.materials:
+                    if tool.Blender.get_ifc_definition_id(mat) == 0:
+                        continue
+                    self.reload_external_style(mat)
             return {"FINISHED"}
 
         updated_materials: set[bpy.types.Material] = set()
@@ -247,8 +253,20 @@ class UpdateCurrentStyle(bpy.types.Operator):
                 if mat in updated_materials:
                     continue
                 msprops_.active_style_type = current_style_type
+                if current_style_type == "External":
+                    self.reload_external_style(mat)
                 updated_materials.add(mat)
         return {"FINISHED"}
+
+    def reload_external_style(self, material: bpy.types.Material) -> None:
+        # Setting active_style_type only flips the cached dual-branch outputs,
+        # so re-append from the .blend to pick up changes made to the external style.
+        if not tool.Style.has_blender_external_style(tool.Style.get_style_elements(material)):
+            return
+        try:
+            bpy.ops.bim.activate_external_style(material_name=material.name)
+        except RuntimeError as error:
+            self.report({"WARNING"}, str(error))
 
 
 class SetAssetMaterialToExternalStyle(bpy.types.Operator):


### PR DESCRIPTION
Fixes #9477

The *Update Current Style* refresh button in the Styles panel (`bim.update_current_style`, added for #3293) stopped reloading external `.blend` styles after the Flat/Pretty dual-branch change in #8342. For a material that already has both branches, setting `active_style_type` only switches between `BIM_Output_External` and `BIM_Output_Flat`, so `bim.activate_external_style` is never called and edits to the external material never come through.

## Changes

- `UpdateCurrentStyle` now calls a new `reload_external_style()` for each material it updates when the style type is External, and for every IFC material on SHIFT+CLICK. It only runs for styles whose external `Location` is a `.blend` file, and it reports a warning if loading fails.
- For dual-branch materials this goes through `Style.update_external_branch()`, which replaces only the external branch and leaves the flat branch alone.
- `Style.switch_shading()` is unchanged. Viewport shading changes and the Flat/Pretty toggle set `active_style_type` on every material, and they should keep switching without reading from disk.
- The tooltip now says that External styles are reloaded from their `.blend` file.

## Testing

Tested manually in Blender on a model whose materials use external styles from a shared `Materials.blend`. After editing and saving materials in that file, clicking the button reloaded each selected object's materials (`activate_external_style` returned `{'FINISHED'}` for each), and the changes appeared in the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
