### PR TITLE
bonsai: don't write a patched model when no output path was given

### DIFF
--- a/src/bonsai/bonsai/bim/module/patch/operator.py
+++ b/src/bonsai/bonsai/bim/module/patch/operator.py
@@ -129,7 +129,7 @@ class ExecuteIfcPatch(bpy.types.Operator):
         ifc_patch_output = props.ifc_patch_output or props.ifc_patch_input
 
         output = ifcpatch.execute(args)
-        if tool.Patch.does_patch_has_output(recipe_name):
+        if tool.Patch.does_patch_has_output(recipe_name) and ifc_patch_output:
             ifcpatch.write(output, ifc_patch_output)
         self.report({"INFO"}, f"{recipe_name} patch executed successfully")
         return {"FINISHED"}


### PR DESCRIPTION
If the user patches a model from memeory and doesn't set an output path, then the in-memory model gets patched as expected, but a 'failed to write to path: .' error is raised.

This is a fix for a glitch revealed by the general arrangement patch recipe #9484 but can be applied independently.

Generated with the assistance of an AI coding tool.