### PR TITLE
bonsai: don't raise when the active drawing has been removed

### DIFF
--- a/src/bonsai/bonsai/bim/module/drawing/prop.py
+++ b/src/bonsai/bonsai/bim/module/drawing/prop.py
@@ -469,7 +469,7 @@ class DocProperties(PropertyGroup):
         drawing_id = self.active_drawing_id
         if drawing_id == 0:
             return None
-        return tool.Ifc.get().by_id(drawing_id)
+        return tool.Ifc.get_entity_by_id(drawing_id)
 
     def get_active_target_view(self) -> Union[str, None]:
         active_drawing = self.get_active_drawing()


### PR DESCRIPTION
DocProperties.get_active_drawing() looked the active drawing up with by_id(), which raises once that drawing no longer exists, such as after a patch recipe removed it.

This is a fix for a glitch revealed by the general arrangement patch recipe #9484 but can be applied independently

Generated with the assistance of an AI coding tool.