### PR TITLE
dev_environment.py: copy the runtime libraries next to the wrapper

### DIFF
--- a/src/bonsai/scripts/dev_environment.py
+++ b/src/bonsai/scripts/dev_environment.py
@@ -19,6 +19,7 @@ import argparse
 import shutil
 import subprocess
 import sys
+import time
 import urllib.request
 from pathlib import Path
 from typing import Union
@@ -95,6 +96,44 @@ BLENDER_VERSION_INT = tuple(map(int, BLENDER_VERSION.split(".")))
 PYTHON_VERSION = "3.13" if BLENDER_VERSION_INT >= (5, 1) else "3.11"
 PACKAGE_PATH = BLENDER_PATH / rf"extensions/.local/lib/python{PYTHON_VERSION}/site-packages"
 
+PARTIAL_LINK_ERROR = """
+Failed while replacing '{path}'.
+
+The extension is now only partially linked and Blender won't be able to import it until
+this completes. This is usually a file lock - close Blender if it's running. An antivirus
+scan of a freshly installed extension can also hold files for a while.
+
+Re-running this script is safe and will finish the job.
+"""
+
+
+def remove_path(path: Path) -> None:
+    """Remove `path` so it can be replaced by a symlink."""
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    # Check `is_symlink` in case if it's a broken symlink.
+    elif path.is_file() or path.is_symlink():
+        path.unlink()
+
+
+def remove_path_with_retries(path: Path, attempts: int = 5, delay: float = 2.0) -> None:
+    """`remove_path`, retrying while the files are still locked by another process.
+
+    `rmtree` is only reached on the first setup, when the extension binaries have just been
+    written and an antivirus scanner may still be holding them. On Windows that surfaces as
+    PermissionError (WinError 5, not the sharing violation you might expect) and usually
+    clears within a few seconds.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            remove_path(path)
+            return
+        except PermissionError:
+            if attempt == attempts:
+                raise
+            print(f"'{path}' is locked, retrying in {delay:.0f}s ({attempt}/{attempts - 1})...")
+            time.sleep(delay)
+
 
 def main() -> None:
     global REPO_PATH
@@ -137,6 +176,8 @@ def main() -> None:
         path.unlink()
     subprocess.check_call(("git", "checkout", "--", symlinks_glob), cwd=REPO_PATH)
 
+    # Note this has to stay ahead of the symlinking below: it's the step that gets the compiled
+    # wrapper out of site-packages before that folder is deleted and replaced by a symlink.
     if args.skip_binaries:
         print("Skipping copying compiled dependencies to the repo...")
     else:
@@ -174,17 +215,13 @@ def main() -> None:
 
     for path, dest in symlinks:
         print(f"Linking {path} -> {dest}.")
-        if path.is_dir():
-            if path.is_symlink():
-                path.unlink()
-            else:
-                shutil.rmtree(path)
-        # Check `is_symlink` in case if it's a broken symlink.
-        elif path.is_file() or path.is_symlink():
-            path.unlink()
-        else:
-            pass
-        path.symlink_to(dest, dest.is_dir())
+        try:
+            remove_path_with_retries(path)
+            path.symlink_to(dest, dest.is_dir())
+        except OSError:
+            # Removal and symlinking can't be atomic, so say what state we're leaving behind.
+            print(PARTIAL_LINK_ERROR.format(path=path))
+            raise
 
     print("Download third party dependencies...")
     BONSAI_DATA = PACKAGE_PATH / "bonsai" / "bim" / "data"

--- a/src/bonsai/scripts/dev_environment.py
+++ b/src/bonsai/scripts/dev_environment.py
@@ -183,8 +183,20 @@ def main() -> None:
     else:
         print("Copying compiled dependencies to the repo...")
         dest = REPO_PATH / "src" / "ifcopenshell-python" / "ifcopenshell"
-        for path in PACKAGE_PATH.glob("ifcopenshell/*_wrapper*"):
+        # Since 0.9.0 the wrapper is no longer self-contained: it sits next to runtime
+        # libraries such as ifcopenshell.parse.dll and the per-schema
+        # ifcopenshell_parse_schema_ifc*.dll, which are loaded by name at runtime rather
+        # than linked. A "*_wrapper*" glob never matched those, so they were left behind
+        # and the wrapper came up without them, surfacing much later as
+        # "RuntimeError: No schema named IFC4". Select on file type instead.
+        library_suffixes = (".dll", ".pyd", ".so", ".dylib")
+        for path in PACKAGE_PATH.glob("ifcopenshell/*"):
+            if not path.is_file():
+                continue
+            # Type stubs are checked into the repo, don't overwrite them.
             if path.suffix.lower() == ".pyi":
+                continue
+            if path.suffix.lower() not in library_suffixes and "_wrapper" not in path.name:
                 continue
             dest_ = dest / path.name
             print(f"Copying {path} -> {dest_}")


### PR DESCRIPTION
Closes #9488.

The compiled dependencies were collected with a `ifcopenshell/*_wrapper*` glob, written when the wrapper was a single self-contained binary.

Since 0.9.0 it isn't. The package ships runtime libraries alongside it — `ifcopenshell.parse.dll`, `ifcopenshell.geometry.dll`, the per-schema `ifcopenshell_parse_schema_ifc*.dll` and friends — which are loaded by name at runtime rather than linked, so none of them match that glob. Only the wrapper was copied into the repo, and the symlink that replaces the package folder then shadowed the originals left behind in site-packages. The wrapper came up without the libraries it needs and failed at import with `RuntimeError: No schema named IFC4`, a long way from the cause.

This selects on file type instead of on the name. Checked against both generations:

| package | before | after |
|---|---|---|
| `ifcopenshell-0.8.6a260708-py313` | 2 files | 2 files (unchanged) |
| `ifcopenshell-0.9.0a260909-py313` | 2 files | 8 files |

No behaviour change on 0.8.6. On 0.9.0 it picks up the six runtime libraries that were being dropped. The schema libraries are collected by the same `.dll` rule once they ship, and `.so` / `.dylib` keep Linux and macOS from hitting the same gap.

Worth noting this is independent of #9423 despite the identical error text: that one is the Windows packaging step failing to collect `ifcopenshell_parse_schema_ifc*.dll` into the published zip, this one is the dev-link script failing to copy runtime libraries that *are* present. They compound — once #9423 ships fixed packages, this glob would still drop the schema libraries on every `dev_environment.py` run.

---

**Stacked on #9240**, which touches the same region of this file — please merge that one first. Until it lands this PR's diff shows both commits; it narrows to the single commit here once #9240 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
