### PR TITLE
Reallow Bonsai without brickschema

### DIFF
--- a/src/bonsai/bonsai/tool/brick.py
+++ b/src/bonsai/bonsai/tool/brick.py
@@ -31,7 +31,6 @@ import ifcopenshell.guid
 import ifcopenshell.util.brick
 import ifcopenshell.util.element
 import ifcopenshell.util.system
-from brickschema.persistent import Changeset
 
 import bonsai.core.brick
 import bonsai.core.tool
@@ -49,6 +48,7 @@ except:
 
 if TYPE_CHECKING:
     import brickschema
+    from brickschema.persistent import Changeset
     from rdflib import BNode, Literal, Namespace, URIRef
 
     from bonsai.bim.module.brick.prop import BIMBrickProperties


### PR DESCRIPTION
6b62723 added a module-level `from brickschema.persistent import Changeset` to `src/bonsai/bonsai/tool/brick.py`, which made `brickschema` a hard dependency again - Bonsai fails to load without it.

This moves the import into the `TYPE_CHECKING` block, where the other `brickschema` imports already live, so it is only used for annotations.

See also #1860.