### PR TITLE
ifcpatch: add GenerateGeneralArrangementDrawings recipe

### DIFF
--- a/src/ifcpatch/README.md
+++ b/src/ifcpatch/README.md
@@ -17,6 +17,9 @@ Utility for applying modification recipes to IFC files. IfcPatch enables program
 - **ConvertPropertiesToQuantities** - Convert properties to quantities
 - **Migrate** - Migrate between IFC schema versions
 
+### Drawings and Documentation
+- **GenerateGeneralArrangementDrawings** - Generate General Arrangement plans, elevations and sheets for each building
+
 ### Element Extraction and Manipulation
 - **ExtractElements** - Extract specific elements into a new model
 - **ExtractPropertiesToSQLite** - Export properties to SQLite database

--- a/src/ifcpatch/ifcpatch/recipes/GenerateGeneralArrangementDrawings.py
+++ b/src/ifcpatch/ifcpatch/recipes/GenerateGeneralArrangementDrawings.py
@@ -1,0 +1,1420 @@
+# IfcPatch - IFC patching utility
+# Copyright (C) 2024-2026 Bruno Postle <bruno@postle.net>
+#
+# This file is part of IfcPatch.
+#
+# IfcPatch is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcPatch is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcPatch.  If not, see <http://www.gnu.org/licenses/>.
+
+import multiprocessing
+import os
+import re
+from logging import Logger
+
+import ifcopenshell
+import ifcopenshell.api.context
+import ifcopenshell.api.document
+import ifcopenshell.api.drawing
+import ifcopenshell.api.group
+import ifcopenshell.api.pset
+import ifcopenshell.api.root
+import ifcopenshell.geom
+import ifcopenshell.util.element
+import ifcopenshell.util.geolocation
+import ifcopenshell.util.placement
+import ifcopenshell.util.representation
+import ifcopenshell.util.shape
+import ifcopenshell.util.unit
+import numpy as np
+
+
+def natural_sort_key(text):
+    """Sort key that orders runs of digits by value, so "B2" comes before "B10"
+
+    Args:
+        text: String to sort by, or None
+
+    Returns:
+        List alternating text and integer parts
+    """
+    # re.split() puts the captured digit runs at the odd indices
+    parts = re.split(r"(\d+)", text or "")
+    return [int(part) if i % 2 else part for i, part in enumerate(parts)]
+
+
+def sanitise_filename(name):
+    """Keep only the characters Bonsai allows in drawing and sheet file names
+
+    Args:
+        name: File name
+
+    Returns:
+        The name without anything but letters, digits and "._- "
+    """
+    return "".join(c for c in name if c.isalnum() or c in "._- ")
+
+
+# Bonsai's default drawing folders and style assets, used where the project's
+# BBIM_Documentation pset doesn't set them
+DOCUMENTATION_DEFAULTS = {
+    "DrawingsDir": "drawings/",
+    "LayoutsDir": "layouts/",
+    "TitleblocksDir": "layouts/titleblocks/",
+    "StylesheetPath": "drawings/assets/default.css",
+    "MarkersPath": "drawings/assets/markers.svg",
+    "SymbolsPath": "drawings/assets/symbols.svg",
+    "PatternsPath": "drawings/assets/patterns.svg",
+    "ShadingStylesPath": "drawings/assets/shading_styles.json",
+}
+
+
+# Bonsai's imperial drawing scales, as {denominator: HumanScale}
+IMPERIAL_HUMAN_SCALES = {
+    1: "1'=1'-0\"",
+    2: '6"=1\'-0"',
+    4: '3"=1\'-0"',
+    8: '1-1/2"=1\'-0"',
+    12: '1"=1\'-0"',
+    16: '3/4"=1\'-0"',
+    24: '1/2"=1\'-0"',
+    32: '3/8"=1\'-0"',
+    48: '1/4"=1\'-0"',
+    64: '3/16"=1\'-0"',
+    96: '1/8"=1\'-0"',
+    120: "1\"=10'",
+    128: '3/32"=1\'-0"',
+    192: '1/16"=1\'-0"',
+    240: "1\"=20'",
+    360: "1\"=30'",
+    384: '1/32"=1\'-0"',
+    480: "1\"=40'",
+    600: "1\"=50'",
+    720: "1\"=60'",
+    768: '1/64"=1\'-0"',
+    840: "1\"=70'",
+    960: "1\"=80'",
+    1080: "1\"=90'",
+    1200: "1\"=100'",
+    1536: '1/128"=1\'-0"',
+    1800: "1\"=150'",
+    2400: "1\"=200'",
+    3600: "1\"=300'",
+    4800: "1\"=400'",
+    6000: "1\"=500'",
+}
+
+# Elevation names, clockwise from true north in 45 degree steps
+COMPASS_POINTS = [
+    "NORTH",
+    "NORTH-EAST",
+    "EAST",
+    "SOUTH-EAST",
+    "SOUTH",
+    "SOUTH-WEST",
+    "WEST",
+    "NORTH-WEST",
+]
+
+
+class ContextManager:
+    """Manages IFC context creation and retrieval"""
+
+    @staticmethod
+    def ensure_contexts(ifc_file):
+        """Create Annotation Context if it doesn't already exist
+
+        Args:
+            ifc_file: The IFC file
+
+        Returns:
+            Dictionary of contexts
+        """
+        model_context = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+        plan_context = ifcopenshell.util.representation.get_context(ifc_file, "Plan")
+
+        if not plan_context:
+            plan_context = ifcopenshell.api.context.add_context(ifc_file, context_type="Plan")
+
+        annotation_context = ifcopenshell.util.representation.get_context(ifc_file, "Plan", subcontext="Annotation")
+
+        if not annotation_context:
+            annotation_context = ifcopenshell.api.context.add_context(
+                ifc_file,
+                context_identifier="Annotation",
+                context_type=plan_context.ContextType,
+                parent=plan_context,
+                target_view="PLAN_VIEW",
+            )
+
+        return {
+            "model": model_context,
+            "plan": plan_context,
+            "annotation": annotation_context,
+        }
+
+
+class GeometryUtils:
+    """Utility functions for geometry operations"""
+
+    @staticmethod
+    def get_location_elements(ifc_file, spatial_elements):
+        """Collect the IfcElements located in any of the spatial elements
+
+        Walks the spatial decomposition directly, which returns the same
+        elements as a selector location="{Name}" query but is much faster on
+        large models and doesn't depend on names being unique or set.
+
+        Args:
+            ifc_file: The IFC file
+            spatial_elements: List of spatial elements
+
+        Returns:
+            Set of IfcElements
+        """
+        elements = set()
+        for spatial_element in spatial_elements:
+            elements.update(
+                e for e in ifcopenshell.util.element.get_decomposition(spatial_element) if e.is_a("IfcElement")
+            )
+        return elements
+
+    @staticmethod
+    def iterate_shapes(ifc_file, elements):
+        """Tessellate elements in one multithreaded iterator pass
+
+        Args:
+            ifc_file: The IFC file
+            elements: Iterable of elements
+
+        Yields:
+            Shapes in world coordinates and project units, for elements that
+            have body geometry
+        """
+        elements = list(elements)
+        if not elements:
+            return
+
+        settings = ifcopenshell.geom.settings()
+        settings.set("use-world-coords", True)
+        settings.set("convert-back-units", True)
+        # Openings only ever remove material, so they can't enlarge a
+        # bounding box, and boolean subtraction is the slowest part of
+        # tessellation. Spaces have no openings.
+        settings.set("disable-opening-subtractions", True)
+        settings.set("no-normals", True)
+        settings.set("weld-vertices", False)
+
+        # The hybrid kernel uses CGAL for polyhedral geometry and OpenCASCADE
+        # only where needed, giving the same bounds around twice as fast.
+        iterator_args = (settings, ifc_file, multiprocessing.cpu_count())
+        try:
+            iterator = ifcopenshell.geom.iterator(
+                *iterator_args,
+                include=elements,
+                geometry_library="hybrid-cgal-simple-opencascade",
+            )
+        except RuntimeError:
+            # Builds without CGAL have no hybrid kernel
+            iterator = ifcopenshell.geom.iterator(*iterator_args, include=elements)
+        if not iterator.initialize():
+            return
+
+        while True:
+            yield iterator.get()
+            if not iterator.next():
+                break
+
+    @staticmethod
+    def get_rotation(element):
+        """Get the rotation about z of an element's absolute placement
+
+        This includes rotations of the placements it's relative to, such as
+        a rotated site above a building.
+
+        Args:
+            element: The element, typically an IfcBuilding
+
+        Returns:
+            3x3 matrix whose columns are the element's x, y and z axes in
+            world coordinates, or None if it isn't rotated
+        """
+        matrix = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement)
+        angle = np.arctan2(matrix[1][0], matrix[0][0])
+        if abs(angle) < 1e-9:
+            return None
+        cos, sin = np.cos(angle), np.sin(angle)
+        return np.array([[cos, -sin, 0.0], [sin, cos, 0.0], [0.0, 0.0, 1.0]])
+
+    @staticmethod
+    def get_oriented_element_bounds(ifc_file, elements, rotations):
+        """Calculate bounding boxes of element geometry, some of them rotated
+
+        Tessellates all elements in one multithreaded iterator pass and takes
+        min/max over each vertex buffer with numpy, so no per-vertex Python
+        loop is involved. Rotating the vertices before taking min/max gives a
+        tighter box than rotating a world-aligned box.
+
+        Args:
+            ifc_file: The IFC file
+            elements: Iterable of IfcElements
+            rotations: Dict of {element id: rotation from get_rotation()}
+
+        Returns:
+            Tuple of two dicts of {element id: (min_xyz, max_xyz)} in project
+            units: world-aligned boxes for all elements, and boxes aligned to
+            the rotated axes, in coordinates along those axes, for elements in
+            rotations. Elements without body geometry are absent.
+        """
+        bounds = {}
+        oriented_bounds = {}
+        for shape in GeometryUtils.iterate_shapes(ifc_file, elements):
+            verts = ifcopenshell.util.shape.get_vertices(shape.geometry)
+            if not len(verts):
+                continue
+            bounds[shape.id] = (verts.min(axis=0), verts.max(axis=0))
+            rotation = rotations.get(shape.id)
+            if rotation is not None:
+                verts = verts @ rotation
+                oriented_bounds[shape.id] = (verts.min(axis=0), verts.max(axis=0))
+        return bounds, oriented_bounds
+
+    @staticmethod
+    def get_element_bounds(ifc_file, elements):
+        """Calculate world bounding boxes of element geometry
+
+        Args:
+            ifc_file: The IFC file
+            elements: Iterable of IfcElements
+
+        Returns:
+            Dict of {element id: (min_xyz, max_xyz)} in project units. Elements
+            without body geometry are absent.
+        """
+        return GeometryUtils.get_oriented_element_bounds(ifc_file, elements, {})[0]
+
+    @staticmethod
+    def get_bbox(ifc_file, spatial_elements, element_bounds=None, rotation=None):
+        """Calculate bounding box for spatial elements
+
+        Encloses the geometry of all elements located in the spatial elements.
+        Elements without geometry contribute their placement origin instead.
+
+        Args:
+            ifc_file: The IFC file
+            spatial_elements: List of spatial elements
+            element_bounds: Optional precomputed element bounds aligned to
+                rotation, from get_element_bounds() or
+                get_oriented_element_bounds(), to avoid tessellating the same
+                elements more than once
+            rotation: Optional rotation from get_rotation() to align the box
+                to, instead of the world axes
+
+        Returns:
+            Tuple of (min_point, mid_point, max_point), in coordinates along
+            the rotated axes if rotation is given
+        """
+        elements = GeometryUtils.get_location_elements(ifc_file, spatial_elements)
+        if element_bounds is None:
+            element_bounds = GeometryUtils.get_oriented_element_bounds(
+                ifc_file, elements, {e.id(): rotation for e in elements}
+            )[0 if rotation is None else 1]
+
+        mins = []
+        maxs = []
+
+        for element in elements:
+            if element.id() in element_bounds:
+                element_min, element_max = element_bounds[element.id()]
+                mins.append(element_min)
+                maxs.append(element_max)
+                continue
+
+            local_placement = ifcopenshell.util.placement.get_local_placement(element.ObjectPlacement)
+            origin = local_placement[:3, 3]
+
+            # Skip only elements sitting at the true world origin, which
+            # are typically unplaced. Elements legitimately placed on a
+            # single world axis (e.g. on x=0 at the grid origin) are kept.
+            if not origin.any():
+                continue
+            if rotation is not None:
+                origin = origin @ rotation
+
+            mins.append(origin)
+            maxs.append(origin)
+
+        # No geometry or validly placed elements found: return a degenerate
+        # bbox at the origin rather than crashing in the midpoint calculation.
+        if not mins:
+            bbox_min = [0.0, 0.0, 0.0]
+            bbox_max = [0.0, 0.0, 0.0]
+        else:
+            bbox_min = [float(v) for v in np.min(mins, axis=0)]
+            bbox_max = [float(v) for v in np.max(maxs, axis=0)]
+
+        # Calculate midpoint
+        bbox_mid = [
+            (bbox_min[0] + bbox_max[0]) / 2,
+            (bbox_min[1] + bbox_max[1]) / 2,
+            (bbox_min[2] + bbox_max[2]) / 2,
+        ]
+
+        return (bbox_min, bbox_mid, bbox_max)
+
+    @staticmethod
+    def get_centroids(ifc_file, elements):
+        """Calculate world centroids of element geometry
+
+        Uses the volume centroid of each mesh, which unlike the mean of its
+        vertices isn't pulled towards densely tessellated edges. A mesh that
+        encloses no volume falls back to the mean of its vertices.
+
+        Args:
+            ifc_file: The IFC file
+            elements: Iterable of elements
+
+        Returns:
+            Dict of {element id: [x, y, z]} in project units. Elements without
+            body geometry are absent.
+        """
+        centroids = {}
+        for shape in GeometryUtils.iterate_shapes(ifc_file, elements):
+            verts = ifcopenshell.util.shape.get_vertices(shape.geometry)
+            if not len(verts):
+                continue
+            # Work relative to the mean vertex so that large survey
+            # coordinates don't lose precision
+            origin = verts.mean(axis=0)
+            triangles = (verts - origin)[ifcopenshell.util.shape.get_faces(shape.geometry)]
+            # Signed volumes of the tetrahedra joining each triangle to origin
+            volumes = (
+                np.einsum(
+                    "ij,ij->i",
+                    triangles[:, 0],
+                    np.cross(triangles[:, 1], triangles[:, 2]),
+                )
+                / 6.0
+            )
+            volume = volumes.sum()
+            if abs(volume) <= 1e-9 * np.ptp(verts, axis=0).max() ** 3:
+                centroids[shape.id] = [float(v) for v in origin]
+                continue
+            # Each tetrahedron's centroid is a quarter of its three triangle
+            # corners, its fourth corner being the origin
+            centroid = origin + (volumes[:, None] * triangles.sum(axis=1)).sum(axis=0) / (4.0 * volume)
+            centroids[shape.id] = [float(v) for v in centroid]
+        return centroids
+
+
+class ShapeCreator:
+    """Creates IFC shape representations"""
+
+    @staticmethod
+    def create_camera_shape(ifc_file, x, y, z):
+        """Create a camera shape representation
+
+        Args:
+            ifc_file: The IFC file
+            x, y, z: Dimensions
+
+        Returns:
+            IfcProductDefinitionShape
+        """
+        body_context = ifcopenshell.util.representation.get_context(ifc_file, "Model", subcontext="Body")
+
+        placement = ifc_file.createIfcAxis2Placement3D(
+            ifc_file.createIfcCartesianPoint([float(x / -2), float(y / -2), float(-z)]),
+            None,
+            None,
+        )
+
+        solid = ifc_file.createIfcCSGSolid(ifc_file.createIfcBlock(placement, x, y, z))
+
+        return ifc_file.createIfcProductDefinitionShape(
+            None,
+            None,
+            [ifc_file.createIfcShapeRepresentation(body_context, "Body", "CSG", [solid])],
+        )
+
+    @staticmethod
+    def create_label_shape(ifc_file):
+        """Create a text label shape representation
+
+        Args:
+            ifc_file: The IFC file
+
+        Returns:
+            IfcProductDefinitionShape
+        """
+        annotation_context = ifcopenshell.util.representation.get_context(ifc_file, "Plan", subcontext="Annotation")
+
+        placement = ifc_file.createIfcAxis2Placement3D(
+            ifc_file.createIfcCartesianPoint([0.0, 0.0, 0.0]),
+            ifc_file.createIfcDirection([0.0, 0.0, 1.0]),
+            ifc_file.createIfcDirection([1.0, 0.0, 0.0]),
+        )
+
+        literal = ifc_file.createIfcTextLiteralWithExtent(
+            "{{Name}}",
+            placement,
+            "RIGHT",
+            ifc_file.createIfcPlanarExtent(1000.0, 1000.0),
+            "center",
+        )
+
+        representation = ifc_file.createIfcShapeRepresentation(
+            annotation_context, "Annotation", "Annotation2D", [literal]
+        )
+
+        return ifc_file.createIfcProductDefinitionShape(None, None, [representation])
+
+
+class DrawingGenerator:
+    """Main drawing generation class"""
+
+    def __init__(self, ifc_file, scale=None, titleblock="A2"):
+        """Initialize the drawing generator
+
+        Args:
+            ifc_file: The IFC file
+            scale: Drawing scale denominator (default 100, or 96 for
+                1/8"=1'-0" in imperial projects)
+            titleblock: Titleblock size (default "A2")
+        """
+        self.ifc_file = ifc_file
+
+        # Validate basic requirements
+        buildings = ifc_file.by_type("IfcBuilding")
+        if not buildings:
+            raise ValueError("No IfcBuilding entities found in IFC file")
+
+        model_context = ifcopenshell.util.representation.get_context(ifc_file, "Model")
+        if not model_context:
+            raise ValueError("No Model context found in IFC file")
+
+        self.imperial = self.is_imperial(ifc_file)
+        # Like Bonsai, default to 1:100, or 1/8"=1'-0" in imperial projects
+        self.scale = scale or (96 if self.imperial else 100)
+        self.titleblock = titleblock
+        self.paths = self.get_documentation_paths(ifc_file)
+        self.contexts = ContextManager.ensure_contexts(ifc_file)
+        # To convert meters to project units: project_units = meters / unit_scale
+        self.unit_scale = ifcopenshell.util.unit.calculate_unit_scale(ifc_file)
+
+        # Calculate overall bounding box for site plan
+        self.buildings = sorted(ifc_file.by_type("IfcBuilding"), key=lambda x: natural_sort_key(x.Name))
+        # A building's orientation comes from its placement alone
+        self.rotations = {building.id(): GeometryUtils.get_rotation(building) for building in self.buildings}
+        self.true_north = ifcopenshell.util.geolocation.get_true_north(ifc_file)
+
+        # Tessellate every element once, reused for all bounding boxes.
+        # Elements of rotated buildings also get boxes aligned to their
+        # building.
+        elements = set()
+        element_rotations = {}
+        for building in self.buildings:
+            building_elements = GeometryUtils.get_location_elements(ifc_file, [building])
+            elements.update(building_elements)
+            rotation = self.rotations[building.id()]
+            if rotation is not None:
+                element_rotations.update((e.id(), rotation) for e in building_elements)
+        self.element_bounds, self.oriented_bounds = GeometryUtils.get_oriented_element_bounds(
+            ifc_file, elements, element_rotations
+        )
+        # The site bbox stays aligned to the world axes, so location plans
+        # are north up
+        self.bbox_all = GeometryUtils.get_bbox(ifc_file, self.buildings, self.element_bounds)
+        self.bbox_all_min, self.bbox_all_mid, self.bbox_all_max = self.bbox_all
+
+        # Calculate dimensions (add 2 meters padding in project units)
+        self.dim_all_x = self.bbox_all_max[0] - self.bbox_all_min[0] + 2.0 / self.unit_scale
+        self.dim_all_y = self.bbox_all_max[1] - self.bbox_all_min[1] + 2.0 / self.unit_scale
+        self.dim_all_z = self.bbox_all_max[2] - self.bbox_all_min[2] + 2.0 / self.unit_scale
+
+    @staticmethod
+    def is_imperial(ifc_file):
+        """Check whether the project's length unit is imperial
+
+        Like Bonsai, any length unit that isn't an SI unit counts as imperial.
+
+        Args:
+            ifc_file: The IFC file
+
+        Returns:
+            True for imperial projects
+        """
+        unit = ifcopenshell.util.unit.get_project_unit(ifc_file, "LENGTHUNIT")
+        return bool(unit) and not unit.is_a("IfcSIUnit")
+
+    @staticmethod
+    def get_documentation_paths(ifc_file):
+        """Get the folders and style assets that drawings and sheets refer to
+
+        As in Bonsai, these come from the project's BBIM_Documentation pset.
+        Bonsai never writes that pset, so it's usually absent or only partly
+        filled in, and each path falls back separately to Bonsai's default.
+        Blender preferences, which Bonsai reads next, are deliberately left
+        out, so the recipe gives the same result wherever it runs.
+
+        Args:
+            ifc_file: The IFC file
+
+        Returns:
+            Dict of {BBIM_Documentation property name: path}, with "/"
+            separators
+        """
+        project = next(iter(ifc_file.by_type("IfcProject")), None)
+        pset = (ifcopenshell.util.element.get_pset(project, "BBIM_Documentation") if project else None) or {}
+        return {
+            name: (pset.get(name) or default).replace("\\", "/") for name, default in DOCUMENTATION_DEFAULTS.items()
+        }
+
+    def get_path(self, directory, filename):
+        """Get the path of a file in one of the documentation folders
+
+        Follows Bonsai's get_default_drawing_path and its siblings, including
+        their file name sanitising.
+
+        Args:
+            directory: BBIM_Documentation folder property, such as "DrawingsDir"
+            filename: File name, to be sanitised
+
+        Returns:
+            Path with "/" separators
+        """
+        return os.path.join(self.paths[directory], sanitise_filename(filename)).replace("\\", "/")
+
+    def get_human_scale(self, scale):
+        """Format a scale denominator for a drawing's HumanScale
+
+        Imperial projects use Bonsai's architectural or engineering notation,
+        such as 1/8"=1'-0" for 1/96, where there is one.
+
+        Args:
+            scale: Drawing scale denominator
+
+        Returns:
+            HumanScale string
+        """
+        scale = int(scale)
+        if self.imperial and scale in IMPERIAL_HUMAN_SCALES:
+            return IMPERIAL_HUMAN_SCALES[scale]
+        return f"1:{scale}"
+
+    def create_drawing_pset(self, annotation, scale=50):
+        """Create EPset_Drawing property set
+
+        Args:
+            annotation: The annotation element
+            scale: Drawing scale denominator
+
+        Returns:
+            The created property set
+        """
+        scale_str = str(int(scale))
+        pset = ifcopenshell.api.pset.add_pset(self.ifc_file, product=annotation, name="EPset_Drawing")
+
+        ifcopenshell.api.pset.edit_pset(
+            self.ifc_file,
+            pset=pset,
+            properties={
+                "GeneratedBy": "endrawing",
+                "TargetView": "PLAN_VIEW",
+                "Scale": f"1/{scale_str}",
+                "HumanScale": self.get_human_scale(scale),
+                "HasUnderlay": False,
+                "HasLinework": True,
+                "HasAnnotation": True,
+                "GlobalReferencing": True,
+                "Stylesheet": self.paths["StylesheetPath"],
+                "Markers": self.paths["MarkersPath"],
+                "Symbols": self.paths["SymbolsPath"],
+                "Patterns": self.paths["PatternsPath"],
+                "ShadingStyles": self.paths["ShadingStylesPath"],
+                "CurrentShadingStyle": "Blender Default",
+            },
+        )
+
+        return pset
+
+    def set_elevation_properties(self, pset, building):
+        """Set elevation view properties
+
+        Args:
+            pset: The property set
+            building: The building element
+        """
+        ifcopenshell.api.pset.edit_pset(
+            self.ifc_file,
+            pset=pset,
+            properties={
+                "TargetView": "ELEVATION_VIEW",
+                # GlobalId rather than Name, which buildings can share
+                "Include": f'IfcTypeProduct, IfcProduct, location="{building.GlobalId}"',
+            },
+        )
+
+    def create_drawing_group(self, annotation):
+        """Create a drawing group
+
+        Args:
+            annotation: The annotation element
+
+        Returns:
+            The created group
+        """
+        group = ifcopenshell.api.group.add_group(self.ifc_file)
+
+        ifcopenshell.api.group.edit_group(
+            self.ifc_file,
+            group=group,
+            attributes={
+                "Name": annotation.Name,
+                "ObjectType": "DRAWING",
+            },
+        )
+
+        ifcopenshell.api.group.assign_group(self.ifc_file, group=group, products=[annotation])
+
+        # Bonsai collects every drawing group in one parent group
+        ifcopenshell.api.group.assign_group(self.ifc_file, group=self.drawings_group, products=[group])
+
+        return group
+
+    def ensure_drawings_parent_document(self):
+        """Get or create the document Bonsai nests drawing documents under
+
+        Shared with drawings made in Bonsai, so cleanup never removes it.
+
+        Returns:
+            IfcDocumentInformation named DRAWINGS
+        """
+        for information in self.ifc_file.by_type("IfcDocumentInformation"):
+            if information.Name == "DRAWINGS" and information.Scope == "DRAWINGS":
+                return information
+        information = ifcopenshell.api.document.add_information(self.ifc_file)
+        self.edit_information(information, Identification="DRAWINGS", Name="DRAWINGS", Scope="DRAWINGS")
+        return information
+
+    def ensure_drawings_parent_group(self):
+        """Get or create the group Bonsai collects drawing groups in
+
+        Shared with drawings made in Bonsai, so cleanup never removes it.
+
+        Returns:
+            IfcGroup named DRAWINGS
+        """
+        for group in self.ifc_file.by_type("IfcGroup"):
+            if group.Name == "DRAWINGS" and group.ObjectType == "DRAWINGS":
+                return group
+        group = ifcopenshell.api.group.add_group(self.ifc_file)
+        ifcopenshell.api.group.edit_group(
+            self.ifc_file,
+            group=group,
+            attributes={"Name": "DRAWINGS", "ObjectType": "DRAWINGS"},
+        )
+        return group
+
+    def edit_information(self, information, **attributes):
+        """Set IfcDocumentInformation attributes, named as in IFC4
+
+        IFC2X3 calls Identification DocumentId.
+
+        Args:
+            information: The IfcDocumentInformation
+            **attributes: Attribute values
+        """
+        if self.ifc_file.schema == "IFC2X3" and "Identification" in attributes:
+            attributes["DocumentId"] = attributes.pop("Identification")
+        ifcopenshell.api.document.edit_information(self.ifc_file, information=information, attributes=attributes)
+
+    def add_reference(self, information, **attributes):
+        """Add an IfcDocumentReference with attributes named as in IFC4
+
+        IFC2X3 calls Identification ItemReference, and has no Description, so
+        Bonsai uses Name instead.
+
+        Args:
+            information: The IfcDocumentInformation to add the reference to
+            **attributes: Attribute values
+
+        Returns:
+            IfcDocumentReference
+        """
+        reference = ifcopenshell.api.document.add_reference(self.ifc_file, information=information)
+        if self.ifc_file.schema == "IFC2X3":
+            if "Identification" in attributes:
+                attributes["ItemReference"] = attributes.pop("Identification")
+            if "Description" in attributes:
+                attributes["Name"] = attributes.pop("Description")
+        ifcopenshell.api.document.edit_reference(self.ifc_file, reference=reference, attributes=attributes)
+        return reference
+
+    def attach_sheet(self, annotation, sheet_info, drawing_id):
+        """Create a drawing's document and place the drawing on a sheet
+
+        Follows Bonsai's add_drawing and AddDrawingToSheet.
+
+        Args:
+            annotation: The annotation element
+            sheet_info: Sheet document information
+            drawing_id: Drawing ID
+        """
+        information = ifcopenshell.api.document.add_information(self.ifc_file, parent=self.drawings_document)
+        self.edit_information(information, Identification="X", Name=annotation.Name, Scope="DRAWING")
+
+        # Associate the drawing SVG with the drawing annotation
+        location = self.get_path("DrawingsDir", f"{annotation.Name}.svg")
+        reference = self.add_reference(information, Location=location)
+        ifcopenshell.api.document.assign_document(self.ifc_file, products=[annotation], document=reference)
+
+        # Place the drawing SVG on the sheet
+        self.add_reference(
+            sheet_info,
+            Location=location,
+            Identification=str(drawing_id),
+            Description="DRAWING",
+        )
+
+    def create_sheet_info(self, identification, building_name):
+        """Create sheet document information
+
+        Follows Bonsai's add_sheet.
+
+        Args:
+            identification: Sheet identifier
+            building_name: Building name
+
+        Returns:
+            IfcDocumentInformation
+        """
+        # Without a parent, the sheet is associated with the IfcProject
+        sheet_info = ifcopenshell.api.document.add_information(self.ifc_file)
+        self.edit_information(
+            sheet_info,
+            Identification=identification,
+            Name=building_name,
+            Description="General Arrangement",
+            Purpose="General Arrangement",
+            Scope="SHEET",
+        )
+
+        self.add_reference(
+            sheet_info,
+            Location=self.get_path("LayoutsDir", f"{identification} - {building_name}.svg"),
+            Description="LAYOUT",
+        )
+        self.add_reference(
+            sheet_info,
+            Location=self.get_path("TitleblocksDir", f"{self.titleblock}.svg"),
+            Description="TITLEBLOCK",
+        )
+
+        return sheet_info
+
+    def create_plan_drawing(
+        self,
+        building,
+        storey,
+        building_bbox,
+        scale,
+        sheet_info,
+        drawing_id,
+        rotation=None,
+    ):
+        """Create a plan drawing for a storey
+
+        The plan is square to its building: the camera's x axis, which runs
+        along the sheet, is the building's x axis.
+
+        Args:
+            building: The building element
+            storey: The building storey
+            building_bbox: Building bounding box tuple
+            scale: Drawing scale
+            sheet_info: Sheet document information
+            drawing_id: Drawing ID
+            rotation: Optional building rotation from
+                GeometryUtils.get_rotation(), along whose axes building_bbox
+                is given
+
+        Returns:
+            Tuple of (new_drawing_id, annotation, group)
+        """
+        bbox_min, bbox_mid, bbox_max = building_bbox
+        dim_x = bbox_max[0] - bbox_min[0] + 2.0 / self.unit_scale
+        dim_y = bbox_max[1] - bbox_min[1] + 2.0 / self.unit_scale
+
+        # Get elevation from storey placement
+        local_placement = ifcopenshell.util.placement.get_local_placement(storey.ObjectPlacement)
+        elevation = local_placement[2][3]
+
+        # Camera 1.8 meters above floor in project units, looking down
+        local_placement = self.create_camera_placement(
+            [bbox_mid[0], bbox_mid[1], elevation + 1.8 / self.unit_scale],
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0],
+            rotation,
+        )
+
+        # Create annotation (camera volume depth 10 meters in project units)
+        annotation = ifcopenshell.api.root.create_entity(self.ifc_file, ifc_class="IfcAnnotation")
+        # Storey names like "Ground Floor" repeat across buildings, and the
+        # name gives the drawing its SVG path, so include the building
+        annotation.Name = f"{building.Name} {storey.Name}"
+        annotation.ObjectType = "DRAWING"
+        annotation.ObjectPlacement = local_placement
+        annotation.Representation = ShapeCreator.create_camera_shape(
+            self.ifc_file, dim_x, dim_y, 10.0 / self.unit_scale
+        )
+
+        # Create property set
+        pset = self.create_drawing_pset(annotation, scale)
+        ifcopenshell.api.pset.edit_pset(
+            self.ifc_file,
+            pset=pset,
+            properties={
+                "TargetView": "PLAN_VIEW",
+            },
+        )
+
+        # Attach to sheet
+        self.attach_sheet(annotation, sheet_info, drawing_id)
+
+        # Create group
+        group = self.create_drawing_group(annotation)
+
+        # Update drawing ID for next drawing
+        drawing_id += 1
+        return drawing_id, annotation, group
+
+    @staticmethod
+    def get_storey_spaces(storey):
+        """Get the spaces that make up a storey
+
+        Args:
+            storey: The building storey
+
+        Returns:
+            List of IfcSpace
+        """
+        return [part for part in ifcopenshell.util.element.get_parts(storey) if part.is_a("IfcSpace")]
+
+    def create_space_labels(self, storey, elevation, group, centroids, rotation=None):
+        """Create labels for spaces in a storey
+
+        Args:
+            storey: The building storey
+            elevation: Elevation value
+            group: Drawing group
+            centroids: Result of GeometryUtils.get_centroids() for the spaces
+            rotation: Optional building rotation from
+                GeometryUtils.get_rotation(), which the text follows so that
+                it runs along the plan
+        """
+        ref_direction = [1.0, 0.0, 0.0] if rotation is None else rotation[:, 0]
+        for space in self.get_storey_spaces(storey):
+            # Spaces without body geometry have no centroid to label
+            centroid = centroids.get(space.id())
+            if centroid is None:
+                continue
+
+            # Create placement (0.1 meters above floor in project units)
+            placement = self.ifc_file.createIfcLocalPlacement(
+                None,
+                self.ifc_file.createIfcAxis2Placement3D(
+                    self.ifc_file.createIfcCartesianPoint(
+                        [centroid[0], centroid[1], float(elevation) + 0.1 / self.unit_scale]
+                    ),
+                    self.ifc_file.createIfcDirection([0.0, 0.0, 1.0]),
+                    self.ifc_file.createIfcDirection([float(v) for v in ref_direction]),
+                ),
+            )
+
+            # Create room label annotation
+            annotation = ifcopenshell.api.root.create_entity(self.ifc_file, ifc_class="IfcAnnotation")
+            annotation.Name = "TEXT"
+            annotation.ObjectType = "TEXT"
+            annotation.ObjectPlacement = placement
+            annotation.Representation = ShapeCreator.create_label_shape(self.ifc_file)
+
+            # Add to group and assign to space
+            ifcopenshell.api.group.assign_group(
+                self.ifc_file,
+                group=group,
+                products=[annotation],
+            )
+
+            ifcopenshell.api.drawing.assign_product(
+                self.ifc_file,
+                relating_product=space,
+                related_object=annotation,
+            )
+
+            # Add properties
+            pset = ifcopenshell.api.pset.add_pset(
+                self.ifc_file,
+                product=annotation,
+                name="EPset_Annotation",
+            )
+
+            ifcopenshell.api.pset.edit_pset(
+                self.ifc_file,
+                pset=pset,
+                properties={
+                    "GeneratedBy": "endrawing",
+                    "Classes": "header",
+                },
+            )
+
+    def create_camera_placement(self, point, axis, ref_direction, rotation=None):
+        """Create an absolute placement for a drawing camera
+
+        Args:
+            point: Camera position
+            axis: Camera z axis, pointing back towards the viewer
+            ref_direction: Camera x axis, which runs along the drawing
+            rotation: Optional rotation from GeometryUtils.get_rotation(),
+                along whose axes point, axis and ref_direction are given
+
+        Returns:
+            IfcLocalPlacement
+        """
+        vectors = [np.array(v, dtype=float) for v in (point, axis, ref_direction)]
+        if rotation is not None:
+            vectors = [rotation @ v for v in vectors]
+        point, axis, ref_direction = ([float(c) for c in v] for v in vectors)
+        return self.ifc_file.createIfcLocalPlacement(
+            None,
+            self.ifc_file.createIfcAxis2Placement3D(
+                self.ifc_file.createIfcCartesianPoint(point),
+                self.ifc_file.createIfcDirection(axis),
+                self.ifc_file.createIfcDirection(ref_direction),
+            ),
+        )
+
+    def get_compass_name(self, direction):
+        """Name a horizontal direction by the nearest of eight compass points
+
+        Bearings are measured clockwise from true north. A bearing exactly
+        between two compass points goes to the cardinal one.
+
+        Args:
+            direction: Direction in world coordinates
+
+        Returns:
+            Compass point name from COMPASS_POINTS, such as "NORTH-EAST"
+        """
+        # World +y is project north, and true north is self.true_north
+        # degrees anticlockwise from it
+        angle = np.degrees(np.arctan2(direction[1], direction[0]))
+        sector = ((90.0 + self.true_north - angle) % 360.0) / 45.0
+        lower = np.floor(sector)
+        if abs(sector - lower - 0.5) < 1e-6:
+            # Cardinal points have even indices
+            index = lower if lower % 2 == 0 else lower + 1
+        else:
+            index = np.floor(sector + 0.5)
+        return COMPASS_POINTS[int(index) % 8]
+
+    def create_elevation_drawing(
+        self,
+        building,
+        building_bbox,
+        normal,
+        sheet_info,
+        drawing_id,
+        rotation=None,
+    ):
+        """Create an elevation drawing of one face of a building's bbox
+
+        The camera looks square on to the face, and the drawing is named by
+        the compass point the face looks towards.
+
+        Args:
+            building: The building element
+            building_bbox: Building bounding box tuple
+            normal: Outward normal of the face along the bbox axes, one of
+                [0, 1, 0], [0, -1, 0], [-1, 0, 0] or [1, 0, 0]
+            sheet_info: Sheet document information
+            drawing_id: Drawing ID
+            rotation: Optional building rotation from
+                GeometryUtils.get_rotation(), along whose axes building_bbox
+                and normal are given
+
+        Returns:
+            new_drawing_id
+        """
+        bbox_min, bbox_mid, bbox_max = (np.array(v, dtype=float) for v in building_bbox)
+        normal = np.array(normal, dtype=float)
+        # Bbox dimensions padded by 2m in project units
+        dims = bbox_max - bbox_min + 2.0 / self.unit_scale
+
+        # Camera 0.5m out from the face in project units, looking back at it,
+        # with the drawing running left to right as seen from outside
+        offset = 0.5 / self.unit_scale
+        point = bbox_mid + normal * ((bbox_max - bbox_min) / 2 + offset)
+        ref_direction = np.cross([0.0, 0.0, 1.0], normal)
+        local_placement = self.create_camera_placement(point, normal, ref_direction, rotation)
+
+        # The camera reaches 1m (in project units) short of the far side of
+        # the padded bbox
+        depth = 1.0 / self.unit_scale
+        camera_dims = (
+            float(np.abs(ref_direction) @ dims),
+            float(dims[2]),
+            float(np.abs(normal) @ dims - depth),
+        )
+
+        direction = self.get_compass_name(normal if rotation is None else rotation @ normal)
+
+        # Create annotation
+        annotation = ifcopenshell.api.root.create_entity(self.ifc_file, ifc_class="IfcAnnotation")
+        annotation.Name = f"{building.Name} {direction}"
+        annotation.ObjectType = "DRAWING"
+        annotation.ObjectPlacement = local_placement
+        annotation.Representation = ShapeCreator.create_camera_shape(
+            self.ifc_file, camera_dims[0], camera_dims[1], camera_dims[2]
+        )
+
+        # Create property set
+        pset = self.create_drawing_pset(annotation, self.scale)
+        self.set_elevation_properties(pset, building)
+
+        # Attach to sheet
+        self.attach_sheet(annotation, sheet_info, drawing_id)
+
+        # Create group
+        self.create_drawing_group(annotation)
+
+        # Update drawing ID for next drawing
+        drawing_id += 1
+
+        return drawing_id
+
+    def create_location_plan(self, building, sheet_info, drawing_id):
+        """Create a location plan drawing
+
+        Args:
+            building: The building element
+            sheet_info: Sheet document information
+            drawing_id: Drawing ID
+
+        Returns:
+            new_drawing_id
+        """
+        # Create point at center of all buildings, above max height (1 meter in project units)
+        point = self.ifc_file.createIfcCartesianPoint(
+            [
+                float(self.bbox_all_mid[0]),
+                float(self.bbox_all_mid[1]),
+                float(self.bbox_all_max[2] + 1.0 / self.unit_scale),
+            ]
+        )
+
+        # Create placement
+        local_placement = self.ifc_file.createIfcLocalPlacement(
+            None, self.ifc_file.createIfcAxis2Placement3D(point, None, None)
+        )
+
+        # Create annotation
+        annotation = ifcopenshell.api.root.create_entity(self.ifc_file, ifc_class="IfcAnnotation")
+        annotation.Name = f"{building.Name} LOCATION"
+        annotation.ObjectType = "DRAWING"
+        annotation.ObjectPlacement = local_placement
+        annotation.Representation = ShapeCreator.create_camera_shape(
+            self.ifc_file, self.dim_all_x, self.dim_all_y, self.dim_all_z
+        )
+
+        # Use larger scale for location plan
+        location_scale = self.scale * 10.0
+
+        # Create property set
+        pset = self.create_drawing_pset(annotation, location_scale)
+        ifcopenshell.api.pset.edit_pset(
+            self.ifc_file,
+            pset=pset,
+            properties={
+                "TargetView": "PLAN_VIEW",
+                "Include": f'IfcSite + IfcRoof, IfcWall, IfcSlab, location="{building.GlobalId}"',
+            },
+        )
+
+        # Attach to sheet
+        self.attach_sheet(annotation, sheet_info, drawing_id)
+
+        # Create group
+        self.create_drawing_group(annotation)
+
+        # Update drawing ID for next drawing
+        drawing_id += 1
+
+        return drawing_id
+
+    def get_references(self, information):
+        """Get the document references of an IfcDocumentInformation
+
+        Args:
+            information: The IfcDocumentInformation
+
+        Returns:
+            List of IfcDocumentReference
+        """
+        if self.ifc_file.schema == "IFC2X3":
+            return list(information.DocumentReferences or [])
+        return list(information.HasDocumentReferences)
+
+    def get_information(self, reference):
+        """Get the IfcDocumentInformation that a reference belongs to
+
+        Args:
+            reference: The IfcDocumentReference
+
+        Returns:
+            IfcDocumentInformation, or None
+        """
+        if self.ifc_file.schema == "IFC2X3":
+            return next(iter(reference.ReferenceToDocument), None)
+        return reference.ReferencedDocument
+
+    def get_reference_description(self, reference):
+        """Get the role of a sheet reference, such as "DRAWING" or "LAYOUT"
+
+        IFC2X3 references have no Description, so Bonsai uses Name instead.
+
+        Args:
+            reference: The IfcDocumentReference
+
+        Returns:
+            Description string, or None
+        """
+        if self.ifc_file.schema == "IFC2X3":
+            return reference.Name
+        return reference.Description
+
+    def is_generated_sheet(self, sheet, drawing_locations):
+        """Check whether a sheet was created by endrawing
+
+        A generated sheet is a General Arrangement sheet whose drawings are
+        all endrawing drawings. A sheet with any other drawing on it, or with
+        none, belongs to the user, whatever its Purpose.
+
+        Args:
+            sheet: IfcDocumentInformation
+            drawing_locations: Set of SVG locations of endrawing drawings
+
+        Returns:
+            True if endrawing created the sheet
+        """
+        if sheet.Scope != "SHEET" or sheet.Purpose != "General Arrangement":
+            return False
+        locations = [
+            reference.Location
+            for reference in self.get_references(sheet)
+            if self.get_reference_description(reference) == "DRAWING"
+        ]
+        return bool(locations) and all(l in drawing_locations for l in locations)
+
+    def cleanup_existing_drawings(self):
+        """Remove all endrawing-generated drawings and sheets
+
+        Everything removed is traced from annotations marked GeneratedBy =
+        "endrawing": the annotations themselves, the documents and groups of
+        the drawings among them, and the sheets holding only those drawings.
+        """
+        drawings = []
+        labels = []
+        for annotation in self.ifc_file.by_type("IfcAnnotation"):
+            psets = ifcopenshell.util.element.get_psets(annotation)
+            if psets.get("EPset_Drawing", {}).get("GeneratedBy") == "endrawing":
+                drawings.append(annotation)
+            elif psets.get("EPset_Annotation", {}).get("GeneratedBy") == "endrawing":
+                labels.append(annotation)
+
+        documents = set()
+        groups = set()
+        drawing_locations = set()
+        for drawing in drawings:
+            for rel in drawing.HasAssociations:
+                if rel.is_a("IfcRelAssociatesDocument") and rel.RelatingDocument.is_a("IfcDocumentReference"):
+                    drawing_locations.add(rel.RelatingDocument.Location)
+                    information = self.get_information(rel.RelatingDocument)
+                    if information:
+                        documents.add(information)
+            for rel in drawing.HasAssignments:
+                if rel.is_a("IfcRelAssignsToGroup") and rel.RelatingGroup.ObjectType == "DRAWING":
+                    groups.add(rel.RelatingGroup)
+
+        # Identify sheets while their drawings still exist
+        sheets = [
+            sheet
+            for sheet in self.ifc_file.by_type("IfcDocumentInformation")
+            if self.is_generated_sheet(sheet, drawing_locations)
+        ]
+
+        # Removing a drawing's document also removes its reference and the
+        # association with the drawing
+        for information in documents:
+            ifcopenshell.api.document.remove_information(self.ifc_file, information=information)
+
+        for annotation in drawings + labels:
+            ifcopenshell.api.root.remove_product(self.ifc_file, product=annotation)
+
+        # A drawing group can also hold annotations the user added to the
+        # drawing, so it's only removed once it's empty
+        for group in groups:
+            if not any(rel.RelatedObjects for rel in group.IsGroupedBy):
+                ifcopenshell.api.group.remove_group(self.ifc_file, group=group)
+
+        for sheet in sheets:
+            ifcopenshell.api.document.remove_information(self.ifc_file, information=sheet)
+
+    def get_storeys(self, building):
+        """Get the storeys of a building, lowest first
+
+        Args:
+            building: The building element
+
+        Returns:
+            List of (elevation, storey) pairs
+        """
+        # Pairs rather than a dict keyed by elevation, so two storeys sharing
+        # an elevation (mezzanines, split levels) don't overwrite each other.
+        # Walking the decomposition rather than querying by location Name
+        # keeps buildings that share a Name apart.
+        storeys = []
+        for ifc_storey in ifcopenshell.util.element.get_decomposition(building):
+            if not ifc_storey.is_a("IfcBuildingStorey"):
+                continue
+            local_placement = ifcopenshell.util.placement.get_local_placement(ifc_storey.ObjectPlacement)
+            storeys.append((local_placement[2][3], ifc_storey))
+        return sorted(storeys, key=lambda s: s[0])
+
+    def generate_drawings(self):
+        """Generate all drawings for buildings"""
+        self.cleanup_existing_drawings()
+        self.drawings_document = self.ensure_drawings_parent_document()
+        self.drawings_group = self.ensure_drawings_parent_group()
+
+        storeys = {building: self.get_storeys(building) for building in self.buildings}
+
+        # Tessellate every labelled space in one pass
+        centroids = GeometryUtils.get_centroids(
+            self.ifc_file,
+            [
+                space
+                for building_storeys in storeys.values()
+                for _, storey in building_storeys
+                for space in self.get_storey_spaces(storey)
+            ],
+        )
+
+        sheet_id = 0
+
+        for building in self.buildings:
+            # Create sheet for the building
+            sheet_id += 1
+            identification = f"A{str(sheet_id).zfill(3)}"
+            sheet_info = self.create_sheet_info(identification, building.Name)
+
+            # Calculate the building bounding box, aligned to the building's
+            # own axes
+            rotation = self.rotations[building.id()]
+            building_bbox = GeometryUtils.get_bbox(
+                self.ifc_file,
+                [building],
+                self.element_bounds if rotation is None else self.oriented_bounds,
+                rotation,
+            )
+
+            # Drawings on a sheet are numbered from 1, as is conventional
+            drawing_id = 1
+
+            # Create plan drawings for each storey
+            for elevation, storey in storeys[building]:
+                drawing_id, annotation, group = self.create_plan_drawing(
+                    building,
+                    storey,
+                    building_bbox,
+                    self.scale,
+                    sheet_info,
+                    drawing_id,
+                    rotation,
+                )
+
+                # Add space labels
+                self.create_space_labels(storey, elevation, group, centroids, rotation)
+
+            # Create elevation drawings of the bbox faces along the building's
+            # +y, -y, -x and +x axes
+            for normal in (
+                [0.0, 1.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [-1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+            ):
+                drawing_id = self.create_elevation_drawing(
+                    building,
+                    building_bbox,
+                    normal,
+                    sheet_info,
+                    drawing_id,
+                    rotation,
+                )
+
+            # Create location plan if there's more than one building
+            if len(self.buildings) > 1:
+                drawing_id = self.create_location_plan(building, sheet_info, drawing_id)
+
+
+class Patcher:
+    def __init__(self, file: ifcopenshell.file, logger: Logger, scale: int = 0, titleblock: str = "A2"):
+        """Generate General Arrangement drawings and sheets for every building
+
+        Each building gets a sheet holding a plan of each of its storeys,
+        elevations of its four faces, and a location plan when the site has
+        more than one building. Plans and elevations follow the building's
+        own axes, taken from its placement, and elevations are named by the
+        nearest compass point to true north. Drawings and sheets are set up
+        the way Bonsai creates them, so they can be generated in Bonsai.
+
+        Running the recipe again replaces the drawings and sheets it created
+        before, which are marked with GeneratedBy "endrawing" in their
+        EPset_Drawing, and leaves all other drawings and sheets alone.
+
+        Drawings, layouts and titleblocks go in the folders set by the
+        project's BBIM_Documentation property set, as in Bonsai, and drawings
+        use the style assets it sets. Anything it doesn't set, which is
+        usually all of it, uses Bonsai's defaults: drawings/, layouts/,
+        layouts/titleblocks/ and drawings/assets/.
+
+        :param scale: Drawing scale denominator, such as 100 for 1:100. 0
+            picks 100, or 96 (1/8"=1'-0") in imperial projects
+        :param titleblock: Name of the sheet titleblock, such as "A2"
+
+        Example:
+
+        .. code:: python
+
+            ifcpatch.execute({"file": model, "recipe": "GenerateGeneralArrangementDrawings", "arguments": [100, "A2"]})
+        """
+        self.file = file
+        self.logger = logger
+        # The command line passes arguments as strings
+        self.scale = int(scale)
+        self.titleblock = titleblock
+
+    def patch(self) -> None:
+        generator = DrawingGenerator(self.file, scale=self.scale or None, titleblock=self.titleblock)
+        generator.generate_drawings()
+        self.logger.info("Generated General Arrangement drawings for %d buildings", len(generator.buildings))

--- a/src/ifcpatch/test/test_GenerateGeneralArrangementDrawings.py
+++ b/src/ifcpatch/test/test_GenerateGeneralArrangementDrawings.py
@@ -1,0 +1,1039 @@
+# IfcPatch - IFC patching utility
+# Copyright (C) 2024-2026 Bruno Postle <bruno@postle.net>
+#
+# This file is part of IfcPatch.
+#
+# IfcPatch is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# IfcPatch is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with IfcPatch.  If not, see <http://www.gnu.org/licenses/>.
+
+from collections.abc import Sequence
+from typing import Optional
+
+import ifcopenshell
+import ifcopenshell.api.aggregate
+import ifcopenshell.api.context
+import ifcopenshell.api.document
+import ifcopenshell.api.geometry
+import ifcopenshell.api.project
+import ifcopenshell.api.pset
+import ifcopenshell.api.root
+import ifcopenshell.api.spatial
+import ifcopenshell.api.unit
+import ifcopenshell.geom
+import ifcopenshell.util.element
+import ifcopenshell.util.placement
+import ifcopenshell.util.representation
+import ifcopenshell.util.selector
+import numpy as np
+import pytest
+
+import ifcpatch
+import ifcpatch.recipes.GenerateGeneralArrangementDrawings as recipe
+import test.bootstrap
+
+RECIPE = "GenerateGeneralArrangementDrawings"
+
+DEFAULT_ASSETS = {
+    "Stylesheet": "drawings/assets/default.css",
+    "Markers": "drawings/assets/markers.svg",
+    "Symbols": "drawings/assets/symbols.svg",
+    "Patterns": "drawings/assets/patterns.svg",
+    "ShadingStyles": "drawings/assets/shading_styles.json",
+}
+
+# Normals of the building bbox faces that elevations are drawn of, in order
+FACE_NORMALS = [[0.0, 1.0, 0.0], [0.0, -1.0, 0.0], [-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+
+
+def run(file: ifcopenshell.file, *arguments) -> None:
+    ifcpatch.execute({"file": file, "recipe": RECIPE, "arguments": list(arguments)})
+
+
+# Model builders
+
+
+def placement(
+    file: ifcopenshell.file,
+    relative_to: Optional[ifcopenshell.entity_instance] = None,
+    rotation: float = 0.0,
+    xyz: Sequence[float] = (0.0, 0.0, 0.0),
+) -> ifcopenshell.entity_instance:
+    """Create a local placement at xyz (project units), rotated about z by rotation degrees"""
+    angle = np.radians(rotation)
+    return file.createIfcLocalPlacement(
+        relative_to,
+        file.createIfcAxis2Placement3D(
+            file.createIfcCartesianPoint([float(c) for c in xyz]),
+            file.createIfcDirection((0.0, 0.0, 1.0)),
+            file.createIfcDirection((float(np.cos(angle)), float(np.sin(angle)), 0.0)),
+        ),
+    )
+
+
+def create_project(
+    file: ifcopenshell.file, prefix: Optional[str] = None, imperial: bool = False, contexts: bool = True
+) -> tuple[ifcopenshell.entity_instance, Optional[ifcopenshell.entity_instance]]:
+    """Add a project with a length unit and, optionally, Model and Body contexts
+
+    :param prefix: SI length unit prefix, such as "MILLI", or None for metres
+    :param imperial: Use feet instead of an SI unit
+    :return: (project, body context) tuple
+    """
+    project = ifcopenshell.api.root.create_entity(file, ifc_class="IfcProject")
+    if imperial:
+        unit = ifcopenshell.api.unit.add_conversion_based_unit(file, name="foot")
+    else:
+        unit = ifcopenshell.api.unit.add_si_unit(file, unit_type="LENGTHUNIT", prefix=prefix)
+    ifcopenshell.api.unit.assign_unit(file, units=[unit])
+    body = None
+    if contexts:
+        model = ifcopenshell.api.context.add_context(file, context_type="Model")
+        body = ifcopenshell.api.context.add_context(
+            file, context_type="Model", context_identifier="Body", target_view="MODEL_VIEW", parent=model
+        )
+    return project, body
+
+
+def add_site(
+    file: ifcopenshell.file, project: ifcopenshell.entity_instance, rotation: float = 0.0
+) -> ifcopenshell.entity_instance:
+    site = ifcopenshell.api.root.create_entity(file, ifc_class="IfcSite")
+    ifcopenshell.api.aggregate.assign_object(file, relating_object=project, products=[site])
+    site.ObjectPlacement = placement(file, None, rotation)
+    return site
+
+
+def add_building(
+    file: ifcopenshell.file,
+    parent: ifcopenshell.entity_instance,
+    name: str = "Test Building",
+    rotation: float = 0.0,
+    xyz: Sequence[float] = (0.0, 0.0, 0.0),
+) -> ifcopenshell.entity_instance:
+    building = ifcopenshell.api.root.create_entity(file, ifc_class="IfcBuilding", name=name)
+    ifcopenshell.api.aggregate.assign_object(file, relating_object=parent, products=[building])
+    building.ObjectPlacement = placement(file, getattr(parent, "ObjectPlacement", None), rotation, xyz)
+    return building
+
+
+def add_storey(
+    file: ifcopenshell.file, building: ifcopenshell.entity_instance, name: str = "Ground Floor"
+) -> ifcopenshell.entity_instance:
+    storey = ifcopenshell.api.root.create_entity(file, ifc_class="IfcBuildingStorey", name=name)
+    ifcopenshell.api.aggregate.assign_object(file, relating_object=building, products=[storey])
+    storey.ObjectPlacement = placement(file, building.ObjectPlacement)
+    return storey
+
+
+def add_wall(
+    file: ifcopenshell.file,
+    storey: ifcopenshell.entity_instance,
+    xyz: Sequence[float] = (0.0, 0.0, 0.0),
+    body: Optional[ifcopenshell.entity_instance] = None,
+    rotation: float = 0.0,
+    length: float = 5.0,
+    thickness: float = 0.2,
+) -> ifcopenshell.entity_instance:
+    """Add a wall at xyz (project units), with a 3m high body if a context is given
+
+    Body dimensions are in metres, converted to project units by the API.
+    """
+    wall = ifcopenshell.api.root.create_entity(file, ifc_class="IfcWall")
+    ifcopenshell.api.spatial.assign_container(file, relating_structure=storey, products=[wall])
+    wall.ObjectPlacement = placement(file, storey.ObjectPlacement, rotation, xyz)
+    if body:
+        representation = ifcopenshell.api.geometry.add_wall_representation(
+            file, context=body, length=length, height=3.0, thickness=thickness
+        )
+        ifcopenshell.api.geometry.assign_representation(file, product=wall, representation=representation)
+    return wall
+
+
+def add_space(
+    file: ifcopenshell.file,
+    storey: ifcopenshell.entity_instance,
+    body: ifcopenshell.entity_instance,
+    name: str = "Kitchen",
+    rotation: float = 0.0,
+    xyz: Sequence[float] = (0.0, 0.0, 0.0),
+    profile_points: Optional[list[tuple[float, float]]] = None,
+) -> ifcopenshell.entity_instance:
+    """Add a 4m x 2m x 3m space, or an extrusion of a closed profile 3m high"""
+    space = ifcopenshell.api.root.create_entity(file, ifc_class="IfcSpace", name=name)
+    ifcopenshell.api.aggregate.assign_object(file, relating_object=storey, products=[space])
+    space.ObjectPlacement = placement(file, storey.ObjectPlacement, rotation, xyz)
+    if profile_points:
+        points = [file.createIfcCartesianPoint(p) for p in profile_points + profile_points[:1]]
+        profile = file.createIfcArbitraryClosedProfileDef("AREA", None, file.createIfcPolyline(points))
+        representation = ifcopenshell.api.geometry.add_profile_representation(
+            file, context=body, profile=profile, depth=3.0
+        )
+    else:
+        representation = ifcopenshell.api.geometry.add_wall_representation(
+            file, context=body, length=4.0, height=3.0, thickness=2.0
+        )
+    ifcopenshell.api.geometry.assign_representation(file, product=space, representation=representation)
+    return space
+
+
+def create_model(file: ifcopenshell.file, building_name: str = "Test Building") -> ifcopenshell.entity_instance:
+    """Add a metre project with one building, a "Ground Floor" storey and a 5m wall
+
+    :return: The IfcProject
+    """
+    project, body = create_project(file)
+    building = add_building(file, add_site(file, project), building_name)
+    add_wall(file, add_storey(file, building), body=body)
+    return project
+
+
+def create_placed_walls(
+    file: ifcopenshell.file, prefix: Optional[str] = None, imperial: bool = False
+) -> ifcopenshell.entity_instance:
+    """Add a project with a "Test Building" whose two walls have placements but no geometry
+
+    The walls are at (1, 1, 0) and (10, 10, 3) in project units.
+
+    :return: The IfcSite
+    """
+    project, _ = create_project(file, prefix=prefix, imperial=imperial)
+    site = add_site(file, project)
+    storey = add_storey(file, add_building(file, site))
+    add_wall(file, storey, (1.0, 1.0, 0.0))
+    add_wall(file, storey, (10.0, 10.0, 3.0))
+    return site
+
+
+def create_block(
+    file: ifcopenshell.file,
+    building_rotation: float = 0.0,
+    site_rotation: float = 0.0,
+    block_rotation: float = 0.0,
+    true_north: Optional[tuple[float, float]] = None,
+) -> ifcopenshell.entity_instance:
+    """Add a metre model with a 10m x 6m x 3m block in a building "Block" at (100, 50, 0)
+
+    The block, and a 4m x 2m "Hall" space, run along the storey's x axis.
+
+    :param building_rotation: Building placement rotation relative to the site, in degrees
+    :param site_rotation: Site placement rotation, in degrees
+    :param block_rotation: Rotation of the block's own placement in the storey, in degrees
+    :param true_north: Optional 2D TrueNorth direction ratios for the Model context
+    :return: The IfcBuilding
+    """
+    project, body = create_project(file)
+    if true_north:
+        model = ifcopenshell.util.representation.get_context(file, "Model")
+        model.TrueNorth = file.createIfcDirection([float(c) for c in true_north])
+    site = add_site(file, project, site_rotation)
+    building = add_building(file, site, "Block", building_rotation, (100.0, 50.0, 0.0))
+    storey = add_storey(file, building)
+    add_wall(file, storey, body=body, rotation=block_rotation, length=10.0, thickness=6.0)
+    add_space(file, storey, body, name="Hall")
+    return building
+
+
+def create_twin_buildings(file: ifcopenshell.file) -> list[tuple]:
+    """Add two buildings both named "Plot", with storeys "Ground A" and "Ground B" holding one wall each
+
+    :return: List of (building, storey, wall) tuples
+    """
+    project, _ = create_project(file)
+    site = add_site(file, project)
+    plots = []
+    for suffix, x in (("A", 0.0), ("B", 50.0)):
+        building = add_building(file, site, "Plot")
+        storey = add_storey(file, building, f"Ground {suffix}")
+        plots.append((building, storey, add_wall(file, storey, (x, 1.0, 0.0))))
+    return plots
+
+
+def add_user_sheet(
+    file: ifcopenshell.file, drawing_locations: list[str], purpose: str = "General Arrangement"
+) -> ifcopenshell.entity_instance:
+    """Add a sheet made by the user, holding drawings at the given locations"""
+    sheet = ifcopenshell.api.document.add_information(file)
+    ifcopenshell.api.document.edit_information(
+        file,
+        information=sheet,
+        attributes={"Identification": "GA-101", "Name": "User GA", "Purpose": purpose, "Scope": "SHEET"},
+    )
+    for i, location in enumerate(drawing_locations):
+        reference = ifcopenshell.api.document.add_reference(file, information=sheet)
+        ifcopenshell.api.document.edit_reference(
+            file,
+            reference=reference,
+            attributes={"Location": location, "Identification": str(i + 1), "Description": "DRAWING"},
+        )
+    return sheet
+
+
+def set_documentation(file: ifcopenshell.file, project: ifcopenshell.entity_instance, properties: dict) -> None:
+    pset = ifcopenshell.api.pset.add_pset(file, product=project, name="BBIM_Documentation")
+    ifcopenshell.api.pset.edit_pset(file, pset=pset, properties=properties)
+
+
+# Queries
+
+
+def get_generated_drawings(file: ifcopenshell.file) -> list[ifcopenshell.entity_instance]:
+    return [
+        a
+        for a in file.by_type("IfcAnnotation")
+        if ifcopenshell.util.element.get_pset(a, "EPset_Drawing", "GeneratedBy") == "endrawing"
+    ]
+
+
+def get_labels(file: ifcopenshell.file) -> list[ifcopenshell.entity_instance]:
+    return [
+        a
+        for a in file.by_type("IfcAnnotation")
+        if ifcopenshell.util.element.get_pset(a, "EPset_Annotation", "GeneratedBy") == "endrawing"
+    ]
+
+
+def get_drawings(file: ifcopenshell.file) -> dict[str, ifcopenshell.entity_instance]:
+    return {a.Name: a for a in file.by_type("IfcAnnotation") if a.ObjectType == "DRAWING"}
+
+
+def get_drawing(file: ifcopenshell.file, name: str) -> ifcopenshell.entity_instance:
+    return get_drawings(file)[name]
+
+
+def get_drawing_reference(drawing: ifcopenshell.entity_instance) -> ifcopenshell.entity_instance:
+    return next(r.RelatingDocument for r in drawing.HasAssociations if r.is_a("IfcRelAssociatesDocument"))
+
+
+def get_drawing_location(drawing: ifcopenshell.entity_instance) -> str:
+    """The location of the SVG that the drawing's document reference points at"""
+    return get_drawing_reference(drawing).Location
+
+
+def get_sheets(file: ifcopenshell.file) -> list[ifcopenshell.entity_instance]:
+    return sorted((d for d in file.by_type("IfcDocumentInformation") if d.Scope == "SHEET"), key=lambda d: d[0] or "")
+
+
+def get_sheets_by_id(file: ifcopenshell.file, identification: str) -> list[ifcopenshell.entity_instance]:
+    return [d for d in file.by_type("IfcDocumentInformation") if d.Identification == identification]
+
+
+def get_sheet_locations(file: ifcopenshell.file) -> dict[str, str]:
+    """The LAYOUT and TITLEBLOCK locations of the only sheet"""
+    [sheet] = get_sheets(file)
+    return {r.Description: r.Location for r in sheet.HasDocumentReferences if r.Description != "DRAWING"}
+
+
+def get_assets(drawing: ifcopenshell.entity_instance) -> dict[str, str]:
+    pset = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing")
+    return {name: pset[name] for name in DEFAULT_ASSETS}
+
+
+def get_scales(file: ifcopenshell.file) -> dict[str, tuple[str, str]]:
+    """{drawing name: (Scale, HumanScale)} for generated drawings"""
+    scales = {}
+    for drawing in get_generated_drawings(file):
+        pset = ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing")
+        scales[drawing.Name] = (pset["Scale"], pset["HumanScale"])
+    return scales
+
+
+def is_elevation(drawing: ifcopenshell.entity_instance) -> bool:
+    return ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing", "TargetView") == "ELEVATION_VIEW"
+
+
+def get_camera(drawing: ifcopenshell.entity_instance) -> tuple:
+    """(location, axis, ref direction, block dimensions) of a drawing camera"""
+    relative_placement = drawing.ObjectPlacement.RelativePlacement
+    block = drawing.Representation.Representations[0].Items[0].TreeRootExpression
+    return (
+        np.array(relative_placement.Location.Coordinates),
+        np.array(relative_placement.Axis.DirectionRatios),
+        np.array(relative_placement.RefDirection.DirectionRatios),
+        (block.XLength, block.YLength, block.ZLength),
+    )
+
+
+def get_axes(rotation: float) -> tuple[np.ndarray, np.ndarray]:
+    angle = np.radians(rotation)
+    return np.array([np.cos(angle), np.sin(angle), 0.0]), np.array([-np.sin(angle), np.cos(angle), 0.0])
+
+
+class TestBasics(test.bootstrap.IFC4):
+    def test_no_buildings_raises_error(self):
+        create_project(self.file)
+        with pytest.raises(ValueError, match="No IfcBuilding"):
+            run(self.file)
+
+    def test_no_model_context_raises_error(self):
+        project, _ = create_project(self.file, contexts=False)
+        add_building(self.file, project)
+        with pytest.raises(ValueError, match="No Model context"):
+            run(self.file)
+
+    def test_generates_marked_drawings(self):
+        create_model(self.file)
+        run(self.file)
+        assert get_generated_drawings(self.file)
+
+    def test_rerun_keeps_counts(self):
+        create_model(self.file)
+        run(self.file)
+        counts = (
+            len(self.file.by_type("IfcAnnotation")),
+            len(self.file.by_type("IfcGroup")),
+            len(get_sheets(self.file)),
+        )
+        assert all(counts)
+
+        run(self.file)
+
+        assert counts == (
+            len(self.file.by_type("IfcAnnotation")),
+            len(self.file.by_type("IfcGroup")),
+            len(get_sheets(self.file)),
+        )
+
+    def test_custom_scale(self):
+        create_model(self.file)
+        run(self.file, 50)
+        assert ("1/50", "1:50") in get_scales(self.file).values()
+
+    def test_scale_and_titleblock_as_strings_from_the_command_line(self):
+        create_model(self.file)
+        run(self.file, "48", "A1")
+        assert set(get_scales(self.file).values()) == {("1/48", "1:48")}
+        assert get_sheet_locations(self.file)["TITLEBLOCK"] == "layouts/titleblocks/A1.svg"
+
+    def test_sheet_drawings_numbered_from_one(self):
+        """Drawings on a sheet are numbered from 1, the industry convention"""
+        create_model(self.file)
+        run(self.file)
+        [sheet] = get_sheets(self.file)
+        numbers = [r.Identification for r in sheet.HasDocumentReferences if r.Description == "DRAWING"]
+        assert sorted(numbers, key=int) == [str(i) for i in range(1, len(numbers) + 1)]
+
+    def test_sheets_in_natural_order_of_building_names(self):
+        project, _ = create_project(self.file)
+        site = add_site(self.file, project)
+        for name in ("Plot 10", "Plot 2", "Plot 1"):
+            add_building(self.file, site, name)
+        run(self.file)
+        assert [(s.Identification, s.Name) for s in get_sheets(self.file)] == [
+            ("A001", "Plot 1"),
+            ("A002", "Plot 2"),
+            ("A003", "Plot 10"),
+        ]
+
+
+class TestCleanup(test.bootstrap.IFC4):
+    def test_manual_drawings_preserved(self):
+        create_model(self.file)
+        manual = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcAnnotation", name="Manual Drawing")
+        manual.ObjectType = "DRAWING"
+        for _ in range(2):
+            run(self.file)
+        assert manual in self.file.by_type("IfcAnnotation")
+
+    def test_annotations_without_psets(self):
+        create_model(self.file)
+        orphan = ifcopenshell.api.root.create_entity(self.file, ifc_class="IfcAnnotation", name="Orphan")
+        orphan.ObjectType = "DRAWING"
+        run(self.file)
+        assert get_generated_drawings(self.file)
+
+    def test_repeated_runs_are_stable(self):
+        create_model(self.file)
+        for _ in range(3):
+            run(self.file)
+        counts = (len(self.file.by_type("IfcAnnotation")), len(self.file.by_type("IfcGroup")))
+        run(self.file)
+        assert (len(self.file.by_type("IfcAnnotation")), len(self.file.by_type("IfcGroup"))) == counts
+
+    def test_repeated_runs_leave_no_orphans(self):
+        """Drawing documents and references are removed with their drawings"""
+        create_model(self.file)
+        run(self.file)
+        count = len(list(self.file))
+        documents = len(self.file.by_type("IfcDocumentInformation"))
+        run(self.file)
+        assert len(self.file.by_type("IfcDocumentInformation")) == documents
+        assert len(list(self.file)) == count
+
+    def test_cleanup_removes_all_generated_entities(self):
+        create_model(self.file)
+        run(self.file)
+        assert get_generated_drawings(self.file)
+        assert [g for g in self.file.by_type("IfcGroup") if g.ObjectType == "DRAWING"]
+        assert get_sheets(self.file)
+
+        recipe.DrawingGenerator(self.file).cleanup_existing_drawings()
+
+        assert not get_generated_drawings(self.file)
+        assert not [g for g in self.file.by_type("IfcGroup") if g.ObjectType == "DRAWING"]
+        assert not [d for d in self.file.by_type("IfcDocumentInformation") if d.Purpose == "General Arrangement"]
+
+    def test_user_general_arrangement_sheet_preserved(self):
+        """A user's sheet with the same Purpose, holding the user's drawing, survives"""
+        create_model(self.file)
+        add_user_sheet(self.file, ["drawings/USER PLAN.svg"])
+        for _ in range(2):
+            run(self.file)
+        [sheet] = get_sheets_by_id(self.file, "GA-101")
+        assert [r.Location for r in sheet.HasDocumentReferences] == ["drawings/USER PLAN.svg"]
+
+    def test_empty_user_sheet_preserved(self):
+        create_model(self.file)
+        add_user_sheet(self.file, [])
+        for _ in range(2):
+            run(self.file)
+        assert len(get_sheets_by_id(self.file, "GA-101")) == 1
+
+    def test_sheet_mixing_user_and_generated_drawings_preserved(self):
+        create_model(self.file)
+        run(self.file)
+        add_user_sheet(self.file, ["drawings/Test Building Ground Floor.svg", "drawings/USER PLAN.svg"])
+        run(self.file)
+        [sheet] = get_sheets_by_id(self.file, "GA-101")
+        assert len(sheet.HasDocumentReferences) == 2
+        assert len(get_sheets_by_id(self.file, "A001")) == 1
+
+    def test_file_writes_after_cleanup(self, tmp_path):
+        create_model(self.file)
+        for _ in range(2):
+            run(self.file)
+        path = tmp_path / "cleanup.ifc"
+        self.file.write(str(path))
+        assert get_generated_drawings(ifcopenshell.open(str(path)))
+
+
+class TestDocuments(test.bootstrap.IFC4):
+    def parents(self) -> tuple[list, list]:
+        documents = [
+            d for d in self.file.by_type("IfcDocumentInformation") if d.Name == "DRAWINGS" and d.Scope == "DRAWINGS"
+        ]
+        groups = [g for g in self.file.by_type("IfcGroup") if g.Name == "DRAWINGS" and g.ObjectType == "DRAWINGS"]
+        return documents, groups
+
+    def test_drawings_nested_under_bonsai_parents(self):
+        create_model(self.file)
+        run(self.file)
+
+        [parent_document], [parent_group] = self.parents()
+        nested = {d for rel in parent_document.IsPointer for d in rel.RelatedDocuments}
+        grouped = {g for rel in parent_group.IsGroupedBy for g in rel.RelatedObjects}
+        drawings = get_generated_drawings(self.file)
+        assert drawings
+        for drawing in drawings:
+            information = get_drawing_reference(drawing).ReferencedDocument
+            assert information in nested
+            assert information.Scope == "DRAWING"
+            assert information.Name == drawing.Name
+            # Nested documents aren't associated with the project directly
+            assert not information.DocumentInfoForObjects
+            group = next(r.RelatingGroup for r in drawing.HasAssignments if r.is_a("IfcRelAssignsToGroup"))
+            assert group in grouped
+
+    def test_bonsai_parents_reused_and_kept(self):
+        """Existing parents are reused, and a Bonsai drawing's document under them survives cleanup"""
+        create_model(self.file)
+        parent = ifcopenshell.api.document.add_information(self.file)
+        ifcopenshell.api.document.edit_information(
+            self.file,
+            information=parent,
+            attributes={"Identification": "DRAWINGS", "Name": "DRAWINGS", "Scope": "DRAWINGS"},
+        )
+        user_drawing = ifcopenshell.api.document.add_information(self.file, parent=parent)
+        ifcopenshell.api.document.edit_information(
+            self.file,
+            information=user_drawing,
+            attributes={"Identification": "X", "Name": "USER SECTION", "Scope": "DRAWING"},
+        )
+
+        for _ in range(2):
+            run(self.file)
+
+        documents, groups = self.parents()
+        assert documents == [parent]
+        assert len(groups) == 1
+        nested = {d for rel in parent.IsPointer for d in rel.RelatedDocuments}
+        assert user_drawing in nested
+        assert len(nested) == len(get_generated_drawings(self.file)) + 1
+
+    def test_plan_context_registered_with_project(self):
+        project = create_model(self.file)
+        recipe.DrawingGenerator(self.file)
+        plan = ifcopenshell.util.representation.get_context(self.file, "Plan")
+        assert plan in project.RepresentationContexts
+
+
+class TestDocumentsIFC2X3(test.bootstrap.IFC2X3):
+    def test_ifc2x3_attribute_names(self, tmp_path):
+        """IFC2X3 models get drawings and sheets, using IFC2X3 attribute names"""
+        create_placed_walls(self.file)
+
+        for _ in range(2):
+            run(self.file)
+
+        [sheet] = get_sheets(self.file)
+        assert sheet.DocumentId == "A001"
+        assert sheet.Purpose == "General Arrangement"
+        drawings = get_generated_drawings(self.file)
+        assert sorted(r.Name for r in sheet.DocumentReferences) == sorted(
+            ["LAYOUT", "TITLEBLOCK"] + ["DRAWING"] * len(drawings)
+        )
+        for drawing in drawings:
+            [information] = get_drawing_reference(drawing).ReferenceToDocument
+            assert information.Name == drawing.Name
+            assert information.Scope == "DRAWING"
+
+        path = tmp_path / "ifc2x3.ifc"
+        self.file.write(str(path))
+        assert len(get_generated_drawings(ifcopenshell.open(str(path)))) == len(drawings)
+
+
+class TestUnits(test.bootstrap.IFC4):
+    @pytest.mark.parametrize(
+        "prefix, imperial, scale",
+        [(None, False, 1.0), ("MILLI", False, 0.001), (None, True, 0.3048)],
+    )
+    def test_unit_scale(self, prefix, imperial, scale):
+        create_placed_walls(self.file, prefix=prefix, imperial=imperial)
+        assert recipe.DrawingGenerator(self.file).unit_scale == pytest.approx(scale, rel=1e-4)
+
+    @pytest.mark.parametrize("prefix, imperial, height", [("MILLI", False, 1800.0), (None, True, 1.8 / 0.3048)])
+    def test_plan_camera_height_in_project_units(self, prefix, imperial, height):
+        """The plan camera is 1.8m above the floor, in project units"""
+        create_placed_walls(self.file, prefix=prefix, imperial=imperial)
+        run(self.file)
+        location = get_drawing(self.file, "Test Building Ground Floor").ObjectPlacement.RelativePlacement.Location
+        assert location.Coordinates[2] == pytest.approx(height, rel=1e-3)
+
+    def test_bbox_padding_in_millimetres(self):
+        """The 2m padding is 2000mm, not 2mm"""
+        create_placed_walls(self.file, prefix="MILLI")
+        generator = recipe.DrawingGenerator(self.file)
+        assert generator.dim_all_x > 1000
+        assert generator.dim_all_y > 1000
+
+    def test_same_building_in_metres_and_millimetres(self):
+        create_placed_walls(self.file)
+        millimetres = ifcopenshell.api.project.create_file()
+        create_placed_walls(millimetres, prefix="MILLI")
+
+        heights = []
+        for file in (self.file, millimetres):
+            run(file)
+            drawing = get_drawing(file, "Test Building Ground Floor")
+            heights.append(drawing.ObjectPlacement.RelativePlacement.Location.Coordinates[2])
+
+        assert heights[1] / heights[0] == pytest.approx(1000.0, rel=0.01)
+
+    @pytest.mark.parametrize("prefix, imperial", [(None, False), ("MILLI", False), (None, True)])
+    def test_generates_drawings_in_any_unit(self, prefix, imperial):
+        create_placed_walls(self.file, prefix=prefix, imperial=imperial)
+        run(self.file)
+        assert get_generated_drawings(self.file)
+
+
+class TestBoundingBox(test.bootstrap.IFC4):
+    def create_storey_with_walls(self, coords: list[tuple[float, float, float]]) -> ifcopenshell.entity_instance:
+        """Add walls at the given placements, without geometry, and return their building"""
+        project, _ = create_project(self.file, contexts=False)
+        building = add_building(self.file, project)
+        storey = add_storey(self.file, building)
+        for xyz in coords:
+            add_wall(self.file, storey, xyz)
+        return building
+
+    def create_building(self, prefix: Optional[str] = None) -> tuple:
+        """Add a building with a storey, and return (building, storey, body context)"""
+        project, body = create_project(self.file, prefix=prefix)
+        building = add_building(self.file, project)
+        return building, add_storey(self.file, building), body
+
+    def test_single_element(self):
+        building = self.create_storey_with_walls([(5.0, 6.0, 7.0)])
+        assert recipe.GeometryUtils.get_bbox(self.file, [building]) == ([5.0, 6.0, 7.0],) * 3
+
+    def test_no_elements_gives_degenerate_bbox(self):
+        building = self.create_storey_with_walls([])
+        assert recipe.GeometryUtils.get_bbox(self.file, [building]) == ([0.0, 0.0, 0.0],) * 3
+
+    def test_elements_on_a_world_axis_kept(self):
+        building = self.create_storey_with_walls([(0.0, 4.0, 0.0), (8.0, 0.0, 0.0)])
+        bbox_min, _, bbox_max = recipe.GeometryUtils.get_bbox(self.file, [building])
+        assert (bbox_min, bbox_max) == ([0.0, 0.0, 0.0], [8.0, 4.0, 0.0])
+
+    def test_only_elements_at_the_world_origin_skipped(self):
+        building = self.create_storey_with_walls([(0.0, 0.0, 0.0), (2.0, 3.0, 4.0), (9.0, 1.0, 1.0)])
+        bbox_min, _, bbox_max = recipe.GeometryUtils.get_bbox(self.file, [building])
+        assert (bbox_min, bbox_max) == ([2.0, 1.0, 1.0], [9.0, 3.0, 4.0])
+
+    def test_spans_all_elements(self):
+        building = self.create_storey_with_walls([(1.0, 1.0, 1.0), (5.0, 5.0, 5.0), (3.0, 9.0, 2.0)])
+        bbox_min, _, bbox_max = recipe.GeometryUtils.get_bbox(self.file, [building])
+        assert (bbox_min, bbox_max) == ([1.0, 1.0, 1.0], [5.0, 9.0, 5.0])
+
+    def test_encloses_geometry_not_origin(self):
+        building, storey, body = self.create_building()
+        add_wall(self.file, storey, (1.0, 2.0, 0.0), body)
+        bbox_min, bbox_mid, bbox_max = recipe.GeometryUtils.get_bbox(self.file, [building])
+        assert bbox_min == pytest.approx([1.0, 2.0, 0.0])
+        assert bbox_max == pytest.approx([6.0, 2.2, 3.0])
+        assert bbox_mid == pytest.approx([3.5, 2.1, 1.5])
+
+    def test_geometry_in_millimetres(self):
+        building, storey, body = self.create_building(prefix="MILLI")
+        add_wall(self.file, storey, (1000.0, 2000.0, 0.0), body)
+        bbox_min, _, bbox_max = recipe.GeometryUtils.get_bbox(self.file, [building])
+        assert bbox_min == pytest.approx([1000.0, 2000.0, 0.0])
+        assert bbox_max == pytest.approx([6000.0, 2200.0, 3000.0])
+
+    def test_mixes_geometry_and_origin_fallback(self):
+        building, storey, body = self.create_building()
+        add_wall(self.file, storey, (1.0, 2.0, 0.0), body)
+        add_wall(self.file, storey, (20.0, 30.0, 1.0))
+        bbox_min, _, bbox_max = recipe.GeometryUtils.get_bbox(self.file, [building])
+        assert bbox_min == pytest.approx([1.0, 2.0, 0.0])
+        assert bbox_max == pytest.approx([20.0, 30.0, 3.0])
+
+    def test_uses_precomputed_bounds(self):
+        building, storey, body = self.create_building()
+        wall = add_wall(self.file, storey, (1.0, 2.0, 0.0), body)
+        fake_bounds = {wall.id(): ([-1.0, -2.0, -3.0], [4.0, 5.0, 6.0])}
+        bbox_min, _, bbox_max = recipe.GeometryUtils.get_bbox(self.file, [building], fake_bounds)
+        assert (bbox_min, bbox_max) == ([-1.0, -2.0, -3.0], [4.0, 5.0, 6.0])
+
+    def test_generator_site_bbox_encloses_geometry(self):
+        building, storey, body = self.create_building()
+        add_wall(self.file, storey, (1.0, 2.0, 0.0), body)
+        assert recipe.DrawingGenerator(self.file).bbox_all_max == pytest.approx([6.0, 2.2, 3.0])
+        run(self.file)
+
+    def test_falls_back_without_cgal(self, monkeypatch):
+        """Builds without the hybrid CGAL kernel fall back to OpenCASCADE"""
+        building, storey, body = self.create_building()
+        add_wall(self.file, storey, (1.0, 2.0, 0.0), body)
+        real_iterator = ifcopenshell.geom.iterator
+        libraries = []
+
+        def iterator(*args, geometry_library="opencascade", **kwargs):
+            libraries.append(geometry_library)
+            if geometry_library != "opencascade":
+                raise RuntimeError(f"No geometry kernel registered for {geometry_library}")
+            return real_iterator(*args, geometry_library=geometry_library, **kwargs)
+
+        monkeypatch.setattr(ifcopenshell.geom, "iterator", iterator)
+        _, _, bbox_max = recipe.GeometryUtils.get_bbox(self.file, [building])
+
+        assert libraries == ["hybrid-cgal-simple-opencascade", "opencascade"]
+        assert bbox_max == pytest.approx([6.0, 2.2, 3.0])
+
+
+class TestCentroids(test.bootstrap.IFC4):
+    def create_space(self, prefix=None, rotation=0.0, xyz=(10.0, 20.0, 0.0), profile_points=None):
+        project, body = create_project(self.file, prefix=prefix)
+        storey = add_storey(self.file, add_building(self.file, add_site(self.file, project)))
+        return add_space(self.file, storey, body, rotation=rotation, xyz=xyz, profile_points=profile_points)
+
+    @pytest.mark.parametrize(
+        "prefix, rotation, xyz, expected",
+        [
+            (None, 0.0, (10.0, 20.0, 0.0), [12.0, 21.0, 1.5]),
+            ("MILLI", 0.0, (10000.0, 20000.0, 0.0), [12000.0, 21000.0, 1500.0]),
+            (None, 90.0, (10.0, 20.0, 0.0), [9.0, 22.0, 1.5]),
+            ("MILLI", 90.0, (10000.0, 20000.0, 0.0), [9000.0, 22000.0, 1500.0]),
+        ],
+    )
+    def test_world_coordinates_in_project_units(self, prefix, rotation, xyz, expected):
+        """Centroids include the placement rotation and are in project units"""
+        space = self.create_space(prefix, rotation, xyz)
+        assert recipe.GeometryUtils.get_centroids(self.file, [space])[space.id()] == pytest.approx(expected)
+
+    def test_volume_centroid_not_vertex_mean(self):
+        """An L-shaped space's centroid is weighted by volume, not by vertex count"""
+        # 4m x 1m leg plus a 1m x 2m leg: area centroid (1.5, 1.0), vertex mean (1.67, 1.33)
+        space = self.create_space(
+            profile_points=[(0.0, 0.0), (4.0, 0.0), (4.0, 1.0), (1.0, 1.0), (1.0, 3.0), (0.0, 3.0)]
+        )
+        assert recipe.GeometryUtils.get_centroids(self.file, [space])[space.id()] == pytest.approx([11.5, 21.0, 1.5])
+
+    def test_spaces_without_geometry_skipped(self):
+        space = self.create_space()
+        ifcopenshell.api.geometry.unassign_representation(
+            self.file, product=space, representation=space.Representation.Representations[0]
+        )
+        assert recipe.GeometryUtils.get_centroids(self.file, [space]) == {}
+
+    def test_space_label_placed_at_centroid(self):
+        """The space label sits over the rotated space in a millimetre model"""
+        self.create_space("MILLI", 90.0, (10000.0, 20000.0, 0.0))
+        run(self.file)
+        [label] = get_labels(self.file)
+        x, y, z = label.ObjectPlacement.RelativePlacement.Location.Coordinates
+        assert (x, y) == pytest.approx((9000.0, 22000.0))
+        assert z == pytest.approx(100.0)
+
+
+class TestDuplicateNames(test.bootstrap.IFC4):
+    def test_buildings_sharing_a_name_keep_their_own_storeys(self):
+        create_twin_buildings(self.file)
+        run(self.file)
+        plan_locations = {"drawings/Plot Ground A.svg", "drawings/Plot Ground B.svg"}
+        plans = [
+            sorted(r.Location for r in sheet.HasDocumentReferences if r.Location in plan_locations)
+            for sheet in get_sheets(self.file)
+        ]
+        assert sorted(plans) == [["drawings/Plot Ground A.svg"], ["drawings/Plot Ground B.svg"]]
+
+    def test_include_filters_select_their_own_building(self):
+        """Elevation and location plan Include filters select one building, not every "Plot" """
+        plots = create_twin_buildings(self.file)
+        run(self.file)
+        includes = [
+            pset["Include"]
+            for drawing in get_generated_drawings(self.file)
+            if "Include" in (pset := ifcopenshell.util.element.get_pset(drawing, "EPset_Drawing"))
+        ]
+        # Four elevations and a location plan per building
+        assert len(includes) == 10
+        walls = {wall for _, _, wall in plots}
+        for include in includes:
+            assert len(ifcopenshell.util.selector.filter_elements(self.file, include) & walls) == 1, include
+
+    def test_storeys_sharing_a_name_get_their_own_svg(self):
+        """Plans are named "{building} {storey}", so each building's "Ground Floor" gets its own SVG"""
+        for (building, storey, _), name in zip(create_twin_buildings(self.file), ("North Block", "South Block")):
+            building.Name = name
+            storey.Name = "Ground Floor"
+        run(self.file)
+        locations = {
+            name: get_drawing_location(drawing)
+            for name, drawing in get_drawings(self.file).items()
+            if name.endswith("Ground Floor")
+        }
+        assert locations == {
+            "North Block Ground Floor": "drawings/North Block Ground Floor.svg",
+            "South Block Ground Floor": "drawings/South Block Ground Floor.svg",
+        }
+
+
+class TestScale(test.bootstrap.IFC4):
+    @pytest.mark.parametrize("prefix", [None, "MILLI"])
+    def test_metric_default(self, prefix):
+        create_placed_walls(self.file, prefix=prefix)
+        run(self.file)
+        assert set(get_scales(self.file).values()) == {("1/100", "1:100")}
+
+    def test_imperial_default(self):
+        """Imperial projects default to 1/8"=1'-0", like Bonsai"""
+        create_placed_walls(self.file, imperial=True)
+        run(self.file)
+        assert set(get_scales(self.file).values()) == {("1/96", '1/8"=1\'-0"')}
+
+    @pytest.mark.parametrize("scale, human_scale", [(48, '1/4"=1\'-0"'), (240, "1\"=20'"), (100, "1:100")])
+    def test_imperial_custom(self, scale, human_scale):
+        """Imperial scales use architectural or engineering notation where Bonsai has one"""
+        create_placed_walls(self.file, imperial=True)
+        run(self.file, scale)
+        assert set(get_scales(self.file).values()) == {(f"1/{scale}", human_scale)}
+
+    def test_imperial_location_plan(self):
+        """The location plan is ten times the drawing scale: 1/960 is 1"=80'"""
+        site = create_placed_walls(self.file, imperial=True)
+        add_building(self.file, site, "Other Building")
+        run(self.file)
+        locations = {scale for name, scale in get_scales(self.file).items() if name.endswith(" LOCATION")}
+        assert locations == {("1/960", "1\"=80'")}
+
+
+class TestOrientation(test.bootstrap.IFC4):
+    ROTATED = [
+        pytest.param({"building_rotation": 30.0}, 30.0, id="30"),
+        pytest.param({"building_rotation": 45.0}, 45.0, id="45"),
+        pytest.param({"site_rotation": 30.0}, 30.0, id="site-30"),
+    ]
+
+    @pytest.mark.parametrize("kwargs, rotation", ROTATED + [pytest.param({}, 0.0, id="0")])
+    def test_building_rotation_from_placement(self, kwargs, rotation):
+        """A building's rotation includes its site's, and unrotated buildings have none"""
+        building = create_block(self.file, **kwargs)
+        matrix = recipe.GeometryUtils.get_rotation(building)
+        if rotation == 0.0:
+            assert matrix is None
+        else:
+            x_axis, y_axis = get_axes(rotation)
+            assert matrix[:, 0] == pytest.approx(x_axis)
+            assert matrix[:, 1] == pytest.approx(y_axis)
+
+    @pytest.mark.parametrize("kwargs, rotation", ROTATED)
+    def test_oriented_bbox_fits_rotated_building(self, kwargs, rotation):
+        """The bbox of a rotated building is aligned to it, not inflated by the world axes"""
+        building = create_block(self.file, **kwargs)
+        bbox_min, _, bbox_max = recipe.GeometryUtils.get_bbox(
+            self.file, [building], rotation=recipe.GeometryUtils.get_rotation(building)
+        )
+        assert np.subtract(bbox_max, bbox_min) == pytest.approx([10.0, 6.0, 3.0])
+
+    @pytest.mark.parametrize("kwargs, rotation", ROTATED + [pytest.param({}, 0.0, id="0")])
+    def test_plan_square_to_building(self, kwargs, rotation):
+        """Plan cameras run along the building's x axis and fit its bbox"""
+        building = create_block(self.file, **kwargs)
+        run(self.file)
+        location, axis, ref_direction, dims = get_camera(get_drawing(self.file, "Block Ground Floor"))
+        assert axis == pytest.approx([0.0, 0.0, 1.0])
+        assert ref_direction == pytest.approx(get_axes(rotation)[0])
+        assert dims == pytest.approx((12.0, 8.0, 10.0))
+        matrix = ifcopenshell.util.placement.get_local_placement(building.ObjectPlacement)
+        assert location == pytest.approx(matrix[:3, :3] @ [5.0, 3.0, 1.8] + matrix[:3, 3])
+
+    @pytest.mark.parametrize(
+        "kwargs, names",
+        [
+            pytest.param({}, ["NORTH", "SOUTH", "WEST", "EAST"], id="0"),
+            pytest.param({"building_rotation": 22.5}, ["NORTH", "SOUTH", "WEST", "EAST"], id="22.5-tie"),
+            pytest.param(
+                {"building_rotation": 30.0}, ["NORTH-WEST", "SOUTH-EAST", "SOUTH-WEST", "NORTH-EAST"], id="30"
+            ),
+            pytest.param(
+                {"building_rotation": 45.0}, ["NORTH-WEST", "SOUTH-EAST", "SOUTH-WEST", "NORTH-EAST"], id="45"
+            ),
+            pytest.param(
+                {"site_rotation": 30.0}, ["NORTH-WEST", "SOUTH-EAST", "SOUTH-WEST", "NORTH-EAST"], id="site-30"
+            ),
+            # True north 90 degrees anticlockwise of project north, towards world -x
+            pytest.param({"true_north": (-1.0, 0.0)}, ["EAST", "WEST", "NORTH", "SOUTH"], id="true-north-90"),
+            pytest.param(
+                {"building_rotation": 30.0, "true_north": (-1.0, 0.0)},
+                ["NORTH-EAST", "SOUTH-WEST", "NORTH-WEST", "SOUTH-EAST"],
+                id="30-true-north-90",
+            ),
+        ],
+    )
+    def test_elevations_named_by_compass_point(self, kwargs, names):
+        """Each elevation looks square on to one face of the building and is named by its compass bearing"""
+        building = create_block(self.file, **kwargs)
+        rotation = recipe.GeometryUtils.get_rotation(building)
+        rotation = np.eye(3) if rotation is None else rotation
+        run(self.file)
+
+        drawings = get_drawings(self.file)
+        assert {n for n, d in drawings.items() if is_elevation(d)} == {f"Block {n}" for n in names}
+        for name, normal in zip(names, FACE_NORMALS):
+            _, axis, ref_direction, dims = get_camera(drawings[f"Block {name}"])
+            assert axis == pytest.approx(rotation @ normal)
+            assert ref_direction == pytest.approx(rotation @ np.cross([0.0, 0.0, 1.0], normal))
+            # Face width and height padded by 2m, depth padded by 2m less 1m
+            width, depth = (12.0, 7.0) if normal[1] else (8.0, 11.0)
+            assert dims == pytest.approx((width, 5.0, depth))
+
+    def test_rotated_elements_in_unrotated_building_stay_world_aligned(self):
+        """Orientation comes from the building placement only, never from its geometry"""
+        create_block(self.file, block_rotation=30.0)
+        run(self.file)
+        drawings = get_drawings(self.file)
+        assert {n for n, d in drawings.items() if is_elevation(d)} == {
+            "Block NORTH",
+            "Block SOUTH",
+            "Block EAST",
+            "Block WEST",
+        }
+        _, _, ref_direction, dims = get_camera(drawings["Block Ground Floor"])
+        assert ref_direction == pytest.approx([1.0, 0.0, 0.0])
+        # World-aligned bbox of the rotated block, padded by 2m
+        angle = np.radians(30.0)
+        assert dims[0] == pytest.approx(10.0 * np.cos(angle) + 6.0 * np.sin(angle) + 2.0)
+
+    def test_location_plan_stays_north_up(self):
+        """The site-wide location plan isn't rotated with the buildings"""
+        create_block(self.file, building_rotation=30.0)
+        add_building(self.file, self.file.by_type("IfcSite")[0], "Other")
+        run(self.file)
+        assert get_drawing(self.file, "Block LOCATION").ObjectPlacement.RelativePlacement.RefDirection is None
+
+    def test_space_labels_follow_rotated_plan(self):
+        """Space label text runs along the building's x axis, like its plan"""
+        create_block(self.file, building_rotation=30.0)
+        run(self.file)
+        [label] = get_labels(self.file)
+        ref_direction = label.ObjectPlacement.RelativePlacement.RefDirection.DirectionRatios
+        assert np.array(ref_direction) == pytest.approx(get_axes(30.0)[0])
+
+
+class TestDocumentationPaths(test.bootstrap.IFC4):
+    def test_bonsai_defaults_without_pset(self):
+        create_model(self.file)
+        run(self.file)
+        drawing = get_drawing(self.file, "Test Building Ground Floor")
+        assert get_drawing_location(drawing) == "drawings/Test Building Ground Floor.svg"
+        assert get_sheet_locations(self.file) == {
+            "LAYOUT": "layouts/A001 - Test Building.svg",
+            "TITLEBLOCK": "layouts/titleblocks/A2.svg",
+        }
+        assert get_assets(drawing) == DEFAULT_ASSETS
+
+    def test_partial_pset_falls_back_per_property(self):
+        project = create_model(self.file)
+        set_documentation(
+            self.file,
+            project,
+            {"DrawingsDir": "docs/plans/", "StylesheetPath": "docs/house.css", "MarkersPath": ""},
+        )
+        run(self.file)
+        drawing = get_drawing(self.file, "Test Building Ground Floor")
+        assert get_drawing_location(drawing) == "docs/plans/Test Building Ground Floor.svg"
+        assert get_sheet_locations(self.file) == {
+            "LAYOUT": "layouts/A001 - Test Building.svg",
+            "TITLEBLOCK": "layouts/titleblocks/A2.svg",
+        }
+        assert get_assets(drawing) == DEFAULT_ASSETS | {"Stylesheet": "docs/house.css"}
+
+    def test_full_pset(self):
+        project = create_model(self.file)
+        set_documentation(
+            self.file,
+            project,
+            {
+                "DrawingsDir": "docs/drawings",
+                "LayoutsDir": "docs/layouts/",
+                # Windows separators and no trailing separator
+                "TitleblocksDir": "docs\\titleblocks",
+                "StylesheetPath": "docs/assets/house.css",
+                "MarkersPath": "docs/assets/markers.svg",
+                "SymbolsPath": "docs/assets/symbols.svg",
+                "PatternsPath": "docs/assets/patterns.svg",
+                "ShadingStylesPath": "docs/assets/shading.json",
+            },
+        )
+        run(self.file, 0, "A1")
+        drawing = get_drawing(self.file, "Test Building Ground Floor")
+        assert get_drawing_location(drawing) == "docs/drawings/Test Building Ground Floor.svg"
+        assert get_sheet_locations(self.file) == {
+            "LAYOUT": "docs/layouts/A001 - Test Building.svg",
+            "TITLEBLOCK": "docs/titleblocks/A1.svg",
+        }
+        assert get_assets(drawing) == {
+            "Stylesheet": "docs/assets/house.css",
+            "Markers": "docs/assets/markers.svg",
+            "Symbols": "docs/assets/symbols.svg",
+            "Patterns": "docs/assets/patterns.svg",
+            "ShadingStyles": "docs/assets/shading.json",
+        }
+
+    def test_file_names_sanitised_like_bonsai(self):
+        create_model(self.file, building_name="Block A/B: East")
+        run(self.file)
+        # The drawing keeps its name, but its file name loses "/" and ":"
+        drawing = get_drawing(self.file, "Block A/B: East Ground Floor")
+        assert get_drawing_location(drawing) == "drawings/Block AB East Ground Floor.svg"
+        assert get_sheet_locations(self.file)["LAYOUT"] == "layouts/A001 - Block AB East.svg"


### PR DESCRIPTION
Generates General Arrangement drawings and sheets for every building: a plan of each storey, elevations of the four faces of the building's bbox named by the nearest compass point to true north, and a location plan when there is more than one building. Plans and elevations follow the building's own axes, taken from its placement.

Drawings and sheets follow the structure Bonsai creates, nested under its DRAWINGS document and group. Folders and style assets come from the project's BBIM_Documentation pset where it sets them, and otherwise from Bonsai's defaults. Running the recipe again replaces only the drawings and sheets it created before, which are marked GeneratedBy 'endrawing' in EPset_Drawing.

Ported from endrawing (https://github.com/brunopostle/endrawing), relicensed from GPL-3.0-or-later to LGPL-3.0-or-later by its author.

Generated with the assistance of an AI coding tool.